### PR TITLE
Remove unused parameters

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -523,7 +523,7 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer implements ITrip
   @Override
   public CasualtyDetails selectCasualties(final Collection<Unit> selectFrom,
       final Map<Unit, Collection<Unit>> dependents, final int count, final String message, final DiceRoll dice,
-      final PlayerId hit, final Collection<Unit> friendlyUnits, final PlayerId enemyPlayer,
+      final PlayerId hit, final Collection<Unit> friendlyUnits,
       final Collection<Unit> enemyUnits, final boolean amphibious, final Collection<Unit> amphibiousLandAttackers,
       final CasualtyList defaultCasualties, final GUID battleId, final Territory battlesite,
       final boolean allowMultipleHitsPerUnit) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
@@ -120,7 +120,7 @@ public abstract class AbstractAi extends AbstractBasePlayer implements ITripleAP
   @Override
   public CasualtyDetails selectCasualties(final Collection<Unit> selectFrom,
       final Map<Unit, Collection<Unit>> dependents, final int count, final String message, final DiceRoll dice,
-      final PlayerId hit, final Collection<Unit> friendlyUnits, final PlayerId enemyPlayer,
+      final PlayerId hit, final Collection<Unit> friendlyUnits,
       final Collection<Unit> enemyUnits, final boolean amphibious, final Collection<Unit> amphibiousLandAttackers,
       final CasualtyList defaultCasualties, final GUID battleId, final Territory battlesite,
       final boolean allowMultipleHitsPerUnit) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProAi.java
