### PR TITLE
Remove editable property reflective access

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
+++ b/game-core/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
+import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 
@@ -171,7 +172,6 @@ public class GameDataExporter {
     editableProperties.values().forEach(this::printEditableProperty);
   }
 
-  @SuppressWarnings("unchecked")
   private void printEditableProperty(final IEditableProperty<?> prop) {
     String typeString = "";
     String value = "" + prop.getValue();
@@ -189,15 +189,11 @@ public class GameDataExporter {
       value = "0x" + Integer.toHexString(((Integer) prop.getValue())).toUpperCase();
     }
     if (prop.getClass().equals(ComboProperty.class)) {
-      final Field listField;
-      try {
-        // TODO: unchecked reflection
-        listField = ComboProperty.class.getDeclaredField(ComboProperty.POSSIBLE_VALUES_FIELD_NAME);
-        listField.setAccessible(true);
-        typeString = "            <list>" + String.join(",", (List<String>) listField.get(prop)) + "</list>\n";
-      } catch (final NoSuchFieldException | IllegalArgumentException | IllegalAccessException e) {
-        log.log(Level.SEVERE, "An Error occured whilst trying to print the Property \"" + value + "\"", e);
-      }
+      final ComboProperty<?> comboProperty = (ComboProperty<?>) prop;
+      final Collection<String> encodedPossibleValues = comboProperty.getPossibleValues().stream()
+          .map(Object::toString)
+          .collect(Collectors.toList());
+      typeString = "            <list>" + String.join(",", encodedPossibleValues) + "</list>\n";
     }
     if (prop.getClass().equals(NumberProperty.class)) {
       final NumberProperty numberProperty = (NumberProperty) prop;

--- a/game-core/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
+++ b/game-core/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
@@ -200,18 +200,9 @@ public class GameDataExporter {
       }
     }
     if (prop.getClass().equals(NumberProperty.class)) {
-      try {
-        // TODO: unchecked reflection
-        final Field maxField = NumberProperty.class.getDeclaredField(NumberProperty.MAX_PROPERTY_NAME);
-        final Field minField = NumberProperty.class.getDeclaredField(NumberProperty.MIN_PROPERTY_NAME);
-        maxField.setAccessible(true);
-        minField.setAccessible(true);
-        final int max = maxField.getInt(prop);
-        final int min = minField.getInt(prop);
-        typeString = "            <number min=\"" + min + "\" max=\"" + max + "\"/>\n";
-      } catch (final NoSuchFieldException | IllegalArgumentException | IllegalAccessException e) {
-        log.log(Level.SEVERE, "An Error occured whilst trying to print a Number-XML Tag", e);
-      }
+      final NumberProperty numberProperty = (NumberProperty) prop;
+      typeString = String.format("            <number min=\"%d\" max=\"%d\"/>\n",
+          numberProperty.getMin(), numberProperty.getMax());
     }
     xmlfile.append("        <property name=\"").append(prop.getName()).append("\" value=\"").append(value)
         .append("\" editable=\"true\">\n");

--- a/game-core/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
+++ b/game-core/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.data.export;
 
 import java.io.File;
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -150,21 +149,11 @@ public class GameDataExporter {
     return returnValue.toString();
   }
 
-  @SuppressWarnings("unchecked")
-  private void propertyList(final GameData data) { // TODO: Unchecked Reflection
+  private void propertyList(final GameData data) {
     xmlfile.append("    <propertyList>\n");
     final GameProperties gameProperties = data.getProperties();
-    try {
-      // TODO: unchecked reflection below.. this is bad stuff.. find ways to remove
-      final Field conPropField = GameProperties.class.getDeclaredField(GameProperties.CONSTANT_PROPERTIES_FIELD_NAME);
-      conPropField.setAccessible(true);
-      final Field edPropField = GameProperties.class.getDeclaredField(GameProperties.EDITABLE_PROPERTIES_FIELD_NAME);
-      edPropField.setAccessible(true);
-      printConstantProperties((Map<String, Object>) conPropField.get(gameProperties));
-      printEditableProperties((Map<String, IEditableProperty<?>>) edPropField.get(gameProperties));
-    } catch (final NoSuchFieldException | IllegalArgumentException | IllegalAccessException e) {
-      log.log(Level.SEVERE, "An Error occured whilst trying trying to setup the Property List", e);
-    }
+    printConstantProperties(gameProperties.getConstantPropertiesByName());
+    printEditableProperties(gameProperties.getEditablePropertiesByName());
     xmlfile.append("    </propertyList>\n");
   }
 

--- a/game-core/src/main/java/games/strategy/engine/data/properties/ComboProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/ComboProperty.java
@@ -2,7 +2,6 @@ package games.strategy.engine.data.properties;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
@@ -15,10 +14,9 @@ import games.strategy.ui.SwingComponents;
  * @param <T> The type of the property value.
  */
 public class ComboProperty<T> extends AbstractEditableProperty<T> {
-  public static final String POSSIBLE_VALUES_FIELD_NAME = "possibleValues";
   private static final long serialVersionUID = -3098612299805630587L;
 
-  private final List<T> possibleValues;
+  private final Collection<T> possibleValues;
   private T value;
 
   /**
@@ -61,5 +59,9 @@ public class ComboProperty<T> extends AbstractEditableProperty<T> {
   @Override
   public boolean validate(final Object value) {
     return possibleValues != null && possibleValues.contains(value);
+  }
+
+  public Collection<T> getPossibleValues() {
+    return new ArrayList<>(possibleValues);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/properties/GameProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/GameProperties.java
@@ -27,10 +27,6 @@ import lombok.extern.java.Log;
  */
 @Log
 public class GameProperties extends GameDataComponent {
-  // keep this in sync with the corresponding property, this name is used by reflection
-  public static final String CONSTANT_PROPERTIES_FIELD_NAME = "constantProperties";
-  // keep this in sync with the corresponding property, this name is used by reflection
-  public static final String EDITABLE_PROPERTIES_FIELD_NAME = "editableProperties";
   private static final long serialVersionUID = -1448163357090677564L;
 
   private final Map<String, Object> constantProperties = new HashMap<>();
@@ -41,6 +37,14 @@ public class GameProperties extends GameDataComponent {
 
   public GameProperties(final GameData data) {
     super(data);
+  }
+
+  public Map<String, Object> getConstantPropertiesByName() {
+    return new HashMap<>(constantProperties);
+  }
+
+  public Map<String, IEditableProperty<?>> getEditablePropertiesByName() {
+    return new HashMap<>(editableProperties);
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/data/properties/NumberProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/NumberProperty.java
@@ -5,18 +5,17 @@ import static com.google.common.base.Preconditions.checkArgument;
 import javax.swing.JComponent;
 
 import games.strategy.ui.IntTextField;
+import lombok.Getter;
 
 /**
  * Implementation of {@link IEditableProperty} for an integer value.
  */
 public class NumberProperty extends AbstractEditableProperty<Integer> {
-  // Keep this in sync with the matching property name, used by reflection.
-  public static final String MAX_PROPERTY_NAME = "max";
-  // Keep this in sync with the matching property name, used by reflection.
-  public static final String MIN_PROPERTY_NAME = "min";
   private static final long serialVersionUID = 6826763550643504789L;
 
+  @Getter
   private final int max;
+  @Getter
   private final int min;
   private int value;
 


### PR DESCRIPTION
## Overview

Removes reflective access to private fields of several types in the `g.s.engine.data.properties` package by adding public accessors for the fields in question.

I'm assuming there must have been a good reason why simply adding accessors wasn't done when this code was introduced.  However, I don't see why reflective access is still necessary today.  (I searched for string literals containing the affected field names and couldn't find any other possible reflective accesses.)

## Functional Changes

None.

## Manual Testing Performed

Exported the game XML before and after this change and verified the XML is identical.

(**NOTE:** I'm unable to find a map that uses `<list>` or `<combo>` properties, so I wasn't able to test the `ComboProperty` change.  Please advise if you're aware of one.)