### PR TITLE
Spotless: Add minimal configuration for Gradle build scripts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,12 +46,25 @@ task validateYamls(group: 'verification', description: 'Validates YAML files.') 
     }
 }
 
+allprojects {
+    apply plugin: 'com.diffplug.gradle.spotless'
+
+    spotless {
+        groovyGradle {
+            target '*.gradle', 'gradle/**/*.gradle'
+
+            endWithNewline()
+            indentWithSpaces()
+            trimTrailingWhitespace()
+        }
+    }
+}
+
 subprojects {
     apply plugin: 'checkstyle'
     apply plugin: 'jacoco'
     apply plugin: 'java'
     apply plugin: 'pmd'
-    apply plugin: 'com.diffplug.gradle.spotless'
     apply plugin: 'net.ltgt.errorprone'
     apply plugin: 'io.franzbecker.gradle-lombok'
 


### PR DESCRIPTION
## Overview

Adds a minimal Spotless configuration for Gradle build scripts.  

## Functional Changes

None.

## Manual Testing Performed

Verified a format problem in a Gradle build script fails the build.  (I tested _build.gradle_, _gradle/scripts/release.gradle_, and _game-core/build.gradle_.)