### PR TITLE
Do not show empty download maps window on internet errors.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/ClientContext.java
+++ b/game-core/src/main/java/games/strategy/engine/ClientContext.java
@@ -1,6 +1,7 @@
 package games.strategy.engine;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.triplea.common.config.product.ProductConfiguration;
 
@@ -58,7 +59,7 @@ public final class ClientContext {
     return instance.productConfiguration.getVersion();
   }
 
-  public static List<DownloadFileDescription> getMapDownloadList() {
+  public static Optional<List<DownloadFileDescription>> getMapDownloadList() {
     final String mapDownloadListUrl = ClientSetting.mapListOverride.isSet()
         ? ClientSetting.mapListOverride.getValueOrThrow().toString()
         : UrlConstants.MAP_DOWNLOAD_LIST.toString();

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -151,12 +151,15 @@ public class DownloadMapsWindow extends JFrame {
       assert SwingUtilities.isEventDispatchThread();
       assert state == State.UNINITIALIZED;
 
-      state = State.INITIALIZING;
       Interruptibles.awaitResult(SingletonManager::getMapDownloadListInBackground).result
-          .ifPresent(downloads -> createAndShow(mapNames, downloads));
+          .ifPresent(downloads -> downloads.ifPresent(d -> {
+            state = State.INITIALIZING;
+            createAndShow(mapNames, d);
+          }));
     }
 
-    private static List<DownloadFileDescription> getMapDownloadListInBackground() throws InterruptedException {
+    private static Optional<List<DownloadFileDescription>> getMapDownloadListInBackground()
+        throws InterruptedException {
       return GameRunner.newBackgroundTaskRunner().runInBackgroundAndReturn(
           "Downloading list of available maps...",
           ClientContext::getMapDownloadList);

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
@@ -28,8 +28,11 @@ public class MapDownloadController {
    */
   public static void checkDownloadedMapsAreLatest() {
     try {
-      final List<DownloadFileDescription> allDownloads = ClientContext.getMapDownloadList();
-      final Collection<String> outOfDateMapNames = getOutOfDateMapNames(allDownloads);
+      final Optional<List<DownloadFileDescription>> allDownloads = ClientContext.getMapDownloadList();
+      if (!allDownloads.isPresent()) {
+        return;
+      }
+      final Collection<String> outOfDateMapNames = getOutOfDateMapNames(allDownloads.get());
       if (!outOfDateMapNames.isEmpty()) {
         final StringBuilder text = new StringBuilder();
         text.append("<html>Some of the maps you have are out of date, and newer versions of those maps exist.<br><br>");
@@ -42,7 +45,7 @@ public class MapDownloadController {
             () -> DownloadMapsWindow.showDownloadMapsWindowAndDownload(outOfDateMapNames));
       }
     } catch (final Exception e) {
-      log.log(Level.SEVERE, "Error while checking for map updates", e);
+      log.log(Level.WARNING, "Failed to getting list of most recent maps", e);
     }
   }
 

--- a/game-core/src/test/java/games/strategy/engine/ClientContextIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/ClientContextIntegrationTest.java
@@ -18,6 +18,6 @@ class ClientContextIntegrationTest extends AbstractClientSettingTestCase {
     assertThat(ClientContext.engineVersion(), notNullValue());
 
     assertThat(ClientContext.getMapDownloadList(), notNullValue());
-    assertThat(ClientContext.getMapDownloadList().isEmpty(), is(false));
+    assertThat(ClientContext.getMapDownloadList().isPresent(), is(true));
   }
 }


### PR DESCRIPTION
## Overview

When we fail to download the list of maps, instead of showing an error
message followed by an empty download window that the user is then left
to close, instead we will just show an error message.

## Functional Changes
When failing to download map list, do not show an empty download window

## Manual Testing Performed
- verified with network turned off
