### PR TITLE
Simple: Remove always false condition from 'or' conditons

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -2439,7 +2439,7 @@ public class UnitAttachment extends DefaultAttachment {
         throw new GameParseException("air units cannot have certain properties, " + thisErrorMsg());
       }
     } else if (isSea) {
-      if (canBlitz || isAir || isStrategicBomber || carrierCost != -1
+      if (canBlitz || isStrategicBomber || carrierCost != -1
           || transportCost != -1 || isMarine != 0 || isLandTransportable || isLandTransport
           || isAirTransportable || isAirTransport || isKamikaze) {
         throw new GameParseException("sea units cannot have certain properties, " + thisErrorMsg());


### PR DESCRIPTION
## Overview
The value is checked a few lines above in an if condition and is always
false at this point.


## Functional Changes
None
