### PR TITLE
Remove undocumented 'do not check for updates' CLI param

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/auto/update/UpdateChecks.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/update/UpdateChecks.java
@@ -1,6 +1,5 @@
 package games.strategy.engine.auto.update;
 
-import static games.strategy.engine.framework.CliProperties.DO_NOT_CHECK_FOR_UPDATES;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_CLIENT;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_GAME;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_SERVER;
@@ -31,10 +30,9 @@ public class UpdateChecks {
   }
 
   private static boolean shouldRun() {
+    // if we are joining a game online, or hosting, or loading straight into a savegame, do not check
     return !System.getProperty(TRIPLEA_SERVER, "false").equalsIgnoreCase("true")
         && !System.getProperty(TRIPLEA_CLIENT, "false").equalsIgnoreCase("true")
-        && !System.getProperty(DO_NOT_CHECK_FOR_UPDATES, "false").equalsIgnoreCase("true")
-        // if we are joining a game online, or hosting, or loading straight into a savegame, do not check
         && System.getProperty(TRIPLEA_GAME, "").isEmpty();
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/CliProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/CliProperties.java
@@ -18,7 +18,6 @@ public class CliProperties {
   public static final String LOBBY_PORT = "triplea.lobby.port";
   public static final String LOBBY_GAME_COMMENTS = "triplea.lobby.game.comments";
   public static final String LOBBY_GAME_SUPPORT_PASSWORD = "triplea.lobby.game.supportPassword";
-  public static final String DO_NOT_CHECK_FOR_UPDATES = "triplea.doNotCheckForUpdates";
 
   public static final String MAP_FOLDER = "triplea.map.folder";
 }


### PR DESCRIPTION
## Overview
We use other parameters to not check for game updates when launching a
game. This flag is only used if the game is launched via CLI and if
someone knows to use the flag.

## Functional Changes
- remove CLI param 'do-not-check-for-updates'