### PR TITLE
Prevent utility classes from being instantiated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,6 +123,7 @@ subprojects {
             check 'NonAtomicVolatileUpdate', CheckSeverity.ERROR
             check 'OperatorPrecedence', CheckSeverity.ERROR
             check 'ParameterName', CheckSeverity.OFF // workaround for https://github.com/google/error-prone/issues/780
+            check 'PrivateConstructorForUtilityClass', CheckSeverity.ERROR
             check 'ReferenceEquality', CheckSeverity.ERROR
             check 'StringSplitter', CheckSeverity.ERROR
             check 'ThreadPriorityCheck', CheckSeverity.ERROR

--- a/game-core/src/main/java/games/strategy/debug/error/reporting/ConfirmationDialogController.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/ConfirmationDialogController.java
@@ -20,7 +20,8 @@ import swinglib.JPanelBuilder;
  * This controller is responsible for showing success/failure confirmation dialogs
  * after an error report has been submitted.
  */
-class ConfirmationDialogController {
+final class ConfirmationDialogController {
+  private ConfirmationDialogController() {}
 
   static void showFailureConfirmation(final ServiceResponse<ErrorReportResponse> response) {
     SwingUtilities.invokeLater(() -> doShowFailureConfirmation(response));

--- a/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportConfiguration.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportConfiguration.java
@@ -16,7 +16,8 @@ import games.strategy.engine.lobby.client.login.LobbyPropertyFetcherConfiguratio
 import games.strategy.engine.lobby.client.login.LobbyServerProperties;
 import games.strategy.triplea.settings.ClientSetting;
 
-class ErrorReportConfiguration {
+final class ErrorReportConfiguration {
+  private ErrorReportConfiguration() {}
 
   /**
    * Creates a 'report handler', this is the component invoked when we have collected all data from

--- a/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportWindow.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportWindow.java
@@ -32,9 +32,11 @@ import swinglib.JTextAreaBuilder;
  * The error data is supplied automatically on error message or when shown from console
  * </p>
  */
-public class ErrorReportWindow {
+public final class ErrorReportWindow {
 
   private static final int MIN_SUBMISSION_LENGTH = 10;
+
+  private ErrorReportWindow() {}
 
   public static void showWindow() {
     showWindow(null);

--- a/game-core/src/main/java/games/strategy/debug/error/reporting/PreviewWindow.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/PreviewWindow.java
@@ -13,7 +13,8 @@ import swinglib.JTextAreaBuilder;
 /**
  * A simple window printing a representation of the bug report upload payload.
  */
-class PreviewWindow {
+final class PreviewWindow {
+  private PreviewWindow() {}
 
   static JFrame build(final JFrame parent, final String previewText) {
     final JFrame frame = JFrameBuilder.builder()

--- a/game-core/src/main/java/games/strategy/engine/auto/update/TutorialMapCheck.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/update/TutorialMapCheck.java
@@ -4,7 +4,9 @@ import games.strategy.engine.framework.map.download.DownloadMapsWindow;
 import games.strategy.engine.framework.map.download.MapDownloadController;
 import games.strategy.ui.SwingComponents;
 
-class TutorialMapCheck {
+final class TutorialMapCheck {
+  private TutorialMapCheck() {}
+
   static void checkForTutorialMap() {
     final boolean promptToDownloadTutorialMap = MapDownloadController.shouldPromptToDownloadTutorialMap();
     MapDownloadController.preventPromptToDownloadTutorialMap();

--- a/game-core/src/main/java/games/strategy/engine/auto/update/UpdateChecks.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/update/UpdateChecks.java
@@ -10,7 +10,8 @@ import games.strategy.engine.framework.map.download.MapDownloadController;
  * Runs background update checks and would prompt user if anything needs to be updated.
  * This class and related ones will control the frequency of how often we prompt the user.
  */
-public class UpdateChecks {
+public final class UpdateChecks {
+  private UpdateChecks() {}
 
   public static void launch() {
     new Thread(UpdateChecks::checkForUpdates).start();

--- a/game-core/src/main/java/games/strategy/engine/data/Unit.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Unit.java
@@ -129,8 +129,10 @@ public class Unit extends GameDataComponent implements DynamicallyModifiable {
    * any serious issues.
    * TODO: fix the root cause of this deserialization issue (probably a circular dependency somewhere)
    */
-  public static class UnitDeserializationErrorLazyMessage {
+  public static final class UnitDeserializationErrorLazyMessage {
     private static boolean shownError = false;
+
+    private UnitDeserializationErrorLazyMessage() {}
 
     private static void printError(final String errorMessage) {
       if (!shownError) {

--- a/game-core/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
@@ -15,7 +15,8 @@ import lombok.extern.java.Log;
  * To hold various static utility methods for running a java program.
  */
 @Log
-class ProcessRunnerUtil {
+final class ProcessRunnerUtil {
+  private ProcessRunnerUtil() {}
 
   static void populateBasicJavaArgs(final List<String> commands) {
     final String javaCommand = SystemProperties.getJavaHome() + File.separator + "bin" + File.separator + "java";

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
@@ -21,7 +21,8 @@ import lombok.extern.java.Log;
 
 /** Controller for in-game map download actions. */
 @Log
-public class MapDownloadController {
+public final class MapDownloadController {
+  private MapDownloadController() {}
 
   /**
    * Prompts user to download map updates if maps are out of date.

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LauncherFactory.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LauncherFactory.java
@@ -13,7 +13,8 @@ import games.strategy.engine.random.PlainRandomSource;
 /**
  * Factory class to create instances of {@code ILauncher}.
  */
-public class LauncherFactory {
+public final class LauncherFactory {
+  private LauncherFactory() {}
 
   /**
    * Creates a launcher for a single player local (no network) game.

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/login/HmacSha512Authenticator.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/login/HmacSha512Authenticator.java
@@ -26,6 +26,8 @@ import com.google.common.collect.Maps;
  * </p>
  */
 final class HmacSha512Authenticator {
+  private HmacSha512Authenticator() {}
+
   @VisibleForTesting
   interface ChallengePropertyNames {
     String NONCE = "authenticator/hmac-sha512/nonce";

--- a/game-core/src/main/java/games/strategy/engine/framework/system/HttpProxy.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/system/HttpProxy.java
@@ -23,7 +23,8 @@ import lombok.extern.java.Log;
  * Provides methods to configure the proxy to use for HTTP requests.
  */
 @Log
-public class HttpProxy {
+public final class HttpProxy {
+  private HttpProxy() {}
 
   /**
    * Set of possible proxy options. Users can change between these via settings.

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/PropertiesSelector.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/PropertiesSelector.java
@@ -16,7 +16,9 @@ import games.strategy.util.Interruptibles;
 /**
  * Wrapper for properties selection window.
  */
-public class PropertiesSelector {
+public final class PropertiesSelector {
+  private PropertiesSelector() {}
+
   /**
    * Displays a property selection window.
    *

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyPropertyFetcherConfiguration.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyPropertyFetcherConfiguration.java
@@ -5,10 +5,12 @@ import games.strategy.engine.framework.map.download.DownloadConfiguration;
 /**
  * Responsible for constructing a {@code LobbyServerPropertiesFetcher}.
  */
-public class LobbyPropertyFetcherConfiguration {
+public final class LobbyPropertyFetcherConfiguration {
 
   private static final LobbyServerPropertiesFetcher lobbyServerPropertiesFetcher =
       new LobbyServerPropertiesFetcher(DownloadConfiguration.contentReader()::download);
+
+  private LobbyPropertyFetcherConfiguration() {}
 
   public static LobbyServerPropertiesFetcher lobbyServerPropertiesFetcher() {
     return lobbyServerPropertiesFetcher;

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyPropertyFileParser.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyPropertyFileParser.java
@@ -20,7 +20,7 @@ import games.strategy.util.Version;
  * Parses a downloaded lobby properties file (yaml format expected).
  * Lobby properties include IP address and port of the lobby.
  */
-class LobbyPropertyFileParser {
+final class LobbyPropertyFileParser {
 
   @VisibleForTesting
   static final String YAML_HOST = "host";
@@ -32,6 +32,8 @@ class LobbyPropertyFileParser {
   static final String YAML_MESSAGE = "message";
   @VisibleForTesting
   static final String YAML_ERROR_MESSAGE = "error_message";
+
+  private LobbyPropertyFileParser() {}
 
   public static LobbyServerProperties parse(final InputStream stream, final Version currentVersion) {
     final Map<String, Object> yamlProps =

--- a/game-core/src/main/java/games/strategy/engine/message/MessageContext.java
+++ b/game-core/src/main/java/games/strategy/engine/message/MessageContext.java
@@ -5,9 +5,11 @@ import games.strategy.net.INode;
 /**
  * Information useful on invocation of remote networked events.
  */
-public class MessageContext {
+public final class MessageContext {
   // the current caller of the remote or channel
   private static final ThreadLocal<INode> sender = new ThreadLocal<>();
+
+  private MessageContext() {}
 
   // should only be called by EndPoint
   public static void setSenderNodeForThread(final INode node) {

--- a/game-core/src/main/java/games/strategy/engine/message/RemoteInterfaceHelper.java
+++ b/game-core/src/main/java/games/strategy/engine/message/RemoteInterfaceHelper.java
@@ -5,7 +5,9 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.stream.IntStream;
 
-class RemoteInterfaceHelper {
+final class RemoteInterfaceHelper {
+  private RemoteInterfaceHelper() {}
+
   static int getNumber(final String methodName, final Class<?>[] argTypes, final Class<?> remoteInterface) {
     final Method[] methods = remoteInterface.getMethods();
     Arrays.sort(methods, methodComparator);

--- a/game-core/src/main/java/games/strategy/net/IpFinder.java
+++ b/game-core/src/main/java/games/strategy/net/IpFinder.java
@@ -32,7 +32,9 @@ import games.strategy.util.Util;
  * some tests, the 1st ip tends to be the IP used by the gateway to connect to the net.
  * This means that TripleA will still work.
  */
-public class IpFinder {
+public final class IpFinder {
+  private IpFinder() {}
+
   /**
    * We iterate through an enumeration of network interfaces on the machine
    * and picks the first IP that is not a loopback and not a link local and not private.

--- a/game-core/src/main/java/games/strategy/sound/SoundPath.java
+++ b/game-core/src/main/java/games/strategy/sound/SoundPath.java
@@ -9,7 +9,7 @@ import java.util.stream.Collectors;
 /**
  * Contains the sound file names and the directory of all sound files.
  */
-public class SoundPath {
+public final class SoundPath {
   // MAKE SURE TO ADD NEW SOUNDS TO THE getAllSoundOptions() METHOD! (or else the user's preference will not be saved)
 
   // standard sounds (files can be found in corresponding data/... folder to this package)
@@ -75,6 +75,8 @@ public class SoundPath {
   public static final String CLIP_TERRITORY_CAPTURE_SEA = "territory_capture_sea";
   public static final String CLIP_USER_ACTION_FAILURE = "user_action_failure";
   public static final String CLIP_USER_ACTION_SUCCESSFUL = "user_action_successful";
+
+  private SoundPath() {}
 
   public static Set<String> getAllSoundOptions() {
     return getAllSoundOptionsWithDescription().keySet();

--- a/game-core/src/main/java/games/strategy/triplea/ai/AiPoliticalUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AiPoliticalUtils.java
@@ -21,7 +21,9 @@ import games.strategy.util.CollectionUtils;
  * state if it is free with everyone this AI will not go through a different Neutral state to reach a War state
  * (i.e. go from NAP to Peace to War).
  */
-public class AiPoliticalUtils {
+public final class AiPoliticalUtils {
+  private AiPoliticalUtils() {}
+
   public static List<PoliticalActionAttachment> getPoliticalActionsTowardsWar(final PlayerId id,
       final Map<ICondition, Boolean> testedConditions, final GameData data) {
     final List<PoliticalActionAttachment> acceptableActions = new ArrayList<>();

--- a/game-core/src/main/java/games/strategy/triplea/ai/AiUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AiUtils.java
@@ -22,7 +22,8 @@ import games.strategy.util.CollectionUtils;
 /**
  * Handy utility methods for the writers of an AI.
  */
-public class AiUtils {
+public final class AiUtils {
+  private AiUtils() {}
 
   /**
    * Returns a comparator that sorts cheaper units before expensive ones.

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProData.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProData.java
@@ -23,7 +23,7 @@ import games.strategy.util.IntegerMap;
 /**
  * Pro AI data.
  */
-public class ProData {
+public final class ProData {
 
   private static ProAi proAi;
   private static GameData data;
@@ -39,6 +39,8 @@ public class ProData {
   public static IntegerMap<UnitType> unitValueMap = new IntegerMap<>();
   public static ProPurchaseOptionMap purchaseOptions = null;
   public static double minCostPerHitPoint = Double.MAX_VALUE;
+
+  private ProData() {}
 
   public static void initialize(final ProAi proAi) {
     hiddenInitialize(proAi, proAi.getGameData(), proAi.getPlayerId(), false);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
@@ -39,6 +39,7 @@ import games.strategy.util.PredicateBuilder;
  * Pro tech AI.
  */
 final class ProTechAi {
+  private ProTechAi() {}
 
   static void tech(final ITechDelegate techDelegate, final GameData data, final PlayerId player) {
     if (!Properties.getWW2V3TechModel(data)) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogUi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogUi.java
@@ -9,10 +9,12 @@ import games.strategy.triplea.ui.TripleAFrame;
 /**
  * Class to manage log window display.
  */
-public class ProLogUi {
+public final class ProLogUi {
   private static ProLogWindow settingsWindow = null;
   private static String currentName = "";
   private static int currentRound = 0;
+
+  private ProLogUi() {}
 
   public static void initialize(final TripleAFrame frame) {
     if (!SwingUtilities.isEventDispatchThread()) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProMetricUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProMetricUtils.java
@@ -6,8 +6,10 @@ import games.strategy.util.IntegerMap;
 /**
  * Pro AI metrics.
  */
-public class ProMetricUtils {
+public final class ProMetricUtils {
   private static final IntegerMap<ProductionRule> totalPurchaseMap = new IntegerMap<>();
+
+  private ProMetricUtils() {}
 
   public static void collectPurchaseStats(final IntegerMap<ProductionRule> purchaseMap) {
     totalPurchaseMap.add(purchaseMap);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
@@ -39,7 +39,9 @@ import games.strategy.util.CollectionUtils;
 /**
  * Pro AI simulate turn utilities.
  */
-public class ProSimulateTurnUtils {
+public final class ProSimulateTurnUtils {
+  private ProSimulateTurnUtils() {}
+
   /**
    * Simulates all pending battles in {@code data}. The simulation results are written as changes to
    * {@code delegateBridge}.

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
@@ -29,10 +29,12 @@ import games.strategy.util.CollectionUtils;
 /**
  * Pro AI battle utilities.
  */
-public class ProBattleUtils {
+public final class ProBattleUtils {
 
   public static final int SHORT_RANGE = 2;
   public static final int MEDIUM_RANGE = 3;
+
+  private ProBattleUtils() {}
 
   /**
    * Return {@code true} if the specified battle would result in an overwhelming win for the attacker. An overwhelming

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -18,7 +18,8 @@ import games.strategy.triplea.delegate.TerritoryEffectHelper;
 /**
  * Pro AI matches.
  */
-public class ProMatches {
+public final class ProMatches {
+  private ProMatches() {}
 
   public static Predicate<Territory> territoryCanLandAirUnits(final PlayerId player, final GameData data,
       final boolean isCombatMove, final List<Territory> enemyTerritories, final List<Territory> alliedTerritories) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -27,7 +27,9 @@ import games.strategy.util.Tuple;
 /**
  * Pro AI move utilities.
  */
-public class ProMoveUtils {
+public final class ProMoveUtils {
+  private ProMoveUtils() {}
+
   /**
    * Calculates normal movement routes (e.g. land, air, sea attack routes, not including amphibious, bombardment, or
    * strategic bombing raid attack routes).

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
@@ -43,7 +43,8 @@ import games.strategy.util.CollectionUtils;
 /**
  * Pro AI purchase utilities.
  */
-public class ProPurchaseUtils {
+public final class ProPurchaseUtils {
+  private ProPurchaseUtils() {}
 
   public static List<ProPurchaseOption> findPurchaseOptionsForTerritory(final PlayerId player,
       final List<ProPurchaseOption> purchaseOptions, final Territory t, final boolean isBid) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
@@ -22,7 +22,9 @@ import games.strategy.triplea.delegate.UnitBattleComparator;
 /**
  * Pro AI attack options utilities.
  */
-public class ProSortMoveOptionsUtils {
+public final class ProSortMoveOptionsUtils {
+  private ProSortMoveOptionsUtils() {}
+
   /**
    * Returns a copy of {@code unitAttackOptions} sorted by number of move options, then by cost of unit, then by unit
    * type name.

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -21,10 +21,12 @@ import games.strategy.util.CollectionUtils;
 /**
  * Pro AI battle utilities.
  */
-public class ProTerritoryValueUtils {
+public final class ProTerritoryValueUtils {
 
   private static final int MIN_FACTORY_CHECK_DISTANCE = 9;
   private static final int MAX_FACTORY_CHECK_DISTANCE = 30;
+
+  private ProTerritoryValueUtils() {}
 
   /**
    * Returns the relative value of attacking the specified territory compared to other territories.

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
@@ -30,7 +30,8 @@ import games.strategy.util.CollectionUtils;
 /**
  * Pro AI transport utilities.
  */
-public class ProTransportUtils {
+public final class ProTransportUtils {
+  private ProTransportUtils() {}
 
   public static int findMaxMovementForTransports(final List<ProPurchaseOption> seaTransportPurchaseOptions) {
     int maxMovement = 2;

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
@@ -29,7 +29,8 @@ import games.strategy.util.Interruptibles;
 /**
  * Pro AI utilities (these are very general and maybe should be moved into delegate or engine).
  */
-public class ProUtils {
+public final class ProUtils {
+  private ProUtils() {}
 
   public static Map<Unit, Territory> newUnitTerritoryMap() {
     final Map<Unit, Territory> unitTerritoryMap = new HashMap<>();

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/Utils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/Utils.java
@@ -15,7 +15,8 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.util.CollectionUtils;
 
-class Utils {
+final class Utils {
+  private Utils() {}
 
   static List<Unit> getUnitsUpToStrength(final double maxStrength, final Collection<Unit> units,
       final boolean sea) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -32,8 +32,10 @@ import games.strategy.util.IntegerMap;
 /**
  * Provides static methods for evaluating movement of air units.
  */
-public class AirMovementValidator {
+public final class AirMovementValidator {
   public static final String NOT_ALL_AIR_UNITS_CAN_LAND = "Not all air units can land";
+
+  private AirMovementValidator() {}
 
   // TODO: this class does a pretty good job already, but could be improved by having the carriers that are potentially
   // moved also look for any owned air units that are in sea zones without carriers. these would be air units that have

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DelegateFinder.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DelegateFinder.java
@@ -6,7 +6,9 @@ import games.strategy.engine.delegate.IDelegate;
 /**
  * A collection of methods for obtaining various types of delegate instances from the game data.
  */
-public class DelegateFinder {
+public final class DelegateFinder {
+  private DelegateFinder() {}
+
   private static IDelegate findDelegate(final GameData data, final String delegateName) {
     final IDelegate delegate = data.getDelegateList().getDelegate(delegateName);
     if (delegate == null) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -24,7 +24,9 @@ import games.strategy.util.Triple;
 /**
  * Provides some static methods for validating game edits.
  */
-class EditValidator {
+final class EditValidator {
+  private EditValidator() {}
+
   private static String validateTerritoryBasic(final GameData data, final Territory territory) {
     // territory cannot be in an UndoableMove route
     final List<UndoableMove> moves = DelegateFinder.moveDelegate(data).getMovesMade();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TerritoryEffectHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TerritoryEffectHelper.java
@@ -17,7 +17,9 @@ import games.strategy.triplea.attachments.TerritoryEffectAttachment;
 /**
  * Placeholder for all calculations to do with TerritoryEffects.
  */
-public class TerritoryEffectHelper {
+public final class TerritoryEffectHelper {
+  private TerritoryEffectHelper() {}
+
   public static Collection<TerritoryEffect> getEffects(final Territory location) {
     final TerritoryAttachment ta = TerritoryAttachment.get(location);
     return (ta != null) ? ta.getTerritoryEffect() : new ArrayList<>();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UnitComparator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UnitComparator.java
@@ -16,7 +16,9 @@ import games.strategy.triplea.util.TransportUtils;
 /**
  * A collection of comparators for sorting units based on various heuristics.
  */
-public class UnitComparator {
+public final class UnitComparator {
+  private UnitComparator() {}
+
   static Comparator<Unit> getLowestToHighestMovementComparator() {
     return Comparator.comparing(TripleAUnit::get,
         Comparator.comparingInt(TripleAUnit::getMovementLeft));

--- a/game-core/src/main/java/games/strategy/triplea/ui/PlayersPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PlayersPanel.java
@@ -13,7 +13,8 @@ import swinglib.JPanelBuilder;
 /**
  * Panel to show who is playing which players.
  */
-public class PlayersPanel {
+public final class PlayersPanel {
+  private PlayersPanel() {}
 
   /**
    * Displays a dialog that shows which node (user) is controlling each player (nation, power, etc.).

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryDrawable.java
@@ -16,6 +16,8 @@ import games.strategy.ui.Util;
  * of {@link Paint} provided by the subclass to fill the territory interior.
  */
 public abstract class TerritoryDrawable {
+  protected TerritoryDrawable() {}
+
   protected static void draw(final Rectangle bounds, final Graphics2D graphics, final MapData mapData,
       final Territory territory, final Paint territoryPaint) {
     final List<Polygon> polys = mapData.getPolygons(territory);

--- a/game-core/src/main/java/games/strategy/triplea/util/BonusIncomeUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/BonusIncomeUtils.java
@@ -11,7 +11,8 @@ import games.strategy.util.IntegerMap;
 /**
  * Provides methods that assist with player bonus income.
  */
-public class BonusIncomeUtils {
+public final class BonusIncomeUtils {
+  private BonusIncomeUtils() {}
 
   /**
    * Add bonus income based on the player's set percentage for all resources.

--- a/game-core/src/main/java/games/strategy/triplea/util/TransportUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/TransportUtils.java
@@ -27,7 +27,8 @@ import games.strategy.util.IntegerMap;
 /**
  * Utilities for loading/unloading various types of transports.
  */
-public class TransportUtils {
+public final class TransportUtils {
+  private TransportUtils() {}
 
   /**
    * Returns a map of unit -> transport.

--- a/game-core/src/main/java/games/strategy/ui/SwingComponents.java
+++ b/game-core/src/main/java/games/strategy/ui/SwingComponents.java
@@ -49,9 +49,11 @@ import games.strategy.triplea.UrlConstants;
  * Wrapper/utility class to give Swing components a nicer API. This class is to help extract pure UI code out of
  * the rest of the code base. This also gives us a cleaner interface between UI and the rest of the code.
  */
-public class SwingComponents {
+public final class SwingComponents {
   private static final String PERIOD = ".";
   private static final Collection<String> visiblePrompts = new HashSet<>();
+
+  private SwingComponents() {}
 
   /**
    * Enum for swing codes that represent key events. In this case holding control or the meta keys.

--- a/game-core/src/main/java/games/strategy/ui/SystemClipboard.java
+++ b/game-core/src/main/java/games/strategy/ui/SystemClipboard.java
@@ -6,7 +6,8 @@ import java.awt.datatransfer.StringSelection;
 /**
  * A utility for interacting with the system clipboard, humble object pattern.
  */
-public class SystemClipboard {
+public final class SystemClipboard {
+  private SystemClipboard() {}
 
   public static void setClipboardContents(final String contents) {
     final StringSelection select = new StringSelection(contents);

--- a/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
+++ b/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
@@ -15,7 +15,7 @@ import lombok.extern.java.Log;
  * local system.
  */
 @Log
-public class LocalizeHtml {
+public final class LocalizeHtml {
   public static final String ASSET_IMAGE_FOLDER = "doc/images/";
   public static final String ASSET_IMAGE_NOT_FOUND = "notFound.png";
   /*
@@ -30,6 +30,8 @@ public class LocalizeHtml {
   public static final String PATTERN_HTML_IMG_TAG = "(?i)<img([^>]+)/>";
   /* Match the src attribute */
   public static final String PATTERN_HTML_IMG_SRC_TAG = "\\s*(?i)src\\s*=\\s*(\"([^\"]*\")|'[^']*'|([^'\">\\s]+))";
+
+  private LocalizeHtml() {}
 
   /**
    * This is only useful once we are IN a game. Before we go into the game, resource loader will either be null, or be

--- a/game-core/src/main/java/swinglib/DialogBuilder.java
+++ b/game-core/src/main/java/swinglib/DialogBuilder.java
@@ -16,7 +16,8 @@ import lombok.RequiredArgsConstructor;
  * Type-safe builder to create a swing dialog confirmation runnable. When the runnable is executed a modal
  * yes/no confirmation dialog will be shown to the user, if yes is clicked the confirm action will be executed.
  */
-public class DialogBuilder {
+public final class DialogBuilder {
+  private DialogBuilder() {}
 
   public static WithParentBuilder builder() {
     return new WithParentBuilder();

--- a/game-core/src/main/java/swinglib/DocumentListenerBuilder.java
+++ b/game-core/src/main/java/swinglib/DocumentListenerBuilder.java
@@ -12,6 +12,7 @@ import javax.swing.text.JTextComponent;
  * should reliably trigger when text is changed.
  */
 public final class DocumentListenerBuilder {
+  private DocumentListenerBuilder() {}
 
   /**
    * Attaches a given (add/remove/changed) text change action to a {@code JTextComponent}.

--- a/http-client/src/main/java/org/triplea/http/client/error/report/ErrorReportClientFactory.java
+++ b/http-client/src/main/java/org/triplea/http/client/error/report/ErrorReportClientFactory.java
@@ -10,7 +10,8 @@ import org.triplea.http.client.error.report.create.ErrorReportResponse;
 /**
  * Creates an http client that can be used to upload error reports to the TripleA server.
  */
-public class ErrorReportClientFactory {
+public final class ErrorReportClientFactory {
+  private ErrorReportClientFactory() {}
 
   /**
    * Creates an error report uploader clients, sends error reports and gets a response back.

--- a/http-client/src/main/java/org/triplea/http/client/github/issues/GithubIssueClientFactory.java
+++ b/http-client/src/main/java/org/triplea/http/client/github/issues/GithubIssueClientFactory.java
@@ -7,6 +7,7 @@ import org.triplea.http.client.github.issues.create.CreateIssueResponse;
 
 /** Creates an http client that can be used to interact with Github 'issues'. */
 public final class GithubIssueClientFactory {
+  private GithubIssueClientFactory() {}
 
   /** Creates an http client that can post a new github issue. */
   public static ServiceClient<CreateIssueRequest, CreateIssueResponse> newGithubIssueCreator(

--- a/http-server/src/main/java/org/triplea/server/reporting/error/ErrorUploadConfiguration.java
+++ b/http-server/src/main/java/org/triplea/server/reporting/error/ErrorUploadConfiguration.java
@@ -10,7 +10,8 @@ import org.triplea.http.client.github.issues.create.CreateIssueResponse;
 import org.triplea.server.EnvironmentVariable;
 
 /** Class that handles object creation and dependencies for error upload. */
-public class ErrorUploadConfiguration {
+public final class ErrorUploadConfiguration {
+  private ErrorUploadConfiguration() {}
 
   /**
    * Factory method for {@code ErrorUploader}.


### PR DESCRIPTION
## Overview

Adds a private constructor to all utility classes to prevent them from being accidentally instantiated.  Enables the Error Prone PrivateConstructorForUtilityClass rule to enforce this.

## Functional Changes

None.

## Manual Testing Performed

Verified the build fails if a utility class does not contain a private constructor.