### PR TITLE
Checkstyle: Enforce declaration order

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -96,6 +96,9 @@
         <module name="MissingSwitchDefault"/>
         <module name="FallThrough"/>
         <module name="UpperEll"/>
+        <module name="DeclarationOrder">
+            <property name="ignoreModifiers" value="true"/>
+        </module>
         <module name="ModifierOrder"/>
         <module name="RedundantModifier"/>
         <module name="EmptyLineSeparator">

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatController.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatController.java
@@ -51,14 +51,6 @@ public class ChatController implements IChatController {
     }
   };
 
-  static RemoteName getChatControlerRemoteName(final String chatName) {
-    return new RemoteName(CHAT_REMOTE + chatName, IChatController.class);
-  }
-
-  public static String getChatChannelName(final String chatName) {
-    return CHAT_CHANNEL + chatName;
-  }
-
   public ChatController(final String name, final IMessenger messenger, final IRemoteMessenger remoteMessenger,
       final IChannelMessenger channelMessenger, final Predicate<INode> isModerator) {
     chatName = name;
@@ -74,6 +66,14 @@ public class ChatController implements IChatController {
 
   public ChatController(final String name, final Messengers messenger, final Predicate<INode> isModerator) {
     this(name, messenger.getMessenger(), messenger.getRemoteMessenger(), messenger.getChannelMessenger(), isModerator);
+  }
+
+  static RemoteName getChatControlerRemoteName(final String chatName) {
+    return new RemoteName(CHAT_REMOTE + chatName, IChatController.class);
+  }
+
+  public static String getChatChannelName(final String chatName) {
+    return CHAT_CHANNEL + chatName;
   }
 
   @SuppressWarnings("FutureReturnValueIgnored") // false positive; see https://github.com/google/error-prone/issues/883

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
@@ -64,14 +64,24 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
   private final SimpleAttributeSet italic = new SimpleAttributeSet();
   private final SimpleAttributeSet normal = new SimpleAttributeSet();
   public static final String ME = "/me ";
-
-  private static boolean isThirdPerson(final String msg) {
-    return msg.toLowerCase().startsWith(ME);
-  }
+  private final Action setStatusAction = SwingAction.of("Status...", e -> {
+    String status = JOptionPane.showInputDialog(JOptionPane.getFrameForComponent(ChatMessagePanel.this),
+        "Enter Status Text (leave blank for no status)", "");
+    if (status != null) {
+      if (status.trim().length() == 0) {
+        status = null;
+      }
+      chat.getStatusManager().setStatus(status);
+    }
+  });
 
   public ChatMessagePanel(final Chat chat) {
     init();
     setChat(chat);
+  }
+
+  private static boolean isThirdPerson(final String msg) {
+    return msg.toLowerCase().startsWith(ME);
   }
 
   private void init() {
@@ -331,17 +341,6 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
       log.log(Level.SEVERE, "There was an Error whilst trying trimming Chat", e);
     }
   }
-
-  private final Action setStatusAction = SwingAction.of("Status...", e -> {
-    String status = JOptionPane.showInputDialog(JOptionPane.getFrameForComponent(ChatMessagePanel.this),
-        "Enter Status Text (leave blank for no status)", "");
-    if (status != null) {
-      if (status.trim().length() == 0) {
-        status = null;
-      }
-      chat.getStatusManager().setStatus(status);
-    }
-  });
 
   private void sendMessage() {
     if (nextMessage.getText().trim().length() == 0) {

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatPanel.java
@@ -34,6 +34,11 @@ public class ChatPanel extends JPanel implements ChatModel {
   private ChatPlayerPanel chatPlayerPanel;
   private ChatMessagePanel chatMessagePanel;
 
+  public ChatPanel(final Chat chat) {
+    init();
+    setChat(chat);
+  }
+
   /**
    * Creates a Chat object instance on the current thread based on the provided arguments
    * and calls the ChatPanel constructor with it on the EDT.
@@ -50,11 +55,6 @@ public class ChatPanel extends JPanel implements ChatModel {
     final Chat chat = new Chat(messenger, chatName, channelMessenger, remoteMessenger, chatSoundProfile);
     return Interruptibles.awaitResult(() -> SwingAction.invokeAndWaitResult(() -> new ChatPanel(chat))).result
         .orElseThrow(() -> new IllegalStateException("Error during Chat Panel creation"));
-  }
-
-  public ChatPanel(final Chat chat) {
-    init();
-    setChat(chat);
   }
 
   private void init() {

--- a/game-core/src/main/java/games/strategy/engine/data/ChangeAttachmentChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/ChangeAttachmentChange.java
@@ -14,14 +14,6 @@ public class ChangeAttachmentChange extends Change {
   private final String property;
   private boolean clearFirst = false;
 
-  public Attachable getAttachedTo() {
-    return attachedTo;
-  }
-
-  public String getAttachmentName() {
-    return attachmentName;
-  }
-
   /**
    * Initializes a new instance of the ChangeAttachmentChange class.
    *
@@ -67,6 +59,14 @@ public class ChangeAttachmentChange extends Change {
     this.oldValue = oldValue;
     this.property = property;
     clearFirst = resetFirst;
+  }
+
+  public Attachable getAttachedTo() {
+    return attachedTo;
+  }
+
+  public String getAttachmentName() {
+    return attachmentName;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/data/GameObjectStreamData.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameObjectStreamData.java
@@ -18,15 +18,6 @@ import java.io.ObjectOutput;
 public class GameObjectStreamData implements Externalizable {
   private static final long serialVersionUID = 740501183336843321L;
 
-  enum GameType {
-    PLAYERID, UNITTYPE, TERRITORY, PRODUCTIONRULE, PRODUCTIONFRONTIER
-  }
-
-  public static boolean canSerialize(final Named obj) {
-    return obj instanceof PlayerId || obj instanceof UnitType || obj instanceof Territory
-        || obj instanceof ProductionRule || obj instanceof IAttachment || obj instanceof ProductionFrontier;
-  }
-
   private String name;
   private GameType type;
 
@@ -47,6 +38,15 @@ public class GameObjectStreamData implements Externalizable {
     } else {
       throw new IllegalArgumentException("Wrong type:" + named);
     }
+  }
+
+  enum GameType {
+    PLAYERID, UNITTYPE, TERRITORY, PRODUCTIONRULE, PRODUCTIONFRONTIER
+  }
+
+  public static boolean canSerialize(final Named obj) {
+    return obj instanceof PlayerId || obj instanceof UnitType || obj instanceof Territory
+        || obj instanceof ProductionRule || obj instanceof IAttachment || obj instanceof ProductionFrontier;
   }
 
   Named getReference(final GameData data) {

--- a/game-core/src/main/java/games/strategy/engine/data/PlayerId.java
+++ b/game-core/src/main/java/games/strategy/engine/data/PlayerId.java
@@ -25,6 +25,16 @@ public class PlayerId extends NamedAttachable implements NamedUnitHolder {
   private static final String DEFAULT_TYPE_AI = "AI";
   private static final String DEFAULT_TYPE_DOES_NOTHING = "DoesNothing";
 
+  public static final PlayerId NULL_PLAYERID =
+      new PlayerId(Constants.PLAYER_NAME_NEUTRAL, true, false, null, false, null) {
+        private static final long serialVersionUID = -6596127754502509049L;
+
+        @Override
+        public boolean isNull() {
+          return true;
+        }
+      };
+
   private final boolean optional;
   private final boolean canBeDisabled;
   private final String defaultType;
@@ -100,17 +110,6 @@ public class PlayerId extends NamedAttachable implements NamedUnitHolder {
   public boolean isNull() {
     return false;
   }
-
-  public static final PlayerId NULL_PLAYERID =
-      new PlayerId(Constants.PLAYER_NAME_NEUTRAL, true, false, null, false, null) {
-        // compatible with 0.9.0.2 saved games
-        private static final long serialVersionUID = -6596127754502509049L;
-
-        @Override
-        public boolean isNull() {
-          return true;
-        }
-      };
 
   @Override
   public String toString() {

--- a/game-core/src/main/java/games/strategy/engine/data/RelationshipTracker.java
+++ b/game-core/src/main/java/games/strategy/engine/data/RelationshipTracker.java
@@ -141,6 +141,9 @@ public class RelationshipTracker extends RelationshipInterpreter {
   public class Relationship implements Serializable {
     private static final long serialVersionUID = -6718866176901627180L;
 
+    private final RelationshipType relationshipType;
+    private final int roundCreated;
+
     /**
      * This should never be called outside of the change factory.
      */
@@ -156,9 +159,6 @@ public class RelationshipTracker extends RelationshipInterpreter {
       this.relationshipType = relationshipType;
       this.roundCreated = roundValue;
     }
-
-    private final RelationshipType relationshipType;
-    private final int roundCreated;
 
     public int getRoundCreated() {
       return roundCreated;

--- a/game-core/src/main/java/games/strategy/engine/data/RelationshipTypeList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/RelationshipTypeList.java
@@ -19,24 +19,6 @@ public class RelationshipTypeList extends GameDataComponent implements Iterable<
   private final Map<String, RelationshipType> relationshipTypes = new HashMap<>();
 
   /**
-   * Convenience method to return the RELATIONSHIP_TYPE_SELF relation (the relation you have with yourself).
-   *
-   * @return the relation one has with oneself.
-   */
-  public RelationshipType getSelfRelation() {
-    return this.getRelationshipType(Constants.RELATIONSHIP_TYPE_SELF);
-  }
-
-  /**
-   * Convenience method to return the RELATIONSHIP_TYPE_NULL relation (the relation you have with the Neutral Player).
-   *
-   * @return the relation one has with the Neutral.
-   */
-  public RelationshipType getNullRelation() {
-    return this.getRelationshipType(Constants.RELATIONSHIP_TYPE_NULL);
-  }
-
-  /**
    * Constructs a new RelationshipTypeList.
    *
    * @param data GameData used for construction
@@ -55,6 +37,24 @@ public class RelationshipTypeList extends GameDataComponent implements Iterable<
       // is supplied, but we never do that
       throw new IllegalStateException(e);
     }
+  }
+
+  /**
+   * Convenience method to return the RELATIONSHIP_TYPE_SELF relation (the relation you have with yourself).
+   *
+   * @return the relation one has with oneself.
+   */
+  public RelationshipType getSelfRelation() {
+    return this.getRelationshipType(Constants.RELATIONSHIP_TYPE_SELF);
+  }
+
+  /**
+   * Convenience method to return the RELATIONSHIP_TYPE_NULL relation (the relation you have with the Neutral Player).
+   *
+   * @return the relation one has with the Neutral.
+   */
+  public RelationshipType getNullRelation() {
+    return this.getRelationshipType(Constants.RELATIONSHIP_TYPE_NULL);
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/ChangeFactory.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/ChangeFactory.java
@@ -65,6 +65,8 @@ public class ChangeFactory {
     }
   };
 
+  private ChangeFactory() {}
+
   public static Change changeOwner(final Territory territory, final PlayerId owner) {
     return new OwnerChange(territory, owner);
   }
@@ -184,8 +186,6 @@ public class ChangeFactory {
   public static Change addBattleRecords(final BattleRecords records, final GameData data) {
     return new AddBattleRecordsChange(records, data);
   }
-
-  private ChangeFactory() {}
 
   /**
    * Creates a change of relationshipType between 2 players, for example: change Germany-France relationship from

--- a/game-core/src/main/java/games/strategy/engine/data/properties/FileProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/FileProperty.java
@@ -40,18 +40,17 @@ public class FileProperty extends AbstractEditableProperty<File> {
     this(name, description, getFileIfExists(new File(fileName)));
   }
 
+  public FileProperty(final String name, final String description, final File file) {
+    super(name, description);
+    this.file = getFileIfExists(file);
+    this.acceptableSuffixes = defaultImageSuffixes;
+  }
+
   private static File getFileIfExists(final File file) {
     if (file.exists()) {
       return file;
     }
     return null;
-  }
-
-
-  public FileProperty(final String name, final String description, final File file) {
-    super(name, description);
-    this.file = getFileIfExists(file);
-    this.acceptableSuffixes = defaultImageSuffixes;
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/framework/CliProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/CliProperties.java
@@ -4,8 +4,6 @@ package games.strategy.engine.framework;
  * A collection of all CLI related constants.
  */
 public class CliProperties {
-  private CliProperties() {}
-
   public static final String TRIPLEA_GAME = "triplea.game";
   static final String TRIPLEA_MAP_DOWNLOAD = "triplea.map.download";
   public static final String TRIPLEA_SERVER = "triplea.server";
@@ -20,4 +18,6 @@ public class CliProperties {
   public static final String LOBBY_GAME_SUPPORT_PASSWORD = "triplea.lobby.game.supportPassword";
 
   public static final String MAP_FOLDER = "triplea.map.folder";
+
+  private CliProperties() {}
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/ClientGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ClientGame.java
@@ -27,11 +27,6 @@ import lombok.extern.java.Log;
  */
 @Log
 public class ClientGame extends AbstractGame {
-  public static RemoteName getRemoteStepAdvancerName(final INode node) {
-    return new RemoteName(ClientGame.class.getName() + ".REMOTE_STEP_ADVANCER:" + node.getName(),
-        IGameStepAdvancer.class);
-  }
-
   public ClientGame(final GameData data, final Set<IGamePlayer> gamePlayers,
       final Map<String, INode> remotePlayerMapping, final Messengers messengers) {
     super(data, gamePlayers, remotePlayerMapping, messengers);
@@ -159,6 +154,11 @@ public class ClientGame extends AbstractGame {
       final IRemoteRandom remoteRandom = new RemoteRandom(this);
       remoteMessenger.registerRemote(remoteRandom, ServerGame.getRemoteRandomName(player));
     }
+  }
+
+  public static RemoteName getRemoteStepAdvancerName(final INode node) {
+    return new RemoteName(ClientGame.class.getName() + ".REMOTE_STEP_ADVANCER:" + node.getName(),
+        IGameStepAdvancer.class);
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/framework/HistorySynchronizer.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/HistorySynchronizer.java
@@ -19,26 +19,6 @@ public class HistorySynchronizer {
   private final GameData gameData;
   private int currentRound;
   private final IGame game;
-
-  public HistorySynchronizer(final GameData data, final IGame game) {
-    // this is not the way to use this.
-    if (game.getData() == data) {
-      throw new IllegalStateException(
-          "You dont need a history synchronizer to synchronize game data that is managed by an IGame");
-    }
-    gameData = data;
-    gameData.forceChangesOnlyInSwingEventThread();
-    data.acquireReadLock();
-    try {
-      currentRound = data.getSequence().getRound();
-    } finally {
-      data.releaseReadLock();
-    }
-    this.game = game;
-    this.game.getChannelMessenger().registerChannelSubscriber(gameModifiedChannelListener,
-        IGame.GAME_MODIFICATION_CHANNEL);
-  }
-
   private final IGameModifiedChannel gameModifiedChannelListener = new IGameModifiedChannel() {
     @Override
     public void gameDataChanged(final Change change) {
@@ -95,6 +75,25 @@ public class HistorySynchronizer {
     @Override
     public void shutDown() {}
   };
+
+  public HistorySynchronizer(final GameData data, final IGame game) {
+    // this is not the way to use this.
+    if (game.getData() == data) {
+      throw new IllegalStateException(
+          "You dont need a history synchronizer to synchronize game data that is managed by an IGame");
+    }
+    gameData = data;
+    gameData.forceChangesOnlyInSwingEventThread();
+    data.acquireReadLock();
+    try {
+      currentRound = data.getSequence().getRound();
+    } finally {
+      data.releaseReadLock();
+    }
+    this.game = game;
+    this.game.getChannelMessenger().registerChannelSubscriber(gameModifiedChannelListener,
+        IGame.GAME_MODIFICATION_CHANNEL);
+  }
 
   public void deactivate() {
     game.getChannelMessenger().unregisterChannelSubscriber(gameModifiedChannelListener,

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadConfiguration.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadConfiguration.java
@@ -21,6 +21,8 @@ public final class DownloadConfiguration {
     downloadLengthReader = new DownloadLengthReader(httpClientSupplier);
   }
 
+  private DownloadConfiguration() {}
+
   public static ContentReader contentReader() {
     return contentReader;
   }
@@ -28,7 +30,4 @@ public final class DownloadConfiguration {
   public static DownloadLengthReader downloadLengthReader() {
     return downloadLengthReader;
   }
-
-
-  private DownloadConfiguration() {}
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileProperties.java
@@ -21,6 +21,8 @@ class DownloadFileProperties {
   static final String VERSION_PROPERTY = "map.version";
   private final Properties props = new Properties();
 
+  DownloadFileProperties() {}
+
   static DownloadFileProperties loadForZip(final File zipFile) {
     if (!fromZip(zipFile).exists()) {
       return new DownloadFileProperties();
@@ -41,8 +43,6 @@ class DownloadFileProperties {
       log.log(Level.SEVERE, "Failed to write property file to: " + fromZip(zipFile).getAbsolutePath(), e);
     }
   }
-
-  DownloadFileProperties() {}
 
   private static File fromZip(final File zipFile) {
     return new File(zipFile.getAbsolutePath() + ".properties");

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/IRemoteModelListener.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/IRemoteModelListener.java
@@ -4,6 +4,14 @@ package games.strategy.engine.framework.startup.mc;
  * A listener that receives network game setup events from a remote node.
  */
 public interface IRemoteModelListener {
+  IRemoteModelListener NULL_LISTENER = new IRemoteModelListener() {
+    @Override
+    public void playerListChanged() {}
+
+    @Override
+    public void playersTakenChanged() {}
+  };
+
   /**
    * The players available have changed.
    */
@@ -13,12 +21,4 @@ public interface IRemoteModelListener {
    * The players taken have changed.
    */
   void playersTakenChanged();
-
-  IRemoteModelListener NULL_LISTENER = new IRemoteModelListener() {
-    @Override
-    public void playerListChanged() {}
-
-    @Override
-    public void playersTakenChanged() {}
-  };
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
@@ -166,6 +166,18 @@ public class ClientSetupPanel extends SetupPanel {
     private final JLabel playerLabel = new JLabel();
     private JComponent playerComponent = new JLabel();
     private final JLabel alliance;
+    private final Action takeAction =
+        SwingAction.of("Play", e -> clientModel.takePlayer(playerNameLabel.getText()));
+    private final Action dontTakeAction =
+        SwingAction.of("Don't Play", e -> clientModel.releasePlayer(playerNameLabel.getText()));
+    private final ActionListener disablePlayerActionListener = e -> {
+      if (enabledCheckBox.isSelected()) {
+        clientModel.enablePlayer(playerNameLabel.getText());
+      } else {
+        clientModel.disablePlayer(playerNameLabel.getText());
+      }
+      setWidgetActivation(true);
+    };
 
     PlayerRow(final String playerName, final Collection<String> playerAlliances, final boolean enabled) {
       playerNameLabel.setText(playerName);
@@ -220,19 +232,6 @@ public class ClientSetupPanel extends SetupPanel {
     public JComponent getPlayerComponent() {
       return playerComponent;
     }
-
-    private final Action takeAction =
-        SwingAction.of("Play", e -> clientModel.takePlayer(playerNameLabel.getText()));
-    private final Action dontTakeAction =
-        SwingAction.of("Don't Play", e -> clientModel.releasePlayer(playerNameLabel.getText()));
-    private final ActionListener disablePlayerActionListener = e -> {
-      if (enabledCheckBox.isSelected()) {
-        clientModel.enablePlayer(playerNameLabel.getText());
-      } else {
-        clientModel.disablePlayer(playerNameLabel.getText());
-      }
-      setWidgetActivation(true);
-    };
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -299,6 +299,30 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
     private final JCheckBox enabledCheckBox;
     private final JComboBox<String> type;
     private final JLabel alliance;
+    private final ActionListener localPlayerActionListener = new ActionListener() {
+      @Override
+      public void actionPerformed(final ActionEvent e) {
+        if (localCheckBox.isSelected()) {
+          model.takePlayer(nameLabel.getText());
+        } else {
+          model.releasePlayer(nameLabel.getText());
+        }
+        setWidgetActivation();
+      }
+    };
+    private final ActionListener disablePlayerActionListener = new ActionListener() {
+      @Override
+      public void actionPerformed(final ActionEvent e) {
+        if (enabledCheckBox.isSelected()) {
+          model.enablePlayer(nameLabel.getText());
+          type.setSelectedItem(PlayerType.HUMAN_PLAYER);
+        } else {
+          model.disablePlayer(nameLabel.getText());
+          type.setSelectedItem(PlayerType.WEAK_AI.name());
+        }
+        setWidgetActivation();
+      }
+    };
 
     PlayerRow(final String playerName, final Map<String, String> reloadSelections,
         final Collection<String> playerAlliances) {
@@ -378,31 +402,6 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
       alliance.setEnabled(enabledCheckBox.isSelected());
       enabledCheckBox.setEnabled(model.getPlayersAllowedToBeDisabled().contains(nameLabel.getText()));
     }
-
-    private final ActionListener localPlayerActionListener = new ActionListener() {
-      @Override
-      public void actionPerformed(final ActionEvent e) {
-        if (localCheckBox.isSelected()) {
-          model.takePlayer(nameLabel.getText());
-        } else {
-          model.releasePlayer(nameLabel.getText());
-        }
-        setWidgetActivation();
-      }
-    };
-    private final ActionListener disablePlayerActionListener = new ActionListener() {
-      @Override
-      public void actionPerformed(final ActionEvent e) {
-        if (enabledCheckBox.isSelected()) {
-          model.enablePlayer(nameLabel.getText());
-          type.setSelectedItem(PlayerType.HUMAN_PLAYER);
-        } else {
-          model.disablePlayer(nameLabel.getText());
-          type.setSelectedItem(PlayerType.WEAK_AI.name());
-        }
-        setWidgetActivation();
-      }
-    };
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
@@ -16,18 +16,18 @@ public final class SaveGameFileChooser extends JFileChooser {
 
   private static SaveGameFileChooser instance;
 
-  public static SaveGameFileChooser getInstance() {
-    if (instance == null) {
-      instance = new SaveGameFileChooser();
-    }
-    return instance;
-  }
-
   private SaveGameFileChooser() {
     setFileFilter(newGameDataFileFilter());
     final File saveGamesFolder = ClientSetting.saveGamesFolderPath.getValueOrThrow().toFile();
     ensureDirectoryExists(saveGamesFolder);
     setCurrentDirectory(saveGamesFolder);
+  }
+
+  public static SaveGameFileChooser getInstance() {
+    if (instance == null) {
+      instance = new SaveGameFileChooser();
+    }
+    return instance;
   }
 
   private static void ensureDirectoryExists(final File f) {

--- a/game-core/src/main/java/games/strategy/engine/history/Event.java
+++ b/game-core/src/main/java/games/strategy/engine/history/Event.java
@@ -10,13 +10,13 @@ public class Event extends IndexedHistoryNode implements Renderable {
   // additional data used for rendering this event
   private Object renderingData;
 
-  public String getDescription() {
-    return description;
-  }
-
   Event(final String description, final int changeStartIndex) {
     super(description, changeStartIndex);
     this.description = description;
+  }
+
+  public String getDescription() {
+    return description;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/history/History.java
+++ b/game-core/src/main/java/games/strategy/engine/history/History.java
@@ -34,15 +34,15 @@ public class History extends DefaultTreeModel {
   private HistoryNode currentNode;
   private HistoryPanel panel = null;
 
+  public History(final GameData data) {
+    super(new RootHistoryNode("Game History"));
+    gameData = data;
+  }
+
   private void assertCorrectThread() {
     if (gameData.areChangesOnlyInSwingEventThread() && !SwingUtilities.isEventDispatchThread()) {
       throw new IllegalStateException("Wrong thread");
     }
-  }
-
-  public History(final GameData data) {
-    super(new RootHistoryNode("Game History"));
-    gameData = data;
   }
 
   public HistoryWriter getHistoryWriter() {

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/CreateUpdateAccountPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/CreateUpdateAccountPanel.java
@@ -50,6 +50,13 @@ public final class CreateUpdateAccountPanel extends JPanel {
   private final JButton cancelButton = new JButton("Cancel");
   private ReturnValue returnValue = ReturnValue.CANCEL;
 
+  private CreateUpdateAccountPanel(final boolean create) {
+    title = create ? "Create Account" : "Update Account";
+
+    layoutComponents();
+    setupListeners();
+  }
+
   /**
    * Creates a new instance of the {@code CreateUpdateAccountPanel} class that is used to update the specified lobby
    * account.
@@ -80,13 +87,6 @@ public final class CreateUpdateAccountPanel extends JPanel {
    */
   public static CreateUpdateAccountPanel newCreatePanel() {
     return new CreateUpdateAccountPanel(true);
-  }
-
-  private CreateUpdateAccountPanel(final boolean create) {
-    title = create ? "Create Account" : "Update Account";
-
-    layoutComponents();
-    setupListeners();
   }
 
   private void layoutComponents() {

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
@@ -28,6 +28,12 @@ public final class DBUser implements Serializable {
   private final String m_email;
   private final Role userRole;
 
+  public DBUser(final UserName name, final UserEmail email, final Role role) {
+    this.m_name = name.userName;
+    this.m_email = email.userEmail;
+    this.userRole = role;
+  }
+
   /**
    * The user's role within the lobby.
    */
@@ -99,15 +105,6 @@ public final class DBUser implements Serializable {
 
   public boolean isAdmin() {
     return userRole == Role.ADMIN;
-  }
-
-  /**
-   * An all-args constructor.
-   */
-  public DBUser(final UserName name, final UserEmail email, final Role role) {
-    this.m_name = name.userName;
-    this.m_email = email.userEmail;
-    this.userRole = role;
   }
 
   public boolean isValid() {

--- a/game-core/src/main/java/games/strategy/engine/message/RemoteInterfaceHelper.java
+++ b/game-core/src/main/java/games/strategy/engine/message/RemoteInterfaceHelper.java
@@ -6,6 +6,23 @@ import java.util.Comparator;
 import java.util.stream.IntStream;
 
 final class RemoteInterfaceHelper {
+  /**
+   * get methods does not guarantee an order, so sort.
+   */
+  private static final Comparator<Method> methodComparator = Comparator
+      .comparing(Method::getName)
+      .thenComparing(Method::getParameterTypes,
+          Comparator.comparingInt((final Class<?>[] a) -> a.length)
+              .thenComparing((o1, o2) -> {
+                for (int i = 0; i < o1.length; i++) {
+                  final int compareValue = o1[i].getName().compareTo(o2[i].getName());
+                  if (compareValue != 0) {
+                    return compareValue;
+                  }
+                }
+                return 0;
+              }));
+
   private RemoteInterfaceHelper() {}
 
   static int getNumber(final String methodName, final Class<?>[] argTypes, final Class<?> remoteInterface) {
@@ -24,21 +41,4 @@ final class RemoteInterfaceHelper {
     Arrays.sort(methods, methodComparator);
     return methods[methodNumber];
   }
-
-  /**
-   * get methods does not guarantee an order, so sort.
-   */
-  private static final Comparator<Method> methodComparator = Comparator
-      .comparing(Method::getName)
-      .thenComparing(Method::getParameterTypes,
-          Comparator.comparingInt((final Class<?>[] a) -> a.length)
-              .thenComparing((o1, o2) -> {
-                for (int i = 0; i < o1.length; i++) {
-                  final int compareValue = o1[i].getName().compareTo(o2[i].getName());
-                  if (compareValue != 0) {
-                    return compareValue;
-                  }
-                }
-                return 0;
-              }));
 }

--- a/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/Invoke.java
+++ b/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/Invoke.java
@@ -19,12 +19,6 @@ public abstract class Invoke implements Externalizable {
 
   public Invoke() {}
 
-  @Override
-  public String toString() {
-    return "invoke on:" + call.getRemoteName() + " method name:" + call.getMethodName() + " method call id:"
-        + methodCallId;
-  }
-
   public Invoke(final GUID methodCallId, final boolean needReturnValues, final RemoteMethodCall call) {
     if (needReturnValues && methodCallId == null) {
       throw new IllegalArgumentException("Cant have no id and need return values");
@@ -35,6 +29,12 @@ public abstract class Invoke implements Externalizable {
     this.methodCallId = methodCallId;
     this.needReturnValues = needReturnValues;
     this.call = call;
+  }
+
+  @Override
+  public String toString() {
+    return "invoke on:" + call.getRemoteName() + " method name:" + call.getMethodName() + " method call id:"
+        + methodCallId;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/random/CryptoRandomSource.java
+++ b/game-core/src/main/java/games/strategy/engine/random/CryptoRandomSource.java
@@ -18,6 +18,15 @@ import games.strategy.engine.vault.VaultId;
  */
 public class CryptoRandomSource implements IRandomSource {
   private final IRandomSource plainRandom = new PlainRandomSource();
+  // the remote players who involved in rolling the dice
+  // dice are rolled securely between us and her
+  private final PlayerId remotePlayer;
+  private final IGame game;
+
+  public CryptoRandomSource(final PlayerId remotePlayer, final IGame game) {
+    this.remotePlayer = remotePlayer;
+    this.game = game;
+  }
 
   /**
    * Converts an {@code int} array to a {@code byte} array. Each {@code int} will be encoded in little endian order in
@@ -67,16 +76,6 @@ public class CryptoRandomSource implements IRandomSource {
       mixedValues[i] = (val1[i] + val2[i]) % max;
     }
     return mixedValues;
-  }
-
-  // the remote players who involved in rolling the dice
-  // dice are rolled securely between us and her
-  private final PlayerId remotePlayer;
-  private final IGame game;
-
-  public CryptoRandomSource(final PlayerId remotePlayer, final IGame game) {
-    this.remotePlayer = remotePlayer;
-    this.game = game;
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
+++ b/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
@@ -34,6 +34,10 @@ public class PbemDiceRoller implements IRandomSource {
   private final IRemoteDiceServer remoteDiceServer;
   private static Frame focusWindow;
 
+  public PbemDiceRoller(final IRemoteDiceServer diceServer) {
+    remoteDiceServer = diceServer;
+  }
+
   /**
    * If the game has multiple frames, allows the UI to set what frame should be the parent of the dice rolling window.
    * If set to null, or not set, we try to guess by finding the currently focused window (or a visible window if none
@@ -41,10 +45,6 @@ public class PbemDiceRoller implements IRandomSource {
    */
   public static void setFocusWindow(final Frame w) {
     focusWindow = w;
-  }
-
-  public PbemDiceRoller(final IRemoteDiceServer diceServer) {
-    remoteDiceServer = diceServer;
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
+++ b/game-core/src/main/java/games/strategy/engine/random/PropertiesDiceRoller.java
@@ -49,6 +49,16 @@ import lombok.extern.java.Log;
  */
 @Log
 public final class PropertiesDiceRoller implements IRemoteDiceServer {
+  private final Properties props;
+  private String toAddress;
+  private String ccAddress;
+  private String gameId;
+
+  @VisibleForTesting
+  PropertiesDiceRoller(final Properties props) {
+    this.props = props;
+  }
+
   /**
    * Loads the property dice rollers from the properties file.
    *
@@ -79,16 +89,6 @@ public final class PropertiesDiceRoller implements IRemoteDiceServer {
       rollers.add(new PropertiesDiceRoller(prop));
     }
     return rollers;
-  }
-
-  private final Properties props;
-  private String toAddress;
-  private String ccAddress;
-  private String gameId;
-
-  @VisibleForTesting
-  PropertiesDiceRoller(final Properties props) {
-    this.props = props;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/random/RemoteRandom.java
+++ b/game-core/src/main/java/games/strategy/engine/random/RemoteRandom.java
@@ -15,14 +15,6 @@ import games.strategy.engine.vault.VaultId;
 public class RemoteRandom implements IRemoteRandom {
   private static final List<VerifiedRandomNumbers> verifiedRandomNumbers = new ArrayList<>();
 
-  public static synchronized List<VerifiedRandomNumbers> getVerifiedRandomNumbers() {
-    return new ArrayList<>(verifiedRandomNumbers);
-  }
-
-  private static synchronized void addVerifiedRandomNumber(final VerifiedRandomNumbers number) {
-    verifiedRandomNumbers.add(number);
-  }
-
   private final PlainRandomSource plainRandom = new PlainRandomSource();
   private final IGame game;
   // remembered from generate to unlock
@@ -33,11 +25,16 @@ public class RemoteRandom implements IRemoteRandom {
   private boolean waitingForUnlock;
   private int[] localNumbers;
 
-  /**
-   * Creates a new instance of RemoteRandom.
-   */
   public RemoteRandom(final IGame game) {
     this.game = game;
+  }
+
+  public static synchronized List<VerifiedRandomNumbers> getVerifiedRandomNumbers() {
+    return new ArrayList<>(verifiedRandomNumbers);
+  }
+
+  private static synchronized void addVerifiedRandomNumber(final VerifiedRandomNumbers number) {
+    verifiedRandomNumbers.add(number);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/vault/VaultId.java
+++ b/game-core/src/main/java/games/strategy/engine/vault/VaultId.java
@@ -12,10 +12,6 @@ public class VaultId implements Serializable {
   private static final long serialVersionUID = 8863728184933393296L;
   private static long currentId;
 
-  private static synchronized long getNextId() {
-    return currentId++;
-  }
-
   private final INode generatedOn;
   // this is a unique and monotone increasing id
   // unique in this vm
@@ -23,6 +19,10 @@ public class VaultId implements Serializable {
 
   VaultId(final INode generatedOn) {
     this.generatedOn = generatedOn;
+  }
+
+  private static synchronized long getNextId() {
+    return currentId++;
   }
 
   INode getGeneratedOn() {

--- a/game-core/src/main/java/games/strategy/net/Node.java
+++ b/game-core/src/main/java/games/strategy/net/Node.java
@@ -29,29 +29,27 @@ public class Node implements INode, Externalizable {
     }
   }
 
-  /** Returns the localhost InetAddress. */
-  public static InetAddress getLocalHost() throws UnknownHostException {
-    // On Mac, InetAddress.getLocalHost() can be extremely slow (30 seconds)
-    // due to a bug in macOS Sierra and higher. Use a work around to avoid
-    // this. See: https://thoeni.io/post/macos-sierra-java/
-    return SystemProperties.isMac() ? InetAddress.getByName("localhost") : InetAddress.getLocalHost();
-  }
-
   // needed to support Externalizable
   public Node() {}
 
-  /** Creates new Node. */
   public Node(final String name, final InetSocketAddress address) {
     this.name = name;
     this.address = address.getAddress();
     port = address.getPort();
   }
 
-  /** Creates new Node. */
   public Node(final String name, final InetAddress address, final int port) {
     this.name = name;
     this.address = address;
     this.port = port;
+  }
+
+  /** Returns the localhost InetAddress. */
+  public static InetAddress getLocalHost() throws UnknownHostException {
+    // On Mac, InetAddress.getLocalHost() can be extremely slow (30 seconds)
+    // due to a bug in macOS Sierra and higher. Use a work around to avoid
+    // this. See: https://thoeni.io/post/macos-sierra-java/
+    return SystemProperties.isMac() ? InetAddress.getByName("localhost") : InetAddress.getLocalHost();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/sound/ClipPlayer.java
+++ b/game-core/src/main/java/games/strategy/sound/ClipPlayer.java
@@ -117,21 +117,6 @@ public class ClipPlayer {
   private final ResourceLoader resourceLoader;
   private static ClipPlayer clipPlayer;
 
-  static synchronized ClipPlayer getInstance() {
-    if (clipPlayer == null) {
-      clipPlayer = new ClipPlayer(ResourceLoader.getGameEngineAssetLoader());
-    }
-    return clipPlayer;
-  }
-
-  public static synchronized void getInstance(final ResourceLoader resourceLoader) {
-    // make a new clip player if we switch resource loaders (ie: if we switch maps)
-    if (clipPlayer == null || clipPlayer.resourceLoader != resourceLoader) {
-      // make a new clip player with our new resource loader
-      clipPlayer = new ClipPlayer(resourceLoader);
-    }
-  }
-
   private ClipPlayer(final ResourceLoader resourceLoader) {
     this.resourceLoader = resourceLoader;
     final Preferences prefs = Preferences.userNodeForPackage(ClipPlayer.class);
@@ -144,6 +129,21 @@ public class ClipPlayer {
       if (muted) {
         mutedClips.add(sound);
       }
+    }
+  }
+
+  static synchronized ClipPlayer getInstance() {
+    if (clipPlayer == null) {
+      clipPlayer = new ClipPlayer(ResourceLoader.getGameEngineAssetLoader());
+    }
+    return clipPlayer;
+  }
+
+  public static synchronized void getInstance(final ResourceLoader resourceLoader) {
+    // make a new clip player if we switch resource loaders (ie: if we switch maps)
+    if (clipPlayer == null || clipPlayer.resourceLoader != resourceLoader) {
+      // make a new clip player with our new resource loader
+      clipPlayer = new ClipPlayer(resourceLoader);
     }
   }
 

--- a/game-core/src/main/java/games/strategy/sound/SoundOptions.java
+++ b/game-core/src/main/java/games/strategy/sound/SoundOptions.java
@@ -14,19 +14,6 @@ import games.strategy.engine.framework.ui.PropertiesSelector;
  * Sound option window framework.
  */
 public final class SoundOptions {
-
-  /**
-   * Adds the "Sound Options" menu item to the specified menu.
-   *
-   * @param parentMenu menu where to add the menu item "Sound Options".
-   */
-  public static void addToMenu(final JMenu parentMenu) {
-    final JMenuItem soundOptions = new JMenuItem("Sound Options");
-    soundOptions.setMnemonic(KeyEvent.VK_S);
-    soundOptions.addActionListener(e -> new SoundOptions(parentMenu));
-    parentMenu.add(soundOptions);
-  }
-
   private SoundOptions(final JComponent parent) {
     final ClipPlayer clipPlayer = ClipPlayer.getInstance();
     final String ok = "OK";
@@ -58,6 +45,18 @@ public final class SoundOptions {
       }
       clipPlayer.saveSoundPreferences();
     }
+  }
+
+  /**
+   * Adds the "Sound Options" menu item to the specified menu.
+   *
+   * @param parentMenu menu where to add the menu item "Sound Options".
+   */
+  public static void addToMenu(final JMenu parentMenu) {
+    final JMenuItem soundOptions = new JMenuItem("Sound Options");
+    soundOptions.setMnemonic(KeyEvent.VK_S);
+    soundOptions.addActionListener(e -> new SoundOptions(parentMenu));
+    parentMenu.add(soundOptions);
   }
 
   public static void addGlobalSoundSwitchMenu(final JMenu parentMenu) {

--- a/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -72,6 +72,19 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer implements ITrip
   private boolean soundPlayedAlreadyBattle = false;
   private boolean soundPlayedAlreadyEndTurn = false;
   private boolean soundPlayedAlreadyPlacement = false;
+  private final ActionListener editModeAction = e -> {
+    final boolean editMode = ((ButtonModel) e.getSource()).isSelected();
+    try {
+      // Set edit mode
+      // All GameDataChangeListeners will be notified upon success
+      final IEditDelegate editDelegate = (IEditDelegate) getPlayerBridge().getRemotePersistentDelegate("edit");
+      editDelegate.setEditMode(editMode);
+    } catch (final Exception exception) {
+      log.log(Level.SEVERE, "Failed to set edit mode to " + editMode, exception);
+      // toggle back to previous state since setEditMode failed
+      ui.getEditModeButtonModel().setSelected(!ui.getEditModeButtonModel().isSelected());
+    }
+  };
 
   public TripleAPlayer(final String name) {
     super(name);
@@ -169,21 +182,6 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer implements ITrip
       ui.getEditModeButtonModel().removeActionListener(editModeAction);
     });
   }
-
-  private final ActionListener editModeAction = e -> {
-    final boolean editMode = ((ButtonModel) e.getSource()).isSelected();
-    try {
-      // Set edit mode
-      // All GameDataChangeListeners will be notified upon success
-      final IEditDelegate editDelegate = (IEditDelegate) getPlayerBridge().getRemotePersistentDelegate("edit");
-      editDelegate.setEditMode(editMode);
-    } catch (final Exception exception) {
-      log.log(Level.SEVERE, "Failed to set edit mode to " + editMode, exception);
-      // toggle back to previous state since setEditMode failed
-      ui.getEditModeButtonModel().setSelected(!ui.getEditModeButtonModel().isSelected());
-    }
-
-  };
 
   private void politics(final boolean firstRun) {
     if (getPlayerBridge().isGameOver()) {

--- a/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -93,12 +93,12 @@ public class TripleAUnit extends Unit {
   // was charged flat fuel cost already this turn
   private boolean chargedFlatFuelCost = false;
 
-  public static TripleAUnit get(final Unit u) {
-    return (TripleAUnit) u;
-  }
-
   public TripleAUnit(final UnitType type, final PlayerId owner, final GameData data) {
     super(type, owner, data);
+  }
+
+  public static TripleAUnit get(final Unit u) {
+    return (TripleAUnit) u;
   }
 
   public TripleAUnit getTransportedBy() {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -35,6 +35,8 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
   public static final String NOTIFICATION = "Notification";
   public static final String AFTER = "after";
   public static final String BEFORE = "before";
+  public static final Predicate<TriggerAttachment> availableUses = t -> t.getUses() != 0;
+
   // "setTrigger" is also a valid setter, and it just calls "setConditions" in AbstractConditionsAttachment. Kept for
   // backwards compatibility.
   private int uses = -1;
@@ -224,8 +226,6 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
       return false;
     };
   }
-
-  public static final Predicate<TriggerAttachment> availableUses = t -> t.getUses() != 0;
 
   public static Predicate<TriggerAttachment> notificationMatch() {
     return t -> t.getNotification() != null;

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -31,22 +31,6 @@ import games.strategy.util.Triple;
 public class PlayerAttachment extends DefaultAttachment {
   private static final long serialVersionUID = 1880755875866426270L;
 
-  /**
-   * Convenience method. can be null
-   */
-  public static PlayerAttachment get(final PlayerId p) {
-    // allow null
-    return p.getPlayerAttachment();
-  }
-
-  static PlayerAttachment get(final PlayerId p, final String nameOfAttachment) {
-    final PlayerAttachment playerAttachment = p.getPlayerAttachment();
-    if (playerAttachment == null) {
-      throw new IllegalStateException("No player attachment for:" + p.getName() + " with name:" + nameOfAttachment);
-    }
-    return playerAttachment;
-  }
-
   private int vps = 0;
   // need to store some data during a turn
   private int captureVps = 0;
@@ -77,9 +61,24 @@ public class PlayerAttachment extends DefaultAttachment {
   // attacking limits on a flexible per player basis
   private Set<Triple<Integer, String, Set<UnitType>>> attackingLimit = new HashSet<>();
 
-  /** Creates new PlayerAttachment. */
   public PlayerAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
+  }
+
+  /**
+   * Convenience method. can be null
+   */
+  public static PlayerAttachment get(final PlayerId p) {
+    // allow null
+    return p.getPlayerAttachment();
+  }
+
+  static PlayerAttachment get(final PlayerId p, final String nameOfAttachment) {
+    final PlayerAttachment playerAttachment = p.getPlayerAttachment();
+    if (playerAttachment == null) {
+      throw new IllegalStateException("No player attachment for:" + p.getName() + " with name:" + nameOfAttachment);
+    }
+    return playerAttachment;
   }
 
   private void setPlacementLimit(final String value) throws GameParseException {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -43,18 +43,6 @@ import games.strategy.util.IntegerMap;
 public class TechAbilityAttachment extends DefaultAttachment {
   private static final long serialVersionUID = 1866305599625384294L;
 
-  public static TechAbilityAttachment get(final TechAdvance type) {
-    if (type instanceof GenericTechAdvance) {
-      // generic techs can name a hardcoded tech, therefore if it exists we should use the hard coded tech's attachment.
-      // (if the map maker doesn't want to use the hardcoded tech's attachment, they should not name a hardcoded tech)
-      final TechAdvance hardCodedAdvance = ((GenericTechAdvance) type).getAdvance();
-      if (hardCodedAdvance != null) {
-        return (TechAbilityAttachment) hardCodedAdvance.getAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME);
-      }
-    }
-    return (TechAbilityAttachment) type.getAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME);
-  }
-
   // unitAbilitiesGained Static Strings
   public static final String ABILITY_CAN_BLITZ = "canBlitz";
   public static final String ABILITY_CAN_BOMBARD = "canBombard";
@@ -89,6 +77,18 @@ public class TechAbilityAttachment extends DefaultAttachment {
 
   public TechAbilityAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
+  }
+
+  public static TechAbilityAttachment get(final TechAdvance type) {
+    if (type instanceof GenericTechAdvance) {
+      // generic techs can name a hardcoded tech, therefore if it exists we should use the hard coded tech's attachment.
+      // (if the map maker doesn't want to use the hardcoded tech's attachment, they should not name a hardcoded tech)
+      final TechAdvance hardCodedAdvance = ((GenericTechAdvance) type).getAdvance();
+      if (hardCodedAdvance != null) {
+        return (TechAbilityAttachment) hardCodedAdvance.getAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME);
+      }
+    }
+    return (TechAbilityAttachment) type.getAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME);
   }
 
   @VisibleForTesting

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAttachment.java
@@ -20,31 +20,6 @@ import games.strategy.triplea.delegate.TechAdvance;
 public class TechAttachment extends DefaultAttachment {
   private static final long serialVersionUID = -8780929085456199961L;
 
-  // attaches to a PlayerId
-  public static TechAttachment get(final PlayerId id) {
-    final TechAttachment attachment = id.getTechAttachment();
-    // dont crash, as a map xml may not set the tech attachment for all players, so just create a new tech attachment
-    // for them
-    if (attachment == null) {
-      return new TechAttachment();
-    }
-    return attachment;
-  }
-
-  static TechAttachment get(final PlayerId id, final String nameOfAttachment) {
-    if (!nameOfAttachment.equals(Constants.TECH_ATTACHMENT_NAME)) {
-      throw new IllegalStateException(
-          "TechAttachment may not yet get attachments not named:" + Constants.TECH_ATTACHMENT_NAME);
-    }
-    final TechAttachment attachment = (TechAttachment) id.getAttachment(nameOfAttachment);
-    // dont crash, as a map xml may not set the tech attachment for all players, so just create a new tech attachment
-    // for them
-    if (attachment == null) {
-      return new TechAttachment();
-    }
-    return attachment;
-  }
-
   private int techCost = 5;
   private boolean heavyBomber = false;
   private boolean longRangeAir = false;
@@ -80,6 +55,31 @@ public class TechAttachment extends DefaultAttachment {
     super(Constants.TECH_ATTACHMENT_NAME, null, null);
     // TODO: not having game data, and not having generic techs, causes problems. Fix by creating real tech attachments
     // for all players who are missing them, at the beginning of the game.
+  }
+
+  // attaches to a PlayerId
+  public static TechAttachment get(final PlayerId id) {
+    final TechAttachment attachment = id.getTechAttachment();
+    // dont crash, as a map xml may not set the tech attachment for all players, so just create a new tech attachment
+    // for them
+    if (attachment == null) {
+      return new TechAttachment();
+    }
+    return attachment;
+  }
+
+  static TechAttachment get(final PlayerId id, final String nameOfAttachment) {
+    if (!nameOfAttachment.equals(Constants.TECH_ATTACHMENT_NAME)) {
+      throw new IllegalStateException(
+          "TechAttachment may not yet get attachments not named:" + Constants.TECH_ATTACHMENT_NAME);
+    }
+    final TechAttachment attachment = (TechAttachment) id.getAttachment(nameOfAttachment);
+    // dont crash, as a map xml may not set the tech attachment for all players, so just create a new tech attachment
+    // for them
+    if (attachment == null) {
+      return new TechAttachment();
+    }
+    return attachment;
   }
 
   // setters

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -44,24 +44,6 @@ import games.strategy.util.Tuple;
 public class UnitAttachment extends DefaultAttachment {
   private static final long serialVersionUID = -2946748686268541820L;
 
-  public static UnitAttachment get(final UnitType type) {
-    return get(type, Constants.UNIT_ATTACHMENT_NAME);
-  }
-
-  static UnitAttachment get(final UnitType type, final String nameOfAttachment) {
-    return getAttachment(type, nameOfAttachment, UnitAttachment.class);
-  }
-
-  private static Collection<UnitType> getUnitTypesFromUnitList(final Collection<Unit> units) {
-    final Collection<UnitType> types = new ArrayList<>();
-    for (final Unit u : units) {
-      if (!types.contains(u.getType())) {
-        types.add(u.getType());
-      }
-    }
-    return types;
-  }
-
   public static final String UNITSMAYNOTLANDONCARRIER = "unitsMayNotLandOnCarrier";
   public static final String UNITSMAYNOTLEAVEALLIEDCARRIER = "unitsMayNotLeaveAlliedCarrier";
   // movement related
@@ -222,6 +204,24 @@ public class UnitAttachment extends DefaultAttachment {
 
   public UnitAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
+  }
+
+  public static UnitAttachment get(final UnitType type) {
+    return get(type, Constants.UNIT_ATTACHMENT_NAME);
+  }
+
+  static UnitAttachment get(final UnitType type, final String nameOfAttachment) {
+    return getAttachment(type, nameOfAttachment, UnitAttachment.class);
+  }
+
+  private static Collection<UnitType> getUnitTypesFromUnitList(final Collection<Unit> units) {
+    final Collection<UnitType> types = new ArrayList<>();
+    for (final Unit u : units) {
+      if (!types.contains(u.getType())) {
+        types.add(u.getType());
+      }
+    }
+    return types;
   }
 
   private void setCanIntercept(final String value) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -47,6 +47,8 @@ import lombok.extern.java.Log;
 public class BattleCalculator {
   private static final Map<String, List<UnitType>> oolCache = new ConcurrentHashMap<>();
 
+  private BattleCalculator() {}
+
   public static void clearOolCache() {
     oolCache.clear();
   }
@@ -909,9 +911,6 @@ public class BattleCalculator {
   private static boolean isPartialAmphibiousRetreat(final GameData data) {
     return Properties.getPartialAmphibiousRetreat(data);
   }
-
-  // nothing but static
-  private BattleCalculator() {}
 
   /**
    * This returns the exact Power that a unit has according to what DiceRoll.rollDiceLowLuck() would give it.

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -57,6 +57,38 @@ public class DiceRoll implements Externalizable {
   private int hits;
   private double expectedHits;
 
+  /**
+   * Initializes a new instance of the DiceRoll class.
+   *
+   * @param dice the dice, 0 based
+   * @param hits the number of hits
+   * @param rollAt what we roll at, [0,Constants.MAX_DICE]
+   * @param hitOnlyIfEquals Do we get a hit only if we are equals, or do we hit when we are equal or less than for
+   *        example a 5 is a hit when rolling at 6 for equal and less than, but is not for equals.
+   */
+  public DiceRoll(final int[] dice, final int hits, final int rollAt, final boolean hitOnlyIfEquals) {
+    this.hits = hits;
+    expectedHits = 0;
+    rolls = new ArrayList<>(dice.length);
+    for (final int element : dice) {
+      final boolean hit;
+      if (hitOnlyIfEquals) {
+        hit = (rollAt == element);
+      } else {
+        hit = element <= rollAt;
+      }
+      rolls.add(new Die(element, rollAt, hit ? DieType.HIT : DieType.MISS));
+    }
+  }
+
+  // only for externalizable
+  public DiceRoll() {}
+
+  private DiceRoll(final List<Die> dice, final int hits, final double expectedHits) {
+    rolls = new ArrayList<>(dice);
+    this.hits = hits;
+    this.expectedHits = expectedHits;
+  }
 
   static Tuple<Integer, Integer> getMaxAaAttackAndDiceSides(final Collection<Unit> aaUnits, final GameData data,
       final boolean defending) {
@@ -1173,39 +1205,6 @@ public class DiceRoll implements Externalizable {
           .append((battle.getBattleRound() + 1));
     }
     return buffer.toString();
-  }
-
-  /**
-   * Initializes a new instance of the DiceRoll class.
-   *
-   * @param dice the dice, 0 based
-   * @param hits the number of hits
-   * @param rollAt what we roll at, [0,Constants.MAX_DICE]
-   * @param hitOnlyIfEquals Do we get a hit only if we are equals, or do we hit when we are equal or less than for
-   *        example a 5 is a hit when rolling at 6 for equal and less than, but is not for equals.
-   */
-  public DiceRoll(final int[] dice, final int hits, final int rollAt, final boolean hitOnlyIfEquals) {
-    this.hits = hits;
-    expectedHits = 0;
-    rolls = new ArrayList<>(dice.length);
-    for (final int element : dice) {
-      final boolean hit;
-      if (hitOnlyIfEquals) {
-        hit = (rollAt == element);
-      } else {
-        hit = element <= rollAt;
-      }
-      rolls.add(new Die(element, rollAt, hit ? DieType.HIT : DieType.MISS));
-    }
-  }
-
-  // only for externalizable
-  public DiceRoll() {}
-
-  private DiceRoll(final List<Die> dice, final int hits, final double expectedHits) {
-    rolls = new ArrayList<>(dice);
-    this.hits = hits;
-    this.expectedHits = expectedHits;
   }
 
   public int getHits() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -44,6 +44,8 @@ import games.strategy.util.Interruptibles;
  */
 @AutoSave(afterStepStart = true)
 public class EndTurnDelegate extends AbstractEndTurnDelegate {
+  private static final Predicate<RulesAttachment> availableUses = ra -> ra.getUses() != 0;
+
   @Override
   protected String doNationalObjectivesAndOtherEndTurnEffects(final IDelegateBridge bridge) {
     final StringBuilder endTurnReport = new StringBuilder();
@@ -338,8 +340,6 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
   private boolean isNationalObjectives() {
     return Properties.getNationalObjectives(getData());
   }
-
-  private static final Predicate<RulesAttachment> availableUses = ra -> ra.getUses() != 0;
 
   @Override
   protected String addOtherResources(final IDelegateBridge bridge) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -61,6 +61,8 @@ public class MoveValidator {
       "Transport cannot both load AND unload after being in combat";
   public static final String NOT_ALL_UNITS_CAN_BLITZ = "Not all units can blitz";
 
+  private MoveValidator() {}
+
   /**
    * Validates the specified move.
    */
@@ -1590,6 +1592,4 @@ public class MoveValidator {
   private static boolean isIgnoreSubInMovement(final GameData data) {
     return Properties.getIgnoreSubInMovement(data);
   }
-
-  private MoveValidator() {}
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -46,6 +46,10 @@ import games.strategy.util.IntegerMap;
  * the adding or removing of resources is done.
  */
 public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDelegate {
+  private static final Comparator<RepairRule> repairRuleComparator = Comparator.comparing(
+      o -> (UnitType) o.getResults().keySet().iterator().next(),
+      new UnitTypeComparator());
+
   private boolean needToInitialize = true;
   public static final String NOT_ENOUGH_RESOURCES = "Not enough resources";
 
@@ -291,10 +295,6 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
     }
     return repairMap;
   }
-
-  private static final Comparator<RepairRule> repairRuleComparator = Comparator.comparing(
-      o -> (UnitType) o.getResults().keySet().iterator().next(),
-      new UnitTypeComparator());
 
   private static IntegerMap<Resource> getCosts(final IntegerMap<ProductionRule> productionRules) {
     final IntegerMap<Resource> costs = new IntegerMap<>();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
@@ -61,6 +61,10 @@ public abstract class TechAdvance extends NamedAttachable {
   private static final Map<String, Class<? extends TechAdvance>> ALL_PREDEFINED_TECHNOLOGIES =
       newPredefinedTechnologyMap();
 
+  public TechAdvance(final String name, final GameData data) {
+    super(name, data);
+  }
+
   private static Map<String, Class<? extends TechAdvance>> newPredefinedTechnologyMap() {
     final Map<String, Class<? extends TechAdvance>> preDefinedTechMap =
         new HashMap<>();
@@ -79,10 +83,6 @@ public abstract class TechAdvance extends NamedAttachable {
     preDefinedTechMap.put(TECH_PROPERTY_INDUSTRIAL_TECHNOLOGY, IndustrialTechnologyAdvance.class);
     preDefinedTechMap.put(TECH_PROPERTY_DESTROYER_BOMBARD, DestroyerBombardTechAdvance.class);
     return Collections.unmodifiableMap(preDefinedTechMap);
-  }
-
-  public TechAdvance(final String name, final GameData data) {
-    super(name, data);
   }
 
   public abstract String getProperty();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
@@ -24,6 +24,7 @@ import games.strategy.triplea.util.TransportUtils;
  * that has been unloaded. To reset the unloaded call clearUnloadedCapacity().
  */
 public class TransportTracker {
+  private TransportTracker() {}
 
   private static int getCost(final Collection<Unit> units) {
     return TransportUtils.getTransportCost(units);
@@ -34,8 +35,6 @@ public class TransportTracker {
       throw new IllegalStateException("Not a transport:" + u);
     }
   }
-
-  private TransportTracker() {}
 
   /**
    * Returns the collection of units that the given transport is transporting.

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
@@ -46,6 +46,11 @@ public class UndoableMove extends AbstractUndoableMove {
   private final Set<Unit> unloaded = new HashSet<>();
   private final Route route;
 
+  public UndoableMove(final Collection<Unit> units, final Route route) {
+    super(new CompositeChange(), units);
+    this.route = route;
+  }
+
   public void addToConquered(final Territory t) {
     conquered.add(t);
   }
@@ -74,11 +79,6 @@ public class UndoableMove extends AbstractUndoableMove {
 
   public void setDescription(final String description) {
     this.description = description;
-  }
-
-  public UndoableMove(final Collection<Unit> units, final Route route) {
-    super(new CompositeChange(), units);
-    this.route = route;
   }
 
   public void load(final Unit transport) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/data/BattleRecord.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/data/BattleRecord.java
@@ -68,6 +68,25 @@ public class BattleRecord implements Serializable {
   private final BattleType battleType;
   private BattleResults battleResults;
 
+  /**
+   * Convenience copy constructor.
+   */
+  protected BattleRecord(final BattleRecord record) {
+    battleSite = record.battleSite;
+    attacker = record.attacker;
+    defender = record.defender;
+    attackerLostTuv = record.attackerLostTuv;
+    defenderLostTuv = record.defenderLostTuv;
+    battleResultDescription = record.battleResultDescription;
+    battleType = record.battleType;
+    battleResults = record.battleResults;
+  }
+
+  protected BattleRecord(final Territory battleSite, final PlayerId attacker, final BattleType battleType) {
+    this.battleSite = battleSite;
+    this.attacker = attacker;
+    this.battleType = battleType;
+  }
 
   @SerializationProxySupport
   private BattleRecord(final Territory battleSite, final PlayerId attacker, final PlayerId defender,
@@ -115,26 +134,6 @@ public class BattleRecord implements Serializable {
       return new BattleRecord(battleSite, attacker, defender, attackerLostTuv, defenderLostTuv, battleResultDescription,
           battleType, battleResults);
     }
-  }
-
-  /**
-   * Convenience copy constructor.
-   */
-  protected BattleRecord(final BattleRecord record) {
-    battleSite = record.battleSite;
-    attacker = record.attacker;
-    defender = record.defender;
-    attackerLostTuv = record.attackerLostTuv;
-    defenderLostTuv = record.defenderLostTuv;
-    battleResultDescription = record.battleResultDescription;
-    battleType = record.battleType;
-    battleResults = record.battleResults;
-  }
-
-  protected BattleRecord(final Territory battleSite, final PlayerId attacker, final BattleType battleType) {
-    this.battleSite = battleSite;
-    this.attacker = attacker;
-    this.battleType = battleType;
   }
 
   protected void setResult(final PlayerId defender, final int attackerLostTuv, final int defenderLostTuv,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/data/BattleRecords.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/data/BattleRecords.java
@@ -33,6 +33,20 @@ public class BattleRecords implements Serializable {
     this.records = records;
   }
 
+  // Create copy
+  public BattleRecords(final BattleRecords records) {
+    this.records = new HashMap<>();
+    for (final Entry<PlayerId, Map<GUID, BattleRecord>> entry : records.records.entrySet()) {
+      final PlayerId p = entry.getKey();
+      final Map<GUID, BattleRecord> record = entry.getValue();
+      final Map<GUID, BattleRecord> map = new HashMap<>();
+      for (final Entry<GUID, BattleRecord> entry2 : record.entrySet()) {
+        map.put(entry2.getKey(), new BattleRecord(entry2.getValue()));
+      }
+      this.records.put(p, map);
+    }
+  }
+
   @SerializationProxySupport
   public Object writeReplace() {
     return new SerializationProxy(this);
@@ -51,20 +65,6 @@ public class BattleRecords implements Serializable {
       return new BattleRecords(records);
     }
 
-  }
-
-  // Create copy
-  public BattleRecords(final BattleRecords records) {
-    this.records = new HashMap<>();
-    for (final Entry<PlayerId, Map<GUID, BattleRecord>> entry : records.records.entrySet()) {
-      final PlayerId p = entry.getKey();
-      final Map<GUID, BattleRecord> record = entry.getValue();
-      final Map<GUID, BattleRecord> map = new HashMap<>();
-      for (final Entry<GUID, BattleRecord> entry2 : record.entrySet()) {
-        map.put(entry2.getKey(), new BattleRecord(entry2.getValue()));
-      }
-      this.records.put(p, map);
-    }
   }
 
   public static Collection<BattleRecord> getAllRecords(final BattleRecords brs) {

--- a/game-core/src/main/java/games/strategy/triplea/formatter/MyFormatter.java
+++ b/game-core/src/main/java/games/strategy/triplea/formatter/MyFormatter.java
@@ -41,6 +41,8 @@ public class MyFormatter {
     plural.put("factory", "factories");
   }
 
+  private MyFormatter() {}
+
   public static String unitsToTextNoOwner(final Collection<Unit> units) {
     return unitsToTextNoOwner(units, null);
   }
@@ -395,6 +397,4 @@ public class MyFormatter {
     }
     return buf.toString().replaceFirst(separator, "");
   }
-
-  private MyFormatter() {}
 }

--- a/game-core/src/main/java/games/strategy/triplea/image/MapImage.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/MapImage.java
@@ -218,8 +218,6 @@ public class MapImage {
     pref.remove(property);
   }
 
-  public MapImage() {}
-
   public BufferedImage getSmallMapImage() {
     return smallMapImage;
   }

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorDialog.java
@@ -31,6 +31,14 @@ public class OddsCalculatorDialog extends JDialog {
   private static List<OddsCalculatorDialog> instances = new ArrayList<>();
   private final OddsCalculatorPanel panel;
 
+  OddsCalculatorDialog(final GameData data, final UiContext uiContext, final JFrame parent, final Territory location) {
+    super(parent, "Odds Calculator");
+    panel = new OddsCalculatorPanel(data, uiContext, location, this);
+    getContentPane().setLayout(new BorderLayout());
+    getContentPane().add(panel, BorderLayout.CENTER);
+    pack();
+  }
+
   /**
    * Shows the Odds Calculator dialog and initializes it using the current state of the specified territory.
    */
@@ -95,14 +103,6 @@ public class OddsCalculatorDialog extends JDialog {
     currentDialog.panel
         .addDefendingUnits(t.getUnits().getMatches(Matches.alliedUnit(currentDialog.panel.getDefender(), t.getData())));
     currentDialog.pack();
-  }
-
-  OddsCalculatorDialog(final GameData data, final UiContext uiContext, final JFrame parent, final Territory location) {
-    super(parent, "Odds Calculator");
-    panel = new OddsCalculatorPanel(data, uiContext, location, this);
-    getContentPane().setLayout(new BorderLayout());
-    getContentPane().add(panel, BorderLayout.CENTER);
-    pack();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -33,7 +33,8 @@ abstract class AbstractMovePanel extends ActionPanel {
   private final JLabel actionLabel = new JLabel();
   private MoveDescription moveMessage;
   private List<UndoableMove> undoableMoves;
-
+  AbstractUndoableMovesPanel undoableMovesPanel;
+  private IPlayerBridge bridge;
 
   private final JButton cancelMoveButton = JButtonBuilder.builder()
       .title("Cancel")
@@ -56,10 +57,6 @@ abstract class AbstractMovePanel extends ActionPanel {
    * sub-classes method for cancel handling
    */
   protected abstract void cancelMoveAction();
-
-
-  AbstractUndoableMovesPanel undoableMovesPanel;
-  private IPlayerBridge bridge;
 
   IPlayerBridge getPlayerBridge() {
     return bridge;

--- a/game-core/src/main/java/games/strategy/triplea/ui/ActionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ActionPanel.java
@@ -22,6 +22,14 @@ public abstract class ActionPanel extends JPanel {
   private CountDownLatch latch;
   private final Object latchLock = new Object();
 
+  /**
+   * Refreshes the action panel. Should be run within the swing event queue.
+   */
+  protected final Runnable refresh = () -> {
+    revalidate();
+    repaint();
+  };
+
   public ActionPanel(final GameData data, final MapPanel map) {
     this.data = data;
     this.map = map;
@@ -128,12 +136,4 @@ public abstract class ActionPanel extends JPanel {
   public boolean getActive() {
     return active;
   }
-
-  /**
-   * Refreshes the action panel. Should be run within the swing event queue.
-   */
-  protected final Runnable refresh = () -> {
-    revalidate();
-    repaint();
-  };
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -82,6 +82,9 @@ public class BattleDisplay extends JPanel {
   private static final String DICE_KEY = "D";
   private static final String CASUALTIES_KEY = "C";
   private static final String MESSAGE_KEY = "M";
+  private static final int MY_WIDTH = 100;
+  private static final int MY_HEIGHT = 100;
+
   private final PlayerId defender;
   private final PlayerId attacker;
   private final Territory location;
@@ -618,9 +621,6 @@ public class BattleDisplay extends JPanel {
     return player;
   }
 
-  private static final int MY_WIDTH = 100;
-  private static final int MY_HEIGHT = 100;
-
   private JComponent getTerritoryComponent() {
     final Image finalImage = Util.newImage(MY_WIDTH, MY_HEIGHT, true);
     final Image territory = mapPanel.getTerritoryImage(location);
@@ -658,21 +658,6 @@ public class BattleDisplay extends JPanel {
     private final Collection<Unit> amphibiousLandAttackers;
     private BattleModel enemyBattleModel = null;
 
-    private static String[] varDiceArray(final GameData data) {
-      // TODO Soft set the maximum bonus to-hit plus 1 for 0 based count(+2 total currently)
-      final String[] diceColumns = new String[data.getDiceSides() + 1];
-      {
-        for (int i = 0; i < diceColumns.length; i++) {
-          if (i == 0) {
-            diceColumns[i] = " ";
-          } else {
-            diceColumns[i] = Integer.toString(i);
-          }
-        }
-      }
-      return diceColumns;
-    }
-
     BattleModel(final Collection<Unit> units, final boolean attack, final BattleType battleType,
         final GameData data, final Territory battleLocation, final Collection<TerritoryEffect> territoryEffects,
         final boolean isAmphibious, final Collection<Unit> amphibiousLandAttackers, final UiContext uiContext) {
@@ -687,6 +672,21 @@ public class BattleDisplay extends JPanel {
       this.territoryEffects = territoryEffects;
       this.isAmphibious = isAmphibious;
       this.amphibiousLandAttackers = amphibiousLandAttackers;
+    }
+
+    private static String[] varDiceArray(final GameData data) {
+      // TODO Soft set the maximum bonus to-hit plus 1 for 0 based count(+2 total currently)
+      final String[] diceColumns = new String[data.getDiceSides() + 1];
+      {
+        for (int i = 0; i < diceColumns.length; i++) {
+          if (i == 0) {
+            diceColumns[i] = " ";
+          } else {
+            diceColumns[i] = Integer.toString(i);
+          }
+        }
+      }
+      return diceColumns;
     }
 
     void setEnemyBattleModel(final BattleModel enemyBattleModel) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/CommentPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/CommentPanel.java
@@ -54,6 +54,13 @@ class CommentPanel extends JPanel {
   private final SimpleAttributeSet bold = new SimpleAttributeSet();
   private final SimpleAttributeSet italic = new SimpleAttributeSet();
   private final SimpleAttributeSet normal = new SimpleAttributeSet();
+  private final Action saveAction = SwingAction.of("Add Comment", e -> {
+    if (nextMessage.getText().trim().length() == 0) {
+      return;
+    }
+    addMessage(nextMessage.getText());
+    nextMessage.setText("");
+  });
 
   CommentPanel(final TripleAFrame frame, final GameData data) {
     this.frame = frame;
@@ -224,12 +231,4 @@ class CommentPanel extends JPanel {
       scrollModel.setValue(scrollModel.getMaximum());
     });
   }
-
-  private final Action saveAction = SwingAction.of("Add Comment", e -> {
-    if (nextMessage.getText().trim().length() == 0) {
-      return;
-    }
-    addMessage(nextMessage.getText());
-    nextMessage.setText("");
-  });
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/EditProductionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EditProductionPanel.java
@@ -23,13 +23,13 @@ import games.strategy.util.IntegerMap;
 class EditProductionPanel extends ProductionPanel {
   private static final long serialVersionUID = 5826523459539469173L;
 
+  private EditProductionPanel(final UiContext uiContext) {
+    super(uiContext);
+  }
+
   static IntegerMap<ProductionRule> getProduction(final PlayerId id, final JFrame parent, final GameData data,
       final UiContext uiContext) {
     return new EditProductionPanel(uiContext).show(id, parent, data, false, new IntegerMap<>());
-  }
-
-  private EditProductionPanel(final UiContext uiContext) {
-    super(uiContext);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
@@ -46,6 +46,149 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
   private Action currentAction = null;
   private @Nullable Territory currentHighlightedTerritory;
 
+  private final Action doneAction = new AbstractAction("Done") {
+    private static final long serialVersionUID = -2376988913511268803L;
+
+    @Override
+    public void actionPerformed(final ActionEvent event) {
+      currentAction = doneAction;
+      setWidgetActivation();
+      if (pickedTerritory == null || !territoryChoices.contains(pickedTerritory)) {
+        EventThreadJOptionPane.showMessageDialog(parent, "Must Pick An Unowned Territory",
+            "Must Pick An Unowned Territory", JOptionPane.WARNING_MESSAGE);
+        currentAction = null;
+        if (currentHighlightedTerritory != null) {
+          getMap().clearTerritoryOverlay(currentHighlightedTerritory);
+        }
+        currentHighlightedTerritory = null;
+        pickedTerritory = null;
+        setWidgetActivation();
+        return;
+      }
+      if (!pickedUnits.isEmpty() && !unitChoices.containsAll(pickedUnits)) {
+        EventThreadJOptionPane.showMessageDialog(parent, "Invalid Units?!?", "Invalid Units?!?",
+            JOptionPane.WARNING_MESSAGE);
+        currentAction = null;
+        pickedUnits.clear();
+        setWidgetActivation();
+        return;
+      }
+      if (pickedUnits.size() > Math.max(0, unitsPerPick)) {
+        EventThreadJOptionPane.showMessageDialog(parent, "Too Many Units?!?", "Too Many Units?!?",
+            JOptionPane.WARNING_MESSAGE);
+        currentAction = null;
+        pickedUnits.clear();
+        setWidgetActivation();
+        return;
+      }
+      if (pickedUnits.size() < unitsPerPick) {
+        if (unitChoices.size() < unitsPerPick) {
+          // if we have fewer units than the number we are supposed to pick, set it to all
+          pickedUnits.addAll(unitChoices);
+        } else if (unitChoices.stream().allMatch(Matches.unitIsOfType(unitChoices.get(0).getType()))) {
+          // if we have only 1 unit type, set it to that
+          pickedUnits.clear();
+          pickedUnits.addAll(CollectionUtils.getNMatches(unitChoices, unitsPerPick, Matches.always()));
+        } else {
+          EventThreadJOptionPane.showMessageDialog(parent, "Must Choose Units For This Territory",
+              "Must Choose Units For This Territory", JOptionPane.WARNING_MESSAGE);
+          currentAction = null;
+          setWidgetActivation();
+          return;
+        }
+      }
+      currentAction = null;
+      if (currentHighlightedTerritory != null) {
+        getMap().clearTerritoryOverlay(currentHighlightedTerritory);
+      }
+      currentHighlightedTerritory = null;
+      setWidgetActivation();
+      release();
+    }
+  };
+
+  private final Action selectUnitsAction = new AbstractAction("Select Units") {
+    private static final long serialVersionUID = 4745335350716395600L;
+
+    @Override
+    public void actionPerformed(final ActionEvent event) {
+      currentAction = selectUnitsAction;
+      setWidgetActivation();
+      final UnitChooser unitChooser = new UnitChooser(unitChoices, Collections.emptyMap(),
+          false, getMap().getUiContext());
+      unitChooser.setMaxAndShowMaxButton(unitsPerPick);
+      if (JOptionPane.OK_OPTION == EventThreadJOptionPane.showConfirmDialog(parent, unitChooser, "Select Units",
+          JOptionPane.OK_CANCEL_OPTION)) {
+        pickedUnits.clear();
+        pickedUnits.addAll(unitChooser.getSelected());
+      }
+      currentAction = null;
+      setWidgetActivation();
+    }
+  };
+
+  private final Action selectTerritoryAction = new AbstractAction("Select Territory") {
+    private static final long serialVersionUID = -8003634505955439651L;
+
+    @Override
+    public void actionPerformed(final ActionEvent event) {
+      currentAction = selectTerritoryAction;
+      setWidgetActivation();
+      getMap().addMapSelectionListener(mapSelectionListener);
+    }
+  };
+
+  private final MapSelectionListener mapSelectionListener = new DefaultMapSelectionListener() {
+    @Override
+    public void territorySelected(final Territory territory, final MouseDetails md) {
+      if (territory == null) {
+        return;
+      }
+      if (currentAction == selectTerritoryAction) {
+        if (!territoryChoices.contains(territory)) {
+          EventThreadJOptionPane.showMessageDialog(parent,
+              "Must Pick An Unowned Territory (will have a white highlight)", "Must Pick An Unowned Territory",
+              JOptionPane.WARNING_MESSAGE);
+          return;
+        }
+        pickedTerritory = territory;
+        SwingUtilities.invokeLater(() -> {
+          getMap().removeMapSelectionListener(mapSelectionListener);
+          currentAction = null;
+          setWidgetActivation();
+        });
+      } else {
+        log.severe("Should not be able to select a territory outside of the selectTerritoryAction.");
+      }
+    }
+
+    @Override
+    public void mouseMoved(final @Nullable Territory territory, final MouseDetails md) {
+      if (!getActive()) {
+        log.severe("Should not be able to select a territory when inactive: " + territory);
+        return;
+      }
+
+      if (territory != null) {
+        // highlight territory
+        if (currentAction == selectTerritoryAction) {
+          if (!territory.equals(currentHighlightedTerritory)) {
+            if (currentHighlightedTerritory != null) {
+              getMap().clearTerritoryOverlay(currentHighlightedTerritory);
+            }
+            currentHighlightedTerritory = territory;
+            if (territoryChoices.contains(currentHighlightedTerritory)) {
+              getMap().setTerritoryOverlay(currentHighlightedTerritory, Color.WHITE, 200);
+            } else {
+              getMap().setTerritoryOverlay(currentHighlightedTerritory, Color.RED, 200);
+            }
+            getMap().repaint();
+          }
+        }
+      }
+    }
+  };
+
   public PickTerritoryAndUnitsPanel(final GameData data, final MapPanel map, final TripleAFrame parent) {
     super(data, map);
     this.parent = parent;
@@ -117,145 +260,4 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
       }
     });
   }
-
-  private final Action doneAction = new AbstractAction("Done") {
-    private static final long serialVersionUID = -2376988913511268803L;
-
-    @Override
-    public void actionPerformed(final ActionEvent event) {
-      currentAction = doneAction;
-      setWidgetActivation();
-      if (pickedTerritory == null || !territoryChoices.contains(pickedTerritory)) {
-        EventThreadJOptionPane.showMessageDialog(parent, "Must Pick An Unowned Territory",
-            "Must Pick An Unowned Territory", JOptionPane.WARNING_MESSAGE);
-        currentAction = null;
-        if (currentHighlightedTerritory != null) {
-          getMap().clearTerritoryOverlay(currentHighlightedTerritory);
-        }
-        currentHighlightedTerritory = null;
-        pickedTerritory = null;
-        setWidgetActivation();
-        return;
-      }
-      if (!pickedUnits.isEmpty() && !unitChoices.containsAll(pickedUnits)) {
-        EventThreadJOptionPane.showMessageDialog(parent, "Invalid Units?!?", "Invalid Units?!?",
-            JOptionPane.WARNING_MESSAGE);
-        currentAction = null;
-        pickedUnits.clear();
-        setWidgetActivation();
-        return;
-      }
-      if (pickedUnits.size() > Math.max(0, unitsPerPick)) {
-        EventThreadJOptionPane.showMessageDialog(parent, "Too Many Units?!?", "Too Many Units?!?",
-            JOptionPane.WARNING_MESSAGE);
-        currentAction = null;
-        pickedUnits.clear();
-        setWidgetActivation();
-        return;
-      }
-      if (pickedUnits.size() < unitsPerPick) {
-        if (unitChoices.size() < unitsPerPick) {
-          // if we have fewer units than the number we are supposed to pick, set it to all
-          pickedUnits.addAll(unitChoices);
-        } else if (unitChoices.stream().allMatch(Matches.unitIsOfType(unitChoices.get(0).getType()))) {
-          // if we have only 1 unit type, set it to that
-          pickedUnits.clear();
-          pickedUnits.addAll(CollectionUtils.getNMatches(unitChoices, unitsPerPick, Matches.always()));
-        } else {
-          EventThreadJOptionPane.showMessageDialog(parent, "Must Choose Units For This Territory",
-              "Must Choose Units For This Territory", JOptionPane.WARNING_MESSAGE);
-          currentAction = null;
-          setWidgetActivation();
-          return;
-        }
-      }
-      currentAction = null;
-      if (currentHighlightedTerritory != null) {
-        getMap().clearTerritoryOverlay(currentHighlightedTerritory);
-      }
-      currentHighlightedTerritory = null;
-      setWidgetActivation();
-      release();
-    }
-  };
-  private final Action selectUnitsAction = new AbstractAction("Select Units") {
-    private static final long serialVersionUID = 4745335350716395600L;
-
-    @Override
-    public void actionPerformed(final ActionEvent event) {
-      currentAction = selectUnitsAction;
-      setWidgetActivation();
-      final UnitChooser unitChooser = new UnitChooser(unitChoices, Collections.emptyMap(),
-          false, getMap().getUiContext());
-      unitChooser.setMaxAndShowMaxButton(unitsPerPick);
-      if (JOptionPane.OK_OPTION == EventThreadJOptionPane.showConfirmDialog(parent, unitChooser, "Select Units",
-          JOptionPane.OK_CANCEL_OPTION)) {
-        pickedUnits.clear();
-        pickedUnits.addAll(unitChooser.getSelected());
-      }
-      currentAction = null;
-      setWidgetActivation();
-    }
-  };
-  private final Action selectTerritoryAction = new AbstractAction("Select Territory") {
-    private static final long serialVersionUID = -8003634505955439651L;
-
-    @Override
-    public void actionPerformed(final ActionEvent event) {
-      currentAction = selectTerritoryAction;
-      setWidgetActivation();
-      getMap().addMapSelectionListener(mapSelectionListener);
-    }
-  };
-
-  private final MapSelectionListener mapSelectionListener = new DefaultMapSelectionListener() {
-    @Override
-    public void territorySelected(final Territory territory, final MouseDetails md) {
-      if (territory == null) {
-        return;
-      }
-      if (currentAction == selectTerritoryAction) {
-        if (!territoryChoices.contains(territory)) {
-          EventThreadJOptionPane.showMessageDialog(parent,
-              "Must Pick An Unowned Territory (will have a white highlight)", "Must Pick An Unowned Territory",
-              JOptionPane.WARNING_MESSAGE);
-          return;
-        }
-        pickedTerritory = territory;
-        SwingUtilities.invokeLater(() -> {
-          getMap().removeMapSelectionListener(mapSelectionListener);
-          currentAction = null;
-          setWidgetActivation();
-        });
-      } else {
-        log.severe("Should not be able to select a territory outside of the selectTerritoryAction.");
-      }
-    }
-
-    @Override
-    public void mouseMoved(final @Nullable Territory territory, final MouseDetails md) {
-      if (!getActive()) {
-        log.severe("Should not be able to select a territory when inactive: " + territory);
-        return;
-      }
-
-      if (territory != null) {
-        // highlight territory
-        if (currentAction == selectTerritoryAction) {
-          if (!territory.equals(currentHighlightedTerritory)) {
-            if (currentHighlightedTerritory != null) {
-              getMap().clearTerritoryOverlay(currentHighlightedTerritory);
-            }
-            currentHighlightedTerritory = territory;
-            if (territoryChoices.contains(currentHighlightedTerritory)) {
-              getMap().setTerritoryOverlay(currentHighlightedTerritory, Color.WHITE, 200);
-            } else {
-              getMap().setTerritoryOverlay(currentHighlightedTerritory, Color.RED, 200);
-            }
-            getMap().repaint();
-          }
-        }
-      }
-    }
-  };
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -35,44 +35,6 @@ class PlacePanel extends AbstractMovePanel {
   private PlaceData placeData;
   private final SimpleUnitPanel unitsToPlace;
 
-  PlacePanel(final GameData data, final MapPanel map, final TripleAFrame frame) {
-    super(data, map, frame);
-    undoableMovesPanel = new UndoablePlacementsPanel(this);
-    unitsToPlace = new SimpleUnitPanel(map.getUiContext());
-    leftToPlaceLabel.setText("Units left to place:");
-  }
-
-  @Override
-  public void display(final PlayerId id) {
-    super.display(id, " place");
-  }
-
-  private void refreshActionLabelText(final boolean bid) {
-    SwingUtilities
-        .invokeLater(() -> actionLabel.setText(getCurrentPlayer().getName() + " place" + (bid ? " for bid" : "")));
-  }
-
-  PlaceData waitForPlace(final boolean bid, final IPlayerBridge playerBridge) {
-    setUp(playerBridge);
-    // workaround: meant to be in setUpSpecific, but it requires a variable
-    refreshActionLabelText(bid);
-    waitForRelease();
-    cleanUp();
-    return placeData;
-  }
-
-  private boolean canProduceFightersOnCarriers() {
-    return Properties.getProduceFightersOnCarriers(getData());
-  }
-
-  private boolean canProduceNewFightersOnOldCarriers() {
-    return Properties.getProduceNewFightersOnOldCarriers(getData());
-  }
-
-  private boolean isLhtrCarrierProductionRules() {
-    return Properties.getLhtrCarrierProductionRules(getData());
-  }
-
   private final MapSelectionListener placeMapSelectionListener = new DefaultMapSelectionListener() {
     @Override
     public void territorySelected(final Territory territory, final MouseDetails e) {
@@ -112,6 +74,44 @@ class PlacePanel extends AbstractMovePanel {
       }
     }
   };
+
+  PlacePanel(final GameData data, final MapPanel map, final TripleAFrame frame) {
+    super(data, map, frame);
+    undoableMovesPanel = new UndoablePlacementsPanel(this);
+    unitsToPlace = new SimpleUnitPanel(map.getUiContext());
+    leftToPlaceLabel.setText("Units left to place:");
+  }
+
+  @Override
+  public void display(final PlayerId id) {
+    super.display(id, " place");
+  }
+
+  private void refreshActionLabelText(final boolean bid) {
+    SwingUtilities
+        .invokeLater(() -> actionLabel.setText(getCurrentPlayer().getName() + " place" + (bid ? " for bid" : "")));
+  }
+
+  PlaceData waitForPlace(final boolean bid, final IPlayerBridge playerBridge) {
+    setUp(playerBridge);
+    // workaround: meant to be in setUpSpecific, but it requires a variable
+    refreshActionLabelText(bid);
+    waitForRelease();
+    cleanUp();
+    return placeData;
+  }
+
+  private boolean canProduceFightersOnCarriers() {
+    return Properties.getProduceFightersOnCarriers(getData());
+  }
+
+  private boolean canProduceNewFightersOnOldCarriers() {
+    return Properties.getProduceNewFightersOnOldCarriers(getData());
+  }
+
+  private boolean isLhtrCarrierProductionRules() {
+    return Properties.getLhtrCarrierProductionRules(getData());
+  }
 
   private Collection<Unit> getUnitsToPlace(final Territory territory, final int[] maxUnits) {
     getData().acquireReadLock();

--- a/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
@@ -51,6 +51,16 @@ public class PoliticsPanel extends ActionPanel {
    */
   private final Action selectPoliticalActionAction;
 
+  /**
+   * This will stop the politicsPhase.
+   */
+  private final Action dontBotherAction = SwingAction.of("Done", e -> {
+    if (!firstRun || youSureDoNothing()) {
+      choice = null;
+      release();
+    }
+  });
+
   public PoliticsPanel(final GameData data, final MapPanel map, final TripleAFrame parent) {
     super(data, map);
     selectPoliticalActionAction = SwingAction.of("Do Politics...", e -> {
@@ -188,16 +198,6 @@ public class PoliticsPanel extends ActionPanel {
     }
     return politicalActionButtonPanel;
   }
-
-  /**
-   * This will stop the politicsPhase.
-   */
-  private final Action dontBotherAction = SwingAction.of("Done", e -> {
-    if (!firstRun || youSureDoNothing()) {
-      choice = null;
-      release();
-    }
-  });
 
   private boolean youSureDoNothing() {
     final int selectedOption = JOptionPane.showConfirmDialog(JOptionPane.getFrameForComponent(PoliticsPanel.this),

--- a/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
@@ -60,6 +60,11 @@ class ProductionPanel extends JPanel {
 
   private JDialog dialog;
   private boolean bid;
+  final Action doneAction = SwingAction.of("Done", e -> dialog.setVisible(false));
+
+  protected ProductionPanel(final UiContext uiContext) {
+    this.uiContext = uiContext;
+  }
 
   static IntegerMap<ProductionRule> getProduction(final PlayerId id, final JFrame parent, final GameData data,
       final boolean bid, final IntegerMap<ProductionRule> initialPurchase, final UiContext uiContext) {
@@ -75,10 +80,6 @@ class ProductionPanel extends JPanel {
       }
     }
     return prod;
-  }
-
-  protected ProductionPanel(final UiContext uiContext) {
-    this.uiContext = uiContext;
   }
 
   /**
@@ -179,8 +180,6 @@ class ProductionPanel extends JPanel {
     }
   }
 
-  final Action doneAction = SwingAction.of("Done", e -> dialog.setVisible(false));
-
   // This method can be overridden by subclasses
   protected void calculateLimits() {
     final ResourceCollection resources = getResources();
@@ -224,6 +223,26 @@ class ProductionPanel extends JPanel {
     private final ProductionRule rule;
     private final PlayerId id;
     private final Set<ScrollableTextField> textFields = new HashSet<>();
+    private final ScrollableTextFieldListener listener = new ScrollableTextFieldListener() {
+      @Override
+      public void changedValue(final ScrollableTextField stf) {
+        if (stf.getValue() != quantity) {
+          quantity = stf.getValue();
+          calculateLimits();
+          for (final ScrollableTextField textField : textFields) {
+            if (!stf.equals(textField)) {
+              textField.setValue(quantity);
+            }
+          }
+        }
+      }
+    };
+
+    Rule(final ProductionRule rule, final PlayerId id) {
+      this.rule = rule;
+      cost = rule.getCosts();
+      this.id = id;
+    }
 
     protected JPanel getPanelComponent() {
       final JPanel panel = new JPanel();
@@ -315,12 +334,6 @@ class ProductionPanel extends JPanel {
       return panel;
     }
 
-    Rule(final ProductionRule rule, final PlayerId id) {
-      this.rule = rule;
-      cost = rule.getCosts();
-      this.id = id;
-    }
-
     IntegerMap<Resource> getCost() {
       return cost;
     }
@@ -347,20 +360,5 @@ class ProductionPanel extends JPanel {
         textField.setMax(max);
       }
     }
-
-    private final ScrollableTextFieldListener listener = new ScrollableTextFieldListener() {
-      @Override
-      public void changedValue(final ScrollableTextField stf) {
-        if (stf.getValue() != quantity) {
-          quantity = stf.getValue();
-          calculateLimits();
-          for (final ScrollableTextField textField : textFields) {
-            if (!stf.equals(textField)) {
-              textField.setValue(quantity);
-            }
-          }
-        }
-      }
-    };
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
@@ -53,6 +53,12 @@ class ProductionRepairPanel extends JPanel {
   private boolean bid;
   private Collection<PlayerId> allowedPlayersToRepair;
   private GameData data;
+  final Action doneAction = SwingAction.of("Done", e -> dialog.setVisible(false));
+  private final ScrollableTextFieldListener listener = stf -> calculateLimits();
+
+  ProductionRepairPanel(final UiContext uiContext) {
+    this.uiContext = uiContext;
+  }
 
   static Map<Unit, IntegerMap<RepairRule>> getProduction(final PlayerId id,
       final Collection<PlayerId> allowedPlayersToRepair, final JFrame parent, final GameData data, final boolean bid,
@@ -104,10 +110,6 @@ class ProductionRepairPanel extends JPanel {
     dialog = new JDialog(root, "Repair", true);
     dialog.getContentPane().add(this);
     SwingComponents.addEscapeKeyListener(dialog, () -> dialog.setVisible(false));
-  }
-
-  ProductionRepairPanel(final UiContext uiContext) {
-    this.uiContext = uiContext;
   }
 
   private void initRules(final PlayerId player, final Collection<PlayerId> allowedPlayersToRepair, final GameData data,
@@ -170,8 +172,6 @@ class ProductionRepairPanel extends JPanel {
     final ResourceCollection total = getResources();
     this.left.setText("<html>You have " + left + " left.<br>Out of " + total + "</html>");
   }
-
-  final Action doneAction = SwingAction.of("Done", e -> dialog.setVisible(false));
 
   protected void calculateLimits() {
     // final IntegerMap<Resource> cost;
@@ -285,6 +285,4 @@ class ProductionRepairPanel extends JPanel {
       return unit;
     }
   }
-
-  private final ScrollableTextFieldListener listener = stf -> calculateLimits();
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
@@ -33,6 +33,88 @@ public class SimpleUnitPanel extends JPanel {
   private static final long serialVersionUID = -3768796793775300770L;
   private final UiContext uiContext;
 
+  final Comparator<ProductionRule> productionRuleComparator = new Comparator<ProductionRule>() {
+    final UnitTypeComparator utc = new UnitTypeComparator();
+
+    @Override
+    public int compare(final ProductionRule o1, final ProductionRule o2) {
+      if (o1.getResults().size() == 1 && o2.getResults().size() == 1) {
+        final NamedAttachable n1 = o1.getResults().keySet().iterator().next();
+        final NamedAttachable n2 = o2.getResults().keySet().iterator().next();
+        if (n1 instanceof UnitType) {
+          final UnitType u1 = (UnitType) n1;
+          if (n2 instanceof UnitType) {
+            final UnitType u2 = (UnitType) n2;
+            return utc.compare(u1, u2);
+          } else if (n2 instanceof Resource) {
+            // final Resource r2 = (Resource) n2;
+            return -1;
+          }
+          return n1.getName().compareTo(n2.getName());
+        } else if (n1 instanceof Resource) {
+          final Resource r1 = (Resource) n1;
+          if (n2 instanceof UnitType) {
+            // final UnitType u2 = (UnitType) n2;
+            return 1;
+          } else if (n2 instanceof Resource) {
+            final Resource r2 = (Resource) n2;
+            return r1.getName().compareTo(r2.getName());
+          } else {
+            return n1.getName().compareTo(n2.getName());
+          }
+        }
+        return n1.getName().compareTo(n2.getName());
+      }
+      if (o1.getResults().size() > o2.getResults().size()) {
+        return -1;
+      } else if (o1.getResults().size() < o2.getResults().size()) {
+        return 1;
+      }
+      return o1.getName().compareTo(o2.getName());
+    }
+  };
+
+  final Comparator<RepairRule> repairRuleComparator = new Comparator<RepairRule>() {
+    final UnitTypeComparator utc = new UnitTypeComparator();
+
+    @Override
+    public int compare(final RepairRule o1, final RepairRule o2) {
+      if (o1.getResults().size() == 1 && o2.getResults().size() == 1) {
+        final NamedAttachable n1 = o1.getResults().keySet().iterator().next();
+        final NamedAttachable n2 = o2.getResults().keySet().iterator().next();
+        if (n1 instanceof UnitType) {
+          final UnitType u1 = (UnitType) n1;
+          if (n2 instanceof UnitType) {
+            final UnitType u2 = (UnitType) n2;
+            return utc.compare(u1, u2);
+          } else if (n2 instanceof Resource) {
+            // final Resource r2 = (Resource) n2;
+            return -1;
+          }
+          return n1.getName().compareTo(n2.getName());
+        } else if (n1 instanceof Resource) {
+          final Resource r1 = (Resource) n1;
+          if (n2 instanceof UnitType) {
+            // final UnitType u2 = (UnitType) n2;
+            return 1;
+          } else if (n2 instanceof Resource) {
+            final Resource r2 = (Resource) n2;
+            return r1.getName().compareTo(r2.getName());
+          } else {
+            return n1.getName().compareTo(n2.getName());
+          }
+        }
+        return n1.getName().compareTo(n2.getName());
+      }
+      if (o1.getResults().size() > o2.getResults().size()) {
+        return -1;
+      } else if (o1.getResults().size() < o2.getResults().size()) {
+        return 1;
+      }
+      return o1.getName().compareTo(o2.getName());
+    }
+  };
+
   public SimpleUnitPanel(final UiContext uiContext) {
     this.uiContext = uiContext;
     setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
@@ -111,85 +193,4 @@ public class SimpleUnitPanel extends JPanel {
     }
     add(label);
   }
-
-  final Comparator<ProductionRule> productionRuleComparator = new Comparator<ProductionRule>() {
-    final UnitTypeComparator utc = new UnitTypeComparator();
-
-    @Override
-    public int compare(final ProductionRule o1, final ProductionRule o2) {
-      if (o1.getResults().size() == 1 && o2.getResults().size() == 1) {
-        final NamedAttachable n1 = o1.getResults().keySet().iterator().next();
-        final NamedAttachable n2 = o2.getResults().keySet().iterator().next();
-        if (n1 instanceof UnitType) {
-          final UnitType u1 = (UnitType) n1;
-          if (n2 instanceof UnitType) {
-            final UnitType u2 = (UnitType) n2;
-            return utc.compare(u1, u2);
-          } else if (n2 instanceof Resource) {
-            // final Resource r2 = (Resource) n2;
-            return -1;
-          }
-          return n1.getName().compareTo(n2.getName());
-        } else if (n1 instanceof Resource) {
-          final Resource r1 = (Resource) n1;
-          if (n2 instanceof UnitType) {
-            // final UnitType u2 = (UnitType) n2;
-            return 1;
-          } else if (n2 instanceof Resource) {
-            final Resource r2 = (Resource) n2;
-            return r1.getName().compareTo(r2.getName());
-          } else {
-            return n1.getName().compareTo(n2.getName());
-          }
-        }
-        return n1.getName().compareTo(n2.getName());
-      }
-      if (o1.getResults().size() > o2.getResults().size()) {
-        return -1;
-      } else if (o1.getResults().size() < o2.getResults().size()) {
-        return 1;
-      }
-      return o1.getName().compareTo(o2.getName());
-    }
-  };
-  final Comparator<RepairRule> repairRuleComparator = new Comparator<RepairRule>() {
-    final UnitTypeComparator utc = new UnitTypeComparator();
-
-    @Override
-    public int compare(final RepairRule o1, final RepairRule o2) {
-      if (o1.getResults().size() == 1 && o2.getResults().size() == 1) {
-        final NamedAttachable n1 = o1.getResults().keySet().iterator().next();
-        final NamedAttachable n2 = o2.getResults().keySet().iterator().next();
-        if (n1 instanceof UnitType) {
-          final UnitType u1 = (UnitType) n1;
-          if (n2 instanceof UnitType) {
-            final UnitType u2 = (UnitType) n2;
-            return utc.compare(u1, u2);
-          } else if (n2 instanceof Resource) {
-            // final Resource r2 = (Resource) n2;
-            return -1;
-          }
-          return n1.getName().compareTo(n2.getName());
-        } else if (n1 instanceof Resource) {
-          final Resource r1 = (Resource) n1;
-          if (n2 instanceof UnitType) {
-            // final UnitType u2 = (UnitType) n2;
-            return 1;
-          } else if (n2 instanceof Resource) {
-            final Resource r2 = (Resource) n2;
-            return r1.getName().compareTo(r2.getName());
-          } else {
-            return n1.getName().compareTo(n2.getName());
-          }
-        }
-        return n1.getName().compareTo(n2.getName());
-      }
-      if (o1.getResults().size() > o2.getResults().size()) {
-        return -1;
-      } else if (o1.getResults().size() < o2.getResults().size()) {
-        return 1;
-      }
-      return o1.getName().compareTo(o2.getName());
-    }
-  };
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/TechPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TechPanel.java
@@ -46,59 +46,6 @@ class TechPanel extends ActionPanel {
   private int quantity;
   private IntegerMap<PlayerId> whoPaysHowMuch = null;
 
-  TechPanel(final GameData data, final MapPanel map) {
-    super(data, map);
-  }
-
-  @Override
-  public void display(final PlayerId id) {
-    super.display(id);
-    SwingUtilities.invokeLater(() -> {
-      removeAll();
-      actionLabel.setText(id.getName() + " Tech Roll");
-      add(actionLabel);
-      if (isWW2V3TechModel()) {
-        add(new JButton(getTechTokenAction));
-        add(new JButton(justRollTech));
-      } else {
-        add(new JButton(getTechRollsAction));
-        add(new JButton(dontBother));
-      }
-    });
-  }
-
-  @Override
-  public String toString() {
-    return "TechPanel";
-  }
-
-  TechRoll waitForTech() {
-    if (getAvailableTechs().isEmpty()) {
-      return null;
-    }
-    waitForRelease();
-    if (techRoll == null) {
-      return null;
-    }
-    if (techRoll.getRolls() == 0) {
-      return null;
-    }
-    return techRoll;
-  }
-
-  private List<TechAdvance> getAvailableTechs() {
-    final Collection<TechAdvance> currentAdvances = TechTracker.getCurrentTechAdvances(getCurrentPlayer(), getData());
-    final Collection<TechAdvance> allAdvances = TechAdvance.getTechAdvances(getData(), getCurrentPlayer());
-    return CollectionUtils.difference(allAdvances, currentAdvances);
-  }
-
-  private List<TechnologyFrontier> getAvailableCategories() {
-    final Collection<TechnologyFrontier> currentAdvances =
-        TechTracker.getFullyResearchedPlayerTechCategories(getCurrentPlayer());
-    final Collection<TechnologyFrontier> allAdvances = TechAdvance.getPlayerTechCategories(getCurrentPlayer());
-    return CollectionUtils.difference(allAdvances, currentAdvances);
-  }
-
   private final Action getTechRollsAction = SwingAction.of("Roll Tech...", e -> {
     TechAdvance advance = null;
     if (isWW2V2() || (isSelectableTechRoll() && !isWW2V3TechModel())) {
@@ -200,8 +147,6 @@ class TechPanel extends ActionPanel {
     techRoll = new TechRoll(category, currTokens, quantity, whoPaysHowMuch);
     techRoll.setNewTokens(quantity);
     release();
-
-
   });
 
   private final Action justRollTech = SwingAction.of("Done/Roll Current Tokens", e -> {
@@ -235,8 +180,60 @@ class TechPanel extends ActionPanel {
       techRoll = null;
     }
     release();
-
   });
+
+  TechPanel(final GameData data, final MapPanel map) {
+    super(data, map);
+  }
+
+  @Override
+  public void display(final PlayerId id) {
+    super.display(id);
+    SwingUtilities.invokeLater(() -> {
+      removeAll();
+      actionLabel.setText(id.getName() + " Tech Roll");
+      add(actionLabel);
+      if (isWW2V3TechModel()) {
+        add(new JButton(getTechTokenAction));
+        add(new JButton(justRollTech));
+      } else {
+        add(new JButton(getTechRollsAction));
+        add(new JButton(dontBother));
+      }
+    });
+  }
+
+  @Override
+  public String toString() {
+    return "TechPanel";
+  }
+
+  TechRoll waitForTech() {
+    if (getAvailableTechs().isEmpty()) {
+      return null;
+    }
+    waitForRelease();
+    if (techRoll == null) {
+      return null;
+    }
+    if (techRoll.getRolls() == 0) {
+      return null;
+    }
+    return techRoll;
+  }
+
+  private List<TechAdvance> getAvailableTechs() {
+    final Collection<TechAdvance> currentAdvances = TechTracker.getCurrentTechAdvances(getCurrentPlayer(), getData());
+    final Collection<TechAdvance> allAdvances = TechAdvance.getTechAdvances(getData(), getCurrentPlayer());
+    return CollectionUtils.difference(allAdvances, currentAdvances);
+  }
+
+  private List<TechnologyFrontier> getAvailableCategories() {
+    final Collection<TechnologyFrontier> currentAdvances =
+        TechTracker.getFullyResearchedPlayerTechCategories(getCurrentPlayer());
+    final Collection<TechnologyFrontier> allAdvances = TechAdvance.getPlayerTechCategories(getCurrentPlayer());
+    return CollectionUtils.difference(allAdvances, currentAdvances);
+  }
 
   private static String getTechListToolTipText(final TechnologyFrontier techCategory) {
     final List<TechAdvance> techList = techCategory.getTechs();

--- a/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -42,6 +42,16 @@ final class UnitChooser extends JPanel {
   private JButton selectNoneButton;
   private final UiContext uiContext;
   private final Predicate<Collection<Unit>> match;
+  private final ScrollableTextFieldListener textFieldListener = new ScrollableTextFieldListener() {
+    @Override
+    public void changedValue(final ScrollableTextField field) {
+      if (match != null) {
+        checkMatches();
+      } else {
+        updateLeft();
+      }
+    }
+  };
 
   UnitChooser(final Collection<Unit> units, final Map<Unit, Collection<Unit>> dependent,
       final boolean allowTwoHit, final UiContext uiContext) {
@@ -303,17 +313,6 @@ final class UnitChooser extends JPanel {
   public void addChangeListener(final ScrollableTextFieldListener listener) {
     entries.forEach(entry -> entry.addChangeListener(listener));
   }
-
-  private final ScrollableTextFieldListener textFieldListener = new ScrollableTextFieldListener() {
-    @Override
-    public void changedValue(final ScrollableTextField field) {
-      if (match != null) {
-        checkMatches();
-      } else {
-        updateLeft();
-      }
-    }
-  };
 
   private static final class ChooserEntry {
     private final UnitCategory category;

--- a/game-core/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
@@ -47,6 +47,52 @@ public class UserActionPanel extends ActionPanel {
   private boolean firstRun = true;
   private List<UserActionAttachment> validUserActions = Collections.emptyList();
 
+  /**
+   * Fires up a JDialog showing valid actions,
+   * choosing an action will release this model and trigger waitForRelease().
+   */
+  private final Action selectUserActionAction = new AbstractAction("Take Action...") {
+    private static final long serialVersionUID = 2389485901611958851L;
+
+    @Override
+    public void actionPerformed(final ActionEvent event) {
+      final JDialog userChoiceDialog = new JDialog(parent, "Actions and Operations", true);
+
+      final JPanel userChoicePanel = new JPanel();
+      userChoicePanel.setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
+      userChoicePanel.setLayout(new GridBagLayout());
+
+      int row = 0;
+      final JScrollPane choiceScroll = new JScrollPane(getUserActionButtonPanel(userChoiceDialog));
+      choiceScroll.setBorder(BorderFactory.createEtchedBorder());
+      userChoicePanel.add(choiceScroll, new GridBagConstraints(0, row++, 2, 1, 1, 1, GridBagConstraints.CENTER,
+          GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
+
+      final JButton noActionButton = new JButton(SwingAction.of("No Actions", e -> userChoiceDialog.setVisible(false)));
+      SwingUtilities.invokeLater(noActionButton::requestFocusInWindow);
+      userChoicePanel.add(noActionButton, new GridBagConstraints(0, row, 2, 1, 0.0, 0.0, GridBagConstraints.EAST,
+          GridBagConstraints.NONE, new Insets(12, 0, 0, 0), 0, 0));
+
+      userChoiceDialog.setContentPane(userChoicePanel);
+      userChoiceDialog.pack();
+      userChoiceDialog.setLocationRelativeTo(parent);
+      userChoiceDialog.setVisible(true);
+      userChoiceDialog.dispose();
+    }
+  };
+
+  /**
+   * This will stop the user action Phase.
+   */
+  private final Action dontBotherAction = SwingAction.of("Done", e -> {
+    if (!firstRun || JOptionPane.showConfirmDialog(JOptionPane.getFrameForComponent(UserActionPanel.this),
+        "Are you sure you dont want to do anything?", "End Actions",
+        JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION) {
+      choice = null;
+      release();
+    }
+  });
+
   public UserActionPanel(final GameData data, final MapPanel map, final TripleAFrame parent) {
     super(data, map);
     this.parent = parent;
@@ -105,40 +151,6 @@ public class UserActionPanel extends ActionPanel {
     return choice;
   }
 
-  /**
-   * Fires up a JDialog showing valid actions,
-   * choosing an action will release this model and trigger waitForRelease().
-   */
-  private final Action selectUserActionAction = new AbstractAction("Take Action...") {
-    private static final long serialVersionUID = 2389485901611958851L;
-
-    @Override
-    public void actionPerformed(final ActionEvent event) {
-      final JDialog userChoiceDialog = new JDialog(parent, "Actions and Operations", true);
-
-      final JPanel userChoicePanel = new JPanel();
-      userChoicePanel.setBorder(BorderFactory.createEmptyBorder(8, 8, 8, 8));
-      userChoicePanel.setLayout(new GridBagLayout());
-
-      int row = 0;
-      final JScrollPane choiceScroll = new JScrollPane(getUserActionButtonPanel(userChoiceDialog));
-      choiceScroll.setBorder(BorderFactory.createEtchedBorder());
-      userChoicePanel.add(choiceScroll, new GridBagConstraints(0, row++, 2, 1, 1, 1, GridBagConstraints.CENTER,
-          GridBagConstraints.BOTH, new Insets(0, 0, 0, 0), 0, 0));
-
-      final JButton noActionButton = new JButton(SwingAction.of("No Actions", e -> userChoiceDialog.setVisible(false)));
-      SwingUtilities.invokeLater(noActionButton::requestFocusInWindow);
-      userChoicePanel.add(noActionButton, new GridBagConstraints(0, row, 2, 1, 0.0, 0.0, GridBagConstraints.EAST,
-          GridBagConstraints.NONE, new Insets(12, 0, 0, 0), 0, 0));
-
-      userChoiceDialog.setContentPane(userChoicePanel);
-      userChoiceDialog.pack();
-      userChoiceDialog.setLocationRelativeTo(parent);
-      userChoiceDialog.setVisible(true);
-      userChoiceDialog.dispose();
-    }
-  };
-
   @VisibleForTesting
   static boolean canSpendResourcesOnUserActions(final Collection<UserActionAttachment> userActions) {
     return userActions.stream().anyMatch(userAction -> !userAction.getCostResources().isEmpty());
@@ -190,18 +202,6 @@ public class UserActionPanel extends ActionPanel {
   static boolean canPlayerAffordUserAction(final PlayerId player, final UserActionAttachment userAction) {
     return player.getResources().has(userAction.getCostResources());
   }
-
-  /**
-   * This will stop the user action Phase.
-   */
-  private final Action dontBotherAction = SwingAction.of("Done", e -> {
-    if (!firstRun || JOptionPane.showConfirmDialog(JOptionPane.getFrameForComponent(UserActionPanel.this),
-        "Are you sure you dont want to do anything?", "End Actions",
-        JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION) {
-      choice = null;
-      release();
-    }
-  });
 
   /**
    * Convenient method to get a JCompenent showing the flags involved in this action.

--- a/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
@@ -45,6 +45,13 @@ public class HistoryPanel extends JPanel {
   private final HistoryDetailsPanel details;
   private HistoryNode currentPopupNode;
   private final JPopupMenu popup;
+  // remember which paths were expanded
+  final Collection<TreePath> stayExpandedPaths = new ArrayList<>();
+  private boolean mouseOverPanel;
+  // to distinguish the first mouse over panel event from the others
+  boolean mouseWasOverPanel;
+  // remember where to start collapsing
+  TreePath lastParent = null;
 
   public HistoryPanel(final GameData data, final HistoryDetailsPanel details, final JPopupMenu popup,
       final UiContext uiContext) {
@@ -272,14 +279,6 @@ public class HistoryPanel extends JPanel {
   public void clearCurrentPopupNode() {
     currentPopupNode = null;
   }
-
-  // remember which paths were expanded
-  final Collection<TreePath> stayExpandedPaths = new ArrayList<>();
-  private boolean mouseOverPanel;
-  // to distinguish the first mouse over panel event from the others
-  boolean mouseWasOverPanel;
-  // remember where to start collapsing
-  TreePath lastParent = null;
 
   private void addToStayExpanded(final Enumeration<TreePath> paths) {
     final Collection<TreePath> expandPaths = new ArrayList<>();

--- a/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -126,14 +126,6 @@ public class MapData implements Closeable {
   private final Map<String, Image> effectImages = new HashMap<>();
   private final ResourceLoader resourceLoader;
 
-  public boolean scrollWrapX() {
-    return Boolean.parseBoolean(mapProperties.getProperty(PROPERTY_MAP_SCROLLWRAPX, "true"));
-  }
-
-  public boolean scrollWrapY() {
-    return Boolean.parseBoolean(mapProperties.getProperty(PROPERTY_MAP_SCROLLWRAPY, "false"));
-  }
-
   public MapData(final String mapNameDir) {
     this(ResourceLoader.getMapResourceLoader(mapNameDir));
   }
@@ -217,6 +209,14 @@ public class MapData implements Closeable {
     try (InputStream is = inputStreamFactory.get()) {
       return reader.apply(is);
     }
+  }
+
+  public boolean scrollWrapX() {
+    return Boolean.parseBoolean(mapProperties.getProperty(PROPERTY_MAP_SCROLLWRAPX, "true"));
+  }
+
+  public boolean scrollWrapY() {
+    return Boolean.parseBoolean(mapProperties.getProperty(PROPERTY_MAP_SCROLLWRAPY, "false"));
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -52,6 +52,7 @@ import swinglib.JLabelBuilder;
  */
 public final class HelpMenu extends JMenu {
   private static final long serialVersionUID = 4070541434144687452L;
+  public static final JEditorPane gameNotesPane = new JEditorPane();
 
   private final UiContext uiContext;
   private final GameData gameData;
@@ -239,8 +240,6 @@ public final class HelpMenu extends JMenu {
     unitMenuItem.setAccelerator(
         KeyStroke.getKeyStroke(KeyEvent.VK_L, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
   }
-
-  public static final JEditorPane gameNotesPane = new JEditorPane();
 
   private void addGameNotesMenu() {
     // allow the game developer to write notes that appear in the game

--- a/game-core/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
+++ b/game-core/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
@@ -52,14 +52,6 @@ public class ImageScrollerLargeView extends JComponent {
   private int dragScrollingLastY;
   private boolean wasLastActionDragging = false;
 
-  public boolean wasLastActionDraggingAndReset() {
-    if (wasLastActionDragging) {
-      wasLastActionDragging = false;
-      return true;
-    }
-    return false;
-  }
-
   private final ActionListener timerAction = new ActionListener() {
     @Override
     public void actionPerformed(final ActionEvent e) {
@@ -236,6 +228,14 @@ public class ImageScrollerLargeView extends JComponent {
       repaint();
       notifyScollListeners();
     });
+  }
+
+  public boolean wasLastActionDraggingAndReset() {
+    if (wasLastActionDragging) {
+      wasLastActionDragging = false;
+      return true;
+    }
+    return false;
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/ui/ImageScrollerSmallView.java
+++ b/game-core/src/main/java/games/strategy/ui/ImageScrollerSmallView.java
@@ -28,6 +28,7 @@ public class ImageScrollerSmallView extends JComponent {
   private final ImageScrollModel model;
   private Image image;
   private final MapData mapData;
+  private long lastUpdate = 0;
 
   public ImageScrollerSmallView(final Image image, final ImageScrollModel model, final MapData mapData) {
     this.model = model;
@@ -152,8 +153,6 @@ public class ImageScrollerSmallView extends JComponent {
   private void setSelection(final int x, final int y) {
     model.set(x, y);
   }
-
-  private long lastUpdate = 0;
 
   public double getRatioY() {
     return image.getHeight(null) / (double) model.getMaxHeight();

--- a/game-core/src/main/java/games/strategy/ui/Util.java
+++ b/game-core/src/main/java/games/strategy/ui/Util.java
@@ -27,11 +27,11 @@ import java.util.Optional;
 public final class Util {
   public static final String TERRITORY_SEA_ZONE_INFIX = "Sea Zone";
 
-  private Util() {}
-
   private static final Component component = new Component() {
     private static final long serialVersionUID = 1800075529163275600L;
   };
+
+  private Util() {}
 
   public static void ensureImageLoaded(final Image anImage) {
     final MediaTracker tracker = new MediaTracker(component);

--- a/game-core/src/main/java/games/strategy/util/Triple.java
+++ b/game-core/src/main/java/games/strategy/util/Triple.java
@@ -19,6 +19,11 @@ public final class Triple<F, S, T> implements Serializable {
   private final Tuple<F, S> tuple;
   private final T third;
 
+  private Triple(final F first, final S second, final T third) {
+    tuple = Tuple.of(first, second);
+    this.third = third;
+  }
+
   /**
    * Static creation method to create a new instance of a triple with the parameters provided.
    *
@@ -40,11 +45,6 @@ public final class Triple<F, S, T> implements Serializable {
    */
   public static <F, S, T> Triple<F, S, T> of(final F first, final S second, final T third) {
     return new Triple<>(first, second, third);
-  }
-
-  private Triple(final F first, final S second, final T third) {
-    tuple = Tuple.of(first, second);
-    this.third = third;
   }
 
   public F getFirst() {

--- a/game-core/src/main/java/games/strategy/util/Tuple.java
+++ b/game-core/src/main/java/games/strategy/util/Tuple.java
@@ -18,6 +18,11 @@ public final class Tuple<T, S> implements Serializable {
   private final T first;
   private final S second;
 
+  private Tuple(final T first, final S second) {
+    this.first = first;
+    this.second = second;
+  }
+
   /**
    * Static creation method to create a new instance of a tuple with the parameters provided.
    *
@@ -39,11 +44,6 @@ public final class Tuple<T, S> implements Serializable {
    */
   public static <T, S> Tuple<T, S> of(final T first, final S second) {
     return new Tuple<>(first, second);
-  }
-
-  private Tuple(final T first, final S second) {
-    this.first = first;
-    this.second = second;
   }
 
   public T getFirst() {

--- a/game-core/src/main/java/games/strategy/util/UrlStreams.java
+++ b/game-core/src/main/java/games/strategy/util/UrlStreams.java
@@ -13,38 +13,8 @@ import java.util.function.Function;
  * Utility class for opening input streams from URL and URI objects.
  */
 public final class UrlStreams {
-
-  /**
-   * Opens an input stream to a given url. Returns Optional.empty() in case there is a failure.
-   * The failure message is logged to the user.
-   *
-   * @return Optional.empty() if there was a failure opening the strema, otherwise an optional
-   *         containing an input stream to the parameter uri.
-   */
-  public static Optional<InputStream> openStream(final URL url) {
-    return new UrlStreams().newStream(url);
-  }
-
-
-  /**
-   * Opens an input stream to a given uri.
-   *
-   * @return Optional.empty() if there was a failure opening the strema, otherwise an optional
-   *         containing an input stream to the parameter uri.
-   *
-   * @throws IllegalStateException if the given uri is malformed
-   */
-  public static Optional<InputStream> openStream(final URI uri) {
-    try {
-      return UrlStreams.openStream(uri.toURL());
-    } catch (final MalformedURLException e) {
-      throw new IllegalStateException("Bad uri specified: " + uri, e);
-    }
-  }
-
   /** Used to obtain a connection from a given URL. */
   private final Function<URL, URLConnection> urlConnectionFactory;
-
 
   protected UrlStreams() {
     // By default just try open a connection, raise any exceptions encountered
@@ -62,6 +32,33 @@ public final class UrlStreams {
    */
   protected UrlStreams(final Function<URL, URLConnection> connectionFactory) {
     this.urlConnectionFactory = connectionFactory;
+  }
+
+  /**
+   * Opens an input stream to a given url. Returns Optional.empty() in case there is a failure.
+   * The failure message is logged to the user.
+   *
+   * @return Optional.empty() if there was a failure opening the strema, otherwise an optional
+   *         containing an input stream to the parameter uri.
+   */
+  public static Optional<InputStream> openStream(final URL url) {
+    return new UrlStreams().newStream(url);
+  }
+
+  /**
+   * Opens an input stream to a given uri.
+   *
+   * @return Optional.empty() if there was a failure opening the strema, otherwise an optional
+   *         containing an input stream to the parameter uri.
+   *
+   * @throws IllegalStateException if the given uri is malformed
+   */
+  public static Optional<InputStream> openStream(final URI uri) {
+    try {
+      return UrlStreams.openStream(uri.toURL());
+    } catch (final MalformedURLException e) {
+      throw new IllegalStateException("Bad uri specified: " + uri, e);
+    }
   }
 
   protected Optional<InputStream> newStream(final URL url) {

--- a/game-core/src/main/java/swinglib/JFrameBuilder.java
+++ b/game-core/src/main/java/swinglib/JFrameBuilder.java
@@ -22,11 +22,6 @@ import games.strategy.ui.SwingComponents;
  * </ul>
  */
 public class JFrameBuilder {
-
-  public static JFrameBuilder builder() {
-    return new JFrameBuilder();
-  }
-
   private final Collection<Component> children = new ArrayList<>();
   private boolean escapeClosesWindow;
   private boolean alwaysOnTop;
@@ -39,6 +34,10 @@ public class JFrameBuilder {
   private int height;
 
   private LayoutManager layoutManager;
+
+  public static JFrameBuilder builder() {
+    return new JFrameBuilder();
+  }
 
   /**
    * Constructs the JFrame instance. It will not be visible.

--- a/game-core/src/main/java/tools/image/DecorationPlacer.java
+++ b/game-core/src/main/java/tools/image/DecorationPlacer.java
@@ -909,11 +909,6 @@ public final class DecorationPlacer {
     private final String description;
     private final String instructions;
 
-    static ImagePointType[] getTypes() {
-      return new ImagePointType[] {decorations, name_place, pu_place, capitols, vc, blockade, convoy, comments,
-          kamikaze_place, territory_effects};
-    }
-
     ImagePointType(final String fileName, final String folderName, final String imageName, final boolean useFolder,
         final boolean endInPng, final boolean fillAll, final boolean canUseBottomLeftPoint,
         final boolean canHaveMultiplePoints, final String description, final String instructions) {
@@ -927,6 +922,11 @@ public final class DecorationPlacer {
       this.canHaveMultiplePoints = canHaveMultiplePoints;
       this.description = description;
       this.instructions = instructions;
+    }
+
+    static ImagePointType[] getTypes() {
+      return new ImagePointType[] {decorations, name_place, pu_place, capitols, vc, blockade, convoy, comments,
+          kamikaze_place, territory_effects};
     }
 
     public String getFileName() {

--- a/game-core/src/main/java/tools/image/PolygonGrabber.java
+++ b/game-core/src/main/java/tools/image/PolygonGrabber.java
@@ -128,6 +128,7 @@ public final class PolygonGrabber {
     // holds the centers for the polygons
     private Map<String, Point> centers;
     private final JLabel location = new JLabel();
+    private final Point testPoint = new Point();
 
     /**
      * Asks user to specify a file with center points. If not program will exit. We setup the mouse listeners and
@@ -536,9 +537,6 @@ public final class PolygonGrabber {
         p.y--;
       }
     }
-
-    // used below
-    private final Point testPoint = new Point();
 
     /**
      * Checks to see if the direction we're going is on the edge.

--- a/game-core/src/main/java/tools/map/making/MapCreator.java
+++ b/game-core/src/main/java/tools/map/making/MapCreator.java
@@ -55,18 +55,6 @@ public class MapCreator extends JFrame {
   private final JPanel panel3 = new JPanel();
   private final JPanel panel4 = new JPanel();
 
-  /**
-   * Opens a map creator window.
-   */
-  public static void openMapCreatorWindow() {
-    Interruptibles.await(() -> SwingAction.invokeAndWait(() -> {
-      final MapCreator creator = new MapCreator();
-      creator.setSize(800, 600);
-      creator.setLocationRelativeTo(null);
-      creator.setVisible(true);
-    }));
-  }
-
   private MapCreator() {
     super("TripleA Map Creator");
     setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
@@ -348,5 +336,17 @@ public class MapCreator extends JFrame {
 
   private static void runUtility(final Consumer<String[]> entryPoint) {
     entryPoint.accept(new String[0]);
+  }
+
+  /**
+   * Opens a map creator window.
+   */
+  public static void openMapCreatorWindow() {
+    Interruptibles.await(() -> SwingAction.invokeAndWait(() -> {
+      final MapCreator creator = new MapCreator();
+      creator.setSize(800, 600);
+      creator.setLocationRelativeTo(null);
+      creator.setVisible(true);
+    }));
   }
 }

--- a/game-core/src/main/java/tools/util/ToolArguments.java
+++ b/game-core/src/main/java/tools/util/ToolArguments.java
@@ -4,10 +4,10 @@ package tools.util;
  * A collection of argument names common to all support tools.
  */
 public final class ToolArguments {
-  private ToolArguments() {}
-
   public static final String MAP_FOLDER = "triplea.map.folder";
   public static final String UNIT_HEIGHT = "triplea.unit.height";
   public static final String UNIT_WIDTH = "triplea.unit.width";
   public static final String UNIT_ZOOM = "triplea.unit.zoom";
+
+  private ToolArguments() {}
 }

--- a/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportUploadActionTest.java
+++ b/game-core/src/test/java/games/strategy/debug/error/reporting/ErrorReportUploadActionTest.java
@@ -29,6 +29,8 @@ import org.triplea.http.client.error.report.create.ErrorReportResponse;
 
 @ExtendWith(MockitoExtension.class)
 class ErrorReportUploadActionTest {
+  private static final UserErrorReport USER_ERROR_REPORT = UserErrorReport.builder()
+      .build();
 
   @Mock
   private ServiceClient<ErrorReport, ErrorReportResponse> serviceClient;
@@ -51,11 +53,6 @@ class ErrorReportUploadActionTest {
         .successConfirmation(successConfirmation)
         .build();
   }
-
-
-  private static final UserErrorReport USER_ERROR_REPORT = UserErrorReport.builder()
-      .build();
-
 
   @ParameterizedTest
   @MethodSource("withNonSuccessSendResults")

--- a/game-core/src/test/java/games/strategy/engine/framework/startup/mc/GameSelectorModelTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/startup/mc/GameSelectorModelTest.java
@@ -30,24 +30,6 @@ import games.strategy.util.Version;
 
 @ExtendWith(MockitoExtension.class)
 class GameSelectorModelTest extends AbstractClientSettingTestCase {
-
-  private static void assertHasEmptyData(final GameSelectorModel objectToCheck) {
-    assertThat(objectToCheck.getGameData(), nullValue());
-    assertHasEmptyDisplayData(objectToCheck);
-  }
-
-  private static void assertHasEmptyDisplayData(final GameSelectorModel objectToCheck) {
-    assertThat(objectToCheck.getFileName(), is("-"));
-    assertThat(objectToCheck.getGameName(), is("-"));
-    assertThat(objectToCheck.getGameRound(), is("-"));
-  }
-
-  private static void assertHasFakeTestData(final GameSelectorModel objectToCheck) {
-    assertThat(objectToCheck.getGameName(), is(fakeGameName));
-    assertThat(objectToCheck.getGameRound(), is(fakeGameRound));
-    assertThat(objectToCheck.getGameVersion(), is(fakeGameVersion));
-  }
-
   private static final String fakeGameVersion = "12.34.56";
   private static final String fakeGameRound = "3";
   private static final String fakeGameName = "_fakeGameName_";
@@ -69,6 +51,23 @@ class GameSelectorModelTest extends AbstractClientSettingTestCase {
 
   @Mock
   private ClientModel mockClientModel;
+
+  private static void assertHasEmptyData(final GameSelectorModel objectToCheck) {
+    assertThat(objectToCheck.getGameData(), nullValue());
+    assertHasEmptyDisplayData(objectToCheck);
+  }
+
+  private static void assertHasEmptyDisplayData(final GameSelectorModel objectToCheck) {
+    assertThat(objectToCheck.getFileName(), is("-"));
+    assertThat(objectToCheck.getGameName(), is("-"));
+    assertThat(objectToCheck.getGameRound(), is("-"));
+  }
+
+  private static void assertHasFakeTestData(final GameSelectorModel objectToCheck) {
+    assertThat(objectToCheck.getGameName(), is(fakeGameName));
+    assertThat(objectToCheck.getGameRound(), is(fakeGameRound));
+    assertThat(objectToCheck.getGameVersion(), is(fakeGameVersion));
+  }
 
   @BeforeEach
   void setup() {

--- a/http-client/src/main/java/org/triplea/http/client/FeignFactory.java
+++ b/http-client/src/main/java/org/triplea/http/client/FeignFactory.java
@@ -17,11 +17,6 @@ import lombok.extern.java.Log;
 final class FeignFactory {
   private static final Encoder gsonEncoder = new GsonEncoder();
   private static final Decoder gsonDecoder = new GsonDecoder();
-
-  private FeignFactory() {
-
-  }
-
   /**
    * How long we can take to start receiving a message.
    */
@@ -30,6 +25,8 @@ final class FeignFactory {
    * How long we can spend receiving a message.
    */
   private static final int DEFAULT_READ_TIME_OUT_MS = 20 * 1000;
+
+  private FeignFactory() {}
 
   static <T> T build(final Class<T> classType, final URI hostUri) {
     Preconditions.checkNotNull(classType);

--- a/http-server/src/test/java/org/triplea/server/http/spark/SparkServerSystemTest.java
+++ b/http-server/src/test/java/org/triplea/server/http/spark/SparkServerSystemTest.java
@@ -37,6 +37,20 @@ class SparkServerSystemTest {
 
   private static final ErrorUploadStrategy errorUploadStrategy = Mockito.mock(ErrorUploadStrategy.class);
 
+  private static final ErrorReportRequest ERROR_REPORT =
+      ErrorReportRequest.builder()
+          .clientIp("")
+          .errorReport(
+              ErrorReport.builder()
+                  .gameVersion("Ah there's nothing like the salty endurance stuttering on the plunder.")
+                  .javaVersion("Where is the shiny jack?")
+                  .operatingSystem("haiti ")
+                  .reportMessage("Never ransack a ship.")
+                  .build())
+          .build();
+
+  private static final String LINK = "http://fictitious-link";
+
   @BeforeAll
   static void startServer() {
     Spark.port(SPARK_PORT);
@@ -55,20 +69,6 @@ class SparkServerSystemTest {
   static void stopServer() {
     Spark.stop();
   }
-
-  private static final ErrorReportRequest ERROR_REPORT =
-      ErrorReportRequest.builder()
-          .clientIp("")
-          .errorReport(
-              ErrorReport.builder()
-                  .gameVersion("Ah there's nothing like the salty endurance stuttering on the plunder.")
-                  .javaVersion("Where is the shiny jack?")
-                  .operatingSystem("haiti ")
-                  .reportMessage("Never ransack a ship.")
-                  .build())
-          .build();
-
-  private static final String LINK = "http://fictitious-link";
 
   @Test
   void errorReportEndpont() {


### PR DESCRIPTION
## Overview

Enforces the conventional Java member order in all types:

1. Fields
1. Constructors
1. Methods

There are a lot of changes in this PR, but they are simply due to moving code around.  I made no other changes except to remove a few useless comments that I encountered next to the members being moved (e.g. "Creates a new instance of class XXX" on a constructor).  There was some collapse of whitespace, as well.

The changes were performed manually because I found the Eclipse member sorter to be a bit over-zealous:  it wanted to make changes that weren't actually necessary and would have blown up this PR a few thousand more lines.

## Functional Changes

None.

## Manual Testing Performed

Smoke tested a local game with the AI.