### PR TITLE
Cleanup: Replace redundant add all call with parameterized constructor

### DIFF
--- a/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -809,8 +809,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     route.setStart(congoSeaZone);
     route.add(westAfricaSea);
     route.add(northAtlantic);
-    Collection<Unit> units = new ArrayList<>();
-    units.addAll(CollectionUtils.getMatches(
+    Collection<Unit> units = new ArrayList<>(CollectionUtils.getMatches(
         gameData.getMap().getTerritory(congoSeaZone.toString()).getUnits().getUnits(), Matches.unitIsCarrier()));
     results = delegate.move(units, route);
     assertValid(results);
@@ -819,8 +818,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     route.setStart(redSea);
     route.add(eastMediteranean);
     route.add(blackSea);
-    units = new ArrayList<>();
-    units.addAll(CollectionUtils.getMatches(
+    units = new ArrayList<>(CollectionUtils.getMatches(
         gameData.getMap().getTerritory(redSea.toString()).getUnits().getUnits(), Matches.unitIsCarrier()));
     results = delegate.move(units, route);
     assertValid(results);
@@ -956,15 +954,15 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // Get the attacking sea units that will retreat
-    final List<Unit> retreatingSeaUnits = new ArrayList<>();
-    retreatingSeaUnits.addAll(balticSeaZone.getUnits().getMatches(Matches.enemyUnit(germans, gameData)));
+    final List<Unit> retreatingSeaUnits =
+        new ArrayList<>(balticSeaZone.getUnits().getMatches(Matches.enemyUnit(germans, gameData)));
     // Get the attacking land units that will retreat and their number
-    final List<Unit> retreatingLandUnits = new ArrayList<>();
-    retreatingLandUnits.addAll(finlandNorway.getUnits().getMatches(Matches.enemyUnit(germans, gameData)));
+    final List<Unit> retreatingLandUnits =
+        new ArrayList<>(finlandNorway.getUnits().getMatches(Matches.enemyUnit(germans, gameData)));
     final int retreatingLandSizeInt = retreatingLandUnits.size();
     // Get the defending land units that and their number
-    final List<Unit> defendingLandUnits = new ArrayList<>();
-    defendingLandUnits.addAll(finlandNorway.getUnits().getMatches(Matches.enemyUnit(british, gameData)));
+    final List<Unit> defendingLandUnits =
+        new ArrayList<>(finlandNorway.getUnits().getMatches(Matches.enemyUnit(british, gameData)));
     final int defendingLandSizeInt = defendingLandUnits.size();
     // Set up the battles and the dependent battles
     final IBattle inFinlandNorway =
@@ -1018,15 +1016,15 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // Get the attacking sea units that will retreat
-    final List<Unit> retreatingSeaUnits = new ArrayList<>();
-    retreatingSeaUnits.addAll(balticSeaZone.getUnits().getMatches(Matches.enemyUnit(germans, gameData)));
+    final List<Unit> retreatingSeaUnits =
+        new ArrayList<>(balticSeaZone.getUnits().getMatches(Matches.enemyUnit(germans, gameData)));
     // Get the attacking land units that will retreat and their number
-    final List<Unit> retreatingLandUnits = new ArrayList<>();
-    retreatingLandUnits.addAll(finlandNorway.getUnits().getMatches(Matches.enemyUnit(germans, gameData)));
+    final List<Unit> retreatingLandUnits =
+        new ArrayList<>(finlandNorway.getUnits().getMatches(Matches.enemyUnit(germans, gameData)));
     final int retreatingLandSizeInt = retreatingLandUnits.size();
     // Get the defending land units that and their number
-    final List<Unit> defendingLandUnits = new ArrayList<>();
-    defendingLandUnits.addAll(finlandNorway.getUnits().getMatches(Matches.enemyUnit(british, gameData)));
+    final List<Unit> defendingLandUnits =
+        new ArrayList<>(finlandNorway.getUnits().getMatches(Matches.enemyUnit(british, gameData)));
     final int defendingLandSizeInt = defendingLandUnits.size();
     // Set up the battles and the dependent battles
     final IBattle inFinlandNorway =
@@ -1080,11 +1078,11 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // Get the attacking sea units that will retreat
-    final List<Unit> retreatingSeaUnits = new ArrayList<>();
-    retreatingSeaUnits.addAll(balticSeaZone.getUnits().getMatches(Matches.enemyUnit(germans, gameData)));
+    final List<Unit> retreatingSeaUnits =
+        new ArrayList<>(balticSeaZone.getUnits().getMatches(Matches.enemyUnit(germans, gameData)));
     // Get the attacking land units that will retreat and their number
-    final List<Unit> retreatingLandUnits = new ArrayList<>();
-    retreatingLandUnits.addAll(karelia.getUnits().getMatches(Matches.isUnitAllied(russians, gameData)));
+    final List<Unit> retreatingLandUnits =
+        new ArrayList<>(karelia.getUnits().getMatches(Matches.isUnitAllied(russians, gameData)));
     final int retreatingLandSizeInt = retreatingLandUnits.size();
     // Get the defending land units that and their number
     retreatingLandUnits.addAll(karelia.getUnits().getMatches(Matches.isUnitAllied(british, gameData)));
@@ -1136,11 +1134,11 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // Get the attacking sea units that will retreat
-    final List<Unit> retreatingSeaUnits = new ArrayList<>();
-    retreatingSeaUnits.addAll(balticSeaZone.getUnits().getMatches(Matches.enemyUnit(germans, gameData)));
+    final List<Unit> retreatingSeaUnits =
+        new ArrayList<>(balticSeaZone.getUnits().getMatches(Matches.enemyUnit(germans, gameData)));
     // Get the attacking land units that will retreat and their number
-    final List<Unit> retreatingLandUnits = new ArrayList<>();
-    retreatingLandUnits.addAll(karelia.getUnits().getMatches(Matches.isUnitAllied(russians, gameData)));
+    final List<Unit> retreatingLandUnits =
+        new ArrayList<>(karelia.getUnits().getMatches(Matches.isUnitAllied(russians, gameData)));
     final int retreatingLandSizeInt = retreatingLandUnits.size();
     // Get the defending land units that and their number
     final List<Unit> defendingLandUnits = new ArrayList<>();

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -1173,9 +1173,8 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
     final Route r = new Route(france, germany, poland);
-    final List<Unit> toMove = new ArrayList<>();
     // 1 armour and 1 infantry
-    toMove.addAll(france.getUnits().getMatches(Matches.unitCanBlitz()));
+    final List<Unit> toMove = new ArrayList<>(france.getUnits().getMatches(Matches.unitCanBlitz()));
     toMove.add(france.getUnits().getMatches(Matches.unitIsLandTransportable()).get(0));
     move(toMove, r);
   }

--- a/game-core/src/test/java/games/strategy/triplea/util/UnitSeparatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/util/UnitSeparatorTest.java
@@ -67,9 +67,8 @@ public class UnitSeparatorTest {
     final GameData data = TestMapGameData.TWW.getGameData();
     final Territory northernGermany = territory("Northern Germany", data);
     northernGermany.getUnits().clear();
-    final List<Unit> units = new ArrayList<>();
     final PlayerId italians = GameDataTestUtil.italy(data);
-    units.addAll(GameDataTestUtil.italianInfantry(data).create(1, italians));
+    final List<Unit> units = new ArrayList<>(GameDataTestUtil.italianInfantry(data).create(1, italians));
     GameDataTestUtil.addTo(northernGermany, units);
     when(mockMapData.shouldDrawUnit(ArgumentMatchers.anyString())).thenReturn(false);
     final List<UnitCategory> categories = UnitSeparator.getSortedUnitCategories(northernGermany, mockMapData);

--- a/game-core/src/test/java/org/triplea/lobby/common/login/RsaAuthenticatorTest.java
+++ b/game-core/src/test/java/org/triplea/lobby/common/login/RsaAuthenticatorTest.java
@@ -34,13 +34,11 @@ final class RsaAuthenticatorTest {
     void shouldBeAbleToDecryptHashedAndSaltedPassword() throws Exception {
       final RsaAuthenticator rsaAuthenticator = new RsaAuthenticator(TestSecurityUtils.loadRsaKeyPair());
       final String password = "password";
-      final Map<String, String> challenge = new HashMap<>();
-      final Map<String, String> response = new HashMap<>();
       @SuppressWarnings("unchecked")
       final Function<String, String> action = mock(Function.class);
 
-      challenge.putAll(rsaAuthenticator.newChallenge());
-      response.putAll(RsaAuthenticator.newResponse(challenge, password));
+      final Map<String, String> challenge = new HashMap<>(rsaAuthenticator.newChallenge());
+      final Map<String, String> response = new HashMap<>(RsaAuthenticator.newResponse(challenge, password));
       rsaAuthenticator.decryptPasswordForAction(response, action);
 
       verify(action).apply(RsaAuthenticator.hashPasswordWithSalt(password));


### PR DESCRIPTION
## Overview

Automatic cleanup via IDE. Instead of:
```
List<String> stringList = new ArrayList<>();
stringList.addAll(someOtherCollection);
```

We can use a constructor that will do this for us:

```
List<String> stringList = new ArrayList<>(someOtherCollection)
```

## Functional Changes
None

## Manual Testing Performed
None
