### PR TITLE
Update lobby connection error message

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/ContentReader.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/ContentReader.java
@@ -45,10 +45,7 @@ public final class ContentReader {
     } catch (final IOException e) {
       log.log(
           Level.SEVERE,
-          "Failed to download: "
-              + uri
-              + ", will attempt to use backup values where available. "
-              + "Please check your network connection.",
+          "Failed to connect to lobby, please check your internet connection",
           e);
       return Optional.empty();
     }


### PR DESCRIPTION
## Overview

The error message is a bit wordy and incorrect in that it says 'will use
backup values where possible'. If we hit an error on this code flow we
will not use backup values and the connect to lobby just fails.

Second, the error message is overly technical/specific in that we first
download a properties file. We can simply say instead 'failed to connect
to lobby' and not give overly technical details that do not help the
user.


## Functional Changes
none, user facing message is updated

## Manual Testing Performed
- verified message with network turned onff
