### PR TITLE
Use URI type parameter for URI client settings

### DIFF
--- a/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportConfiguration.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportConfiguration.java
@@ -28,16 +28,15 @@ class ErrorReportConfiguration {
   }
 
   @VisibleForTesting
-  static BiConsumer<JFrame, UserErrorReport> newReportHandler(final Supplier<Optional<String>> clientSettingProvider) {
+  static BiConsumer<JFrame, UserErrorReport> newReportHandler(final Supplier<Optional<URI>> clientSettingProvider) {
     return httpLobbyUri(clientSettingProvider)
         .map(ErrorReportConfiguration::uploadActionAsBackgroundTask)
         .orElse(ErrorReportUploadAction.OFFLINE_STRATEGY);
   }
 
-  private static Optional<URI> httpLobbyUri(final Supplier<Optional<String>> clientSettingProvider) {
+  private static Optional<URI> httpLobbyUri(final Supplier<Optional<URI>> clientSettingProvider) {
     return Optional.ofNullable(
         clientSettingProvider.get()
-            .map(URI::create)
             .orElseGet(() -> LobbyPropertyFetcherConfiguration.lobbyServerPropertiesFetcher()
                 .fetchLobbyServerProperties()
                 .map(LobbyServerProperties::getHttpServerUri)

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcher.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcher.java
@@ -82,13 +82,13 @@ public final class LobbyServerPropertiesFetcher {
   static Optional<LobbyServerProperties> getTestOverrideProperties(
       final GameSetting<String> testLobbyHostSetting,
       final GameSetting<Integer> testLobbyPortSetting,
-      final GameSetting<String> testLobbyHttpUri) {
+      final GameSetting<URI> testLobbyHttpUri) {
     if (testLobbyHostSetting.isSet() && testLobbyPortSetting.isSet() && testLobbyHttpUri.isSet()) {
       return Optional.of(
           LobbyServerProperties.builder()
               .host(testLobbyHostSetting.getValueOrThrow())
               .port(testLobbyPortSetting.getValueOrThrow())
-              .httpServerUri(URI.create(testLobbyHttpUri.getValueOrThrow()))
+              .httpServerUri(testLobbyHttpUri.getValueOrThrow())
               .build());
     }
 
@@ -106,7 +106,7 @@ public final class LobbyServerPropertiesFetcher {
     lobbyProps.ifPresent(props -> {
       ClientSetting.lobbyLastUsedHost.setValue(props.getHost());
       ClientSetting.lobbyLastUsedPort.setValue(props.getPort());
-      ClientSetting.lobbyLastUsedHttpHostUri.setValue(props.getHttpServerUri().toString());
+      ClientSetting.lobbyLastUsedHttpHostUri.setValue(props.getHttpServerUri());
       ClientSetting.flush();
     });
 
@@ -121,7 +121,7 @@ public final class LobbyServerPropertiesFetcher {
       return Optional.of(LobbyServerProperties.builder()
           .host(ClientSetting.lobbyLastUsedHost.getValueOrThrow())
           .port(ClientSetting.lobbyLastUsedPort.getValueOrThrow())
-          .httpServerUri(URI.create(ClientSetting.lobbyLastUsedHttpHostUri.getValueOrThrow()))
+          .httpServerUri(ClientSetting.lobbyLastUsedHttpHostUri.getValueOrThrow())
           .build());
     }
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -2,6 +2,7 @@ package games.strategy.triplea.settings;
 
 import static games.strategy.util.Util.not;
 
+import java.net.URI;
 import java.nio.file.Path;
 import java.util.Collection;
 import java.util.Optional;
@@ -71,8 +72,7 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
       new BooleanClientSetting("SPACE_BAR_CONFIRMS_CASUALTIES", true);
   public static final ClientSetting<String> lobbyLastUsedHost = new StringClientSetting("LOBBY_LAST_USED_HOST");
   public static final ClientSetting<Integer> lobbyLastUsedPort = new IntegerClientSetting("LOBBY_LAST_USED_PORT");
-  public static final ClientSetting<String> lobbyLastUsedHttpHostUri =
-      new StringClientSetting("LOBBY_LAST_USED_HTTP_HOST");
+  public static final ClientSetting<URI> lobbyLastUsedHttpHostUri = new UriClientSetting("LOBBY_LAST_USED_HTTP_HOST");
   public static final ClientSetting<String> lookAndFeel =
       new StringClientSetting("LOOK_AND_FEEL_PREF", LookAndFeel.getDefaultLookAndFeelClassName());
   public static final ClientSetting<Integer> mapEdgeScrollSpeed = new IntegerClientSetting("MAP_EDGE_SCROLL_SPEED", 30);
@@ -97,7 +97,7 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
   public static final ClientSetting<Boolean> showConsole = new BooleanClientSetting("SHOW_CONSOLE", false);
   public static final ClientSetting<String> testLobbyHost = new StringClientSetting("TEST_LOBBY_HOST");
   public static final ClientSetting<Integer> testLobbyPort = new IntegerClientSetting("TEST_LOBBY_PORT");
-  public static final ClientSetting<String> httpLobbyUriOverride = new StringClientSetting("TEST_HTTP_LOBBY_URI");
+  public static final ClientSetting<URI> httpLobbyUriOverride = new UriClientSetting("TEST_HTTP_LOBBY_URI");
   public static final ClientSetting<Boolean> firstTimeThisVersion =
       new BooleanClientSetting("TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY", true);
   public static final ClientSetting<String> lastCheckForEngineUpdate =

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -8,6 +8,8 @@ import static games.strategy.triplea.settings.SelectionComponentFactory.proxySet
 import static games.strategy.triplea.settings.SelectionComponentFactory.selectionBox;
 import static games.strategy.triplea.settings.SelectionComponentFactory.textField;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collection;
 
 import javax.swing.JComponent;
@@ -234,7 +236,17 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
       "Specifies host and port for connecting to a test HTTP lobby.") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return textField(ClientSetting.httpLobbyUriOverride);
+      return textField(
+          ClientSetting.httpLobbyUriOverride,
+          value -> value.toString(),
+          encodedValue -> {
+            try {
+              return new URI(encodedValue);
+            } catch (final URISyntaxException e) {
+              throw new SelectionComponentFactory.ValueEncodingException(e);
+            }
+          },
+          "Must be a valid URI (e.g. \"http://localhost:5678)\"");
     }
   },
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -238,7 +238,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
     public SelectionComponent<JComponent> newSelectionComponent() {
       return textField(
           ClientSetting.httpLobbyUriOverride,
-          value -> value.toString(),
+          Object::toString,
           encodedValue -> {
             try {
               return new URI(encodedValue);

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
@@ -474,11 +474,9 @@ final class SelectionComponentFactory {
       @Override
       public void save(final SaveContext context) {
         final String encodedValue = textField.getText();
-        if (encodedValue.isEmpty()) {
-          context.setValue(clientSetting, null);
-        } else {
-          decode(encodedValue).ifPresent(value -> context.setValue(clientSetting, value));
-        }
+        // FIXME: isValid() is only called when context.setValue() is called; we should change the SelectionComponent
+        // design to simply return a result from this method to avoid a double evaluation of the value validity.
+        context.setValue(clientSetting, encodedValue.isEmpty() ? null : decode(encodedValue).orElse(null));
       }
 
       @Override

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.logging.Level;
 
 import javax.annotation.Nullable;
 import javax.swing.DefaultListCellRenderer;
@@ -35,6 +36,8 @@ import com.google.common.base.Strings;
 import games.strategy.engine.framework.system.HttpProxy;
 import games.strategy.engine.pbem.IEmailSender;
 import games.strategy.ui.SwingComponents;
+import games.strategy.util.function.ThrowingFunction;
+import lombok.extern.java.Log;
 import swinglib.JButtonBuilder;
 import swinglib.JComboBoxBuilder;
 import swinglib.JPanelBuilder;
@@ -44,6 +47,7 @@ import swinglib.JPanelBuilder;
  * For example, if we have a setting that needs a number, we could create an integer text field with this
  * class. This class takes care of the UI code to ensure we render the proper swing component with validation.
  */
+@Log
 final class SelectionComponentFactory {
   private SelectionComponentFactory() {}
 
@@ -412,8 +416,32 @@ final class SelectionComponentFactory {
   }
 
   static SelectionComponent<JComponent> textField(final ClientSetting<String> clientSetting) {
-    return new AlwaysValidInputSelectionComponent() {
-      final JTextField textField = new JTextField(clientSetting.getValue().orElse(""), 20);
+    return textField(clientSetting, value -> value, encodedValue -> encodedValue, "");
+  }
+
+  static <T> SelectionComponent<JComponent> textField(
+      final ClientSetting<T> clientSetting,
+      final ThrowingFunction<T, String, ValueEncodingException> encodeValue,
+      final ThrowingFunction<String, T, ValueEncodingException> decodeValue,
+      final String validValueDescription) {
+    return new SelectionComponent<JComponent>() {
+      private final JTextField textField = new JTextField(encode(clientSetting::getValue), 20);
+
+      private String encode(final Supplier<Optional<T>> valueSupplier) {
+        return valueSupplier.get()
+            .map(value -> {
+              try {
+                return encodeValue.apply(value);
+              } catch (final ValueEncodingException e) {
+                log.log(
+                    Level.FINE,
+                    String.format("Failed to encode value '%s' from client setting '%s'", value, clientSetting),
+                    e);
+                return null;
+              }
+            })
+            .orElse("");
+      }
 
       @Override
       public JComponent getUiComponent() {
@@ -421,19 +449,46 @@ final class SelectionComponentFactory {
       }
 
       @Override
+      public boolean isValid() {
+        final String encodedValue = textField.getText();
+        return encodedValue.isEmpty() || decode(encodedValue).isPresent();
+      }
+
+      private Optional<T> decode(final String encodedValue) {
+        try {
+          return Optional.of(decodeValue.apply(encodedValue));
+        } catch (final ValueEncodingException e) {
+          log.log(
+              Level.FINE,
+              String.format("Failed to decode value '%s' for client setting '%s'", encodedValue, clientSetting),
+              e);
+          return Optional.empty();
+        }
+      }
+
+      @Override
+      public String validValueDescription() {
+        return validValueDescription;
+      }
+
+      @Override
       public void save(final SaveContext context) {
-        final String value = textField.getText();
-        context.setValue(clientSetting, value.isEmpty() ? null : value);
+        final String encodedValue = textField.getText();
+        if (encodedValue.isEmpty()) {
+          context.setValue(clientSetting, null);
+        } else {
+          decode(encodedValue).ifPresent(value -> context.setValue(clientSetting, value));
+        }
       }
 
       @Override
       public void reset() {
-        textField.setText(clientSetting.getValue().orElse(""));
+        textField.setText(encode(clientSetting::getValue));
       }
 
       @Override
       public void resetToDefault() {
-        textField.setText(clientSetting.getDefaultValue().orElse(""));
+        textField.setText(encode(clientSetting::getDefaultValue));
       }
     };
   }
@@ -600,6 +655,14 @@ final class SelectionComponentFactory {
     @Override
     public String validValueDescription() {
       return "";
+    }
+  }
+
+  static final class ValueEncodingException extends Exception {
+    private static final long serialVersionUID = 4544282783923154696L;
+
+    ValueEncodingException(final Throwable cause) {
+      super(cause);
     }
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/settings/UriClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/UriClientSetting.java
@@ -1,0 +1,24 @@
+package games.strategy.triplea.settings;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+final class UriClientSetting extends ClientSetting<URI> {
+  protected UriClientSetting(final String name) {
+    super(URI.class, name);
+  }
+
+  @Override
+  protected String encodeValue(final URI value) {
+    return value.toString();
+  }
+
+  @Override
+  protected URI decodeValue(final String encodedValue) throws ValueEncodingException {
+    try {
+      return new URI(encodedValue);
+    } catch (final URISyntaxException e) {
+      throw new ValueEncodingException(e);
+    }
+  }
+}

--- a/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportConfigurationTest.java
+++ b/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportConfigurationTest.java
@@ -1,5 +1,6 @@
 package games.strategy.debug.error.reporting;
 
+import java.net.URI;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
@@ -7,14 +8,12 @@ import org.triplea.test.common.Integration;
 
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 
-
 @Integration
 class ErrorReportConfigurationTest extends AbstractClientSettingTestCase {
-
   @Test
   void verifyConstructionIsWithoutError() {
     ErrorReportConfiguration.newReportHandler();
     ErrorReportConfiguration.newReportHandler(Optional::empty);
-    ErrorReportConfiguration.newReportHandler(() -> Optional.of("http://sample.uri"));
+    ErrorReportConfiguration.newReportHandler(() -> Optional.of(URI.create("http://sample.uri")));
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcherTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcherTest.java
@@ -76,7 +76,7 @@ class LobbyServerPropertiesFetcherTest {
     private GameSetting<Integer> testLobbyPortSetting;
 
     @Mock
-    private GameSetting<String> testLobbyHttpUriSetting;
+    private GameSetting<URI> testLobbyHttpUriSetting;
 
     private Optional<LobbyServerProperties> result;
 
@@ -90,7 +90,7 @@ class LobbyServerPropertiesFetcherTest {
 
     private void givenTestLobbyHttpUriIsSet() {
       when(testLobbyHttpUriSetting.isSet()).thenReturn(true);
-      when(testLobbyHttpUriSetting.getValueOrThrow()).thenReturn("http://uri");
+      when(testLobbyHttpUriSetting.getValueOrThrow()).thenReturn(URI.create("http://uri"));
     }
 
     private void givenTestLobbyHostIsSetTo(final String host) {

--- a/game-core/src/test/java/games/strategy/triplea/settings/UriClientSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/UriClientSettingTest.java
@@ -1,0 +1,40 @@
+package games.strategy.triplea.settings;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class UriClientSettingTest {
+  private final UriClientSetting clientSetting = new UriClientSetting("name");
+
+  @Nested
+  final class EncodeValueTest {
+    @Test
+    void shouldReturnEncodedValue() {
+      assertThat(clientSetting.encodeValue(URI.create("http://localhost:1234/path")), is("http://localhost:1234/path"));
+    }
+  }
+
+  @Nested
+  final class DecodeValueTest {
+    @Test
+    void shouldReturnUriWhenEncodedValueIsLegal() throws Exception {
+      assertThat(clientSetting.decodeValue("http://localhost:1234/path"), is(URI.create("http://localhost:1234/path")));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenEncodedValueIsIllegal() {
+      final Exception e = assertThrows(
+          ClientSetting.ValueEncodingException.class,
+          () -> clientSetting.decodeValue(":not_a_uri"));
+      assertThat(e.getCause(), is(instanceOf(URISyntaxException.class)));
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Converts the `httpLobbyUriOverride` and `lobbyLastUsedHttpHostUri` client settings from `ClientSetting<String>` to `ClientSetting<URI>`.

## Functional Changes

None.

## Refactoring Changes

* Changed the `SelectionComponentFactory#textField()` implementation to handle arbitrary types, as long as the type defines a conversion from-and-to `String`.

## Manual Testing Performed

Smoke tested the **Testing** tab of the engine preferences dialog:

* Verified I could save/reset lobby host/port and HTTP server URI.
* Verified saving an illegal HTTP server URI displayed an appropriate failure message.

## Additional Review Notes

* I came across a design deficiency in `SaveFunction`, as noted by the `FIXME` in these changes.  See the second commit for more details.  I will follow up in a subsequent PR to address this issue.
* I did not convert `ClientSetting#defaultGameUri` to `ClientSetting<URI>` in this PR.  The way this setting is used in `GameSelectorModel#loadDefaultGameSameThread()` is kind of hokey, and it will require some significant refactoring of that method to accommodate the use of `ClientSetting<URI>` in an idiomatic way.  That seems complex enough to justify its own PR.