### PR TITLE
Get Spotless from Gradle plugin portal

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,8 @@
 import net.ltgt.gradle.errorprone.CheckSeverity
 
-// TODO: Remove once Spotless 3.17.0 is published to Gradle plugin portal and replace with entry under plugins
-// see https://github.com/triplea-game/triplea/pull/4569#discussion_r247326720
-buildscript {
-    repositories {
-        jcenter()
-    }
-
-    dependencies {
-        classpath 'com.diffplug.spotless:spotless-plugin-gradle:3.17.0'
-    }
-}
-
 plugins {
     id 'java'
+    id 'com.diffplug.gradle.spotless' version '3.17.0' apply false
     id 'com.github.ben-manes.versions' version '0.20.0'
     id 'io.franzbecker.gradle-lombok' version '1.14' apply false
     id 'net.ltgt.errorprone' version '0.6.1' apply false


### PR DESCRIPTION
## Overview

Resolves the TODO added in https://github.com/triplea-game/triplea/pull/4569/#discussion_r247326720.  Version 3.17.0 of the Spotless Gradle plugin is now available on the Gradle plugin portal.

## Functional Changes

None.

## Manual Testing Performed

Verified I could run `spotlessCheck` and `spotlessApply` locally.