### PR TITLE
Refactor DownloadRunnable

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/ClientContext.java
+++ b/game-core/src/main/java/games/strategy/engine/ClientContext.java
@@ -1,7 +1,6 @@
 package games.strategy.engine;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.triplea.common.config.product.ProductConfiguration;
 
@@ -59,7 +58,7 @@ public final class ClientContext {
     return instance.productConfiguration.getVersion();
   }
 
-  public static Optional<List<DownloadFileDescription>> getMapDownloadList() {
+  public static List<DownloadFileDescription> getMapDownloadList() {
     return ClientSetting.mapListOverride.getValue()
         .map(DownloadRunnable::readLocalFile)
         .orElseGet(() -> DownloadRunnable.download(UrlConstants.MAP_DOWNLOAD_LIST.toString()));

--- a/game-core/src/main/java/games/strategy/engine/ClientContext.java
+++ b/game-core/src/main/java/games/strategy/engine/ClientContext.java
@@ -60,10 +60,9 @@ public final class ClientContext {
   }
 
   public static Optional<List<DownloadFileDescription>> getMapDownloadList() {
-    final String mapDownloadListUrl = ClientSetting.mapListOverride.getValue()
-        .map(Object::toString)
-        .orElse(UrlConstants.MAP_DOWNLOAD_LIST.toString());
 
-    return new DownloadRunnable(mapDownloadListUrl).getDownloads();
+    return ClientSetting.mapListOverride.getValue()
+        .map(DownloadRunnable::readLocalFile)
+        .orElseGet(() -> DownloadRunnable.download(UrlConstants.MAP_DOWNLOAD_LIST.toString()));
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/ClientContext.java
+++ b/game-core/src/main/java/games/strategy/engine/ClientContext.java
@@ -60,7 +60,6 @@ public final class ClientContext {
   }
 
   public static Optional<List<DownloadFileDescription>> getMapDownloadList() {
-
     return ClientSetting.mapListOverride.getValue()
         .map(DownloadRunnable::readLocalFile)
         .orElseGet(() -> DownloadRunnable.download(UrlConstants.MAP_DOWNLOAD_LIST.toString()));

--- a/game-core/src/main/java/games/strategy/engine/ClientContext.java
+++ b/game-core/src/main/java/games/strategy/engine/ClientContext.java
@@ -60,9 +60,9 @@ public final class ClientContext {
   }
 
   public static Optional<List<DownloadFileDescription>> getMapDownloadList() {
-    final String mapDownloadListUrl = ClientSetting.mapListOverride.isSet()
-        ? ClientSetting.mapListOverride.getValueOrThrow().toString()
-        : UrlConstants.MAP_DOWNLOAD_LIST.toString();
+    final String mapDownloadListUrl = ClientSetting.mapListOverride.getValue()
+        .map(Object::toString)
+        .orElse(UrlConstants.MAP_DOWNLOAD_LIST.toString());
 
     return new DownloadRunnable(mapDownloadListUrl).getDownloads();
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/ContentReader.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/ContentReader.java
@@ -100,9 +100,6 @@ public final class ContentReader {
    */
   private <T> T downloadInternal(final String uri, final ThrowingFunction<InputStream, T, IOException> action)
       throws IOException {
-    checkNotNull(uri);
-    checkNotNull(action);
-
     try (CloseableHttpClient client = httpClientFactory.get()) {
       return download(uri, action, client);
     }

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/ContentReader.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/ContentReader.java
@@ -35,7 +35,8 @@ public final class ContentReader {
   private final Supplier<CloseableHttpClient> httpClientFactory;
 
   /**
-   * Downloads the resource at the specified URI to the specified file.
+   * Downloads the resource at the specified URI, applies the given
+   * Function to it and returns the result.
    *
    * @param uri The resource URI; must not be {@code null}.
    * @param action The action to perform using the give InputStream; must not be {@code null}.
@@ -92,8 +93,9 @@ public final class ContentReader {
 
 
   /**
-   * Downloads the resource at the specified URI to the specified file.
+   * Downloads the resource at the specified URI using the configured httpClientFactory.
    *
+   * @see #download(String, Function)
    * @param uri The resource URI; must not be {@code null}.
    * @param action The action to perform using the give InputStream; must not be {@code null}.
    * @throws IOException If an error occurs during the download.

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -15,6 +15,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -152,10 +153,11 @@ public class DownloadMapsWindow extends JFrame {
       assert state == State.UNINITIALIZED;
 
       Interruptibles.awaitResult(SingletonManager::getMapDownloadListInBackground).result
-          .ifPresent(downloads -> downloads.ifPresent(d -> {
+          .flatMap(Function.identity())
+          .ifPresent(downloads -> {
             state = State.INITIALIZING;
-            createAndShow(mapNames, d);
-          }));
+            createAndShow(mapNames, downloads);
+          });
     }
 
     private static Optional<List<DownloadFileDescription>> getMapDownloadListInBackground()

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -3,6 +3,7 @@ package games.strategy.engine.framework.map.download;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
+import static games.strategy.util.Util.not;
 
 import java.awt.BorderLayout;
 import java.awt.Component;
@@ -15,7 +16,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 
@@ -153,14 +153,14 @@ public class DownloadMapsWindow extends JFrame {
       assert state == State.UNINITIALIZED;
 
       Interruptibles.awaitResult(SingletonManager::getMapDownloadListInBackground).result
-          .flatMap(Function.identity())
+          .filter(not(Collection::isEmpty))
           .ifPresent(downloads -> {
             state = State.INITIALIZING;
             createAndShow(mapNames, downloads);
           });
     }
 
-    private static Optional<List<DownloadFileDescription>> getMapDownloadListInBackground()
+    private static List<DownloadFileDescription> getMapDownloadListInBackground()
         throws InterruptedException {
       return GameRunner.newBackgroundTaskRunner().runInBackgroundAndReturn(
           "Downloading list of available maps...",

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
@@ -38,7 +38,7 @@ public class DownloadRunnable {
         return DownloadFileParser.parse(response.getEntity().getContent());
       }
     } catch (final IOException e) {
-      log.log(Level.SEVERE, "Error while downloading map download info file.");
+      log.log(Level.SEVERE, "Error while downloading map download info.");
       return Collections.emptyList();
     }
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
@@ -1,12 +1,9 @@
 package games.strategy.engine.framework.map.download;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -26,32 +23,17 @@ import lombok.extern.java.Log;
  */
 @Log
 public class DownloadRunnable {
-  private final String locator;
 
-  public DownloadRunnable(final String locator) {
-    this.locator = locator;
-  }
+  private DownloadRunnable() {}
 
-  /**
-   * Returns a parsed list of parsed downloadable maps. If initialized with a URL then we will do a network fetch and
-   * parse those contents, otherwise (for testing) we assume a local file reference and parse that.
-   */
-  public Optional<List<DownloadFileDescription>> getDownloads() {
-    return beginsWithHttpProtocol() ? downloadFile() : Optional.of(readLocalFile());
-  }
-
-  private boolean beginsWithHttpProtocol() {
-    return locator.startsWith("http://") || locator.startsWith("https://");
-  }
-
-  private Optional<List<DownloadFileDescription>> downloadFile() {
+  public static Optional<List<DownloadFileDescription>> download(final String url) {
     try (CloseableHttpClient client = HttpClients.custom().disableCookieManagement().build()) {
-      final HttpGet request = new HttpGet(locator);
+      final HttpGet request = new HttpGet(url);
       HttpProxy.addProxy(request);
       try (CloseableHttpResponse response = client.execute(request)) {
         final int status = response.getStatusLine().getStatusCode();
         if (status != HttpStatus.SC_OK) {
-          log.log(Level.WARNING, "Invalid map link '" + locator + "'. Server returned " + status);
+          log.log(Level.WARNING, "Invalid map link '" + url + "'. Server returned " + status);
           return Optional.empty();
         }
         return Optional.of(DownloadFileParser.parse(response.getEntity().getContent()));
@@ -62,13 +44,12 @@ public class DownloadRunnable {
     }
   }
 
-  private List<DownloadFileDescription> readLocalFile() {
-    final Path targetFile = Paths.get(locator);
-    try (InputStream inputStream = Files.newInputStream(targetFile)) {
-      return checkNotNull(DownloadFileParser.parse(inputStream));
+  public static Optional<List<DownloadFileDescription>> readLocalFile(final Path path) {
+    try (InputStream inputStream = Files.newInputStream(path)) {
+      return Optional.of(DownloadFileParser.parse(inputStream));
     } catch (final IOException e) {
-      log.log(Level.SEVERE, "Failed to read file at: " + targetFile.toAbsolutePath(), e);
-      return new ArrayList<>();
+      log.log(Level.SEVERE, "Failed to read file at: " + path.toAbsolutePath(), e);
+      return Optional.of(new ArrayList<>());
     }
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
@@ -1,7 +1,5 @@
 package games.strategy.engine.framework.map.download;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -47,7 +45,7 @@ public class DownloadRunnable {
 
   public static List<DownloadFileDescription> readLocalFile(final Path path) {
     try (InputStream inputStream = Files.newInputStream(path)) {
-      return checkNotNull(DownloadFileParser.parse(inputStream));
+      return DownloadFileParser.parse(inputStream);
     } catch (final IOException e) {
       log.log(Level.SEVERE, "Failed to read file at: " + path.toAbsolutePath(), e);
       return Collections.emptyList();

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
@@ -49,7 +49,7 @@ public class DownloadRunnable {
       return Optional.of(DownloadFileParser.parse(inputStream));
     } catch (final IOException e) {
       log.log(Level.SEVERE, "Failed to read file at: " + path.toAbsolutePath(), e);
-      return Optional.of(new ArrayList<>());
+      return Optional.of(Collections.emptyList());
     }
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
@@ -32,13 +32,13 @@ public class DownloadRunnable {
       try (CloseableHttpResponse response = client.execute(request)) {
         final int status = response.getStatusLine().getStatusCode();
         if (status != HttpStatus.SC_OK) {
-          log.log(Level.WARNING, "Invalid map link '" + url + "'. Server returned " + status);
+          log.warning("Invalid map link '" + url + "'. Server returned " + status);
           return Collections.emptyList();
         }
         return DownloadFileParser.parse(response.getEntity().getContent());
       }
     } catch (final IOException e) {
-      log.log(Level.SEVERE, "Error while downloading map download info.");
+      log.log(Level.SEVERE, "Error while downloading map download info.", e);
       return Collections.emptyList();
     }
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
@@ -8,13 +8,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 
-import org.apache.http.HttpStatus;
-import org.apache.http.client.methods.CloseableHttpResponse;
-import org.apache.http.client.methods.HttpGet;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-
-import games.strategy.engine.framework.system.HttpProxy;
 import lombok.extern.java.Log;
 
 /**
@@ -30,21 +23,8 @@ public class DownloadRunnable {
    * If an error occurs this will return an empty list.
    */
   public static List<DownloadFileDescription> download(final String url) {
-    try (CloseableHttpClient client = HttpClients.custom().disableCookieManagement().build()) {
-      final HttpGet request = new HttpGet(url);
-      HttpProxy.addProxy(request);
-      try (CloseableHttpResponse response = client.execute(request)) {
-        final int status = response.getStatusLine().getStatusCode();
-        if (status != HttpStatus.SC_OK) {
-          log.warning("Invalid map link '" + url + "'. Server returned " + status);
-          return Collections.emptyList();
-        }
-        return DownloadFileParser.parse(response.getEntity().getContent());
-      }
-    } catch (final IOException e) {
-      log.log(Level.SEVERE, "Error while downloading map download info.", e);
-      return Collections.emptyList();
-    }
+    return DownloadConfiguration.contentReader().download(url, DownloadFileParser::parse)
+        .orElseGet(Collections::emptyList);
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
@@ -25,6 +25,10 @@ public class DownloadRunnable {
 
   private DownloadRunnable() {}
 
+  /**
+   * Parses a file at the given URL into a List of {@link DownloadFileDescription}s.
+   * If an error occurs this will return an empty list.
+   */
   public static List<DownloadFileDescription> download(final String url) {
     try (CloseableHttpClient client = HttpClients.custom().disableCookieManagement().build()) {
       final HttpGet request = new HttpGet(url);
@@ -43,6 +47,10 @@ public class DownloadRunnable {
     }
   }
 
+  /**
+   * Parses a file at the given {@link Path} into a List of {@link DownloadFileDescription}s.
+   * If an error occurs this will return an empty list.
+   */
   public static List<DownloadFileDescription> readLocalFile(final Path path) {
     try (InputStream inputStream = Files.newInputStream(path)) {
       return DownloadFileParser.parse(inputStream);

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
@@ -1,12 +1,13 @@
 package games.strategy.engine.framework.map.download;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.logging.Level;
 
 import org.apache.http.HttpStatus;
@@ -26,7 +27,7 @@ public class DownloadRunnable {
 
   private DownloadRunnable() {}
 
-  public static Optional<List<DownloadFileDescription>> download(final String url) {
+  public static List<DownloadFileDescription> download(final String url) {
     try (CloseableHttpClient client = HttpClients.custom().disableCookieManagement().build()) {
       final HttpGet request = new HttpGet(url);
       HttpProxy.addProxy(request);
@@ -34,22 +35,22 @@ public class DownloadRunnable {
         final int status = response.getStatusLine().getStatusCode();
         if (status != HttpStatus.SC_OK) {
           log.log(Level.WARNING, "Invalid map link '" + url + "'. Server returned " + status);
-          return Optional.empty();
+          return Collections.emptyList();
         }
-        return Optional.of(DownloadFileParser.parse(response.getEntity().getContent()));
+        return DownloadFileParser.parse(response.getEntity().getContent());
       }
     } catch (final IOException e) {
       log.log(Level.SEVERE, "Error while downloading map download info file.");
-      return Optional.empty();
+      return Collections.emptyList();
     }
   }
 
-  public static Optional<List<DownloadFileDescription>> readLocalFile(final Path path) {
+  public static List<DownloadFileDescription> readLocalFile(final Path path) {
     try (InputStream inputStream = Files.newInputStream(path)) {
-      return Optional.of(DownloadFileParser.parse(inputStream));
+      return checkNotNull(DownloadFileParser.parse(inputStream));
     } catch (final IOException e) {
       log.log(Level.SEVERE, "Failed to read file at: " + path.toAbsolutePath(), e);
-      return Optional.of(Collections.emptyList());
+      return Collections.emptyList();
     }
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
@@ -28,11 +28,7 @@ public class MapDownloadController {
    */
   public static void checkDownloadedMapsAreLatest() {
     try {
-      final Optional<List<DownloadFileDescription>> allDownloads = ClientContext.getMapDownloadList();
-      if (!allDownloads.isPresent()) {
-        return;
-      }
-      final Collection<String> outOfDateMapNames = getOutOfDateMapNames(allDownloads.get());
+      final Collection<String> outOfDateMapNames = getOutOfDateMapNames(ClientContext.getMapDownloadList());
       if (!outOfDateMapNames.isEmpty()) {
         final StringBuilder text = new StringBuilder();
         text.append("<html>Some of the maps you have are out of date, and newer versions of those maps exist.<br><br>");

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyPropertyFetcherConfiguration.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyPropertyFetcherConfiguration.java
@@ -8,7 +8,7 @@ import games.strategy.engine.framework.map.download.DownloadConfiguration;
 public class LobbyPropertyFetcherConfiguration {
 
   private static final LobbyServerPropertiesFetcher lobbyServerPropertiesFetcher =
-      new LobbyServerPropertiesFetcher(url -> DownloadConfiguration.contentReader().downloadToFile(url));
+      new LobbyServerPropertiesFetcher(DownloadConfiguration.contentReader()::download);
 
   public static LobbyServerPropertiesFetcher lobbyServerPropertiesFetcher() {
     return lobbyServerPropertiesFetcher;

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyPropertyFileParser.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyPropertyFileParser.java
@@ -33,9 +33,9 @@ class LobbyPropertyFileParser {
   @VisibleForTesting
   static final String YAML_ERROR_MESSAGE = "error_message";
 
-  public static LobbyServerProperties parse(final InputStream fileContents, final Version currentVersion) {
+  public static LobbyServerProperties parse(final InputStream stream, final Version currentVersion) {
     final Map<String, Object> yamlProps =
-        OpenJsonUtils.toMap(matchCurrentVersion(loadYaml(fileContents), currentVersion));
+        OpenJsonUtils.toMap(matchCurrentVersion(loadYaml(stream), currentVersion));
 
     return LobbyServerProperties.builder()
         .host((String) yamlProps.get("host"))
@@ -56,8 +56,8 @@ class LobbyPropertyFileParser {
         .orElse(lobbyProps.getJSONObject(0));
   }
 
-  private static JSONArray loadYaml(final InputStream yamlContent) {
+  private static JSONArray loadYaml(final InputStream stream) {
     final Yaml yaml = new Yaml();
-    return new JSONArray(yaml.loadAs(yamlContent, List.class));
+    return new JSONArray(yaml.loadAs(stream, List.class));
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyPropertyFileParser.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyPropertyFileParser.java
@@ -2,6 +2,7 @@ package games.strategy.engine.lobby.client.login;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.io.InputStream;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -32,7 +33,7 @@ class LobbyPropertyFileParser {
   @VisibleForTesting
   static final String YAML_ERROR_MESSAGE = "error_message";
 
-  public static LobbyServerProperties parse(final String fileContents, final Version currentVersion) {
+  public static LobbyServerProperties parse(final InputStream fileContents, final Version currentVersion) {
     final Map<String, Object> yamlProps =
         OpenJsonUtils.toMap(matchCurrentVersion(loadYaml(fileContents), currentVersion));
 
@@ -55,7 +56,7 @@ class LobbyPropertyFileParser {
         .orElse(lobbyProps.getJSONObject(0));
   }
 
-  private static JSONArray loadYaml(final String yamlContent) {
+  private static JSONArray loadYaml(final InputStream yamlContent) {
     final Yaml yaml = new Yaml();
     return new JSONArray(yaml.loadAs(yamlContent, List.class));
   }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcher.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcher.java
@@ -22,12 +22,15 @@ import lombok.extern.java.Log;
  */
 @Log
 public final class LobbyServerPropertiesFetcher {
-  private final BiFunction<String, Function<InputStream, LobbyServerProperties>, Optional<LobbyServerProperties>> fileDownloader;
+  private final BiFunction<String, Function<InputStream, LobbyServerProperties>,
+      Optional<LobbyServerProperties>> fileDownloader;
   @Nullable
   private LobbyServerProperties lobbyServerProperties;
 
 
-  LobbyServerPropertiesFetcher(final BiFunction<String, Function<InputStream, LobbyServerProperties>, Optional<LobbyServerProperties>> fileDownloader) {
+  LobbyServerPropertiesFetcher(
+      final BiFunction<String, Function<InputStream, LobbyServerProperties>,
+          Optional<LobbyServerProperties>> fileDownloader) {
     this.fileDownloader = fileDownloader;
   }
 

--- a/game-core/src/test/java/games/strategy/engine/ClientContextIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/ClientContextIntegrationTest.java
@@ -2,7 +2,6 @@ package games.strategy.engine;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.core.Is.is;
 
 import org.junit.jupiter.api.Test;
 import org.triplea.test.common.Integration;

--- a/game-core/src/test/java/games/strategy/engine/ClientContextIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/ClientContextIntegrationTest.java
@@ -1,11 +1,16 @@
 package games.strategy.engine;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
+
+import java.util.List;
 
 import org.junit.jupiter.api.Test;
 import org.triplea.test.common.Integration;
 
+import games.strategy.engine.framework.map.download.DownloadFileDescription;
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 
 @Integration
@@ -16,6 +21,9 @@ class ClientContextIntegrationTest extends AbstractClientSettingTestCase {
     assertThat(ClientContext.downloadCoordinator(), notNullValue());
     assertThat(ClientContext.engineVersion(), notNullValue());
 
-    assertThat(ClientContext.getMapDownloadList(), notNullValue());
+    final List<DownloadFileDescription> list = ClientContext.getMapDownloadList();
+
+    assertThat(list, notNullValue());
+    assertThat(list, not(empty()));
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/ClientContextIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/ClientContextIntegrationTest.java
@@ -18,6 +18,5 @@ class ClientContextIntegrationTest extends AbstractClientSettingTestCase {
     assertThat(ClientContext.engineVersion(), notNullValue());
 
     assertThat(ClientContext.getMapDownloadList(), notNullValue());
-    assertThat(ClientContext.getMapDownloadList().isPresent(), is(true));
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/framework/map/download/ContentReaderTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/map/download/ContentReaderTest.java
@@ -76,9 +76,7 @@ final class ContentReaderTest extends AbstractClientSettingTestCase {
     }
 
     private void downloadToFile() throws Exception {
-      try (FileOutputStream os = new FileOutputStream(file)) {
-        ContentReader.downloadToFile(URI, os, client);
-      }
+      new ContentReader(() -> client).downloadToFile(URI, file);
     }
 
     private byte[] fileContent() throws Exception {

--- a/game-core/src/test/java/games/strategy/engine/framework/map/download/ContentReaderTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/map/download/ContentReaderTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;

--- a/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyPropertyFileParserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyPropertyFileParserTest.java
@@ -5,7 +5,10 @@ import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.stream.Collectors;
 
@@ -59,7 +62,7 @@ class LobbyPropertyFileParserTest {
     testProps.message = TestData.message;
     testProps.version = TestData.clientCurrentVersion;
 
-    final String yamlContents = newYaml(testProps);
+    final InputStream yamlContents = newYaml(testProps);
 
     final LobbyServerProperties result =
         LobbyPropertyFileParser.parse(yamlContents, new Version(TestData.clientCurrentVersion));
@@ -70,10 +73,10 @@ class LobbyPropertyFileParserTest {
     assertThat(result.getServerErrorMessage(), isPresentAndIs(TestData.errorMessage));
   }
 
-  private static String newYaml(final TestProps... testProps) {
-    return Arrays.stream(testProps)
+  private static ByteArrayInputStream newYaml(final TestProps... testProps) {
+    return new ByteArrayInputStream(Arrays.stream(testProps)
         .map(TestProps::toYaml)
-        .collect(Collectors.joining("\n"));
+        .collect(Collectors.joining("\n")).getBytes(StandardCharsets.UTF_8));
   }
 
   /**
@@ -82,7 +85,7 @@ class LobbyPropertyFileParserTest {
    */
   @Test
   void checkVersionSelection() {
-    final String yamlContents = newYaml(testDataSet());
+    final InputStream yamlContents = newYaml(testDataSet());
 
     final LobbyServerProperties result =
         LobbyPropertyFileParser.parse(yamlContents, new Version(TestData.clientCurrentVersion));

--- a/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyPropertyFileParserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyPropertyFileParserTest.java
@@ -62,10 +62,10 @@ class LobbyPropertyFileParserTest {
     testProps.message = TestData.message;
     testProps.version = TestData.clientCurrentVersion;
 
-    final InputStream yamlContents = newYaml(testProps);
+    final InputStream stream = newYaml(testProps);
 
     final LobbyServerProperties result =
-        LobbyPropertyFileParser.parse(yamlContents, new Version(TestData.clientCurrentVersion));
+        LobbyPropertyFileParser.parse(stream, new Version(TestData.clientCurrentVersion));
     assertThat(result.getHost(), is(TestData.host));
     assertThat(result.getPort(), is(Integer.valueOf(TestData.port)));
     assertThat(result.getHttpServerUri(), is(TestData.httpHostUri));
@@ -73,7 +73,7 @@ class LobbyPropertyFileParserTest {
     assertThat(result.getServerErrorMessage(), isPresentAndIs(TestData.errorMessage));
   }
 
-  private static ByteArrayInputStream newYaml(final TestProps... testProps) {
+  private static InputStream newYaml(final TestProps... testProps) {
     return new ByteArrayInputStream(Arrays.stream(testProps)
         .map(TestProps::toYaml)
         .collect(Collectors.joining("\n")).getBytes(StandardCharsets.UTF_8));
@@ -85,10 +85,10 @@ class LobbyPropertyFileParserTest {
    */
   @Test
   void checkVersionSelection() {
-    final InputStream yamlContents = newYaml(testDataSet());
+    final InputStream stream = newYaml(testDataSet());
 
     final LobbyServerProperties result =
-        LobbyPropertyFileParser.parse(yamlContents, new Version(TestData.clientCurrentVersion));
+        LobbyPropertyFileParser.parse(stream, new Version(TestData.clientCurrentVersion));
 
     assertThat(result.getHost(), is(TestData.hostOther));
     assertThat(result.getPort(), is(Integer.valueOf(TestData.portOther)));

--- a/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcherTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcherTest.java
@@ -29,8 +29,8 @@ import games.strategy.util.Version;
 @ExtendWith(MockitoExtension.class)
 class LobbyServerPropertiesFetcherTest {
   @Mock
-  private BiFunction<String, Function<InputStream, LobbyServerProperties>, Optional<LobbyServerProperties>>
-      mockFileDownloader;
+  private BiFunction<String, Function<InputStream, LobbyServerProperties>,
+      Optional<LobbyServerProperties>> mockFileDownloader;
 
   private LobbyServerPropertiesFetcher testObj;
 
@@ -46,9 +46,6 @@ class LobbyServerPropertiesFetcherTest {
      */
     @Test
     void happyCase() {
-
-
-
       when(mockFileDownloader.apply(eq(TestData.url), any())).thenReturn(Optional.of(TestData.lobbyServerProperties));
 
       final Optional<LobbyServerProperties> result = testObj.downloadAndParseRemoteFile(TestData.url,
@@ -67,6 +64,7 @@ class LobbyServerPropertiesFetcherTest {
       assertThat(result, isEmpty());
     }
   }
+
 
   @Nested
   final class GetTestOverridePropertiesTest {
@@ -167,6 +165,7 @@ class LobbyServerPropertiesFetcherTest {
       thenResultHasHostAndPort("foo", 4242);
     }
   }
+
 
   private interface TestData {
     Version version = new Version("0.0.0.0");

--- a/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcherTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcherTest.java
@@ -5,11 +5,14 @@ import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
-import java.io.File;
+import java.io.InputStream;
 import java.net.URI;
 import java.util.Optional;
+import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -26,7 +29,8 @@ import games.strategy.util.Version;
 @ExtendWith(MockitoExtension.class)
 class LobbyServerPropertiesFetcherTest {
   @Mock
-  private Function<String, Optional<File>> mockFileDownloader;
+  private BiFunction<String, Function<InputStream, LobbyServerProperties>, Optional<LobbyServerProperties>>
+      mockFileDownloader;
 
   private LobbyServerPropertiesFetcher testObj;
 
@@ -41,27 +45,24 @@ class LobbyServerPropertiesFetcherTest {
      * Happy case test path, download file, parse it, return values parsed.
      */
     @Test
-    void happyCase() throws Exception {
-      givenHappyCase();
+    void happyCase() {
+
+
+
+      when(mockFileDownloader.apply(eq(TestData.url), any())).thenReturn(Optional.of(TestData.lobbyServerProperties));
 
       final Optional<LobbyServerProperties> result = testObj.downloadAndParseRemoteFile(TestData.url,
-          TestData.version, (a, b) -> TestData.lobbyServerProperties);
+          TestData.version, (a, b) -> null);
 
       assertThat(result, isPresentAndIs(TestData.lobbyServerProperties));
     }
 
-    private void givenHappyCase() throws Exception {
-      final File temp = File.createTempFile("temp", "tmp");
-      temp.deleteOnExit();
-      when(mockFileDownloader.apply(TestData.url)).thenReturn(Optional.of(temp));
-    }
-
     @Test
     void throwsOnDownloadFailure() {
-      when(mockFileDownloader.apply(TestData.url)).thenReturn(Optional.empty());
+      when(mockFileDownloader.apply(eq(TestData.url), any())).thenReturn(Optional.empty());
 
       final Optional<LobbyServerProperties> result =
-          testObj.downloadAndParseRemoteFile(TestData.url, TestData.version, (a, b) -> TestData.lobbyServerProperties);
+          testObj.downloadAndParseRemoteFile(TestData.url, TestData.version, (a, b) -> null);
 
       assertThat(result, isEmpty());
     }


### PR DESCRIPTION
## Overview
I originally wanted this PR to be a 2-liner change, but suddenly I discovered ugly code and couldn't stop myself from cleaning up the mess.

## Functional Changes
The Map Information File is no longer being downloaded to an intermediate File first, but instead piped directly into the parser to reduce latency.

## Manual Testing Performed
Verified all the maps are being displayed correctly.