### PR TITLE
AI - Add logic to check if landing territory isn't neutral or enemy

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -22,11 +22,15 @@ public class ProMatches {
 
   public static Predicate<Territory> territoryCanLandAirUnits(final PlayerId player, final GameData data,
       final boolean isCombatMove, final List<Territory> enemyTerritories, final List<Territory> alliedTerritories) {
-    return Matches.territoryIsInList(alliedTerritories).or(
-        Matches.airCanLandOnThisAlliedNonConqueredLandTerritory(player, data)
-            .and(Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, false,
-                false, true, true))
-            .and(Matches.territoryIsInList(enemyTerritories).negate()));
+    Predicate<Territory> match = Matches.airCanLandOnThisAlliedNonConqueredLandTerritory(player, data)
+        .and(Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(player, data, isCombatMove, false,
+            false, true, true))
+        .and(Matches.territoryIsInList(enemyTerritories).negate());
+    if (!isCombatMove) {
+      match = match.and(Matches.territoryIsNeutralButNotWater()
+          .or(Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(player, data)).negate());
+    }
+    return Matches.territoryIsInList(alliedTerritories).or(match);
   }
 
   public static Predicate<Territory> territoryCanMoveAirUnits(final PlayerId player, final GameData data,


### PR DESCRIPTION
## Overview
- Fixes AI issue when `canLandAirUnitsOnOwnedLand` relationship property on enemies where the AI thinks it can land air units on enemy territories during non-combat move

## Manual Testing Performed
- Here is a save game that shows before and after moving a young dragon to a safer location instead of having a failed move:
[test_blue.zip](https://github.com/triplea-game/triplea/files/2769236/test_blue.zip)
