### PR TITLE
Improved: Show territory effect image tooltip text

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -670,6 +670,7 @@ public final class TripleAFrame extends JFrame {
       for (final TerritoryEffect territoryEffect : territoryEffects) {
         try {
           final JLabel territoryEffectLabel = new JLabel();
+          territoryEffectLabel.setToolTipText(territoryEffect.getName());
           territoryEffectLabel.setIcon(uiContext.getTerritoryEffectImageFactory().getIcon(territoryEffect, false));
           territoryEffectLabel.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 10));
           territoryInfo.add(territoryEffectLabel,
@@ -1393,7 +1394,7 @@ public final class TripleAFrame extends JFrame {
     return selection;
   }
 
-  private JOptionPane getOptionPane(final JComponent parent) {
+  private static JOptionPane getOptionPane(final JComponent parent) {
     return !(parent instanceof JOptionPane)
         ? getOptionPane((JComponent) parent.getParent())
         : (JOptionPane) parent;
@@ -1895,7 +1896,7 @@ public final class TripleAFrame extends JFrame {
           try {
             final File f = TripleAMenuBar.getSaveGameLocation(TripleAFrame.this);
             if (f != null) {
-              try (FileOutputStream fout = new FileOutputStream(f)) {
+              try (final FileOutputStream fout = new FileOutputStream(f)) {
                 final GameData datacopy = GameDataUtils.cloneGameData(data, true);
                 datacopy.getHistory().gotoNode(historyPanel.getCurrentPopupNode());
                 datacopy.getHistory().removeAllHistoryAfterNode(historyPanel.getCurrentPopupNode());

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1896,7 +1896,7 @@ public final class TripleAFrame extends JFrame {
           try {
             final File f = TripleAMenuBar.getSaveGameLocation(TripleAFrame.this);
             if (f != null) {
-              try (final FileOutputStream fout = new FileOutputStream(f)) {
+              try (FileOutputStream fout = new FileOutputStream(f)) {
                 final GameData datacopy = GameDataUtils.cloneGameData(data, true);
                 datacopy.getHistory().gotoNode(historyPanel.getCurrentPopupNode());
                 datacopy.getHistory().removeAllHistoryAfterNode(historyPanel.getCurrentPopupNode());


### PR DESCRIPTION
## Overview

Most of the icons on the lower menu bar in the game will show tooltip
text, territory effect is an exception. This update will add a tooltip
text.

## Functional Changes
Territory effect icon now has a hover text.

## Manual Testing Performed
- Launched game with territory effects (Total World War December)
- Hovered over a territory effect icon after mousing over a territory with a 'mountain' territory effect. Screenshots below

## Before & After Screen Shots
<!-- Leave blank if no UI changes -->
### Before
![screenshot from 2019-01-23 20-26-18](https://user-images.githubusercontent.com/12397753/51654757-321a3800-1f4e-11e9-911f-bf5c46f7fdda.png)

### After
![screenshot from 2019-01-23 20-26-23](https://user-images.githubusercontent.com/12397753/51654760-37778280-1f4e-11e9-9276-c1ff2dbe8afa.png)

