### PR TITLE
Improve SelectionComponent validation design

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -246,7 +246,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
               throw new SelectionComponentFactory.ValueEncodingException(e);
             }
           },
-          "Must be a valid URI (e.g. \"http://localhost:5678\")");
+          "must be a valid URI, e.g. \"http://localhost:5678\"");
     }
   },
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/SaveFunction.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SaveFunction.java
@@ -35,27 +35,30 @@ final class SaveFunction {
     // save all the values, save stuff that is valid and that was updated
     selectionComponents.forEach(selectionComponent -> {
       final SelectionComponent.SaveContext context = new SelectionComponent.SaveContext() {
-        private final boolean selectionComponentValid = selectionComponent.isValid();
+        @Override
+        public void reportError(
+            final GameSetting<?> gameSetting,
+            final String message,
+            final @Nullable Object value,
+            final ValueSensitivity valueSensitivity) {
+          failMsg.append(String.format(
+              "Could not set %s to %s (%s)\n",
+              gameSetting,
+              toDisplayString(value, gameSetting.getDefaultValue().orElse(null), valueSensitivity),
+              message));
+        }
 
         @Override
         public <T> void setValue(
             final GameSetting<T> gameSetting,
-            final T value,
+            final @Nullable T value,
             final ValueSensitivity valueSensitivity) {
-          if (selectionComponentValid) {
-            if (doesNewSettingValueDiffer(gameSetting, value)) {
-              gameSetting.setValue(value);
-              successMsg.append(String.format(
-                  "%s was updated to %s\n",
-                  gameSetting,
-                  toDisplayString(value, gameSetting.getDefaultValue().orElse(null), valueSensitivity)));
-            }
-          } else {
-            failMsg.append(String.format(
-                "Could not set %s to %s (%s)\n",
+          if (doesNewSettingValueDiffer(gameSetting, value)) {
+            gameSetting.setValue(value);
+            successMsg.append(String.format(
+                "%s was updated to %s\n",
                 gameSetting,
-                toDisplayString(value, gameSetting.getDefaultValue().orElse(null), valueSensitivity),
-                selectionComponent.validValueDescription()));
+                toDisplayString(value, gameSetting.getDefaultValue().orElse(null), valueSensitivity)));
           }
         }
       };

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponent.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponent.java
@@ -12,13 +12,6 @@ public interface SelectionComponent<T> {
   T getUiComponent();
 
   /**
-   * Reads the value set in the UI and return true if it is valid, false otherwise.
-   */
-  boolean isValid();
-
-  String validValueDescription();
-
-  /**
    * Saves values stored in the UI components to the underlying game settings.
    */
   void save(SaveContext context);
@@ -34,6 +27,39 @@ public interface SelectionComponent<T> {
    * The execution context for the {@link SelectionComponent#save(SaveContext)} method.
    */
   interface SaveContext {
+    /**
+     * Reports an error when failing to set the insensitive value for the specified game setting (e.g. if the value is
+     * invalid or malformed in some way).
+     *
+     * @param gameSetting The game setting whose value failed to be set.
+     * @param message A message providing guidance to the user as to what constitutes a valid value.
+     * @param value The new setting value that could not be set. The value may be in an encoded form and does not have
+     *        to have the same type as the game setting (e.g. if the {@code String} from a text field could not be
+     *        parsed into an {@code Integer} for a {@code GameSetting<Integer>}).
+     */
+    default void reportError(final GameSetting<?> gameSetting, final String message, final @Nullable Object value) {
+      reportError(gameSetting, message, value, ValueSensitivity.INSENSITIVE);
+    }
+
+    /**
+     * Reports an error when failing to set the value with the specified sensitivity for the specified game setting
+     * (e.g. if the value is invalid or malformed in some way).
+     *
+     * @param gameSetting The game setting whose value failed to be set.
+     * @param message A message providing guidance to the user as to what constitutes a valid value.
+     * @param value The new setting value that could not be set. The value may be in an encoded form and does not have
+     *        to have the same type as the game setting (e.g. if the {@code String} from a text field could not be
+     *        parsed into an {@code Integer} for a {@code GameSetting<Integer>}).
+     * @param valueSensitivity The sensitivity of the new setting value to disclosure. Use
+     *        {@link ValueSensitivity#INSENSITIVE} if the value can be displayed to the user in the UI; otherwise use
+     *        {@link ValueSensitivity#SENSITIVE} if the value should be masked before it is displayed to the user.
+     */
+    void reportError(
+        GameSetting<?> gameSetting,
+        String message,
+        @Nullable Object value,
+        ValueSensitivity valueSensitivity);
+
     /**
      * Sets the insensitive value for the specified game setting. Selection components must call this method to change a
      * setting value and must not call {@link GameSetting#setValue(Object)} directly.

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
@@ -122,14 +122,14 @@ final class SelectionComponentFactory {
           OptionalUtils.ifEmpty(optionalHost, () -> context.reportError(
               proxyHostClientSetting,
               "must be a network name or an IP address",
-              encodedHost));
+              Strings.emptyToNull(encodedHost)));
 
           final String encodedPort = portText.getText().trim();
           final Optional<Integer> optionalPort = parsePort(encodedPort);
           OptionalUtils.ifEmpty(optionalPort, () -> context.reportError(
               proxyPortClientSetting,
               "must be a positive integer, usually 4 to 5 digits",
-              encodedPort));
+              Strings.emptyToNull(encodedPort)));
 
           OptionalUtils.ifAllPresent(optionalHost, optionalPort, (host, port) -> {
             context.setValue(proxyChoiceClientSetting, HttpProxy.ProxyChoice.USE_USER_PREFERENCES);

--- a/game-core/src/main/java/games/strategy/util/OptionalUtils.java
+++ b/game-core/src/main/java/games/strategy/util/OptionalUtils.java
@@ -3,6 +3,7 @@ package games.strategy.util;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Optional;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 /**
@@ -10,6 +11,33 @@ import java.util.function.Consumer;
  */
 public final class OptionalUtils {
   private OptionalUtils() {}
+
+  /**
+   * If a value is present in both {@code optional1} and {@code optional2}, performs the given action with the values,
+   * otherwise does nothing.
+   */
+  public static <T, U> void ifAllPresent(
+      final Optional<T> optional1,
+      final Optional<U> optional2,
+      final BiConsumer<? super T, ? super U> action) {
+    checkNotNull(optional1);
+    checkNotNull(optional2);
+    checkNotNull(action);
+
+    optional1.ifPresent(value1 -> optional2.ifPresent(value2 -> action.accept(value1, value2)));
+  }
+
+  /**
+   * If no value is present in {@code optional}, performs the given action.
+   */
+  public static void ifEmpty(final Optional<?> optional, final Runnable action) {
+    checkNotNull(optional);
+    checkNotNull(action);
+
+    if (!optional.isPresent()) {
+      action.run();
+    }
+  }
 
   /**
    * If a value is present in the specified {@code Optional}, performs the given action with the value, otherwise

--- a/game-core/src/test/java/games/strategy/util/OptionalUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/util/OptionalUtilsTest.java
@@ -3,14 +3,80 @@ package games.strategy.util;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiConsumer;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 final class OptionalUtilsTest {
+  @ExtendWith(MockitoExtension.class)
+  @Nested
+  final class IfAllPresentTest {
+    private static final String FIRST_VALUE = "value";
+    private static final int SECOND_VALUE = 42;
+
+    @Mock
+    private BiConsumer<String, Integer> action;
+
+    @Test
+    void shouldInvokeActionWhenOptional1PresentAndOptional2Present() {
+      OptionalUtils.ifAllPresent(Optional.of(FIRST_VALUE), Optional.of(SECOND_VALUE), action);
+
+      verify(action).accept(FIRST_VALUE, SECOND_VALUE);
+    }
+
+    @Test
+    void shouldNotInvokeActionWhenOptional1PresentAndOptional2Absent() {
+      OptionalUtils.ifAllPresent(Optional.of(FIRST_VALUE), Optional.empty(), action);
+
+      verify(action, never()).accept(any(), any());
+    }
+
+    @Test
+    void shouldNotInvokeActionWhenOptional1AbsentAndOptional2Present() {
+      OptionalUtils.ifAllPresent(Optional.empty(), Optional.of(SECOND_VALUE), action);
+
+      verify(action, never()).accept(any(), any());
+    }
+
+    @Test
+    void shouldNotInvokeActionWhenOptional1AbsentAndOptional2Absent() {
+      OptionalUtils.ifAllPresent(Optional.empty(), Optional.empty(), action);
+
+      verify(action, never()).accept(any(), any());
+    }
+  }
+
+  @ExtendWith(MockitoExtension.class)
+  @Nested
+  final class IfEmptyTest {
+    @Mock
+    private Runnable action;
+
+    @Test
+    void shouldNotInvokeActionWhenValuePresent() {
+      OptionalUtils.ifEmpty(Optional.of(42), action);
+
+      verify(action, never()).run();
+    }
+
+    @Test
+    void shouldInvokeActionWhenValueAbsent() {
+      OptionalUtils.ifEmpty(Optional.empty(), action);
+
+      verify(action).run();
+    }
+  }
+
   @Nested
   final class IfPresentOrElseTest {
     @Test

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/SettingsPane.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/SettingsPane.java
@@ -121,6 +121,13 @@ class SettingsPane extends StackPane {
   private void save() {
     final SelectionComponent.SaveContext context = new SelectionComponent.SaveContext() {
       @Override
+      public void reportError(
+          final GameSetting<?> gameSetting,
+          final String message,
+          final @Nullable Object value,
+          final SelectionComponent.SaveContext.ValueSensitivity valueSensitivity) {}
+
+      @Override
       public <T> void setValue(
           final GameSetting<T> gameSetting,
           final @Nullable T value,


### PR DESCRIPTION
## Overview

Addresses the `FIXME` introduced in #4577 by redesigning how a `SelectionComponent` is validated.

## Functional Changes

* Clear the network proxy host/port if anything other than `USE_USER_PREFERENCES` is selected.

## Refactoring Changes

* Removed the `SelectionComponent#isValid()` method, as it was confusing that it was called while `SelectionComponent#save()` was already active.  This caused the parsing/validation to effectively be performed twice.  It also prevented reporting the invalid value when parsing failed, as the `String` (usually) could not be converted to type `T`, as required by the `SaveContext#setValue()` method.
* Added the `SaveContext#reportError()` method for `save()` implementations to report parsing/validation failures.  Thus, setting a value and reporting an error are now co-located within the `save()` method.  In addition, unparseable values can be passed to this method because it accepts values of any type that do not necessarily have to match the type of the game setting.
* Each game setting can now have a separate validation message instead of trying to cram them all in a single string for multi-setting `SelectionComponent`s (e.g. network proxy).

## Manual Testing Performed

* Tested various success/failure scenarios with the test lobby host/port and HTTP server URI override settings.
* Tested various valid/invalid combinations of the network proxy settings.