### PR TITLE
Replace IllegalThreadStateException with IllegalArgumentException

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/properties/DoubleProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/DoubleProperty.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.data.properties;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 
@@ -18,15 +20,19 @@ public class DoubleProperty extends AbstractEditableProperty<Double> {
   private double value;
   private final int places;
 
+  /**
+   * Initializes a new instance of the {@link DoubleProperty} class.
+   *
+   * @throws IllegalArgumentException If {@code max} is less than {@code min}; if {@code def} is less than {@code min};
+   *         or if {@code def} is greater than {@code max}.
+   */
   public DoubleProperty(final String name, final String description, final double max, final double min,
       final double def, final int numberOfPlaces) {
     super(name, description);
-    if (max < min) {
-      throw new IllegalThreadStateException("Max must be greater than min");
-    }
-    if (def > max || def < min) {
-      throw new IllegalThreadStateException("Default value out of range");
-    }
+
+    checkArgument(max >= min, "Max must be greater than min");
+    checkArgument((def >= min) && (def <= max), "Default value out of range");
+
     this.max = max;
     this.min = min;
     places = numberOfPlaces;

--- a/game-core/src/main/java/games/strategy/engine/data/properties/NumberProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/NumberProperty.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.data.properties;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import javax.swing.JComponent;
 
 import games.strategy.ui.IntTextField;
@@ -18,14 +20,18 @@ public class NumberProperty extends AbstractEditableProperty<Integer> {
   private final int min;
   private int value;
 
+  /**
+   * Initializes a new instance of the {@link NumberProperty} class.
+   *
+   * @throws IllegalArgumentException If {@code max} is less than {@code min}; if {@code def} is less than {@code min};
+   *         or if {@code def} is greater than {@code max}.
+   */
   public NumberProperty(final String name, final String description, final int max, final int min, final int def) {
     super(name, description);
-    if (max < min) {
-      throw new IllegalThreadStateException("Max must be greater than min");
-    }
-    if (def > max || def < min) {
-      throw new IllegalThreadStateException("Default value out of range");
-    }
+
+    checkArgument(max >= min, "Max must be greater than min");
+    checkArgument((def >= min) && (def <= max), "Default value out of range");
+
     this.max = max;
     this.min = min;
     value = def;

--- a/game-core/src/test/java/games/strategy/engine/data/properties/DoublePropertyTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/properties/DoublePropertyTest.java
@@ -1,0 +1,44 @@
+package games.strategy.engine.data.properties;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class DoublePropertyTest {
+  @Nested
+  final class ConstructorTest {
+    private static final String NAME = "name";
+    private static final String DESCRIPTION = "description";
+    private static final double MAX_VALUE = 100.0;
+    private static final double MIN_VALUE = 0.0;
+    private static final double DEFAULT_VALUE = 42.0;
+    private static final int NUMBER_OF_PLACES = 10;
+
+    @Test
+    void shouldThrowExceptionWhenMaxValueLessThanMinValue() {
+      final Exception e = assertThrows(
+          IllegalArgumentException.class,
+          () -> new DoubleProperty(NAME, DESCRIPTION, MIN_VALUE - 1.0, MIN_VALUE, DEFAULT_VALUE, NUMBER_OF_PLACES));
+      assertThat(e.getMessage(), is("Max must be greater than min"));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenDefaultValueGreaterThanMaxValue() {
+      final Exception e = assertThrows(
+          IllegalArgumentException.class,
+          () -> new DoubleProperty(NAME, DESCRIPTION, MAX_VALUE, MIN_VALUE, MAX_VALUE + 1.0, NUMBER_OF_PLACES));
+      assertThat(e.getMessage(), is("Default value out of range"));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenDefaultValueLessThanMinValue() {
+      final Exception e = assertThrows(
+          IllegalArgumentException.class,
+          () -> new DoubleProperty(NAME, DESCRIPTION, MAX_VALUE, MIN_VALUE, MIN_VALUE - 1.0, NUMBER_OF_PLACES));
+      assertThat(e.getMessage(), is("Default value out of range"));
+    }
+  }
+}

--- a/game-core/src/test/java/games/strategy/engine/data/properties/NumberPropertyTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/properties/NumberPropertyTest.java
@@ -1,0 +1,43 @@
+package games.strategy.engine.data.properties;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+final class NumberPropertyTest {
+  @Nested
+  final class ConstructorTest {
+    private static final String NAME = "name";
+    private static final String DESCRIPTION = "description";
+    private static final int MAX_VALUE = 100;
+    private static final int MIN_VALUE = 0;
+    private static final int DEFAULT_VALUE = 42;
+
+    @Test
+    void shouldThrowExceptionWhenMaxValueLessThanMinValue() {
+      final Exception e = assertThrows(
+          IllegalArgumentException.class,
+          () -> new NumberProperty(NAME, DESCRIPTION, MIN_VALUE - 1, MIN_VALUE, DEFAULT_VALUE));
+      assertThat(e.getMessage(), is("Max must be greater than min"));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenDefaultValueGreaterThanMaxValue() {
+      final Exception e = assertThrows(
+          IllegalArgumentException.class,
+          () -> new NumberProperty(NAME, DESCRIPTION, MAX_VALUE, MIN_VALUE, MAX_VALUE + 1));
+      assertThat(e.getMessage(), is("Default value out of range"));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenDefaultValueLessThanMinValue() {
+      final Exception e = assertThrows(
+          IllegalArgumentException.class,
+          () -> new NumberProperty(NAME, DESCRIPTION, MAX_VALUE, MIN_VALUE, MIN_VALUE - 1));
+      assertThat(e.getMessage(), is("Default value out of range"));
+    }
+  }
+}


### PR DESCRIPTION
## Overview

Not sure why `IllegalThreadStateException` was being thrown in these scenarios, but this PR simply replaces such uses with its superclass `IllegalArgumentException`.

## Functional Changes

None.

## Manual Testing Performed

None.