### PR TITLE
Checkstyle: Enforce field modifier order

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -96,9 +96,7 @@
         <module name="MissingSwitchDefault"/>
         <module name="FallThrough"/>
         <module name="UpperEll"/>
-        <module name="DeclarationOrder">
-            <property name="ignoreModifiers" value="true"/>
-        </module>
+        <module name="DeclarationOrder"/>
         <module name="ModifierOrder"/>
         <module name="RedundantModifier"/>
         <module name="EmptyLineSeparator">

--- a/game-core/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/Chat.java
@@ -29,6 +29,8 @@ import games.strategy.util.Tuple;
  * </p>
  */
 public class Chat {
+  private static final String TAG_MODERATOR = "[Mod]";
+
   private final List<IChatListener> listeners = new CopyOnWriteArrayList<>();
   private final Messengers messengers;
   private final String chatChannelName;
@@ -47,7 +49,6 @@ public class Chat {
   private final StatusManager statusManager;
   private final ChatIgnoreList ignoreList = new ChatIgnoreList();
   private final Map<INode, Set<String>> notesMap = new HashMap<>();
-  private static final String TAG_MODERATOR = "[Mod]";
   private final ChatSoundProfile chatSoundProfile;
   private final List<INode> playersThatLeftLast10 = new ArrayList<>();
   private final IChatChannel chatChannelSubscriber = new IChatChannel() {

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatFloodControl.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatFloodControl.java
@@ -8,9 +8,10 @@ import java.util.Map;
  * sends more than "N" messages will be filtered until the next time window begins.
  */
 class ChatFloodControl {
-  private static final int ONE_MINUTE = 60 * 1000;
   static final int EVENTS_PER_WINDOW = 20;
+  private static final int ONE_MINUTE = 60 * 1000;
   static final int WINDOW = ONE_MINUTE;
+
   private final Object lock = new Object();
   private final Map<String, Integer> messageCount = new HashMap<>();
   private long clearTime;

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
@@ -50,9 +50,11 @@ import lombok.extern.java.Log;
  */
 @Log
 public class ChatMessagePanel extends JPanel implements IChatListener {
+  public static final String ME = "/me ";
   private static final long serialVersionUID = 118727200083595226L;
-  private final ChatFloodControl floodControl = new ChatFloodControl();
   private static final int MAX_LINES = 5000;
+
+  private final ChatFloodControl floodControl = new ChatFloodControl();
   private JTextPane text;
   private JScrollPane scrollPane;
   private JTextField nextMessage;
@@ -63,7 +65,6 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
   private final SimpleAttributeSet bold = new SimpleAttributeSet();
   private final SimpleAttributeSet italic = new SimpleAttributeSet();
   private final SimpleAttributeSet normal = new SimpleAttributeSet();
-  public static final String ME = "/me ";
   private final Action setStatusAction = SwingAction.of("Status...", e -> {
     String status = JOptionPane.showInputDialog(JOptionPane.getFrameForComponent(ChatMessagePanel.this),
         "Enter Status Text (leave blank for no status)", "");

--- a/game-core/src/main/java/games/strategy/engine/data/properties/ComboProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/ComboProperty.java
@@ -15,8 +15,9 @@ import games.strategy.ui.SwingComponents;
  * @param <T> The type of the property value.
  */
 public class ComboProperty<T> extends AbstractEditableProperty<T> {
-  private static final long serialVersionUID = -3098612299805630587L;
   public static final String POSSIBLE_VALUES_FIELD_NAME = "possibleValues";
+  private static final long serialVersionUID = -3098612299805630587L;
+
   private final List<T> possibleValues;
   private T value;
 

--- a/game-core/src/main/java/games/strategy/engine/data/properties/GameProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/GameProperties.java
@@ -27,20 +27,16 @@ import lombok.extern.java.Log;
  */
 @Log
 public class GameProperties extends GameDataComponent {
-  private static final long serialVersionUID = -1448163357090677564L;
-
   // keep this in sync with the corresponding property, this name is used by reflection
   public static final String CONSTANT_PROPERTIES_FIELD_NAME = "constantProperties";
-  private final Map<String, Object> constantProperties = new HashMap<>();
-
-
   // keep this in sync with the corresponding property, this name is used by reflection
   public static final String EDITABLE_PROPERTIES_FIELD_NAME = "editableProperties";
-  private final Map<String, IEditableProperty<?>> editableProperties = new HashMap<>();
+  private static final long serialVersionUID = -1448163357090677564L;
 
+  private final Map<String, Object> constantProperties = new HashMap<>();
+  private final Map<String, IEditableProperty<?>> editableProperties = new HashMap<>();
   // This list is used to keep track of order properties were added.
   private final List<String> ordering = new ArrayList<>();
-
   private final Map<String, IEditableProperty<?>> playerProperties = new HashMap<>();
 
   public GameProperties(final GameData data) {

--- a/game-core/src/main/java/games/strategy/engine/data/properties/NumberProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/NumberProperty.java
@@ -8,16 +8,14 @@ import games.strategy.ui.IntTextField;
  * Implementation of {@link IEditableProperty} for an integer value.
  */
 public class NumberProperty extends AbstractEditableProperty<Integer> {
-  private static final long serialVersionUID = 6826763550643504789L;
-
   // Keep this in sync with the matching property name, used by reflection.
   public static final String MAX_PROPERTY_NAME = "max";
-  private final int max;
-
   // Keep this in sync with the matching property name, used by reflection.
   public static final String MIN_PROPERTY_NAME = "min";
-  private final int min;
+  private static final long serialVersionUID = 6826763550643504789L;
 
+  private final int max;
+  private final int min;
   private int value;
 
   public NumberProperty(final String name, final String description, final int max, final int min, final int def) {

--- a/game-core/src/main/java/games/strategy/engine/framework/CliProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/CliProperties.java
@@ -5,7 +5,6 @@ package games.strategy.engine.framework;
  */
 public class CliProperties {
   public static final String TRIPLEA_GAME = "triplea.game";
-  static final String TRIPLEA_MAP_DOWNLOAD = "triplea.map.download";
   public static final String TRIPLEA_SERVER = "triplea.server";
   public static final String TRIPLEA_CLIENT = "triplea.client";
   public static final String TRIPLEA_HOST = "triplea.host";
@@ -16,8 +15,8 @@ public class CliProperties {
   public static final String LOBBY_PORT = "triplea.lobby.port";
   public static final String LOBBY_GAME_COMMENTS = "triplea.lobby.game.comments";
   public static final String LOBBY_GAME_SUPPORT_PASSWORD = "triplea.lobby.game.supportPassword";
-
   public static final String MAP_FOLDER = "triplea.map.folder";
+  static final String TRIPLEA_MAP_DOWNLOAD = "triplea.map.download";
 
   private CliProperties() {}
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -59,11 +59,10 @@ import lombok.extern.java.Log;
  */
 @Log
 public class ServerGame extends AbstractGame {
-  static final RemoteName SERVER_REMOTE =
-      new RemoteName("games.strategy.engine.framework.ServerGame.SERVER_REMOTE", IServerRemote.class);
-
   public static final String GAME_HAS_BEEN_SAVED_PROPERTY =
       "games.strategy.engine.framework.ServerGame.GameHasBeenSaved";
+  static final RemoteName SERVER_REMOTE =
+      new RemoteName("games.strategy.engine.framework.ServerGame.SERVER_REMOTE", IServerRemote.class);
 
   private final RandomStats randomStats;
   private IRandomSource randomSource = new PlainRandomSource();

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadLengthReader.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadLengthReader.java
@@ -26,11 +26,9 @@ import lombok.extern.java.Log;
 @Log
 @AllArgsConstructor
 final class DownloadLengthReader {
-
-  private final Supplier<CloseableHttpClient> httpClientFactory;
-
   @VisibleForTesting
   final ConcurrentMap<String, Long> downloadLengthsByUri = new ConcurrentHashMap<>();
+  private final Supplier<CloseableHttpClient> httpClientFactory;
 
   /**
    * Gets the download length for the resource at the specified URI.

--- a/game-core/src/main/java/games/strategy/engine/framework/network/ui/SetMapClientAction.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/network/ui/SetMapClientAction.java
@@ -18,9 +18,10 @@ import games.strategy.net.INode;
  */
 public class SetMapClientAction extends AbstractAction {
   private static final long serialVersionUID = -9156920997678163614L;
+
+  final List<String> availableGames;
   private final Component parent;
   private final IClientMessenger clientMessenger;
-  final List<String> availableGames;
 
   public SetMapClientAction(final Component parent, final IClientMessenger clientMessenger,
       final List<String> availableGames) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/DiceServerEditor.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/editors/DiceServerEditor.java
@@ -23,6 +23,11 @@ import swinglib.DocumentListenerBuilder;
  */
 public class DiceServerEditor extends EditorPanel {
   private static final long serialVersionUID = -451810815037661114L;
+  private static final ImmutableMap<String, PropertiesDiceRoller> diceRollersByDisplayName = PropertiesDiceRoller
+      .loadFromFile()
+      .stream()
+      .collect(ImmutableMap.toImmutableMap(IRemoteDiceServer::getDisplayName, Function.identity()));
+
   private final JButton testDiceButton = new JButton("Test Server");
   private final JTextField toAddress = new JTextField();
   private final JTextField ccAddress = new JTextField();
@@ -32,10 +37,6 @@ public class DiceServerEditor extends EditorPanel {
   private final JLabel ccLabel = new JLabel("Cc:");
   private final JComboBox<String> servers = new JComboBox<>();
   private final Runnable readyCallback;
-  private static final ImmutableMap<String, PropertiesDiceRoller> diceRollersByDisplayName = PropertiesDiceRoller
-      .loadFromFile()
-      .stream()
-      .collect(ImmutableMap.toImmutableMap(IRemoteDiceServer::getDisplayName, Function.identity()));
 
   public DiceServerEditor(final Runnable readyCallback) {
     this.readyCallback = readyCallback;

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/TimespanDialog.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/TimespanDialog.java
@@ -29,10 +29,9 @@ import swinglib.JPanelBuilder;
  * A UI-Utility class that can be used to prompt the user for a ban or mute time.
  */
 public final class TimespanDialog extends JDialog {
-  private static final long serialVersionUID = 1367343948352548021L;
-
   @VisibleForTesting
   static final int MAX_DURATION = 99_999_999;
+  private static final long serialVersionUID = 1367343948352548021L;
 
   private final JSpinner durationSpinner = new JSpinner(new SpinnerNumberModel(1, 1, MAX_DURATION, 1));
   private final JComboBox<TimeUnit> timeUnitComboBox = new JComboBox<>(TimeUnit.values());

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/userDB/DBUser.java
@@ -43,9 +43,9 @@ public final class DBUser implements Serializable {
 
   /** User name value object with validation methods. */
   public static class UserName {
-    private static final int MIN_LENGTH = 3;
     @VisibleForTesting
     public static final int MAX_LENGTH = 40;
+    private static final int MIN_LENGTH = 3;
 
     public final String userName;
 

--- a/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
+++ b/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
@@ -31,8 +31,9 @@ import games.strategy.util.Interruptibles;
  * before returning.
  */
 public class PbemDiceRoller implements IRandomSource {
-  private final IRemoteDiceServer remoteDiceServer;
   private static Frame focusWindow;
+
+  private final IRemoteDiceServer remoteDiceServer;
 
   public PbemDiceRoller(final IRemoteDiceServer diceServer) {
     remoteDiceServer = diceServer;

--- a/game-core/src/main/java/games/strategy/engine/vault/Vault.java
+++ b/game-core/src/main/java/games/strategy/engine/vault/Vault.java
@@ -40,11 +40,12 @@ public class Vault {
   private static final RemoteName VAULT_CHANNEL =
       new RemoteName("games.strategy.engine.vault.IServerVault.VAULT_CHANNEL", IRemoteVault.class);
   private static final String ALGORITHM = "DES";
-  private final SecretKeyFactory secretKeyFactory;
   // 0xCAFEBABE
   // we encrypt both this value and data when we encrypt data.
   // when decrypting we ensure that KNOWN_VAL is correct and thus guarantee that we are being given the right key
   private static final byte[] KNOWN_VAL = new byte[] {0xC, 0xA, 0xF, 0xE, 0xB, 0xA, 0xB, 0xE};
+
+  private final SecretKeyFactory secretKeyFactory;
   private final KeyGenerator keyGen;
   private final IChannelMessenger channelMessenger;
   // Maps VaultId -> SecretKey

--- a/game-core/src/main/java/games/strategy/net/Node.java
+++ b/game-core/src/main/java/games/strategy/net/Node.java
@@ -15,11 +15,12 @@ import games.strategy.engine.framework.system.SystemProperties;
  * Written very often over the network, so make externalizable to make faster and reduce traffic.
  */
 public class Node implements INode, Externalizable {
+  public static final INode NULL_NODE;
   private static final long serialVersionUID = -2908980662926959943L;
+
   private String name;
   private int port;
   private InetAddress address;
-  public static final INode NULL_NODE;
 
   static {
     try {

--- a/game-core/src/main/java/games/strategy/net/nio/SocketReadData.java
+++ b/game-core/src/main/java/games/strategy/net/nio/SocketReadData.java
@@ -17,10 +17,11 @@ import lombok.extern.java.Log;
 @Log
 class SocketReadData {
   public static final int MAX_MESSAGE_SIZE = 1000 * 1000 * 10;
-  private static final AtomicInteger counter = new AtomicInteger();
   // as a sanity check to make sure we are talking to another triplea instance
   // that the upper bits of the packet size we send is 0x9b
   public static final int MAGIC = 0x9b000000;
+  private static final AtomicInteger counter = new AtomicInteger();
+
   private int targetSize = -1;
   // we read into here the first four bytes to find out size
   private ByteBuffer sizeBuffer;

--- a/game-core/src/main/java/games/strategy/security/DefaultCredentialManager.java
+++ b/game-core/src/main/java/games/strategy/security/DefaultCredentialManager.java
@@ -33,10 +33,9 @@ import com.google.common.base.Splitter;
  * </p>
  */
 final class DefaultCredentialManager implements CredentialManager {
-  private static final String CIPHER_ALGORITHM = "AES";
-
   @VisibleForTesting
   static final String PREFERENCE_KEY_MASTER_PASSWORD = "DEFAULT_CREDENTIAL_MANAGER_MASTER_PASSWORD";
+  private static final String CIPHER_ALGORITHM = "AES";
 
   private final char[] masterPassword;
 

--- a/game-core/src/main/java/games/strategy/sound/ClipPlayer.java
+++ b/game-core/src/main/java/games/strategy/sound/ClipPlayer.java
@@ -107,15 +107,13 @@ public class ClipPlayer {
   private static final String SOUND_PREFERENCE_GLOBAL_SWITCH = "beSilent2";
   private static final String SOUND_PREFERENCE_PREFIX = "sound_";
   private static final boolean DEFAULT_SOUND_SILENCED_SWITCH_SETTING = false;
-
   private static final String MP3_SUFFIX = ".mp3";
-
+  private static ClipPlayer clipPlayer;
 
   protected final Map<String, List<URL>> sounds = new HashMap<>();
   private final Set<String> mutedClips = new HashSet<>();
   private boolean beSilent;
   private final ResourceLoader resourceLoader;
-  private static ClipPlayer clipPlayer;
 
   private ClipPlayer(final ResourceLoader resourceLoader) {
     this.resourceLoader = resourceLoader;

--- a/game-core/src/main/java/games/strategy/sound/SoundProperties.java
+++ b/game-core/src/main/java/games/strategy/sound/SoundProperties.java
@@ -17,13 +17,14 @@ import lombok.extern.java.Log;
  */
 @Log
 class SoundProperties {
+  static final String GENERIC_FOLDER = "generic";
   // Filename
   private static final String PROPERTY_FILE = "sounds.properties";
   private static final String PROPERTY_DEFAULT_FOLDER = "Sound.Default.Folder";
   private static final String DEFAULT_ERA_FOLDER = "ww2";
-  static final String GENERIC_FOLDER = "generic";
   private static SoundProperties instance = null;
   private static Instant timestamp = Instant.EPOCH;
+
   private final Properties properties = new Properties();
 
   SoundProperties(final ResourceLoader loader) {

--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -36,9 +36,9 @@ import lombok.extern.java.Log;
  */
 @Log
 public class ResourceLoader implements Closeable {
-  private final URLClassLoader loader;
   public static final String RESOURCE_FOLDER = "assets";
 
+  private final URLClassLoader loader;
   private final ResourceLocationTracker resourceLocationTracker;
 
   private ResourceLoader(final String mapName, final String[] paths) {

--- a/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -35,8 +35,6 @@ import games.strategy.util.Tuple;
  * </p>
  */
 public class TripleAUnit extends Unit {
-  // compatable with 0.9.2
-  private static final long serialVersionUID = 8811372406957115036L;
   public static final String TRANSPORTED_BY = "transportedBy";
   public static final String UNLOADED = "unloaded";
   public static final String LOADED_THIS_TURN = "wasLoadedThisTurn";
@@ -55,6 +53,7 @@ public class TripleAUnit extends Unit {
   public static final String LAUNCHED = "launched";
   public static final String AIRBORNE = "airborne";
   public static final String CHARGED_FLAT_FUEL_COST = "chargedFlatFuelCost";
+  private static final long serialVersionUID = 8811372406957115036L;
 
   // the transport that is currently transporting us
   private TripleAUnit transportedBy = null;

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProData.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProData.java
@@ -24,11 +24,6 @@ import games.strategy.util.IntegerMap;
  * Pro AI data.
  */
 public final class ProData {
-
-  private static ProAi proAi;
-  private static GameData data;
-  private static PlayerId player;
-
   // Default values
   public static boolean isSimulation = false;
   public static double winPercentage = 95;
@@ -39,6 +34,10 @@ public final class ProData {
   public static IntegerMap<UnitType> unitValueMap = new IntegerMap<>();
   public static ProPurchaseOptionMap purchaseOptions = null;
   public static double minCostPerHitPoint = Double.MAX_VALUE;
+
+  private static ProAi proAi;
+  private static GameData data;
+  private static PlayerId player;
 
   private ProData() {}
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -33,14 +33,14 @@ import games.strategy.triplea.formatter.MyFormatter;
  * RulesAttachments), should extend this instead of DefaultAttachment.
  */
 public abstract class AbstractConditionsAttachment extends DefaultAttachment implements ICondition {
-  private static final long serialVersionUID = -9008441256118867078L;
-  private static final Splitter HYPHEN_SPLITTER = Splitter.on('-');
+  public static final String TRIGGER_CHANCE_SUCCESSFUL = "Trigger Rolling is a Success!";
+  public static final String TRIGGER_CHANCE_FAILURE = "Trigger Rolling is a Failure!";
   protected static final String AND = "AND";
   protected static final String OR = "OR";
   protected static final String DEFAULT_CHANCE = "1:1";
   protected static final String CHANCE = "chance";
-  public static final String TRIGGER_CHANCE_SUCCESSFUL = "Trigger Rolling is a Success!";
-  public static final String TRIGGER_CHANCE_FAILURE = "Trigger Rolling is a Failure!";
+  private static final long serialVersionUID = -9008441256118867078L;
+  private static final Splitter HYPHEN_SPLITTER = Splitter.on('-');
 
   // list of conditions that this condition can contain
   protected List<RulesAttachment> conditions = new ArrayList<>();

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -30,12 +30,11 @@ import games.strategy.util.Tuple;
  * </p>
  */
 public abstract class AbstractTriggerAttachment extends AbstractConditionsAttachment {
-  private static final long serialVersionUID = 5866039180681962697L;
-
   public static final String NOTIFICATION = "Notification";
   public static final String AFTER = "after";
   public static final String BEFORE = "before";
   public static final Predicate<TriggerAttachment> availableUses = t -> t.getUses() != 0;
+  private static final long serialVersionUID = 5866039180681962697L;
 
   // "setTrigger" is also a valid setter, and it just calls "setConditions" in AbstractConditionsAttachment. Kept for
   // backwards compatibility.

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -20,8 +20,8 @@ import games.strategy.util.IntegerMap;
  * Abstract class for holding various action/condition things for PoliticalActionAttachment and UserActionAttachment.
  */
 public abstract class AbstractUserActionAttachment extends AbstractConditionsAttachment {
-  private static final long serialVersionUID = 3569461523853104614L;
   public static final String ATTEMPTS_LEFT_THIS_TURN = "attemptsLeftThisTurn";
+  private static final long serialVersionUID = 3569461523853104614L;
 
   // a key referring to politicaltexts.properties or other .properties for all the UI messages belonging to this action.
   protected String text = "";

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RelationshipTypeAttachment.java
@@ -16,8 +16,6 @@ import games.strategy.triplea.Constants;
  * An attachment for instances of {@link RelationshipType}.
  */
 public class RelationshipTypeAttachment extends DefaultAttachment {
-  private static final long serialVersionUID = -4367286684249791984L;
-
   public static final String ARCHETYPE_NEUTRAL = Constants.RELATIONSHIP_ARCHETYPE_NEUTRAL;
   public static final String ARCHETYPE_WAR = Constants.RELATIONSHIP_ARCHETYPE_WAR;
   public static final String ARCHETYPE_ALLIED = Constants.RELATIONSHIP_ARCHETYPE_ALLIED;
@@ -26,6 +24,7 @@ public class RelationshipTypeAttachment extends DefaultAttachment {
   public static final String PROPERTY_DEFAULT = Constants.RELATIONSHIP_PROPERTY_DEFAULT;
   public static final String PROPERTY_TRUE = Constants.RELATIONSHIP_PROPERTY_TRUE;
   public static final String PROPERTY_FALSE = Constants.RELATIONSHIP_PROPERTY_FALSE;
+  private static final long serialVersionUID = -4367286684249791984L;
 
   private String archeType = ARCHETYPE_WAR;
   private String canMoveLandUnitsOverOwnedLand = PROPERTY_DEFAULT;

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -41,11 +41,12 @@ import games.strategy.util.IntegerMap;
  * Also contains static methods of interpreting data from all technology attachments that a player has.
  */
 public class TechAbilityAttachment extends DefaultAttachment {
-  private static final long serialVersionUID = 1866305599625384294L;
-
   // unitAbilitiesGained Static Strings
   public static final String ABILITY_CAN_BLITZ = "canBlitz";
   public static final String ABILITY_CAN_BOMBARD = "canBombard";
+
+  private static final long serialVersionUID = 1866305599625384294L;
+
   // attachment fields
   private IntegerMap<UnitType> attackBonus = new IntegerMap<>();
   private IntegerMap<UnitType> defenseBonus = new IntegerMap<>();

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -42,10 +42,10 @@ import games.strategy.util.Tuple;
  * Despite the misleading name, this attaches not to individual Units but to UnitTypes.
  */
 public class UnitAttachment extends DefaultAttachment {
-  private static final long serialVersionUID = -2946748686268541820L;
-
   public static final String UNITSMAYNOTLANDONCARRIER = "unitsMayNotLandOnCarrier";
   public static final String UNITSMAYNOTLEAVEALLIEDCARRIER = "unitsMayNotLeaveAlliedCarrier";
+  private static final long serialVersionUID = -2946748686268541820L;
+
   // movement related
   private boolean isAir = false;
   private boolean isSea = false;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractBattle.java
@@ -59,8 +59,7 @@ abstract class AbstractBattle implements IBattle {
   WhoWon whoWon = WhoWon.NOTFINISHED;
   int attackerLostTuv = 0;
   int defenderLostTuv = 0;
-
-  protected final GameData gameData;
+  final GameData gameData;
 
   AbstractBattle(final Territory battleSite, final PlayerId attacker, final BattleTracker battleTracker,
       final boolean isBombingRun, final BattleType battleType, final GameData data) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveExtendedDelegateState.java
@@ -8,6 +8,6 @@ class AbstractMoveExtendedDelegateState implements Serializable {
 
   Serializable superState;
   // add other variables here
-  public List<UndoableMove> movesToUndo;
-  public MovePerformer tempMovePerformer;
+  List<UndoableMove> movesToUndo;
+  MovePerformer tempMovePerformer;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -43,13 +43,13 @@ import lombok.extern.java.Log;
  */
 @Log
 public class AirBattle extends AbstractBattle {
-  private static final long serialVersionUID = 4686241714027216395L;
   protected static final String AIR_BATTLE = "Air Battle";
   protected static final String INTERCEPTORS_LAUNCH = "Defender Launches Interceptors";
   protected static final String ATTACKERS_FIRE = "Attackers Fire";
   protected static final String DEFENDERS_FIRE = "Defenders Fire";
   protected static final String ATTACKERS_WITHDRAW = "Attackers Withdraw?";
   protected static final String DEFENDERS_WITHDRAW = "Defenders Withdraw?";
+  private static final long serialVersionUID = 4686241714027216395L;
 
   protected final ExecutionStack stack = new ExecutionStack();
   protected List<String> steps;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleExtendedDelegateState.java
@@ -8,7 +8,7 @@ class BattleExtendedDelegateState implements Serializable {
   Serializable superState;
   // add other variables here:
   BattleTracker battleTracker = new BattleTracker();
-  public boolean needToInitialize;
+  boolean needToInitialize;
   boolean needToScramble;
   boolean needToCreateRockets;
   boolean needToKamikazeSuicideAttacks;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundExtendedDelegateState.java
@@ -11,6 +11,6 @@ class EndRoundExtendedDelegateState implements Serializable {
 
   Serializable superState;
   // add other variables here:
-  public boolean gameOver = false;
-  public Collection<PlayerId> winners = new ArrayList<>();
+  boolean gameOver = false;
+  Collection<PlayerId> winners = new ArrayList<>();
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnExtendedDelegateState.java
@@ -7,6 +7,6 @@ class EndTurnExtendedDelegateState implements Serializable {
 
   Serializable superState;
   // add other variables here:
-  public boolean needToInitialize;
-  public boolean hasPostedTurnSummary;
+  boolean needToInitialize;
+  boolean hasPostedTurnSummary;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/InitializationExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/InitializationExtendedDelegateState.java
@@ -6,5 +6,5 @@ class InitializationExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = -9000446777655823735L;
 
   Serializable superState;
-  public boolean needToInitialize;
+  boolean needToInitialize;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveExtendedDelegateState.java
@@ -10,7 +10,7 @@ class MoveExtendedDelegateState implements Serializable {
 
   Serializable superState;
   // add other variables here:
-  public boolean needToInitialize;
-  public boolean needToDoRockets;
-  public IntegerMap<Territory> pusLost;
+  boolean needToInitialize;
+  boolean needToDoRockets;
+  IntegerMap<Territory> pusLost;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -95,10 +95,10 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   // the middle of a battle.
   private final ExecutionStack stack = new ExecutionStack();
   private List<String> stepStrings;
-  protected List<Unit> defendingAa;
-  protected List<Unit> offensiveAa;
-  protected List<String> defendingAaTypes;
-  protected List<String> offensiveAaTypes;
+  private List<Unit> defendingAa;
+  private List<Unit> offensiveAa;
+  private List<String> defendingAaTypes;
+  private List<String> offensiveAaTypes;
   private final List<Unit> attackingUnitsRetreated = new ArrayList<>();
   private final List<Unit> defendingUnitsRetreated = new ArrayList<>();
   // -1 would mean forever until one side is eliminated (the default is infinite)
@@ -2065,7 +2065,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     private final boolean defending;
     private DiceRoll dice;
     private CasualtyDetails casualties;
-    final Collection<Unit> casualtiesSoFar = new ArrayList<>();
+    private final Collection<Unit> casualtiesSoFar = new ArrayList<>();
 
     private FireAa(final boolean defending) {
       this.defending = defending;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PlaceExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PlaceExtendedDelegateState.java
@@ -13,6 +13,6 @@ class PlaceExtendedDelegateState implements Serializable {
 
   Serializable superState;
   // add other variables here:
-  public Map<Territory, Collection<Unit>> produced;
-  public List<UndoablePlacement> placements;
+  Map<Territory, Collection<Unit>> produced;
+  List<UndoablePlacement> placements;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -46,12 +46,12 @@ import games.strategy.util.IntegerMap;
  * the adding or removing of resources is done.
  */
 public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDelegate {
+  public static final String NOT_ENOUGH_RESOURCES = "Not enough resources";
   private static final Comparator<RepairRule> repairRuleComparator = Comparator.comparing(
       o -> (UnitType) o.getResults().keySet().iterator().next(),
       new UnitTypeComparator());
 
   private boolean needToInitialize = true;
-  public static final String NOT_ENOUGH_RESOURCES = "Not enough resources";
 
   @Override
   public void start() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseExtendedDelegateState.java
@@ -7,5 +7,5 @@ class PurchaseExtendedDelegateState implements Serializable {
 
   Serializable superState;
   // add other variables here:
-  public boolean needToInitialize;
+  boolean needToInitialize;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartExtendedDelegateState.java
@@ -9,5 +9,5 @@ class RandomStartExtendedDelegateState implements Serializable {
 
   Serializable superState;
   // add other variables here:
-  public PlayerId currentPickingPlayer;
+  PlayerId currentPickingPlayer;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveExtendedDelegateState.java
@@ -6,5 +6,5 @@ class SpecialMoveExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = 7781410008392307104L;
 
   Serializable superState;
-  public boolean needToInitialize;
+  boolean needToInitialize;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechActivationExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechActivationExtendedDelegateState.java
@@ -6,5 +6,5 @@ class TechActivationExtendedDelegateState implements Serializable {
   private static final long serialVersionUID = 1742776261442260882L;
 
   Serializable superState;
-  public boolean needToInitialize;
+  boolean needToInitialize;
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
@@ -23,8 +23,6 @@ import games.strategy.util.Tuple;
  * Superclass for all technology advances.
  */
 public abstract class TechAdvance extends NamedAttachable {
-  private static final long serialVersionUID = -1076712297024403156L;
-  private static final Class<?>[] preDefinedTechConstructorParameter = new Class<?>[] {GameData.class};
   public static final String TECH_NAME_SUPER_SUBS = "Super subs";
   public static final String TECH_PROPERTY_SUPER_SUBS = "superSub";
   public static final String TECH_NAME_JET_POWER = "Jet Power";
@@ -58,6 +56,8 @@ public abstract class TechAdvance extends NamedAttachable {
           TECH_NAME_LONG_RANGE_AIRCRAFT, TECH_NAME_HEAVY_BOMBER, TECH_NAME_IMPROVED_ARTILLERY_SUPPORT,
           TECH_NAME_ROCKETS, TECH_NAME_PARATROOPERS, TECH_NAME_INCREASED_FACTORY_PRODUCTION, TECH_NAME_WAR_BONDS,
           TECH_NAME_MECHANIZED_INFANTRY, TECH_NAME_INDUSTRIAL_TECHNOLOGY, TECH_NAME_DESTROYER_BOMBARD));
+  private static final long serialVersionUID = -1076712297024403156L;
+  private static final Class<?>[] preDefinedTechConstructorParameter = new Class<?>[] {GameData.class};
   private static final Map<String, Class<? extends TechAdvance>> ALL_PREDEFINED_TECHNOLOGIES =
       newPredefinedTechnologyMap();
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyExtendedDelegateState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyExtendedDelegateState.java
@@ -11,6 +11,6 @@ class TechnologyExtendedDelegateState implements Serializable {
 
   Serializable superState;
   // add other variables here:
-  public boolean needToInitialize;
+  boolean needToInitialize;
   Map<PlayerId, Collection<TechAdvance>> techs;
 }

--- a/game-core/src/main/java/games/strategy/triplea/image/DiceImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/DiceImageFactory.java
@@ -28,10 +28,10 @@ import games.strategy.ui.Util;
 public class DiceImageFactory {
   public static final int DIE_WIDTH = 32;
   public static final int DIE_HEIGHT = 32;
-  private final int diceSides;
-  private final ResourceLoader resourceLoader;
   private static final Color IGNORED = new Color(100, 100, 100, 200);
 
+  private final int diceSides;
+  private final ResourceLoader resourceLoader;
   private final Map<Integer, Image> images;
   private final Map<Integer, Image> imagesHit;
   private final Map<Integer, Image> imagesIgnored;

--- a/game-core/src/main/java/games/strategy/triplea/image/MapImage.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/MapImage.java
@@ -21,8 +21,6 @@ import games.strategy.ui.Util;
  * Is not responsible for drawing things on top of the map, such as units, routes etc.
  */
 public class MapImage {
-
-  private BufferedImage smallMapImage;
   private static Font propertyMapFont = null;
   private static Color propertyTerritoryNameAndPuAndCommentColor = null;
   private static Color propertyUnitCountColor = null;
@@ -41,7 +39,6 @@ public class MapImage {
   private static final String PROPERTY_UNIT_FACTORY_DAMAGE_OUTLINE_STRING = "PROPERTY_UNIT_FACTORY_DAMAGE_OUTLINE";
   private static final String PROPERTY_UNIT_HIT_DAMAGE_COLOR_STRING = "PROPERTY_UNIT_HIT_DAMAGE_COLOR";
   private static final String PROPERTY_UNIT_HIT_DAMAGE_OUTLINE_STRING = "PROPERTY_UNIT_HIT_DAMAGE_OUTLINE";
-
   private static final int MAP_FONT_SIZE_DEFAULT = 12;
   private static final Color TERRITORY_NAME_AND_PU_AND_COMMENT_COLOR_DEFAULT = Color.BLACK;
   private static final Color UNIT_COUNT_COLOR_DEFAULT = Color.WHITE;
@@ -51,6 +48,7 @@ public class MapImage {
   private static final Color UNIT_HIT_DAMAGE_COLOR_DEFAULT = Color.BLACK;
   private static final Color UNIT_HIT_DAMAGE_OUTLINE_DEFAULT = Color.LIGHT_GRAY;
 
+  private BufferedImage smallMapImage;
 
   public static Font getPropertyMapFont() {
     if (propertyMapFont == null) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/AbstractForumPosterPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/AbstractForumPosterPanel.java
@@ -15,11 +15,12 @@ import games.strategy.triplea.delegate.remote.IAbstractForumPosterDelegate;
 
 abstract class AbstractForumPosterPanel extends ActionPanel {
   private static final long serialVersionUID = -5084680807785728744L;
-  private final JLabel actionLabel;
+
   IPlayerBridge playerBridge;
   PbemMessagePoster pbemMessagePoster;
-  private TripleAFrame tripleAFrame;
   ForumPosterComponent forumPosterComponent;
+  private final JLabel actionLabel;
+  private TripleAFrame tripleAFrame;
 
   AbstractForumPosterPanel(final GameData data, final MapPanel map) {
     super(data, map);

--- a/game-core/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -28,14 +28,14 @@ import swinglib.JButtonBuilder;
 abstract class AbstractMovePanel extends ActionPanel {
   private static final long serialVersionUID = -4153574987414031433L;
   private static final int entryPadding = 15;
+
+  AbstractUndoableMovesPanel undoableMovesPanel;
   private final TripleAFrame frame;
   private boolean listening = false;
   private final JLabel actionLabel = new JLabel();
   private MoveDescription moveMessage;
   private List<UndoableMove> undoableMoves;
-  AbstractUndoableMovesPanel undoableMovesPanel;
   private IPlayerBridge bridge;
-
   private final JButton cancelMoveButton = JButtonBuilder.builder()
       .title("Cancel")
       .actionListener(this::cancelMove)

--- a/game-core/src/main/java/games/strategy/triplea/ui/ActionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ActionPanel.java
@@ -15,13 +15,8 @@ import games.strategy.triplea.Properties;
  */
 public abstract class ActionPanel extends JPanel {
   private static final long serialVersionUID = -5954576036704958641L;
-  private final GameData data;
-  private PlayerId currentPlayer;
-  protected final MapPanel map;
-  private boolean active;
-  private CountDownLatch latch;
-  private final Object latchLock = new Object();
 
+  protected final MapPanel map;
   /**
    * Refreshes the action panel. Should be run within the swing event queue.
    */
@@ -29,6 +24,11 @@ public abstract class ActionPanel extends JPanel {
     revalidate();
     repaint();
   };
+  private final GameData data;
+  private PlayerId currentPlayer;
+  private boolean active;
+  private CountDownLatch latch;
+  private final Object latchLock = new Object();
 
   public ActionPanel(final GameData data, final MapPanel map) {
     this.data = data;

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -63,7 +63,7 @@ public class BattlePanel extends ActionPanel {
   // there is a bug in linux jdk1.5.0_6 where frames are not being garbage collected
   // reuse one frame
   private final JFrame battleFrame;
-  Map<BattleType, Collection<Territory>> battles;
+  private Map<BattleType, Collection<Territory>> battles;
 
   public BattlePanel(final GameData data, final MapPanel map) {
     super(data, map);

--- a/game-core/src/main/java/games/strategy/triplea/ui/IndividualUnitPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/IndividualUnitPanel.java
@@ -212,9 +212,10 @@ public class IndividualUnitPanel extends JPanel {
 
   private static final class SingleUnitPanel extends JPanel {
     private static final long serialVersionUID = 5034287842323633030L;
+    private static final Insets nullInsets = new Insets(0, 0, 0, 0);
+
     private final Unit unit;
     private final ScrollableTextField textField;
-    private static final Insets nullInsets = new Insets(0, 0, 0, 0);
     private final ScrollableTextFieldListener countTextFieldListener;
 
     SingleUnitPanel(final Unit unit, final UiContext uiContext,

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -65,6 +65,8 @@ public class MovePanel extends AbstractMovePanel {
    * changed it after feedback).
    */
   private static final int deselectNumber = 10;
+  private static final Map<Unit, Collection<Unit>> dependentUnits = new HashMap<>();
+
   // access only through getter and setter!
   private Territory firstSelectedTerritory;
   private Territory selectedEndpointTerritory;
@@ -77,7 +79,6 @@ public class MovePanel extends AbstractMovePanel {
   private Point mouseLastUpdatePoint;
   // use a LinkedHashSet because we want to know the order
   private final Set<Unit> selectedUnits = new LinkedHashSet<>();
-  private static final Map<Unit, Collection<Unit>> dependentUnits = new HashMap<>();
   // the must move with details for the currently selected territory
   // note this is kept in sync because we do not modify selectedTerritory directly
   // instead we only do so through the private setter

--- a/game-core/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
@@ -111,7 +111,7 @@ public class ObjectivePanel extends AbstractStatPanel {
     private static final int COLUMNS_TOTAL = 2;
     private boolean isDirty = true;
     private String[][] collectedData;
-    final Map<String, List<String>> sections = new LinkedHashMap<>();
+    private final Map<String, List<String>> sections = new LinkedHashMap<>();
     private Instant timestamp = Instant.EPOCH;
 
     ObjectiveTableModel() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/ObjectiveProperties.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ObjectiveProperties.java
@@ -7,10 +7,9 @@ import java.util.Set;
  * Loads objective text from objectives.properties.
  */
 public class ObjectiveProperties extends PropertyFile {
-
+  static final String GROUP_PROPERTY = "TABLEGROUP";
   private static final String PROPERTY_FILE = "objectives.properties";
   private static final String OBJECTIVES_PANEL_NAME = "Objectives.Panel.Name";
-  static final String GROUP_PROPERTY = "TABLEGROUP";
 
   protected ObjectiveProperties() {
     super(PROPERTY_FILE);

--- a/game-core/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PoliticalStateOverview.java
@@ -29,7 +29,8 @@ import games.strategy.util.Triple;
  */
 public class PoliticalStateOverview extends JPanel {
   private static final long serialVersionUID = -8445782272897831080L;
-  public static final String LABEL_SELF = "----";
+  private static final String LABEL_SELF = "----";
+
   private final UiContext uiContext;
   private final GameData data;
   private final boolean editable;

--- a/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
@@ -43,7 +43,7 @@ public class PoliticsPanel extends ActionPanel {
   private JButton doneButton = null;
   private PoliticalActionAttachment choice = null;
   private boolean firstRun = true;
-  protected List<PoliticalActionAttachment> validPoliticalActions = null;
+  private List<PoliticalActionAttachment> validPoliticalActions = null;
 
   /**
    * Fires up a JDialog showing the political landscape and valid actions,

--- a/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
@@ -34,6 +34,11 @@ import games.strategy.util.IntegerMap;
  */
 public class PurchasePanel extends ActionPanel {
   private static final long serialVersionUID = -6121756876868623355L;
+  // if this is set Purchase will use the tabbedProductionPanel - this is modifyable through the View Menu
+  private static boolean tabbedProduction = true;
+  private static final String BUY = "Buy...";
+  private static final String CHANGE = "Change...";
+
   private final JLabel actionLabel = new JLabel();
   private IntegerMap<ProductionRule> purchase;
   private boolean bid;
@@ -42,10 +47,6 @@ public class PurchasePanel extends ActionPanel {
   private final SimpleUnitPanel purhcasedUnits;
   private final JLabel purchasedLabel = new JLabel();
   private final JButton buyButton;
-  // if this is set Purchase will use the tabbedProductionPanel - this is modifyable through the View Menu
-  private static boolean tabbedProduction = true;
-  private static final String BUY = "Buy...";
-  private static final String CHANGE = "Change...";
 
   private final AbstractAction purchaseAction = new AbstractAction("Buy") {
     private static final long serialVersionUID = -2931438906267249990L;

--- a/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
@@ -33,7 +33,7 @@ public class SimpleUnitPanel extends JPanel {
   private static final long serialVersionUID = -3768796793775300770L;
   private final UiContext uiContext;
 
-  final Comparator<ProductionRule> productionRuleComparator = new Comparator<ProductionRule>() {
+  private final Comparator<ProductionRule> productionRuleComparator = new Comparator<ProductionRule>() {
     final UnitTypeComparator utc = new UnitTypeComparator();
 
     @Override
@@ -74,7 +74,7 @@ public class SimpleUnitPanel extends JPanel {
     }
   };
 
-  final Comparator<RepairRule> repairRuleComparator = new Comparator<RepairRule>() {
+  private final Comparator<RepairRule> repairRuleComparator = new Comparator<RepairRule>() {
     final UnitTypeComparator utc = new UnitTypeComparator();
 
     @Override

--- a/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -44,11 +44,12 @@ import games.strategy.util.IntegerMap;
 
 class StatPanel extends AbstractStatPanel {
   private static final long serialVersionUID = 4340684166664492498L;
+
+  IStat[] stats;
+  final Map<PlayerId, ImageIcon> mapPlayerImage = new HashMap<>();
+  final UiContext uiContext;
   private final StatTableModel dataModel;
   private final TechTableModel techModel;
-  protected IStat[] stats;
-  protected final Map<PlayerId, ImageIcon> mapPlayerImage = new HashMap<>();
-  protected final UiContext uiContext;
 
   StatPanel(final GameData data, final UiContext uiContext) {
     super(data);

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -222,7 +222,7 @@ public final class TripleAFrame extends JFrame {
   private final MapUnitTooltipManager tooltipManager;
   private boolean isCtrlPressed = false;
 
-  public final MapSelectionListener mapSelectionListener = new DefaultMapSelectionListener() {
+  private final MapSelectionListener mapSelectionListener = new DefaultMapSelectionListener() {
     @Override
     public void mouseEntered(final Territory territory) {
       territoryLastEntered = territory;
@@ -296,9 +296,10 @@ public final class TripleAFrame extends JFrame {
     }
   };
 
-  final GameStepListener stepListener = (stepName, delegateName, player1, round1, stepDisplayName) -> updateStep();
+  private final GameStepListener stepListener =
+      (stepName, delegateName, player1, round1, stepDisplayName) -> updateStep();
 
-  final GameDataChangeListener dataChangeListener = new GameDataChangeListener() {
+  private final GameDataChangeListener dataChangeListener = new GameDataChangeListener() {
     @Override
     public void gameDataChanged(final Change change) {
       try {

--- a/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -315,6 +315,8 @@ final class UnitChooser extends JPanel {
   }
 
   private static final class ChooserEntry {
+    private static final Insets nullInsets = new Insets(0, 0, 0, 0);
+
     private final UnitCategory category;
     private final ScrollableTextFieldListener hitTextFieldListener;
     private final boolean hasMultipleHits;
@@ -322,7 +324,6 @@ final class UnitChooser extends JPanel {
     private final List<ScrollableTextField> hitTexts;
     private final List<JLabel> hitLabel = new ArrayList<>();
     private int leftToSelect;
-    private static final Insets nullInsets = new Insets(0, 0, 0, 0);
     private final UiContext uiContext;
 
     ChooserEntry(final UnitCategory category, final int leftToSelect, final ScrollableTextFieldListener listener,

--- a/game-core/src/main/java/games/strategy/triplea/ui/UserActionText.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UserActionText.java
@@ -21,7 +21,6 @@ public class UserActionText {
   private static final String PROPERTY_FILE = "actionstext.properties";
   private static UserActionText text = null;
   private static Instant timestamp = Instant.EPOCH;
-  private final Properties properties = new Properties();
   private static final String BUTTON = "BUTTON";
   private static final String DESCRIPTION = "DESCRIPTION";
   private static final String NOTIFICATION_SUCCESS = "NOTIFICATION_SUCCESS";
@@ -31,6 +30,8 @@ public class UserActionText {
   private static final String TARGET_NOTIFICATION_FAILURE = "TARGET_NOTIFICATION_FAILURE";
   private static final String OTHER_NOTIFICATION_FAILURE = "OTHER_NOTIFICATION_FAILURE";
   private static final String ACCEPT_QUESTION = "ACCEPT_QUESTION";
+
+  private final Properties properties = new Properties();
 
   protected UserActionText() {
     final ResourceLoader loader = AbstractUiContext.getResourceLoader();

--- a/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
@@ -46,12 +46,12 @@ public class HistoryPanel extends JPanel {
   private HistoryNode currentPopupNode;
   private final JPopupMenu popup;
   // remember which paths were expanded
-  final Collection<TreePath> stayExpandedPaths = new ArrayList<>();
+  private final Collection<TreePath> stayExpandedPaths = new ArrayList<>();
   private boolean mouseOverPanel;
   // to distinguish the first mouse over panel event from the others
-  boolean mouseWasOverPanel;
+  private boolean mouseWasOverPanel;
   // remember where to start collapsing
-  TreePath lastParent = null;
+  private TreePath lastParent = null;
 
   public HistoryPanel(final GameData data, final HistoryDetailsPanel details, final JPopupMenu popup,
       final UiContext uiContext) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -51,8 +51,8 @@ import swinglib.JLabelBuilder;
  * The help menu.
  */
 public final class HelpMenu extends JMenu {
-  private static final long serialVersionUID = 4070541434144687452L;
   public static final JEditorPane gameNotesPane = new JEditorPane();
+  private static final long serialVersionUID = 4070541434144687452L;
 
   private final UiContext uiContext;
   private final GameData gameData;

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -40,6 +40,9 @@ import lombok.extern.java.Log;
  */
 @Log
 public class UnitsDrawer implements IDrawable {
+  public static boolean enabledFlags = false;
+  private static UnitFlagDrawMode drawUnitNationMode = UnitFlagDrawMode.NEXT_TO;
+
   private final int count;
   private final String unitType;
   private final String playerName;
@@ -50,7 +53,6 @@ public class UnitsDrawer implements IDrawable {
   private final boolean overflow;
   private final String territoryName;
   private final UiContext uiContext;
-  private static UnitFlagDrawMode drawUnitNationMode = UnitFlagDrawMode.NEXT_TO;
 
   /**
    * The keys for {@link UnitsDrawer} preferences.
@@ -58,8 +60,6 @@ public class UnitsDrawer implements IDrawable {
   public enum PreferenceKeys {
     DRAW_MODE, DRAWING_ENABLED
   }
-
-  public static boolean enabledFlags = false;
 
   /**
    * Identifies the location where a nation flag is drawn relative to a unit.

--- a/game-core/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
+++ b/game-core/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
@@ -44,10 +44,9 @@ public class ImageScrollerLargeView extends JComponent {
   private static final int TOP = 0b0100;
   private static final int BOTTOM = 0b1000;
 
-  private final int tileSize;
   protected final ImageScrollModel model;
   protected double scale = 1;
-
+  private final int tileSize;
   private int dragScrollingLastX;
   private int dragScrollingLastY;
   private boolean wasLastActionDragging = false;

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -55,21 +55,18 @@ public class HeadlessGameServer {
   public static final String BOT_GAME_HOST_NAME_PREFIX = "Bot";
   private static final int LOBBY_RECONNECTION_REFRESH_SECONDS_DEFAULT = (int) TimeUnit.DAYS.toSeconds(2);
   private static final String NO_REMOTE_REQUESTS_ALLOWED = "noRemoteRequestsAllowed";
+  private static HeadlessGameServer instance = null;
 
   private final AvailableGames availableGames = new AvailableGames();
   private final GameSelectorModel gameSelectorModel = new GameSelectorModel();
   private final ScheduledExecutorService lobbyWatcherResetupThread = Executors.newScheduledThreadPool(1);
-  private static HeadlessGameServer instance = null;
   private final HeadlessServerSetupPanelModel setupPanelModel = new HeadlessServerSetupPanelModel(gameSelectorModel);
   private ServerGame game = null;
   private boolean shutDown = false;
-
-
   private final List<Runnable> shutdownListeners = Arrays.asList(
       lobbyWatcherResetupThread::shutdown,
       () -> Optional.ofNullable(game).ifPresent(ServerGame::stopGame),
       () -> setupPanelModel.getPanel().cancel());
-
 
   private HeadlessGameServer() {
     if (instance != null) {

--- a/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorTest.java
@@ -52,16 +52,16 @@ public final class LobbyLoginValidatorTest {
     static final String PASSWORD = "password";
 
     @Mock
-    private AccessLog accessLog;
-
-    @Mock
-    private BadWordDao badWordDao;
-
-    @Mock
     BannedMacDao bannedMacDao;
 
     @Mock
     BannedUsernameDao bannedUsernameDao;
+
+    @Mock
+    private AccessLog accessLog;
+
+    @Mock
+    private BadWordDao badWordDao;
 
     @Mock
     private UserDao userDao;


### PR DESCRIPTION
## Overview

Sets the `ignoreModifiers` property of the Checkstyle DeclarationOrder rule to `false`.  This was done to ensure class (static) fields appear before instance fields.  However, it has the side-effect of also enforcing that fields appear in order of decreasing accessibility.  That is, the enforced order is

1. Class (static) fields, in order of decreasing accessibility
1. Instance fields, in order of decreasing accessibility

There doesn't appear to be a way to disable the secondary ordering, so I'm not sure if everyone will agree to this change.

The good news is that there wasn't that many accessibility ordering violations.  In many cases, such violations could be fixed by simply reducing the field accessibility to the minimum required instead of re-ordering the field.

## Functional Changes

None.

## Manual Testing Performed

None.