### PR TITLE
Disallow unused elements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ subprojects {
     apply plugin: 'checkstyle'
     apply plugin: 'jacoco'
     apply plugin: 'java'
+    apply plugin: 'pmd'
     apply plugin: 'com.diffplug.gradle.spotless'
     apply plugin: 'net.ltgt.errorprone'
     apply plugin: 'io.franzbecker.gradle-lombok'
@@ -182,6 +183,12 @@ subprojects {
     lombok {
         version = '1.18.4'
         sha256 = '39f3922deb679b1852af519eb227157ef2dd0a21eec3542c8ce1b45f2df39742'
+    }
+
+    pmd {
+        consoleOutput = true
+        ruleSetFiles = files(rootProject.file('config/pmd/pmd.xml'))
+        ruleSets = []
     }
 
     spotless {

--- a/config/pmd/pmd.xml
+++ b/config/pmd/pmd.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<ruleset name="TripleA"
+    xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 https://pmd.sourceforge.io/ruleset_2_0_0.xsd">
+
+    <description>TripleA custom rules.</description>
+
+    <rule ref="category/java/bestpractices.xml/UnusedFormalParameter"/>
+    <rule ref="category/java/bestpractices.xml/UnusedLocalVariable"/>
+    <rule ref="category/java/bestpractices.xml/UnusedPrivateField"/>
+    <rule ref="category/java/bestpractices.xml/UnusedPrivateMethod">
+        <properties>
+            <property name="ignoredAnnotations" value="java.lang.Deprecated|javafx.fxml.FXML"/>
+        </properties>
+    </rule>
+</ruleset>

--- a/game-core/src/main/java/games/strategy/triplea/player/AbstractBasePlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/player/AbstractBasePlayer.java
@@ -23,8 +23,6 @@ public abstract class AbstractBasePlayer implements IGamePlayer {
   private PlayerId playerId;
   @Getter
   private IPlayerBridge playerBridge;
-  private boolean isStoppedGame = false;
-
 
   public AbstractBasePlayer(final String name) {
     this.name = name;
@@ -79,7 +77,5 @@ public abstract class AbstractBasePlayer implements IGamePlayer {
   }
 
   @Override
-  public void stopGame() {
-    isStoppedGame = true;
-  }
+  public void stopGame() {}
 }

--- a/game-core/src/test/java/swinglib/JComboBoxBuilderTest.java
+++ b/game-core/src/test/java/swinglib/JComboBoxBuilderTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.awt.Component;
-import java.awt.event.ItemEvent;
 import java.util.Arrays;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -17,15 +16,8 @@ import org.hamcrest.MatcherAssert;
 import org.hamcrest.core.Is;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-@ExtendWith(MockitoExtension.class)
 class JComboBoxBuilderTest {
-  @Mock
-  private ItemEvent mockItemEvent;
-
   @Test
   void builderNoItemsSpecified() {
     assertThrows(IllegalStateException.class, JComboBoxBuilder.builder(Object.class)::build);


### PR DESCRIPTION
## Overview

Adds PMD to the Gradle build to disallow:

* Unused formal parameters (private methods only)
* Unused local variables
* Unused private fields
* Unused private methods

## Functional Changes

None.

## Refactoring Changes

* Removed the write-only `AbstractBasePlayer#isStoppedGame` field.
* Removed the unused `JComboBoxBuilderTest#mockItemEvent` field.

## Manual Testing Performed

Verified the build fails if one of the four configured PMD rules is violated.

## Additional Review Notes

The following warning will now appear several times in the build:

> This analysis could be faster, please consider using Incremental Analysis: https://pmd.github.io/pmd-6.8.0/pmd_userdocs_incremental_analysis.html

Currently, there is no way to explicitly enable or disable the PMD cache via the Gradle plugin, so it's not possible to get rid of the warning.  gradle/gradle#8277 is a short-term proposal to disable the cache in the plugin (see the issue description for a history of long-term solutions to this problem); hopefully it will be addressed soon.