### PR TITLE
Simplify, remove "n" requests sent to "sourceforge", just send one network request

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/auto/update/EngineVersionCheck.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/update/EngineVersionCheck.java
@@ -26,10 +26,8 @@ final class EngineVersionCheck {
         return;
       }
 
-      final EngineVersionProperties latestEngineOut = EngineVersionProperties.contactServerForEngineVersionProperties();
-      if (latestEngineOut == null) {
-        return;
-      }
+      final EngineVersionProperties latestEngineOut = new EngineVersionProperties();
+
       if (ClientContext.engineVersion().isLessThan(latestEngineOut.getLatestVersionOut())) {
         SwingUtilities
             .invokeLater(() -> EventThreadJOptionPane.showMessageDialog(null, latestEngineOut.getOutOfDateComponent(),

--- a/game-core/src/main/java/games/strategy/engine/auto/update/EngineVersionProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/update/EngineVersionProperties.java
@@ -6,9 +6,6 @@ import java.awt.Dimension;
 import java.io.IOException;
 import java.net.URL;
 import java.util.Properties;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 
 import javax.swing.BorderFactory;
@@ -32,7 +29,7 @@ class EngineVersionProperties {
   private final String link;
   private final String changelogLink;
 
-  private EngineVersionProperties() {
+  EngineVersionProperties() {
     this(getProperties());
   }
 
@@ -43,34 +40,6 @@ class EngineVersionProperties {
     changelogLink = props.getProperty("CHANGELOG", UrlConstants.RELEASE_NOTES.toString());
   }
 
-
-  static EngineVersionProperties contactServerForEngineVersionProperties() {
-    // sourceforge sometimes takes a long while to return results
-    // so run a couple requests in parallel, starting with delays to try and get a response quickly
-    final AtomicReference<EngineVersionProperties> ref = new AtomicReference<>();
-    final CountDownLatch latch = new CountDownLatch(1);
-    for (int i = 0; i < 5; i++) {
-      new Thread(() -> {
-        ref.set(new EngineVersionProperties());
-        latch.countDown();
-      }).start();
-      try {
-        latch.await(2, TimeUnit.SECONDS);
-      } catch (final InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
-      if (ref.get() != null) {
-        break;
-      }
-    }
-    // we have spawned a bunch of requests
-    try {
-      latch.await(15, TimeUnit.SECONDS);
-    } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
-    }
-    return ref.get();
-  }
 
   private static Properties getProperties() {
     final Properties props = new Properties();


### PR DESCRIPTION
## Overview
TCP/IP will handle retries for us, github so far has good reliability and the parallel request to 'sourceforge' should not be necessary and can be simplified away.

## Functional Changes
Remove parallel calls to get lobby properties file and just send one.
