### PR TITLE
Fix: resize territory effect image

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/image/AbstractImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/AbstractImageFactory.java
@@ -1,7 +1,10 @@
 package games.strategy.triplea.image;
 
+import java.awt.Graphics2D;
 import java.awt.Image;
+import java.awt.RenderingHints;
 import java.awt.Toolkit;
+import java.awt.image.BufferedImage;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
@@ -53,10 +56,23 @@ public abstract class AbstractImageFactory {
     if (icons.containsKey(fullName)) {
       return icons.get(fullName);
     }
-    final Image img = getBaseImage(fullName);
+    // we draw the icon size to fit in the lower window bar
+    final int imageDimension = 32;
+    final Image img = getScaledImage(getBaseImage(fullName), imageDimension, imageDimension);
     final ImageIcon icon = new ImageIcon(img);
     icons.put(fullName, icon);
     return icon;
+  }
+
+  private static Image getScaledImage(final Image srcImg, final int width, final int height) {
+    final BufferedImage resizedImg = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
+    final Graphics2D g2 = resizedImg.createGraphics();
+
+    g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
+    g2.drawImage(srcImg, 0, 0, width, height, null);
+    g2.dispose();
+
+    return resizedImg;
   }
 
 }


### PR DESCRIPTION
## Overview
If a territory effect image is larger than the needed 32x32 (or
smaller), we'll resize it to the needed size instead of showing a
cropped version.

Fixes: https://github.com/triplea-game/triplea/issues/3396

## Functional Changes
- Territory effect image is resized

## Manual Testing Performed
- On Total World War December map, I replaced Mountain.png with the example from #3396 
- Hovering over a mountain territory I also repro a before and after

## Before & After Screen Shots
<!-- Leave blank if no UI changes -->
### Before
![screenshot from 2019-01-23 20-11-02](https://user-images.githubusercontent.com/12397753/51654640-aaccc480-1f4d-11e9-815b-8d434e67b6aa.png)

### After

![screenshot from 2019-01-23 20-20-24](https://user-images.githubusercontent.com/12397753/51654666-cb951a00-1f4d-11e9-8d51-d23ad60a5208.png)

