### PR TITLE
Checkstyle: Disallow redundant modifiers

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -97,6 +97,7 @@
         <module name="FallThrough"/>
         <module name="UpperEll"/>
         <module name="ModifierOrder"/>
+        <module name="RedundantModifier"/>
         <module name="EmptyLineSeparator">
             <property name="allowNoEmptyLineBetweenFields" value="true"/>
         </module>

--- a/game-core/src/main/java/games/strategy/engine/chat/IChatChannel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/IChatChannel.java
@@ -12,17 +12,17 @@ import games.strategy.net.INode;
  */
 public interface IChatChannel extends IChannelSubscriber {
   // we get the sender from MessageContext
-  void chatOccured(final String message);
+  void chatOccured(String message);
 
-  void meMessageOccured(final String message);
+  void meMessageOccured(String message);
 
-  void slapOccured(final String playerName);
+  void slapOccured(String playerName);
 
-  void speakerAdded(final INode node, final Tag tag, final long version);
+  void speakerAdded(INode node, Tag tag, long version);
 
-  void speakerRemoved(final INode node, final long version);
+  void speakerRemoved(INode node, long version);
 
-  void speakerTagUpdated(final INode node, final Tag tag);
+  void speakerTagUpdated(INode node, Tag tag);
 
   // purely here to keep connections open and stop NATs and crap from thinking that our connection is closed when it is
   // not.

--- a/game-core/src/main/java/games/strategy/engine/chat/IChatListener.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/IChatListener.java
@@ -8,12 +8,11 @@ import games.strategy.net.INode;
  * An interface to allow for testing.
  */
 public interface IChatListener {
-  void updatePlayerList(final Collection<INode> players);
+  void updatePlayerList(Collection<INode> players);
 
-  void addMessage(final String message, final String from, final boolean thirdperson);
+  void addMessage(String message, String from, boolean thirdperson);
 
-  void addMessageWithSound(final String message, final String from, final boolean thirdperson,
-      final String sound);
+  void addMessageWithSound(String message, String from, boolean thirdperson, String sound);
 
-  void addStatusMessage(final String message);
+  void addStatusMessage(String message);
 }

--- a/game-core/src/main/java/games/strategy/engine/data/AllianceTracker.java
+++ b/game-core/src/main/java/games/strategy/engine/data/AllianceTracker.java
@@ -41,7 +41,7 @@ public class AllianceTracker implements Serializable {
     private static final long serialVersionUID = -4193924040595347947L;
     private final Multimap<PlayerId, String> alliances;
 
-    public SerializationProxy(final AllianceTracker allianceTracker) {
+    SerializationProxy(final AllianceTracker allianceTracker) {
       alliances = ImmutableMultimap.copyOf(allianceTracker.alliances);
     }
 

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AddAttachmentChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AddAttachmentChange.java
@@ -14,7 +14,7 @@ class AddAttachmentChange extends Change {
   private final Attachable attachable;
   private final String name;
 
-  public AddAttachmentChange(final IAttachment attachment, final Attachable attachable, final String name) {
+  AddAttachmentChange(final IAttachment attachment, final Attachable attachable, final String name) {
     this.attachment = attachment;
     originalAttachmentName = attachment.getName();
     originalAttachable = attachment.getAttachedTo();

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AddAvailableTech.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AddAvailableTech.java
@@ -15,7 +15,7 @@ class AddAvailableTech extends Change {
   private final TechnologyFrontier frontier;
   private final PlayerId player;
 
-  public AddAvailableTech(final TechnologyFrontier front, final TechAdvance tech, final PlayerId player) {
+  AddAvailableTech(final TechnologyFrontier front, final TechAdvance tech, final PlayerId player) {
     checkNotNull(front);
     checkNotNull(tech);
 

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AddProductionRule.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AddProductionRule.java
@@ -13,7 +13,7 @@ class AddProductionRule extends Change {
   private final ProductionRule rule;
   private final ProductionFrontier frontier;
 
-  public AddProductionRule(final ProductionRule rule, final ProductionFrontier frontier) {
+  AddProductionRule(final ProductionRule rule, final ProductionFrontier frontier) {
     checkNotNull(rule);
     checkNotNull(frontier);
 

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/GenericTechChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/GenericTechChange.java
@@ -26,7 +26,7 @@ class GenericTechChange extends Change {
     this.property = property;
   }
 
-  public GenericTechChange(final Attachable attachTo, final String attachmentName, final boolean newValue,
+  GenericTechChange(final Attachable attachTo, final String attachmentName, final boolean newValue,
       final boolean oldValue, final String property) {
     this.attachmentName = attachmentName;
     attachedTo = attachTo;

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveAttachmentChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveAttachmentChange.java
@@ -14,7 +14,7 @@ class RemoveAttachmentChange extends Change {
   private final Attachable attachable;
   private final String name;
 
-  public RemoveAttachmentChange(final IAttachment attachment, final Attachable attachable, final String name) {
+  RemoveAttachmentChange(final IAttachment attachment, final Attachable attachable, final String name) {
     this.attachment = attachment;
     originalAttachmentName = attachment.getName();
     originalAttachable = attachment.getAttachedTo();

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveAvailableTech.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveAvailableTech.java
@@ -15,7 +15,7 @@ class RemoveAvailableTech extends Change {
   private final TechnologyFrontier frontier;
   private final PlayerId player;
 
-  public RemoveAvailableTech(final TechnologyFrontier front, final TechAdvance tech, final PlayerId player) {
+  RemoveAvailableTech(final TechnologyFrontier front, final TechAdvance tech, final PlayerId player) {
     checkNotNull(front);
     checkNotNull(tech);
 

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveProductionRule.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveProductionRule.java
@@ -13,7 +13,7 @@ class RemoveProductionRule extends Change {
   private final ProductionRule rule;
   private final ProductionFrontier frontier;
 
-  public RemoveProductionRule(final ProductionRule rule, final ProductionFrontier frontier) {
+  RemoveProductionRule(final ProductionRule rule, final ProductionFrontier frontier) {
     checkNotNull(rule);
     checkNotNull(frontier);
 

--- a/game-core/src/main/java/games/strategy/engine/delegate/IDelegate.java
+++ b/game-core/src/main/java/games/strategy/engine/delegate/IDelegate.java
@@ -18,14 +18,14 @@ public interface IDelegate {
   /**
    * Uses name as the internal unique name and displayName for display to users.
    */
-  void initialize(final String name, final String displayName);
+  void initialize(String name, String displayName);
 
   /**
    * Called before the delegate will run and before "start" is called.
    *
    * @param delegateBridge the IDelegateBridge
    */
-  void setDelegateBridgeAndPlayer(final IDelegateBridge delegateBridge);
+  void setDelegateBridgeAndPlayer(IDelegateBridge delegateBridge);
 
   /**
    * Called before the delegate will run.
@@ -74,7 +74,7 @@ public interface IDelegate {
    *
    * @param state the delegates state.
    */
-  void loadState(final Serializable state);
+  void loadState(Serializable state);
 
   /**
    * Returns the remote type of this delegate for use by a RemoteMessenger.

--- a/game-core/src/main/java/games/strategy/engine/delegate/IDelegateBridge.java
+++ b/game-core/src/main/java/games/strategy/engine/delegate/IDelegateBridge.java
@@ -45,7 +45,7 @@ public interface IDelegateBridge {
   /**
    * equivalent to getRandom(max,1,annotation)[0].
    */
-  int getRandom(final int max, final PlayerId player, final DiceType diceType, final String annotation);
+  int getRandom(int max, PlayerId player, DiceType diceType, String annotation);
 
   /**
    * Return a random value to be used by the delegate.
@@ -55,8 +55,7 @@ public interface IDelegateBridge {
    *
    * @param annotation a string used to describe the random event.
    */
-  int[] getRandom(final int max, final int count, final PlayerId player, final DiceType diceType,
-      final String annotation);
+  int[] getRandom(int max, int count, PlayerId player, DiceType diceType, String annotation);
 
   /**
    * return the delegate history writer for this game.

--- a/game-core/src/main/java/games/strategy/engine/framework/IGameModifiedChannel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/IGameModifiedChannel.java
@@ -8,22 +8,21 @@ import games.strategy.engine.message.IChannelSubscriber;
  * All changes to game data (Changes and History events) can be tracked through this channel.
  */
 public interface IGameModifiedChannel extends IChannelSubscriber {
-  void gameDataChanged(final Change change);
+  void gameDataChanged(Change change);
 
-  void startHistoryEvent(final String event, final Object renderingData);
+  void startHistoryEvent(String event, Object renderingData);
 
-  void startHistoryEvent(final String event);
+  void startHistoryEvent(String event);
 
-  // public void setRenderingData(final Object renderingData);
-  void addChildToEvent(final String text, final Object renderingData);
+  void addChildToEvent(String text, Object renderingData);
 
   /**
    * Invoked when a game step has changed.
    *
    * @param loadedFromSavedGame - true if the game step has changed because we were loaded from a saved game.
    */
-  void stepChanged(final String stepName, final String delegateName, final PlayerId player, final int round,
-      final String displayName, final boolean loadedFromSavedGame);
+  void stepChanged(String stepName, String delegateName, PlayerId player, int round,
+      String displayName, boolean loadedFromSavedGame);
 
   void shutDown();
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/IServerStartupRemote.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/IServerStartupRemote.java
@@ -35,15 +35,15 @@ public interface IServerStartupRemote extends IRemote {
 
   Set<String> getAvailableGames();
 
-  void changeServerGameTo(final String gameName);
+  void changeServerGameTo(String gameName);
 
-  void changeToLatestAutosave(final HeadlessAutoSaveType typeOfAutosave);
+  void changeToLatestAutosave(HeadlessAutoSaveType typeOfAutosave);
 
-  void changeToGameSave(final byte[] bytes, final String fileName);
+  void changeToGameSave(byte[] bytes, String fileName);
 
   byte[] getSaveGame();
 
   byte[] getGameOptions();
 
-  void changeToGameOptions(final byte[] bytes);
+  void changeToGameOptions(byte[] bytes);
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -76,7 +76,7 @@ public class InGameLobbyWatcher {
    * to ensure headless clients don't need to depend on UI classes.
    */
   public interface LobbyWatcherHandler {
-    void reportError(final String message);
+    void reportError(String message);
 
     boolean isPlayer();
   }

--- a/game-core/src/main/java/games/strategy/engine/history/ChangeSerializationWriter.java
+++ b/game-core/src/main/java/games/strategy/engine/history/ChangeSerializationWriter.java
@@ -7,7 +7,7 @@ class ChangeSerializationWriter implements SerializationWriter {
 
   private final Change change;
 
-  public ChangeSerializationWriter(final Change change) {
+  ChangeSerializationWriter(final Change change) {
     this.change = change;
   }
 

--- a/game-core/src/main/java/games/strategy/engine/history/EventChildWriter.java
+++ b/game-core/src/main/java/games/strategy/engine/history/EventChildWriter.java
@@ -6,7 +6,7 @@ class EventChildWriter implements SerializationWriter {
   private final String text;
   private final Object renderingData;
 
-  public EventChildWriter(final String text, final Object renderingData) {
+  EventChildWriter(final String text, final Object renderingData) {
     this.text = text;
     this.renderingData = renderingData;
   }

--- a/game-core/src/main/java/games/strategy/engine/history/EventHistorySerializer.java
+++ b/game-core/src/main/java/games/strategy/engine/history/EventHistorySerializer.java
@@ -6,7 +6,7 @@ class EventHistorySerializer implements SerializationWriter {
   private final String eventName;
   private final Object renderingData;
 
-  public EventHistorySerializer(final String eventName, final Object renderingData) {
+  EventHistorySerializer(final String eventName, final Object renderingData) {
     this.eventName = eventName;
     this.renderingData = renderingData;
   }

--- a/game-core/src/main/java/games/strategy/engine/history/RootHistoryNode.java
+++ b/game-core/src/main/java/games/strategy/engine/history/RootHistoryNode.java
@@ -3,7 +3,7 @@ package games.strategy.engine.history;
 class RootHistoryNode extends HistoryNode {
   private static final long serialVersionUID = 625147613043836829L;
 
-  public RootHistoryNode(final String title) {
+  RootHistoryNode(final String title) {
     super(title);
   }
 

--- a/game-core/src/main/java/games/strategy/engine/history/RoundHistorySerializer.java
+++ b/game-core/src/main/java/games/strategy/engine/history/RoundHistorySerializer.java
@@ -5,7 +5,7 @@ class RoundHistorySerializer implements SerializationWriter {
 
   private final int roundNo;
 
-  public RoundHistorySerializer(final int roundNo) {
+  RoundHistorySerializer(final int roundNo) {
     this.roundNo = roundNo;
   }
 

--- a/game-core/src/main/java/games/strategy/engine/history/SerializedHistory.java
+++ b/game-core/src/main/java/games/strategy/engine/history/SerializedHistory.java
@@ -20,7 +20,7 @@ class SerializedHistory implements Serializable {
   private final List<SerializationWriter> writers = new ArrayList<>();
   private final GameData gameData;
 
-  public SerializedHistory(final History history, final GameData data, final List<Change> changes) {
+  SerializedHistory(final History history, final GameData data, final List<Change> changes) {
     gameData = data;
     final Enumeration<?> enumeration = ((DefaultMutableTreeNode) history.getRoot()).preorderEnumeration();
     enumeration.nextElement();

--- a/game-core/src/main/java/games/strategy/engine/history/StepHistorySerializer.java
+++ b/game-core/src/main/java/games/strategy/engine/history/StepHistorySerializer.java
@@ -10,7 +10,7 @@ class StepHistorySerializer implements SerializationWriter {
   private final PlayerId playerId;
   private final String displayName;
 
-  public StepHistorySerializer(final String stepName, final String delegateName, final PlayerId playerId,
+  StepHistorySerializer(final String stepName, final String delegateName, final PlayerId playerId,
       final String displayName) {
     this.stepName = stepName;
     this.delegateName = delegateName;

--- a/game-core/src/main/java/games/strategy/engine/message/UnifiedInvocationHandler.java
+++ b/game-core/src/main/java/games/strategy/engine/message/UnifiedInvocationHandler.java
@@ -19,7 +19,7 @@ class UnifiedInvocationHandler extends WrappedInvocationHandler {
   private final boolean ignoreResults;
   private final Class<?> remoteType;
 
-  public UnifiedInvocationHandler(final UnifiedMessenger messenger, final String endPointName,
+  UnifiedInvocationHandler(final UnifiedMessenger messenger, final String endPointName,
       final boolean ignoreResults, final Class<?> remoteType) {
     // equality and hash code are based on end point name
     super(endPointName);

--- a/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/EndPoint.java
+++ b/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/EndPoint.java
@@ -31,7 +31,7 @@ class EndPoint {
   private final List<Object> implementors = new ArrayList<>();
   private final boolean singleThreaded;
 
-  public EndPoint(final String name, final Class<?> remoteClass, final boolean singleThreaded) {
+  EndPoint(final String name, final Class<?> remoteClass, final boolean singleThreaded) {
     this.name = name;
     this.remoteClass = remoteClass;
     this.singleThreaded = singleThreaded;

--- a/game-core/src/main/java/games/strategy/engine/pbem/IForumPoster.java
+++ b/game-core/src/main/java/games/strategy/engine/pbem/IForumPoster.java
@@ -28,7 +28,7 @@ public interface IForumPoster {
    * @param subject the forum subject
    * @return true if the post was successful
    */
-  CompletableFuture<String> postTurnSummary(String summary, final String subject, final Path savegame);
+  CompletableFuture<String> postTurnSummary(String summary, String subject, Path savegame);
 
   String getDisplayName();
 

--- a/game-core/src/main/java/games/strategy/engine/player/DefaultPlayerBridge.java
+++ b/game-core/src/main/java/games/strategy/engine/player/DefaultPlayerBridge.java
@@ -131,7 +131,7 @@ public class DefaultPlayerBridge implements IPlayerBridge {
     private final Object delegate;
     private final IGame game;
 
-    public GameOverInvocationHandler(final Object delegate, final IGame game) {
+    GameOverInvocationHandler(final Object delegate, final IGame game) {
       this.delegate = delegate;
       this.game = game;
     }

--- a/game-core/src/main/java/games/strategy/engine/random/IRandomStats.java
+++ b/game-core/src/main/java/games/strategy/engine/random/IRandomStats.java
@@ -17,5 +17,5 @@ public interface IRandomStats extends IRemote {
     COMBAT, BOMBING, NONCOMBAT, TECH, ENGINE
   }
 
-  RandomStatsDetails getRandomStats(final int diceSides);
+  RandomStatsDetails getRandomStats(int diceSides);
 }

--- a/game-core/src/main/java/games/strategy/net/IClientMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/IClientMessenger.java
@@ -8,11 +8,11 @@ import games.strategy.engine.framework.HeadlessAutoSaveType;
  * A client messenger. Additional methods for selecting the game on the server.
  */
 public interface IClientMessenger extends IMessenger {
-  void changeServerGameTo(final String gameName);
+  void changeServerGameTo(String gameName);
 
-  void changeToLatestAutosave(final HeadlessAutoSaveType typeOfAutosave);
+  void changeToLatestAutosave(HeadlessAutoSaveType typeOfAutosave);
 
-  void changeToGameSave(final byte[] bytes, final String fileName);
+  void changeToGameSave(byte[] bytes, String fileName);
 
-  void changeToGameSave(final File saveGame, final String fileName);
+  void changeToGameSave(File saveGame, String fileName);
 }

--- a/game-core/src/main/java/games/strategy/net/nio/SocketReadData.java
+++ b/game-core/src/main/java/games/strategy/net/nio/SocketReadData.java
@@ -30,7 +30,7 @@ class SocketReadData {
   private final int number = counter.incrementAndGet();
   private int readCalls;
 
-  public SocketReadData(final SocketChannel channel) {
+  SocketReadData(final SocketChannel channel) {
     this.channel = channel;
   }
 

--- a/game-core/src/main/java/games/strategy/sound/ISound.java
+++ b/game-core/src/main/java/games/strategy/sound/ISound.java
@@ -19,7 +19,7 @@ public interface ISound extends IChannelSubscriber {
    * @param playerId The player who's sound we want to play (ie: russians infantry might make different sounds from
    *        german infantry, etc). Can be null.
    */
-  void playSoundForAll(final String clipName, final PlayerId playerId);
+  void playSoundForAll(String clipName, PlayerId playerId);
 
   /**
    * You will want to call this from things that the server only runs (like delegates), and not call this from user
@@ -32,7 +32,6 @@ public interface ISound extends IChannelSubscriber {
    *        null.)
    * @param includeObservers Whether to include non-playing machines
    */
-  void playSoundToPlayers(final String clipName,
-      final Collection<PlayerId> playersToSendTo, final Collection<PlayerId> butNotThesePlayers,
-      final boolean includeObservers);
+  void playSoundToPlayers(String clipName,
+      Collection<PlayerId> playersToSendTo, Collection<PlayerId> butNotThesePlayers, boolean includeObservers);
 }

--- a/game-core/src/main/java/games/strategy/thread/LockUtil.java
+++ b/game-core/src/main/java/games/strategy/thread/LockUtil.java
@@ -130,7 +130,7 @@ public enum LockUtil {
     // cache the hash code to make sure it doesn't change if our reference has been cleared
     private final int hashCode;
 
-    public WeakLockRef(final Lock referent) {
+    WeakLockRef(final Lock referent) {
       super(referent);
       hashCode = Objects.hashCode(referent);
     }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/ICondition.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/ICondition.java
@@ -26,7 +26,7 @@ public interface ICondition extends IAttachment {
    * HashMap&lt;ICondition, Boolean> testedConditions filled out), then IDelegateBridge is not required and can be null
    * (or use the shortcut method). Therefore use this method while testing the conditions the first time.
    */
-  boolean isSatisfied(Map<ICondition, Boolean> testedConditions, final IDelegateBridge bridge);
+  boolean isSatisfied(Map<ICondition, Boolean> testedConditions, IDelegateBridge bridge);
 
   /**
    * HashMap&lt;ICondition, Boolean> testedConditions must be filled with completed tests of all conditions already, or

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AaRadarAdvance.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AaRadarAdvance.java
@@ -11,7 +11,7 @@ import games.strategy.triplea.attachments.TechAttachment;
 final class AaRadarAdvance extends TechAdvance {
   private static final long serialVersionUID = 6464021231625252901L;
 
-  public AaRadarAdvance(final GameData data) {
+  AaRadarAdvance(final GameData data) {
     super(TECH_NAME_AA_RADAR, data);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
@@ -126,8 +126,8 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
   }
 
   @Override
-  public abstract String move(final Collection<Unit> units, final Route route,
-      final Collection<Unit> transportsThatCanBeLoaded, final Map<Unit, Collection<Unit>> newDependents);
+  public abstract String move(Collection<Unit> units, Route route,
+      Collection<Unit> transportsThatCanBeLoaded, Map<Unit, Collection<Unit>> newDependents);
 
   public static MoveValidationResult validateMove(final MoveType moveType, final Collection<Unit> units,
       final Route route, final PlayerId player, final Collection<Unit> transportsToLoad,
@@ -210,12 +210,12 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
   /**
    * Returns the number of PUs that have been lost by bombing, rockets, etc.
    */
-  public abstract int pusAlreadyLost(final Territory t);
+  public abstract int pusAlreadyLost(Territory t);
 
   /**
    * Add more PUs lost to a territory due to bombing, rockets, etc.
    */
-  public abstract void pusLost(final Territory t, final int amt);
+  public abstract void pusLost(Territory t, int amt);
 
   @Override
   public Class<IMoveDelegate> getRemoteType() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -323,12 +323,12 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     Collection<Unit> validAttackingUnitsForThisRoll;
     final boolean determineAttackers;
 
-    public FireAa(final Collection<Unit> attackers) {
+    FireAa(final Collection<Unit> attackers) {
       validAttackingUnitsForThisRoll = attackers;
       determineAttackers = false;
     }
 
-    public FireAa() {
+    FireAa() {
       validAttackingUnitsForThisRoll = Collections.emptyList();
       determineAttackers = true;
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
@@ -2,7 +2,6 @@ package games.strategy.triplea.delegate;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.lang.reflect.Constructor;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -176,14 +175,12 @@ public abstract class TechAdvance extends NamedAttachable {
     if (clazz == null) {
       throw new IllegalArgumentException(technologyName + " is not a valid technology");
     }
-    final TechAdvance ta;
+
     try {
-      final Constructor<? extends TechAdvance> constructor = clazz.getConstructor(preDefinedTechConstructorParameter);
-      ta = constructor.newInstance(data);
+      return clazz.getDeclaredConstructor(preDefinedTechConstructorParameter).newInstance(data);
     } catch (final Exception e) {
       throw new IllegalStateException(technologyName + " is not a valid technology or could not be instantiated", e);
     }
-    return ta;
   }
 
   static TechAdvance findAdvance(final String propertyString, final GameData data, final PlayerId player) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/data/BattleRecord.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/data/BattleRecord.java
@@ -100,7 +100,7 @@ public class BattleRecord implements Serializable {
     private final BattleType battleType;
     private final BattleResults battleResults;
 
-    public SerializationProxy(final BattleRecord battleRecord) {
+    SerializationProxy(final BattleRecord battleRecord) {
       battleSite = battleRecord.battleSite;
       attacker = battleRecord.attacker;
       defender = battleRecord.defender;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/data/BattleRecords.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/data/BattleRecords.java
@@ -43,7 +43,7 @@ public class BattleRecords implements Serializable {
     private static final long serialVersionUID = 3837818110273155404L;
     private final Map<PlayerId, Map<GUID, BattleRecord>> records;
 
-    public SerializationProxy(final BattleRecords battleRecords) {
+    SerializationProxy(final BattleRecords battleRecords) {
       this.records = battleRecords.records;
     }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractForumPosterDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractForumPosterDelegate.java
@@ -9,7 +9,7 @@ import games.strategy.engine.pbem.PbemMessagePoster;
  * save game (e.g. at the end of a game turn).
  */
 public interface IAbstractForumPosterDelegate extends IRemote, IDelegate {
-  boolean postTurnSummary(final PbemMessagePoster poster, final String title);
+  boolean postTurnSummary(PbemMessagePoster poster, String title);
 
   void setHasPostedTurnSummary(boolean hasPostedTurnSummary);
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/remote/IEditDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/remote/IEditDelegate.java
@@ -34,9 +34,9 @@ public interface IEditDelegate extends IRemote, IPersistentDelegate {
 
   String removeTechAdvance(PlayerId player, Collection<TechAdvance> advance);
 
-  String changeUnitHitDamage(final IntegerMap<Unit> unitDamageMap, final Territory territory);
+  String changeUnitHitDamage(IntegerMap<Unit> unitDamageMap, Territory territory);
 
-  String changeUnitBombingDamage(final IntegerMap<Unit> unitDamageMap, final Territory territory);
+  String changeUnitBombingDamage(IntegerMap<Unit> unitDamageMap, Territory territory);
 
   String addComment(String message);
 

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/IOddsCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/IOddsCalculator.java
@@ -12,35 +12,35 @@ import games.strategy.engine.data.Unit;
  * Interface to ensure different implementations of the odds calculator all have the same public methods.
  */
 public interface IOddsCalculator {
-  void setGameData(final GameData data);
+  void setGameData(GameData data);
 
-  void setCalculateData(final PlayerId attacker, final PlayerId defender, final Territory location,
-      final Collection<Unit> attacking, final Collection<Unit> defending, final Collection<Unit> bombarding,
-      final Collection<TerritoryEffect> territoryEffects, final int runCount);
+  void setCalculateData(PlayerId attacker, PlayerId defender, Territory location,
+      Collection<Unit> attacking, Collection<Unit> defending, Collection<Unit> bombarding,
+      Collection<TerritoryEffect> territoryEffects, int runCount);
 
   AggregateResults calculate();
 
-  AggregateResults setCalculateDataAndCalculate(final PlayerId attacker, final PlayerId defender,
-      final Territory location, final Collection<Unit> attacking, final Collection<Unit> defending,
-      final Collection<Unit> bombarding, final Collection<TerritoryEffect> territoryEffects, final int runCount);
+  AggregateResults setCalculateDataAndCalculate(PlayerId attacker, PlayerId defender,
+      Territory location, Collection<Unit> attacking, Collection<Unit> defending,
+      Collection<Unit> bombarding, Collection<TerritoryEffect> territoryEffects, int runCount);
 
   int getRunCount();
 
   boolean getIsReady();
 
-  void setKeepOneAttackingLandUnit(final boolean bool);
+  void setKeepOneAttackingLandUnit(boolean bool);
 
-  void setAmphibious(final boolean bool);
+  void setAmphibious(boolean bool);
 
-  void setRetreatAfterRound(final int value);
+  void setRetreatAfterRound(int value);
 
-  void setRetreatAfterXUnitsLeft(final int value);
+  void setRetreatAfterXUnitsLeft(int value);
 
-  void setRetreatWhenOnlyAirLeft(final boolean value);
+  void setRetreatWhenOnlyAirLeft(boolean value);
 
-  void setAttackerOrderOfLosses(final String attackerOrderOfLosses);
+  void setAttackerOrderOfLosses(String attackerOrderOfLosses);
 
-  void setDefenderOrderOfLosses(final String defenderOrderOfLosses);
+  void setDefenderOrderOfLosses(String defenderOrderOfLosses);
 
   void cancel();
 

--- a/game-core/src/main/java/games/strategy/triplea/player/ITripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/player/ITripleAPlayer.java
@@ -121,8 +121,7 @@ public interface ITripleAPlayer extends IRemotePlayer {
    * One or more bombers have just moved into a territory where a strategic bombing
    * raid can be conducted, what should the bomber bomb.
    */
-  Unit whatShouldBomberBomb(Territory territory, final Collection<Unit> potentialTargets,
-      final Collection<Unit> bombers);
+  Unit whatShouldBomberBomb(Territory territory, Collection<Unit> potentialTargets, Collection<Unit> bombers);
 
   /**
    * Choose where my rockets should fire.
@@ -148,7 +147,7 @@ public interface ITripleAPlayer extends IRemotePlayer {
    * @param candidates - a list of territories - these are the places where air units can land
    * @return - the territory to land the fighters in, must be non null
    */
-  Territory selectTerritoryForAirToLand(Collection<Territory> candidates, final Territory currentTerritory,
+  Territory selectTerritoryForAirToLand(Collection<Territory> candidates, Territory currentTerritory,
       String unitMessage);
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/ui/AbstractUiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/AbstractUiContext.java
@@ -122,7 +122,7 @@ public abstract class AbstractUiContext implements UiContext {
     }
   }
 
-  protected abstract void internalSetMapDir(final String dir, final GameData data);
+  protected abstract void internalSetMapDir(String dir, GameData data);
 
   public static String getMapDir() {
     return mapDir;

--- a/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
@@ -173,7 +173,7 @@ abstract class AbstractUndoableMovesPanel extends JPanel {
     private static final long serialVersionUID = -397312652244693138L;
     private final int moveIndex;
 
-    public UndoMoveActionListener(final int index) {
+    UndoMoveActionListener(final int index) {
       super("Undo");
       moveIndex = index;
     }
@@ -194,7 +194,7 @@ abstract class AbstractUndoableMovesPanel extends JPanel {
   class UndoAllMovesActionListener extends AbstractAction {
     private static final long serialVersionUID = 7908136093303143896L;
 
-    public UndoAllMovesActionListener() {
+    UndoAllMovesActionListener() {
       super("UndoAllMoves");
     }
 
@@ -213,7 +213,7 @@ abstract class AbstractUndoableMovesPanel extends JPanel {
     private static final long serialVersionUID = -6999284663802575467L;
     private final AbstractUndoableMove move;
 
-    public ViewAction(final AbstractUndoableMove move) {
+    ViewAction(final AbstractUndoableMove move) {
       super("Show");
       this.move = move;
     }
@@ -228,5 +228,5 @@ abstract class AbstractUndoableMovesPanel extends JPanel {
     }
   }
 
-  protected abstract void specificViewAction(final AbstractUndoableMove move);
+  protected abstract void specificViewAction(AbstractUndoableMove move);
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/EconomyPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EconomyPanel.java
@@ -63,7 +63,7 @@ class EconomyPanel extends AbstractStatPanel {
     private boolean isDirty = true;
     private String[][] collectedData;
 
-    public ResourceTableModel() {
+    ResourceTableModel() {
       setResourceColumns();
       gameData.addDataChangeListener(this);
     }

--- a/game-core/src/main/java/games/strategy/triplea/ui/EndTurnPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EndTurnPanel.java
@@ -19,7 +19,7 @@ class EndTurnPanel extends AbstractForumPosterPanel {
     }
   });
 
-  public EndTurnPanel(final GameData data, final MapPanel map) {
+  EndTurnPanel(final GameData data, final MapPanel map) {
     super(data, map);
     forumPosterComponent = new ForumPosterComponent(getData(), doneAction, getTitle());
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
@@ -224,7 +224,7 @@ public class ExtendedStats extends StatPanel {
   }
 
   class TechTokenStat extends ResourceStat {
-    public TechTokenStat() {
+    TechTokenStat() {
       super(gameData.getResourceList().getResource(Constants.TECH_TOKENS));
     }
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/ObjectiveDummyDelegateBridge.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ObjectiveDummyDelegateBridge.java
@@ -144,7 +144,7 @@ public class ObjectiveDummyDelegateBridge implements IDelegateBridge {
   }
 
   static class ObjectivePanelDummyPlayer extends AbstractAi {
-    public ObjectivePanelDummyPlayer(final String name) {
+    ObjectivePanelDummyPlayer(final String name) {
       super(name);
     }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
@@ -114,7 +114,7 @@ public class ObjectivePanel extends AbstractStatPanel {
     final Map<String, List<String>> sections = new LinkedHashMap<>();
     private Instant timestamp = Instant.EPOCH;
 
-    public ObjectiveTableModel() {
+    ObjectiveTableModel() {
       setObjectiveStats();
       gameData.addDataChangeListener(this);
     }

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1030,7 +1030,7 @@ public final class TripleAFrame extends JFrame {
 
     private static final long serialVersionUID = 1749164256040268579L;
 
-    public UnitRenderer() {
+    UnitRenderer() {
       setOpaque(true);
     }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -66,9 +66,7 @@ public interface UiContext {
     return newUnitImageLabel(type, player, UnitDamage.NOT_DAMAGED, UnitEnable.ENABLED);
   }
 
-  JLabel newUnitImageLabel(final UnitType type, final PlayerId player,
-      final UnitDamage damaged,
-      final UnitEnable disabled);
+  JLabel newUnitImageLabel(UnitType type, PlayerId player, UnitDamage damaged, UnitEnable disabled);
 
   ResourceImageFactory getResourceImageFactory();
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/display/ITripleADisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/display/ITripleADisplay.java
@@ -20,15 +20,15 @@ public interface ITripleADisplay extends IDisplay {
   /**
    * Sends a message to all TripleAFrame that have joined the game, possibly including observers.
    */
-  void reportMessageToAll(final String message, final String title, final boolean doNotIncludeHost,
-      final boolean doNotIncludeClients, final boolean doNotIncludeObservers);
+  void reportMessageToAll(String message, String title, boolean doNotIncludeHost,
+      boolean doNotIncludeClients, boolean doNotIncludeObservers);
 
   /**
    * Sends a message to all TripleAFrame's that are playing AND are controlling one or more of the players listed but
    * NOT any of the players listed as butNotThesePlayers. (No message to any observers or players not in the list.)
    */
-  void reportMessageToPlayers(final Collection<PlayerId> playersToSendTo,
-      final Collection<PlayerId> butNotThesePlayers, final String message, final String title);
+  void reportMessageToPlayers(Collection<PlayerId> playersToSendTo,
+      Collection<PlayerId> butNotThesePlayers, String message, String title);
 
   /**
    * Display info about the battle. This is the first message to be displayed in a battle.
@@ -45,9 +45,8 @@ public interface ITripleADisplay extends IDisplay {
    */
   void showBattle(GUID battleId, Territory location, String battleTitle, Collection<Unit> attackingUnits,
       Collection<Unit> defendingUnits, Collection<Unit> killedUnits, Collection<Unit> attackingWaitingToDie,
-      Collection<Unit> defendingWaitingToDie, Map<Unit, Collection<Unit>> dependentUnits, final PlayerId attacker,
-      final PlayerId defender, final boolean isAmphibious, final BattleType battleType,
-      final Collection<Unit> amphibiousLandAttackers);
+      Collection<Unit> defendingWaitingToDie, Map<Unit, Collection<Unit>> dependentUnits, PlayerId attacker,
+      PlayerId defender, boolean isAmphibious, BattleType battleType, Collection<Unit> amphibiousLandAttackers);
 
   /**
    * Displays the steps for the specified battle.

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -162,7 +162,7 @@ final class ViewMenu extends JMenu {
       private static final long serialVersionUID = -6280511505686687867L;
       private final double scaleFactor;
 
-      public UnitSizeAction(final double scaleFactor) {
+      UnitSizeAction(final double scaleFactor) {
         super(decimalFormat.format(scaleFactor * 100) + "%");
         this.scaleFactor = scaleFactor;
       }

--- a/game-core/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
+++ b/game-core/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
@@ -62,7 +62,7 @@ public class ImageScrollerLargeView extends JComponent {
 
   private final ActionListener timerAction = new ActionListener() {
     @Override
-    public final void actionPerformed(final ActionEvent e) {
+    public void actionPerformed(final ActionEvent e) {
       if (JOptionPane.getFrameForComponent(ImageScrollerLargeView.this).getFocusOwner() == null) {
         insideCount = 0;
         return;

--- a/game-core/src/main/java/org/triplea/game/chat/ChatModel.java
+++ b/game-core/src/main/java/org/triplea/game/chat/ChatModel.java
@@ -8,11 +8,11 @@ import games.strategy.engine.chat.Chat;
  */
 public interface ChatModel {
 
-  void setChat(final Chat chat);
+  void setChat(Chat chat);
 
   Chat getChat();
 
   String getAllText();
 
-  void setShowChatTime(final boolean showTime);
+  void setShowChatTime(boolean showTime);
 }

--- a/game-core/src/main/java/org/triplea/game/startup/SetupModel.java
+++ b/game-core/src/main/java/org/triplea/game/startup/SetupModel.java
@@ -17,7 +17,7 @@ import games.strategy.engine.random.IRemoteDiceServer;
  */
 public interface SetupModel {
 
-  void addObserver(final Observer observer);
+  void addObserver(Observer observer);
 
   void notifyObservers();
 

--- a/game-core/src/main/java/org/triplea/lobby/common/IModeratorController.java
+++ b/game-core/src/main/java/org/triplea/lobby/common/IModeratorController.java
@@ -153,5 +153,5 @@ public interface IModeratorController extends IRemote {
   /**
    * Is this node an admin.
    */
-  boolean isPlayerAdmin(final INode node);
+  boolean isPlayerAdmin(INode node);
 }

--- a/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadFileDescriptionTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadFileDescriptionTest.java
@@ -98,7 +98,7 @@ public class DownloadFileDescriptionTest extends AbstractClientSettingTestCase {
   @Nested
   final class EqualsAndHashCodeTest {
     @Test
-    final void shouldBeEquatableAndHashable() {
+    void shouldBeEquatableAndHashable() {
       EqualsVerifier.forClass(DownloadFileDescription.class)
           .withOnlyTheseFields("url")
           .verify();

--- a/game-core/src/test/java/org/triplea/common/config/AbstractPropertyReaderTestCase.java
+++ b/game-core/src/test/java/org/triplea/common/config/AbstractPropertyReaderTestCase.java
@@ -50,7 +50,7 @@ public abstract class AbstractPropertyReaderTestCase {
     private PropertyReader propertyReader;
 
     @BeforeEach
-    public final void setupPropertyReader() throws Exception {
+    public void setupPropertyReader() throws Exception {
       propertyReader = newSingletonPropertyReader(PRESENT_PROPERTY_VALUE);
     }
 

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/DownloadPane.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/DownloadPane.java
@@ -18,7 +18,7 @@ class DownloadPane extends VBox {
    * @param triplea The root pane.
    * @throws IOException If the FXML file is not present.
    */
-  public DownloadPane(final TripleA triplea) throws IOException {
+  DownloadPane(final TripleA triplea) throws IOException {
     final FXMLLoader loader = FxmlManager.getLoader(getClass().getResource(FxmlManager.DOWNLOAD_PANE.toString()));
     loader.setRoot(this);
     loader.setController(this);

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/MainMenuPane.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/MainMenuPane.java
@@ -61,7 +61,7 @@ class MainMenuPane extends BorderPane {
    * @param triplea The root pane.
    * @throws IOException If the FXML file is not present.
    */
-  public MainMenuPane(final TripleA triplea) throws IOException {
+  MainMenuPane(final TripleA triplea) throws IOException {
     this.triplea = triplea;
     final FXMLLoader loader = FxmlManager.getLoader(getClass().getResource(FxmlManager.MAIN_MENU_PANE.toString()));
     loader.setRoot(this);

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/SettingsPane.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/SettingsPane.java
@@ -54,7 +54,7 @@ class SettingsPane extends StackPane {
    * @param triplea The root pane.
    * @throws IOException If the FXML file is not present.
    */
-  public SettingsPane(final TripleA triplea) throws IOException {
+  SettingsPane(final TripleA triplea) throws IOException {
     final FXMLLoader loader = FxmlManager.getLoader(getClass().getResource(FxmlManager.SETTINGS_PANE.toString()));
     loader.setRoot(this);
     loader.setController(this);

--- a/http-client/src/main/java/org/triplea/http/client/github/issues/GithubIssueClient.java
+++ b/http-client/src/main/java/org/triplea/http/client/github/issues/GithubIssueClient.java
@@ -25,10 +25,10 @@ interface GithubIssueClient {
       "Accept: application/json"
   })
   CreateIssueResponse newIssue(
-      final @HeaderMap Map<String, Object> headerMap,
-      final @Param("org") String org,
-      final @Param("repo") String repo,
-      final CreateIssueRequest createIssueRequest);
+      @HeaderMap Map<String, Object> headerMap,
+      @Param("org") String org,
+      @Param("repo") String repo,
+      CreateIssueRequest createIssueRequest);
 
 
   default CreateIssueResponse newIssue(


### PR DESCRIPTION
## Overview

Enables the Checkstyle RedundantModifier rule to prevent redundant modifiers from being introduced into the code.  Existing redundant modifiers are removed as part of this PR.

## Functional Changes

None.

## Refactoring Changes

`TechAdvance#findDefinedAdvanceAndCreateAdvance()` creates `TechAdvance` instances reflectively.  In order to accommodate the removal of the `public` modifier on the constructor of package-private `TechAdvance` subtypes, the call to `Class#getConstructor()` in this method was changed to `Class#getDeclaredConstructor()` so that any accessible constructor can be used instead of just public constructors.

## Manual Testing Performed

Smoke tested any possible reflection issues when changing accessibility of public constructors to package-private:

* Saved and loaded a local game.
* Ran the JFX client.

I also verified that adding `final` on a variable declared as part of a try-with-resources statement fails the build.