@@ -313,7 +313,7 @@ public class ProAi extends AbstractAi {
   @Override
   public CasualtyDetails selectCasualties(final Collection<Unit> selectFrom,
       final Map<Unit, Collection<Unit>> dependents, final int count, final String message, final DiceRoll dice,
-      final PlayerId hit, final Collection<Unit> friendlyUnits, final PlayerId enemyPlayer,
+      final PlayerId hit, final Collection<Unit> friendlyUnits,
       final Collection<Unit> enemyUnits, final boolean amphibious, final Collection<Unit> amphibiousLandAttackers,
       final CasualtyList defaultCasualties, final GUID battleId, final Territory battlesite,
       final boolean allowMultipleHitsPerUnit) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -581,7 +581,7 @@ public class AirBattle extends AbstractBattle {
 
         @Override
         public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-          details = BattleCalculator.selectCasualties(ATTACKERS_FIRE, defender, defendingUnits, defendingUnits,
+          details = BattleCalculator.selectCasualties(defender, defendingUnits, defendingUnits,
               attacker, attackingUnits, false, new ArrayList<>(), battleSite, null, bridge, ATTACKERS_FIRE,
               dice, true, battleId, false, dice.getHits(), true);
           defendingWaitingToDie.addAll(details.getKilled());
@@ -627,7 +627,7 @@ public class AirBattle extends AbstractBattle {
 
         @Override
         public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-          details = BattleCalculator.selectCasualties(DEFENDERS_FIRE, attacker, attackingUnits, attackingUnits,
+          details = BattleCalculator.selectCasualties(attacker, attackingUnits, attackingUnits,
               defender, defendingUnits, false, new ArrayList<>(), battleSite, null, bridge, DEFENDERS_FIRE,
               dice, false, battleId, false, dice.getHits(), true);
           attackingWaitingToDie.addAll(details.getKilled());

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -582,7 +582,7 @@ public class AirBattle extends AbstractBattle {
         @Override
         public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
           details = BattleCalculator.selectCasualties(defender, defendingUnits, defendingUnits,
-              attacker, attackingUnits, false, new ArrayList<>(), battleSite, null, bridge, ATTACKERS_FIRE,
+              attackingUnits, false, new ArrayList<>(), battleSite, null, bridge, ATTACKERS_FIRE,
               dice, true, battleId, false, dice.getHits(), true);
           defendingWaitingToDie.addAll(details.getKilled());
           markDamaged(details.getDamaged(), bridge);
@@ -628,7 +628,7 @@ public class AirBattle extends AbstractBattle {
         @Override
         public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
           details = BattleCalculator.selectCasualties(attacker, attackingUnits, attackingUnits,
-              defender, defendingUnits, false, new ArrayList<>(), battleSite, null, bridge, DEFENDERS_FIRE,
+              defendingUnits, false, new ArrayList<>(), battleSite, null, bridge, DEFENDERS_FIRE,
               dice, false, battleId, false, dice.getHits(), true);
           attackingWaitingToDie.addAll(details.getKilled());
           markDamaged(details.getDamaged(), bridge);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -104,7 +104,7 @@ public class BattleCalculator {
             && defendingAa.stream().allMatch(Matches.unitAaShotDamageableInsteadOfKillingInstantly());
     if (isChooseAa(data)) {
       final String text = "Select " + dice.getHits() + " casualties from aa fire in " + terr.getName();
-      return selectCasualties(hitPlayer, planes, allFriendlyUnits, firingPlayer, allEnemyUnits, amphibious,
+      return selectCasualties(hitPlayer, planes, allFriendlyUnits, allEnemyUnits, amphibious,
           amphibiousLandAttackers, terr, territoryEffects, bridge, text, dice, defending, battleId, false,
           dice.getHits(), allowMultipleHitsPerUnit);
     }
@@ -435,7 +435,7 @@ public class BattleCalculator {
    * @param battleId may be null if we are not in a battle (eg, if this is an aa fire due to moving).
    */
   public static CasualtyDetails selectCasualties(final PlayerId player,
-      final Collection<Unit> targetsToPickFrom, final Collection<Unit> friendlyUnits, final PlayerId enemyPlayer,
+      final Collection<Unit> targetsToPickFrom, final Collection<Unit> friendlyUnits,
       final Collection<Unit> enemyUnits, final boolean amphibious, final Collection<Unit> amphibiousLandAttackers,
       final Territory battlesite, final Collection<TerritoryEffect> territoryEffects, final IDelegateBridge bridge,
       final String text, final DiceRoll dice, final boolean defending, final GUID battleId, final boolean headLess,
@@ -454,7 +454,7 @@ public class BattleCalculator {
     final Map<Unit, Collection<Unit>> dependents = headLess ? Collections.emptyMap() : getDependents(targetsToPickFrom);
     if (isEditMode && !headLess) {
       final CasualtyDetails editSelection = tripleaPlayer.selectCasualties(targetsToPickFrom, dependents, 0, text, dice,
-          player, friendlyUnits, enemyPlayer, enemyUnits, amphibious, amphibiousLandAttackers, new CasualtyList(),
+          player, friendlyUnits, enemyUnits, amphibious, amphibiousLandAttackers, new CasualtyList(),
           battleId, battlesite, allowMultipleHitsPerUnit);
       final List<Unit> killed = editSelection.getKilled();
       // if partial retreat is possible, kill amphibious units first
@@ -500,7 +500,7 @@ public class BattleCalculator {
       casualtySelection = new CasualtyDetails(defaultCasualties, true);
     } else {
       casualtySelection = tripleaPlayer.selectCasualties(sortedTargetsToPickFrom, dependents, hitsRemaining, text, dice,
-          player, friendlyUnits, enemyPlayer, enemyUnits, amphibious, amphibiousLandAttackers, defaultCasualties,
+          player, friendlyUnits, enemyUnits, amphibious, amphibiousLandAttackers, defaultCasualties,
           battleId, battlesite, allowMultipleHitsPerUnit);
     }
     final List<Unit> killed = casualtySelection.getKilled();
@@ -532,7 +532,7 @@ public class BattleCalculator {
             + (hitsRemaining > totalHitpoints ? totalHitpoints : hitsRemaining) + ", for "
             + casualtySelection.toString());
       }
-      return selectCasualties(player, sortedTargetsToPickFrom, friendlyUnits, enemyPlayer, enemyUnits, amphibious,
+      return selectCasualties(player, sortedTargetsToPickFrom, friendlyUnits, enemyUnits, amphibious,
           amphibiousLandAttackers, battlesite, territoryEffects, bridge, text, dice, defending, battleId, headLess,
           extraHits, allowMultipleHitsPerUnit);
     }
@@ -543,7 +543,7 @@ public class BattleCalculator {
         log.severe("Possible Infinite Loop: Cannot remove enough units of those types: targets "
             + MyFormatter.unitsToTextNoOwner(sortedTargetsToPickFrom) + ", for " + casualtySelection.toString());
       }
-      return selectCasualties(player, sortedTargetsToPickFrom, friendlyUnits, enemyPlayer, enemyUnits, amphibious,
+      return selectCasualties(player, sortedTargetsToPickFrom, friendlyUnits, enemyUnits, amphibious,
           amphibiousLandAttackers, battlesite, territoryEffects, bridge, text, dice, defending, battleId, headLess,
           extraHits, allowMultipleHitsPerUnit);
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -104,7 +104,7 @@ public class BattleCalculator {
             && defendingAa.stream().allMatch(Matches.unitAaShotDamageableInsteadOfKillingInstantly());
     if (isChooseAa(data)) {
       final String text = "Select " + dice.getHits() + " casualties from aa fire in " + terr.getName();
-      return selectCasualties(null, hitPlayer, planes, allFriendlyUnits, firingPlayer, allEnemyUnits, amphibious,
+      return selectCasualties(hitPlayer, planes, allFriendlyUnits, firingPlayer, allEnemyUnits, amphibious,
           amphibiousLandAttackers, terr, territoryEffects, bridge, text, dice, defending, battleId, false,
           dice.getHits(), allowMultipleHitsPerUnit);
     }
@@ -434,7 +434,7 @@ public class BattleCalculator {
    *
    * @param battleId may be null if we are not in a battle (eg, if this is an aa fire due to moving).
    */
-  public static CasualtyDetails selectCasualties(final String step, final PlayerId player,
+  public static CasualtyDetails selectCasualties(final PlayerId player,
       final Collection<Unit> targetsToPickFrom, final Collection<Unit> friendlyUnits, final PlayerId enemyPlayer,
       final Collection<Unit> enemyUnits, final boolean amphibious, final Collection<Unit> amphibiousLandAttackers,
       final Territory battlesite, final Collection<TerritoryEffect> territoryEffects, final IDelegateBridge bridge,
@@ -532,7 +532,7 @@ public class BattleCalculator {
             + (hitsRemaining > totalHitpoints ? totalHitpoints : hitsRemaining) + ", for "
             + casualtySelection.toString());
       }
-      return selectCasualties(step, player, sortedTargetsToPickFrom, friendlyUnits, enemyPlayer, enemyUnits, amphibious,
+      return selectCasualties(player, sortedTargetsToPickFrom, friendlyUnits, enemyPlayer, enemyUnits, amphibious,
           amphibiousLandAttackers, battlesite, territoryEffects, bridge, text, dice, defending, battleId, headLess,
           extraHits, allowMultipleHitsPerUnit);
     }
@@ -543,7 +543,7 @@ public class BattleCalculator {
         log.severe("Possible Infinite Loop: Cannot remove enough units of those types: targets "
             + MyFormatter.unitsToTextNoOwner(sortedTargetsToPickFrom) + ", for " + casualtySelection.toString());
       }
-      return selectCasualties(step, player, sortedTargetsToPickFrom, friendlyUnits, enemyPlayer, enemyUnits, amphibious,
+      return selectCasualties(player, sortedTargetsToPickFrom, friendlyUnits, enemyPlayer, enemyUnits, amphibious,
           amphibiousLandAttackers, battlesite, territoryEffects, bridge, text, dice, defending, battleId, headLess,
           extraHits, allowMultipleHitsPerUnit);
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Fire.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Fire.java
@@ -132,7 +132,7 @@ public class Fire implements IExecutable {
           extraHits = transportsOnly.size();
         }
         message = BattleCalculator.selectCasualties(hitPlayer, transportsOnly,
-            allEnemyUnitsNotIncludingWaitingToDie, firingPlayer, allFriendlyUnitsNotIncludingWaitingToDie,
+            allEnemyUnitsNotIncludingWaitingToDie, allFriendlyUnitsNotIncludingWaitingToDie,
             isAmphibious, amphibiousLandAttackers, battleSite, territoryEffects, bridge, text, dice,
             !defending, battleId, isHeadless, extraHits, true);
         killed.addAll(message.getKilled());
@@ -143,7 +143,7 @@ public class Fire implements IExecutable {
         confirmOwnCasualties = true;
       } else { // less than possible number
         message = BattleCalculator.selectCasualties(hitPlayer, nonTransports,
-            allEnemyUnitsNotIncludingWaitingToDie, firingPlayer, allFriendlyUnitsNotIncludingWaitingToDie,
+            allEnemyUnitsNotIncludingWaitingToDie, allFriendlyUnitsNotIncludingWaitingToDie,
             isAmphibious, amphibiousLandAttackers, battleSite, territoryEffects, bridge, text, dice,
             !defending, battleId, isHeadless, dice.getHits(), true);
         killed = message.getKilled();
@@ -160,7 +160,7 @@ public class Fire implements IExecutable {
       } else { // Choose casualties
         final CasualtyDetails message;
         message = BattleCalculator.selectCasualties(hitPlayer, attackableUnits,
-            allEnemyUnitsNotIncludingWaitingToDie, firingPlayer, allFriendlyUnitsNotIncludingWaitingToDie,
+            allEnemyUnitsNotIncludingWaitingToDie, allFriendlyUnitsNotIncludingWaitingToDie,
             isAmphibious, amphibiousLandAttackers, battleSite, territoryEffects, bridge, text, dice,
             !defending, battleId, isHeadless, dice.getHits(), true);
         killed = message.getKilled();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Fire.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Fire.java
@@ -131,7 +131,7 @@ public class Fire implements IExecutable {
         if (extraHits > transportsOnly.size()) {
           extraHits = transportsOnly.size();
         }
-        message = BattleCalculator.selectCasualties(stepName, hitPlayer, transportsOnly,
+        message = BattleCalculator.selectCasualties(hitPlayer, transportsOnly,
             allEnemyUnitsNotIncludingWaitingToDie, firingPlayer, allFriendlyUnitsNotIncludingWaitingToDie,
             isAmphibious, amphibiousLandAttackers, battleSite, territoryEffects, bridge, text, dice,
             !defending, battleId, isHeadless, extraHits, true);
@@ -142,7 +142,7 @@ public class Fire implements IExecutable {
         damaged = Collections.emptyList();
         confirmOwnCasualties = true;
       } else { // less than possible number
-        message = BattleCalculator.selectCasualties(stepName, hitPlayer, nonTransports,
+        message = BattleCalculator.selectCasualties(hitPlayer, nonTransports,
             allEnemyUnitsNotIncludingWaitingToDie, firingPlayer, allFriendlyUnitsNotIncludingWaitingToDie,
             isAmphibious, amphibiousLandAttackers, battleSite, territoryEffects, bridge, text, dice,
             !defending, battleId, isHeadless, dice.getHits(), true);
@@ -159,7 +159,7 @@ public class Fire implements IExecutable {
         confirmOwnCasualties = true;
       } else { // Choose casualties
         final CasualtyDetails message;
-        message = BattleCalculator.selectCasualties(stepName, hitPlayer, attackableUnits,
+        message = BattleCalculator.selectCasualties(hitPlayer, attackableUnits,
             allEnemyUnitsNotIncludingWaitingToDie, firingPlayer, allFriendlyUnitsNotIncludingWaitingToDie,
             isAmphibious, amphibiousLandAttackers, battleSite, territoryEffects, bridge, text, dice,
             !defending, battleId, isHeadless, dice.getHits(), true);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -461,7 +461,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
             && defendingAa.stream().allMatch(Matches.unitAaShotDamageableInsteadOfKillingInstantly());
     if (isEditMode) {
       final String text = currentTypeAa + AA_GUNS_FIRE_SUFFIX;
-      return BattleCalculator.selectCasualties(RAID, attacker,
+      return BattleCalculator.selectCasualties(attacker,
           validAttackingUnitsForThisRoll, attackingUnits, defender, defendingUnits, isAmphibious,
           amphibiousLandAttackers, battleSite, territoryEffects, bridge, text, /* dice */null,
           /* defending */false, battleId, /* head-less */false, 0, allowMultipleHitsPerUnit);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -462,7 +462,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     if (isEditMode) {
       final String text = currentTypeAa + AA_GUNS_FIRE_SUFFIX;
       return BattleCalculator.selectCasualties(attacker,
-          validAttackingUnitsForThisRoll, attackingUnits, defender, defendingUnits, isAmphibious,
+          validAttackingUnitsForThisRoll, attackingUnits, defendingUnits, isAmphibious,
           amphibiousLandAttackers, battleSite, territoryEffects, bridge, text, /* dice */null,
           /* defending */false, battleId, /* head-less */false, 0, allowMultipleHitsPerUnit);
     }

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyPlayer.java
@@ -165,7 +165,7 @@ class DummyPlayer extends AbstractAi {
   @Override
   public CasualtyDetails selectCasualties(final Collection<Unit> selectFrom,
       final Map<Unit, Collection<Unit>> dependents, final int count, final String message, final DiceRoll dice,
-      final PlayerId hit, final Collection<Unit> friendlyUnits, final PlayerId enemyPlayer,
+      final PlayerId hit, final Collection<Unit> friendlyUnits,
       final Collection<Unit> enemyUnits, final boolean amphibious, final Collection<Unit> amphibiousLandAttackers,
       final CasualtyList defaultCasualties, final GUID battleId, final Territory battlesite,
       final boolean allowMultipleHitsPerUnit) {

--- a/game-core/src/main/java/games/strategy/triplea/player/ITripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/player/ITripleAPlayer.java
@@ -32,7 +32,6 @@ public interface ITripleAPlayer extends IRemotePlayer {
    * @param dice - the dice rolled for the casualties
    * @param hit - the player hit
    * @param friendlyUnits - all friendly units in the battle (or moving)
-   * @param enemyPlayer - the player who has hit you
    * @param enemyUnits - all enemy units in the battle (or defending aa)
    * @param amphibious - is the battle amphibious?
    * @param amphibiousLandAttackers - can be null
@@ -43,7 +42,7 @@ public interface ITripleAPlayer extends IRemotePlayer {
    * @return CasualtyDetails
    */
   CasualtyDetails selectCasualties(Collection<Unit> selectFrom, Map<Unit, Collection<Unit>> dependents, int count,
-      String message, DiceRoll dice, PlayerId hit, Collection<Unit> friendlyUnits, PlayerId enemyPlayer,
+      String message, DiceRoll dice, PlayerId hit, Collection<Unit> friendlyUnits,
       Collection<Unit> enemyUnits, boolean amphibious, Collection<Unit> amphibiousLandAttackers,
       CasualtyList defaultCasualties, GUID battleId, Territory battlesite, boolean allowMultipleHitsPerUnit);
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/ObjectiveDummyDelegateBridge.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ObjectiveDummyDelegateBridge.java
@@ -204,7 +204,7 @@ public class ObjectiveDummyDelegateBridge implements IDelegateBridge {
     @Override
     public CasualtyDetails selectCasualties(final Collection<Unit> selectFrom,
         final Map<Unit, Collection<Unit>> dependents, final int count, final String message, final DiceRoll dice,
-        final PlayerId hit, final Collection<Unit> friendlyUnits, final PlayerId enemyPlayer,
+        final PlayerId hit, final Collection<Unit> friendlyUnits,
         final Collection<Unit> enemyUnits, final boolean amphibious, final Collection<Unit> amphibiousLandAttackers,
         final CasualtyList defaultCasualties, final GUID battleId, final Territory battlesite,
         final boolean allowMultipleHitsPerUnit) {

--- a/game-core/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
@@ -48,7 +48,6 @@ public class BattleCalculatorTest {
         any(),
         any(),
         any(),
-        any(),
         anyBoolean(),
         any(),
         any(),

--- a/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -104,7 +104,6 @@ public class RevisedTest {
         any(),
         any(),
         any(),
-        any(),
         anyBoolean(),
         any(),
         any(),

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -117,7 +117,6 @@ public class WW2V3Year41Test {
         any(),
         any(),
         any(),
-        any(),
         anyBoolean(),
         any(),
         any(),


### PR DESCRIPTION
## Overview
- Removes unused `enemyPlayer` parameter from `TripleAPlayer#selectCasualties`
- Removes unused `step` parameter from `BattleCalculator#selectCasualties`

## Functional Changes
Should be none
