### PR TITLE
Script update: run-docker.sh restarts container

### DIFF
--- a/lobby-db/run-docker.sh
+++ b/lobby-db/run-docker.sh
@@ -1,3 +1,17 @@
 #!/bin/bash
 
-docker run -d --name=triplea-lobby-db -p 5432:5432 triplea/lobby-db
+set -eux
+function stop_container() {
+  local runningContainerId=$(docker container ls | grep triplea-lobby-db | cut -f 1 -d ' ')
+  if [ ! -z "$runningContainerId" ]; then
+     docker container stop $runningContainerId
+     docker container rm $runningContainerId
+  fi
+}
+
+function start_container() {
+  docker run -d --name=triplea-lobby-db -p 5432:5432 triplea/lobby-db
+}
+
+stop_container
+start_container


### PR DESCRIPTION
## Overview
Update to convenience script to make  'run-docker.sh' a "restart". After this update it will first stop any running containers to otherwise avoid this error message:

>  docker: Error response from daemon: Conflict. The container name "/triplea-lobby-db" is already in use by container "79930e5a0df00ffda22ece226461abf995ea9a555b21c0989875db27046bd1d9". You have to remove (or rename) that container to be able to reuse that name.
See 'docker run --help'.


## Functional Changes
- none, update to a dev support script
