### PR TITLE
Cleanup: Replace empty and single Arrays.asList

### DIFF
--- a/game-core/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -63,7 +64,7 @@ public class MapDownloadListTest extends AbstractClientSettingTestCase {
 
     final List<DownloadFileDescription> available = testObj.getAvailableExcluding(Arrays.asList(download1, download3));
 
-    assertThat(available, is(Arrays.asList(download2)));
+    assertThat(available, is(Collections.singletonList(download2)));
   }
 
   private static DownloadFileDescription newDownloadWithUrl(final String url) {
@@ -116,7 +117,7 @@ public class MapDownloadListTest extends AbstractClientSettingTestCase {
 
     final List<DownloadFileDescription> outOfDate = testObj.getOutOfDateExcluding(Arrays.asList(download1, download3));
 
-    assertThat(outOfDate, is(Arrays.asList(download2)));
+    assertThat(outOfDate, is(Collections.singletonList(download2)));
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -58,7 +59,8 @@ public class TriggerAttachmentTest {
 
     final ProductionFrontierList productionFrontierList = gameData.getProductionFrontierList();
     productionFrontierList
-        .addProductionFrontier(new ProductionFrontier("frontier", gameData, Arrays.asList(productionRule2)));
+        .addProductionFrontier(
+            new ProductionFrontier("frontier", gameData, Collections.singletonList(productionRule2)));
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -959,7 +959,7 @@ public class WW2V3Year41Test {
         steps.toString());
     givenRemotePlayerWillSelectCasualtiesPer(bridge, invocation -> {
       final Collection<Unit> selectFrom = invocation.getArgument(0);
-      return new CasualtyDetails(Arrays.asList(selectFrom.iterator().next()), new ArrayList<>(), false);
+      return new CasualtyDetails(Collections.singletonList(selectFrom.iterator().next()), new ArrayList<>(), false);
     });
     // attacking subs sneak attack and hit
     // no chance to return fire

--- a/game-core/src/test/java/games/strategy/util/CollectionUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/util/CollectionUtilsTest.java
@@ -11,6 +11,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Nested;
@@ -25,9 +26,9 @@ final class CollectionUtilsTest {
   final class CountMatchesTest {
     @Test
     void shouldReturnCountOfMatches() {
-      assertEquals(0, countMatches(Arrays.asList(), IS_ZERO));
+      assertEquals(0, countMatches(Collections.emptyList(), IS_ZERO));
 
-      assertEquals(1, countMatches(Arrays.asList(0), IS_ZERO));
+      assertEquals(1, countMatches(Collections.singletonList(0), IS_ZERO));
       assertEquals(1, countMatches(Arrays.asList(-1, 0, 1), IS_ZERO));
 
       assertEquals(2, countMatches(Arrays.asList(0, 0), IS_ZERO));
@@ -41,8 +42,8 @@ final class CollectionUtilsTest {
     void shouldFilterOutNonMatchingElementsAndReturnAllMatches() {
       final Collection<Integer> input = Arrays.asList(-1, 0, 1);
 
-      assertEquals(Arrays.asList(), getMatches(Arrays.asList(), ALWAYS), "empty collection");
-      assertEquals(Arrays.asList(), getMatches(input, NEVER), "none match");
+      assertEquals(Collections.emptyList(), getMatches(Collections.emptyList(), ALWAYS), "empty collection");
+      assertEquals(Collections.emptyList(), getMatches(input, NEVER), "none match");
       assertEquals(Arrays.asList(-1, 1), getMatches(input, IS_ZERO.negate()), "some match");
       assertEquals(Arrays.asList(-1, 0, 1), getMatches(input, ALWAYS), "all match");
     }
@@ -54,10 +55,11 @@ final class CollectionUtilsTest {
     void shouldFilterOutNonMatchingElementsAndReturnMaxMatches() {
       final Collection<Integer> input = Arrays.asList(-1, 0, 1);
 
-      assertEquals(Arrays.asList(), getNMatches(Arrays.asList(), 999, ALWAYS), "empty collection");
-      assertEquals(Arrays.asList(), getNMatches(input, 0, NEVER), "max = 0");
-      assertEquals(Arrays.asList(), getNMatches(input, input.size(), NEVER), "none match");
-      assertEquals(Arrays.asList(0), getNMatches(Arrays.asList(-1, 0, 0, 1), 1, IS_ZERO), "some match; max < count");
+      assertEquals(Collections.emptyList(), getNMatches(Collections.emptyList(), 999, ALWAYS), "empty collection");
+      assertEquals(Collections.emptyList(), getNMatches(input, 0, NEVER), "max = 0");
+      assertEquals(Collections.emptyList(), getNMatches(input, input.size(), NEVER), "none match");
+      assertEquals(Collections.singletonList(0), getNMatches(Arrays.asList(-1, 0, 0, 1), 1, IS_ZERO),
+          "some match; max < count");
       assertEquals(Arrays.asList(0, 0), getNMatches(Arrays.asList(-1, 0, 0, 1), 2, IS_ZERO), "some match; max = count");
       assertEquals(Arrays.asList(0, 0), getNMatches(Arrays.asList(-1, 0, 0, 1), 3, IS_ZERO), "some match; max > count");
       assertEquals(Arrays.asList(-1, 0), getNMatches(input, input.size() - 1, ALWAYS), "all match; max < count");

--- a/game-core/src/test/java/games/strategy/util/OpenJsonUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/util/OpenJsonUtilsTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -76,16 +77,16 @@ final class OpenJsonUtilsTest {
 
     @Test
     void shouldNotConvertNullSentinelValue() {
-      final JSONArray jsonArray = new JSONArray(Arrays.asList(JSONObject.NULL));
+      final JSONArray jsonArray = new JSONArray(Collections.singletonList(JSONObject.NULL));
 
       final List<Object> elements = OpenJsonUtils.stream(jsonArray).collect(Collectors.toList());
 
-      assertThat(elements, is(Arrays.asList(JSONObject.NULL)));
+      assertThat(elements, is(Collections.singletonList(JSONObject.NULL)));
     }
 
     @Test
     void shouldNotConvertJsonArrayValue() {
-      final List<Object> expectedElements = Arrays.asList(new JSONArray(Arrays.asList(42)));
+      final List<Object> expectedElements = Collections.singletonList(new JSONArray(Collections.singletonList(42)));
       final JSONArray jsonArray = new JSONArray(expectedElements);
 
       final List<Object> actualElements = OpenJsonUtils.stream(jsonArray).collect(Collectors.toList());
@@ -95,7 +96,7 @@ final class OpenJsonUtilsTest {
 
     @Test
     void shouldNotConvertJsonObjectValue() {
-      final List<Object> expectedElements = Arrays.asList(new JSONObject(ImmutableMap.of("name", 42)));
+      final List<Object> expectedElements = Collections.singletonList(new JSONObject(ImmutableMap.of("name", 42)));
       final JSONArray jsonArray = new JSONArray(expectedElements);
 
       final List<Object> actualElements = OpenJsonUtils.stream(jsonArray).collect(Collectors.toList());
@@ -126,7 +127,7 @@ final class OpenJsonUtilsTest {
 
     @Test
     void shouldConvertNullSentinelValueToNull() {
-      final JSONArray jsonArray = new JSONArray(Arrays.asList(JSONObject.NULL));
+      final JSONArray jsonArray = new JSONArray(Collections.singletonList(JSONObject.NULL));
 
       final List<Object> elements = OpenJsonUtils.toList(jsonArray);
 
@@ -136,20 +137,21 @@ final class OpenJsonUtilsTest {
 
     @Test
     void shouldConvertJsonArrayValueToList() {
-      final JSONArray jsonArray = new JSONArray(Arrays.asList(new JSONArray(Arrays.asList(42))));
+      final JSONArray jsonArray =
+          new JSONArray(Collections.singletonList(new JSONArray(Collections.singletonList(42))));
 
       final List<Object> elements = OpenJsonUtils.toList(jsonArray);
 
-      assertThat(elements, is(Arrays.asList(Arrays.asList(42))));
+      assertThat(elements, is(Collections.singletonList(Collections.singletonList(42))));
     }
 
     @Test
     void shouldConvertJsonObjectValueToMap() {
-      final JSONArray jsonArray = new JSONArray(Arrays.asList(new JSONObject(ImmutableMap.of("name", 42))));
+      final JSONArray jsonArray = new JSONArray(Collections.singletonList(new JSONObject(ImmutableMap.of("name", 42))));
 
       final List<Object> elements = OpenJsonUtils.toList(jsonArray);
 
-      assertThat(elements, is(Arrays.asList(ImmutableMap.of("name", 42))));
+      assertThat(elements, is(Collections.singletonList(ImmutableMap.of("name", 42))));
     }
   }
 
@@ -192,11 +194,11 @@ final class OpenJsonUtilsTest {
     @Test
     void shouldConvertJsonArrayValueToList() {
       final JSONObject jsonObject = new JSONObject(ImmutableMap.of(
-          "name", new JSONArray(Arrays.asList(42))));
+          "name", new JSONArray(Collections.singletonList(42))));
 
       final Map<String, Object> properties = OpenJsonUtils.toMap(jsonObject);
 
-      assertThat(properties, is(ImmutableMap.of("name", Arrays.asList(42))));
+      assertThat(properties, is(ImmutableMap.of("name", Collections.singletonList(42))));
     }
 
     @Test

--- a/game-core/src/test/java/games/strategy/util/PointFileReaderWriterTest.java
+++ b/game-core/src/test/java/games/strategy/util/PointFileReaderWriterTest.java
@@ -185,7 +185,7 @@ public final class PointFileReaderWriterTest {
       assertThat(pointListsByName, is(ImmutableMap.of(
           "Belarus", Arrays.asList(new Point(1011, 1021), new Point(1012, 1022), new Point(1013, 1023)),
           "54 Sea Zone", Arrays.asList(new Point(2011, 2021), new Point(2012, 2022)),
-          "Philippines", Arrays.asList(new Point(3011, 3021)))));
+          "Philippines", Collections.singletonList(new Point(3011, 3021)))));
     }
 
     @Test
@@ -263,9 +263,9 @@ public final class PointFileReaderWriterTest {
           "Belarus",
           Tuple.of(Arrays.asList(new Point(1011, 1021), new Point(1012, 1022), new Point(1013, 1023)), false),
           "54 Sea Zone", Tuple.of(Arrays.asList(new Point(2011, 2021), new Point(2012, 2022)), true),
-          "Philippines", Tuple.of(Arrays.asList(new Point(3011, 3021)), false),
-          "East America", Tuple.of(Arrays.asList(new Point(4011, 4021)), false),
-          "East Africa", Tuple.of(Arrays.asList(new Point(5011, 5021)), false))));
+          "Philippines", Tuple.of(Collections.singletonList(new Point(3011, 3021)), false),
+          "East America", Tuple.of(Collections.singletonList(new Point(4011, 4021)), false),
+          "East Africa", Tuple.of(Collections.singletonList(new Point(5011, 5021)), false))));
     }
 
     @Test
@@ -343,7 +343,7 @@ public final class PointFileReaderWriterTest {
 
       assertThat(polygonListsByName, is(aMapWithSize(3)));
       assertThat(polygonListsByName, hasKey("Belarus"));
-      assertThat(points(polygonListsByName.get("Belarus")), is(Arrays.asList(
+      assertThat(points(polygonListsByName.get("Belarus")), is(Collections.singletonList(
           Arrays.asList(new Point(1011, 1021), new Point(1012, 1022), new Point(1013, 1023)))));
       assertThat(polygonListsByName, hasKey("54 Sea Zone"));
       assertThat(points(polygonListsByName.get("54 Sea Zone")), is(Arrays.asList(
@@ -353,7 +353,7 @@ public final class PointFileReaderWriterTest {
       assertThat(points(polygonListsByName.get("Philippines")), is(Arrays.asList(
           Arrays.asList(new Point(3011, 3021), new Point(3012, 3022), new Point(3013, 3023)),
           Arrays.asList(new Point(3111, 3121), new Point(3112, 3122)),
-          Arrays.asList(new Point(3211, 3221)))));
+          Collections.singletonList(new Point(3211, 3221)))));
     }
 
     @Test
@@ -400,9 +400,8 @@ public final class PointFileReaderWriterTest {
       final Map<String, List<Polygon>> polygonListsByName =
           readFromString(PointFileReaderWriter::readOneToManyPolygons, content);
 
-      assertThat(points(polygonListsByName.get("United Kingdom")), is(Arrays
-          .asList(Arrays
-              .asList(new Point(-1011, 1021), new Point(1234, -12424), new Point(-123, -456)))));
+      assertThat(points(polygonListsByName.get("United Kingdom")), is(Collections.singletonList(Arrays
+          .asList(new Point(-1011, 1021), new Point(1234, -12424), new Point(-123, -456)))));
     }
   }
 
@@ -449,7 +448,7 @@ public final class PointFileReaderWriterTest {
       final Map<String, List<Point>> pointListsByName = ImmutableMap.of(
           "Belarus", Arrays.asList(new Point(1011, 1021), new Point(1012, 1022), new Point(1013, 1023)),
           "54 Sea Zone", Arrays.asList(new Point(2011, 2021), new Point(2012, 2022)),
-          "Philippines", Arrays.asList(new Point(3011, 3021)));
+          "Philippines", Collections.singletonList(new Point(3011, 3021)));
 
       final String content = writeToString(os -> PointFileReaderWriter.writeOneToMany(os, pointListsByName));
 
@@ -505,7 +504,7 @@ public final class PointFileReaderWriterTest {
     @Test
     public void shouldWriteMultiplePolygonsPerName() throws Exception {
       final Map<String, List<Polygon>> polygonListsByName = ImmutableMap.of(
-          "Belarus", Arrays.asList(
+          "Belarus", Collections.singletonList(
               polygon(new Point(1011, 1021), new Point(1012, 1022), new Point(1013, 1023))),
           "54 Sea Zone", Arrays.asList(
               polygon(new Point(2011, 2021), new Point(2012, 2022), new Point(2013, 2023)),

--- a/game-core/src/test/java/games/strategy/util/UtilTest.java
+++ b/game-core/src/test/java/games/strategy/util/UtilTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 import org.junit.jupiter.api.Test;
 
@@ -48,7 +49,7 @@ public class UtilTest {
 
   @Test
   public void isMailValid_ShouldReturnFalseWhenAddressIsInvalid() {
-    Arrays.asList(
+    Collections.singletonList(
         "test")
         .forEach(it -> assertThat("'" + it + "' should be invalid", Util.isMailValid(it), is(false)));
   }


### PR DESCRIPTION
## Overview

Automatic cleanup via IDEA code inspection.

Instead of:
```
Arrays.asList()
Arrays.asList("one")
```

We convert that to:
```
Collections.emptyList()
Collections.singletonList("one")
```
