### PR TITLE
Simple: Remove variable that is always null

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveBattleRecordsChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveBattleRecordsChange.java
@@ -37,7 +37,7 @@ class RemoveBattleRecordsChange extends Change {
     // This only occurs when serialization went badly, or something cannot be serialized.
     if (recordsToRemove == null) {
       throw new IllegalStateException(
-          "Records cannot be null (most likely caused by improper or impossible serialization): " + recordsToRemove);
+          "Records cannot be null (most likely caused by improper or impossible serialization)");
     }
     return "Adding Battle Records: " + recordsToRemove;
   }


### PR DESCRIPTION
## Overview
Simple code cleanup, no need to print 'null' when a variable is always null.
