### PR TITLE
Rename getunits

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/BombingUnitDamageChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/BombingUnitDamageChange.java
@@ -39,7 +39,7 @@ public class BombingUnitDamageChange extends Change {
     }
     final Set<Unit> units = hits.keySet();
     for (final Territory element : data.getMap().getTerritories()) {
-      if (!Collections.disjoint(element.getUnitCollection().getUnits(), units)) {
+      if (!Collections.disjoint(element.getUnits(), units)) {
         element.notifyChanged();
       }
     }

--- a/game-core/src/main/java/games/strategy/engine/data/BombingUnitDamageChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/BombingUnitDamageChange.java
@@ -39,7 +39,7 @@ public class BombingUnitDamageChange extends Change {
     }
     final Set<Unit> units = hits.keySet();
     for (final Territory element : data.getMap().getTerritories()) {
-      if (!Collections.disjoint(element.getUnits().getUnits(), units)) {
+      if (!Collections.disjoint(element.getUnitCollection().getUnits(), units)) {
         element.notifyChanged();
       }
     }

--- a/game-core/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameParser.java
@@ -1373,7 +1373,7 @@ public final class GameParser {
         unitDamage = 0;
       }
       final int quantity = Integer.parseInt(current.getAttribute("quantity"));
-      territory.getUnits().addAll(type.create(quantity, owner, false, hits, unitDamage));
+      territory.getUnitCollection().addAll(type.create(quantity, owner, false, hits, unitDamage));
     }
   }
 
@@ -1382,7 +1382,7 @@ public final class GameParser {
       final PlayerId player = getPlayerId(current, "player", true);
       final UnitType type = getUnitType(current, "unitType", true);
       final int quantity = Integer.parseInt(current.getAttribute("quantity"));
-      player.getUnits().addAll(type.create(quantity, player));
+      player.getUnitCollection().addAll(type.create(quantity, player));
     }
   }
 

--- a/game-core/src/main/java/games/strategy/engine/data/PlayerId.java
+++ b/game-core/src/main/java/games/strategy/engine/data/PlayerId.java
@@ -76,7 +76,7 @@ public class PlayerId extends NamedAttachable implements NamedUnitHolder {
   }
 
   @Override
-  public UnitCollection getUnits() {
+  public UnitCollection getUnitCollection() {
     return unitsHeld;
   }
 
@@ -170,14 +170,14 @@ public class PlayerId extends NamedAttachable implements NamedUnitHolder {
    */
   public boolean amNotDeadYet(final GameData data) {
     for (final Territory t : data.getMap().getTerritories()) {
-      if (t.getUnits().anyMatch(Matches.unitIsOwnedBy(this)
+      if (t.getUnitCollection().anyMatch(Matches.unitIsOwnedBy(this)
           .and(Matches.unitHasAttackValueOfAtLeast(1))
           .and(Matches.unitCanMove())
           .and(Matches.unitIsLand()))) {
         return true;
       }
       if (t.getOwner().equals(this)
-          && t.getUnits().anyMatch(Matches.unitIsOwnedBy(this).and(Matches.unitCanProduceUnits()))) {
+          && t.getUnitCollection().anyMatch(Matches.unitIsOwnedBy(this).and(Matches.unitCanProduceUnits()))) {
         return true;
       }
     }

--- a/game-core/src/main/java/games/strategy/engine/data/Territory.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Territory.java
@@ -20,7 +20,7 @@ public class Territory extends NamedAttachable implements NamedUnitHolder, Compa
   private PlayerId owner = PlayerId.NULL_PLAYERID;
 
   @Getter(onMethod_ = {@Override})
-  private final UnitCollection units;
+  private final UnitCollection unitCollection;
 
   public Territory(final String name, final GameData data) {
     this(name, false, data);
@@ -29,7 +29,7 @@ public class Territory extends NamedAttachable implements NamedUnitHolder, Compa
   public Territory(final String name, final boolean water, final GameData data) {
     super(name, data);
     this.water = water;
-    units = new UnitCollection(this, getData());
+    unitCollection = new UnitCollection(this, getData());
   }
 
   public void setOwner(final @Nullable PlayerId owner) {

--- a/game-core/src/main/java/games/strategy/engine/data/UnitHitsChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitHitsChange.java
@@ -34,7 +34,7 @@ public class UnitHitsChange extends Change {
     }
     final Set<Unit> units = hits.keySet();
     for (final Territory element : data.getMap().getTerritories()) {
-      if (!Collections.disjoint(element.getUnitCollection().getUnits(), units)) {
+      if (!Collections.disjoint(element.getUnits(), units)) {
         element.notifyChanged();
       }
     }

--- a/game-core/src/main/java/games/strategy/engine/data/UnitHitsChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitHitsChange.java
@@ -34,7 +34,7 @@ public class UnitHitsChange extends Change {
     }
     final Set<Unit> units = hits.keySet();
     for (final Territory element : data.getMap().getTerritories()) {
-      if (!Collections.disjoint(element.getUnits().getUnits(), units)) {
+      if (!Collections.disjoint(element.getUnitCollection().getUnits(), units)) {
         element.notifyChanged();
       }
     }

--- a/game-core/src/main/java/games/strategy/engine/data/UnitHolder.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitHolder.java
@@ -1,5 +1,7 @@
 package games.strategy.engine.data;
 
+import java.util.Collection;
+
 /**
  * An object that contains a collection of {@link Unit}s.
  */
@@ -12,4 +14,8 @@ public interface UnitHolder {
   void notifyChanged();
 
   String getType();
+
+  default Collection<Unit> getUnits() {
+    return getUnitCollection().getUnits();
+  }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/UnitHolder.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitHolder.java
@@ -7,7 +7,7 @@ public interface UnitHolder {
   String TERRITORY = "T";
   String PLAYER = "P";
 
-  UnitCollection getUnits();
+  UnitCollection getUnitCollection();
 
   void notifyChanged();
 

--- a/game-core/src/main/java/games/strategy/engine/data/UnitType.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitType.java
@@ -124,7 +124,7 @@ public class UnitType extends NamedAttachable {
       // This is because the null player does not have a production frontier, and we also do not know what units we have
       // art for, so only use the units on a map.
       for (final Territory t : data.getMap()) {
-        for (final Unit u : t.getUnits()) {
+        for (final Unit u : t.getUnitCollection()) {
           if (u.getOwner().equals(player)) {
             final UnitType ut = u.getType();
             if (!unitTypes.contains(ut)) {

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AddUnits.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AddUnits.java
@@ -39,7 +39,7 @@ class AddUnits extends Change {
   @Override
   protected void perform(final GameData data) {
     final UnitHolder holder = data.getUnitHolder(name, type);
-    holder.getUnits().addAll(units);
+    holder.getUnitCollection().addAll(units);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/ChangeFactory.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/ChangeFactory.java
@@ -80,19 +80,19 @@ public class ChangeFactory {
   }
 
   public static Change addUnits(final Territory territory, final Collection<Unit> units) {
-    return new AddUnits(territory.getUnits(), units);
+    return new AddUnits(territory.getUnitCollection(), units);
   }
 
   public static Change addUnits(final PlayerId player, final Collection<Unit> units) {
-    return new AddUnits(player.getUnits(), units);
+    return new AddUnits(player.getUnitCollection(), units);
   }
 
   public static Change removeUnits(final Territory territory, final Collection<Unit> units) {
-    return new RemoveUnits(territory.getUnits(), units);
+    return new RemoveUnits(territory.getUnitCollection(), units);
   }
 
   public static Change removeUnits(final PlayerId player, final Collection<Unit> units) {
-    return new RemoveUnits(player.getUnits(), units);
+    return new RemoveUnits(player.getUnitCollection(), units);
   }
 
   public static Change moveUnits(final Territory start, final Territory end, final Collection<Unit> units) {

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveUnits.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveUnits.java
@@ -34,11 +34,11 @@ class RemoveUnits extends Change {
   @Override
   protected void perform(final GameData data) {
     final UnitHolder holder = data.getUnitHolder(name, type);
-    if (!holder.getUnits().containsAll(units)) {
+    if (!holder.getUnitCollection().containsAll(units)) {
       throw new IllegalStateException("Not all units present in:" + name + ".  Trying to remove:" + units
-          + " present:" + holder.getUnits().getUnits());
+          + " present:" + holder.getUnitCollection().getUnits());
     }
-    holder.getUnits().removeAll(units);
+    holder.getUnitCollection().removeAll(units);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveUnits.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/RemoveUnits.java
@@ -36,7 +36,7 @@ class RemoveUnits extends Change {
     final UnitHolder holder = data.getUnitHolder(name, type);
     if (!holder.getUnitCollection().containsAll(units)) {
       throw new IllegalStateException("Not all units present in:" + name + ".  Trying to remove:" + units
-          + " present:" + holder.getUnitCollection().getUnits());
+          + " present:" + holder.getUnits());
     }
     holder.getUnitCollection().removeAll(units);
   }

--- a/game-core/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
+++ b/game-core/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
@@ -289,7 +289,7 @@ public class GameDataExporter {
   private void unitInitialize(final GameData data) {
     xmlfile.append("        <unitInitialize>\n");
     for (final Territory terr : data.getMap().getTerritories()) {
-      final UnitCollection uc = terr.getUnits();
+      final UnitCollection uc = terr.getUnitCollection();
       for (final PlayerId player : uc.getPlayersWithUnits()) {
         final IntegerMap<UnitType> ucp = uc.getUnitsByType(player);
         for (final UnitType unit : ucp.keySet()) {

--- a/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -368,7 +368,7 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer implements ITrip
         final Predicate<Unit> myDamaged = Matches.unitIsOwnedBy(id).and(Matches.unitHasTakenSomeBombingUnitDamage());
         final Collection<Unit> damagedUnits = new ArrayList<>();
         for (final Territory t : data.getMap().getTerritories()) {
-          damagedUnits.addAll(CollectionUtils.getMatches(t.getUnits().getUnits(), myDamaged));
+          damagedUnits.addAll(CollectionUtils.getMatches(t.getUnitCollection().getUnits(), myDamaged));
         }
         if (damagedUnits.size() > 0) {
           final Map<Unit, IntegerMap<RepairRule>> repair =

--- a/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -368,7 +368,7 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer implements ITrip
         final Predicate<Unit> myDamaged = Matches.unitIsOwnedBy(id).and(Matches.unitHasTakenSomeBombingUnitDamage());
         final Collection<Unit> damagedUnits = new ArrayList<>();
         for (final Territory t : data.getMap().getTerritories()) {
-          damagedUnits.addAll(CollectionUtils.getMatches(t.getUnitCollection().getUnits(), myDamaged));
+          damagedUnits.addAll(CollectionUtils.getMatches(t.getUnits(), myDamaged));
         }
         if (damagedUnits.size() > 0) {
           final Map<Unit, IntegerMap<RepairRule>> repair =

--- a/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -116,8 +116,8 @@ public class TripleAUnit extends Unit {
     // rather we look at the transported by property of units
     for (final Territory t : getData().getMap()) {
       // find the territory this transport is in
-      if (t.getUnits().contains(this)) {
-        return getTransporting(t.getUnits());
+      if (t.getUnitCollection().contains(this)) {
+        return getTransporting(t.getUnitCollection());
       }
     }
     return Collections.emptyList();

--- a/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
@@ -506,7 +506,7 @@ public abstract class AbstractAi extends AbstractBasePlayer implements ITripleAP
   protected abstract void move(boolean nonCombat, IMoveDelegate moveDel, GameData data, PlayerId player);
 
   /**
-   * It is the AI's turn to place units. get the units available to place with player.getUnits()
+   * It is the AI's turn to place units. get the units available to place with player.getUnitCollection()
    *
    * @param placeForBid - is this a placement for bid
    * @param placeDelegate - the place delegate to place with

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -464,7 +464,7 @@ class ProCombatMoveAi {
 
       // Remove empty convoy zones that can't be held
       if (!patd.isCanHold() && enemyAttackOptions.getMax(t) != null && t.isWater()
-          && !t.getUnits().anyMatch(Matches.enemyUnit(player, data))) {
+          && !t.getUnitCollection().anyMatch(Matches.enemyUnit(player, data))) {
         ProLogger.debug("Removing convoy zone that can't be held: " + t.getName() + ", enemyAttackers="
             + enemyAttackOptions.getMax(t).getMaxUnits());
         it.remove();
@@ -547,14 +547,14 @@ class ProCombatMoveAi {
     final List<Unit> alreadyMovedUnits = new ArrayList<>();
     for (final Territory t : ProData.myUnitTerritories) {
       final boolean hasAlliedLandUnits =
-          t.getUnits().anyMatch(ProMatches.unitCantBeMovedAndIsAlliedDefenderAndNotInfra(player, data, t));
+          t.getUnitCollection().anyMatch(ProMatches.unitCantBeMovedAndIsAlliedDefenderAndNotInfra(player, data, t));
       final Set<Territory> enemyNeighbors = data.getMap().getNeighbors(t,
           Matches.territoryIsEnemyNonNeutralAndHasEnemyUnitMatching(data, player, Matches.unitIsLand()));
       enemyNeighbors.removeAll(territoriesToAttack);
       if (!t.isWater() && !hasAlliedLandUnits && !enemyNeighbors.isEmpty()) {
         int minCost = Integer.MAX_VALUE;
         Unit minUnit = null;
-        for (final Unit u : t.getUnits().getMatches(Matches.unitIsOwnedBy(player))) {
+        for (final Unit u : t.getUnitCollection().getMatches(Matches.unitIsOwnedBy(player))) {
           if (ProData.unitValueMap.getInt(u.getType()) < minCost) {
             minCost = ProData.unitValueMap.getInt(u.getType());
             minUnit = u;
@@ -633,7 +633,8 @@ class ProCombatMoveAi {
           if (enemyAttackOptions.getMax(unloadTerritory) != null) {
             final List<Unit> enemyAttackers = enemyAttackOptions.getMax(unloadTerritory).getMaxUnits();
             final Set<Unit> defenders =
-                new HashSet<>(unloadTerritory.getUnits().getMatches(ProMatches.unitIsAlliedNotOwned(player, data)));
+                new HashSet<>(
+                    unloadTerritory.getUnitCollection().getMatches(ProMatches.unitIsAlliedNotOwned(player, data)));
             defenders.addAll(territoryTransportAndBombardMap.get(unloadTerritory));
             if (defendMap.get(unloadTerritory) != null) {
               defenders.addAll(defendMap.get(unloadTerritory).getMaxUnits());
@@ -718,12 +719,13 @@ class ProCombatMoveAi {
         Optional<Territory> maxBombingTerritory = Optional.empty();
         int maxBombingScore = MIN_BOMBING_SCORE;
         for (final Territory t : bomberMoveMap.get(unit)) {
-          final boolean canBeBombedByThisUnit = t.getUnits()
+          final boolean canBeBombedByThisUnit = t.getUnitCollection()
               .anyMatch(Matches.unitCanProduceUnitsAndCanBeDamaged().and(Matches.unitIsLegalBombingTargetBy(unit)));
           final boolean canCreateAirBattle = Properties.getRaidsMayBePreceededByAirBattles(data)
               && AirBattle.territoryCouldPossiblyHaveAirBattleDefenders(t, player, data, true);
           if (canBeBombedByThisUnit && !canCreateAirBattle && canAirSafelyLandAfterAttack(unit, t)) {
-            final int noAaBombingDefense = t.getUnits().anyMatch(Matches.unitIsAaForBombingThisUnitOnly()) ? 0 : 1;
+            final int noAaBombingDefense =
+                t.getUnitCollection().anyMatch(Matches.unitIsAaForBombingThisUnitOnly()) ? 0 : 1;
             int maxDamage = 0;
             final TerritoryAttachment ta = TerritoryAttachment.get(t);
             if (ta != null) {
@@ -1340,7 +1342,7 @@ class ProCombatMoveAi {
                       attackers = enemyAttackOptions.getMax(territoryToMoveTransport).getMaxUnits();
                     }
                     final List<Unit> defenders =
-                        territoryToMoveTransport.getUnits().getMatches(Matches.isUnitAllied(player, data));
+                        territoryToMoveTransport.getUnitCollection().getMatches(Matches.isUnitAllied(player, data));
                     defenders.add(transport);
                     final double strengthDifference =
                         ProBattleUtils.estimateStrengthDifference(territoryToMoveTransport, attackers, defenders);
@@ -1486,10 +1488,10 @@ class ProCombatMoveAi {
       // Find max remaining defenders
       final Set<Territory> territoriesAdjacentToCapital =
           data.getMap().getNeighbors(myCapital, Matches.territoryIsLand());
-      final List<Unit> defenders = myCapital.getUnits().getMatches(Matches.isUnitAllied(player, data));
+      final List<Unit> defenders = myCapital.getUnitCollection().getMatches(Matches.isUnitAllied(player, data));
       defenders.addAll(placeUnits);
       for (final Territory t : territoriesAdjacentToCapital) {
-        defenders.addAll(t.getUnits().getMatches(ProMatches.unitCanBeMovedAndIsOwnedLand(player, false)));
+        defenders.addAll(t.getUnitCollection().getMatches(ProMatches.unitCanBeMovedAndIsOwnedLand(player, false)));
       }
       for (final ProTerritory t : attackMap.values()) {
         defenders.removeAll(t.getUnits());
@@ -1552,7 +1554,8 @@ class ProCombatMoveAi {
             data.getMap().getNeighbors(t, ProMatches.territoryCanMoveSeaUnitsThrough(player, data, true));
         if (!possibleMoveTerritories.isEmpty()) {
           final Territory moveToTerritory = possibleMoveTerritories.iterator().next();
-          final List<Unit> mySeaUnits = t.getUnits().getMatches(ProMatches.unitCanBeMovedAndIsOwnedSea(player, true));
+          final List<Unit> mySeaUnits =
+              t.getUnitCollection().getMatches(ProMatches.unitCanBeMovedAndIsOwnedSea(player, true));
           if (attackMap.containsKey(moveToTerritory)) {
             attackMap.get(moveToTerritory).addUnits(mySeaUnits);
           } else {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -673,7 +673,7 @@ class ProNonCombatMoveAi {
           if (Matches.unitIsCarrier().test(unit)) {
             final Territory unitTerritory = unitTerritoryMap.get(unit);
             final Map<Unit, Collection<Unit>> carrierMustMoveWith =
-                MoveValidator.carrierMustMoveWith(unitTerritory.getUnitCollection().getUnits(), unitTerritory, data,
+                MoveValidator.carrierMustMoveWith(unitTerritory.getUnits(), unitTerritory, data,
                     player);
             if (carrierMustMoveWith.containsKey(unit)) {
               moveMap.get(maxWinTerritory).getTempUnits().addAll(carrierMustMoveWith.get(unit));
@@ -1366,7 +1366,7 @@ class ProNonCombatMoveAi {
                 if (Matches.unitIsCarrier().test(u)) {
                   final Territory unitTerritory = unitTerritoryMap.get(u);
                   final Map<Unit, Collection<Unit>> carrierMustMoveWith = MoveValidator
-                      .carrierMustMoveWith(unitTerritory.getUnitCollection().getUnits(), unitTerritory, data, player);
+                      .carrierMustMoveWith(unitTerritory.getUnits(), unitTerritory, data, player);
                   if (carrierMustMoveWith.containsKey(u)) {
                     moveMap.get(t).getTempUnits().addAll(carrierMustMoveWith.get(u));
                   }
@@ -1443,7 +1443,7 @@ class ProNonCombatMoveAi {
             if (Matches.unitIsCarrier().test(u)) {
               final Territory unitTerritory = unitTerritoryMap.get(u);
               final Map<Unit, Collection<Unit>> carrierMustMoveWith =
-                  MoveValidator.carrierMustMoveWith(unitTerritory.getUnitCollection().getUnits(), unitTerritory, data,
+                  MoveValidator.carrierMustMoveWith(unitTerritory.getUnits(), unitTerritory, data,
                       player);
               if (carrierMustMoveWith.containsKey(u)) {
                 moveMap.get(maxValueTerritory).getTempUnits().addAll(carrierMustMoveWith.get(u));
@@ -1482,7 +1482,7 @@ class ProNonCombatMoveAi {
               if (Matches.unitIsCarrier().test(u)) {
                 final Territory unitTerritory = unitTerritoryMap.get(u);
                 final Map<Unit, Collection<Unit>> carrierMustMoveWith =
-                    MoveValidator.carrierMustMoveWith(unitTerritory.getUnitCollection().getUnits(), unitTerritory, data,
+                    MoveValidator.carrierMustMoveWith(unitTerritory.getUnits(), unitTerritory, data,
                         player);
                 if (carrierMustMoveWith.containsKey(u)) {
                   moveMap.get(minTerritory).getTempUnits().addAll(carrierMustMoveWith.get(u));

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -203,7 +203,7 @@ class ProNonCombatMoveAi {
     // Add all units that can't move (allied units, 0 move units, etc)
     for (final Territory t : moveMap.keySet()) {
       moveMap.get(t).getCantMoveUnits()
-          .addAll(t.getUnits().getMatches(ProMatches.unitCantBeMovedAndIsAlliedDefender(player, data, t)));
+          .addAll(t.getUnitCollection().getMatches(ProMatches.unitCantBeMovedAndIsAlliedDefender(player, data, t)));
     }
 
     // Add all units that only have 1 move option and can't be transported
@@ -673,7 +673,8 @@ class ProNonCombatMoveAi {
           if (Matches.unitIsCarrier().test(unit)) {
             final Territory unitTerritory = unitTerritoryMap.get(unit);
             final Map<Unit, Collection<Unit>> carrierMustMoveWith =
-                MoveValidator.carrierMustMoveWith(unitTerritory.getUnits().getUnits(), unitTerritory, data, player);
+                MoveValidator.carrierMustMoveWith(unitTerritory.getUnitCollection().getUnits(), unitTerritory, data,
+                    player);
             if (carrierMustMoveWith.containsKey(unit)) {
               moveMap.get(maxWinTerritory).getTempUnits().addAll(carrierMustMoveWith.get(unit));
             }
@@ -1365,7 +1366,7 @@ class ProNonCombatMoveAi {
                 if (Matches.unitIsCarrier().test(u)) {
                   final Territory unitTerritory = unitTerritoryMap.get(u);
                   final Map<Unit, Collection<Unit>> carrierMustMoveWith = MoveValidator
-                      .carrierMustMoveWith(unitTerritory.getUnits().getUnits(), unitTerritory, data, player);
+                      .carrierMustMoveWith(unitTerritory.getUnitCollection().getUnits(), unitTerritory, data, player);
                   if (carrierMustMoveWith.containsKey(u)) {
                     moveMap.get(t).getTempUnits().addAll(carrierMustMoveWith.get(u));
                   }
@@ -1442,7 +1443,8 @@ class ProNonCombatMoveAi {
             if (Matches.unitIsCarrier().test(u)) {
               final Territory unitTerritory = unitTerritoryMap.get(u);
               final Map<Unit, Collection<Unit>> carrierMustMoveWith =
-                  MoveValidator.carrierMustMoveWith(unitTerritory.getUnits().getUnits(), unitTerritory, data, player);
+                  MoveValidator.carrierMustMoveWith(unitTerritory.getUnitCollection().getUnits(), unitTerritory, data,
+                      player);
               if (carrierMustMoveWith.containsKey(u)) {
                 moveMap.get(maxValueTerritory).getTempUnits().addAll(carrierMustMoveWith.get(u));
               }
@@ -1480,7 +1482,8 @@ class ProNonCombatMoveAi {
               if (Matches.unitIsCarrier().test(u)) {
                 final Territory unitTerritory = unitTerritoryMap.get(u);
                 final Map<Unit, Collection<Unit>> carrierMustMoveWith =
-                    MoveValidator.carrierMustMoveWith(unitTerritory.getUnits().getUnits(), unitTerritory, data, player);
+                    MoveValidator.carrierMustMoveWith(unitTerritory.getUnitCollection().getUnits(), unitTerritory, data,
+                        player);
                 if (carrierMustMoveWith.containsKey(u)) {
                   moveMap.get(minTerritory).getTempUnits().addAll(carrierMustMoveWith.get(u));
                 }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -90,7 +90,8 @@ class ProPurchaseAi {
           continue;
         }
         final Unit possibleFactoryNeedingRepair = TripleAUnit.getBiggestProducer(
-            CollectionUtils.getMatches(fixTerr.getUnits().getUnits(), ourFactories), fixTerr, player, data, false);
+            CollectionUtils.getMatches(fixTerr.getUnitCollection().getUnits(), ourFactories), fixTerr, player, data,
+            false);
         if (Matches.unitHasTakenSomeBombingUnitDamage().test(possibleFactoryNeedingRepair)) {
           unitsThatCanProduceNeedingRepair.put(possibleFactoryNeedingRepair, fixTerr);
         }
@@ -141,8 +142,8 @@ class ProPurchaseAi {
     final ProPurchaseOptionMap purchaseOptions = ProData.purchaseOptions;
 
     ProLogger.info("Starting bid phase with resources: " + resourceTracker);
-    if (!player.getUnits().getUnits().isEmpty()) {
-      ProLogger.info("Starting bid phase with unplaced units=" + player.getUnits().getUnits());
+    if (!player.getUnitCollection().getUnits().isEmpty()) {
+      ProLogger.info("Starting bid phase with unplaced units=" + player.getUnitCollection().getUnits());
     }
 
     // Find all purchase/place territories
@@ -233,8 +234,8 @@ class ProPurchaseAi {
     final ProPurchaseOptionMap purchaseOptions = ProData.purchaseOptions;
 
     ProLogger.info("Starting purchase phase with resources: " + resourceTracker);
-    if (!player.getUnits().getUnits().isEmpty()) {
-      ProLogger.info("Starting purchase phase with unplaced units=" + player.getUnits().getUnits());
+    if (!player.getUnitCollection().getUnits().isEmpty()) {
+      ProLogger.info("Starting purchase phase with unplaced units=" + player.getUnitCollection().getUnits());
     }
 
     // Find all purchase/place territories
@@ -331,7 +332,7 @@ class ProPurchaseAi {
           if (!ppt.getTerritory().isWater()) {
             final List<Unit> unitsToPlace = new ArrayList<>();
             for (final Unit placeUnit : ppt.getPlaceUnits()) {
-              for (final Unit myUnit : player.getUnits()) {
+              for (final Unit myUnit : player.getUnitCollection()) {
                 if (myUnit.getType().equals(placeUnit.getType()) && !unitsToPlace.contains(myUnit)) {
                   unitsToPlace.add(myUnit);
                   break;
@@ -348,7 +349,7 @@ class ProPurchaseAi {
           if (ppt.getTerritory().isWater()) {
             final List<Unit> unitsToPlace = new ArrayList<>();
             for (final Unit placeUnit : ppt.getPlaceUnits()) {
-              for (final Unit myUnit : player.getUnits()) {
+              for (final Unit myUnit : player.getUnitCollection()) {
                 if (myUnit.getType().equals(placeUnit.getType()) && !unitsToPlace.contains(myUnit)) {
                   unitsToPlace.add(myUnit);
                   break;
@@ -363,12 +364,12 @@ class ProPurchaseAi {
     }
 
     // Place remaining units (currently only implemented to handle land units, ex. WW2v3 China)
-    if (player.getUnits().getUnits().isEmpty()) {
+    if (player.getUnitCollection().getUnits().isEmpty()) {
       return;
     }
 
     // Current data at the start of place
-    ProLogger.debug("Remaining units to place: " + player.getUnits().getUnits());
+    ProLogger.debug("Remaining units to place: " + player.getUnitCollection().getUnits());
 
     // Find all place territories
     final Map<Territory, ProPurchaseTerritory> placeNonConstructionTerritories =
@@ -428,7 +429,7 @@ class ProPurchaseAi {
     for (final ProPurchaseTerritory ppt : purchaseTerritories.values()) {
       for (final ProPlaceTerritory placeTerritory : ppt.getCanPlaceTerritories()) {
         final Territory t = placeTerritory.getTerritory();
-        final List<Unit> units = t.getUnits().getMatches(Matches.isUnitAllied(player, data));
+        final List<Unit> units = t.getUnitCollection().getMatches(Matches.isUnitAllied(player, data));
         placeTerritory.setDefendingUnits(units);
         ProLogger.debug(t + " has numDefenders=" + units.size());
       }
@@ -549,7 +550,7 @@ class ProPurchaseAi {
           + enemyAttackOptions.getMax(t).getMaxAmphibUnits() + ", defenders=" + placeTerritory.getDefendingUnits());
 
       // Find local owned units
-      final List<Unit> ownedLocalUnits = t.getUnits().getMatches(Matches.unitIsOwnedBy(player));
+      final List<Unit> ownedLocalUnits = t.getUnitCollection().getMatches(Matches.unitIsOwnedBy(player));
       int unusedCarrierCapacity = Math.min(0, ProTransportUtils.getUnusedCarrierCapacity(player, t, new ArrayList<>()));
       int unusedLocalCarrierCapacity = ProTransportUtils.getUnusedLocalCarrierCapacity(player, t, new ArrayList<>());
       ProLogger.trace(t + ", unusedCarrierCapacity=" + unusedCarrierCapacity + ", unusedLocalCarrierCapacity="
@@ -719,8 +720,8 @@ class ProPurchaseAi {
       // Check if territory needs AA
       final boolean enemyCanBomb =
           enemyAttackOptions.getMax(t).getMaxUnits().stream().anyMatch(Matches.unitIsStrategicBomber());
-      final boolean territoryCanBeBombed = t.getUnits().anyMatch(Matches.unitCanProduceUnitsAndCanBeDamaged());
-      final boolean hasAaBombingDefense = t.getUnits().anyMatch(Matches.unitIsAaForBombingThisUnitOnly());
+      final boolean territoryCanBeBombed = t.getUnitCollection().anyMatch(Matches.unitCanProduceUnitsAndCanBeDamaged());
+      final boolean hasAaBombingDefense = t.getUnitCollection().anyMatch(Matches.unitIsAaForBombingThisUnitOnly());
       ProLogger.debug(t + ", enemyCanBomb=" + enemyCanBomb + ", territoryCanBeBombed=" + territoryCanBeBombed
           + ", hasAABombingDefense=" + hasAaBombingDefense);
       if (!enemyCanBomb || !territoryCanBeBombed || hasAaBombingDefense) {
@@ -766,7 +767,7 @@ class ProPurchaseAi {
       final List<ProPlaceTerritory> prioritizedLandTerritories, final ProPurchaseOptionMap purchaseOptions,
       final Map<Territory, Double> territoryValueMap) {
 
-    final List<Unit> unplacedUnits = player.getUnits().getMatches(Matches.unitIsNotSea());
+    final List<Unit> unplacedUnits = player.getUnitCollection().getMatches(Matches.unitIsNotSea());
     if (resourceTracker.isEmpty() && unplacedUnits.isEmpty()) {
       return;
     }
@@ -807,7 +808,7 @@ class ProPurchaseAi {
       neighbors.add(t);
       final List<Unit> ownedLocalUnits = new ArrayList<>();
       for (final Territory neighbor : neighbors) {
-        ownedLocalUnits.addAll(neighbor.getUnits().getMatches(Matches.unitIsOwnedBy(player)));
+        ownedLocalUnits.addAll(neighbor.getUnitCollection().getMatches(Matches.unitIsOwnedBy(player)));
       }
 
       // Check for unplaced units
@@ -924,7 +925,7 @@ class ProPurchaseAi {
       } else {
 
         // Find current battle result
-        final List<Unit> defenders = t.getUnits().getMatches(Matches.isUnitAllied(player, data));
+        final List<Unit> defenders = t.getUnitCollection().getMatches(Matches.isUnitAllied(player, data));
         final Set<Unit> enemyAttackingUnits = new HashSet<>(enemyAttackOptions.getMax(t).getMaxUnits());
         enemyAttackingUnits.addAll(enemyAttackOptions.getMax(t).getMaxAmphibUnits());
         final ProBattleResult result = calc.estimateDefendBattleResults(t, new ArrayList<>(enemyAttackingUnits),
@@ -1132,7 +1133,7 @@ class ProPurchaseAi {
       neighbors.add(t);
       final List<Unit> ownedLocalUnits = new ArrayList<>();
       for (final Territory neighbor : neighbors) {
-        ownedLocalUnits.addAll(neighbor.getUnits().getMatches(Matches.unitIsOwnedBy(player)));
+        ownedLocalUnits.addAll(neighbor.getUnitCollection().getMatches(Matches.unitIsOwnedBy(player)));
       }
       int unusedCarrierCapacity = Math.min(0, ProTransportUtils.getUnusedCarrierCapacity(player, t, new ArrayList<>()));
       int unusedLocalCarrierCapacity = ProTransportUtils.getUnusedLocalCarrierCapacity(player, t, new ArrayList<>());
@@ -1145,7 +1146,8 @@ class ProPurchaseAi {
 
         // Determine if need destroyer
         if (enemyAttackOptions.getMax(t).getMaxUnits().stream().anyMatch(Matches.unitIsSub())
-            && t.getUnits().getMatches(Matches.unitIsOwnedBy(player)).stream().noneMatch(Matches.unitIsDestroyer())) {
+            && t.getUnitCollection().getMatches(Matches.unitIsOwnedBy(player)).stream()
+                .noneMatch(Matches.unitIsDestroyer())) {
           needDestroyer = true;
         }
         ProLogger.trace(t + ", needDestroyer=" + needDestroyer + ", checking defense since has enemy attackers: "
@@ -1265,12 +1267,12 @@ class ProPurchaseAi {
       final List<Unit> enemyUnitsInLandTerritories = new ArrayList<>();
       for (final Territory nearbyLandTerritory : nearbyLandTerritories) {
         enemyUnitsInLandTerritories
-            .addAll(nearbyLandTerritory.getUnits().getMatches(ProMatches.unitIsEnemyAir(player, data)));
+            .addAll(nearbyLandTerritory.getUnitCollection().getMatches(ProMatches.unitIsEnemyAir(player, data)));
       }
       final List<Unit> enemyUnitsInSeaTerritories = new ArrayList<>();
       for (final Territory nearbySeaTerritory : nearbyEnemySeaTerritories) {
         final List<Unit> enemySeaUnits =
-            nearbySeaTerritory.getUnits().getMatches(ProMatches.unitIsEnemyNotLand(player, data));
+            nearbySeaTerritory.getUnitCollection().getMatches(ProMatches.unitIsEnemyNotLand(player, data));
         if (enemySeaUnits.isEmpty()) {
           continue;
         }
@@ -1289,7 +1291,7 @@ class ProPurchaseAi {
       final List<Unit> myUnitsInSeaTerritories = new ArrayList<>();
       for (final Territory nearbySeaTerritory : nearbyAlliedSeaTerritories) {
         myUnitsInSeaTerritories
-            .addAll(nearbySeaTerritory.getUnits().getMatches(ProMatches.unitIsOwnedNotLand(player)));
+            .addAll(nearbySeaTerritory.getUnitCollection().getMatches(ProMatches.unitIsOwnedNotLand(player)));
         myUnitsInSeaTerritories.addAll(ProPurchaseUtils.getPlaceUnits(nearbySeaTerritory, purchaseTerritories));
       }
 
@@ -1376,7 +1378,8 @@ class ProPurchaseAi {
         }
 
         // Find local owned units
-        final List<Unit> ownedLocalAmphibUnits = landTerritory.getUnits().getMatches(Matches.unitIsOwnedBy(player));
+        final List<Unit> ownedLocalAmphibUnits =
+            landTerritory.getUnitCollection().getMatches(Matches.unitIsOwnedBy(player));
 
         // Determine sea and transport units that can be produced in this territory
         final List<ProPurchaseOption> seaTransportPurchaseOptionsForTerritory = ProPurchaseUtils
@@ -1392,7 +1395,7 @@ class ProPurchaseAi {
             ProMatches.territoryCanMoveSeaUnits(player, data, false));
         for (final Territory seaTerritory : seaTerritories) {
           final List<Unit> unitsInTerritory = ProPurchaseUtils.getPlaceUnits(seaTerritory, purchaseTerritories);
-          unitsInTerritory.addAll(seaTerritory.getUnits().getUnits());
+          unitsInTerritory.addAll(seaTerritory.getUnitCollection().getUnits());
           final List<Unit> transports =
               CollectionUtils.getMatches(unitsInTerritory, ProMatches.unitIsOwnedTransport(player));
           for (final Unit transport : transports) {
@@ -1412,7 +1415,7 @@ class ProPurchaseAi {
         final Set<Territory> landNeighbors = data.getMap().getNeighbors(t, Matches.territoryIsLand());
         for (final Territory neighbor : landNeighbors) {
           if (territoryValueMap.get(neighbor) <= 0.25) {
-            final List<Unit> unitsInTerritory = new ArrayList<>(neighbor.getUnits().getUnits());
+            final List<Unit> unitsInTerritory = new ArrayList<>(neighbor.getUnitCollection().getUnits());
             unitsInTerritory.addAll(ProPurchaseUtils.getPlaceUnits(neighbor, purchaseTerritories));
             potentialUnitsToLoad.addAll(
                 CollectionUtils.getMatches(unitsInTerritory, ProMatches.unitIsOwnedCombatTransportableUnit(player)));
@@ -1594,7 +1597,7 @@ class ProPurchaseAi {
       ProLogger.debug("Checking territory: " + t);
 
       // Find local owned units
-      final List<Unit> ownedLocalUnits = t.getUnits().getMatches(Matches.unitIsOwnedBy(player));
+      final List<Unit> ownedLocalUnits = t.getUnitCollection().getMatches(Matches.unitIsOwnedBy(player));
 
       // Determine units that can be produced in this territory
       final List<ProPurchaseOption> airAndLandPurchaseOptions = new ArrayList<>(airPurchaseOptions);
@@ -1762,7 +1765,7 @@ class ProPurchaseAi {
       final Map<Territory, ProPurchaseTerritory> purchaseTerritories, final ProPurchaseOptionMap purchaseOptions) {
 
     ProLogger.info("Populate production rule map");
-    final List<Unit> unplacedUnits = player.getUnits().getMatches(Matches.unitIsNotSea());
+    final List<Unit> unplacedUnits = player.getUnitCollection().getMatches(Matches.unitIsNotSea());
     final IntegerMap<ProductionRule> purchaseMap = new IntegerMap<>();
     for (final ProPurchaseOption ppo : purchaseOptions.getAllOptions()) {
       final int numUnits = (int) purchaseTerritories.values().stream()
@@ -1785,7 +1788,7 @@ class ProPurchaseAi {
   private void placeDefenders(final Map<Territory, ProPurchaseTerritory> placeNonConstructionTerritories,
       final List<ProPlaceTerritory> needToDefendTerritories, final IAbstractPlaceDelegate placeDelegate) {
 
-    ProLogger.info("Place defenders with units=" + player.getUnits().getUnits());
+    ProLogger.info("Place defenders with units=" + player.getUnitCollection().getUnits());
 
     final ProOtherMoveOptions enemyAttackOptions = territoryManager.getEnemyAttackOptions();
 
@@ -1798,7 +1801,7 @@ class ProPurchaseAi {
 
       // Check if any units can be placed
       final PlaceableUnits placeableUnits =
-          placeDelegate.getPlaceableUnits(player.getUnits().getMatches(Matches.unitIsNotConstruction()), t);
+          placeDelegate.getPlaceableUnits(player.getUnitCollection().getMatches(Matches.unitIsNotConstruction()), t);
       if (placeableUnits.isError()) {
         ProLogger.trace(t + " can't place units with error: " + placeableUnits.getErrorMessage());
         continue;
@@ -1854,7 +1857,7 @@ class ProPurchaseAi {
   private void placeUnits(final List<ProPlaceTerritory> prioritizedTerritories,
       final IAbstractPlaceDelegate placeDelegate, final boolean isConstruction) {
 
-    ProLogger.info("Place with isConstruction=" + isConstruction + ", units=" + player.getUnits().getUnits());
+    ProLogger.info("Place with isConstruction=" + isConstruction + ", units=" + player.getUnitCollection().getUnits());
 
     Predicate<Unit> unitMatch = Matches.unitIsNotConstruction();
     if (isConstruction) {
@@ -1867,7 +1870,8 @@ class ProPurchaseAi {
       ProLogger.debug("Checking place for " + t.getName());
 
       // Check if any units can be placed
-      final PlaceableUnits placeableUnits = placeDelegate.getPlaceableUnits(player.getUnits().getMatches(unitMatch), t);
+      final PlaceableUnits placeableUnits =
+          placeDelegate.getPlaceableUnits(player.getUnitCollection().getMatches(unitMatch), t);
       if (placeableUnits.isError()) {
         ProLogger.trace(t + " can't place units with error: " + placeableUnits.getErrorMessage());
         continue;

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -90,7 +90,7 @@ class ProPurchaseAi {
           continue;
         }
         final Unit possibleFactoryNeedingRepair = TripleAUnit.getBiggestProducer(
-            CollectionUtils.getMatches(fixTerr.getUnitCollection().getUnits(), ourFactories), fixTerr, player, data,
+            CollectionUtils.getMatches(fixTerr.getUnits(), ourFactories), fixTerr, player, data,
             false);
         if (Matches.unitHasTakenSomeBombingUnitDamage().test(possibleFactoryNeedingRepair)) {
           unitsThatCanProduceNeedingRepair.put(possibleFactoryNeedingRepair, fixTerr);
@@ -142,8 +142,8 @@ class ProPurchaseAi {
     final ProPurchaseOptionMap purchaseOptions = ProData.purchaseOptions;
 
     ProLogger.info("Starting bid phase with resources: " + resourceTracker);
-    if (!player.getUnitCollection().getUnits().isEmpty()) {
-      ProLogger.info("Starting bid phase with unplaced units=" + player.getUnitCollection().getUnits());
+    if (!player.getUnits().isEmpty()) {
+      ProLogger.info("Starting bid phase with unplaced units=" + player.getUnits());
     }
 
     // Find all purchase/place territories
@@ -234,8 +234,8 @@ class ProPurchaseAi {
     final ProPurchaseOptionMap purchaseOptions = ProData.purchaseOptions;
 
     ProLogger.info("Starting purchase phase with resources: " + resourceTracker);
-    if (!player.getUnitCollection().getUnits().isEmpty()) {
-      ProLogger.info("Starting purchase phase with unplaced units=" + player.getUnitCollection().getUnits());
+    if (!player.getUnits().isEmpty()) {
+      ProLogger.info("Starting purchase phase with unplaced units=" + player.getUnits());
     }
 
     // Find all purchase/place territories
@@ -364,12 +364,12 @@ class ProPurchaseAi {
     }
 
     // Place remaining units (currently only implemented to handle land units, ex. WW2v3 China)
-    if (player.getUnitCollection().getUnits().isEmpty()) {
+    if (player.getUnits().isEmpty()) {
       return;
     }
 
     // Current data at the start of place
-    ProLogger.debug("Remaining units to place: " + player.getUnitCollection().getUnits());
+    ProLogger.debug("Remaining units to place: " + player.getUnits());
 
     // Find all place territories
     final Map<Territory, ProPurchaseTerritory> placeNonConstructionTerritories =
@@ -1395,7 +1395,7 @@ class ProPurchaseAi {
             ProMatches.territoryCanMoveSeaUnits(player, data, false));
         for (final Territory seaTerritory : seaTerritories) {
           final List<Unit> unitsInTerritory = ProPurchaseUtils.getPlaceUnits(seaTerritory, purchaseTerritories);
-          unitsInTerritory.addAll(seaTerritory.getUnitCollection().getUnits());
+          unitsInTerritory.addAll(seaTerritory.getUnits());
           final List<Unit> transports =
               CollectionUtils.getMatches(unitsInTerritory, ProMatches.unitIsOwnedTransport(player));
           for (final Unit transport : transports) {
@@ -1415,7 +1415,7 @@ class ProPurchaseAi {
         final Set<Territory> landNeighbors = data.getMap().getNeighbors(t, Matches.territoryIsLand());
         for (final Territory neighbor : landNeighbors) {
           if (territoryValueMap.get(neighbor) <= 0.25) {
-            final List<Unit> unitsInTerritory = new ArrayList<>(neighbor.getUnitCollection().getUnits());
+            final List<Unit> unitsInTerritory = new ArrayList<>(neighbor.getUnits());
             unitsInTerritory.addAll(ProPurchaseUtils.getPlaceUnits(neighbor, purchaseTerritories));
             potentialUnitsToLoad.addAll(
                 CollectionUtils.getMatches(unitsInTerritory, ProMatches.unitIsOwnedCombatTransportableUnit(player)));
@@ -1788,7 +1788,7 @@ class ProPurchaseAi {
   private void placeDefenders(final Map<Territory, ProPurchaseTerritory> placeNonConstructionTerritories,
       final List<ProPlaceTerritory> needToDefendTerritories, final IAbstractPlaceDelegate placeDelegate) {
 
-    ProLogger.info("Place defenders with units=" + player.getUnitCollection().getUnits());
+    ProLogger.info("Place defenders with units=" + player.getUnits());
 
     final ProOtherMoveOptions enemyAttackOptions = territoryManager.getEnemyAttackOptions();
 
@@ -1857,7 +1857,7 @@ class ProPurchaseAi {
   private void placeUnits(final List<ProPlaceTerritory> prioritizedTerritories,
       final IAbstractPlaceDelegate placeDelegate, final boolean isConstruction) {
 
-    ProLogger.info("Place with isConstruction=" + isConstruction + ", units=" + player.getUnitCollection().getUnits());
+    ProLogger.info("Place with isConstruction=" + isConstruction + ", units=" + player.getUnits());
 
     Predicate<Unit> unitMatch = Matches.unitIsNotConstruction();
     if (isConstruction) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProRetreatAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProRetreatAi.java
@@ -106,7 +106,7 @@ class ProRetreatAi {
           break;
         }
         final double strength = ProBattleUtils.estimateStrength(t,
-            t.getUnits().getMatches(Matches.isUnitAllied(player, data)), new ArrayList<>(), false);
+            t.getUnitCollection().getMatches(Matches.isUnitAllied(player, data)), new ArrayList<>(), false);
         if (strength > maxStrength) {
           retreatTerritory = t;
           maxStrength = strength;

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
@@ -47,11 +47,11 @@ final class ProTechAi {
     }
     final Territory myCapitol = TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
     final float enemyStrength = getStrengthOfPotentialAttackers(myCapitol, data, player);
-    float myStrength = (myCapitol == null || myCapitol.getUnits() == null) ? 0.0F
-        : strength(myCapitol.getUnits().getUnits(), false, false, false);
+    float myStrength = (myCapitol == null || myCapitol.getUnitCollection() == null) ? 0.0F
+        : strength(myCapitol.getUnitCollection().getUnits(), false, false, false);
     final List<Territory> areaStrength = getNeighboringLandTerritories(data, player, myCapitol);
     for (final Territory areaTerr : areaStrength) {
-      myStrength += strength(areaTerr.getUnits().getUnits(), false, false, false) * 0.75F;
+      myStrength += strength(areaTerr.getUnitCollection().getUnits(), false, false, false) * 0.75F;
     }
     final boolean capDanger = myStrength < (enemyStrength * 1.25F + 3.0F);
     final Resource pus = data.getResourceList().getResource(Constants.PUS);
@@ -133,7 +133,7 @@ final class ProTechAi {
       // reality is 99% of time units considered will have full move.
       // and likely player will have at least 1 max move plane.
       for (final Territory enemyFighterTerritory : enemyFighterTerritories) {
-        final List<Unit> enemyFighterUnits = enemyFighterTerritory.getUnits().getMatches(enemyPlane);
+        final List<Unit> enemyFighterUnits = enemyFighterTerritory.getUnitCollection().getMatches(enemyPlane);
         maxFighterDistance = Math.max(maxFighterDistance, MoveValidator.getMaxMovement(enemyFighterUnits));
       }
       // must be able to land...we will miss fighters who have a Carrier that can reach same sea zone...C'est la vie
@@ -144,7 +144,7 @@ final class ProTechAi {
       final List<Territory> enemyTransportTerritories = findUnitTerr(data, transport);
       int maxTransportDistance = 0;
       for (final Territory enemyTransportTerritory : enemyTransportTerritories) {
-        final List<Unit> enemyTransportUnits = enemyTransportTerritory.getUnits().getMatches(transport);
+        final List<Unit> enemyTransportUnits = enemyTransportTerritory.getUnitCollection().getMatches(transport);
         maxTransportDistance = Math.max(maxTransportDistance, MoveValidator.getMaxMovement(enemyTransportUnits));
       }
       final List<Unit> alreadyLoaded = new ArrayList<>();
@@ -153,7 +153,7 @@ final class ProTechAi {
       final List<Unit> enemyWaterUnits = new ArrayList<>();
       for (final Territory t : data.getMap().getNeighbors(location,
           onWater ? Matches.territoryIsWater() : Matches.territoryIsLand())) {
-        final List<Unit> enemies = t.getUnits().getMatches(Matches.unitIsOwnedBy(enemyPlayer));
+        final List<Unit> enemies = t.getUnitCollection().getMatches(Matches.unitIsOwnedBy(enemyPlayer));
         enemyWaterUnits.addAll(enemies);
         firstStrength += strength(enemies, true, onWater, transportsFirst);
         checked.add(t);
@@ -186,7 +186,7 @@ final class ProTechAi {
             if (enemyPlayer == null) {
               continue;
             }
-            final List<Unit> transports = t4.getUnits().getMatches(enemyTransport);
+            final List<Unit> transports = t4.getUnitCollection().getMatches(enemyTransport);
             if (transports.isEmpty()) {
               continue;
             }
@@ -219,7 +219,7 @@ final class ProTechAi {
             final Set<Territory> transNeighbors =
                 data.getMap().getNeighbors(t4, Matches.isTerritoryAllied(enemyPlayer, data));
             for (final Territory transNeighbor : transNeighbors) {
-              final List<Unit> transUnits = transNeighbor.getUnits().getMatches(enemyTransportable);
+              final List<Unit> transUnits = transNeighbor.getUnitCollection().getMatches(enemyTransportable);
               transUnits.removeAll(alreadyLoaded);
               final List<Unit> availTransUnits = sortTransportUnits(transUnits);
               for (final Unit transUnit : availTransUnits) {
@@ -388,7 +388,7 @@ final class ProTechAi {
       }
       for (final Territory neighbor : data.getMap().getNeighbors(current)) {
         if (!distance.keySet().contains(neighbor)) {
-          if (!neighbor.getUnits().anyMatch(unitCondition)) {
+          if (!neighbor.getUnitCollection().anyMatch(unitCondition)) {
             if (!routeCondition.test(neighbor)) {
               continue;
             }
@@ -408,7 +408,7 @@ final class ProTechAi {
           if (ignoreDistance.contains(dist)) {
             continue;
           }
-          for (final Unit u : neighbor.getUnits()) {
+          for (final Unit u : neighbor.getUnitCollection()) {
             if (unitCondition.test(u) && Matches.unitHasEnoughMovementForRoutes(routes).test(u)) {
               units.add(u);
             }
@@ -469,13 +469,13 @@ final class ProTechAi {
             lz = neighbor;
           }
           if (checked.contains(neighbor)) {
-            for (final Unit u : neighbor.getUnits()) {
+            for (final Unit u : neighbor.getUnitCollection()) {
               if (ac == null && enemyCarrier.test(u)) {
                 ac = neighbor;
               }
             }
           } else {
-            for (final Unit u : neighbor.getUnits()) {
+            for (final Unit u : neighbor.getUnitCollection()) {
               if (ac == null && enemyCarrier.test(u)) {
                 ac = neighbor;
               }
@@ -640,7 +640,7 @@ final class ProTechAi {
     final List<Territory> shipTerr = new ArrayList<>();
     final Collection<Territory> neighbors = data.getMap().getTerritories();
     for (final Territory t2 : neighbors) {
-      if (t2.getUnits().anyMatch(unitCondition)) {
+      if (t2.getUnitCollection().anyMatch(unitCondition)) {
         shipTerr.add(t2);
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
@@ -48,10 +48,10 @@ final class ProTechAi {
     final Territory myCapitol = TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
     final float enemyStrength = getStrengthOfPotentialAttackers(myCapitol, data, player);
     float myStrength = (myCapitol == null || myCapitol.getUnitCollection() == null) ? 0.0F
-        : strength(myCapitol.getUnitCollection().getUnits(), false, false, false);
+        : strength(myCapitol.getUnits(), false, false, false);
     final List<Territory> areaStrength = getNeighboringLandTerritories(data, player, myCapitol);
     for (final Territory areaTerr : areaStrength) {
-      myStrength += strength(areaTerr.getUnitCollection().getUnits(), false, false, false) * 0.75F;
+      myStrength += strength(areaTerr.getUnits(), false, false, false) * 0.75F;
     }
     final boolean capDanger = myStrength < (enemyStrength * 1.25F + 3.0F);
     final Resource pus = data.getResourceList().getResource(Constants.PUS);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseTerritory.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseTerritory.java
@@ -51,7 +51,7 @@ public class ProPurchaseTerritory {
       if (ProMatches.territoryHasFactoryAndIsNotConqueredOwnedLand(player, data).test(territory)) {
         for (final Territory t : data.getMap().getNeighbors(territory, Matches.territoryIsWater())) {
           if (Properties.getWW2V2(data) || Properties.getUnitPlacementInEnemySeas(data)
-              || !t.getUnits().anyMatch(Matches.enemyUnit(player, data))) {
+              || !t.getUnitCollection().anyMatch(Matches.enemyUnit(player, data))) {
             canPlaceTerritories.add(new ProPlaceTerritory(t));
           }
         }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritory.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritory.java
@@ -151,7 +151,7 @@ public class ProTerritory {
   }
 
   public List<Unit> getMaxEnemyDefenders(final PlayerId player, final GameData data) {
-    final List<Unit> defenders = territory.getUnits().getMatches(Matches.enemyUnit(player, data));
+    final List<Unit> defenders = territory.getUnitCollection().getMatches(Matches.enemyUnit(player, data));
     defenders.addAll(maxScrambleUnits);
     return defenders;
   }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -121,7 +121,7 @@ public class ProTerritoryManager {
 
       // Check if I can win without amphib units
       final List<Unit> defenders =
-          new ArrayList<>(isIgnoringRelationships ? t.getUnits() : patd.getMaxEnemyDefenders(player, data));
+          new ArrayList<>(isIgnoringRelationships ? t.getUnitCollection() : patd.getMaxEnemyDefenders(player, data));
       patd.setMaxBattleResult(calc.estimateAttackBattleResults(t, patd.getMaxUnits(), defenders, new HashSet<>()));
 
       // Add in amphib units if I can't win without them
@@ -333,10 +333,10 @@ public class ProTerritoryManager {
       for (final Territory from : scrambleTerrs.get(to)) {
 
         // Find potential scramble units from territory
-        final Collection<Unit> airbases = from.getUnits().getMatches(airbasesCanScramble);
+        final Collection<Unit> airbases = from.getUnitCollection().getMatches(airbasesCanScramble);
         final int maxCanScramble = getMaxScrambleCount(airbases);
         final Route toBattleRoute = data.getMap().getRoute_IgnoreEnd(from, to, Matches.territoryIsNotImpassable());
-        List<Unit> canScrambleAir = from.getUnits().getMatches(Matches.unitIsEnemyOf(data, player)
+        List<Unit> canScrambleAir = from.getUnitCollection().getMatches(Matches.unitIsEnemyOf(data, player)
             .and(Matches.unitCanScramble())
             .and(Matches.unitIsNotDisabled())
             .and(Matches.unitWasScrambled().negate())
@@ -537,7 +537,7 @@ public class ProTerritoryManager {
 
       // Find my naval units that have movement left
       final List<Unit> mySeaUnits =
-          myUnitTerritory.getUnits().getMatches(ProMatches.unitCanBeMovedAndIsOwnedSea(player, isCombatMove));
+          myUnitTerritory.getUnitCollection().getMatches(ProMatches.unitCanBeMovedAndIsOwnedSea(player, isCombatMove));
 
       // Check each sea unit individually since they can have different ranges
       for (final Unit mySeaUnit : mySeaUnits) {
@@ -545,7 +545,8 @@ public class ProTerritoryManager {
         // If my combat move and carrier has dependent allied fighters then skip it
         if (isCombatMove && !isCheckingEnemyAttacks) {
           final Map<Unit, Collection<Unit>> carrierMustMoveWith =
-              MoveValidator.carrierMustMoveWith(myUnitTerritory.getUnits().getUnits(), myUnitTerritory, data, player);
+              MoveValidator.carrierMustMoveWith(myUnitTerritory.getUnitCollection().getUnits(), myUnitTerritory, data,
+                  player);
           if (carrierMustMoveWith.containsKey(mySeaUnit) && !carrierMustMoveWith.get(mySeaUnit).isEmpty()) {
             continue;
           }
@@ -647,7 +648,7 @@ public class ProTerritoryManager {
 
       // Find my land units that have movement left
       final List<Unit> myLandUnits =
-          myUnitTerritory.getUnits().getMatches(ProMatches.unitCanBeMovedAndIsOwnedLand(player, isCombatMove));
+          myUnitTerritory.getUnitCollection().getMatches(ProMatches.unitCanBeMovedAndIsOwnedLand(player, isCombatMove));
 
       // Check each land unit individually since they can have different ranges
       for (final Unit myLandUnit : myLandUnits) {
@@ -744,7 +745,7 @@ public class ProTerritoryManager {
         }
       }
       for (final Territory t : data.getMap().getTerritories()) {
-        if (t.getUnits().anyMatch(Matches.unitIsAlliedCarrier(player, data))) {
+        if (t.getUnitCollection().anyMatch(Matches.unitIsAlliedCarrier(player, data))) {
           possibleCarrierTerritories.add(t);
         }
       }
@@ -754,7 +755,7 @@ public class ProTerritoryManager {
 
       // Find my air units that have movement left
       final List<Unit> myAirUnits =
-          myUnitTerritory.getUnits().getMatches(ProMatches.unitCanBeMovedAndIsOwnedAir(player, isCombatMove));
+          myUnitTerritory.getUnitCollection().getMatches(ProMatches.unitCanBeMovedAndIsOwnedAir(player, isCombatMove));
 
       // Check each air unit individually since they can have different ranges
       for (final Unit myAirUnit : myAirUnits) {
@@ -850,7 +851,8 @@ public class ProTerritoryManager {
 
       // Find my transports and amphibious units that have movement left
       final List<Unit> myTransportUnits =
-          myUnitTerritory.getUnits().getMatches(ProMatches.unitCanBeMovedAndIsOwnedTransport(player, isCombatMove));
+          myUnitTerritory.getUnitCollection()
+              .getMatches(ProMatches.unitCanBeMovedAndIsOwnedTransport(player, isCombatMove));
       Predicate<Territory> unloadAmphibTerritoryMatch = ProMatches.territoryCanMoveLandUnits(player, data, isCombatMove)
           .and(moveAmphibToTerritoryMatch);
       if (isIgnoringRelationships) {
@@ -898,10 +900,10 @@ public class ProTerritoryManager {
             } else if (Matches.territoryHasEnemySeaUnits(player, data).negate().test(currentTerritory)) {
               final Set<Territory> possibleLoadTerritories = data.getMap().getNeighbors(currentTerritory);
               for (final Territory possibleLoadTerritory : possibleLoadTerritories) {
-                List<Unit> possibleUnits = possibleLoadTerritory.getUnits().getMatches(
+                List<Unit> possibleUnits = possibleLoadTerritory.getUnitCollection().getMatches(
                     ProMatches.unitIsOwnedTransportableUnitAndCanBeLoaded(player, myTransportUnit, isCombatMove));
                 if (isCheckingEnemyAttacks) {
-                  possibleUnits = possibleLoadTerritory.getUnits()
+                  possibleUnits = possibleLoadTerritory.getUnitCollection()
                       .getMatches(ProMatches.unitIsOwnedCombatTransportableUnit(player));
                 }
                 for (final Unit possibleUnit : possibleUnits) {
@@ -1027,7 +1029,7 @@ public class ProTerritoryManager {
 
       // Find my bombard units that have movement left
       final List<Unit> mySeaUnits =
-          myUnitTerritory.getUnits().getMatches(ProMatches.unitCanBeMovedAndIsOwnedBombard(player));
+          myUnitTerritory.getUnitCollection().getMatches(ProMatches.unitCanBeMovedAndIsOwnedBombard(player));
 
       // Check each sea unit individually since they can have different ranges
       for (final Unit mySeaUnit : mySeaUnits) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -545,7 +545,7 @@ public class ProTerritoryManager {
         // If my combat move and carrier has dependent allied fighters then skip it
         if (isCombatMove && !isCheckingEnemyAttacks) {
           final Map<Unit, Collection<Unit>> carrierMustMoveWith =
-              MoveValidator.carrierMustMoveWith(myUnitTerritory.getUnitCollection().getUnits(), myUnitTerritory, data,
+              MoveValidator.carrierMustMoveWith(myUnitTerritory.getUnits(), myUnitTerritory, data,
                   player);
           if (carrierMustMoveWith.containsKey(mySeaUnit) && !carrierMustMoveWith.get(mySeaUnit).isEmpty()) {
             continue;

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
@@ -58,9 +58,9 @@ public final class ProSimulateTurnUtils {
         final IBattle battle =
             battleDelegate.getBattleTracker().getPendingBattle(t, entry.getKey().isBombingRun(), entry.getKey());
         final List<Unit> attackers = (List<Unit>) battle.getAttackingUnits();
-        attackers.retainAll(t.getUnitCollection().getUnits());
+        attackers.retainAll(t.getUnits());
         final List<Unit> defenders = (List<Unit>) battle.getDefendingUnits();
-        defenders.retainAll(t.getUnitCollection().getUnits());
+        defenders.retainAll(t.getUnits());
         final Set<Unit> bombardingUnits = new HashSet<>(battle.getBombardingUnits());
         ProLogger.debug("---" + t);
         ProLogger.debug("attackers=" + attackers);
@@ -93,7 +93,7 @@ public final class ProSimulateTurnUtils {
         final Territory updatedTerritory = data.getMap().getTerritory(t.getName());
         ProLogger.debug(
             "after changes owner=" + updatedTerritory.getOwner() + ", units="
-                + updatedTerritory.getUnitCollection().getUnits());
+                + updatedTerritory.getUnits());
       }
     }
   }
@@ -191,7 +191,7 @@ public final class ProSimulateTurnUtils {
         final Change takeOverFriendlyTerritories = ChangeFactory.changeOwner(item, terrOrigOwner);
         delegateBridge.addChange(takeOverFriendlyTerritories);
         final Collection<Unit> units =
-            CollectionUtils.getMatches(item.getUnitCollection().getUnits(), Matches.unitIsInfrastructure());
+            CollectionUtils.getMatches(item.getUnits(), Matches.unitIsInfrastructure());
         if (!units.isEmpty()) {
           final Change takeOverNonComUnits = ChangeFactory.changeOwner(units, terrOrigOwner, t);
           delegateBridge.addChange(takeOverNonComUnits);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
@@ -58,9 +58,9 @@ public final class ProSimulateTurnUtils {
         final IBattle battle =
             battleDelegate.getBattleTracker().getPendingBattle(t, entry.getKey().isBombingRun(), entry.getKey());
         final List<Unit> attackers = (List<Unit>) battle.getAttackingUnits();
-        attackers.retainAll(t.getUnits().getUnits());
+        attackers.retainAll(t.getUnitCollection().getUnits());
         final List<Unit> defenders = (List<Unit>) battle.getDefendingUnits();
-        defenders.retainAll(t.getUnits().getUnits());
+        defenders.retainAll(t.getUnitCollection().getUnits());
         final Set<Unit> bombardingUnits = new HashSet<>(battle.getBombardingUnits());
         ProLogger.debug("---" + t);
         ProLogger.debug("attackers=" + attackers);
@@ -92,7 +92,8 @@ public final class ProSimulateTurnUtils {
         battleDelegate.getBattleTracker().removeBattle(battle, data);
         final Territory updatedTerritory = data.getMap().getTerritory(t.getName());
         ProLogger.debug(
-            "after changes owner=" + updatedTerritory.getOwner() + ", units=" + updatedTerritory.getUnits().getUnits());
+            "after changes owner=" + updatedTerritory.getOwner() + ", units="
+                + updatedTerritory.getUnitCollection().getUnits());
       }
     }
   }
@@ -190,7 +191,7 @@ public final class ProSimulateTurnUtils {
         final Change takeOverFriendlyTerritories = ChangeFactory.changeOwner(item, terrOrigOwner);
         delegateBridge.addChange(takeOverFriendlyTerritories);
         final Collection<Unit> units =
-            CollectionUtils.getMatches(item.getUnits().getUnits(), Matches.unitIsInfrastructure());
+            CollectionUtils.getMatches(item.getUnitCollection().getUnits(), Matches.unitIsInfrastructure());
         if (!units.isEmpty()) {
           final Change takeOverNonComUnits = ChangeFactory.changeOwner(units, terrOrigOwner, t);
           delegateBridge.addChange(takeOverNonComUnits);
@@ -205,7 +206,7 @@ public final class ProSimulateTurnUtils {
       final List<Unit> usedUnits, final GameData toData, final PlayerId player) {
 
     final Territory unitTerritory = unitTerritoryMap.get(u);
-    final List<Unit> toUnits = toData.getMap().getTerritory(unitTerritory.getName()).getUnits()
+    final List<Unit> toUnits = toData.getMap().getTerritory(unitTerritory.getName()).getUnitCollection()
         .getMatches(ProMatches.unitIsOwnedAndMatchesTypeAndNotTransporting(player, u.getType()));
     for (final Unit toUnit : toUnits) {
       if (!usedUnits.contains(toUnit)) {
@@ -221,7 +222,7 @@ public final class ProSimulateTurnUtils {
       final PlayerId player) {
 
     final Territory unitTerritory = unitTerritoryMap.get(transport);
-    final List<Unit> toTransports = toData.getMap().getTerritory(unitTerritory.getName()).getUnits()
+    final List<Unit> toTransports = toData.getMap().getTerritory(unitTerritory.getName()).getUnitCollection()
         .getMatches(ProMatches.unitIsOwnedAndMatchesTypeAndIsTransporting(player, transport.getType()));
     for (final Unit toTransport : toTransports) {
       if (!usedUnits.contains(toTransport)) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
@@ -145,7 +145,8 @@ public final class ProBattleUtils {
       nearbyTerritoriesForEnemy.add(t);
       final List<Unit> enemyUnits = new ArrayList<>();
       for (final Territory nearbyTerritory : nearbyTerritoriesForEnemy) {
-        enemyUnits.addAll(nearbyTerritory.getUnits().getMatches(ProMatches.unitIsEnemyNotNeutral(player, data)));
+        enemyUnits
+            .addAll(nearbyTerritory.getUnitCollection().getMatches(ProMatches.unitIsEnemyNotNeutral(player, data)));
       }
 
       // Find allied strength
@@ -154,7 +155,7 @@ public final class ProBattleUtils {
       nearbyTerritoriesForAllied.add(t);
       final List<Unit> alliedUnits = new ArrayList<>();
       for (final Territory nearbyTerritory : nearbyTerritoriesForAllied) {
-        alliedUnits.addAll(nearbyTerritory.getUnits().getMatches(Matches.isUnitAllied(player, data)));
+        alliedUnits.addAll(nearbyTerritory.getUnitCollection().getMatches(Matches.isUnitAllied(player, data)));
       }
       for (final ProPurchaseTerritory purchaseTerritory : purchaseTerritories.values()) {
         for (final ProPlaceTerritory ppt : purchaseTerritory.getCanPlaceTerritories()) {
@@ -189,7 +190,7 @@ public final class ProBattleUtils {
     nearbyTerritoriesForEnemy.add(t);
     final List<Unit> enemyUnits = new ArrayList<>();
     for (final Territory nearbyTerritory : nearbyTerritoriesForEnemy) {
-      enemyUnits.addAll(nearbyTerritory.getUnits().getMatches(ProMatches.unitIsEnemyNotNeutral(player, data)));
+      enemyUnits.addAll(nearbyTerritory.getUnitCollection().getMatches(ProMatches.unitIsEnemyNotNeutral(player, data)));
     }
 
     // Find allied strength
@@ -235,12 +236,12 @@ public final class ProBattleUtils {
     final List<Unit> enemyUnitsInLandTerritories = new ArrayList<>();
     for (final Territory nearbyLandTerritory : nearbyLandTerritories) {
       enemyUnitsInLandTerritories
-          .addAll(nearbyLandTerritory.getUnits().getMatches(ProMatches.unitIsEnemyAir(player, data)));
+          .addAll(nearbyLandTerritory.getUnitCollection().getMatches(ProMatches.unitIsEnemyAir(player, data)));
     }
     final List<Unit> enemyUnitsInSeaTerritories = new ArrayList<>();
     for (final Territory nearbySeaTerritory : nearbyEnemySeaTerritories) {
       final List<Unit> enemySeaUnits =
-          nearbySeaTerritory.getUnits().getMatches(ProMatches.unitIsEnemyNotLand(player, data));
+          nearbySeaTerritory.getUnitCollection().getMatches(ProMatches.unitIsEnemyNotLand(player, data));
       if (enemySeaUnits.isEmpty()) {
         continue;
       }
@@ -259,10 +260,11 @@ public final class ProBattleUtils {
     final List<Unit> alliedUnitsInSeaTerritories = new ArrayList<>();
     final List<Unit> myUnitsInSeaTerritories = new ArrayList<>();
     for (final Territory nearbySeaTerritory : nearbyAlliedSeaTerritories) {
-      myUnitsInSeaTerritories.addAll(nearbySeaTerritory.getUnits().getMatches(ProMatches.unitIsOwnedNotLand(player)));
+      myUnitsInSeaTerritories
+          .addAll(nearbySeaTerritory.getUnitCollection().getMatches(ProMatches.unitIsOwnedNotLand(player)));
       myUnitsInSeaTerritories.addAll(ProPurchaseUtils.getPlaceUnits(nearbySeaTerritory, purchaseTerritories));
       alliedUnitsInSeaTerritories
-          .addAll(nearbySeaTerritory.getUnits().getMatches(ProMatches.unitIsAlliedNotOwned(player, data)));
+          .addAll(nearbySeaTerritory.getUnitCollection().getMatches(ProMatches.unitIsAlliedNotOwned(player, data)));
     }
     ProLogger.trace(t + ", enemyDistance=" + enemyDistance + ", alliedDistance=" + alliedDistance + ", enemyAirUnits="
         + enemyUnitsInLandTerritories + ", enemySeaUnits=" + enemyUnitsInSeaTerritories + ", mySeaUnits="

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -398,7 +398,7 @@ public final class ProMatches {
     final Predicate<Unit> alliedUnitMatch = Matches.unitIsOwnedBy(player).negate()
         .and(Matches.isUnitAllied(player, data))
         .and(Matches.unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(
-            t.getUnitCollection().getUnits(), player, data, false).negate());
+            t.getUnits(), player, data, false).negate());
     return myUnitHasNoMovementMatch.or(alliedUnitMatch);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -175,7 +175,7 @@ public final class ProMatches {
       final Predicate<Unit> subOnly = Matches.unitIsInfrastructure()
           .or(Matches.unitIsSub())
           .or(Matches.enemyUnit(player, data).negate());
-      return (Properties.getIgnoreSubInMovement(data) && t.getUnits().allMatch(subOnly))
+      return (Properties.getIgnoreSubInMovement(data) && t.getUnitCollection().allMatch(subOnly))
           || Matches.territoryHasNoEnemyUnits(player, data).test(t);
     };
   }
@@ -398,7 +398,7 @@ public final class ProMatches {
     final Predicate<Unit> alliedUnitMatch = Matches.unitIsOwnedBy(player).negate()
         .and(Matches.isUnitAllied(player, data))
         .and(Matches.unitIsBeingTransportedByOrIsDependentOfSomeUnitInThisList(
-            t.getUnits().getUnits(), player, data, false).negate());
+            t.getUnitCollection().getUnits(), player, data, false).negate());
     return myUnitHasNoMovementMatch.or(alliedUnitMatch);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -80,7 +80,7 @@ public final class ProMoveUtils {
         // If carrier has dependent allied fighters then move them too
         if (Matches.unitIsCarrier().test(u)) {
           final Map<Unit, Collection<Unit>> carrierMustMoveWith =
-              MoveValidator.carrierMustMoveWith(startTerritory.getUnitCollection().getUnits(), startTerritory, data,
+              MoveValidator.carrierMustMoveWith(startTerritory.getUnits(), startTerritory, data,
                   player);
           if (carrierMustMoveWith.containsKey(u)) {
             unitList.addAll(carrierMustMoveWith.get(u));

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -80,7 +80,8 @@ public final class ProMoveUtils {
         // If carrier has dependent allied fighters then move them too
         if (Matches.unitIsCarrier().test(u)) {
           final Map<Unit, Collection<Unit>> carrierMustMoveWith =
-              MoveValidator.carrierMustMoveWith(startTerritory.getUnits().getUnits(), startTerritory, data, player);
+              MoveValidator.carrierMustMoveWith(startTerritory.getUnitCollection().getUnits(), startTerritory, data,
+                  player);
           if (carrierMustMoveWith.containsKey(u)) {
             unitList.addAll(carrierMustMoveWith.get(u));
           }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
@@ -311,7 +311,7 @@ public final class ProPurchaseUtils {
     if (ra != null && ra.getPlacementAnyTerritory()) {
       return Integer.MAX_VALUE;
     }
-    return TripleAUnit.getProductionPotentialOfTerritory(territory.getUnitCollection().getUnits(),
+    return TripleAUnit.getProductionPotentialOfTerritory(territory.getUnits(),
         territory, player, data, true, true);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
@@ -132,7 +132,7 @@ public final class ProPurchaseUtils {
         final Predicate<Unit> unitTypeOwnedBy = Matches.unitIsOfType(type).and(Matches.unitIsOwnedBy(player));
         final List<Territory> allTerritories = data.getMap().getTerritories();
         for (final Territory t : allTerritories) {
-          currentlyBuilt += t.getUnits().countMatches(unitTypeOwnedBy);
+          currentlyBuilt += t.getUnitCollection().countMatches(unitTypeOwnedBy);
         }
         currentlyBuilt += CollectionUtils.countMatches(unitsToPlace, unitTypeOwnedBy);
         for (final ProPurchaseTerritory t : purchaseTerritories.values()) {
@@ -296,7 +296,7 @@ public final class ProPurchaseUtils {
     final Predicate<Unit> factoryMatch = Matches.unitIsOwnedAndIsFactoryOrCanProduceUnits(player)
         .and(Matches.unitIsBeingTransported().negate())
         .and((territory.isWater() ? Matches.unitIsLand() : Matches.unitIsSea()).negate());
-    final Collection<Unit> factoryUnits = territory.getUnits().getMatches(factoryMatch);
+    final Collection<Unit> factoryUnits = territory.getUnitCollection().getMatches(factoryMatch);
     final TerritoryAttachment ta = TerritoryAttachment.get(territory);
     final boolean originalFactory = (ta != null && ta.getOriginalFactory());
     final boolean playerIsOriginalOwner =
@@ -311,13 +311,13 @@ public final class ProPurchaseUtils {
     if (ra != null && ra.getPlacementAnyTerritory()) {
       return Integer.MAX_VALUE;
     }
-    return TripleAUnit.getProductionPotentialOfTerritory(territory.getUnits().getUnits(),
+    return TripleAUnit.getProductionPotentialOfTerritory(territory.getUnitCollection().getUnits(),
         territory, player, data, true, true);
   }
 
   private static PlayerId getOriginalFactoryOwner(final Territory territory, final PlayerId player) {
 
-    final Collection<Unit> factoryUnits = territory.getUnits().getMatches(Matches.unitCanProduceUnits());
+    final Collection<Unit> factoryUnits = territory.getUnitCollection().getMatches(Matches.unitCanProduceUnits());
     if (factoryUnits.size() == 0) {
       throw new IllegalStateException("No factory in territory:" + territory);
     }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
@@ -152,7 +152,7 @@ public final class ProSortMoveOptionsUtils {
       int minPower1 = Integer.MAX_VALUE;
       for (final Territory t : o1.getValue()) {
         if (!attackMap.get(t).isCurrentlyWins()) {
-          final List<Unit> defendingUnits = t.getUnits().getMatches(Matches.enemyUnit(player, data));
+          final List<Unit> defendingUnits = t.getUnitCollection().getMatches(Matches.enemyUnit(player, data));
           final List<Unit> sortedUnitsList = new ArrayList<>(attackMap.get(t).getUnits());
           sortedUnitsList.sort(new UnitBattleComparator(false, ProData.unitValueMap,
               TerritoryEffectHelper.getEffects(t), data, false, false));
@@ -180,7 +180,7 @@ public final class ProSortMoveOptionsUtils {
       int minPower2 = Integer.MAX_VALUE;
       for (final Territory t : o2.getValue()) {
         if (!attackMap.get(t).isCurrentlyWins()) {
-          final List<Unit> defendingUnits = t.getUnits().getMatches(Matches.enemyUnit(player, data));
+          final List<Unit> defendingUnits = t.getUnitCollection().getMatches(Matches.enemyUnit(player, data));
           final List<Unit> sortedUnitsList = new ArrayList<>(attackMap.get(t).getUnits());
           sortedUnitsList.sort(new UnitBattleComparator(false, ProData.unitValueMap,
               TerritoryEffectHelper.getEffects(t), data, false, false));

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -37,7 +37,8 @@ public final class ProTerritoryValueUtils {
     double value = 3.0 * TerritoryAttachment.getProduction(t) * (isEnemyFactory + 1);
     if (ProUtils.isNeutralLand(t)) {
       final double strength =
-          ProBattleUtils.estimateStrength(t, new ArrayList<>(t.getUnits().getUnits()), new ArrayList<>(), false);
+          ProBattleUtils.estimateStrength(t, new ArrayList<>(t.getUnitCollection().getUnits()), new ArrayList<>(),
+              false);
 
       // Estimate TUV swing as number of casualties * cost
       final double tuvSwing = -(strength / 8) * ProData.minCostPerHitPoint;
@@ -131,7 +132,7 @@ public final class ProTerritoryValueUtils {
           final int distance = route.numberOfSteps();
           if (distance > 0) {
             nearbyEnemySeaUnitValue +=
-                nearbyEnemySeaTerritory.getUnits().countMatches(Matches.unitIsEnemyOf(data, player))
+                nearbyEnemySeaTerritory.getUnitCollection().countMatches(Matches.unitIsEnemyOf(data, player))
                     / Math.pow(2, distance);
           }
         }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -37,7 +37,7 @@ public final class ProTerritoryValueUtils {
     double value = 3.0 * TerritoryAttachment.getProduction(t) * (isEnemyFactory + 1);
     if (ProUtils.isNeutralLand(t)) {
       final double strength =
-          ProBattleUtils.estimateStrength(t, new ArrayList<>(t.getUnitCollection().getUnits()), new ArrayList<>(),
+          ProBattleUtils.estimateStrength(t, new ArrayList<>(t.getUnits()), new ArrayList<>(),
               false);
 
       // Estimate TUV swing as number of casualties * cost

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
@@ -57,7 +57,7 @@ public final class ProTransportUtils {
       // Get all units that can be transported
       final List<Unit> units = new ArrayList<>();
       for (final Territory loadFrom : territoriesToLoadFrom) {
-        units.addAll(loadFrom.getUnits()
+        units.addAll(loadFrom.getUnitCollection()
             .getMatches(ProMatches.unitIsOwnedTransportableUnitAndCanBeLoaded(player, transport, true)));
       }
       units.removeAll(unitsToIgnore);
@@ -101,7 +101,7 @@ public final class ProTransportUtils {
       // Get all units that can be transported
       final List<Unit> units = new ArrayList<>();
       for (final Territory loadFrom : territoriesToLoadFrom) {
-        units.addAll(loadFrom.getUnits().getMatches(validUnitMatch));
+        units.addAll(loadFrom.getUnitCollection().getMatches(validUnitMatch));
       }
       units.removeAll(unitsToIgnore);
 
@@ -205,7 +205,7 @@ public final class ProTransportUtils {
       return new ArrayList<>();
     }
     final PlayerId player = unit.getOwner();
-    final List<Unit> units = t.getUnits().getMatches(Matches.unitIsOwnedBy(player)
+    final List<Unit> units = t.getUnitCollection().getMatches(Matches.unitIsOwnedBy(player)
         .and(Matches.unitIsLandTransportable()).and(ProMatches.unitHasLessMovementThan(unit)));
     units.removeAll(usedUnits);
     if (Matches.unitIsLandTransport().negate().test(unit) || !TechAttachment.isMechanizedInfantry(player)
@@ -312,7 +312,7 @@ public final class ProTransportUtils {
     final List<Unit> ownedNearbyUnits = new ArrayList<>();
     int capacity = 0;
     for (final Territory nearbyTerritory : nearbyTerritories) {
-      final List<Unit> units = nearbyTerritory.getUnits().getMatches(Matches.unitIsOwnedBy(player));
+      final List<Unit> units = nearbyTerritory.getUnitCollection().getMatches(Matches.unitIsOwnedBy(player));
       if (nearbyTerritory.equals(t)) {
         units.addAll(unitsToPlace);
       }
@@ -337,7 +337,7 @@ public final class ProTransportUtils {
    */
   public static int getUnusedCarrierCapacity(final PlayerId player, final Territory t, final List<Unit> unitsToPlace) {
     final List<Unit> units = new ArrayList<>(unitsToPlace);
-    units.addAll(t.getUnits().getUnits());
+    units.addAll(t.getUnitCollection().getUnits());
     int capacity = AirMovementValidator.carrierCapacity(units, t);
     final Collection<Unit> airUnits = CollectionUtils.getMatches(units, ProMatches.unitIsOwnedAir(player));
     for (final Unit airUnit : airUnits) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
@@ -337,7 +337,7 @@ public final class ProTransportUtils {
    */
   public static int getUnusedCarrierCapacity(final PlayerId player, final Territory t, final List<Unit> unitsToPlace) {
     final List<Unit> units = new ArrayList<>(unitsToPlace);
-    units.addAll(t.getUnitCollection().getUnits());
+    units.addAll(t.getUnits());
     int capacity = AirMovementValidator.carrierCapacity(units, t);
     final Collection<Unit> airUnits = CollectionUtils.getMatches(units, ProMatches.unitIsOwnedAir(player));
     for (final Unit airUnit : airUnits) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
@@ -35,7 +35,7 @@ public final class ProUtils {
   public static Map<Unit, Territory> newUnitTerritoryMap() {
     final Map<Unit, Territory> unitTerritoryMap = new HashMap<>();
     for (final Territory t : ProData.getData().getMap().getTerritories()) {
-      for (final Unit u : t.getUnitCollection().getUnits()) {
+      for (final Unit u : t.getUnits()) {
         unitTerritoryMap.put(u, t);
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
@@ -35,7 +35,7 @@ public final class ProUtils {
   public static Map<Unit, Territory> newUnitTerritoryMap() {
     final Map<Unit, Territory> unitTerritoryMap = new HashMap<>();
     for (final Territory t : ProData.getData().getMap().getTerritories()) {
-      for (final Unit u : t.getUnits().getUnits()) {
+      for (final Unit u : t.getUnitCollection().getUnits()) {
         unitTerritoryMap.put(u, t);
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/DoesNothingAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/DoesNothingAi.java
@@ -53,7 +53,7 @@ public class DoesNothingAi extends AbstractAi {
   protected void place(final boolean placeForBid, final IAbstractPlaceDelegate placeDelegate, final GameData data,
       final PlayerId player) {
     // place whatever we have
-    if (!player.getUnits().isEmpty()) {
+    if (!player.getUnitCollection().isEmpty()) {
       new WeakAi(this.getName()).place(placeForBid, placeDelegate, data, player);
     }
     pause();

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/Utils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/Utils.java
@@ -37,7 +37,7 @@ final class Utils {
     float strength = 0;
     for (final Territory t : data.getMap().getNeighbors(location,
         location.isWater() ? Matches.territoryIsWater() : Matches.territoryIsLand())) {
-      final List<Unit> enemies = t.getUnits().getMatches(Matches.enemyUnit(location.getOwner(), data));
+      final List<Unit> enemies = t.getUnitCollection().getMatches(Matches.enemyUnit(location.getOwner(), data));
       strength += AiUtils.strength(enemies, true, location.isWater());
     }
     return strength;
@@ -88,7 +88,7 @@ final class Utils {
     final List<Territory> shipTerr = new ArrayList<>();
     final Collection<Territory> neighbors = data.getMap().getTerritories();
     for (final Territory t2 : neighbors) {
-      if (t2.getUnits().anyMatch(unitCondition)) {
+      if (t2.getUnitCollection().anyMatch(unitCondition)) {
         shipTerr.add(t2);
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -359,7 +359,7 @@ public class WeakAi extends AbstractAi {
       if (!t.getUnitCollection().anyMatch(Matches.enemyUnit(player, data))) {
         continue;
       }
-      final float enemyStrength = AiUtils.strength(t.getUnitCollection().getUnits(), false, true);
+      final float enemyStrength = AiUtils.strength(t.getUnits(), false, true);
       if (enemyStrength > 0) {
         final Predicate<Unit> attackable = Matches.unitIsOwnedBy(player).and(o -> !unitsAlreadyMoved.contains(o));
         final Set<Territory> dontMoveFrom = new HashSet<>();
@@ -435,7 +435,7 @@ public class WeakAi extends AbstractAi {
       if (TerritoryAttachment.get(t) != null && TerritoryAttachment.get(t).isCapital()) {
         // if they are a threat to take our capitol, dont move
         // compare the strength of units we can place
-        final float ourStrength = AiUtils.strength(player.getUnitCollection().getUnits(), false, false);
+        final float ourStrength = AiUtils.strength(player.getUnits(), false, false);
         final float attackerStrength = Utils.getStrengthOfPotentialAttackers(t, data);
         if (attackerStrength > ourStrength) {
           continue;
@@ -589,7 +589,7 @@ public class WeakAi extends AbstractAi {
     enemyOwned.removeAll(isWaterTerr);
     // first find the territories we can just walk into
     for (final Territory enemy : enemyOwned) {
-      if (AiUtils.strength(enemy.getUnitCollection().getUnits(), false, false) == 0) {
+      if (AiUtils.strength(enemy.getUnits(), false, false) == 0) {
         // only take it with 1 unit
         boolean taken = false;
         for (final Territory attackFrom : data.getMap().getNeighbors(enemy,
@@ -598,7 +598,7 @@ public class WeakAi extends AbstractAi {
             break;
           }
           // get the cheapest unit to move in
-          final List<Unit> unitsSortedByCost = new ArrayList<>(attackFrom.getUnitCollection().getUnits());
+          final List<Unit> unitsSortedByCost = new ArrayList<>(attackFrom.getUnits());
           unitsSortedByCost.sort(AiUtils.getCostComparator());
           for (final Unit unit : unitsSortedByCost) {
             final Predicate<Unit> match = Matches.unitIsOwnedBy(player)
@@ -630,7 +630,7 @@ public class WeakAi extends AbstractAi {
     }
     // find the territories we can reasonably expect to take
     for (final Territory enemy : enemyOwned) {
-      final float enemyStrength = AiUtils.strength(enemy.getUnitCollection().getUnits(), false, false);
+      final float enemyStrength = AiUtils.strength(enemy.getUnits(), false, false);
       if (enemyStrength > 0) {
         final Predicate<Unit> attackable = Matches.unitIsOwnedBy(player)
             .and(Matches.unitIsStrategicBomber().negate())
@@ -648,7 +648,7 @@ public class WeakAi extends AbstractAi {
         for (final Territory owned : attackFrom) {
           if (TerritoryAttachment.get(owned) != null && TerritoryAttachment.get(owned).isCapital()
               && (Utils.getStrengthOfPotentialAttackers(owned, data) > AiUtils.strength(
-                  owned.getUnitCollection().getUnits(),
+                  owned.getUnits(),
                   false, false))) {
             dontMoveFrom.add(owned);
             continue;
@@ -805,7 +805,7 @@ public class WeakAi extends AbstractAi {
           continue;
         }
         final Unit possibleFactoryNeedingRepair = TripleAUnit.getBiggestProducer(
-            CollectionUtils.getMatches(fixTerr.getUnitCollection().getUnits(), ourFactories), fixTerr, player, data,
+            CollectionUtils.getMatches(fixTerr.getUnits(), ourFactories), fixTerr, player, data,
             false);
         if (Matches.unitHasTakenSomeBombingUnitDamage().test(possibleFactoryNeedingRepair)) {
           unitsThatCanProduceNeedingRepair.put(possibleFactoryNeedingRepair, fixTerr);
@@ -1006,7 +1006,7 @@ public class WeakAi extends AbstractAi {
       final Territory placeAt,
       final IAbstractPlaceDelegate placeDelegate,
       final PlayerId player) {
-    final PlaceableUnits pu = placeDelegate.getPlaceableUnits(player.getUnitCollection().getUnits(), placeAt);
+    final PlaceableUnits pu = placeDelegate.getPlaceableUnits(player.getUnits(), placeAt);
     if (pu.getErrorMessage() != null) {
       return;
     }

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -177,14 +177,14 @@ public class WeakAi extends AbstractAi {
     if (capitol == null || !capitol.getOwner().equals(player)) {
       return;
     }
-    List<Unit> unitsToLoad = capitol.getUnits().getMatches(Matches.unitIsInfrastructure().negate());
+    List<Unit> unitsToLoad = capitol.getUnitCollection().getMatches(Matches.unitIsInfrastructure().negate());
     unitsToLoad = CollectionUtils.getMatches(unitsToLoad, Matches.unitIsOwnedBy(getPlayerId()));
     for (final Territory neighbor : data.getMap().getNeighbors(capitol)) {
       if (!neighbor.isWater()) {
         continue;
       }
       final List<Unit> units = new ArrayList<>();
-      for (final Unit transport : neighbor.getUnits().getMatches(Matches.unitIsOwnedBy(player))) {
+      for (final Unit transport : neighbor.getUnitCollection().getMatches(Matches.unitIsOwnedBy(player))) {
         int free = TransportTracker.getAvailableCapacity(transport);
         if (free <= 0) {
           continue;
@@ -209,7 +209,7 @@ public class WeakAi extends AbstractAi {
         route.add(neighbor);
         moveUnits.add(units);
         moveRoutes.add(route);
-        transportsToLoad.add(neighbor.getUnits().getMatches(Matches.unitIsTransport()));
+        transportsToLoad.add(neighbor.getUnitCollection().getMatches(Matches.unitIsTransport()));
       }
     }
   }
@@ -223,7 +223,7 @@ public class WeakAi extends AbstractAi {
     final Territory lastSeaZoneOnAmphib = amphibRoute.getAllTerritories().get(amphibRoute.numberOfSteps() - 1);
     final Territory landOn = amphibRoute.getEnd();
     final Predicate<Unit> landAndOwned = Matches.unitIsLand().and(Matches.unitIsOwnedBy(player));
-    final List<Unit> units = lastSeaZoneOnAmphib.getUnits().getMatches(landAndOwned);
+    final List<Unit> units = lastSeaZoneOnAmphib.getUnitCollection().getMatches(landAndOwned);
     if (units.size() > 0) {
       // just try to make the move, the engine will stop us if it doesnt work
       final Route route = new Route();
@@ -276,7 +276,7 @@ public class WeakAi extends AbstractAi {
         .and(Matches.unitHasNotMoved())
         .and(Matches.unitIsTransporting());
     final List<Unit> unitsToMove = new ArrayList<>();
-    final List<Unit> transports = firstSeaZoneOnAmphib.getUnits().getMatches(ownedAndNotMoved);
+    final List<Unit> transports = firstSeaZoneOnAmphib.getUnitCollection().getMatches(ownedAndNotMoved);
     if (transports.size() <= maxTrans) {
       unitsToMove.addAll(transports);
     } else {
@@ -306,24 +306,24 @@ public class WeakAi extends AbstractAi {
       // move sea units to the capitol, unless they are loaded transports
       if (t.isWater()) {
         // land units, move all towards the end point
-        if (t.getUnits().anyMatch(Matches.unitIsLand())) {
+        if (t.getUnitCollection().anyMatch(Matches.unitIsLand())) {
           // move along amphi route
           if (lastSeaZoneOnAmphib != null) {
             // two move route to end
             final Route r = getMaxSeaRoute(data, t, lastSeaZoneOnAmphib, player);
             if (r != null && r.numberOfSteps() > 0) {
               moveRoutes.add(r);
-              final List<Unit> unitsToMove = t.getUnits().getMatches(Matches.unitIsOwnedBy(player));
+              final List<Unit> unitsToMove = t.getUnitCollection().getMatches(Matches.unitIsOwnedBy(player));
               moveUnits.add(unitsToMove);
             }
           }
         }
-        if (nonCombat && t.getUnits().anyMatch(ownedAndNotMoved)) {
+        if (nonCombat && t.getUnitCollection().anyMatch(ownedAndNotMoved)) {
           // move toward the start of the amphib route
           if (firstSeaZoneOnAmphib != null) {
             final Route r = getMaxSeaRoute(data, t, firstSeaZoneOnAmphib, player);
             moveRoutes.add(r);
-            moveUnits.add(t.getUnits().getMatches(ownedAndNotMoved));
+            moveUnits.add(t.getUnitCollection().getMatches(ownedAndNotMoved));
           }
         }
       }
@@ -356,10 +356,10 @@ public class WeakAi extends AbstractAi {
       if (!t.isWater()) {
         continue;
       }
-      if (!t.getUnits().anyMatch(Matches.enemyUnit(player, data))) {
+      if (!t.getUnitCollection().anyMatch(Matches.enemyUnit(player, data))) {
         continue;
       }
-      final float enemyStrength = AiUtils.strength(t.getUnits().getUnits(), false, true);
+      final float enemyStrength = AiUtils.strength(t.getUnitCollection().getUnits(), false, true);
       if (enemyStrength > 0) {
         final Predicate<Unit> attackable = Matches.unitIsOwnedBy(player).and(o -> !unitsAlreadyMoved.contains(o));
         final Set<Territory> dontMoveFrom = new HashSet<>();
@@ -368,18 +368,18 @@ public class WeakAi extends AbstractAi {
         final Collection<Territory> attackFrom = data.getMap().getNeighbors(t, Matches.territoryIsWater());
         for (final Territory owned : attackFrom) {
           // dont risk units we are carrying
-          if (owned.getUnits().anyMatch(Matches.unitIsLand())) {
+          if (owned.getUnitCollection().anyMatch(Matches.unitIsLand())) {
             dontMoveFrom.add(owned);
             continue;
           }
-          ourStrength += AiUtils.strength(owned.getUnits().getMatches(attackable), true, true);
+          ourStrength += AiUtils.strength(owned.getUnitCollection().getMatches(attackable), true, true);
         }
         if (ourStrength > 1.32 * enemyStrength) {
           for (final Territory owned : attackFrom) {
             if (dontMoveFrom.contains(owned)) {
               continue;
             }
-            final List<Unit> units = owned.getUnits().getMatches(attackable);
+            final List<Unit> units = owned.getUnitCollection().getMatches(attackable);
             unitsAlreadyMoved.addAll(units);
             moveUnits.add(units);
             moveRoutes.add(data.getMap().getRoute(owned, t));
@@ -412,7 +412,7 @@ public class WeakAi extends AbstractAi {
           .and(Matches.territoryIsLand())
           .and(Matches.territoryIsNeutralButNotWater().negate())
           .and(Matches.territoryIsEmpty());
-      final int trans = t.getUnits().countMatches(ownedTransports);
+      final int trans = t.getUnitCollection().countMatches(ownedTransports);
       if (trans > 0) {
         final Route newRoute = Utils.findNearest(t, enemyTerritory, routeCondition, data);
         if (newRoute != null && length > newRoute.numberOfSteps()) {
@@ -435,7 +435,7 @@ public class WeakAi extends AbstractAi {
       if (TerritoryAttachment.get(t) != null && TerritoryAttachment.get(t).isCapital()) {
         // if they are a threat to take our capitol, dont move
         // compare the strength of units we can place
-        final float ourStrength = AiUtils.strength(player.getUnits().getUnits(), false, false);
+        final float ourStrength = AiUtils.strength(player.getUnitCollection().getUnits(), false, false);
         final float attackerStrength = Utils.getStrengthOfPotentialAttackers(t, data);
         if (attackerStrength > ourStrength) {
           continue;
@@ -451,7 +451,7 @@ public class WeakAi extends AbstractAi {
       final Predicate<Territory> moveThrough = Matches.territoryIsImpassable().negate()
           .and(Matches.territoryIsNeutralButNotWater().negate())
           .and(Matches.territoryIsLand());
-      final List<Unit> units = t.getUnits().getMatches(moveOfType);
+      final List<Unit> units = t.getUnitCollection().getMatches(moveOfType);
       if (units.size() == 0) {
         continue;
       }
@@ -515,7 +515,7 @@ public class WeakAi extends AbstractAi {
       final Route noAaRoute = Utils.findNearest(t, canLand, routeCondition, data);
       final Route aaRoute = Utils.findNearest(t, canLand, Matches.territoryIsImpassable().negate(), data);
       final Collection<Unit> airToLand =
-          t.getUnits().getMatches(Matches.unitIsAir().and(Matches.unitIsOwnedBy(player)));
+          t.getUnitCollection().getMatches(Matches.unitIsAir().and(Matches.unitIsOwnedBy(player)));
       // don't bother to see if all the air units have enough movement points to move without aa guns firing
       // simply move first over no aa, then with aa one (but hopefully not both) will be rejected
       moveUnits.add(airToLand);
@@ -564,8 +564,8 @@ public class WeakAi extends AbstractAi {
       if (!ta1.isCapital() && ta2.isCapital()) {
         return 1;
       }
-      final boolean factoryInT1 = o1.getUnits().anyMatch(Matches.unitCanProduceUnits());
-      final boolean factoryInT2 = o2.getUnits().anyMatch(Matches.unitCanProduceUnits());
+      final boolean factoryInT1 = o1.getUnitCollection().anyMatch(Matches.unitCanProduceUnits());
+      final boolean factoryInT2 = o2.getUnitCollection().anyMatch(Matches.unitCanProduceUnits());
       // next take territories which can produce
       if (factoryInT1 && !factoryInT2) {
         return -1;
@@ -573,8 +573,8 @@ public class WeakAi extends AbstractAi {
       if (!factoryInT1 && factoryInT2) {
         return 1;
       }
-      final boolean infrastructureInT1 = o1.getUnits().anyMatch(Matches.unitIsInfrastructure());
-      final boolean infrastructureInT2 = o2.getUnits().anyMatch(Matches.unitIsInfrastructure());
+      final boolean infrastructureInT1 = o1.getUnitCollection().anyMatch(Matches.unitIsInfrastructure());
+      final boolean infrastructureInT2 = o2.getUnitCollection().anyMatch(Matches.unitIsInfrastructure());
       // next take territories with infrastructure
       if (infrastructureInT1 && !infrastructureInT2) {
         return -1;
@@ -589,7 +589,7 @@ public class WeakAi extends AbstractAi {
     enemyOwned.removeAll(isWaterTerr);
     // first find the territories we can just walk into
     for (final Territory enemy : enemyOwned) {
-      if (AiUtils.strength(enemy.getUnits().getUnits(), false, false) == 0) {
+      if (AiUtils.strength(enemy.getUnitCollection().getUnits(), false, false) == 0) {
         // only take it with 1 unit
         boolean taken = false;
         for (final Territory attackFrom : data.getMap().getNeighbors(enemy,
@@ -598,7 +598,7 @@ public class WeakAi extends AbstractAi {
             break;
           }
           // get the cheapest unit to move in
-          final List<Unit> unitsSortedByCost = new ArrayList<>(attackFrom.getUnits().getUnits());
+          final List<Unit> unitsSortedByCost = new ArrayList<>(attackFrom.getUnitCollection().getUnits());
           unitsSortedByCost.sort(AiUtils.getCostComparator());
           for (final Unit unit : unitsSortedByCost) {
             final Predicate<Unit> match = Matches.unitIsOwnedBy(player)
@@ -613,7 +613,8 @@ public class WeakAi extends AbstractAi {
               // in non com, for land moves we want to move the minimal
               // number of units, to leave units free to move elsewhere
               if (attackFrom.isWater()) {
-                final List<Unit> units = attackFrom.getUnits().getMatches(Matches.unitIsLandAndOwnedBy(player));
+                final List<Unit> units =
+                    attackFrom.getUnitCollection().getMatches(Matches.unitIsLandAndOwnedBy(player));
                 moveUnits.add(CollectionUtils.difference(units, unitsAlreadyMoved));
                 unitsAlreadyMoved.addAll(units);
               } else {
@@ -629,7 +630,7 @@ public class WeakAi extends AbstractAi {
     }
     // find the territories we can reasonably expect to take
     for (final Territory enemy : enemyOwned) {
-      final float enemyStrength = AiUtils.strength(enemy.getUnits().getUnits(), false, false);
+      final float enemyStrength = AiUtils.strength(enemy.getUnitCollection().getUnits(), false, false);
       if (enemyStrength > 0) {
         final Predicate<Unit> attackable = Matches.unitIsOwnedBy(player)
             .and(Matches.unitIsStrategicBomber().negate())
@@ -646,12 +647,13 @@ public class WeakAi extends AbstractAi {
             data.getMap().getNeighbors(enemy, Matches.territoryHasLandUnitsOwnedBy(player));
         for (final Territory owned : attackFrom) {
           if (TerritoryAttachment.get(owned) != null && TerritoryAttachment.get(owned).isCapital()
-              && (Utils.getStrengthOfPotentialAttackers(owned, data) > AiUtils.strength(owned.getUnits().getUnits(),
+              && (Utils.getStrengthOfPotentialAttackers(owned, data) > AiUtils.strength(
+                  owned.getUnitCollection().getUnits(),
                   false, false))) {
             dontMoveFrom.add(owned);
             continue;
           }
-          ourStrength += AiUtils.strength(owned.getUnits().getMatches(attackable), true, false);
+          ourStrength += AiUtils.strength(owned.getUnitCollection().getMatches(attackable), true, false);
         }
         // prevents 2 infantry from attacking 1 infantry
         if (ourStrength > 1.37 * enemyStrength) {
@@ -662,7 +664,7 @@ public class WeakAi extends AbstractAi {
             if (dontMoveFrom.contains(owned)) {
               continue;
             }
-            List<Unit> units = owned.getUnits().getMatches(attackable);
+            List<Unit> units = owned.getUnitCollection().getMatches(attackable);
             // only take the units we need if
             // 1) we are not an amphibious attack
             // 2) we can potentially attack another territory
@@ -688,7 +690,7 @@ public class WeakAi extends AbstractAi {
         Matches.unitCanProduceUnitsAndCanBeDamaged());
     final Predicate<Unit> ownBomber = Matches.unitIsStrategicBomber().and(Matches.unitIsOwnedBy(player));
     for (final Territory t : data.getMap().getTerritories()) {
-      final Collection<Unit> bombers = t.getUnits().getMatches(ownBomber);
+      final Collection<Unit> bombers = t.getUnitCollection().getMatches(ownBomber);
       if (bombers.isEmpty()) {
         continue;
       }
@@ -702,7 +704,7 @@ public class WeakAi extends AbstractAi {
   private static int countTransports(final GameData data, final PlayerId player) {
     final Predicate<Unit> ownedTransport = Matches.unitIsTransport().and(Matches.unitIsOwnedBy(player));
     return Streams.stream(data.getMap())
-        .map(Territory::getUnits)
+        .map(Territory::getUnitCollection)
         .mapToInt(c -> c.countMatches(ownedTransport))
         .sum();
   }
@@ -710,7 +712,7 @@ public class WeakAi extends AbstractAi {
   private static int countLandUnits(final GameData data, final PlayerId player) {
     final Predicate<Unit> ownedLandUnit = Matches.unitIsLand().and(Matches.unitIsOwnedBy(player));
     return Streams.stream(data.getMap())
-        .map(Territory::getUnits)
+        .map(Territory::getUnitCollection)
         .mapToInt(c -> c.countMatches(ownedLandUnit))
         .sum();
   }
@@ -770,7 +772,7 @@ public class WeakAi extends AbstractAi {
     final int landUnitCount = countLandUnits(data, player);
     int defUnitsAtAmpibRoute = 0;
     if (isAmphib && amphibRoute != null) {
-      defUnitsAtAmpibRoute = amphibRoute.getEnd().getUnits().getUnitCount();
+      defUnitsAtAmpibRoute = amphibRoute.getEnd().getUnitCollection().getUnitCount();
     }
     final Resource pus = data.getResourceList().getResource(Constants.PUS);
     final int totalPu = player.getResources().getQuantity(pus);
@@ -803,7 +805,8 @@ public class WeakAi extends AbstractAi {
           continue;
         }
         final Unit possibleFactoryNeedingRepair = TripleAUnit.getBiggestProducer(
-            CollectionUtils.getMatches(fixTerr.getUnits().getUnits(), ourFactories), fixTerr, player, data, false);
+            CollectionUtils.getMatches(fixTerr.getUnitCollection().getUnits(), ourFactories), fixTerr, player, data,
+            false);
         if (Matches.unitHasTakenSomeBombingUnitDamage().test(possibleFactoryNeedingRepair)) {
           unitsThatCanProduceNeedingRepair.put(possibleFactoryNeedingRepair, fixTerr);
         }
@@ -982,7 +985,7 @@ public class WeakAi extends AbstractAi {
   @Override
   public void place(final boolean bid, final IAbstractPlaceDelegate placeDelegate, final GameData data,
       final PlayerId player) {
-    if (player.getUnits().size() == 0) {
+    if (player.getUnitCollection().size() == 0) {
       return;
     }
     final @Nullable Territory capitol = TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
@@ -991,7 +994,8 @@ public class WeakAi extends AbstractAi {
     final List<Territory> randomTerritories = new ArrayList<>(data.getMap().getTerritories());
     Collections.shuffle(randomTerritories);
     for (final Territory t : randomTerritories) {
-      if (!t.equals(capitol) && t.getOwner().equals(player) && t.getUnits().anyMatch(Matches.unitCanProduceUnits())) {
+      if (!t.equals(capitol) && t.getOwner().equals(player)
+          && t.getUnitCollection().anyMatch(Matches.unitCanProduceUnits())) {
         placeAllWeCanOn(data, t, placeDelegate, player);
       }
     }
@@ -1002,7 +1006,7 @@ public class WeakAi extends AbstractAi {
       final Territory placeAt,
       final IAbstractPlaceDelegate placeDelegate,
       final PlayerId player) {
-    final PlaceableUnits pu = placeDelegate.getPlaceableUnits(player.getUnits().getUnits(), placeAt);
+    final PlaceableUnits pu = placeDelegate.getPlaceableUnits(player.getUnitCollection().getUnits(), placeAt);
     if (pu.getErrorMessage() != null) {
       return;
     }
@@ -1010,7 +1014,7 @@ public class WeakAi extends AbstractAi {
     if (placementLeft == -1) {
       placementLeft = Integer.MAX_VALUE;
     }
-    final List<Unit> seaUnits = new ArrayList<>(player.getUnits().getMatches(Matches.unitIsSea()));
+    final List<Unit> seaUnits = new ArrayList<>(player.getUnitCollection().getMatches(Matches.unitIsSea()));
     if (seaUnits.size() > 0) {
       final Route amphibRoute = getAmphibRoute(player, data);
       Territory seaPlaceAt = null;
@@ -1029,7 +1033,7 @@ public class WeakAi extends AbstractAi {
         doPlace(seaPlaceAt, toPlace, placeDelegate);
       }
     }
-    final List<Unit> landUnits = new ArrayList<>(player.getUnits().getMatches(Matches.unitIsLand()));
+    final List<Unit> landUnits = new ArrayList<>(player.getUnitCollection().getMatches(Matches.unitIsLand()));
     if (!landUnits.isEmpty()) {
       final int landPlaceCount = Math.min(placementLeft, landUnits.size());
       final Collection<Unit> toPlace = landUnits.subList(0, landPlaceCount);

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -232,7 +232,7 @@ public class PlayerAttachment extends DefaultAttachment {
       final int max = currentLimit.getFirst();
       final String type = currentLimit.getSecond();
       final Set<UnitType> unitsToTest = currentLimit.getThird();
-      final Collection<Unit> currentInTerritory = toMoveInto.getUnitCollection().getUnits();
+      final Collection<Unit> currentInTerritory = toMoveInto.getUnits();
       // first remove units that do not apply to our current type
       if (type.equals("owned")) {
         currentInTerritory

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -232,7 +232,7 @@ public class PlayerAttachment extends DefaultAttachment {
       final int max = currentLimit.getFirst();
       final String type = currentLimit.getSecond();
       final Set<UnitType> unitsToTest = currentLimit.getThird();
-      final Collection<Unit> currentInTerritory = toMoveInto.getUnits().getUnits();
+      final Collection<Unit> currentInTerritory = toMoveInto.getUnitCollection().getUnits();
       // first remove units that do not apply to our current type
       if (type.equals("owned")) {
         currentInTerritory

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -893,7 +893,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     boolean satisfied = false;
     int numberMet = 0;
     for (final Territory terr : territories) {
-      final Collection<Unit> allUnits = new ArrayList<>(terr.getUnits().getUnits());
+      final Collection<Unit> allUnits = new ArrayList<>(terr.getUnitCollection().getUnits());
       switch (exclType) {
         case "direct":
           allUnits.removeAll(
@@ -968,7 +968,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     int numberMet = 0;
     for (final Territory terr : territories) {
       // get all the units in the territory
-      final Collection<Unit> allUnits = new ArrayList<>(terr.getUnits().getUnits());
+      final Collection<Unit> allUnits = new ArrayList<>(terr.getUnitCollection().getUnits());
       switch (exclType) {
         case "allied": // any allied units in the territory. (does not include owned units)
           allUnits.removeAll(CollectionUtils.getMatches(allUnits, Matches.unitIsOwnedByOfAnyOfThesePlayers(players)));

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -893,7 +893,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     boolean satisfied = false;
     int numberMet = 0;
     for (final Territory terr : territories) {
-      final Collection<Unit> allUnits = new ArrayList<>(terr.getUnitCollection().getUnits());
+      final Collection<Unit> allUnits = new ArrayList<>(terr.getUnits());
       switch (exclType) {
         case "direct":
           allUnits.removeAll(
@@ -968,7 +968,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     int numberMet = 0;
     for (final Territory terr : territories) {
       // get all the units in the territory
-      final Collection<Unit> allUnits = new ArrayList<>(terr.getUnitCollection().getUnits());
+      final Collection<Unit> allUnits = new ArrayList<>(terr.getUnits());
       switch (exclType) {
         case "allied": // any allied units in the territory. (does not include owned units)
           allUnits.removeAll(CollectionUtils.getMatches(allUnits, Matches.unitIsOwnedByOfAnyOfThesePlayers(players)));

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -1299,7 +1299,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     final Collection<Unit> totalRemoved = new ArrayList<>();
     for (final UnitType ut : utMap.keySet()) {
       final int removeNum = utMap.getInt(ut);
-      final Collection<Unit> toRemove = CollectionUtils.getNMatches(terr.getUnitCollection().getUnits(), removeNum,
+      final Collection<Unit> toRemove = CollectionUtils.getNMatches(terr.getUnits(), removeNum,
           Matches.unitIsOwnedBy(player).and(Matches.unitIsOfType(ut)));
       if (!toRemove.isEmpty()) {
         totalRemoved.addAll(toRemove);

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -1299,7 +1299,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     final Collection<Unit> totalRemoved = new ArrayList<>();
     for (final UnitType ut : utMap.keySet()) {
       final int removeNum = utMap.getInt(ut);
-      final Collection<Unit> toRemove = CollectionUtils.getNMatches(terr.getUnits().getUnits(), removeNum,
+      final Collection<Unit> toRemove = CollectionUtils.getNMatches(terr.getUnitCollection().getUnits(), removeNum,
           Matches.unitIsOwnedBy(player).and(Matches.unitIsOfType(ut)));
       if (!toRemove.isEmpty()) {
         totalRemoved.addAll(toRemove);

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -2426,7 +2426,7 @@ public class UnitAttachment extends DefaultAttachment {
         break;
     }
     // else if (stackingType.equals("total"))
-    final int totalInTerritory = CollectionUtils.countMatches(t.getUnitCollection().getUnits(), stackingMatch);
+    final int totalInTerritory = CollectionUtils.countMatches(t.getUnits(), stackingMatch);
     return Math.max(0, max - totalInTerritory);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -2426,7 +2426,7 @@ public class UnitAttachment extends DefaultAttachment {
         break;
     }
     // else if (stackingType.equals("total"))
-    final int totalInTerritory = CollectionUtils.countMatches(t.getUnits().getUnits(), stackingMatch);
+    final int totalInTerritory = CollectionUtils.countMatches(t.getUnitCollection().getUnits(), stackingMatch);
     return Math.max(0, max - totalInTerritory);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
@@ -87,7 +87,7 @@ class AaInMoveUtil implements Serializable {
     final PlayerId movingPlayer = movingPlayer(units);
     final Map<String, Set<UnitType>> airborneTechTargetsAllowed =
         TechAbilityAttachment.getAirborneTargettedByAa(movingPlayer, getData());
-    final List<Unit> defendingAa = territory.getUnits().getMatches(Matches.unitIsAaThatCanFire(units,
+    final List<Unit> defendingAa = territory.getUnitCollection().getMatches(Matches.unitIsAaThatCanFire(units,
         airborneTechTargetsAllowed, movingPlayer, Matches.unitIsAaForFlyOverOnly(), 1, true, getData()));
     // comes ordered alphabetically already
     final List<String> aaTypes = UnitAttachment.getAllOfTypeAas(defendingAa);
@@ -201,12 +201,12 @@ class AaInMoveUtil implements Serializable {
     // AA guns in transports shouldn't be able to fire
     final List<Territory> territoriesWhereAaWillFire = new ArrayList<>();
     for (final Territory current : route.getMiddleSteps()) {
-      if (current.getUnits().anyMatch(hasAa)) {
+      if (current.getUnitCollection().anyMatch(hasAa)) {
         territoriesWhereAaWillFire.add(current);
       }
     }
     if (Properties.getForceAaAttacksForLastStepOfFlyOver(data)) {
-      if (route.getEnd().getUnits().anyMatch(hasAa)) {
+      if (route.getEnd().getUnitCollection().anyMatch(hasAa)) {
         territoriesWhereAaWillFire.add(route.getEnd());
       }
     } else {
@@ -216,7 +216,8 @@ class AaInMoveUtil implements Serializable {
       // wants to fire after the battle.
       // TODO: there is a bug in which if you move an air unit to a battle site in the middle of non combat, it wont
       // fire
-      if (route.getStart().getUnits().anyMatch(hasAa) && !getBattleTracker().wasBattleFought(route.getStart())) {
+      if (route.getStart().getUnitCollection().anyMatch(hasAa)
+          && !getBattleTracker().wasBattleFought(route.getStart())) {
         territoriesWhereAaWillFire.add(route.getStart());
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractBattle.java
@@ -126,8 +126,8 @@ abstract class AbstractBattle implements IBattle {
     }
     // we were having a problem with units that had been killed previously were still part of
     // MFB's variables, so we double check that the stuff still exists here.
-    defendingUnits.retainAll(battleSite.getUnitCollection().getUnits());
-    attackingUnits.retainAll(battleSite.getUnitCollection().getUnits());
+    defendingUnits.retainAll(battleSite.getUnits());
+    attackingUnits.retainAll(battleSite.getUnits());
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractBattle.java
@@ -126,8 +126,8 @@ abstract class AbstractBattle implements IBattle {
     }
     // we were having a problem with units that had been killed previously were still part of
     // MFB's variables, so we double check that the stuff still exists here.
-    defendingUnits.retainAll(battleSite.getUnits().getUnits());
-    attackingUnits.retainAll(battleSite.getUnits().getUnits());
+    defendingUnits.retainAll(battleSite.getUnitCollection().getUnits());
+    attackingUnits.retainAll(battleSite.getUnitCollection().getUnits());
   }
 
   @Override
@@ -273,7 +273,7 @@ abstract class AbstractBattle implements IBattle {
     }
     if (defender == null || battleSite.isWater() || !data.getRelationshipTracker().isAtWar(attacker, defender)) {
       // if water find the defender based on who has the most units in the territory
-      final IntegerMap<PlayerId> players = battleSite.getUnits().getPlayerUnitCounts();
+      final IntegerMap<PlayerId> players = battleSite.getUnitCollection().getPlayerUnitCounts();
       int max = -1;
       for (final PlayerId current : players.keySet()) {
         if (current.equals(attacker) || !data.getRelationshipTracker().isAtWar(attacker, current)) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -408,7 +408,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
       if (maxLoss <= 0) {
         continue;
       }
-      final Collection<Unit> enemies = CollectionUtils.getMatches(b.getUnitCollection().getUnits(), enemyUnits);
+      final Collection<Unit> enemies = CollectionUtils.getMatches(b.getUnits(), enemyUnits);
       if (enemies.isEmpty()) {
         continue;
       }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -327,7 +327,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
         for (final PlayerId terrNewOwner : terrNewOwners) {
           if (possibleNewOwners.contains(terrNewOwner)) {
             // PlayerOwnerChange
-            final Collection<Unit> units = currTerritory.getUnits()
+            final Collection<Unit> units = currTerritory.getUnitCollection()
                 .getMatches(Matches.unitOwnedBy(player).and(Matches.unitCanBeGivenByTerritoryTo(terrNewOwner)));
             if (!units.isEmpty()) {
               change.add(ChangeFactory.changeOwner(units, terrNewOwner, currTerritory));
@@ -408,7 +408,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate implem
       if (maxLoss <= 0) {
         continue;
       }
-      final Collection<Unit> enemies = CollectionUtils.getMatches(b.getUnits().getUnits(), enemyUnits);
+      final Collection<Unit> enemies = CollectionUtils.getMatches(b.getUnitCollection().getUnits(), enemyUnits);
       if (enemies.isEmpty()) {
         continue;
       }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -71,7 +71,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   private void doAfterEnd() {
     final PlayerId player = bridge.getPlayerId();
     // clear all units not placed
-    final Collection<Unit> units = player.getUnitCollection().getUnits();
+    final Collection<Unit> units = player.getUnits();
     final GameData data = getData();
     if (!Properties.getUnplacedUnitsLive(data) && !units.isEmpty()) {
       bridge.getHistoryWriter()
@@ -536,7 +536,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
    */
   private static String playerHasEnoughUnits(final Collection<Unit> units, final PlayerId player) {
     // make sure the player has enough units in hand to place
-    if (!player.getUnitCollection().getUnits().containsAll(units)) {
+    if (!player.getUnits().containsAll(units)) {
       return "Not enough units";
     }
     return null;
@@ -1071,7 +1071,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       if (ra != null && ra.getPlacementPerTerritory() > 0) {
         final int allowedPlacement = ra.getPlacementPerTerritory();
         final int ownedUnitsInTerritory =
-            CollectionUtils.countMatches(to.getUnitCollection().getUnits(), Matches.unitIsOwnedBy(player));
+            CollectionUtils.countMatches(to.getUnits(), Matches.unitIsOwnedBy(player));
         if (ownedUnitsInTerritory >= allowedPlacement) {
           return 0;
         }
@@ -1201,7 +1201,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       return new IntegerMap<>();
     }
     final Collection<Unit> unitsAtStartOfTurnInTo = unitsAtStartOfStepInTerritory(to);
-    final Collection<Unit> unitsInTo = to.getUnitCollection().getUnits();
+    final Collection<Unit> unitsInTo = to.getUnits();
     final Collection<Unit> unitsPlacedAlready = getAlreadyProduced(to);
     // build an integer map of each unit we have in our list of held units, as well as integer maps for maximum units
     // and units per turn
@@ -1459,7 +1459,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (to == null) {
       return new ArrayList<>();
     }
-    final Collection<Unit> unitsInTo = to.getUnitCollection().getUnits();
+    final Collection<Unit> unitsInTo = to.getUnits();
     final Collection<Unit> unitsPlacedAlready = getAlreadyProduced(to);
     if (Matches.territoryIsWater().test(to)) {
       for (final Territory current : getAllProducers(to, player, null, true)) {
@@ -1475,7 +1475,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (to == null) {
       return new ArrayList<>();
     }
-    final Collection<Unit> unitsInTo = to.getUnitCollection().getUnits();
+    final Collection<Unit> unitsInTo = to.getUnits();
     final Collection<Unit> unitsAtStartOfStep = unitsAtStartOfStepInTerritory(to);
     unitsInTo.removeAll(unitsAtStartOfStep);
     return unitsInTo;
@@ -1524,7 +1524,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   private static String validateNewAirCanLandOnCarriers(final Territory to, final Collection<Unit> units) {
     final int cost = AirMovementValidator.carrierCost(units);
     int capacity = AirMovementValidator.carrierCapacity(units, to);
-    capacity += AirMovementValidator.carrierCapacity(to.getUnitCollection().getUnits(), to);
+    capacity += AirMovementValidator.carrierCapacity(to.getUnits(), to);
     // TODO: This method considers existing carriers but not existing air units
     if (cost > capacity) {
       return "Not enough new carriers to land all the fighters";

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -71,7 +71,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   private void doAfterEnd() {
     final PlayerId player = bridge.getPlayerId();
     // clear all units not placed
-    final Collection<Unit> units = player.getUnits().getUnits();
+    final Collection<Unit> units = player.getUnitCollection().getUnits();
     final GameData data = getData();
     if (!Properties.getUnplacedUnitsLive(data) && !units.isEmpty()) {
       bridge.getHistoryWriter()
@@ -90,7 +90,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   @Override
   public boolean delegateCurrentlyRequiresUserInput() {
     // nothing to place
-    return !(player == null || (player.getUnits().size() == 0 && getPlacementsMade() == 0));
+    return !(player == null || (player.getUnitCollection().size() == 0 && getPlacementsMade() == 0));
   }
 
   protected void removeAirThatCantLand() {
@@ -479,11 +479,11 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (!Matches.territoryIsLand().test(producer)) {
       return null;
     }
-    if (!producer.getUnits().anyMatch(Matches.unitCanProduceUnits())) {
+    if (!producer.getUnitCollection().anyMatch(Matches.unitCanProduceUnits())) {
       return null;
     }
     final Predicate<Unit> ownedFighters = Matches.unitCanLandOnCarrier().and(Matches.unitIsOwnedBy(player));
-    if (!producer.getUnits().anyMatch(ownedFighters)) {
+    if (!producer.getUnitCollection().anyMatch(ownedFighters)) {
       return null;
     }
     if (wasConquered(producer)) {
@@ -492,7 +492,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (getAlreadyProduced(producer).stream().anyMatch(Matches.unitCanProduceUnits())) {
       return null;
     }
-    final List<Unit> fighters = producer.getUnits().getMatches(ownedFighters);
+    final List<Unit> fighters = producer.getUnitCollection().getMatches(ownedFighters);
     final Collection<Unit> movedFighters = getRemotePlayer().getNumberOfFightersToMoveToNewCarrier(fighters, producer);
     if (movedFighters == null || movedFighters.isEmpty()) {
       return null;
@@ -536,7 +536,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
    */
   private static String playerHasEnoughUnits(final Collection<Unit> units, final PlayerId player) {
     // make sure the player has enough units in hand to place
-    if (!player.getUnits().getUnits().containsAll(units)) {
+    if (!player.getUnitCollection().getUnits().containsAll(units)) {
       return "Not enough units";
     }
     return null;
@@ -635,7 +635,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       return "You do not have the required units to build in " + producer.getName();
     }
     if (to.isWater() && (!isWW2V2() && !isUnitPlacementInEnemySeas())
-        && to.getUnits().anyMatch(Matches.enemyUnit(player, getData()))) {
+        && to.getUnitCollection().anyMatch(Matches.enemyUnit(player, getData()))) {
       return "Cannot place sea units with enemy naval units";
     }
     // make sure there is a factory
@@ -754,7 +754,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
         if (GameStepPropertiesHelper.isBid(getData())) {
           final PlayerAttachment pa = PlayerAttachment.get(to.getOwner());
           if ((pa == null || pa.getGiveUnitControl() == null || !pa.getGiveUnitControl().contains(player))
-              && !to.getUnits().anyMatch(Matches.unitIsOwnedBy(player))) {
+              && !to.getUnitCollection().anyMatch(Matches.unitIsOwnedBy(player))) {
             return "You don't own " + to.getName();
           }
         } else {
@@ -838,7 +838,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       final PlayerId player) {
     final boolean water = to.isWater();
     if (water && (!isWW2V2() && !isUnitPlacementInEnemySeas())
-        && to.getUnits().anyMatch(Matches.enemyUnit(player, getData()))) {
+        && to.getUnitCollection().anyMatch(Matches.enemyUnit(player, getData()))) {
       return null;
     }
     final Collection<Unit> units = new ArrayList<>(allUnits);
@@ -861,7 +861,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       } else if (((isBid || canProduceFightersOnCarriers() || AirThatCantLandUtil.isLhtrCarrierProduction(getData()))
           && allProducedUnits.stream().anyMatch(Matches.unitIsCarrier()))
           || ((isBid || canProduceNewFightersOnOldCarriers() || AirThatCantLandUtil.isLhtrCarrierProduction(getData()))
-              && to.getUnits().anyMatch(Matches.unitIsCarrier().and(Matches
+              && to.getUnitCollection().anyMatch(Matches.unitIsCarrier().and(Matches
                   .unitIsOwnedByOfAnyOfThesePlayers(GameStepPropertiesHelper.getCombinedTurns(getData(), player)))))) {
         placeableUnits
             .addAll(CollectionUtils.getMatches(units, Matches.unitIsAir().and(Matches.unitCanLandOnCarrier())));
@@ -1051,7 +1051,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
         .and(producer.isWater()
             ? Matches.unitIsLand().negate()
             : Matches.unitIsSea().negate());
-    final Collection<Unit> factoryUnits = producer.getUnits().getMatches(factoryMatch);
+    final Collection<Unit> factoryUnits = producer.getUnitCollection().getMatches(factoryMatch);
     // boolean placementRestrictedByFactory = isPlacementRestrictedByFactory();
     final boolean unitPlacementPerTerritoryRestricted = isUnitPlacementPerTerritoryRestricted();
     final boolean originalFactory = (ta != null && ta.getOriginalFactory());
@@ -1071,7 +1071,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       if (ra != null && ra.getPlacementPerTerritory() > 0) {
         final int allowedPlacement = ra.getPlacementPerTerritory();
         final int ownedUnitsInTerritory =
-            CollectionUtils.countMatches(to.getUnits().getUnits(), Matches.unitIsOwnedBy(player));
+            CollectionUtils.countMatches(to.getUnitCollection().getUnits(), Matches.unitIsOwnedBy(player));
         if (ownedUnitsInTerritory >= allowedPlacement) {
           return 0;
         }
@@ -1201,7 +1201,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
       return new IntegerMap<>();
     }
     final Collection<Unit> unitsAtStartOfTurnInTo = unitsAtStartOfStepInTerritory(to);
-    final Collection<Unit> unitsInTo = to.getUnits().getUnits();
+    final Collection<Unit> unitsInTo = to.getUnitCollection().getUnits();
     final Collection<Unit> unitsPlacedAlready = getAlreadyProduced(to);
     // build an integer map of each unit we have in our list of held units, as well as integer maps for maximum units
     // and units per turn
@@ -1459,7 +1459,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (to == null) {
       return new ArrayList<>();
     }
-    final Collection<Unit> unitsInTo = to.getUnits().getUnits();
+    final Collection<Unit> unitsInTo = to.getUnitCollection().getUnits();
     final Collection<Unit> unitsPlacedAlready = getAlreadyProduced(to);
     if (Matches.territoryIsWater().test(to)) {
       for (final Territory current : getAllProducers(to, player, null, true)) {
@@ -1475,7 +1475,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
     if (to == null) {
       return new ArrayList<>();
     }
-    final Collection<Unit> unitsInTo = to.getUnits().getUnits();
+    final Collection<Unit> unitsInTo = to.getUnitCollection().getUnits();
     final Collection<Unit> unitsAtStartOfStep = unitsAtStartOfStepInTerritory(to);
     unitsInTo.removeAll(unitsAtStartOfStep);
     return unitsInTo;
@@ -1505,7 +1505,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
    * will be thrown. return value may be null.
    */
   private PlayerId getOriginalFactoryOwner(final Territory territory) {
-    final Collection<Unit> factoryUnits = territory.getUnits().getMatches(Matches.unitCanProduceUnits());
+    final Collection<Unit> factoryUnits = territory.getUnitCollection().getMatches(Matches.unitCanProduceUnits());
     if (factoryUnits.size() == 0) {
       throw new IllegalStateException("No factory in territory:" + territory);
     }
@@ -1524,7 +1524,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate implemen
   private static String validateNewAirCanLandOnCarriers(final Territory to, final Collection<Unit> units) {
     final int cost = AirMovementValidator.carrierCost(units);
     int capacity = AirMovementValidator.carrierCapacity(units, to);
-    capacity += AirMovementValidator.carrierCapacity(to.getUnits().getUnits(), to);
+    capacity += AirMovementValidator.carrierCapacity(to.getUnitCollection().getUnits(), to);
     // TODO: This method considers existing carriers but not existing air units
     if (cost > capacity) {
       return "Not enough new carriers to land all the fighters";

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -72,9 +72,10 @@ public class AirBattle extends AbstractBattle {
     // fill in defenders
     if (isBombingRun) {
       defendingUnits =
-          battleSite.getUnits().getMatches(defendingBombingRaidInterceptors(battleSite, attacker, gameData));
+          battleSite.getUnitCollection().getMatches(defendingBombingRaidInterceptors(battleSite, attacker, gameData));
     } else {
-      defendingUnits = battleSite.getUnits().getMatches(defendingGroundSeaBattleInterceptors(attacker, gameData));
+      defendingUnits =
+          battleSite.getUnitCollection().getMatches(defendingGroundSeaBattleInterceptors(attacker, gameData));
     }
   }
 
@@ -311,7 +312,7 @@ public class AirBattle extends AbstractBattle {
       final Collection<Unit> bombers = CollectionUtils.getMatches(attackingUnits, Matches.unitIsStrategicBomber());
       if (!bombers.isEmpty()) {
         Map<Unit, Set<Unit>> targets = null;
-        final Collection<Unit> enemyTargetsTotal = battleSite.getUnits().getMatches(
+        final Collection<Unit> enemyTargetsTotal = battleSite.getUnitCollection().getMatches(
             Matches.enemyUnit(bridge.getPlayerId(), gameData)
                 .and(Matches.unitCanBeDamaged())
                 .and(Matches.unitIsBeingTransported().negate()));
@@ -487,7 +488,7 @@ public class AirBattle extends AbstractBattle {
       return Integer.MAX_VALUE;
     }
     int result = 0;
-    for (final Unit base : t.getUnits().getMatches(Matches.unitIsAirBase().and(Matches.unitIsNotDisabled()))) {
+    for (final Unit base : t.getUnitCollection().getMatches(Matches.unitIsAirBase().and(Matches.unitIsNotDisabled()))) {
       final int baseMax = UnitAttachment.get(base.getType()).getMaxInterceptCount();
       if (baseMax == -1) {
         return Integer.MAX_VALUE;
@@ -708,10 +709,10 @@ public class AirBattle extends AbstractBattle {
         }
       }
     } else {
-      return territory.getUnits().anyMatch(defendingAirMatch);
+      return territory.getUnitCollection().anyMatch(defendingAirMatch);
     }
     // should we check if the territory also has an air base?
-    return territory.getUnits().anyMatch(defendingAirMatch)
+    return territory.getUnitCollection().anyMatch(defendingAirMatch)
         || data.getMap().getNeighbors(territory, maxScrambleDistance).stream()
             .anyMatch(Matches.territoryHasUnitsThatMatch(defendingAirMatch));
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -68,7 +68,7 @@ public final class AirMovementValidator {
         .and(Matches.unitCanLandOnCarrier());
     final Set<Unit> airThatMustLandOnCarriersHash = new HashSet<>();
     airThatMustLandOnCarriersHash
-        .addAll(CollectionUtils.getMatches(routeEnd.getUnitCollection().getUnits(), airAlliedNotOwned));
+        .addAll(CollectionUtils.getMatches(routeEnd.getUnits(), airAlliedNotOwned));
     airThatMustLandOnCarriersHash.addAll(CollectionUtils.getMatches(units, airAlliedNotOwned));
     // now we must see if we also need to account for units (allied cargo) that are moving with our carriers, if we have
     // selected any carriers
@@ -148,7 +148,7 @@ public final class AirMovementValidator {
   }
 
   private static int getMovementLeftForAirUnitNotMovedYet(final Unit airBeingValidated, final Route route) {
-    return route.getEnd().getUnitCollection().getUnits().contains(airBeingValidated)
+    return route.getEnd().getUnits().contains(airBeingValidated)
         // they are not being moved, they are already at the end
         ? ((TripleAUnit) airBeingValidated).getMovementLeft()
         // they are being moved (they are still at the start location)
@@ -230,7 +230,7 @@ public final class AirMovementValidator {
       if (airCanReach.isEmpty()) {
         continue;
       }
-      final Collection<Unit> unitsInLandingSpot = landingSpot.getUnitCollection().getUnits();
+      final Collection<Unit> unitsInLandingSpot = landingSpot.getUnits();
       unitsInLandingSpot.removeAll(movedCarriersAndTheirFighters.keySet());
       // make sure to remove any units we have already moved, or units that are excluded
       unitsInLandingSpot.removeAll(airNotToConsider);
@@ -277,7 +277,7 @@ public final class AirMovementValidator {
       final Iterator<Territory> iter = potentialCarrierOrigins.iterator();
       while (iter.hasNext()) {
         final Territory carrierSpot = iter.next();
-        final Collection<Unit> unitsInCarrierSpot = carrierSpot.getUnitCollection().getUnits();
+        final Collection<Unit> unitsInCarrierSpot = carrierSpot.getUnits();
         // remove carriers we have already moved
         unitsInCarrierSpot.removeAll(movedCarriersAndTheirFighters.keySet());
         // remove units we do not want to consider because they are in our mouse selection
@@ -528,7 +528,7 @@ public final class AirMovementValidator {
         .and(Matches.unitOwnedBy(player))
         .and(Matches.unitIsKamikaze().negate());
     final List<Unit> ownedAir = new ArrayList<>();
-    ownedAir.addAll(CollectionUtils.getMatches(route.getEnd().getUnitCollection().getUnits(), ownedAirMatch));
+    ownedAir.addAll(CollectionUtils.getMatches(route.getEnd().getUnits(), ownedAirMatch));
     ownedAir.addAll(CollectionUtils.getMatches(units, ownedAirMatch));
 
     // Remove suicide units if combat move and any enemy units at destination

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -67,7 +67,8 @@ public final class AirMovementValidator {
         .and(Matches.unitIsAir())
         .and(Matches.unitCanLandOnCarrier());
     final Set<Unit> airThatMustLandOnCarriersHash = new HashSet<>();
-    airThatMustLandOnCarriersHash.addAll(CollectionUtils.getMatches(routeEnd.getUnits().getUnits(), airAlliedNotOwned));
+    airThatMustLandOnCarriersHash
+        .addAll(CollectionUtils.getMatches(routeEnd.getUnitCollection().getUnits(), airAlliedNotOwned));
     airThatMustLandOnCarriersHash.addAll(CollectionUtils.getMatches(units, airAlliedNotOwned));
     // now we must see if we also need to account for units (allied cargo) that are moving with our carriers, if we have
     // selected any carriers
@@ -147,7 +148,7 @@ public final class AirMovementValidator {
   }
 
   private static int getMovementLeftForAirUnitNotMovedYet(final Unit airBeingValidated, final Route route) {
-    return route.getEnd().getUnits().getUnits().contains(airBeingValidated)
+    return route.getEnd().getUnitCollection().getUnits().contains(airBeingValidated)
         // they are not being moved, they are already at the end
         ? ((TripleAUnit) airBeingValidated).getMovementLeft()
         // they are being moved (they are still at the start location)
@@ -164,7 +165,7 @@ public final class AirMovementValidator {
     final boolean landAirOnNewCarriers = AirThatCantLandUtil.isLhtrCarrierProduction(data)
         || AirThatCantLandUtil.isLandExistingFightersOnNewCarriers(data);
     final List<Unit> carriersInProductionQueue = GameStepPropertiesHelper.getCombinedTurns(data, player).stream()
-        .map(PlayerId::getUnits)
+        .map(PlayerId::getUnitCollection)
         .map(units -> units.getMatches(Matches.unitIsCarrier()))
         .flatMap(List::stream)
         .collect(Collectors.toList());
@@ -184,7 +185,7 @@ public final class AirMovementValidator {
           carriersInProductionQueue.clear();
         }
       }
-      final Collection<Unit> alliedCarriers = t.getUnits().getMatches(carrierAlliedNotOwned);
+      final Collection<Unit> alliedCarriers = t.getUnitCollection().getMatches(carrierAlliedNotOwned);
       alliedCarriers.removeAll(movedCarriersAndTheirFighters.keySet());
       final int alliedCarrierCapacity = carrierCapacity(alliedCarriers, t);
       startingSpace.add(t, alliedCarrierCapacity);
@@ -229,7 +230,7 @@ public final class AirMovementValidator {
       if (airCanReach.isEmpty()) {
         continue;
       }
-      final Collection<Unit> unitsInLandingSpot = landingSpot.getUnits().getUnits();
+      final Collection<Unit> unitsInLandingSpot = landingSpot.getUnitCollection().getUnits();
       unitsInLandingSpot.removeAll(movedCarriersAndTheirFighters.keySet());
       // make sure to remove any units we have already moved, or units that are excluded
       unitsInLandingSpot.removeAll(airNotToConsider);
@@ -276,7 +277,7 @@ public final class AirMovementValidator {
       final Iterator<Territory> iter = potentialCarrierOrigins.iterator();
       while (iter.hasNext()) {
         final Territory carrierSpot = iter.next();
-        final Collection<Unit> unitsInCarrierSpot = carrierSpot.getUnits().getUnits();
+        final Collection<Unit> unitsInCarrierSpot = carrierSpot.getUnitCollection().getUnits();
         // remove carriers we have already moved
         unitsInCarrierSpot.removeAll(movedCarriersAndTheirFighters.keySet());
         // remove units we do not want to consider because they are in our mouse selection
@@ -307,7 +308,7 @@ public final class AirMovementValidator {
           // we still have a capacity for allied carriers, but only to carry other allied or local owned units, not to
           // carry our selected units.
           carrierSpotCapacity =
-              carrierCapacity(carrierSpot.getUnits().getMatches(alliedNotOwnedCarrierMatch), carrierSpot);
+              carrierCapacity(carrierSpot.getUnitCollection().getMatches(alliedNotOwnedCarrierMatch), carrierSpot);
           landingSpotsWithCarrierCapacity.put(carrierSpot, carrierSpotCapacity);
         }
         // we have allied air here, so we need to account for them before moving any carriers
@@ -467,7 +468,7 @@ public final class AirMovementValidator {
     int max = 0;
     final Predicate<Unit> ownedCarrier = Matches.unitIsCarrier().and(Matches.unitIsOwnedBy(player));
     for (final Territory t : data.getMap().getTerritories()) {
-      for (final Unit carrier : t.getUnits().getMatches(ownedCarrier)) {
+      for (final Unit carrier : t.getUnitCollection().getMatches(ownedCarrier)) {
         max = Math.max(max, ((TripleAUnit) carrier).getMovementLeft());
       }
     }
@@ -527,12 +528,12 @@ public final class AirMovementValidator {
         .and(Matches.unitOwnedBy(player))
         .and(Matches.unitIsKamikaze().negate());
     final List<Unit> ownedAir = new ArrayList<>();
-    ownedAir.addAll(CollectionUtils.getMatches(route.getEnd().getUnits().getUnits(), ownedAirMatch));
+    ownedAir.addAll(CollectionUtils.getMatches(route.getEnd().getUnitCollection().getUnits(), ownedAirMatch));
     ownedAir.addAll(CollectionUtils.getMatches(units, ownedAirMatch));
 
     // Remove suicide units if combat move and any enemy units at destination
     final Collection<Unit> enemyUnitsAtEnd =
-        route.getEnd().getUnits().getMatches(Matches.enemyUnit(player, player.getData()));
+        route.getEnd().getUnitCollection().getMatches(Matches.enemyUnit(player, player.getData()));
     if (!enemyUnitsAtEnd.isEmpty() && GameStepPropertiesHelper.isCombatMove(player.getData())) {
       ownedAir.removeIf(Matches.unitIsSuicide());
     }
@@ -673,7 +674,7 @@ public final class AirMovementValidator {
         // and we must check to make sure we let any allied air that are cargo stay here
         if (Matches.unitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLEAVEALLIEDCARRIER).test(unit)) {
           int cargo = 0;
-          final Collection<Unit> airCargo = territoryUnitsAreCurrentlyIn.getUnits()
+          final Collection<Unit> airCargo = territoryUnitsAreCurrentlyIn.getUnitCollection()
               .getMatches(Matches.unitIsAir().and(Matches.unitCanLandOnCarrier()));
           for (final Unit airUnit : airCargo) {
             final TripleAUnit taUnit = (TripleAUnit) airUnit;
@@ -715,7 +716,7 @@ public final class AirMovementValidator {
   }
 
   public static Collection<Unit> getFriendly(final Territory territory, final PlayerId player, final GameData data) {
-    return territory.getUnits().getMatches(Matches.alliedUnit(player, data));
+    return territory.getUnitCollection().getMatches(Matches.alliedUnit(player, data));
   }
 
   private static boolean isKamikazeAircraft(final GameData data) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
@@ -39,7 +39,7 @@ public class AirThatCantLandUtil {
     final Collection<Territory> cantLand = new ArrayList<>();
     for (final Territory current : data.getMap().getTerritories()) {
       final Predicate<Unit> ownedAir = Matches.unitIsAir().and(Matches.unitIsOwnedBy(player));
-      final Collection<Unit> air = current.getUnits().getMatches(ownedAir);
+      final Collection<Unit> air = current.getUnitCollection().getMatches(ownedAir);
       if (air.size() != 0 && !AirMovementValidator.canLand(air, current, player, data)) {
         cantLand.add(current);
       }
@@ -52,7 +52,7 @@ public class AirThatCantLandUtil {
     final GameMap map = data.getMap();
     for (final Territory current : getTerritoriesWhereAirCantLand(player)) {
       final Predicate<Unit> ownedAir = Matches.unitIsAir().and(Matches.alliedUnit(player, data));
-      final Collection<Unit> air = current.getUnits().getMatches(ownedAir);
+      final Collection<Unit> air = current.getUnitCollection().getMatches(ownedAir);
       final boolean hasNeighboringFriendlyFactory =
           map.getNeighbors(current, Matches.territoryHasAlliedIsFactoryOrCanProduceUnits(data, player)).size() > 0;
       final boolean skip = spareAirInSeaZonesBesideFactories && current.isWater() && hasNeighboringFriendlyFactory;
@@ -70,7 +70,8 @@ public class AirThatCantLandUtil {
       toRemove.addAll(airUnits);
     } else { // on water we may just no have enough carriers
       // find the carrier capacity
-      final Collection<Unit> carriers = territory.getUnits().getMatches(Matches.alliedUnit(player, bridge.getData()));
+      final Collection<Unit> carriers =
+          territory.getUnitCollection().getMatches(Matches.alliedUnit(player, bridge.getData()));
       int capacity = AirMovementValidator.carrierCapacity(carriers, territory);
       for (final Unit unit : airUnits) {
         final UnitAttachment ua = UnitAttachment.get(unit.getType());

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -270,7 +270,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         Collection<IBattle> battles = adjBombardment.get(t);
         battles = CollectionUtils.getMatches(battles, Matches.battleIsAmphibious());
         if (!battles.isEmpty()) {
-          final Collection<Unit> bombardUnits = t.getUnits().getMatches(ownedAndCanBombard);
+          final Collection<Unit> bombardUnits = t.getUnitCollection().getMatches(ownedAndCanBombard);
           final List<Unit> listedBombardUnits = new ArrayList<>(bombardUnits);
           sortUnitsToBombard(listedBombardUnits, attacker);
           if (!bombardUnits.isEmpty()) {
@@ -377,9 +377,9 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       final IDelegateBridge bridge) {
     if (TechTracker.hasParatroopers(player)) {
       final Collection<Unit> airTransports =
-          CollectionUtils.getMatches(battleSite.getUnits(), Matches.unitIsAirTransport());
+          CollectionUtils.getMatches(battleSite.getUnitCollection(), Matches.unitIsAirTransport());
       final Collection<Unit> paratroops =
-          CollectionUtils.getMatches(battleSite.getUnits(), Matches.unitIsAirTransportable());
+          CollectionUtils.getMatches(battleSite.getUnitCollection(), Matches.unitIsAirTransportable());
       if (!airTransports.isEmpty() && !paratroops.isEmpty()) {
         final CompositeChange change = new CompositeChange();
         for (final Unit u : paratroops) {
@@ -420,10 +420,10 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final List<Territory> battleTerritories =
         CollectionUtils.getMatches(data.getMap().getTerritories(), enemyUnitsOrEnemyTerritory);
     for (final Territory territory : battleTerritories) {
-      final List<Unit> attackingUnits = territory.getUnits().getMatches(Matches.unitIsOwnedBy(player));
+      final List<Unit> attackingUnits = territory.getUnitCollection().getMatches(Matches.unitIsOwnedBy(player));
       // now make sure to add any units that must move with these attacking units, so that they get included as
       // dependencies
-      final Map<Unit, Collection<Unit>> transportMap = TransportTracker.transporting(territory.getUnits());
+      final Map<Unit, Collection<Unit>> transportMap = TransportTracker.transporting(territory.getUnitCollection());
       final Set<Unit> dependants = new HashSet<>();
       for (final Entry<Unit, Collection<Unit>> entry : transportMap.entrySet()) {
         // only consider those transports that we are attacking with. allied and enemy transports are not added.
@@ -435,7 +435,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       dependants.removeAll(attackingUnits);
       // add the dependants to the attacking list
       attackingUnits.addAll(dependants);
-      final List<Unit> enemyUnits = territory.getUnits().getMatches(Matches.enemyUnit(player, data));
+      final List<Unit> enemyUnits = territory.getUnitCollection().getMatches(Matches.enemyUnit(player, data));
       final IBattle bombingBattle = battleTracker.getPendingBattle(territory, true, null);
       if (bombingBattle != null) {
         // we need to remove any units which are participating in bombing raids
@@ -563,11 +563,11 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             .and(Matches.territoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemy(player, data)));
     // all territories that contain enemy units, where the territory is owned by an enemy of these units
     for (final Territory territory : battleTerritories) {
-      final List<Unit> abandonedToUnits = territory.getUnits().getMatches(Matches.enemyUnit(player, data));
+      final List<Unit> abandonedToUnits = territory.getUnitCollection().getMatches(Matches.enemyUnit(player, data));
       final PlayerId abandonedToPlayer = AbstractBattle.findPlayerWithMostUnits(abandonedToUnits);
 
       // now make sure to add any units that must move with these units, so that they get included as dependencies
-      final Map<Unit, Collection<Unit>> transportMap = TransportTracker.transporting(territory.getUnits());
+      final Map<Unit, Collection<Unit>> transportMap = TransportTracker.transporting(territory.getUnitCollection());
 
       abandonedToUnits.addAll(transportMap.entrySet().stream()
           .filter(e -> abandonedToUnits.contains(e.getKey()))
@@ -583,7 +583,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
           .map(p -> Matches.unitIsEnemyOf(data, p)
               .and(Matches.unitIsNotAir())
               .and(Matches.unitIsNotInfrastructure()))
-          .map(territory.getUnits()::getMatches)
+          .map(territory.getUnitCollection()::getMatches)
           .flatMap(Collection::stream)
           .collect(Collectors.toSet());
       // only look at bombing battles, because otherwise the normal attack will determine the ownership of the territory
@@ -703,10 +703,10 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
           defender = AbstractBattle.findDefender(from, player, data);
         }
         // find how many is the max this territory can scramble
-        final Collection<Unit> airbases = from.getUnits().getMatches(airbasesCanScramble);
+        final Collection<Unit> airbases = from.getUnitCollection().getMatches(airbasesCanScramble);
         final int maxCanScramble = getMaxScrambleCount(airbases);
         final Route toBattleRoute = data.getMap().getRoute_IgnoreEnd(from, to, Matches.territoryIsNotImpassable());
-        final Collection<Unit> canScrambleAir = from.getUnits().getMatches(Matches.unitIsEnemyOf(data, player)
+        final Collection<Unit> canScrambleAir = from.getUnitCollection().getMatches(Matches.unitIsEnemyOf(data, player)
             .and(Matches.unitCanScramble())
             .and(Matches.unitIsNotDisabled())
             .and(Matches.unitWasScrambled().negate())
@@ -738,7 +738,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         final Iterator<Territory> territoryIter = scramblers.keySet().iterator();
         while (territoryIter.hasNext()) {
           final Territory t = territoryIter.next();
-          scramblers.get(t).getSecond().retainAll(t.getUnits());
+          scramblers.get(t).getSecond().retainAll(t.getUnitCollection());
           if (scramblers.get(t).getSecond().isEmpty()) {
             territoryIter.remove();
           }
@@ -792,7 +792,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             continue;
           }
           int numberScrambled = scrambling.size();
-          final Collection<Unit> airbases = t.getUnits().getMatches(airbasesCanScramble);
+          final Collection<Unit> airbases = t.getUnitCollection().getMatches(airbasesCanScramble);
           final int maxCanScramble = getMaxScrambleCount(airbases);
           if (maxCanScramble != Integer.MAX_VALUE) {
             // TODO: maybe sort from biggest to smallest first?
@@ -836,7 +836,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       final IBattle bombing = battleTracker.getPendingBattle(to, true, null);
       IBattle battle = battleTracker.getPendingBattle(to, false, BattleType.NORMAL);
       if (battle == null) {
-        final List<Unit> attackingUnits = to.getUnits().getMatches(Matches.unitIsOwnedBy(player));
+        final List<Unit> attackingUnits = to.getUnitCollection().getMatches(Matches.unitIsOwnedBy(player));
         if (bombing != null) {
           attackingUnits.removeAll(bombing.getAttackingUnits());
         }
@@ -880,7 +880,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
               // All other maps, must hold only the transported units that in their territory
               final Collection<Unit> allNeighborUnits =
                   new ArrayList<>(CollectionUtils.getMatches(attackingUnits, Matches.unitIsTransport()));
-              allNeighborUnits.addAll(t.getUnits().getMatches(Matches.unitIsLandAndOwnedBy(player)));
+              allNeighborUnits.addAll(t.getUnitCollection().getMatches(Matches.unitIsLandAndOwnedBy(player)));
               final Map<Unit, Collection<Unit>> dependenciesForNeighbors =
                   TransportTracker.transportingWithAllPossibleUnits(
                       CollectionUtils.getMatches(allNeighborUnits, Matches.unitIsTransport().negate()));
@@ -969,7 +969,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final boolean mustReturnToBase = Properties.getScrambledUnitsReturnToBase(data);
     for (final Territory t : data.getMap().getTerritories()) {
       int carrierCostOfCurrentTerr = 0;
-      final Collection<Unit> wasScrambled = t.getUnits().getMatches(Matches.unitWasScrambled());
+      final Collection<Unit> wasScrambled = t.getUnitCollection().getMatches(Matches.unitWasScrambled());
       for (final Unit u : wasScrambled) {
         final CompositeChange change = new CompositeChange();
         final Territory originatedFrom = TripleAUnit.get(u).getOriginatedFrom();
@@ -1018,7 +1018,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     }
     final CompositeChange change = new CompositeChange();
     for (final Territory t : data.getMap().getTerritories()) {
-      final Collection<Unit> airbases = t.getUnits().getMatches(Matches.unitIsAirBase());
+      final Collection<Unit> airbases = t.getUnitCollection().getMatches(Matches.unitIsAirBase());
       for (final Unit u : airbases) {
         final UnitAttachment ua = UnitAttachment.get(u.getType());
         final int currentMax = ((TripleAUnit) u).getMaxScrambleCount();
@@ -1041,7 +1041,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     }
     final CompositeChange change = new CompositeChange();
     for (final Territory t : data.getMap().getTerritories()) {
-      for (final Unit u : t.getUnits().getMatches(Matches.unitWasInAirBattle())) {
+      for (final Unit u : t.getUnitCollection().getMatches(Matches.unitWasInAirBattle())) {
         change.add(ChangeFactory.unitPropertyChange(u, false, TripleAUnit.WAS_IN_AIR_BATTLE));
       }
     }
@@ -1063,7 +1063,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       if (defendingAir == null || defendingAir.isEmpty()) {
         continue;
       }
-      defendingAir.retainAll(battleSite.getUnits());
+      defendingAir.retainAll(battleSite.getUnitCollection());
       if (defendingAir.isEmpty()) {
         continue;
       }
@@ -1087,8 +1087,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       // See if neighboring carriers have any capacity available
       for (final Territory currentTerritory : areSeaNeighbors) {
         // get the capacity of the carriers and cost of fighters
-        final Collection<Unit> alliedCarriers = currentTerritory.getUnits().getMatches(alliedCarrier);
-        final Collection<Unit> alliedPlanes = currentTerritory.getUnits().getMatches(alliedPlane);
+        final Collection<Unit> alliedCarriers = currentTerritory.getUnitCollection().getMatches(alliedCarrier);
+        final Collection<Unit> alliedPlanes = currentTerritory.getUnitCollection().getMatches(alliedPlane);
         final int alliedCarrierCapacity = AirMovementValidator.carrierCapacity(alliedCarriers, currentTerritory);
         final int alliedPlaneCost = AirMovementValidator.carrierCost(alliedPlanes);
         // if there is free capacity, add the territory to landing possibilities
@@ -1152,8 +1152,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       final Collection<Unit> defendingAir, final Predicate<Unit> alliedCarrier,
       final Predicate<Unit> alliedPlane, final Territory newTerritory, final Territory battleSite) {
     // Get the capacity of the carriers in the selected zone
-    final Collection<Unit> alliedCarriersSelected = newTerritory.getUnits().getMatches(alliedCarrier);
-    final Collection<Unit> alliedPlanesSelected = newTerritory.getUnits().getMatches(alliedPlane);
+    final Collection<Unit> alliedCarriersSelected = newTerritory.getUnitCollection().getMatches(alliedCarrier);
+    final Collection<Unit> alliedPlanesSelected = newTerritory.getUnitCollection().getMatches(alliedPlane);
     final int alliedCarrierCapacitySelected =
         AirMovementValidator.carrierCapacity(alliedCarriersSelected, newTerritory);
     final int alliedPlaneCostSelected = AirMovementValidator.carrierCost(alliedPlanesSelected);
@@ -1224,7 +1224,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         continue;
       }
       if (enemies.contains(owner)) {
-        if (t.getUnits().getUnits().stream().noneMatch(Matches.unitIsOwnedBy(player))) {
+        if (t.getUnitCollection().getUnits().stream().noneMatch(Matches.unitIsOwnedBy(player))) {
           continue;
         }
         if (onlyWhereThereAreBattlesOrAmphibious) {
@@ -1298,7 +1298,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       final Collection<Territory> kamikazeZones = entry.getValue();
       final Map<Territory, Collection<Unit>> possibleUnitsToAttack = new HashMap<>();
       for (final Territory t : kamikazeZones) {
-        final List<Unit> validTargets = t.getUnits().getMatches(canBeAttacked);
+        final List<Unit> validTargets = t.getUnitCollection().getMatches(canBeAttacked);
         if (!validTargets.isEmpty()) {
           possibleUnitsToAttack.put(t, validTargets);
         }
@@ -1493,9 +1493,9 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       while (waterIter.hasNext()) {
         final Territory t = waterIter.next();
         int carrierCapacity = AirMovementValidator
-            .carrierCapacity(t.getUnits().getMatches(Matches.unitIsAlliedCarrier(alliedPlayer, data)), t);
+            .carrierCapacity(t.getUnitCollection().getMatches(Matches.unitIsAlliedCarrier(alliedPlayer, data)), t);
         if (!t.equals(currentTerr)) {
-          carrierCapacity -= AirMovementValidator.carrierCost(t.getUnits().getMatches(
+          carrierCapacity -= AirMovementValidator.carrierCost(t.getUnitCollection().getMatches(
               Matches.unitCanLandOnCarrier().and(Matches.alliedUnit(alliedPlayer, data))));
         } else {
           carrierCapacity -= carrierCostForCurrentTerr;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -1224,7 +1224,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         continue;
       }
       if (enemies.contains(owner)) {
-        if (t.getUnitCollection().getUnits().stream().noneMatch(Matches.unitIsOwnedBy(player))) {
+        if (t.getUnits().stream().noneMatch(Matches.unitIsOwnedBy(player))) {
           continue;
         }
         if (onlyWhereThereAreBattlesOrAmphibious) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -713,7 +713,7 @@ public class BattleTracker implements Serializable {
           changeTracker.addChange(takeOverFriendlyTerritories);
         }
         final Collection<Unit> units =
-            CollectionUtils.getMatches(item.getUnitCollection().getUnits(), Matches.unitIsInfrastructure());
+            CollectionUtils.getMatches(item.getUnits(), Matches.unitIsInfrastructure());
         if (!units.isEmpty()) {
           final Change takeOverNonComUnits = ChangeFactory.changeOwner(units, terrOrigOwner, territory);
           bridge.addChange(takeOverNonComUnits);
@@ -894,7 +894,7 @@ public class BattleTracker implements Serializable {
     }
     // if just an enemy factory &/or AA then no battle
     final Collection<Unit> enemyUnits =
-        CollectionUtils.getMatches(site.getUnitCollection().getUnits(), Matches.enemyUnit(id, data));
+        CollectionUtils.getMatches(site.getUnits(), Matches.enemyUnit(id, data));
     if (route.getEnd() != null && !enemyUnits.isEmpty()
         && enemyUnits.stream().allMatch(Matches.unitIsInfrastructure())) {
       return ChangeFactory.EMPTY_CHANGE;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -679,7 +679,7 @@ public class BattleTracker implements Serializable {
     }
     // Remove any bombing raids against captured territory
     // TODO: see if necessary
-    if (territory.getUnits().anyMatch(Matches.unitIsEnemyOf(data, id).and(Matches.unitCanBeDamaged()))) {
+    if (territory.getUnitCollection().anyMatch(Matches.unitIsEnemyOf(data, id).and(Matches.unitCanBeDamaged()))) {
       final IBattle bombingBattle = getPendingBattle(territory, true, null);
       if (bombingBattle != null) {
         final BattleResults results = new BattleResults(bombingBattle, WhoWon.DRAW, data);
@@ -713,7 +713,7 @@ public class BattleTracker implements Serializable {
           changeTracker.addChange(takeOverFriendlyTerritories);
         }
         final Collection<Unit> units =
-            CollectionUtils.getMatches(item.getUnits().getUnits(), Matches.unitIsInfrastructure());
+            CollectionUtils.getMatches(item.getUnitCollection().getUnits(), Matches.unitIsInfrastructure());
         if (!units.isEmpty()) {
           final Change takeOverNonComUnits = ChangeFactory.changeOwner(units, terrOrigOwner, territory);
           bridge.addChange(takeOverNonComUnits);
@@ -743,7 +743,7 @@ public class BattleTracker implements Serializable {
     if (Properties.getUnitsCanBeDestroyedInsteadOfCaptured(data)) {
       final Predicate<Unit> enemyToBeDestroyed = Matches.enemyUnit(id, data)
           .and(Matches.unitDestroyedWhenCapturedByOrFrom(id));
-      final Collection<Unit> destroyed = territory.getUnits().getMatches(enemyToBeDestroyed);
+      final Collection<Unit> destroyed = territory.getUnitCollection().getMatches(enemyToBeDestroyed);
       if (!destroyed.isEmpty()) {
         final Change destroyUnits = ChangeFactory.removeUnits(territory, destroyed);
         bridge.getHistoryWriter().addChildToEvent("Some non-combat units are destroyed: ", destroyed);
@@ -756,7 +756,8 @@ public class BattleTracker implements Serializable {
     // destroy any capture on entering units, IF the property to destroy them instead of capture is turned on
     if (Properties.getOnEnteringUnitsDestroyedInsteadOfCaptured(data)) {
       final Collection<Unit> destroyed =
-          territory.getUnits().getMatches(Matches.unitCanBeCapturedOnEnteringToInThisTerritory(id, territory, data));
+          territory.getUnitCollection()
+              .getMatches(Matches.unitCanBeCapturedOnEnteringToInThisTerritory(id, territory, data));
       if (!destroyed.isEmpty()) {
         final Change destroyUnits = ChangeFactory.removeUnits(territory, destroyed);
         bridge.getHistoryWriter().addChildToEvent(id.getName() + " destroys some units instead of capturing them",
@@ -771,7 +772,7 @@ public class BattleTracker implements Serializable {
     final Predicate<Unit> enemyToBeDestroyed = Matches.enemyUnit(id, data)
         .and(Matches.unitIsDisabled())
         .and(Matches.unitIsInfrastructure().negate());
-    final Collection<Unit> destroyed = territory.getUnits().getMatches(enemyToBeDestroyed);
+    final Collection<Unit> destroyed = territory.getUnitCollection().getMatches(enemyToBeDestroyed);
     if (!destroyed.isEmpty()) {
       final Change destroyUnits = ChangeFactory.removeUnits(territory, destroyed);
       bridge.getHistoryWriter().addChildToEvent(id.getName() + " destroys some disabled combat units", destroyed);
@@ -784,7 +785,7 @@ public class BattleTracker implements Serializable {
     final Predicate<Unit> enemyNonCom = Matches.enemyUnit(id, data).and(Matches.unitIsInfrastructure());
     final Predicate<Unit> willBeCaptured = enemyNonCom
         .or(Matches.unitCanBeCapturedOnEnteringToInThisTerritory(id, territory, data));
-    final Collection<Unit> nonCom = territory.getUnits().getMatches(willBeCaptured);
+    final Collection<Unit> nonCom = territory.getUnitCollection().getMatches(willBeCaptured);
     // change any units that change unit types on capture
     if (Properties.getUnitsCanBeChangedOnCapture(data)) {
       final Collection<Unit> toReplace =
@@ -893,7 +894,7 @@ public class BattleTracker implements Serializable {
     }
     // if just an enemy factory &/or AA then no battle
     final Collection<Unit> enemyUnits =
-        CollectionUtils.getMatches(site.getUnits().getUnits(), Matches.enemyUnit(id, data));
+        CollectionUtils.getMatches(site.getUnitCollection().getUnits(), Matches.enemyUnit(id, data));
     if (route.getEnd() != null && !enemyUnits.isEmpty()
         && enemyUnits.stream().allMatch(Matches.unitIsInfrastructure())) {
       return ChangeFactory.EMPTY_CHANGE;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
@@ -40,9 +40,9 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
     if (to.isWater()) {
       if (units.stream().anyMatch(Matches.unitIsLand())) {
         return "Cant place land units at sea";
-      } else if (to.getUnits().anyMatch(Matches.enemyUnit(player, getData()))) {
+      } else if (to.getUnitCollection().anyMatch(Matches.enemyUnit(player, getData()))) {
         return "Cant place in sea zone containing enemy units";
-      } else if (!to.getUnits().anyMatch(Matches.unitIsOwnedBy(player))) {
+      } else if (!to.getUnitCollection().anyMatch(Matches.unitIsOwnedBy(player))) {
         return "Cant place in sea zone that does not contain a unit owned by you";
       } else {
         return null;
@@ -58,7 +58,7 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
       final PlayerAttachment pa = PlayerAttachment.get(to.getOwner());
       if (pa != null && pa.getGiveUnitControl() != null && pa.getGiveUnitControl().contains(player)) {
         return null;
-      } else if (to.getUnits().anyMatch(Matches.unitIsOwnedBy(player))) {
+      } else if (to.getUnitCollection().anyMatch(Matches.unitIsOwnedBy(player))) {
         return null;
       }
       return "You dont own " + to.getName();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -91,7 +91,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
           if (landUnitsToAdd.isEmpty() || !landUnitsToAdd.stream().allMatch(Matches.unitCanBeTransported())) {
             return "Can't add land units that can't be transported, to water";
           }
-          seaTransports.addAll(territory.getUnits().getMatches(friendlySeaTransports));
+          seaTransports.addAll(territory.getUnitCollection().getMatches(friendlySeaTransports));
           if (seaTransports.isEmpty()) {
             return "Can't add land units to water without enough transports";
           }
@@ -133,13 +133,13 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
         + player.getName(), territory);
     if (!data.getRelationshipTracker().isAtWar(territory.getOwner(), player)) {
       // change ownership of friendly factories
-      final Collection<Unit> units = territory.getUnits().getMatches(Matches.unitIsInfrastructure());
+      final Collection<Unit> units = territory.getUnitCollection().getMatches(Matches.unitIsInfrastructure());
       for (final Unit unit : units) {
         bridge.addChange(ChangeFactory.changeOwner(unit, player, territory));
       }
     } else {
       final Predicate<Unit> enemyNonCom = Matches.unitIsInfrastructure().and(Matches.enemyUnit(player, data));
-      final Collection<Unit> units = territory.getUnits().getMatches(enemyNonCom);
+      final Collection<Unit> units = territory.getUnitCollection().getMatches(enemyNonCom);
       // mark no movement for enemy units
       bridge.addChange(ChangeFactory.markNoMovementChange(units));
       // change ownership of enemy AA and factories

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -197,7 +197,7 @@ final class EditValidator {
       return result;
     }
     final Collection<Unit> units = new ArrayList<>(unitDamageMap.keySet());
-    if (!territory.getUnitCollection().getUnits().containsAll(units)) {
+    if (!territory.getUnits().containsAll(units)) {
       return "Selected Territory does not contain all of the selected units";
     }
     final PlayerId player = units.iterator().next().getOwner();
@@ -231,7 +231,7 @@ final class EditValidator {
       return "Game does not allow bombing damage";
     }
     final Collection<Unit> units = new ArrayList<>(unitDamageMap.keySet());
-    if (!territory.getUnitCollection().getUnits().containsAll(units)) {
+    if (!territory.getUnits().containsAll(units)) {
       return "Selected Territory does not contain all of the selected units";
     }
     final PlayerId player = units.iterator().next().getOwner();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -66,7 +66,7 @@ final class EditValidator {
           if (landUnitsToAdd.isEmpty() || !landUnitsToAdd.stream().allMatch(Matches.unitCanBeTransported())) {
             return "Can't add land units that can't be transported, to water";
           }
-          seaTransports.addAll(territory.getUnits().getMatches(friendlySeaTransports));
+          seaTransports.addAll(territory.getUnitCollection().getMatches(friendlySeaTransports));
           if (seaTransports.isEmpty()) {
             return "Can't add land units to water without enough transports";
           }
@@ -85,10 +85,12 @@ final class EditValidator {
           final Predicate<Unit> friendlyAirUnits = Matches.unitIsAir().and(Matches.alliedUnit(player, data));
           // Determine transport capacity
           final int carrierCapacityTotal =
-              AirMovementValidator.carrierCapacity(territory.getUnits().getMatches(friendlyCarriers), territory)
+              AirMovementValidator.carrierCapacity(territory.getUnitCollection().getMatches(friendlyCarriers),
+                  territory)
                   + AirMovementValidator.carrierCapacity(units, territory);
-          final int carrierCost = AirMovementValidator.carrierCost(territory.getUnits().getMatches(friendlyAirUnits))
-              + AirMovementValidator.carrierCost(units);
+          final int carrierCost =
+              AirMovementValidator.carrierCost(territory.getUnitCollection().getMatches(friendlyAirUnits))
+                  + AirMovementValidator.carrierCost(units);
           if (carrierCapacityTotal < carrierCost) {
             return "Can't add more air units to water without sufficient space";
           }
@@ -195,7 +197,7 @@ final class EditValidator {
       return result;
     }
     final Collection<Unit> units = new ArrayList<>(unitDamageMap.keySet());
-    if (!territory.getUnits().getUnits().containsAll(units)) {
+    if (!territory.getUnitCollection().getUnits().containsAll(units)) {
       return "Selected Territory does not contain all of the selected units";
     }
     final PlayerId player = units.iterator().next().getOwner();
@@ -229,7 +231,7 @@ final class EditValidator {
       return "Game does not allow bombing damage";
     }
     final Collection<Unit> units = new ArrayList<>(unitDamageMap.keySet());
-    if (!territory.getUnits().getUnits().containsAll(units)) {
+    if (!territory.getUnitCollection().getUnits().containsAll(units)) {
       return "Selected Territory does not contain all of the selected units";
     }
     final PlayerId player = units.iterator().next().getOwner();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -80,7 +80,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     final Predicate<Unit> myCreatorsMatch = Matches.unitIsOwnedBy(player).and(Matches.unitCreatesUnits());
     final CompositeChange change = new CompositeChange();
     for (final Territory t : data.getMap().getTerritories()) {
-      final Collection<Unit> myCreators = CollectionUtils.getMatches(t.getUnits().getUnits(), myCreatorsMatch);
+      final Collection<Unit> myCreators = CollectionUtils.getMatches(t.getUnitCollection().getUnits(), myCreatorsMatch);
       if (myCreators != null && !myCreators.isEmpty()) {
         final Collection<Unit> toAdd = new ArrayList<>();
         final Collection<Unit> toAddSea = new ArrayList<>();
@@ -202,7 +202,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     final IntegerMap<Resource> resourceTotalsMap = new IntegerMap<>();
     final Predicate<Unit> myCreatorsMatch = Matches.unitIsOwnedBy(player).and(Matches.unitCreatesResources());
     for (final Territory t : data.getMap().getTerritories()) {
-      final Collection<Unit> myCreators = CollectionUtils.getMatches(t.getUnits().getUnits(), myCreatorsMatch);
+      final Collection<Unit> myCreators = CollectionUtils.getMatches(t.getUnitCollection().getUnits(), myCreatorsMatch);
       for (final Unit unit : myCreators) {
         final IntegerMap<Resource> generatedResourcesMap = UnitAttachment.get(unit.getType()).getCreatesResourcesList();
         resourceTotalsMap.add(generatedResourcesMap);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -80,7 +80,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     final Predicate<Unit> myCreatorsMatch = Matches.unitIsOwnedBy(player).and(Matches.unitCreatesUnits());
     final CompositeChange change = new CompositeChange();
     for (final Territory t : data.getMap().getTerritories()) {
-      final Collection<Unit> myCreators = CollectionUtils.getMatches(t.getUnitCollection().getUnits(), myCreatorsMatch);
+      final Collection<Unit> myCreators = CollectionUtils.getMatches(t.getUnits(), myCreatorsMatch);
       if (myCreators != null && !myCreators.isEmpty()) {
         final Collection<Unit> toAdd = new ArrayList<>();
         final Collection<Unit> toAddSea = new ArrayList<>();
@@ -202,7 +202,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     final IntegerMap<Resource> resourceTotalsMap = new IntegerMap<>();
     final Predicate<Unit> myCreatorsMatch = Matches.unitIsOwnedBy(player).and(Matches.unitCreatesResources());
     for (final Territory t : data.getMap().getTerritories()) {
-      final Collection<Unit> myCreators = CollectionUtils.getMatches(t.getUnitCollection().getUnits(), myCreatorsMatch);
+      final Collection<Unit> myCreators = CollectionUtils.getMatches(t.getUnits(), myCreatorsMatch);
       for (final Unit unit : myCreators) {
         final IntegerMap<Resource> generatedResourcesMap = UnitAttachment.get(unit.getType()).getCreatesResourcesList();
         resourceTotalsMap.add(generatedResourcesMap);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -112,7 +112,7 @@ public class InitializationDelegate extends BaseTripleADelegate {
       if (!current.isWater()) {
         continue;
       }
-      final Collection<Unit> units = current.getUnits().getUnits();
+      final Collection<Unit> units = current.getUnitCollection().getUnits();
       if (units.size() == 0 || units.stream().noneMatch(Matches.unitIsLand())) {
         continue;
       }
@@ -180,13 +180,13 @@ public class InitializationDelegate extends BaseTripleADelegate {
           change.add(ChangeFactory.changeResourcesChange(player, r, -deleted));
         }
       }
-      final Collection<Unit> heldUnits = player.getUnits().getUnits();
+      final Collection<Unit> heldUnits = player.getUnitCollection().getUnits();
       if (!heldUnits.isEmpty()) {
         change.add(ChangeFactory.removeUnits(player, heldUnits));
       }
       final Predicate<Unit> owned = Matches.unitIsOwnedBy(player);
       for (final Territory t : data.getMap().getTerritories()) {
-        final Collection<Unit> terrUnits = t.getUnits().getMatches(owned);
+        final Collection<Unit> terrUnits = t.getUnitCollection().getMatches(owned);
         if (!terrUnits.isEmpty()) {
           change.add(ChangeFactory.removeUnits(t, terrUnits));
         }
@@ -323,7 +323,8 @@ public class InitializationDelegate extends BaseTripleADelegate {
         if (territoryAttachment.getOriginalOwner() == null && current.getOwner() != null) {
           changes.add(OriginalOwnerTracker.addOriginalOwnerChange(current, current.getOwner()));
         }
-        final Collection<Unit> factoryAndInfrastructure = current.getUnits().getMatches(Matches.unitIsInfrastructure());
+        final Collection<Unit> factoryAndInfrastructure =
+            current.getUnitCollection().getMatches(Matches.unitIsInfrastructure());
         changes.add(OriginalOwnerTracker.addOriginalOwnerChange(factoryAndInfrastructure, current.getOwner()));
       } else if (!current.isWater()) {
         final TerritoryAttachment territoryAttachment = TerritoryAttachment.get(current);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -112,7 +112,7 @@ public class InitializationDelegate extends BaseTripleADelegate {
       if (!current.isWater()) {
         continue;
       }
-      final Collection<Unit> units = current.getUnitCollection().getUnits();
+      final Collection<Unit> units = current.getUnits();
       if (units.size() == 0 || units.stream().noneMatch(Matches.unitIsLand())) {
         continue;
       }
@@ -180,7 +180,7 @@ public class InitializationDelegate extends BaseTripleADelegate {
           change.add(ChangeFactory.changeResourcesChange(player, r, -deleted));
         }
       }
-      final Collection<Unit> heldUnits = player.getUnitCollection().getUnits();
+      final Collection<Unit> heldUnits = player.getUnits();
       if (!heldUnits.isEmpty()) {
         change.add(ChangeFactory.removeUnits(player, heldUnits));
       }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1154,7 +1154,7 @@ public final class Matches {
   }
 
   static Predicate<Unit> unitIsInTerritory(final Territory territory) {
-    return o -> territory.getUnitCollection().getUnits().contains(o);
+    return o -> territory.getUnits().contains(o);
   }
 
   public static Predicate<Territory> isTerritoryEnemy(final PlayerId player, final GameData data) {
@@ -1697,7 +1697,7 @@ public final class Matches {
 
       final Predicate<Unit> unitIsOwnedByAndNotDisabled = isUnitAllied(unit.getOwner(), data).and(unitIsNotDisabled());
       final List<Unit> units =
-          CollectionUtils.getMatches(t.getUnitCollection().getUnits(), unitIsOwnedByAndNotDisabled);
+          CollectionUtils.getMatches(t.getUnits(), unitIsOwnedByAndNotDisabled);
       for (final String[] array : ua.getRequiresUnitsToMove()) {
         boolean haveAll = true;
         for (final UnitType ut : ua.getListedUnits(array)) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -495,7 +495,7 @@ public final class Matches {
   }
 
   static Predicate<Territory> territoryHasOwnedCarrier(final PlayerId player) {
-    return t -> t.getUnits().anyMatch(unitIsOwnedBy(player).and(unitIsCarrier()));
+    return t -> t.getUnitCollection().anyMatch(unitIsOwnedBy(player).and(unitIsCarrier()));
   }
 
   public static Predicate<Unit> unitIsAlliedCarrier(final PlayerId player, final GameData data) {
@@ -774,7 +774,7 @@ public final class Matches {
   }
 
   public static Predicate<Territory> territoryIsEmpty() {
-    return t -> t.getUnits().size() == 0;
+    return t -> t.getUnitCollection().size() == 0;
   }
 
   /**
@@ -841,11 +841,11 @@ public final class Matches {
 
   public static Predicate<Territory> territoryIsOwnedAndHasOwnedUnitMatching(final PlayerId player,
       final Predicate<Unit> unitMatch) {
-    return t -> t.getOwner().equals(player) && t.getUnits().anyMatch(unitIsOwnedBy(player).and(unitMatch));
+    return t -> t.getOwner().equals(player) && t.getUnitCollection().anyMatch(unitIsOwnedBy(player).and(unitMatch));
   }
 
   public static Predicate<Territory> territoryHasOwnedIsFactoryOrCanProduceUnits(final PlayerId player) {
-    return t -> t.getOwner().equals(player) && t.getUnits().anyMatch(unitCanProduceUnits());
+    return t -> t.getOwner().equals(player) && t.getUnitCollection().anyMatch(unitCanProduceUnits());
   }
 
   private static Predicate<Territory> territoryHasOwnedAtBeginningOfTurnIsFactoryOrCanProduceUnits(final GameData data,
@@ -854,7 +854,7 @@ public final class Matches {
       if (!GameStepPropertiesHelper.getCombinedTurns(data, player).contains(t.getOwner())) {
         return false;
       }
-      if (!t.getUnits().anyMatch(unitCanProduceUnits())) {
+      if (!t.getUnitCollection().anyMatch(unitCanProduceUnits())) {
         return false;
       }
       final BattleTracker bt = AbstractMoveDelegate.getBattleTracker(data);
@@ -863,7 +863,7 @@ public final class Matches {
   }
 
   static Predicate<Territory> territoryHasAlliedIsFactoryOrCanProduceUnits(final GameData data, final PlayerId player) {
-    return t -> isTerritoryAllied(player, data).test(t) && t.getUnits().anyMatch(unitCanProduceUnits());
+    return t -> isTerritoryAllied(player, data).test(t) && t.getUnitCollection().anyMatch(unitCanProduceUnits());
   }
 
   public static Predicate<Territory> territoryIsEnemyNonNeutralAndHasEnemyUnitMatching(final GameData data,
@@ -872,12 +872,12 @@ public final class Matches {
       if (!data.getRelationshipTracker().isAtWar(player, t.getOwner())) {
         return false;
       }
-      return !t.getOwner().isNull() && t.getUnits().anyMatch(enemyUnit(player, data).and(unitMatch));
+      return !t.getOwner().isNull() && t.getUnitCollection().anyMatch(enemyUnit(player, data).and(unitMatch));
     };
   }
 
   static Predicate<Territory> territoryIsEmptyOfCombatUnits(final GameData data, final PlayerId player) {
-    return t -> t.getUnits().allMatch(unitIsInfrastructure().or(enemyUnit(player, data).negate()));
+    return t -> t.getUnitCollection().allMatch(unitIsInfrastructure().or(enemyUnit(player, data).negate()));
   }
 
   public static Predicate<Territory> territoryIsNeutralButNotWater() {
@@ -1154,7 +1154,7 @@ public final class Matches {
   }
 
   static Predicate<Unit> unitIsInTerritory(final Territory territory) {
-    return o -> territory.getUnits().getUnits().contains(o);
+    return o -> territory.getUnitCollection().getUnits().contains(o);
   }
 
   public static Predicate<Territory> isTerritoryEnemy(final PlayerId player, final GameData data) {
@@ -1210,7 +1210,7 @@ public final class Matches {
           .orIf(!Properties.getWW2V2(data) && !Properties.getBlitzThroughFactoriesAndAaRestricted(data),
               unitIsInfrastructure())
           .build();
-      return t.getUnits().allMatch(blitzableUnits);
+      return t.getUnitCollection().allMatch(blitzableUnits);
     };
   }
 
@@ -1261,45 +1261,45 @@ public final class Matches {
   }
 
   public static Predicate<Territory> territoryHasLandUnitsOwnedBy(final PlayerId player) {
-    return t -> t.getUnits().anyMatch(unitIsOwnedBy(player).and(unitIsLand()));
+    return t -> t.getUnitCollection().anyMatch(unitIsOwnedBy(player).and(unitIsLand()));
   }
 
   public static Predicate<Territory> territoryHasUnitsOwnedBy(final PlayerId player) {
     final Predicate<Unit> unitOwnedBy = unitIsOwnedBy(player);
-    return t -> t.getUnits().anyMatch(unitOwnedBy);
+    return t -> t.getUnitCollection().anyMatch(unitOwnedBy);
   }
 
   public static Predicate<Territory> territoryHasUnitsThatMatch(final Predicate<Unit> cond) {
-    return t -> t.getUnits().anyMatch(cond);
+    return t -> t.getUnitCollection().anyMatch(cond);
   }
 
   public static Predicate<Territory> territoryHasEnemyAaForFlyOver(final PlayerId player, final GameData data) {
-    return t -> t.getUnits().anyMatch(unitIsEnemyAaForFlyOver(player, data));
+    return t -> t.getUnitCollection().anyMatch(unitIsEnemyAaForFlyOver(player, data));
   }
 
   public static Predicate<Territory> territoryHasNoEnemyUnits(final PlayerId player, final GameData data) {
-    return t -> !t.getUnits().anyMatch(enemyUnit(player, data));
+    return t -> !t.getUnitCollection().anyMatch(enemyUnit(player, data));
   }
 
   public static Predicate<Territory> territoryHasAlliedUnits(final PlayerId player, final GameData data) {
-    return t -> t.getUnits().anyMatch(alliedUnit(player, data));
+    return t -> t.getUnitCollection().anyMatch(alliedUnit(player, data));
   }
 
   static Predicate<Territory> territoryHasNonSubmergedEnemyUnits(final PlayerId player, final GameData data) {
     final Predicate<Unit> match = enemyUnit(player, data).and(unitIsSubmerged().negate());
-    return t -> t.getUnits().anyMatch(match);
+    return t -> t.getUnitCollection().anyMatch(match);
   }
 
   public static Predicate<Territory> territoryHasEnemyLandUnits(final PlayerId player, final GameData data) {
-    return t -> t.getUnits().anyMatch(enemyUnit(player, data).and(unitIsLand()));
+    return t -> t.getUnitCollection().anyMatch(enemyUnit(player, data).and(unitIsLand()));
   }
 
   public static Predicate<Territory> territoryHasEnemySeaUnits(final PlayerId player, final GameData data) {
-    return t -> t.getUnits().anyMatch(enemyUnit(player, data).and(unitIsSea()));
+    return t -> t.getUnitCollection().anyMatch(enemyUnit(player, data).and(unitIsSea()));
   }
 
   public static Predicate<Territory> territoryHasEnemyUnits(final PlayerId player, final GameData data) {
-    return t -> t.getUnits().anyMatch(enemyUnit(player, data));
+    return t -> t.getUnitCollection().anyMatch(enemyUnit(player, data));
   }
 
   static Predicate<Territory> territoryIsNotUnownedWater() {
@@ -1313,7 +1313,7 @@ public final class Matches {
   static Predicate<Territory> territoryHasEnemyUnitsThatCanCaptureItAndIsOwnedByTheirEnemy(
       final PlayerId player, final GameData gameData) {
     return t -> {
-      final List<Unit> enemyUnits = t.getUnits().getMatches(enemyUnit(player, gameData)
+      final List<Unit> enemyUnits = t.getUnitCollection().getMatches(enemyUnit(player, gameData)
           .and(unitIsNotAir())
           .and(unitIsNotInfrastructure()));
       final Collection<PlayerId> enemyPlayers = enemyUnits.stream()
@@ -1499,7 +1499,7 @@ public final class Matches {
       final Predicate<Unit> repairUnit = alliedUnit(player, data)
           .and(unitCanRepairOthers())
           .and(unitCanRepairThisUnit(damagedUnit, territory));
-      if (territory.getUnits().anyMatch(repairUnit)) {
+      if (territory.getUnitCollection().anyMatch(repairUnit)) {
         return true;
       }
       if (unitIsSea().test(damagedUnit)) {
@@ -1510,7 +1510,7 @@ public final class Matches {
               .and(unitCanRepairOthers())
               .and(unitCanRepairThisUnit(damagedUnit, current))
               .and(unitIsLand());
-          if (current.getUnits().anyMatch(repairUnitLand)) {
+          if (current.getUnitCollection().anyMatch(repairUnitLand)) {
             return true;
           }
         }
@@ -1521,7 +1521,7 @@ public final class Matches {
               .and(unitCanRepairOthers())
               .and(unitCanRepairThisUnit(damagedUnit, current))
               .and(unitIsSea());
-          if (current.getUnits().anyMatch(repairUnitSea)) {
+          if (current.getUnitCollection().anyMatch(repairUnitSea)) {
             return true;
           }
         }
@@ -1564,14 +1564,14 @@ public final class Matches {
     return unitWhichWillGetBonus -> {
       final Predicate<Unit> givesBonusUnit = alliedUnit(player, data)
           .and(unitCanGiveBonusMovementToThisUnit(unitWhichWillGetBonus));
-      if (territory.getUnits().anyMatch(givesBonusUnit)) {
+      if (territory.getUnitCollection().anyMatch(givesBonusUnit)) {
         return true;
       }
       if (unitIsSea().test(unitWhichWillGetBonus)) {
         final Predicate<Unit> givesBonusUnitLand = givesBonusUnit.and(unitIsLand());
         final List<Territory> neighbors = new ArrayList<>(data.getMap().getNeighbors(territory, territoryIsLand()));
         for (final Territory current : neighbors) {
-          if (current.getUnits().anyMatch(givesBonusUnitLand)) {
+          if (current.getUnitCollection().anyMatch(givesBonusUnitLand)) {
             return true;
           }
         }
@@ -1696,7 +1696,8 @@ public final class Matches {
       }
 
       final Predicate<Unit> unitIsOwnedByAndNotDisabled = isUnitAllied(unit.getOwner(), data).and(unitIsNotDisabled());
-      final List<Unit> units = CollectionUtils.getMatches(t.getUnits().getUnits(), unitIsOwnedByAndNotDisabled);
+      final List<Unit> units =
+          CollectionUtils.getMatches(t.getUnitCollection().getUnits(), unitIsOwnedByAndNotDisabled);
       for (final String[] array : ua.getRequiresUnitsToMove()) {
         boolean haveAll = true;
         for (final UnitType ut : ua.getListedUnits(array)) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -327,7 +327,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
         continue;
       }
       final Collection<Unit> crippledAlliedCarriers =
-          CollectionUtils.getMatches(t.getUnitCollection().getUnits(), crippledAlliedCarriersMatch);
+          CollectionUtils.getMatches(t.getUnits(), crippledAlliedCarriersMatch);
       if (crippledAlliedCarriers.isEmpty()) {
         continue;
       }
@@ -356,7 +356,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
 
   static Change giveBonusMovementToUnits(final PlayerId player, final GameData data, final Territory t) {
     final CompositeChange change = new CompositeChange();
-    for (final Unit u : t.getUnitCollection().getUnits()) {
+    for (final Unit u : t.getUnits()) {
       if (Matches.unitCanBeGivenBonusMovementByFacilitiesInItsTerritory(t, player, data).test(u)) {
         if (!Matches.isUnitAllied(player, data).test(u)) {
           continue;
@@ -365,20 +365,20 @@ public class MoveDelegate extends AbstractMoveDelegate {
         final Predicate<Unit> givesBonusUnit = Matches.alliedUnit(player, data)
             .and(Matches.unitCanGiveBonusMovementToThisUnit(u));
         final Collection<Unit> givesBonusUnits =
-            new ArrayList<>(CollectionUtils.getMatches(t.getUnitCollection().getUnits(), givesBonusUnit));
+            new ArrayList<>(CollectionUtils.getMatches(t.getUnits(), givesBonusUnit));
         if (Matches.unitIsSea().test(u)) {
           final Predicate<Unit> givesBonusUnitLand = givesBonusUnit.and(Matches.unitIsLand());
           final Set<Territory> neighbors = new HashSet<>(data.getMap().getNeighbors(t, Matches.territoryIsLand()));
           for (final Territory current : neighbors) {
             givesBonusUnits
-                .addAll(CollectionUtils.getMatches(current.getUnitCollection().getUnits(), givesBonusUnitLand));
+                .addAll(CollectionUtils.getMatches(current.getUnits(), givesBonusUnitLand));
           }
         } else if (Matches.unitIsLand().test(u)) {
           final Predicate<Unit> givesBonusUnitSea = givesBonusUnit.and(Matches.unitIsSea());
           final Set<Territory> neighbors = new HashSet<>(data.getMap().getNeighbors(t, Matches.territoryIsWater()));
           for (final Territory current : neighbors) {
             givesBonusUnits
-                .addAll(CollectionUtils.getMatches(current.getUnitCollection().getUnits(), givesBonusUnitSea));
+                .addAll(CollectionUtils.getMatches(current.getUnits(), givesBonusUnitSea));
           }
         }
         for (final Unit bonusGiver : givesBonusUnits) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -169,7 +169,8 @@ public class MovePerformer implements Serializable {
         if (route.anyMatch(mustFightThrough) && arrived.size() != 0) {
           boolean ignoreBattle = false;
           // could it be a bombing raid
-          final Collection<Unit> enemyUnits = route.getEnd().getUnits().getMatches(Matches.enemyUnit(id, data));
+          final Collection<Unit> enemyUnits =
+              route.getEnd().getUnitCollection().getMatches(Matches.enemyUnit(id, data));
           final Collection<Unit> enemyTargetsTotal = CollectionUtils.getMatches(enemyUnits,
               Matches.unitCanBeDamaged().and(Matches.unitIsBeingTransported().negate()));
           final boolean canCreateAirBattle =
@@ -324,7 +325,7 @@ public class MovePerformer implements Serializable {
       }
     }
     if (routeEnd != null && Properties.getSubsCanEndNonCombatMoveWithEnemies(data)
-        && GameStepPropertiesHelper.isNonCombatMove(data, false) && routeEnd.getUnits()
+        && GameStepPropertiesHelper.isNonCombatMove(data, false) && routeEnd.getUnitCollection()
             .anyMatch(Matches.unitIsEnemyOf(data, id).and(Matches.unitIsDestroyer()))) {
       // if we are allowed to have our subs enter any sea zone with enemies during noncombat, we want to make sure we
       // can't keep moving them if there is an enemy destroyer there

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -1119,7 +1119,7 @@ public class MoveValidator {
           && route.getEnd().getUnitCollection().anyMatch(enemyNonSubmerged)
           && nonParatroopersPresent(player, landAndAir) && !onlyIgnoredUnitsOnPath(route, player, data, false)
           && !AbstractMoveDelegate.getBattleTracker(data).didAllThesePlayersJustGoToWarThisTurn(player,
-              route.getEnd().getUnitCollection().getUnits(), data)) {
+              route.getEnd().getUnits(), data)) {
         return result.setErrorReturnResult("Cannot load when enemy sea units are present");
       }
       final Map<Unit, Unit> unitsToTransports = TransportUtils.mapTransports(route, land, transportsToLoad);
@@ -1391,7 +1391,7 @@ public class MoveValidator {
 
   public static Map<Unit, Collection<Unit>> carrierMustMoveWith(final Collection<Unit> units, final Territory start,
       final GameData data, final PlayerId player) {
-    return carrierMustMoveWith(units, start.getUnitCollection().getUnits(), data, player);
+    return carrierMustMoveWith(units, start.getUnits(), data, player);
   }
 
   static Map<Unit, Collection<Unit>> carrierMustMoveWith(final Collection<Unit> units,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -189,7 +189,7 @@ public class MoveValidator {
       }
     }
     // make sure all units are actually in the start territory
-    if (!route.getStart().getUnits().containsAll(units)) {
+    if (!route.getStart().getUnitCollection().containsAll(units)) {
       return result.setErrorReturnResult("Not enough units in starting territory");
     }
     return result;
@@ -416,7 +416,7 @@ public class MoveValidator {
     if (units.stream().anyMatch(Matches.unitWasInCombat())
         && units.stream().anyMatch(Matches.unitWasUnloadedThisTurn())) {
       if (Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(player, data).test(route.getEnd())
-          && !route.getEnd().getUnits().isEmpty()) {
+          && !route.getEnd().getUnitCollection().isEmpty()) {
         return result.setErrorReturnResult("Units cannot participate in multiple battles");
       }
     }
@@ -460,11 +460,11 @@ public class MoveValidator {
         return result.setErrorReturnResult("Cannot move submarines under destroyers");
       }
     }
-    if (end.getUnits().anyMatch(Matches.enemyUnit(player, data))) {
+    if (end.getUnitCollection().anyMatch(Matches.enemyUnit(player, data))) {
       if (!onlyIgnoredUnitsOnPath(route, player, data, false)) {
         final Predicate<Unit> friendlyOrSubmerged =
             Matches.enemyUnit(player, data).negate().or(Matches.unitIsSubmerged());
-        if (!end.getUnits().allMatch(friendlyOrSubmerged)
+        if (!end.getUnitCollection().allMatch(friendlyOrSubmerged)
             && !(!units.isEmpty() && units.stream().allMatch(Matches.unitIsAir()) && end.isWater())) {
           if (units.isEmpty() || !units.stream().allMatch(Matches.unitIsSub())
               || !Properties.getSubsCanEndNonCombatMoveWithEnemies(data)) {
@@ -571,7 +571,7 @@ public class MoveValidator {
       final Map<Unit, Collection<Unit>> newDependents, final MoveValidationResult result) {
     final boolean isEditMode = getEditMode(data);
     // make sure transports in the destination
-    if (route.getEnd() != null && !route.getEnd().getUnits().containsAll(transportsToLoad)
+    if (route.getEnd() != null && !route.getEnd().getUnitCollection().containsAll(transportsToLoad)
         && !units.containsAll(transportsToLoad)) {
       return result.setErrorReturnResult("Transports not found in route end");
     }
@@ -659,7 +659,7 @@ public class MoveValidator {
       for (final Territory t : route.getSteps()) {
         final Collection<Unit> unitsAllowedSoFar = new ArrayList<>();
         if (Matches.isTerritoryEnemyAndNotUnownedWater(player, data).test(t)
-            || t.getUnits().anyMatch(Matches.unitIsEnemyOf(data, player))) {
+            || t.getUnitCollection().anyMatch(Matches.unitIsEnemyOf(data, player))) {
           for (final Unit unit : unitsWithStackingLimits) {
             final UnitType ut = unit.getType();
             int maxAllowed = UnitAttachment.getMaximumNumberOfThisUnitTypeToReachStackingLimit("attackingLimit", ut, t,
@@ -802,7 +802,7 @@ public class MoveValidator {
         Matches.unitIsInfrastructure().or(Matches.enemyUnit(player, data).negate()).or(Matches.unitIsSubmerged());
     // Submerged units do not interfere with movement
     return route.getMiddleSteps().stream()
-        .allMatch(current -> current.getUnits().allMatch(alliedOrNonCombat));
+        .allMatch(current -> current.getUnitCollection().allMatch(alliedOrNonCombat));
   }
 
   /**
@@ -835,15 +835,17 @@ public class MoveValidator {
     boolean validMove = false;
     for (final Territory current : steps) {
       if (current.isWater()) {
-        if (getIgnoreTransportInMovement && getIgnoreSubInMovement && current.getUnits().allMatch(transportOrSubOnly)) {
+        if (getIgnoreTransportInMovement && getIgnoreSubInMovement
+            && current.getUnitCollection().allMatch(transportOrSubOnly)) {
           validMove = true;
           continue;
         }
-        if (getIgnoreTransportInMovement && !getIgnoreSubInMovement && current.getUnits().allMatch(transportOnly)) {
+        if (getIgnoreTransportInMovement && !getIgnoreSubInMovement
+            && current.getUnitCollection().allMatch(transportOnly)) {
           validMove = true;
           continue;
         }
-        if (!getIgnoreTransportInMovement && getIgnoreSubInMovement && current.getUnits().allMatch(subOnly)) {
+        if (!getIgnoreTransportInMovement && getIgnoreSubInMovement && current.getUnitCollection().allMatch(subOnly)) {
           validMove = true;
           continue;
         }
@@ -856,7 +858,7 @@ public class MoveValidator {
   private static boolean enemyDestroyerOnPath(final Route route, final PlayerId player, final GameData data) {
     final Predicate<Unit> enemyDestroyer = Matches.unitIsDestroyer().and(Matches.enemyUnit(player, data));
     return route.getMiddleSteps().stream()
-        .anyMatch(current -> current.getUnits().anyMatch(enemyDestroyer));
+        .anyMatch(current -> current.getUnitCollection().anyMatch(enemyDestroyer));
   }
 
   private static boolean getEditMode(final GameData data) {
@@ -1113,10 +1115,11 @@ public class MoveValidator {
         return result.setErrorReturnResult("Units cannot move before loading onto transports");
       }
       final Predicate<Unit> enemyNonSubmerged = Matches.enemyUnit(player, data).and(Matches.unitIsSubmerged().negate());
-      if (!Properties.getUnitsCanLoadInHostileSeaZones(data) && route.getEnd().getUnits().anyMatch(enemyNonSubmerged)
+      if (!Properties.getUnitsCanLoadInHostileSeaZones(data)
+          && route.getEnd().getUnitCollection().anyMatch(enemyNonSubmerged)
           && nonParatroopersPresent(player, landAndAir) && !onlyIgnoredUnitsOnPath(route, player, data, false)
           && !AbstractMoveDelegate.getBattleTracker(data).didAllThesePlayersJustGoToWarThisTurn(player,
-              route.getEnd().getUnits().getUnits(), data)) {
+              route.getEnd().getUnitCollection().getUnits(), data)) {
         return result.setErrorReturnResult("Cannot load when enemy sea units are present");
       }
       final Map<Unit, Unit> unitsToTransports = TransportUtils.mapTransports(route, land, transportsToLoad);
@@ -1388,7 +1391,7 @@ public class MoveValidator {
 
   public static Map<Unit, Collection<Unit>> carrierMustMoveWith(final Collection<Unit> units, final Territory start,
       final GameData data, final PlayerId player) {
-    return carrierMustMoveWith(units, start.getUnits().getUnits(), data, player);
+    return carrierMustMoveWith(units, start.getUnitCollection().getUnits(), data, player);
   }
 
   static Map<Unit, Collection<Unit>> carrierMustMoveWith(final Collection<Unit> units,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -479,7 +479,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       }
       if (!battleSite.isWater() && TechAttachment.isAirTransportable(attacker)) {
         final Collection<Unit> bombers =
-            CollectionUtils.getMatches(battleSite.getUnitCollection().getUnits(), Matches.unitIsAirTransport());
+            CollectionUtils.getMatches(battleSite.getUnits(), Matches.unitIsAirTransport());
         if (!bombers.isEmpty()) {
           final Collection<Unit> dependents = getDependentUnits(bombers);
           if (!dependents.isEmpty()) {
@@ -772,14 +772,14 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
                 .and(Matches.unitIsNotCombatTransport())
                 .and(Matches.isUnitAllied(attacker, gameData));
             final List<Unit> alliedTransports =
-                CollectionUtils.getMatches(battleSite.getUnitCollection().getUnits(), matchAllied);
+                CollectionUtils.getMatches(battleSite.getUnits(), matchAllied);
             // If no transports, just end the battle
             if (alliedTransports.isEmpty()) {
               endBattle(bridge);
               defenderWins(bridge);
             } else if (round <= 1) {
               attackingUnits =
-                  CollectionUtils.getMatches(battleSite.getUnitCollection().getUnits(),
+                  CollectionUtils.getMatches(battleSite.getUnits(),
                       Matches.unitIsOwnedBy(attacker));
             } else {
               endBattle(bridge);
@@ -1388,7 +1388,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   public List<Unit> getRemainingAttackingUnits() {
     final List<Unit> remaining = new ArrayList<>(attackingUnitsRetreated);
     if (getWhoWon() != WhoWon.DEFENDER) {
-      final Collection<Unit> unitsLeftInTerritory = battleSite.getUnitCollection().getUnits();
+      final Collection<Unit> unitsLeftInTerritory = battleSite.getUnits();
       unitsLeftInTerritory.removeAll(killed);
       remaining.addAll(CollectionUtils.getMatches(unitsLeftInTerritory, Matches.unitOwnedBy(attacker)));
     }
@@ -1399,7 +1399,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   public List<Unit> getRemainingDefendingUnits() {
     final List<Unit> remaining = new ArrayList<>(defendingUnitsRetreated);
     if (getWhoWon() != WhoWon.ATTACKER || attackingUnits.stream().allMatch(Matches.unitIsAir())) {
-      final Collection<Unit> unitsLeftInTerritory = battleSite.getUnitCollection().getUnits();
+      final Collection<Unit> unitsLeftInTerritory = battleSite.getUnits();
       unitsLeftInTerritory.removeAll(killed);
       remaining.addAll(CollectionUtils.getMatches(unitsLeftInTerritory, Matches.enemyUnit(attacker, gameData)));
     }
@@ -1650,7 +1650,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         .and(Matches.isUnitAllied(player, gameData))
         .and(Matches.unitIsSea());
     final List<Unit> alliedTransports =
-        CollectionUtils.getMatches(battleSite.getUnitCollection().getUnits(), matchAllied);
+        CollectionUtils.getMatches(battleSite.getUnits(), matchAllied);
     // If no transports, just return
     if (alliedTransports.isEmpty()) {
       return;
@@ -1660,7 +1660,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         .and(Matches.unitIsNotLand())
         .and(Matches.unitIsSubmerged().negate());
     final Collection<Unit> alliedUnits =
-        CollectionUtils.getMatches(battleSite.getUnitCollection().getUnits(), alliedUnitsMatch);
+        CollectionUtils.getMatches(battleSite.getUnits(), alliedUnitsMatch);
     // If transports are unescorted, check opposing forces to see if the Trns die automatically
     if (alliedTransports.size() == alliedUnits.size()) {
       // Get all the ENEMY sea and air units (that can attack) in the territory
@@ -1668,7 +1668,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
           .and(Matches.unitIsSubmerged().negate())
           .and(Matches.unitCanAttack(player));
       final Collection<Unit> enemyUnits =
-          CollectionUtils.getMatches(battleSite.getUnitCollection().getUnits(), enemyUnitsMatch);
+          CollectionUtils.getMatches(battleSite.getUnits(), enemyUnitsMatch);
       // If there are attackers set their movement to 0 and kill the transports
       if (enemyUnits.size() > 0) {
         final Change change =
@@ -2277,7 +2277,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   private void landParatroops(final IDelegateBridge bridge) {
     if (TechAttachment.isAirTransportable(attacker)) {
       final Collection<Unit> airTransports =
-          CollectionUtils.getMatches(battleSite.getUnitCollection().getUnits(), Matches.unitIsAirTransport());
+          CollectionUtils.getMatches(battleSite.getUnits(), Matches.unitIsAirTransport());
       if (!airTransports.isEmpty()) {
         final Collection<Unit> dependents = getDependentUnits(airTransports);
         if (!dependents.isEmpty()) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -107,7 +107,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   public MustFightBattle(final Territory battleSite, final PlayerId attacker, final GameData data,
       final BattleTracker battleTracker) {
     super(battleSite, attacker, battleTracker, data);
-    defendingUnits.addAll(this.battleSite.getUnits().getMatches(Matches.enemyUnit(attacker, data)));
+    defendingUnits.addAll(this.battleSite.getUnitCollection().getMatches(Matches.enemyUnit(attacker, data)));
     if (battleSite.isWater()) {
       maxRounds = Properties.getSeaBattleRounds(data);
     } else {
@@ -117,7 +117,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
   public void resetDefendingUnits(final PlayerId attacker, final GameData data) {
     defendingUnits.clear();
-    defendingUnits.addAll(battleSite.getUnits().getMatches(Matches.enemyUnit(attacker, data)));
+    defendingUnits.addAll(battleSite.getUnitCollection().getMatches(Matches.enemyUnit(attacker, data)));
   }
 
   /**
@@ -361,7 +361,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (headless) {
       return;
     }
-    final Set<PlayerId> playerSet = battleSite.getUnits().getPlayersWithUnits();
+    final Set<PlayerId> playerSet = battleSite.getUnitCollection().getPlayersWithUnits();
     // find all attacking players (unsorted)
     final Collection<PlayerId> attackers = new ArrayList<>();
     for (final PlayerId current : playerSet) {
@@ -479,7 +479,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       }
       if (!battleSite.isWater() && TechAttachment.isAirTransportable(attacker)) {
         final Collection<Unit> bombers =
-            CollectionUtils.getMatches(battleSite.getUnits().getUnits(), Matches.unitIsAirTransport());
+            CollectionUtils.getMatches(battleSite.getUnitCollection().getUnits(), Matches.unitIsAirTransport());
         if (!bombers.isEmpty()) {
           final Collection<Unit> dependents = getDependentUnits(bombers);
           if (!dependents.isEmpty()) {
@@ -772,14 +772,15 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
                 .and(Matches.unitIsNotCombatTransport())
                 .and(Matches.isUnitAllied(attacker, gameData));
             final List<Unit> alliedTransports =
-                CollectionUtils.getMatches(battleSite.getUnits().getUnits(), matchAllied);
+                CollectionUtils.getMatches(battleSite.getUnitCollection().getUnits(), matchAllied);
             // If no transports, just end the battle
             if (alliedTransports.isEmpty()) {
               endBattle(bridge);
               defenderWins(bridge);
             } else if (round <= 1) {
               attackingUnits =
-                  CollectionUtils.getMatches(battleSite.getUnits().getUnits(), Matches.unitIsOwnedBy(attacker));
+                  CollectionUtils.getMatches(battleSite.getUnitCollection().getUnits(),
+                      Matches.unitIsOwnedBy(attacker));
             } else {
               endBattle(bridge);
               defenderWins(bridge);
@@ -1270,7 +1271,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     Collection<Unit> units = defender ? defendingUnits : attackingUnits;
     if (!defender) {
       units = new HashSet<>(units);
-      units.addAll(battleSite.getUnits().getMatches(Matches.unitIsOwnedBy(attacker)));
+      units.addAll(battleSite.getUnitCollection().getMatches(Matches.unitIsOwnedBy(attacker)));
       units.removeAll(killed);
     }
     if (subs) {
@@ -1387,7 +1388,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   public List<Unit> getRemainingAttackingUnits() {
     final List<Unit> remaining = new ArrayList<>(attackingUnitsRetreated);
     if (getWhoWon() != WhoWon.DEFENDER) {
-      final Collection<Unit> unitsLeftInTerritory = battleSite.getUnits().getUnits();
+      final Collection<Unit> unitsLeftInTerritory = battleSite.getUnitCollection().getUnits();
       unitsLeftInTerritory.removeAll(killed);
       remaining.addAll(CollectionUtils.getMatches(unitsLeftInTerritory, Matches.unitOwnedBy(attacker)));
     }
@@ -1398,7 +1399,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   public List<Unit> getRemainingDefendingUnits() {
     final List<Unit> remaining = new ArrayList<>(defendingUnitsRetreated);
     if (getWhoWon() != WhoWon.ATTACKER || attackingUnits.stream().allMatch(Matches.unitIsAir())) {
-      final Collection<Unit> unitsLeftInTerritory = battleSite.getUnits().getUnits();
+      final Collection<Unit> unitsLeftInTerritory = battleSite.getUnitCollection().getUnits();
       unitsLeftInTerritory.removeAll(killed);
       remaining.addAll(CollectionUtils.getMatches(unitsLeftInTerritory, Matches.enemyUnit(attacker, gameData)));
     }
@@ -1648,7 +1649,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         .and(Matches.unitIsNotCombatTransport())
         .and(Matches.isUnitAllied(player, gameData))
         .and(Matches.unitIsSea());
-    final List<Unit> alliedTransports = CollectionUtils.getMatches(battleSite.getUnits().getUnits(), matchAllied);
+    final List<Unit> alliedTransports =
+        CollectionUtils.getMatches(battleSite.getUnitCollection().getUnits(), matchAllied);
     // If no transports, just return
     if (alliedTransports.isEmpty()) {
       return;
@@ -1658,7 +1660,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         .and(Matches.unitIsNotLand())
         .and(Matches.unitIsSubmerged().negate());
     final Collection<Unit> alliedUnits =
-        CollectionUtils.getMatches(battleSite.getUnits().getUnits(), alliedUnitsMatch);
+        CollectionUtils.getMatches(battleSite.getUnitCollection().getUnits(), alliedUnitsMatch);
     // If transports are unescorted, check opposing forces to see if the Trns die automatically
     if (alliedTransports.size() == alliedUnits.size()) {
       // Get all the ENEMY sea and air units (that can attack) in the territory
@@ -1666,7 +1668,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
           .and(Matches.unitIsSubmerged().negate())
           .and(Matches.unitCanAttack(player));
       final Collection<Unit> enemyUnits =
-          CollectionUtils.getMatches(battleSite.getUnits().getUnits(), enemyUnitsMatch);
+          CollectionUtils.getMatches(battleSite.getUnitCollection().getUnits(), enemyUnitsMatch);
       // If there are attackers set their movement to 0 and kill the transports
       if (enemyUnits.size() > 0) {
         final Change change =
@@ -2275,7 +2277,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   private void landParatroops(final IDelegateBridge bridge) {
     if (TechAttachment.isAirTransportable(attacker)) {
       final Collection<Unit> airTransports =
-          CollectionUtils.getMatches(battleSite.getUnits().getUnits(), Matches.unitIsAirTransport());
+          CollectionUtils.getMatches(battleSite.getUnitCollection().getUnits(), Matches.unitIsAirTransport());
       if (!airTransports.isEmpty()) {
         final Collection<Unit> dependents = getDependentUnits(airTransports);
         if (!dependents.isEmpty()) {
@@ -2406,7 +2408,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     getDisplay(bridge).battleEnd(battleId, defender.getName() + " win");
     if (Properties.getAbandonedTerritoriesMayBeTakenOverImmediately(gameData)) {
       if (CollectionUtils.getMatches(defendingUnits, Matches.unitIsNotInfrastructure()).size() == 0) {
-        final List<Unit> allyOfAttackerUnits = battleSite.getUnits().getMatches(Matches.unitIsNotInfrastructure());
+        final List<Unit> allyOfAttackerUnits =
+            battleSite.getUnitCollection().getMatches(Matches.unitIsNotInfrastructure());
         if (!allyOfAttackerUnits.isEmpty()) {
           final PlayerId abandonedToPlayer = AbstractBattle.findPlayerWithMostUnits(allyOfAttackerUnits);
           bridge.getHistoryWriter().addChildToEvent(
@@ -2551,7 +2554,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
           .and(Matches.unitIsAir())
           .and(Matches.unitCanLandOnCarrier());
       final Collection<Unit> alliedAirInTerr = CollectionUtils.getMatches(
-          Sets.union(Sets.newHashSet(attackingUnits), Sets.newHashSet(battleSite.getUnits())),
+          Sets.union(Sets.newHashSet(attackingUnits), Sets.newHashSet(battleSite.getUnitCollection())),
           alliedFighters);
       for (final Unit fighter : alliedAirInTerr) {
         final TripleAUnit taUnit = (TripleAUnit) fighter;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
@@ -84,7 +84,7 @@ public class NonFightingBattle extends DependentBattle {
 
   boolean hasAttackingUnits() {
     final Predicate<Unit> attackingLand = Matches.alliedUnit(attacker, gameData).and(Matches.unitIsLand());
-    return battleSite.getUnits().anyMatch(attackingLand);
+    return battleSite.getUnitCollection().anyMatch(attackingLand);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -166,12 +166,12 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
           return "May not build any of this unit right now: " + type.getName();
         } else if (maxBuilt > 0) {
           // count how many units are yet to be placed or are in the field
-          int currentlyBuilt = player.getUnits().countMatches(Matches.unitIsOfType(type));
+          int currentlyBuilt = player.getUnitCollection().countMatches(Matches.unitIsOfType(type));
 
           final Predicate<Unit> unitTypeOwnedBy = Matches.unitIsOfType(type).and(Matches.unitIsOwnedBy(player));
           final Collection<Territory> allTerrs = getData().getMap().getTerritories();
           for (final Territory t : allTerrs) {
-            currentlyBuilt += t.getUnits().countMatches(unitTypeOwnedBy);
+            currentlyBuilt += t.getUnitCollection().countMatches(unitTypeOwnedBy);
           }
 
           final int allowedBuild = maxBuilt - currentlyBuilt;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -101,7 +101,7 @@ public class RandomStartDelegate extends BaseTripleADelegate {
         pos += hitRandom[i];
         i++;
         final IntegerMap<UnitType> costs = TuvUtils.getCostsForTuv(currentPickingPlayer, data);
-        final List<Unit> units = new ArrayList<>(currentPickingPlayer.getUnits().getUnits());
+        final List<Unit> units = new ArrayList<>(currentPickingPlayer.getUnitCollection().getUnits());
 
         units.sort(Comparator.comparingInt(unit -> costs.getInt(unit.getType())));
         final Set<Unit> unitsToPlace = new HashSet<>();
@@ -124,13 +124,13 @@ public class RandomStartDelegate extends BaseTripleADelegate {
         while (true) {
           final Tuple<Territory, Set<Unit>> pick = getRemotePlayer(currentPickingPlayer).pickTerritoryAndUnits(
               new ArrayList<>(allPickableTerritories),
-              new ArrayList<>(currentPickingPlayer.getUnits().getUnits()), UNITS_PER_PICK);
+              new ArrayList<>(currentPickingPlayer.getUnitCollection().getUnits()), UNITS_PER_PICK);
           picked = pick.getFirst();
           unitsToPlace = pick.getSecond();
           if (!allPickableTerritories.contains(picked)
-              || !currentPickingPlayer.getUnits().getUnits().containsAll(unitsToPlace)
+              || !currentPickingPlayer.getUnitCollection().getUnits().containsAll(unitsToPlace)
               || unitsToPlace.size() > UNITS_PER_PICK || (unitsToPlace.size() < UNITS_PER_PICK
-                  && unitsToPlace.size() < currentPickingPlayer.getUnits().getUnits().size())) {
+                  && unitsToPlace.size() < currentPickingPlayer.getUnitCollection().getUnits().size())) {
             getRemotePlayer(currentPickingPlayer).reportMessage("Chosen territory or units invalid!",
                 "Chosen territory or units invalid!");
           } else {
@@ -171,13 +171,13 @@ public class RandomStartDelegate extends BaseTripleADelegate {
       while (true) {
         final Tuple<Territory, Set<Unit>> pick = getRemotePlayer(currentPickingPlayer).pickTerritoryAndUnits(
             new ArrayList<>(territoriesToPickFrom),
-            new ArrayList<>(currentPickingPlayer.getUnits().getUnits()), UNITS_PER_PICK);
+            new ArrayList<>(currentPickingPlayer.getUnitCollection().getUnits()), UNITS_PER_PICK);
         picked = pick.getFirst();
         unitsToPlace = pick.getSecond();
         if (!territoriesToPickFrom.contains(picked)
-            || !currentPickingPlayer.getUnits().getUnits().containsAll(unitsToPlace)
+            || !currentPickingPlayer.getUnitCollection().getUnits().containsAll(unitsToPlace)
             || unitsToPlace.size() > UNITS_PER_PICK || (unitsToPlace.size() < UNITS_PER_PICK
-                && unitsToPlace.size() < currentPickingPlayer.getUnits().getUnits().size())) {
+                && unitsToPlace.size() < currentPickingPlayer.getUnitCollection().getUnits().size())) {
           getRemotePlayer(currentPickingPlayer).reportMessage("Chosen territory or units invalid!",
               "Chosen territory or units invalid!");
         } else {
@@ -231,7 +231,7 @@ public class RandomStartDelegate extends BaseTripleADelegate {
   private static Predicate<PlayerId> getPlayerCanPickMatch() {
     return player -> player != null
         && !player.equals(PlayerId.NULL_PLAYERID)
-        && !player.getUnits().isEmpty()
+        && !player.getUnitCollection().isEmpty()
         && !player.getIsDisabled();
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -101,7 +101,7 @@ public class RandomStartDelegate extends BaseTripleADelegate {
         pos += hitRandom[i];
         i++;
         final IntegerMap<UnitType> costs = TuvUtils.getCostsForTuv(currentPickingPlayer, data);
-        final List<Unit> units = new ArrayList<>(currentPickingPlayer.getUnitCollection().getUnits());
+        final List<Unit> units = new ArrayList<>(currentPickingPlayer.getUnits());
 
         units.sort(Comparator.comparingInt(unit -> costs.getInt(unit.getType())));
         final Set<Unit> unitsToPlace = new HashSet<>();
@@ -124,13 +124,13 @@ public class RandomStartDelegate extends BaseTripleADelegate {
         while (true) {
           final Tuple<Territory, Set<Unit>> pick = getRemotePlayer(currentPickingPlayer).pickTerritoryAndUnits(
               new ArrayList<>(allPickableTerritories),
-              new ArrayList<>(currentPickingPlayer.getUnitCollection().getUnits()), UNITS_PER_PICK);
+              new ArrayList<>(currentPickingPlayer.getUnits()), UNITS_PER_PICK);
           picked = pick.getFirst();
           unitsToPlace = pick.getSecond();
           if (!allPickableTerritories.contains(picked)
-              || !currentPickingPlayer.getUnitCollection().getUnits().containsAll(unitsToPlace)
+              || !currentPickingPlayer.getUnits().containsAll(unitsToPlace)
               || unitsToPlace.size() > UNITS_PER_PICK || (unitsToPlace.size() < UNITS_PER_PICK
-                  && unitsToPlace.size() < currentPickingPlayer.getUnitCollection().getUnits().size())) {
+                  && unitsToPlace.size() < currentPickingPlayer.getUnits().size())) {
             getRemotePlayer(currentPickingPlayer).reportMessage("Chosen territory or units invalid!",
                 "Chosen territory or units invalid!");
           } else {
@@ -171,13 +171,13 @@ public class RandomStartDelegate extends BaseTripleADelegate {
       while (true) {
         final Tuple<Territory, Set<Unit>> pick = getRemotePlayer(currentPickingPlayer).pickTerritoryAndUnits(
             new ArrayList<>(territoriesToPickFrom),
-            new ArrayList<>(currentPickingPlayer.getUnitCollection().getUnits()), UNITS_PER_PICK);
+            new ArrayList<>(currentPickingPlayer.getUnits()), UNITS_PER_PICK);
         picked = pick.getFirst();
         unitsToPlace = pick.getSecond();
         if (!territoriesToPickFrom.contains(picked)
-            || !currentPickingPlayer.getUnitCollection().getUnits().containsAll(unitsToPlace)
+            || !currentPickingPlayer.getUnits().containsAll(unitsToPlace)
             || unitsToPlace.size() > UNITS_PER_PICK || (unitsToPlace.size() < UNITS_PER_PICK
-                && unitsToPlace.size() < currentPickingPlayer.getUnitCollection().getUnits().size())) {
+                && unitsToPlace.size() < currentPickingPlayer.getUnits().size())) {
           getRemotePlayer(currentPickingPlayer).reportMessage("Chosen territory or units invalid!",
               "Chosen territory or units invalid!");
         } else {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -156,7 +156,7 @@ public class RocketsFireHelper implements Serializable {
         Unit unitTarget = null;
         if (isDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
           final Collection<Unit> rocketTargets = new ArrayList<>(
-              CollectionUtils.getMatches(attackFrom.getUnitCollection().getUnits(), rocketMatch(player)));
+              CollectionUtils.getMatches(attackFrom.getUnits(), rocketMatch(player)));
           final HashSet<UnitType> legalTargetsForTheseRockets = new HashSet<>();
           // a hack for now, we let the rockets fire at anyone who could be targetted by any rocket
           // Not sure if that comment is still current
@@ -286,7 +286,7 @@ public class RocketsFireHelper implements Serializable {
       numberOfAttacks = 1;
     } else {
       rockets =
-          new ArrayList<>(CollectionUtils.getMatches(attackFrom.getUnitCollection().getUnits(), rocketMatch(player)));
+          new ArrayList<>(CollectionUtils.getMatches(attackFrom.getUnits(), rocketMatch(player)));
       numberOfAttacks = Math.min(TechAbilityAttachment.getRocketNumberPerTerritory(player, data),
           TechAbilityAttachment.getRocketDiceNumber(rockets, data));
     }
@@ -458,7 +458,7 @@ public class RocketsFireHelper implements Serializable {
         final Change change = ChangeFactory.markNoMovementChange(Collections.singleton(rockets.iterator().next()));
         bridge.addChange(change);
       } else {
-        throw new IllegalStateException("No rockets?" + attackFrom.getUnitCollection().getUnits());
+        throw new IllegalStateException("No rockets?" + attackFrom.getUnits());
       }
     }
     // kill any units that can die if they have reached max damage (veqryn)

--- a/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -149,14 +149,14 @@ public class RocketsFireHelper implements Serializable {
         if (targetTerritory == null) {
           break;
         }
-        final Collection<Unit> enemyUnits = CollectionUtils.getMatches(targetTerritory.getUnits(),
+        final Collection<Unit> enemyUnits = CollectionUtils.getMatches(targetTerritory.getUnitCollection(),
             Matches.enemyUnit(player, data).and(Matches.unitIsBeingTransported().negate()));
         final Collection<Unit> enemyTargetsTotal = CollectionUtils.getMatches(
             enemyUnits, Matches.unitIsAtMaxDamageOrNotCanBeDamaged(targetTerritory).negate());
         Unit unitTarget = null;
         if (isDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
           final Collection<Unit> rocketTargets = new ArrayList<>(
-              CollectionUtils.getMatches(attackFrom.getUnits().getUnits(), rocketMatch(player)));
+              CollectionUtils.getMatches(attackFrom.getUnitCollection().getUnits(), rocketMatch(player)));
           final HashSet<UnitType> legalTargetsForTheseRockets = new HashSet<>();
           // a hack for now, we let the rockets fire at anyone who could be targetted by any rocket
           // Not sure if that comment is still current
@@ -222,7 +222,7 @@ public class RocketsFireHelper implements Serializable {
       if (tracker.wasConquered(current)) {
         continue;
       }
-      if (current.getUnits().anyMatch(ownedRockets)) {
+      if (current.getUnitCollection().anyMatch(ownedRockets)) {
         territories.add(current);
       }
     }
@@ -252,7 +252,7 @@ public class RocketsFireHelper implements Serializable {
     for (final Territory current : possible) {
       final Route route = data.getMap().getRoute(territory, current, allowed);
       if (route != null && route.numberOfSteps() <= maxDistance) {
-        if (current.getUnits().anyMatch(attackableUnits
+        if (current.getUnitCollection().anyMatch(attackableUnits
             .and(Matches.unitIsAtMaxDamageOrNotCanBeDamaged(current).negate()))) {
           hasFactory.add(current);
         }
@@ -274,7 +274,7 @@ public class RocketsFireHelper implements Serializable {
     final Resource pus = data.getResourceList().getResource(Constants.PUS);
     final boolean damageFromBombingDoneToUnits = isDamageFromBombingDoneToUnitsInsteadOfTerritories(data);
     // unit damage vs territory damage
-    final Collection<Unit> enemyUnits = attackedTerritory.getUnits().getMatches(
+    final Collection<Unit> enemyUnits = attackedTerritory.getUnitCollection().getMatches(
         Matches.enemyUnit(player, data).and(Matches.unitIsBeingTransported().negate()));
     final Collection<Unit> enemyTargetsTotal =
         CollectionUtils.getMatches(enemyUnits, Matches.unitIsAtMaxDamageOrNotCanBeDamaged(attackedTerritory).negate());
@@ -285,7 +285,8 @@ public class RocketsFireHelper implements Serializable {
       rockets = new ArrayList<>();
       numberOfAttacks = 1;
     } else {
-      rockets = new ArrayList<>(CollectionUtils.getMatches(attackFrom.getUnits().getUnits(), rocketMatch(player)));
+      rockets =
+          new ArrayList<>(CollectionUtils.getMatches(attackFrom.getUnitCollection().getUnits(), rocketMatch(player)));
       numberOfAttacks = Math.min(TechAbilityAttachment.getRocketNumberPerTerritory(player, data),
           TechAbilityAttachment.getRocketDiceNumber(rockets, data));
     }
@@ -457,7 +458,7 @@ public class RocketsFireHelper implements Serializable {
         final Change change = ChangeFactory.markNoMovementChange(Collections.singleton(rockets.iterator().next()));
         bridge.addChange(change);
       } else {
-        throw new IllegalStateException("No rockets?" + attackFrom.getUnits().getUnits());
+        throw new IllegalStateException("No rockets?" + attackFrom.getUnitCollection().getUnits());
       }
     }
     // kill any units that can die if they have reached max damage (veqryn)

--- a/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -137,7 +137,8 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
     }
     currentMove.addChange(airborneChange);
     // make the bases start filling up their capacity
-    final Collection<Unit> basesAtStart = route.getStart().getUnits().getMatches(getAirborneBaseMatch(player, data));
+    final Collection<Unit> basesAtStart =
+        route.getStart().getUnitCollection().getMatches(getAirborneBaseMatch(player, data));
     final Change fillLaunchCapacity = getNewAssignmentOfNumberLaunchedChange(units.size(), basesAtStart, player, data);
     currentMove.addChange(fillLaunchCapacity);
     // start event
@@ -197,7 +198,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
     final Predicate<Unit> airborneBaseMatch = getAirborneMatch(airborneBases, alliesForBases);
     final Territory start = route.getStart();
     final Territory end = route.getEnd();
-    final Collection<Unit> basesAtStart = start.getUnits().getMatches(airborneBaseMatch);
+    final Collection<Unit> basesAtStart = start.getUnitCollection().getMatches(airborneBaseMatch);
     if (basesAtStart.isEmpty()) {
       return result.setErrorReturnResult("Require Airborne Base At Originating Territory");
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -74,9 +74,9 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     }
     // we were having a problem with units that had been killed previously were still part of battle's variables, so we
     // double check that the stuff still exists here.
-    defendingUnits.retainAll(battleSite.getUnits().getUnits());
-    attackingUnits.retainAll(battleSite.getUnits().getUnits());
-    targets.keySet().removeIf(unit -> !battleSite.getUnits().getUnits().contains(unit));
+    defendingUnits.retainAll(battleSite.getUnitCollection().getUnits());
+    attackingUnits.retainAll(battleSite.getUnitCollection().getUnits());
+    targets.keySet().removeIf(unit -> !battleSite.getUnitCollection().getUnits().contains(unit));
   }
 
   protected void updateDefendingUnits() {
@@ -88,11 +88,13 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
             .or(Matches.unitIsAaThatCanFire(attackingUnits, airborneTechTargetsAllowed, attacker,
                 Matches.unitIsAaForBombingThisUnitOnly(), round, true, gameData)));
     if (targets.isEmpty()) {
-      defendingUnits = CollectionUtils.getMatches(battleSite.getUnits().getUnits(), defenders);
+      defendingUnits = CollectionUtils.getMatches(battleSite.getUnitCollection().getUnits(), defenders);
     } else {
       final List<Unit> targets =
-          CollectionUtils.getMatches(battleSite.getUnits().getUnits(), Matches.unitIsAaThatCanFire(attackingUnits,
-              airborneTechTargetsAllowed, attacker, Matches.unitIsAaForBombingThisUnitOnly(), round, true, gameData));
+          CollectionUtils.getMatches(battleSite.getUnitCollection().getUnits(),
+              Matches.unitIsAaThatCanFire(attackingUnits,
+                  airborneTechTargetsAllowed, attacker, Matches.unitIsAaForBombingThisUnitOnly(), round, true,
+                  gameData));
       targets.addAll(this.targets.keySet());
       defendingUnits = targets;
     }
@@ -167,7 +169,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     // TODO: determine if the target has the property, not just any unit with the property isAAforBombingThisUnitOnly
     final Map<String, Set<UnitType>> airborneTechTargetsAllowed =
         TechAbilityAttachment.getAirborneTargettedByAa(attacker, gameData);
-    defendingAa = battleSite.getUnits().getMatches(Matches.unitIsAaThatCanFire(attackingUnits,
+    defendingAa = battleSite.getUnitCollection().getMatches(Matches.unitIsAaThatCanFire(attackingUnits,
         airborneTechTargetsAllowed, attacker, Matches.unitIsAaForBombingThisUnitOnly(), round, true, gameData));
     aaTypes = UnitAttachment.getAllOfTypeAas(defendingAa);
     // reverse since stacks are in reverse order

--- a/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -74,9 +74,9 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     }
     // we were having a problem with units that had been killed previously were still part of battle's variables, so we
     // double check that the stuff still exists here.
-    defendingUnits.retainAll(battleSite.getUnitCollection().getUnits());
-    attackingUnits.retainAll(battleSite.getUnitCollection().getUnits());
-    targets.keySet().removeIf(unit -> !battleSite.getUnitCollection().getUnits().contains(unit));
+    defendingUnits.retainAll(battleSite.getUnits());
+    attackingUnits.retainAll(battleSite.getUnits());
+    targets.keySet().removeIf(unit -> !battleSite.getUnits().contains(unit));
   }
 
   protected void updateDefendingUnits() {
@@ -88,10 +88,10 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
             .or(Matches.unitIsAaThatCanFire(attackingUnits, airborneTechTargetsAllowed, attacker,
                 Matches.unitIsAaForBombingThisUnitOnly(), round, true, gameData)));
     if (targets.isEmpty()) {
-      defendingUnits = CollectionUtils.getMatches(battleSite.getUnitCollection().getUnits(), defenders);
+      defendingUnits = CollectionUtils.getMatches(battleSite.getUnits(), defenders);
     } else {
       final List<Unit> targets =
-          CollectionUtils.getMatches(battleSite.getUnitCollection().getUnits(),
+          CollectionUtils.getMatches(battleSite.getUnits(),
               Matches.unitIsAaThatCanFire(attackingUnits,
                   airborneTechTargetsAllowed, attacker, Matches.unitIsAaForBombingThisUnitOnly(), round, true,
                   gameData));

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
@@ -120,7 +120,7 @@ public class UndoableMove extends AbstractUndoableMove {
           Unit target = null;
           if (routeUnitUsedToMove != null && routeUnitUsedToMove.getEnd() != null) {
             final Territory end = routeUnitUsedToMove.getEnd();
-            final Collection<Unit> enemyTargetsTotal = end.getUnits().getMatches(
+            final Collection<Unit> enemyTargetsTotal = end.getUnitCollection().getMatches(
                 Matches.enemyUnit(bridge.getPlayerId(), data)
                     .and(Matches.unitCanBeDamaged())
                     .and(Matches.unitIsBeingTransported().negate()));

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UnitsThatCantFightUtil.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UnitsThatCantFightUtil.java
@@ -29,13 +29,13 @@ public class UnitsThatCantFightUtil {
           .andIf(current.isWater(), Matches.unitIsLand().negate())
           .and(Matches.unitIsOwnedBy(player))
           .build();
-      final int countAllOwnedUnits = current.getUnits().countMatches(ownedUnitsMatch);
+      final int countAllOwnedUnits = current.getUnitCollection().countMatches(ownedUnitsMatch);
       final Collection<Unit> nonCombatUnits =
-          current.getUnits().getMatches(ownedUnitsMatch.and(Matches.unitCanAttack(player).negate()));
+          current.getUnitCollection().getMatches(ownedUnitsMatch.and(Matches.unitCanAttack(player).negate()));
       if (nonCombatUnits.isEmpty() || nonCombatUnits.size() != countAllOwnedUnits) {
         continue;
       }
-      if (current.getUnits().anyMatch(enemyAttackUnits)) {
+      if (current.getUnitCollection().anyMatch(enemyAttackUnits)) {
         cantFight.add(current);
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculator.java
@@ -94,7 +94,7 @@ class OddsCalculator implements IOddsCalculator, Callable<AggregateResults> {
     defendingUnits = GameDataUtils.translateIntoOtherGameData(defending, gameData);
     bombardingUnits = GameDataUtils.translateIntoOtherGameData(bombarding, gameData);
     this.territoryEffects = GameDataUtils.translateIntoOtherGameData(territoryEffects, gameData);
-    gameData.performChange(ChangeFactory.removeUnits(this.location, this.location.getUnits().getUnits()));
+    gameData.performChange(ChangeFactory.removeUnits(this.location, this.location.getUnitCollection().getUnits()));
     gameData.performChange(ChangeFactory.addUnits(this.location, attackingUnits));
     gameData.performChange(ChangeFactory.addUnits(this.location, defendingUnits));
     this.runCount = runCount;

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculator.java
@@ -94,7 +94,7 @@ class OddsCalculator implements IOddsCalculator, Callable<AggregateResults> {
     defendingUnits = GameDataUtils.translateIntoOtherGameData(defending, gameData);
     bombardingUnits = GameDataUtils.translateIntoOtherGameData(bombarding, gameData);
     this.territoryEffects = GameDataUtils.translateIntoOtherGameData(territoryEffects, gameData);
-    gameData.performChange(ChangeFactory.removeUnits(this.location, this.location.getUnitCollection().getUnits()));
+    gameData.performChange(ChangeFactory.removeUnits(this.location, this.location.getUnits()));
     gameData.performChange(ChangeFactory.addUnits(this.location, attackingUnits));
     gameData.performChange(ChangeFactory.addUnits(this.location, defendingUnits));
     this.runCount = runCount;

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorDialog.java
@@ -92,7 +92,7 @@ public class OddsCalculatorDialog extends JDialog {
       return;
     }
     final OddsCalculatorPanel currentPanel = instances.get(instances.size() - 1).panel;
-    currentPanel.addAttackingUnits(t.getUnits().getMatches(Matches.unitIsOwnedBy(currentPanel.getAttacker())));
+    currentPanel.addAttackingUnits(t.getUnitCollection().getMatches(Matches.unitIsOwnedBy(currentPanel.getAttacker())));
   }
 
   public static void addDefenders(final Territory t) {
@@ -101,7 +101,8 @@ public class OddsCalculatorDialog extends JDialog {
     }
     final OddsCalculatorDialog currentDialog = instances.get(instances.size() - 1);
     currentDialog.panel
-        .addDefendingUnits(t.getUnits().getMatches(Matches.alliedUnit(currentDialog.panel.getDefender(), t.getData())));
+        .addDefendingUnits(
+            t.getUnitCollection().getMatches(Matches.alliedUnit(currentDialog.panel.getDefender(), t.getData())));
     currentDialog.pack();
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
@@ -445,7 +445,7 @@ class OddsCalculatorPanel extends JPanel {
         }
 
         // Get players with units sorted
-        final List<PlayerId> players = location.getUnits().getPlayersByUnitCount();
+        final List<PlayerId> players = location.getUnitCollection().getPlayersByUnitCount();
         if (players.contains(currentPlayer)) {
           players.remove(currentPlayer);
           players.add(0, currentPlayer);
@@ -478,8 +478,8 @@ class OddsCalculatorPanel extends JPanel {
           }
         }
 
-        setAttackingUnits(location.getUnits().getMatches(Matches.unitIsOwnedBy(getAttacker())));
-        setDefendingUnits(location.getUnits().getMatches(Matches.alliedUnit(getDefender(), data)));
+        setAttackingUnits(location.getUnitCollection().getMatches(Matches.unitIsOwnedBy(getAttacker())));
+        setDefendingUnits(location.getUnitCollection().getMatches(Matches.alliedUnit(getDefender(), data)));
       } finally {
         data.releaseReadLock();
       }
@@ -784,7 +784,7 @@ class OddsCalculatorPanel extends JPanel {
 
   private static boolean doesPlayerHaveUnitsOnMap(final PlayerId player, final GameData data) {
     for (final Territory t : data.getMap()) {
-      for (final Unit u : t.getUnits()) {
+      for (final Unit u : t.getUnitCollection()) {
         if (u.getOwner().equals(player)) {
           return true;
         }

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/PlayerUnitsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/PlayerUnitsPanel.java
@@ -204,7 +204,7 @@ public class PlayerUnitsPanel extends JPanel {
       }
     }
     for (final Territory t : data.getMap()) {
-      for (final Unit u : t.getUnits()) {
+      for (final Unit u : t.getUnitCollection()) {
         if (u.getOwner().equals(player)) {
           unitTypes.add(u.getType());
         }

--- a/game-core/src/main/java/games/strategy/triplea/printgenerator/CountryChart.java
+++ b/game-core/src/main/java/games/strategy/triplea/printgenerator/CountryChart.java
@@ -35,7 +35,7 @@ class CountryChart {
     Iterator<UnitType> availableUnits = gameData.getUnitTypeList().iterator();
     while (terrIterator.hasNext()) {
       final Territory currentTerritory = terrIterator.next();
-      final UnitCollection unitsHere = currentTerritory.getUnits();
+      final UnitCollection unitsHere = currentTerritory.getUnitCollection();
       final List<Map<UnitType, Integer>> unitPairs = new ArrayList<>();
       while (availableUnits.hasNext()) {
         final UnitType currentUnit = availableUnits.next();

--- a/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -155,7 +155,7 @@ class EditPanel extends ActionPanel {
     private void selectUnitsToRemove(final List<Unit> units, final Territory t, final MouseDetails md) {
       if (units.isEmpty() && selectedUnits.isEmpty()) {
         if (!md.isShiftDown()) {
-          final Collection<Unit> unitsToMove = t.getUnitCollection().getUnits();
+          final Collection<Unit> unitsToMove = t.getUnits();
           if (unitsToMove.isEmpty()) {
             return;
           }
@@ -181,7 +181,7 @@ class EditPanel extends ActionPanel {
       }
       // select all
       if (md.isShiftDown()) {
-        selectedUnits.addAll(t.getUnitCollection().getUnits());
+        selectedUnits.addAll(t.getUnits());
       } else if (md.isControlDown()) {
         selectedUnits.addAll(units);
       } else { // select one
@@ -349,7 +349,7 @@ class EditPanel extends ActionPanel {
       public void actionPerformed(final ActionEvent event) {
         currentAction = this;
         setWidgetActivation();
-        final List<Unit> allUnits = new ArrayList<>(selectedTerritory.getUnitCollection().getUnits());
+        final List<Unit> allUnits = new ArrayList<>(selectedTerritory.getUnits());
         sortUnitsToRemove(allUnits);
         final MustMoveWithDetails mustMoveWithDetails;
         try {
@@ -566,7 +566,7 @@ class EditPanel extends ActionPanel {
         currentAction = this;
         setWidgetActivation();
         final List<Unit> units = CollectionUtils.getMatches(selectedUnits, Matches.unitHasMoreThanOneHitPointTotal());
-        if (units == null || units.isEmpty() || !selectedTerritory.getUnitCollection().getUnits().containsAll(units)) {
+        if (units == null || units.isEmpty() || !selectedTerritory.getUnits().containsAll(units)) {
           cancelEditAction.actionPerformed(null);
           return;
         }
@@ -614,7 +614,7 @@ class EditPanel extends ActionPanel {
         currentAction = this;
         setWidgetActivation();
         final List<Unit> units = CollectionUtils.getMatches(selectedUnits, Matches.unitCanBeDamaged());
-        if (units == null || units.isEmpty() || !selectedTerritory.getUnitCollection().getUnits().containsAll(units)) {
+        if (units == null || units.isEmpty() || !selectedTerritory.getUnits().containsAll(units)) {
           cancelEditAction.actionPerformed(null);
           return;
         }

--- a/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -155,7 +155,7 @@ class EditPanel extends ActionPanel {
     private void selectUnitsToRemove(final List<Unit> units, final Territory t, final MouseDetails md) {
       if (units.isEmpty() && selectedUnits.isEmpty()) {
         if (!md.isShiftDown()) {
-          final Collection<Unit> unitsToMove = t.getUnits().getUnits();
+          final Collection<Unit> unitsToMove = t.getUnitCollection().getUnits();
           if (unitsToMove.isEmpty()) {
             return;
           }
@@ -181,7 +181,7 @@ class EditPanel extends ActionPanel {
       }
       // select all
       if (md.isShiftDown()) {
-        selectedUnits.addAll(t.getUnits().getUnits());
+        selectedUnits.addAll(t.getUnitCollection().getUnits());
       } else if (md.isControlDown()) {
         selectedUnits.addAll(units);
       } else { // select one
@@ -349,7 +349,7 @@ class EditPanel extends ActionPanel {
       public void actionPerformed(final ActionEvent event) {
         currentAction = this;
         setWidgetActivation();
-        final List<Unit> allUnits = new ArrayList<>(selectedTerritory.getUnits().getUnits());
+        final List<Unit> allUnits = new ArrayList<>(selectedTerritory.getUnitCollection().getUnits());
         sortUnitsToRemove(allUnits);
         final MustMoveWithDetails mustMoveWithDetails;
         try {
@@ -566,7 +566,7 @@ class EditPanel extends ActionPanel {
         currentAction = this;
         setWidgetActivation();
         final List<Unit> units = CollectionUtils.getMatches(selectedUnits, Matches.unitHasMoreThanOneHitPointTotal());
-        if (units == null || units.isEmpty() || !selectedTerritory.getUnits().getUnits().containsAll(units)) {
+        if (units == null || units.isEmpty() || !selectedTerritory.getUnitCollection().getUnits().containsAll(units)) {
           cancelEditAction.actionPerformed(null);
           return;
         }
@@ -614,7 +614,7 @@ class EditPanel extends ActionPanel {
         currentAction = this;
         setWidgetActivation();
         final List<Unit> units = CollectionUtils.getMatches(selectedUnits, Matches.unitCanBeDamaged());
-        if (units == null || units.isEmpty() || !selectedTerritory.getUnits().getUnits().containsAll(units)) {
+        if (units == null || units.isEmpty() || !selectedTerritory.getUnitCollection().getUnits().containsAll(units)) {
           cancelEditAction.actionPerformed(null);
           return;
         }
@@ -836,7 +836,7 @@ class EditPanel extends ActionPanel {
 
   private static boolean doesPlayerHaveUnitsOnMap(final PlayerId player, final GameData data) {
     for (final Territory t : data.getMap()) {
-      for (final Unit u : t.getUnits()) {
+      for (final Unit u : t.getUnitCollection()) {
         if (u.getOwner().equals(player)) {
           return true;
         }

--- a/game-core/src/main/java/games/strategy/triplea/ui/EditProductionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EditProductionPanel.java
@@ -62,7 +62,7 @@ class EditProductionPanel extends ProductionPanel {
       // This is because the null player does not have a production frontier, and we also do not know what units we have
       // art for, so only use the units on a map.
       for (final Territory t : data.getMap()) {
-        for (final Unit u : t.getUnits()) {
+        for (final Unit u : t.getUnitCollection()) {
           if (u.getOwner().equals(player)) {
             final UnitType ut = u.getType();
             if (!unitsAllowed.contains(ut)) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
@@ -217,7 +217,7 @@ public class ExtendedStats extends StatPanel {
       int matchCount = 0;
       final Predicate<Unit> ownedBy = Matches.unitIsOwnedBy(player).and(Matches.unitIsOfType(ut));
       for (final Territory place : data.getMap().getTerritories()) {
-        matchCount += place.getUnits().countMatches(ownedBy);
+        matchCount += place.getUnitCollection().countMatches(ownedBy);
       }
       return matchCount;
     }

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -199,7 +199,7 @@ public class MovePanel extends AbstractMovePanel {
         } else {
           ownedNotFactoryBuilder
               .and(unitsToMoveMatch)
-              .and(Matches.unitIsOwnedBy(getUnitOwner(t.getUnitCollection().getUnits())));
+              .and(Matches.unitIsOwnedBy(getUnitOwner(t.getUnits())));
         }
         selectedUnits.addAll(t.getUnitCollection().getMatches(ownedNotFactoryBuilder.build()));
       } else if (me.isControlDown()) {
@@ -237,7 +237,7 @@ public class MovePanel extends AbstractMovePanel {
               .and(Matches.unitIsOwnedBy(player))
               .and(Matches.unitHasNotMoved());
           final Collection<Unit> unitsToLoad =
-              CollectionUtils.getMatches(route.getStart().getUnitCollection().getUnits(), unitsToLoadMatch);
+              CollectionUtils.getMatches(route.getStart().getUnits(), unitsToLoadMatch);
           unitsToLoad.removeAll(selectedUnits);
           for (final Collection<Unit> units2 : dependentUnits.values()) {
             unitsToLoad.removeAll(units2);
@@ -346,7 +346,7 @@ public class MovePanel extends AbstractMovePanel {
           }
           dependentUnits.put(airTransport, unitsColl);
           mustMoveWithDetails = MoveValidator.getMustMoveWith(route.getStart(),
-              route.getStart().getUnitCollection().getUnits(), dependentUnits, getData(), player);
+              route.getStart().getUnits(), dependentUnits, getData(), player);
         }
       }
       return loadedUnits;
@@ -665,7 +665,7 @@ public class MovePanel extends AbstractMovePanel {
    * in the case where some transports have different movement, different units etc
    */
   private Collection<Unit> getUnitsToUnload(final Route route, final Collection<Unit> unitsToUnload) {
-    final Collection<Unit> allUnits = getFirstSelectedTerritory().getUnitCollection().getUnits();
+    final Collection<Unit> allUnits = getFirstSelectedTerritory().getUnits();
     final List<Unit> candidateUnits = CollectionUtils.getMatches(allUnits, getUnloadableMatch(route, unitsToUnload));
     if (unitsToUnload.size() == candidateUnits.size()) {
       return unitsToUnload;
@@ -1049,7 +1049,7 @@ public class MovePanel extends AbstractMovePanel {
     if (unitsToLoad.stream().anyMatch(Matches.unitIsAir())) {
       return Collections.emptyList();
     }
-    final Collection<Unit> endOwnedUnits = route.getEnd().getUnitCollection().getUnits();
+    final Collection<Unit> endOwnedUnits = route.getEnd().getUnits();
     final PlayerId unitOwner = getUnitOwner(unitsToLoad);
     final MustMoveWithDetails endMustMoveWith =
         MoveValidator.getMustMoveWith(route.getEnd(), endOwnedUnits, dependentUnits, getData(), unitOwner);
@@ -1283,7 +1283,7 @@ public class MovePanel extends AbstractMovePanel {
       mustMoveWithDetails = null;
     } else {
       mustMoveWithDetails = MoveValidator.getMustMoveWith(firstSelectedTerritory,
-          firstSelectedTerritory.getUnitCollection().getUnits(), dependentUnits, getData(), getCurrentPlayer());
+          firstSelectedTerritory.getUnits(), dependentUnits, getData(), getCurrentPlayer());
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -149,7 +149,7 @@ public class MovePanel extends AbstractMovePanel {
       };
       if (units.isEmpty() && selectedUnits.isEmpty()) {
         if (!me.isShiftDown()) {
-          final List<Unit> unitsToMove = t.getUnits().getMatches(unitsToMoveMatch);
+          final List<Unit> unitsToMove = t.getUnitCollection().getMatches(unitsToMoveMatch);
           if (unitsToMove.isEmpty()) {
             return;
           }
@@ -199,9 +199,9 @@ public class MovePanel extends AbstractMovePanel {
         } else {
           ownedNotFactoryBuilder
               .and(unitsToMoveMatch)
-              .and(Matches.unitIsOwnedBy(getUnitOwner(t.getUnits().getUnits())));
+              .and(Matches.unitIsOwnedBy(getUnitOwner(t.getUnitCollection().getUnits())));
         }
-        selectedUnits.addAll(t.getUnits().getMatches(ownedNotFactoryBuilder.build()));
+        selectedUnits.addAll(t.getUnitCollection().getMatches(ownedNotFactoryBuilder.build()));
       } else if (me.isControlDown()) {
         selectedUnits.addAll(CollectionUtils.getMatches(units, unitsToMoveMatch));
       } else { // add one
@@ -237,7 +237,7 @@ public class MovePanel extends AbstractMovePanel {
               .and(Matches.unitIsOwnedBy(player))
               .and(Matches.unitHasNotMoved());
           final Collection<Unit> unitsToLoad =
-              CollectionUtils.getMatches(route.getStart().getUnits().getUnits(), unitsToLoadMatch);
+              CollectionUtils.getMatches(route.getStart().getUnitCollection().getUnits(), unitsToLoadMatch);
           unitsToLoad.removeAll(selectedUnits);
           for (final Collection<Unit> units2 : dependentUnits.values()) {
             unitsToLoad.removeAll(units2);
@@ -248,7 +248,8 @@ public class MovePanel extends AbstractMovePanel {
               .and(Matches.unitHasNotMoved())
               .and(Matches.transportIsNotTransporting());
           final Collection<Unit> candidateAirTransports =
-              CollectionUtils.getMatches(t.getUnits().getMatches(unitsToMoveMatch), candidateAirTransportsMatch);
+              CollectionUtils.getMatches(t.getUnitCollection().getMatches(unitsToMoveMatch),
+                  candidateAirTransportsMatch);
           // candidateAirTransports.removeAll(selectedUnits);
           candidateAirTransports.removeAll(dependentUnits.keySet());
           if (unitsToLoad.size() > 0 && candidateAirTransports.size() > 0) {
@@ -345,7 +346,7 @@ public class MovePanel extends AbstractMovePanel {
           }
           dependentUnits.put(airTransport, unitsColl);
           mustMoveWithDetails = MoveValidator.getMustMoveWith(route.getStart(),
-              route.getStart().getUnits().getUnits(), dependentUnits, getData(), player);
+              route.getStart().getUnitCollection().getUnits(), dependentUnits, getData(), player);
         }
       }
       return loadedUnits;
@@ -664,7 +665,7 @@ public class MovePanel extends AbstractMovePanel {
    * in the case where some transports have different movement, different units etc
    */
   private Collection<Unit> getUnitsToUnload(final Route route, final Collection<Unit> unitsToUnload) {
-    final Collection<Unit> allUnits = getFirstSelectedTerritory().getUnits().getUnits();
+    final Collection<Unit> allUnits = getFirstSelectedTerritory().getUnitCollection().getUnits();
     final List<Unit> candidateUnits = CollectionUtils.getMatches(allUnits, getUnloadableMatch(route, unitsToUnload));
     if (unitsToUnload.size() == candidateUnits.size()) {
       return unitsToUnload;
@@ -937,7 +938,7 @@ public class MovePanel extends AbstractMovePanel {
     // TODO kev check for already loaded airTransports
     Collection<Unit> transportsToLoad = Collections.emptyList();
     if (MoveValidator.isLoad(units, dependentUnits, route, getData(), getCurrentPlayer())) {
-      transportsToLoad = route.getEnd().getUnits().getMatches(
+      transportsToLoad = route.getEnd().getUnitCollection().getMatches(
           Matches.unitIsTransport().and(Matches.alliedUnit(getCurrentPlayer(), getData())));
     }
     List<Unit> best = new ArrayList<>(units);
@@ -1048,7 +1049,7 @@ public class MovePanel extends AbstractMovePanel {
     if (unitsToLoad.stream().anyMatch(Matches.unitIsAir())) {
       return Collections.emptyList();
     }
-    final Collection<Unit> endOwnedUnits = route.getEnd().getUnits().getUnits();
+    final Collection<Unit> endOwnedUnits = route.getEnd().getUnitCollection().getUnits();
     final PlayerId unitOwner = getUnitOwner(unitsToLoad);
     final MustMoveWithDetails endMustMoveWith =
         MoveValidator.getMustMoveWith(route.getEnd(), endOwnedUnits, dependentUnits, getData(), unitOwner);
@@ -1196,7 +1197,8 @@ public class MovePanel extends AbstractMovePanel {
       final Route route,
       final boolean initialMustQueryUser,
       final Predicate<Collection<Unit>> matchCriteria) {
-    final List<Unit> candidateUnits = getFirstSelectedTerritory().getUnits().getMatches(getMovableMatch(route, units));
+    final List<Unit> candidateUnits =
+        getFirstSelectedTerritory().getUnitCollection().getMatches(getMovableMatch(route, units));
     boolean mustQueryUser = initialMustQueryUser;
     if (!mustQueryUser) {
       final Set<UnitCategory> categories =
@@ -1281,7 +1283,7 @@ public class MovePanel extends AbstractMovePanel {
       mustMoveWithDetails = null;
     } else {
       mustMoveWithDetails = MoveValidator.getMustMoveWith(firstSelectedTerritory,
-          firstSelectedTerritory.getUnits().getUnits(), dependentUnits, getData(), getCurrentPlayer());
+          firstSelectedTerritory.getUnitCollection().getUnits(), dependentUnits, getData(), getCurrentPlayer());
     }
   }
 
@@ -1443,7 +1445,7 @@ public class MovePanel extends AbstractMovePanel {
     int i = 0;
     while (i < size) {
       final Territory t = allTerritories.get(newFocusedIndex);
-      final List<Unit> matchedUnits = t.getUnits().getMatches(moveableUnitOwnedByMe);
+      final List<Unit> matchedUnits = t.getUnitCollection().getMatches(moveableUnitOwnedByMe);
       if (matchedUnits.size() > 0) {
         newFocusedTerritory = t;
         final Map<Territory, List<Unit>> highlight = new HashMap<>();
@@ -1481,7 +1483,7 @@ public class MovePanel extends AbstractMovePanel {
         .build();
     final Map<Territory, List<Unit>> highlight = new HashMap<>();
     for (final Territory t : allTerritories) {
-      final List<Unit> moveableUnits = t.getUnits().getMatches(moveableUnitOwnedByMe);
+      final List<Unit> moveableUnits = t.getUnitCollection().getMatches(moveableUnitOwnedByMe);
       if (!moveableUnits.isEmpty()) {
         highlight.put(t, moveableUnits);
       }

--- a/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -129,7 +129,7 @@ class PlacePanel extends AbstractMovePanel {
         }
       }
       // get the units that can be placed on this territory.
-      Collection<Unit> units = getCurrentPlayer().getUnitCollection().getUnits();
+      Collection<Unit> units = getCurrentPlayer().getUnits();
       if (territory.isWater()) {
         if (!(canProduceFightersOnCarriers() || canProduceNewFightersOnOldCarriers()
             || isLhtrCarrierProductionRules() || GameStepPropertiesHelper.isBid(getData()))) {
@@ -160,7 +160,7 @@ class PlacePanel extends AbstractMovePanel {
 
   private void updateUnits() {
     final Collection<UnitCategory> unitCategories =
-        UnitSeparator.categorize(getCurrentPlayer().getUnitCollection().getUnits());
+        UnitSeparator.categorize(getCurrentPlayer().getUnits());
     unitsToPlace.setUnitsFromCategories(unitCategories);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -121,7 +121,7 @@ class PlacePanel extends AbstractMovePanel {
         if (GameStepPropertiesHelper.isBid(getData())) {
           final PlayerAttachment pa = PlayerAttachment.get(territory.getOwner());
           if ((pa == null || pa.getGiveUnitControl() == null || !pa.getGiveUnitControl().contains(getCurrentPlayer()))
-              && !territory.getUnits().anyMatch(Matches.unitIsOwnedBy(getCurrentPlayer()))) {
+              && !territory.getUnitCollection().anyMatch(Matches.unitIsOwnedBy(getCurrentPlayer()))) {
             return Collections.emptyList();
           }
         } else {
@@ -129,7 +129,7 @@ class PlacePanel extends AbstractMovePanel {
         }
       }
       // get the units that can be placed on this territory.
-      Collection<Unit> units = getCurrentPlayer().getUnits().getUnits();
+      Collection<Unit> units = getCurrentPlayer().getUnitCollection().getUnits();
       if (territory.isWater()) {
         if (!(canProduceFightersOnCarriers() || canProduceNewFightersOnOldCarriers()
             || isLhtrCarrierProductionRules() || GameStepPropertiesHelper.isBid(getData()))) {
@@ -159,7 +159,8 @@ class PlacePanel extends AbstractMovePanel {
   }
 
   private void updateUnits() {
-    final Collection<UnitCategory> unitCategories = UnitSeparator.categorize(getCurrentPlayer().getUnits().getUnits());
+    final Collection<UnitCategory> unitCategories =
+        UnitSeparator.categorize(getCurrentPlayer().getUnitCollection().getUnits());
     unitsToPlace.setUnitsFromCategories(unitCategories);
   }
 
@@ -192,7 +193,7 @@ class PlacePanel extends AbstractMovePanel {
 
   @Override
   protected boolean doneMoveAction() {
-    if (getCurrentPlayer().getUnits().size() > 0) {
+    if (getCurrentPlayer().getUnitCollection().size() > 0) {
       final int option = JOptionPane.showConfirmDialog(getTopLevelAncestor(),
           "You have not placed all your units yet.  Are you sure you want to end your turn?", "TripleA",
           JOptionPane.YES_NO_OPTION, JOptionPane.PLAIN_MESSAGE);

--- a/game-core/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
@@ -127,7 +127,7 @@ class ProductionRepairPanel extends JPanel {
           .getMatches(data.getMap().getTerritories(), Matches.territoryHasUnitsThatMatch(myDamagedUnits));
       for (final RepairRule repairRule : player.getRepairFrontier()) {
         for (final Territory terr : terrsWithPotentiallyDamagedUnits) {
-          for (final Unit unit : CollectionUtils.getMatches(terr.getUnits().getUnits(), myDamagedUnits)) {
+          for (final Unit unit : CollectionUtils.getMatches(terr.getUnitCollection().getUnits(), myDamagedUnits)) {
             if (!repairRule.getResults().keySet().iterator().next().equals(unit.getType())) {
               continue;
             }

--- a/game-core/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
@@ -127,7 +127,7 @@ class ProductionRepairPanel extends JPanel {
           .getMatches(data.getMap().getTerritories(), Matches.territoryHasUnitsThatMatch(myDamagedUnits));
       for (final RepairRule repairRule : player.getRepairFrontier()) {
         for (final Territory terr : terrsWithPotentiallyDamagedUnits) {
-          for (final Unit unit : CollectionUtils.getMatches(terr.getUnitCollection().getUnits(), myDamagedUnits)) {
+          for (final Unit unit : CollectionUtils.getMatches(terr.getUnits(), myDamagedUnits)) {
             if (!repairRule.getResults().keySet().iterator().next().equals(unit.getType())) {
               continue;
             }

--- a/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
@@ -92,7 +92,7 @@ public class PurchasePanel extends ActionPanel {
         for (final Territory t : CollectionUtils.getMatches(getData().getMap().getTerritories(),
             Matches.territoryHasOwnedIsFactoryOrCanProduceUnits(getCurrentPlayer()))) {
           totalProd +=
-              TripleAUnit.getProductionPotentialOfTerritory(t.getUnitCollection().getUnits(), t, getCurrentPlayer(),
+              TripleAUnit.getProductionPotentialOfTerritory(t.getUnits(), t, getCurrentPlayer(),
                   getData(), true, true);
         }
       } finally {
@@ -111,7 +111,7 @@ public class PurchasePanel extends ActionPanel {
       }
       final PlayerId player = getCurrentPlayer();
       final Collection<Unit> unitsNeedingFactory =
-          CollectionUtils.getMatches(player.getUnitCollection().getUnits(), Matches.unitIsNotConstruction());
+          CollectionUtils.getMatches(player.getUnits(), Matches.unitIsNotConstruction());
       if (!bid && totalProduced + unitsNeedingFactory.size() > totalProd && !isUnlimitedProduction(player)) {
         final String text = "You have purchased " + (totalProduced + unitsNeedingFactory.size())
             + " units, and can only place " + totalProd + " of them. Continue with purchase?";
@@ -161,7 +161,7 @@ public class PurchasePanel extends ActionPanel {
       getData().acquireReadLock();
       try {
         purchasedPreviousRoundsUnits
-            .setUnitsFromCategories(UnitSeparator.categorize(id.getUnitCollection().getUnits()));
+            .setUnitsFromCategories(UnitSeparator.categorize(id.getUnits()));
         add(Box.createVerticalStrut(4));
         if (!id.getUnitCollection().isEmpty()) {
           add(purchasedPreviousRoundsLabel);

--- a/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
@@ -91,8 +91,9 @@ public class PurchasePanel extends ActionPanel {
       try {
         for (final Territory t : CollectionUtils.getMatches(getData().getMap().getTerritories(),
             Matches.territoryHasOwnedIsFactoryOrCanProduceUnits(getCurrentPlayer()))) {
-          totalProd += TripleAUnit.getProductionPotentialOfTerritory(t.getUnits().getUnits(), t, getCurrentPlayer(),
-              getData(), true, true);
+          totalProd +=
+              TripleAUnit.getProductionPotentialOfTerritory(t.getUnitCollection().getUnits(), t, getCurrentPlayer(),
+                  getData(), true, true);
         }
       } finally {
         getData().releaseReadLock();
@@ -110,7 +111,7 @@ public class PurchasePanel extends ActionPanel {
       }
       final PlayerId player = getCurrentPlayer();
       final Collection<Unit> unitsNeedingFactory =
-          CollectionUtils.getMatches(player.getUnits().getUnits(), Matches.unitIsNotConstruction());
+          CollectionUtils.getMatches(player.getUnitCollection().getUnits(), Matches.unitIsNotConstruction());
       if (!bid && totalProduced + unitsNeedingFactory.size() > totalProd && !isUnlimitedProduction(player)) {
         final String text = "You have purchased " + (totalProduced + unitsNeedingFactory.size())
             + " units, and can only place " + totalProd + " of them. Continue with purchase?";
@@ -159,9 +160,10 @@ public class PurchasePanel extends ActionPanel {
 
       getData().acquireReadLock();
       try {
-        purchasedPreviousRoundsUnits.setUnitsFromCategories(UnitSeparator.categorize(id.getUnits().getUnits()));
+        purchasedPreviousRoundsUnits
+            .setUnitsFromCategories(UnitSeparator.categorize(id.getUnitCollection().getUnits()));
         add(Box.createVerticalStrut(4));
-        if (!id.getUnits().isEmpty()) {
+        if (!id.getUnitCollection().isEmpty()) {
           add(purchasedPreviousRoundsLabel);
         }
         add(purchasedPreviousRoundsUnits);

--- a/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -440,7 +440,7 @@ class StatPanel extends AbstractStatPanel {
       final Predicate<Unit> ownedBy = Matches.unitIsOwnedBy(player);
       // sum the total match count
       return data.getMap().getTerritories().stream()
-          .map(Territory::getUnits)
+          .map(Territory::getUnitCollection)
           .mapToInt(units -> units.countMatches(ownedBy))
           .sum();
     }
@@ -457,7 +457,7 @@ class StatPanel extends AbstractStatPanel {
       final IntegerMap<UnitType> costs = TuvUtils.getCostsForTuv(player, data);
       final Predicate<Unit> unitIsOwnedBy = Matches.unitIsOwnedBy(player);
       return data.getMap().getTerritories().stream()
-          .map(Territory::getUnits)
+          .map(Territory::getUnitCollection)
           .map(units -> units.getMatches(unitIsOwnedBy))
           .mapToInt(owned -> TuvUtils.getTuv(owned, costs))
           .sum();

--- a/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -95,7 +95,7 @@ class TerritoryDetailPanel extends AbstractStatPanel {
       labelText = "<html>" + ta.toStringForInfo(true, true) + "<br></html>";
     }
     add(new JLabel(labelText));
-    add(new JLabel("Units: " + territory.getUnits().getUnits().stream()
+    add(new JLabel("Units: " + territory.getUnitCollection().getUnits().stream()
         .filter(u -> uiContext.getMapData().shouldDrawUnit(u.getType().getName())).count()));
     final JScrollPane scroll = new JScrollPane(unitsInTerritoryPanel(territory, uiContext));
     scroll.setBorder(BorderFactory.createEmptyBorder());

--- a/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -95,7 +95,7 @@ class TerritoryDetailPanel extends AbstractStatPanel {
       labelText = "<html>" + ta.toStringForInfo(true, true) + "<br></html>";
     }
     add(new JLabel(labelText));
-    add(new JLabel("Units: " + territory.getUnitCollection().getUnits().stream()
+    add(new JLabel("Units: " + territory.getUnits().stream()
         .filter(u -> uiContext.getMapData().shouldDrawUnit(u.getType().getName())).count()));
     final JScrollPane scroll = new JScrollPane(unitsInTerritoryPanel(territory, uiContext));
     scroll.setBorder(BorderFactory.createEmptyBorder());

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -936,7 +936,7 @@ public final class TripleAFrame extends JFrame {
     final boolean lhtrProd = AirThatCantLandUtil.isLhtrCarrierProduction(data)
         || AirThatCantLandUtil.isLandExistingFightersOnNewCarriers(data);
     final int carrierCount = GameStepPropertiesHelper.getCombinedTurns(data, id).stream()
-        .map(PlayerId::getUnits)
+        .map(PlayerId::getUnitCollection)
         .map(units -> units.getMatches(Matches.unitIsCarrier()))
         .mapToInt(List::size)
         .sum();

--- a/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
@@ -470,7 +470,7 @@ public class HistoryLog extends JFrame {
     // print all units in all territories, including "flags"
     logWriter.println("Territory Summary for " + MyFormatter.defaultNamedToTextList(players) + " : \n");
     for (final Territory t : territories) {
-      final List<Unit> ownedUnits = t.getUnits().getMatches(Matches.unitIsOwnedByOfAnyOfThesePlayers(players));
+      final List<Unit> ownedUnits = t.getUnitCollection().getMatches(Matches.unitIsOwnedByOfAnyOfThesePlayers(players));
       // see if there's a flag
       final TerritoryAttachment ta = TerritoryAttachment.get(t);
       final boolean hasFlag = ta != null

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -244,7 +244,7 @@ public class UnitsDrawer implements IDrawable {
         .and(bombingUnitDamage > 0
             ? Matches.unitHasTakenSomeBombingUnitDamage()
             : Matches.unitHasNotTakenAnyBombingUnitDamage());
-    return Tuple.of(t, t.getUnits().getMatches(selectedUnits));
+    return Tuple.of(t, t.getUnitCollection().getMatches(selectedUnits));
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/BattleDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/BattleDrawable.java
@@ -31,7 +31,7 @@ public class BattleDrawable extends TerritoryDrawable implements IDrawable {
   public void draw(final Rectangle bounds, final GameData data, final Graphics2D graphics, final MapData mapData,
       final AffineTransform unscaled, final AffineTransform scaled) {
     final Set<PlayerId> players = new HashSet<>();
-    for (final Unit u : data.getMap().getTerritory(territoryName).getUnits()) {
+    for (final Unit u : data.getMap().getTerritory(territoryName).getUnitCollection()) {
       if (!TripleAUnit.get(u).getSubmerged()) {
         players.add(u.getOwner());
       }

--- a/game-core/src/main/java/games/strategy/triplea/util/TransportUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/TransportUtils.java
@@ -39,7 +39,7 @@ public final class TransportUtils {
       return mapTransportsToLoad(units, transportsToLoad);
     }
     if (route.isUnload()) {
-      return mapTransportsAlreadyLoaded(units, route.getStart().getUnits().getUnits());
+      return mapTransportsAlreadyLoaded(units, route.getStart().getUnitCollection().getUnits());
     }
     return mapTransportsAlreadyLoaded(units, units);
   }

--- a/game-core/src/main/java/games/strategy/triplea/util/TransportUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/TransportUtils.java
@@ -39,7 +39,7 @@ public final class TransportUtils {
       return mapTransportsToLoad(units, transportsToLoad);
     }
     if (route.isUnload()) {
-      return mapTransportsAlreadyLoaded(units, route.getStart().getUnitCollection().getUnits());
+      return mapTransportsAlreadyLoaded(units, route.getStart().getUnits());
     }
     return mapTransportsAlreadyLoaded(units, units);
   }

--- a/game-core/src/main/java/games/strategy/triplea/util/UnitSeparator.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/UnitSeparator.java
@@ -35,7 +35,7 @@ public class UnitSeparator {
    */
   public static List<UnitCategory> getSortedUnitCategories(final Territory t, final MapData mapData) {
     final GameData data = t.getData();
-    final List<UnitCategory> categories = new ArrayList<>(UnitSeparator.categorize(t.getUnits().getUnits()));
+    final List<UnitCategory> categories = new ArrayList<>(UnitSeparator.categorize(t.getUnitCollection().getUnits()));
     categories.removeIf(uc -> !mapData.shouldDrawUnit(uc.getType().getName()));
     final List<UnitType> xmlUnitTypes = new ArrayList<>(data.getUnitTypeList().getAllUnitTypes());
     categories.sort(Comparator

--- a/game-core/src/main/java/games/strategy/triplea/util/UnitSeparator.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/UnitSeparator.java
@@ -35,7 +35,7 @@ public class UnitSeparator {
    */
   public static List<UnitCategory> getSortedUnitCategories(final Territory t, final MapData mapData) {
     final GameData data = t.getData();
-    final List<UnitCategory> categories = new ArrayList<>(UnitSeparator.categorize(t.getUnitCollection().getUnits()));
+    final List<UnitCategory> categories = new ArrayList<>(UnitSeparator.categorize(t.getUnits()));
     categories.removeIf(uc -> !mapData.shouldDrawUnit(uc.getType().getName()));
     final List<UnitType> xmlUnitTypes = new ArrayList<>(data.getUnitTypeList().getAllUnitTypes());
     categories.sort(Comparator

--- a/game-core/src/test/java/games/strategy/engine/data/ChangeTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/ChangeTest.java
@@ -47,115 +47,115 @@ public class ChangeTest {
   public void testUnitsAddTerritory() {
     // make sure we know where we are starting
     final Territory can = gameData.getMap().getTerritory("canada");
-    assertEquals(5, can.getUnits().getUnitCount());
+    assertEquals(5, can.getUnitCollection().getUnitCount());
     // add some units
     final Change change =
         ChangeFactory.addUnits(can, gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF).create(10, null));
     gameData.performChange(change);
-    assertEquals(15, can.getUnits().getUnitCount());
+    assertEquals(15, can.getUnitCollection().getUnitCount());
     // invert the change
     gameData.performChange(change.invert());
-    assertEquals(5, can.getUnits().getUnitCount());
+    assertEquals(5, can.getUnitCollection().getUnitCount());
   }
 
   @Test
   public void testUnitsRemoveTerritory() {
     // make sure we now where we are starting
     final Territory can = gameData.getMap().getTerritory("canada");
-    assertEquals(5, can.getUnits().getUnitCount());
+    assertEquals(5, can.getUnitCollection().getUnitCount());
     // remove some units
     final Collection<Unit> units =
-        can.getUnits().getUnits(gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF), 3);
+        can.getUnitCollection().getUnits(gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF), 3);
     final Change change = ChangeFactory.removeUnits(can, units);
     gameData.performChange(change);
 
-    assertEquals(2, can.getUnits().getUnitCount());
+    assertEquals(2, can.getUnitCollection().getUnitCount());
     gameData.performChange(change.invert());
-    assertEquals(5, can.getUnits().getUnitCount(), "last change inverted, should have gained units.");
+    assertEquals(5, can.getUnitCollection().getUnitCount(), "last change inverted, should have gained units.");
   }
 
   @Test
   public void testSerializeUnitsRemoteTerritory() throws Exception {
     // make sure we now where we are starting
     final Territory can = gameData.getMap().getTerritory("canada");
-    assertEquals(5, can.getUnits().getUnitCount());
+    assertEquals(5, can.getUnitCollection().getUnitCount());
     // remove some units
     final Collection<Unit> units =
-        can.getUnits().getUnits(gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF), 3);
+        can.getUnitCollection().getUnits(gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF), 3);
     Change change = ChangeFactory.removeUnits(can, units);
     change = serialize(change);
     gameData.performChange(change);
-    assertEquals(2, can.getUnits().getUnitCount());
+    assertEquals(2, can.getUnitCollection().getUnitCount());
     // invert the change
     gameData.performChange(change.invert());
-    assertEquals(5, can.getUnits().getUnitCount());
+    assertEquals(5, can.getUnitCollection().getUnitCount());
   }
 
   @Test
   public void testUnitsAddPlayer() {
     // make sure we know where we are starting
     final PlayerId chretian = gameData.getPlayerList().getPlayerId("chretian");
-    assertEquals(10, chretian.getUnits().getUnitCount());
+    assertEquals(10, chretian.getUnitCollection().getUnitCount());
     // add some units
     final Change change =
         ChangeFactory.addUnits(chretian,
             gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF).create(10, null));
     gameData.performChange(change);
-    assertEquals(20, chretian.getUnits().getUnitCount());
+    assertEquals(20, chretian.getUnitCollection().getUnitCount());
     // invert the change
     gameData.performChange(change.invert());
-    assertEquals(10, chretian.getUnits().getUnitCount());
+    assertEquals(10, chretian.getUnitCollection().getUnitCount());
   }
 
   @Test
   public void testUnitsRemovePlayer() {
     // make sure we know where we are starting
     final PlayerId chretian = gameData.getPlayerList().getPlayerId("chretian");
-    assertEquals(10, chretian.getUnits().getUnitCount());
+    assertEquals(10, chretian.getUnitCollection().getUnitCount());
     // remove some units
     final Collection<Unit> units =
-        chretian.getUnits().getUnits(gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF), 3);
+        chretian.getUnitCollection().getUnits(gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF), 3);
     final Change change = ChangeFactory.removeUnits(chretian, units);
     gameData.performChange(change);
-    assertEquals(7, chretian.getUnits().getUnitCount());
+    assertEquals(7, chretian.getUnitCollection().getUnitCount());
     // invert the change
     gameData.performChange(change.invert());
-    assertEquals(10, chretian.getUnits().getUnitCount());
+    assertEquals(10, chretian.getUnitCollection().getUnitCount());
   }
 
   @Test
   public void testUnitsMove() {
     final Territory canada = gameData.getMap().getTerritory("canada");
     final Territory greenland = gameData.getMap().getTerritory("greenland");
-    assertEquals(5, canada.getUnits().getUnitCount());
-    assertEquals(0, greenland.getUnits().getUnitCount());
+    assertEquals(5, canada.getUnitCollection().getUnitCount());
+    assertEquals(0, greenland.getUnitCollection().getUnitCount());
     final Collection<Unit> units =
-        canada.getUnits().getUnits(gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF), 3);
+        canada.getUnitCollection().getUnits(gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF), 3);
     final Change change = ChangeFactory.moveUnits(canada, greenland, units);
     gameData.performChange(change);
-    assertEquals(2, canada.getUnits().getUnitCount());
-    assertEquals(3, greenland.getUnits().getUnitCount());
+    assertEquals(2, canada.getUnitCollection().getUnitCount());
+    assertEquals(3, greenland.getUnitCollection().getUnitCount());
     gameData.performChange(change.invert());
-    assertEquals(5, canada.getUnits().getUnitCount());
-    assertEquals(0, greenland.getUnits().getUnitCount());
+    assertEquals(5, canada.getUnitCollection().getUnitCount());
+    assertEquals(0, greenland.getUnitCollection().getUnitCount());
   }
 
   @Test
   public void testUnitsMoveSerialization() throws Exception {
     final Territory canada = gameData.getMap().getTerritory("canada");
     final Territory greenland = gameData.getMap().getTerritory("greenland");
-    assertEquals(5, canada.getUnits().getUnitCount());
-    assertEquals(0, greenland.getUnits().getUnitCount());
+    assertEquals(5, canada.getUnitCollection().getUnitCount());
+    assertEquals(0, greenland.getUnitCollection().getUnitCount());
     final Collection<Unit> units =
-        canada.getUnits().getUnits(gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF), 3);
+        canada.getUnitCollection().getUnits(gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INF), 3);
     Change change = ChangeFactory.moveUnits(canada, greenland, units);
     change = serialize(change);
     gameData.performChange(change);
-    assertEquals(2, canada.getUnits().getUnitCount());
-    assertEquals(3, greenland.getUnits().getUnitCount());
+    assertEquals(2, canada.getUnitCollection().getUnitCount());
+    assertEquals(3, greenland.getUnitCollection().getUnitCount());
     gameData.performChange(change.invert());
-    assertEquals(5, canada.getUnits().getUnitCount());
-    assertEquals(0, greenland.getUnits().getUnitCount());
+    assertEquals(5, canada.getUnitCollection().getUnitCount());
+    assertEquals(0, greenland.getUnitCollection().getUnitCount());
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/engine/data/ChangeTripleATest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/ChangeTripleATest.java
@@ -24,7 +24,7 @@ public class ChangeTripleATest {
   public void setUp() throws Exception {
     gameData = TestMapGameData.BIG_WORLD_1942.getGameData();
     can = gameData.getMap().getTerritory("Western Canada");
-    assertEquals(2, can.getUnits().getUnitCount());
+    assertEquals(2, can.getUnitCollection().getUnitCount());
   }
 
   private Change serialize(final Change change) throws Exception {
@@ -48,34 +48,34 @@ public class ChangeTripleATest {
     final Change change =
         ChangeFactory.addUnits(can, GameDataTestUtil.infantry(gameData).create(10, null));
     gameData.performChange(change);
-    assertEquals(12, can.getUnits().getUnitCount());
+    assertEquals(12, can.getUnitCollection().getUnitCount());
     // invert the change
     gameData.performChange(change.invert());
-    assertEquals(2, can.getUnits().getUnitCount());
+    assertEquals(2, can.getUnitCollection().getUnitCount());
   }
 
   @Test
   public void testUnitsRemoveTerritory() {
     // remove some units
-    final Collection<Unit> units = can.getUnits().getUnits(GameDataTestUtil.infantry(gameData), 1);
+    final Collection<Unit> units = can.getUnitCollection().getUnits(GameDataTestUtil.infantry(gameData), 1);
     final Change change = ChangeFactory.removeUnits(can, units);
     gameData.performChange(change);
-    assertEquals(1, can.getUnits().getUnitCount());
+    assertEquals(1, can.getUnitCollection().getUnitCount());
     // invert the change
     gameData.performChange(change.invert());
-    assertEquals(2, can.getUnits().getUnitCount());
+    assertEquals(2, can.getUnitCollection().getUnitCount());
   }
 
   @Test
   public void testSerializeUnitsRemoteTerritory() throws Exception {
     // remove some units
-    final Collection<Unit> units = can.getUnits().getUnits(GameDataTestUtil.infantry(gameData), 1);
+    final Collection<Unit> units = can.getUnitCollection().getUnits(GameDataTestUtil.infantry(gameData), 1);
     Change change = ChangeFactory.removeUnits(can, units);
     change = serialize(change);
     gameData.performChange(change);
-    assertEquals(1, can.getUnits().getUnitCount());
+    assertEquals(1, can.getUnitCollection().getUnitCount());
     // invert the change
     gameData.performChange(change.invert());
-    assertEquals(2, can.getUnits().getUnitCount());
+    assertEquals(2, can.getUnitCollection().getUnitCount());
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/xml/ParserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/xml/ParserTest.java
@@ -143,13 +143,13 @@ public class ParserTest {
   @Test
   public void testUnitsHeldInitialized() {
     final PlayerId bush = gameData.getPlayerList().getPlayerId("bush");
-    assertEquals(20, bush.getUnits().getUnitCount());
+    assertEquals(20, bush.getUnitCollection().getUnitCount());
   }
 
   @Test
   public void testUnitsPlacedInitialized() {
     final Territory terr = gameData.getMap().getTerritory("canada");
-    assertEquals(5, terr.getUnits().getUnitCount());
+    assertEquals(5, terr.getUnitCollection().getUnitCount());
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/triplea/ai/AiUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ai/AiUtilsTest.java
@@ -36,7 +36,7 @@ public class AiUtilsTest {
   @Test
   public void testSortByCost() {
     final Territory germany = gameData.getMap().getTerritory("Germany");
-    final List<Unit> sorted = new ArrayList<>(germany.getUnitCollection().getUnits());
+    final List<Unit> sorted = new ArrayList<>(germany.getUnits());
     Collections.sort(sorted, AiUtils.getCostComparator());
     assertEquals(Constants.UNIT_TYPE_INFANTRY, sorted.get(0).getType().getName());
   }

--- a/game-core/src/test/java/games/strategy/triplea/ai/AiUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ai/AiUtilsTest.java
@@ -36,7 +36,7 @@ public class AiUtilsTest {
   @Test
   public void testSortByCost() {
     final Territory germany = gameData.getMap().getTerritory("Germany");
-    final List<Unit> sorted = new ArrayList<>(germany.getUnits().getUnits());
+    final List<Unit> sorted = new ArrayList<>(germany.getUnitCollection().getUnits());
     Collections.sort(sorted, AiUtils.getCostComparator());
     assertEquals(Constants.UNIT_TYPE_INFANTRY, sorted.get(0).getType().getName());
   }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
@@ -72,7 +72,7 @@ public class AirThatCantLandUtilTest {
     assertEquals(balkans, cantLand.iterator().next());
     airThatCantLandUtil.removeAirThatCantLand(player, false);
     // jsut the original german fighter
-    assertEquals(1, balkans.getUnits().getMatches(Matches.unitIsAir()).size());
+    assertEquals(1, balkans.getUnitCollection().getMatches(Matches.unitIsAir()).size());
   }
 
   @Test
@@ -87,7 +87,7 @@ public class AirThatCantLandUtilTest {
     assertEquals(1, cantLand.size());
     assertEquals(sz55, cantLand.iterator().next());
     airThatCantLandUtil.removeAirThatCantLand(player, false);
-    assertEquals(0, sz55.getUnits().getMatches(Matches.unitIsAir()).size());
+    assertEquals(0, sz55.getUnitCollection().getMatches(Matches.unitIsAir()).size());
   }
 
   @Test
@@ -99,7 +99,7 @@ public class AirThatCantLandUtilTest {
     gameData.performChange(addAir);
     final AirThatCantLandUtil airThatCantLandUtil = new AirThatCantLandUtil(bridge);
     airThatCantLandUtil.removeAirThatCantLand(player, true);
-    assertEquals(2, sz55.getUnits().getMatches(Matches.unitIsAir()).size());
+    assertEquals(2, sz55.getUnitCollection().getMatches(Matches.unitIsAir()).size());
   }
 
   @Test
@@ -116,7 +116,7 @@ public class AirThatCantLandUtilTest {
     assertEquals(sz52, cantLand.iterator().next());
     airThatCantLandUtil.removeAirThatCantLand(player, false);
     // just the original american fighter, plus one that can land on the carrier
-    assertEquals(2, sz52.getUnits().getMatches(Matches.unitIsAir()).size());
+    assertEquals(2, sz52.getUnitCollection().getMatches(Matches.unitIsAir()).size());
   }
 
   @Test
@@ -142,14 +142,14 @@ public class AirThatCantLandUtilTest {
     gameData.performChange(ChangeFactory.addUnits(sz44, carrierType.create(1, americans)));
     gameData.performChange(ChangeFactory.addUnits(sz44, fighterType.create(1, americans)));
     // Get total number of defending units before the battle
-    final int preCountSz52 = sz52.getUnits().size();
-    final int preCountAirSz44 = sz44.getUnits().getMatches(Matches.unitIsAir()).size();
+    final int preCountSz52 = sz52.getUnitCollection().size();
+    final int preCountAirSz44 = sz44.getUnitCollection().getMatches(Matches.unitIsAir()).size();
     // now move to attack
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    moveDelegate.move(sz45.getUnits().getUnits(), gameData.getMap().getRoute(sz45, sz44));
+    moveDelegate.move(sz45.getUnitCollection().getUnits(), gameData.getMap().getRoute(sz45, sz44));
     moveDelegate.end();
     // fight the battle
     final BattleDelegate battle = (BattleDelegate) gameData.getDelegateList().getDelegate("battle");
@@ -162,7 +162,7 @@ public class AirThatCantLandUtilTest {
     battle.start();
     battle.end();
     // Get the total number of units that should be left after the planes retreat
-    final int expectedCountSz52 = sz52.getUnits().size();
+    final int expectedCountSz52 = sz52.getUnitCollection().size();
     final int postCountInt = preCountSz52 + preCountAirSz44;
     // Compare the expected count with the actual number of units in landing zone
     assertEquals(expectedCountSz52, postCountInt);
@@ -193,14 +193,14 @@ public class AirThatCantLandUtilTest {
     gameData.performChange(ChangeFactory.addUnits(sz44, fighterType.create(3, americans)));
     gameData.performChange(ChangeFactory.addUnits(sz43, carrierType.create(1, americans)));
     // Get total number of defending units before the battle
-    final int preCountSz52 = sz52.getUnits().size();
-    final int preCountSz43 = sz43.getUnits().size();
+    final int preCountSz52 = sz52.getUnitCollection().size();
+    final int preCountSz43 = sz43.getUnitCollection().size();
     // now move to attack
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    moveDelegate.move(sz45.getUnits().getUnits(), gameData.getMap().getRoute(sz45, sz44));
+    moveDelegate.move(sz45.getUnitCollection().getUnits(), gameData.getMap().getRoute(sz45, sz44));
     moveDelegate.end();
     // fight the battle
     final BattleDelegate battle = (BattleDelegate) gameData.getDelegateList().getDelegate("battle");
@@ -211,8 +211,8 @@ public class AirThatCantLandUtilTest {
     battle.start();
     battle.end();
     // Get the total number of units that should be left after the planes retreat
-    final int expectedCountSz52 = sz52.getUnits().size();
-    final int expectedCountSz43 = sz43.getUnits().size();
+    final int expectedCountSz52 = sz52.getUnitCollection().size();
+    final int expectedCountSz43 = sz43.getUnitCollection().size();
     final int postCountSz52 = preCountSz52 + 1;
     final int postCountSz43 = preCountSz43 + 2;
     // Compare the expected count with the actual number of units in landing zone
@@ -243,14 +243,14 @@ public class AirThatCantLandUtilTest {
     gameData.performChange(ChangeFactory.addUnits(sz9, carrierType.create(1, americans)));
     gameData.performChange(ChangeFactory.addUnits(sz9, fighterType.create(1, americans)));
     // Get total number of defending units before the battle
-    final int preCountCanada = eastCanada.getUnits().size();
-    final int preCountAirSz9 = sz9.getUnits().getMatches(Matches.unitIsAir()).size();
+    final int preCountCanada = eastCanada.getUnitCollection().size();
+    final int preCountAirSz9 = sz9.getUnitCollection().getMatches(Matches.unitIsAir()).size();
     // now move to attack
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    moveDelegate.move(sz11.getUnits().getUnits(), gameData.getMap().getRoute(sz11, sz9));
+    moveDelegate.move(sz11.getUnitCollection().getUnits(), gameData.getMap().getRoute(sz11, sz9));
     moveDelegate.end();
     // fight the battle
     final BattleDelegate battle = (BattleDelegate) gameData.getDelegateList().getDelegate("battle");
@@ -259,7 +259,7 @@ public class AirThatCantLandUtilTest {
     battle.start();
     battle.end();
     // Get the total number of units that should be left after the planes retreat
-    final int expectedCountCanada = eastCanada.getUnits().size();
+    final int expectedCountCanada = eastCanada.getUnitCollection().size();
     final int postCountInt = preCountCanada + preCountAirSz9;
     // Compare the expected count with the actual number of units in landing zone
     assertEquals(expectedCountCanada, postCountInt);
@@ -292,15 +292,15 @@ public class AirThatCantLandUtilTest {
     initDel.start();
     initDel.end();
     // Get total number of defending units before the battle
-    final int preCountCanada = eastCanada.getUnits().size();
-    final int preCountAirSz9 = sz9.getUnits().getMatches(Matches.unitIsAir()).size();
+    final int preCountCanada = eastCanada.getUnitCollection().size();
+    final int preCountAirSz9 = sz9.getUnitCollection().getMatches(Matches.unitIsAir()).size();
     // now move to attack
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    moveDelegate.move(sz11.getUnits().getUnits(), gameData.getMap().getRoute(sz11, sz9));
-    moveDelegate.move(sz9.getUnits().getUnits(infantryType, 1), gameData.getMap().getRoute(sz9, eastCanada));
+    moveDelegate.move(sz11.getUnitCollection().getUnits(), gameData.getMap().getRoute(sz11, sz9));
+    moveDelegate.move(sz9.getUnitCollection().getUnits(infantryType, 1), gameData.getMap().getRoute(sz9, eastCanada));
     moveDelegate.end();
     // fight the battle
     final BattleDelegate battle = (BattleDelegate) gameData.getDelegateList().getDelegate("battle");
@@ -312,7 +312,7 @@ public class AirThatCantLandUtilTest {
     fight(battle, sz9, false);
     battle.end();
     // Get the total number of units that should be left after the planes retreat
-    final int expectedCountCanada = eastCanada.getUnits().size();
+    final int expectedCountCanada = eastCanada.getUnitCollection().size();
     final int postCountInt = preCountCanada + preCountAirSz9;
     // Compare the expected count with the actual number of units in landing zone
     assertEquals(expectedCountCanada, postCountInt);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
@@ -149,7 +149,7 @@ public class AirThatCantLandUtilTest {
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    moveDelegate.move(sz45.getUnitCollection().getUnits(), gameData.getMap().getRoute(sz45, sz44));
+    moveDelegate.move(sz45.getUnits(), gameData.getMap().getRoute(sz45, sz44));
     moveDelegate.end();
     // fight the battle
     final BattleDelegate battle = (BattleDelegate) gameData.getDelegateList().getDelegate("battle");
@@ -200,7 +200,7 @@ public class AirThatCantLandUtilTest {
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    moveDelegate.move(sz45.getUnitCollection().getUnits(), gameData.getMap().getRoute(sz45, sz44));
+    moveDelegate.move(sz45.getUnits(), gameData.getMap().getRoute(sz45, sz44));
     moveDelegate.end();
     // fight the battle
     final BattleDelegate battle = (BattleDelegate) gameData.getDelegateList().getDelegate("battle");
@@ -250,7 +250,7 @@ public class AirThatCantLandUtilTest {
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    moveDelegate.move(sz11.getUnitCollection().getUnits(), gameData.getMap().getRoute(sz11, sz9));
+    moveDelegate.move(sz11.getUnits(), gameData.getMap().getRoute(sz11, sz9));
     moveDelegate.end();
     // fight the battle
     final BattleDelegate battle = (BattleDelegate) gameData.getDelegateList().getDelegate("battle");
@@ -299,7 +299,7 @@ public class AirThatCantLandUtilTest {
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    moveDelegate.move(sz11.getUnitCollection().getUnits(), gameData.getMap().getRoute(sz11, sz9));
+    moveDelegate.move(sz11.getUnits(), gameData.getMap().getRoute(sz11, sz9));
     moveDelegate.move(sz9.getUnitCollection().getUnits(infantryType, 1), gameData.getMap().getRoute(sz9, eastCanada));
     moveDelegate.end();
     // fight the battle

--- a/game-core/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
@@ -74,7 +74,7 @@ public class BattleCalculatorTest {
     final DiceRoll roll = new DiceRoll(new int[] {0}, 1, 1, false);
     final Collection<Unit> planes = bomber(data).create(5, british(data));
     final Collection<Unit> defendingAa =
-        territory("Germany", data).getUnits().getMatches(Matches.unitIsAaForAnything());
+        territory("Germany", data).getUnitCollection().getMatches(Matches.unitIsAaForAnything());
     whenGetRandom(bridge).thenAnswer(withValues(0));
     final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
         defendingAa, roll, bridge, null, null, territory("Germany", data), null, false, null).getKilled();
@@ -90,7 +90,7 @@ public class BattleCalculatorTest {
     final DiceRoll roll = new DiceRoll(new int[] {0}, 1, 1, false);
     final List<Unit> planes = bomber(data).create(5, british(data));
     final Collection<Unit> defendingAa =
-        territory("Germany", data).getUnits().getMatches(Matches.unitIsAaForAnything());
+        territory("Germany", data).getUnitCollection().getMatches(Matches.unitIsAaForAnything());
     whenGetRandom(bridge).thenAnswer(withValues(0));
     TripleAUnit.get(planes.get(0)).setAlreadyMoved(1);
     final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
@@ -108,11 +108,12 @@ public class BattleCalculatorTest {
     final Collection<Unit> planes = bomber(data).create(6, british(data));
     planes.addAll(fighter(data).create(6, british(data)));
     final Collection<Unit> defendingAa =
-        territory("Germany", data).getUnits().getMatches(Matches.unitIsAaForAnything());
+        territory("Germany", data).getUnitCollection().getMatches(Matches.unitIsAaForAnything());
     // don't allow rolling, 6 of each is deterministic
     final DiceRoll roll = DiceRoll.rollAa(CollectionUtils.getMatches(planes,
         Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
-        defendingAa, planes, territory("Germany", data).getUnits().getUnits(), bridge, territory("Germany", data),
+        defendingAa, planes, territory("Germany", data).getUnitCollection().getUnits(), bridge,
+        territory("Germany", data),
         true);
     final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
         defendingAa, roll, bridge, null, null, territory("Germany", data), null, false, null).getKilled();
@@ -132,14 +133,15 @@ public class BattleCalculatorTest {
     final Collection<Unit> planes = bomber(data).create(5, british(data));
     planes.addAll(fighter(data).create(5, british(data)));
     final Collection<Unit> defendingAa =
-        territory("Germany", data).getUnits().getMatches(Matches.unitIsAaForAnything());
+        territory("Germany", data).getUnitCollection().getMatches(Matches.unitIsAaForAnything());
     // should roll once, a hit
     whenGetRandom(bridge)
         .thenAnswer(withValues(0))
         .thenAnswer(withValues(1, 1));
     final DiceRoll roll = DiceRoll.rollAa(CollectionUtils.getMatches(planes,
         Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
-        defendingAa, planes, territory("Germany", data).getUnits().getUnits(), bridge, territory("Germany", data),
+        defendingAa, planes, territory("Germany", data).getUnitCollection().getUnits(), bridge,
+        territory("Germany", data),
         true);
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
     final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
@@ -161,13 +163,14 @@ public class BattleCalculatorTest {
     final Collection<Unit> planes = bomber(data).create(6, british(data));
     planes.addAll(fighter(data).create(6, british(data)));
     final Collection<Unit> defendingAa =
-        territory("Germany", data).getUnits().getMatches(Matches.unitIsAaForAnything());
+        territory("Germany", data).getUnitCollection().getMatches(Matches.unitIsAaForAnything());
     givenRemotePlayerWillSelectStrategicBombersForCasualties();
     // don't allow rolling, 6 of each is deterministic
     final DiceRoll roll = DiceRoll.rollAa(
         CollectionUtils.getMatches(planes,
             Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
-        defendingAa, planes, territory("Germany", data).getUnits().getUnits(), bridge, territory("Germany", data),
+        defendingAa, planes, territory("Germany", data).getUnitCollection().getUnits(), bridge,
+        territory("Germany", data),
         true);
     final Collection<Unit> casualties =
         BattleCalculator.getAaCasualties(false, planes, planes, defendingAa, defendingAa, roll, bridge,
@@ -188,13 +191,14 @@ public class BattleCalculatorTest {
     final Collection<Unit> planes = bomber(data).create(7, british(data));
     planes.addAll(fighter(data).create(7, british(data)));
     final Collection<Unit> defendingAa =
-        territory("Germany", data).getUnits().getMatches(Matches.unitIsAaForAnything());
+        territory("Germany", data).getUnitCollection().getMatches(Matches.unitIsAaForAnything());
     givenRemotePlayerWillSelectStrategicBombersForCasualties();
     // only 1 roll, a hit
     whenGetRandom(bridge).thenAnswer(withValues(0));
     final DiceRoll roll = DiceRoll.rollAa(CollectionUtils.getMatches(planes,
         Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
-        defendingAa, planes, territory("Germany", data).getUnits().getUnits(), bridge, territory("Germany", data),
+        defendingAa, planes, territory("Germany", data).getUnitCollection().getUnits(), bridge,
+        territory("Germany", data),
         true);
     final Collection<Unit> casualties =
         BattleCalculator.getAaCasualties(false, planes, planes, defendingAa, defendingAa, roll, bridge,
@@ -216,14 +220,15 @@ public class BattleCalculatorTest {
     final Collection<Unit> planes = bomber(data).create(7, british(data));
     planes.addAll(fighter(data).create(7, british(data)));
     final Collection<Unit> defendingAa =
-        territory("Germany", data).getUnits().getMatches(Matches.unitIsAaForAnything());
+        territory("Germany", data).getUnitCollection().getMatches(Matches.unitIsAaForAnything());
     // one roll, a hit
     whenGetRandom(bridge)
         .thenAnswer(withValues(0))
         .thenAnswer(withValues(0));
     final DiceRoll roll = DiceRoll.rollAa(CollectionUtils.getMatches(planes,
         Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
-        defendingAa, planes, territory("Germany", data).getUnits().getUnits(), bridge, territory("Germany", data),
+        defendingAa, planes, territory("Germany", data).getUnitCollection().getUnits(), bridge,
+        territory("Germany", data),
         true);
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
@@ -247,7 +252,7 @@ public class BattleCalculatorTest {
     final Collection<Unit> planes = bomber(data).create(7, british(data));
     planes.addAll(fighter(data).create(7, british(data)));
     final Collection<Unit> defendingAa =
-        territory("Germany", data).getUnits().getMatches(Matches.unitIsAaForAnything());
+        territory("Germany", data).getUnitCollection().getMatches(Matches.unitIsAaForAnything());
     // one roll, a miss
     whenGetRandom(bridge)
         .thenAnswer(withValues(2))
@@ -256,7 +261,8 @@ public class BattleCalculatorTest {
     final DiceRoll roll = DiceRoll
         .rollAa(CollectionUtils.getMatches(planes,
             Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
-            defendingAa, planes, territory("Germany", data).getUnits().getUnits(), bridge, territory("Germany", data),
+            defendingAa, planes, territory("Germany", data).getUnitCollection().getUnits(), bridge,
+            territory("Germany", data),
             true);
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
@@ -278,12 +284,13 @@ public class BattleCalculatorTest {
     final Collection<Unit> planes = bomber(data).create(6, british(data));
     planes.addAll(fighter(data).create(7, british(data)));
     final Collection<Unit> defendingAa =
-        territory("Germany", data).getUnits().getMatches(Matches.unitIsAaForAnything());
+        territory("Germany", data).getUnitCollection().getMatches(Matches.unitIsAaForAnything());
     // 1 roll for the extra fighter
     whenGetRandom(bridge).thenAnswer(withValues(0));
     final DiceRoll roll = DiceRoll.rollAa(CollectionUtils.getMatches(planes,
         Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
-        defendingAa, planes, territory("Germany", data).getUnits().getUnits(), bridge, territory("Germany", data),
+        defendingAa, planes, territory("Germany", data).getUnitCollection().getUnits(), bridge,
+        territory("Germany", data),
         true);
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));

--- a/game-core/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/BattleCalculatorTest.java
@@ -112,7 +112,7 @@ public class BattleCalculatorTest {
     // don't allow rolling, 6 of each is deterministic
     final DiceRoll roll = DiceRoll.rollAa(CollectionUtils.getMatches(planes,
         Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
-        defendingAa, planes, territory("Germany", data).getUnitCollection().getUnits(), bridge,
+        defendingAa, planes, territory("Germany", data).getUnits(), bridge,
         territory("Germany", data),
         true);
     final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
@@ -140,7 +140,7 @@ public class BattleCalculatorTest {
         .thenAnswer(withValues(1, 1));
     final DiceRoll roll = DiceRoll.rollAa(CollectionUtils.getMatches(planes,
         Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
-        defendingAa, planes, territory("Germany", data).getUnitCollection().getUnits(), bridge,
+        defendingAa, planes, territory("Germany", data).getUnits(), bridge,
         territory("Germany", data),
         true);
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
@@ -169,7 +169,7 @@ public class BattleCalculatorTest {
     final DiceRoll roll = DiceRoll.rollAa(
         CollectionUtils.getMatches(planes,
             Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
-        defendingAa, planes, territory("Germany", data).getUnitCollection().getUnits(), bridge,
+        defendingAa, planes, territory("Germany", data).getUnits(), bridge,
         territory("Germany", data),
         true);
     final Collection<Unit> casualties =
@@ -197,7 +197,7 @@ public class BattleCalculatorTest {
     whenGetRandom(bridge).thenAnswer(withValues(0));
     final DiceRoll roll = DiceRoll.rollAa(CollectionUtils.getMatches(planes,
         Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
-        defendingAa, planes, territory("Germany", data).getUnitCollection().getUnits(), bridge,
+        defendingAa, planes, territory("Germany", data).getUnits(), bridge,
         territory("Germany", data),
         true);
     final Collection<Unit> casualties =
@@ -227,7 +227,7 @@ public class BattleCalculatorTest {
         .thenAnswer(withValues(0));
     final DiceRoll roll = DiceRoll.rollAa(CollectionUtils.getMatches(planes,
         Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
-        defendingAa, planes, territory("Germany", data).getUnitCollection().getUnits(), bridge,
+        defendingAa, planes, territory("Germany", data).getUnits(), bridge,
         territory("Germany", data),
         true);
     // make sure we rolled once
@@ -261,7 +261,7 @@ public class BattleCalculatorTest {
     final DiceRoll roll = DiceRoll
         .rollAa(CollectionUtils.getMatches(planes,
             Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
-            defendingAa, planes, territory("Germany", data).getUnitCollection().getUnits(), bridge,
+            defendingAa, planes, territory("Germany", data).getUnits(), bridge,
             territory("Germany", data),
             true);
     // make sure we rolled once
@@ -289,7 +289,7 @@ public class BattleCalculatorTest {
     whenGetRandom(bridge).thenAnswer(withValues(0));
     final DiceRoll roll = DiceRoll.rollAa(CollectionUtils.getMatches(planes,
         Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(data))),
-        defendingAa, planes, territory("Germany", data).getUnitCollection().getUnits(), bridge,
+        defendingAa, planes, territory("Germany", data).getUnits(), bridge,
         territory("Germany", data),
         true);
     // make sure we rolled once

--- a/game-core/src/test/java/games/strategy/triplea/delegate/BigWorldTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/BigWorldTest.java
@@ -33,7 +33,7 @@ public class BigWorldTest {
     final MoveDelegate moveDelegate = moveDelegate(gameData);
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    final String error = moveDelegate.move(sz28.getUnitCollection().getUnits(), new Route(sz28, sz27, sz29));
+    final String error = moveDelegate.move(sz28.getUnits(), new Route(sz28, sz27, sz29));
     assertError(error);
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/BigWorldTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/BigWorldTest.java
@@ -33,7 +33,7 @@ public class BigWorldTest {
     final MoveDelegate moveDelegate = moveDelegate(gameData);
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    final String error = moveDelegate.move(sz28.getUnits().getUnits(), new Route(sz28, sz27, sz29));
+    final String error = moveDelegate.move(sz28.getUnitCollection().getUnits(), new Route(sz28, sz27, sz29));
     assertError(error);
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -400,7 +400,8 @@ public class DiceRollTest {
     TechTracker.addAdvance(british, testDelegateBridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     final List<Unit> bombers =
-        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.unitIsStrategicBomber());
+        gameData.getMap().getTerritory("United Kingdom").getUnitCollection()
+            .getMatches(Matches.unitIsStrategicBomber());
     whenGetRandom(testDelegateBridge).thenAnswer(withValues(2, 3, 2));
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, false, british, testDelegateBridge, mock(IBattle.class), "",
@@ -417,7 +418,8 @@ public class DiceRollTest {
     TechTracker.addAdvance(british, testDelegateBridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     final List<Unit> bombers =
-        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.unitIsStrategicBomber());
+        gameData.getMap().getTerritory("United Kingdom").getUnitCollection()
+            .getMatches(Matches.unitIsStrategicBomber());
     whenGetRandom(testDelegateBridge).thenAnswer(withValues(0));
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, true, british, testDelegateBridge, mock(IBattle.class), "",
@@ -432,7 +434,8 @@ public class DiceRollTest {
     gameData.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, true);
     final IDelegateBridge testDelegateBridge = newDelegateBridge(british);
     final List<Unit> bombers =
-        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.unitIsStrategicBomber());
+        gameData.getMap().getTerritory("United Kingdom").getUnitCollection()
+            .getMatches(Matches.unitIsStrategicBomber());
     whenGetRandom(testDelegateBridge).thenAnswer(withValues(0));
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, true, british, testDelegateBridge, mock(IBattle.class), "",
@@ -450,7 +453,8 @@ public class DiceRollTest {
     TechTracker.addAdvance(british, testDelegateBridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     final List<Unit> bombers =
-        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.unitIsStrategicBomber());
+        gameData.getMap().getTerritory("United Kingdom").getUnitCollection()
+            .getMatches(Matches.unitIsStrategicBomber());
     whenGetRandom(testDelegateBridge).thenAnswer(withValues(2, 3));
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, false, british, testDelegateBridge, mock(IBattle.class), "",
@@ -469,7 +473,8 @@ public class DiceRollTest {
     TechTracker.addAdvance(british, testDelegateBridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     final List<Unit> bombers =
-        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.unitIsStrategicBomber());
+        gameData.getMap().getTerritory("United Kingdom").getUnitCollection()
+            .getMatches(Matches.unitIsStrategicBomber());
     whenGetRandom(testDelegateBridge).thenAnswer(withValues(3, 2));
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, false, british, testDelegateBridge, mock(IBattle.class), "",
@@ -487,7 +492,8 @@ public class DiceRollTest {
     TechTracker.addAdvance(british, testDelegateBridge,
         TechAdvance.findAdvance(TechAdvance.TECH_PROPERTY_HEAVY_BOMBER, gameData, british));
     final List<Unit> bombers =
-        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.unitIsStrategicBomber());
+        gameData.getMap().getTerritory("United Kingdom").getUnitCollection()
+            .getMatches(Matches.unitIsStrategicBomber());
     whenGetRandom(testDelegateBridge).thenAnswer(withValues(0, 1));
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final DiceRoll dice = DiceRoll.rollDice(bombers, true, british, testDelegateBridge, mock(IBattle.class), "",
@@ -502,7 +508,8 @@ public class DiceRollTest {
   public void testSbrRolls() {
     final PlayerId british = GameDataTestUtil.british(gameData);
     final Unit bomber =
-        gameData.getMap().getTerritory("United Kingdom").getUnits().getMatches(Matches.unitIsStrategicBomber()).get(0);
+        gameData.getMap().getTerritory("United Kingdom").getUnitCollection().getMatches(Matches.unitIsStrategicBomber())
+            .get(0);
     // default 1 roll
     assertThat(StrategicBombingRaidBattle.getSbrRolls(bomber, british), is(1));
     assertThat(StrategicBombingRaidBattle.getSbrRolls(bomber, british), is(1));

--- a/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -428,7 +428,7 @@ public final class GameDataTestUtil {
     }
     final MoveDelegate moveDelegate = moveDelegate(route.getStart().getData());
     final Collection<Unit> transports =
-        route.getEnd().getUnits().getMatches(Matches.unitIsOwnedBy(units.iterator().next().getOwner()));
+        route.getEnd().getUnitCollection().getMatches(Matches.unitIsOwnedBy(units.iterator().next().getOwner()));
     final String error = moveDelegate.move(units, route, transports);
     if (error != null) {
       throw new AssertionFailedError("Illegal move:" + error);
@@ -527,7 +527,7 @@ public final class GameDataTestUtil {
     checkNotNull(from);
 
     return maxUnitCountsByType.entrySet().stream()
-        .flatMap(entry -> from.getUnits().getUnits(entry.getKey(), entry.getValue()).stream())
+        .flatMap(entry -> from.getUnitCollection().getUnits(entry.getKey(), entry.getValue()).stream())
         .collect(Collectors.toList());
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
@@ -67,7 +67,7 @@ public class LhtrTest {
     route.setStart(easternEurope);
     route.add(baltic);
     final UnitType fighterType = GameDataTestUtil.fighter(gameData);
-    delegate.move(easternEurope.getUnits().getMatches(Matches.unitIsOfType(fighterType)), route);
+    delegate.move(easternEurope.getUnitCollection().getMatches(Matches.unitIsOfType(fighterType)), route);
     // add a carrier to be produced in germany
     final TripleAUnit carrier = new TripleAUnit(carrirType, germans, gameData);
     gameData.performChange(ChangeFactory.addUnits(germans, Collections.singleton(carrier)));
@@ -75,7 +75,7 @@ public class LhtrTest {
     delegate.end();
     // make sure the fighter is still there
     // in lhtr fighters can hover, and carriers placed beneath them
-    assertTrue(baltic.getUnits().anyMatch(Matches.unitIsOfType(fighterType)));
+    assertTrue(baltic.getUnitCollection().anyMatch(Matches.unitIsOfType(fighterType)));
   }
 
   @Test
@@ -94,12 +94,12 @@ public class LhtrTest {
     route.setStart(easternEurope);
     route.add(baltic);
     final UnitType fighterType = GameDataTestUtil.fighter(gameData);
-    delegate.move(easternEurope.getUnits().getMatches(Matches.unitIsOfType(fighterType)), route);
+    delegate.move(easternEurope.getUnitCollection().getMatches(Matches.unitIsOfType(fighterType)), route);
     // end the move phase
     delegate.end();
     // there is no pending carrier to be placed
     // the fighter cannot hover
-    assertFalse(baltic.getUnits().anyMatch(Matches.unitIsOfType(fighterType)));
+    assertFalse(baltic.getUnitCollection().anyMatch(Matches.unitIsOfType(fighterType)));
   }
 
   @Test
@@ -116,7 +116,7 @@ public class LhtrTest {
     route.setStart(gameData.getMap().getTerritory("Ukraine S.S.R."));
     route.add(gameData.getMap().getTerritory("Caucasus"));
     route.add(gameData.getMap().getTerritory("West Russia"));
-    final List<Unit> fighter = route.getStart().getUnits().getMatches(Matches.unitIsAir());
+    final List<Unit> fighter = route.getStart().getUnitCollection().getMatches(Matches.unitIsAir());
     delegate.move(fighter, route);
     // if we try to move aa, then the game will ask us if we want to move
     thenRemotePlayerShouldNeverBeAskedToConfirmMove(bridge);
@@ -151,8 +151,8 @@ public class LhtrTest {
     final BattleTracker tracker = new BattleTracker();
     final StrategicBombingRaidBattle battle = new StrategicBombingRaidBattle(germany, gameData, british, tracker);
     battle.addAttackChange(gameData.getMap().getRoute(uk, germany),
-        uk.getUnits().getMatches(Matches.unitIsStrategicBomber()), null);
-    addTo(germany, uk.getUnits().getMatches(Matches.unitIsStrategicBomber()));
+        uk.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()), null);
+    addTo(germany, uk.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()));
     tracker.getBattleRecords().addBattle(british, battle.getBattleId(), germany, battle.getBattleType());
     final IDelegateBridge bridge = newDelegateBridge(british);
     TechTracker.addAdvance(british, bridge,
@@ -182,8 +182,8 @@ public class LhtrTest {
     final BattleTracker tracker = new BattleTracker();
     final StrategicBombingRaidBattle battle = new StrategicBombingRaidBattle(germany, gameData, british, tracker);
     battle.addAttackChange(gameData.getMap().getRoute(uk, germany),
-        uk.getUnits().getMatches(Matches.unitIsStrategicBomber()), null);
-    addTo(germany, uk.getUnits().getMatches(Matches.unitIsStrategicBomber()));
+        uk.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()), null);
+    addTo(germany, uk.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()));
     tracker.getBattleRecords().addBattle(british, battle.getBattleId(), germany, battle.getBattleType());
     final IDelegateBridge bridge = newDelegateBridge(british);
     TechTracker.addAdvance(british, bridge,

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MatchesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MatchesTest.java
@@ -121,19 +121,19 @@ public final class MatchesTest {
 
       territory = gameData.getMap().getTerritory("Germany");
       territory.setOwner(player);
-      territory.getUnits().clear();
+      territory.getUnitCollection().clear();
     }
 
     @Test
     public void shouldNotMatchWhenTerritoryContainsOnlyAlliedLandUnits() {
-      territory.getUnits().add(newLandUnitFor(alliedPlayer));
+      territory.getUnitCollection().add(newLandUnitFor(alliedPlayer));
 
       assertThat(newMatch(), notMatches(territory));
     }
 
     @Test
     public void shouldMatchWhenTerritoryContainsEnemyLandUnits() {
-      territory.getUnits().addAll(Arrays.asList(
+      territory.getUnitCollection().addAll(Arrays.asList(
           newLandUnitFor(player),
           newLandUnitFor(enemyPlayer),
           newAirUnitFor(enemyPlayer),
@@ -144,7 +144,7 @@ public final class MatchesTest {
 
     @Test
     public void shouldMatchWhenTerritoryContainsEnemySeaUnits() {
-      territory.getUnits().addAll(Arrays.asList(
+      territory.getUnitCollection().addAll(Arrays.asList(
           newSeaUnitFor(player),
           newSeaUnitFor(enemyPlayer),
           newAirUnitFor(enemyPlayer),
@@ -155,14 +155,14 @@ public final class MatchesTest {
 
     @Test
     public void shouldNotMatchWhenTerritoryContainsOnlyEnemyAirUnits() {
-      territory.getUnits().add(newAirUnitFor(enemyPlayer));
+      territory.getUnitCollection().add(newAirUnitFor(enemyPlayer));
 
       assertThat(newMatch(), notMatches(territory));
     }
 
     @Test
     public void shouldNotMatchWhenTerritoryContainsOnlyEnemyInfrastructureUnits() {
-      territory.getUnits().add(newInfrastructureUnitFor(enemyPlayer));
+      territory.getUnitCollection().add(newInfrastructureUnitFor(enemyPlayer));
 
       assertThat(newMatch(), notMatches(territory));
     }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -278,7 +278,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     assertEquals(4, redSea.getUnitCollection().size());
     final String results =
         delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route,
-            route.getEnd().getUnitCollection().getUnits());
+            route.getEnd().getUnits());
     assertValid(results);
     assertEquals(16, egypt.getUnitCollection().size());
     assertEquals(6, redSea.getUnitCollection().size());
@@ -453,7 +453,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     route.add(redSea);
     String results =
         delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route,
-            route.getEnd().getUnitCollection().getUnits());
+            route.getEnd().getUnits());
     assertValid(results);
     map = new IntegerMap<>();
     map.put(transport, 2);
@@ -473,7 +473,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     route.add(redSea);
     String results =
         delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route,
-            route.getEnd().getUnitCollection().getUnits());
+            route.getEnd().getUnits());
     assertValid(results);
     map = new IntegerMap<>();
     map.put(armour, 2);
@@ -527,9 +527,9 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     delegate.setDelegateBridgeAndPlayer(bridge);
     delegate.start();
     // Set up the test
-    removeFrom(manchuria, manchuria.getUnitCollection().getUnits());
+    removeFrom(manchuria, manchuria.getUnits());
     manchuria.setOwner(russians);
-    removeFrom(japanSeaZone, japanSeaZone.getUnitCollection().getUnits());
+    removeFrom(japanSeaZone, japanSeaZone.getUnits());
     gameData.performChange(ChangeFactory.addUnits(japanSeaZone, transport.create(3, japanese)));
     gameData.performChange(ChangeFactory.addUnits(japan, infantry.create(3, japanese)));
     // Perform the first load
@@ -538,15 +538,15 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     load.add(japanSeaZone);
     String results =
         delegate.move(
-            CollectionUtils.getNMatches(japan.getUnitCollection().getUnits(), 1, Matches.unitIsOfType(infantry)), load,
-            CollectionUtils.getMatches(japanSeaZone.getUnitCollection().getUnits(), Matches.unitIsOfType(transport)));
+            CollectionUtils.getNMatches(japan.getUnits(), 1, Matches.unitIsOfType(infantry)), load,
+            CollectionUtils.getMatches(japanSeaZone.getUnits(), Matches.unitIsOfType(transport)));
     assertNull(results);
     // Perform the first unload
     final Route unload = new Route();
     unload.setStart(japanSeaZone);
     unload.add(manchuria);
     results = delegate.move(
-        CollectionUtils.getNMatches(japanSeaZone.getUnitCollection().getUnits(), 1, Matches.unitIsOfType(infantry)),
+        CollectionUtils.getNMatches(japanSeaZone.getUnits(), 1, Matches.unitIsOfType(infantry)),
         unload);
     assertNull(results);
     // Load another trn
@@ -554,15 +554,15 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     route2.setStart(japan);
     route2.add(japanSeaZone);
     results = delegate.move(
-        CollectionUtils.getNMatches(japan.getUnitCollection().getUnits(), 1, Matches.unitIsOfType(infantry)),
+        CollectionUtils.getNMatches(japan.getUnits(), 1, Matches.unitIsOfType(infantry)),
         route2,
-        CollectionUtils.getMatches(japanSeaZone.getUnitCollection().getUnits(), Matches.unitIsOfType(transport)));
+        CollectionUtils.getMatches(japanSeaZone.getUnits(), Matches.unitIsOfType(transport)));
     assertNull(results);
     // Move remaining units
     final Route route3 = new Route();
     route3.setStart(japanSeaZone);
     route3.add(sfeSeaZone);
-    final Collection<Unit> remainingTrns = CollectionUtils.getMatches(japanSeaZone.getUnitCollection().getUnits(),
+    final Collection<Unit> remainingTrns = CollectionUtils.getMatches(japanSeaZone.getUnits(),
         Matches.unitHasNotMoved().and(Matches.unitWasNotLoadedThisTurn()));
     results = delegate.move(remainingTrns, route3);
     assertNull(results);
@@ -617,7 +617,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     map.put(armour, 1);
     String results =
         delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route,
-            route.getEnd().getUnitCollection().getUnits());
+            route.getEnd().getUnits());
     assertValid(results);
     // move two infantry to red sea
     route = new Route();
@@ -627,7 +627,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     map.put(infantry, 2);
     results =
         delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route,
-            route.getEnd().getUnitCollection().getUnits());
+            route.getEnd().getUnits());
     assertValid(results);
     // try to move 1 transport to indian ocean with 1 tank
     route = new Route();
@@ -819,7 +819,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     route.add(westAfricaSea);
     route.add(northAtlantic);
     Collection<Unit> units = new ArrayList<>(CollectionUtils.getMatches(
-        gameData.getMap().getTerritory(congoSeaZone.toString()).getUnitCollection().getUnits(),
+        gameData.getMap().getTerritory(congoSeaZone.toString()).getUnits(),
         Matches.unitIsCarrier()));
     results = delegate.move(units, route);
     assertValid(results);
@@ -829,7 +829,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     route.add(eastMediteranean);
     route.add(blackSea);
     units = new ArrayList<>(CollectionUtils.getMatches(
-        gameData.getMap().getTerritory(redSea.toString()).getUnitCollection().getUnits(), Matches.unitIsCarrier()));
+        gameData.getMap().getTerritory(redSea.toString()).getUnits(), Matches.unitIsCarrier()));
     results = delegate.move(units, route);
     assertValid(results);
     // make sure the place cant use it to land

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -65,11 +65,11 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     route.setStart(egypt);
     route.add(eastAfrica);
     final String results = delegate.move(armour.create(10, british), route);
-    assertEquals(18, egypt.getUnits().size());
-    assertEquals(2, eastAfrica.getUnits().size());
+    assertEquals(18, egypt.getUnitCollection().size());
+    assertEquals(2, eastAfrica.getUnitCollection().size());
     assertError(results);
-    assertEquals(18, egypt.getUnits().size());
-    assertEquals(2, eastAfrica.getUnits().size());
+    assertEquals(18, egypt.getUnitCollection().size());
+    assertEquals(2, eastAfrica.getUnitCollection().size());
   }
 
   @Test
@@ -79,12 +79,12 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     final Route route = new Route();
     route.setStart(algeria);
     route.add(libya);
-    assertEquals(1, algeria.getUnits().size());
-    assertEquals(0, libya.getUnits().size());
+    assertEquals(1, algeria.getUnitCollection().size());
+    assertEquals(0, libya.getUnitCollection().size());
     final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
-    assertEquals(1, algeria.getUnits().size());
-    assertEquals(0, libya.getUnits().size());
+    assertEquals(1, algeria.getUnitCollection().size());
+    assertEquals(0, libya.getUnitCollection().size());
   }
 
   @Test
@@ -94,12 +94,12 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     final Route route = new Route();
     route.setStart(egypt);
     route.add(eastAfrica);
-    assertEquals(18, egypt.getUnits().size());
-    assertEquals(2, eastAfrica.getUnits().size());
+    assertEquals(18, egypt.getUnitCollection().size());
+    assertEquals(2, eastAfrica.getUnitCollection().size());
     final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
-    assertEquals(16, egypt.getUnits().size());
-    assertEquals(4, eastAfrica.getUnits().size());
+    assertEquals(16, egypt.getUnitCollection().size());
+    assertEquals(4, eastAfrica.getUnitCollection().size());
   }
 
   @Test
@@ -110,12 +110,12 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     route.setStart(egypt);
     route.add(eastAfrica);
     route.add(kenya);
-    assertEquals(18, egypt.getUnits().size());
-    assertEquals(0, kenya.getUnits().size());
+    assertEquals(18, egypt.getUnitCollection().size());
+    assertEquals(0, kenya.getUnitCollection().size());
     final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
-    assertEquals(16, egypt.getUnits().size());
-    assertEquals(2, kenya.getUnits().size());
+    assertEquals(16, egypt.getUnitCollection().size());
+    assertEquals(2, kenya.getUnitCollection().size());
   }
 
   @Test
@@ -141,12 +141,12 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     route.add(kenya);
     route.add(mozambiqueSeaZone);
     route.add(redSea);
-    assertEquals(18, egypt.getUnits().size());
-    assertEquals(4, redSea.getUnits().size());
+    assertEquals(18, egypt.getUnitCollection().size());
+    assertEquals(4, redSea.getUnitCollection().size());
     final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
-    assertEquals(16, egypt.getUnits().size());
-    assertEquals(6, redSea.getUnits().size());
+    assertEquals(16, egypt.getUnitCollection().size());
+    assertEquals(6, redSea.getUnitCollection().size());
   }
 
   @Test
@@ -161,12 +161,12 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     route.add(redSea);
     // no carriers
     route.add(mozambiqueSeaZone);
-    assertEquals(18, egypt.getUnits().size());
-    assertEquals(4, redSea.getUnits().size());
+    assertEquals(18, egypt.getUnitCollection().size());
+    assertEquals(4, redSea.getUnitCollection().size());
     final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
-    assertEquals(18, egypt.getUnits().size());
-    assertEquals(4, redSea.getUnits().size());
+    assertEquals(18, egypt.getUnitCollection().size());
+    assertEquals(4, redSea.getUnitCollection().size());
   }
 
   @Test
@@ -180,12 +180,12 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     route.add(kenya);
     route.add(mozambiqueSeaZone);
     route.add(redSea);
-    assertEquals(18, egypt.getUnits().size());
-    assertEquals(4, redSea.getUnits().size());
+    assertEquals(18, egypt.getUnitCollection().size());
+    assertEquals(4, redSea.getUnitCollection().size());
     final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
-    assertEquals(18, egypt.getUnits().size());
-    assertEquals(4, redSea.getUnits().size());
+    assertEquals(18, egypt.getUnitCollection().size());
+    assertEquals(4, redSea.getUnitCollection().size());
   }
 
   @Test
@@ -196,12 +196,12 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     route.setStart(egypt);
     // exast movement to force landing
     route.add(eastMediteranean);
-    assertEquals(18, egypt.getUnits().size());
-    assertEquals(0, eastMediteranean.getUnits().size());
+    assertEquals(18, egypt.getUnitCollection().size());
+    assertEquals(0, eastMediteranean.getUnitCollection().size());
     final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
-    assertEquals(18, egypt.getUnits().size());
-    assertEquals(0, eastMediteranean.getUnits().size());
+    assertEquals(18, egypt.getUnitCollection().size());
+    assertEquals(0, eastMediteranean.getUnitCollection().size());
   }
 
   @Test
@@ -212,12 +212,12 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     route.setStart(redSea);
     // exast movement to force landing
     route.add(mozambiqueSeaZone);
-    assertEquals(4, redSea.getUnits().size());
-    assertEquals(0, mozambiqueSeaZone.getUnits().size());
+    assertEquals(4, redSea.getUnitCollection().size());
+    assertEquals(0, mozambiqueSeaZone.getUnitCollection().size());
     final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
-    assertEquals(2, redSea.getUnits().size());
-    assertEquals(2, mozambiqueSeaZone.getUnits().size());
+    assertEquals(2, redSea.getUnitCollection().size());
+    assertEquals(2, mozambiqueSeaZone.getUnitCollection().size());
   }
 
   @Test
@@ -228,12 +228,12 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     route.setStart(redSea);
     // exast movement to force landing
     route.add(egypt);
-    assertEquals(4, redSea.getUnits().size());
-    assertEquals(18, egypt.getUnits().size());
+    assertEquals(4, redSea.getUnitCollection().size());
+    assertEquals(18, egypt.getUnitCollection().size());
     final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
-    assertEquals(4, redSea.getUnits().size());
-    assertEquals(18, egypt.getUnits().size());
+    assertEquals(4, redSea.getUnitCollection().size());
+    assertEquals(18, egypt.getUnitCollection().size());
   }
 
   @Test
@@ -245,12 +245,12 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     route.setStart(equatorialAfrica);
     // exast movement to force landing
     route.add(congoSeaZone);
-    assertEquals(4, equatorialAfrica.getUnits().size());
-    assertEquals(11, congoSeaZone.getUnits().size());
+    assertEquals(4, equatorialAfrica.getUnitCollection().size());
+    assertEquals(11, congoSeaZone.getUnitCollection().size());
     final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
-    assertEquals(4, equatorialAfrica.getUnits().size());
-    assertEquals(11, congoSeaZone.getUnits().size());
+    assertEquals(4, equatorialAfrica.getUnitCollection().size());
+    assertEquals(11, congoSeaZone.getUnitCollection().size());
   }
 
   @Test
@@ -274,13 +274,14 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     route.setStart(egypt);
     // exast movement to force landing
     route.add(redSea);
-    assertEquals(18, egypt.getUnits().size());
-    assertEquals(4, redSea.getUnits().size());
+    assertEquals(18, egypt.getUnitCollection().size());
+    assertEquals(4, redSea.getUnitCollection().size());
     final String results =
-        delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
+        delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route,
+            route.getEnd().getUnitCollection().getUnits());
     assertValid(results);
-    assertEquals(16, egypt.getUnits().size());
-    assertEquals(6, redSea.getUnits().size());
+    assertEquals(16, egypt.getUnitCollection().size());
+    assertEquals(6, redSea.getUnitCollection().size());
   }
 
   @Test
@@ -291,13 +292,13 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     route.setStart(egypt);
     route.add(libya);
     route.add(algeria);
-    assertEquals(18, egypt.getUnits().size());
-    assertEquals(1, algeria.getUnits().size());
+    assertEquals(18, egypt.getUnitCollection().size());
+    assertEquals(1, algeria.getUnitCollection().size());
     assertEquals(libya.getOwner(), japanese);
     final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
-    assertEquals(16, egypt.getUnits().size());
-    assertEquals(3, algeria.getUnits().size());
+    assertEquals(16, egypt.getUnitCollection().size());
+    assertEquals(3, algeria.getUnitCollection().size());
     assertEquals(libya.getOwner(), british);
   }
 
@@ -313,7 +314,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     // Validate move happened
-    assertEquals(1, libya.getUnits().size());
+    assertEquals(1, libya.getUnitCollection().size());
     assertEquals(libya.getOwner(), british);
     // Try to move 2nd space
     route = new Route();
@@ -332,12 +333,12 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     route.setStart(equatorialAfrica);
     route.add(westAfrica);
     route.add(algeria);
-    assertEquals(4, equatorialAfrica.getUnits().size());
-    assertEquals(1, algeria.getUnits().size());
+    assertEquals(4, equatorialAfrica.getUnitCollection().size());
+    assertEquals(1, algeria.getUnitCollection().size());
     final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
-    assertEquals(4, equatorialAfrica.getUnits().size());
-    assertEquals(1, algeria.getUnits().size());
+    assertEquals(4, equatorialAfrica.getUnitCollection().size());
+    assertEquals(1, algeria.getUnitCollection().size());
   }
 
   @Test
@@ -347,14 +348,14 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     final Route route = new Route();
     route.setStart(equatorialAfrica);
     route.add(westAfrica);
-    assertEquals(4, equatorialAfrica.getUnits().size());
-    assertEquals(0, westAfrica.getUnits().size());
+    assertEquals(4, equatorialAfrica.getUnitCollection().size());
+    assertEquals(0, westAfrica.getUnitCollection().size());
     assertEquals(PlayerId.NULL_PLAYERID, westAfrica.getOwner());
     assertEquals(35, british.getResources().getQuantity(pus));
     final String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
-    assertEquals(2, equatorialAfrica.getUnits().size());
-    assertEquals(2, westAfrica.getUnits().size());
+    assertEquals(2, equatorialAfrica.getUnitCollection().size());
+    assertEquals(2, westAfrica.getUnitCollection().size());
     assertEquals(westAfrica.getOwner(), british);
     assertEquals(32, british.getResources().getQuantity(pus));
   }
@@ -397,21 +398,21 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     Route route = new Route();
     route.setStart(eastAfrica);
     route.add(kenya);
-    assertEquals(2, eastAfrica.getUnits().size());
-    assertEquals(0, kenya.getUnits().size());
+    assertEquals(2, eastAfrica.getUnitCollection().size());
+    assertEquals(0, kenya.getUnitCollection().size());
     String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
-    assertEquals(0, eastAfrica.getUnits().size());
-    assertEquals(2, kenya.getUnits().size());
+    assertEquals(0, eastAfrica.getUnitCollection().size());
+    assertEquals(2, kenya.getUnitCollection().size());
     route = new Route();
     route.setStart(kenya);
     route.add(egypt);
-    assertEquals(2, kenya.getUnits().size());
-    assertEquals(18, egypt.getUnits().size());
+    assertEquals(2, kenya.getUnitCollection().size());
+    assertEquals(18, egypt.getUnitCollection().size());
     results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertError(results);
-    assertEquals(2, kenya.getUnits().size());
-    assertEquals(18, egypt.getUnits().size());
+    assertEquals(2, kenya.getUnitCollection().size());
+    assertEquals(18, egypt.getUnitCollection().size());
   }
 
   @Test
@@ -422,12 +423,12 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     Route route = new Route();
     route.setStart(egypt);
     route.add(equatorialAfrica);
-    assertEquals(18, egypt.getUnits().size());
-    assertEquals(4, equatorialAfrica.getUnits().size());
+    assertEquals(18, egypt.getUnitCollection().size());
+    assertEquals(4, equatorialAfrica.getUnitCollection().size());
     String results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
-    assertEquals(16, egypt.getUnits().size());
-    assertEquals(6, equatorialAfrica.getUnits().size());
+    assertEquals(16, egypt.getUnitCollection().size());
+    assertEquals(6, equatorialAfrica.getUnitCollection().size());
     // now move 2 tanks out of equatorial africa to east africa
     // only the tanks with movement 2 can make it,
     // this makes sure that the correct units are moving
@@ -435,12 +436,12 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     route.setStart(equatorialAfrica);
     route.add(egypt);
     route.add(eastAfrica);
-    assertEquals(6, equatorialAfrica.getUnits().size());
-    assertEquals(2, eastAfrica.getUnits().size());
+    assertEquals(6, equatorialAfrica.getUnitCollection().size());
+    assertEquals(2, eastAfrica.getUnitCollection().size());
     results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
-    assertEquals(4, equatorialAfrica.getUnits().size());
-    assertEquals(4, eastAfrica.getUnits().size());
+    assertEquals(4, equatorialAfrica.getUnitCollection().size());
+    assertEquals(4, eastAfrica.getUnitCollection().size());
   }
 
   @Test
@@ -451,7 +452,8 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     route.setStart(egypt);
     route.add(redSea);
     String results =
-        delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
+        delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route,
+            route.getEnd().getUnitCollection().getUnits());
     assertValid(results);
     map = new IntegerMap<>();
     map.put(transport, 2);
@@ -470,7 +472,8 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     route.setStart(egypt);
     route.add(redSea);
     String results =
-        delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
+        delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route,
+            route.getEnd().getUnitCollection().getUnits());
     assertValid(results);
     map = new IntegerMap<>();
     map.put(armour, 2);
@@ -524,9 +527,9 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     delegate.setDelegateBridgeAndPlayer(bridge);
     delegate.start();
     // Set up the test
-    removeFrom(manchuria, manchuria.getUnits().getUnits());
+    removeFrom(manchuria, manchuria.getUnitCollection().getUnits());
     manchuria.setOwner(russians);
-    removeFrom(japanSeaZone, japanSeaZone.getUnits().getUnits());
+    removeFrom(japanSeaZone, japanSeaZone.getUnitCollection().getUnits());
     gameData.performChange(ChangeFactory.addUnits(japanSeaZone, transport.create(3, japanese)));
     gameData.performChange(ChangeFactory.addUnits(japan, infantry.create(3, japanese)));
     // Perform the first load
@@ -534,28 +537,32 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     load.setStart(japan);
     load.add(japanSeaZone);
     String results =
-        delegate.move(CollectionUtils.getNMatches(japan.getUnits().getUnits(), 1, Matches.unitIsOfType(infantry)), load,
-            CollectionUtils.getMatches(japanSeaZone.getUnits().getUnits(), Matches.unitIsOfType(transport)));
+        delegate.move(
+            CollectionUtils.getNMatches(japan.getUnitCollection().getUnits(), 1, Matches.unitIsOfType(infantry)), load,
+            CollectionUtils.getMatches(japanSeaZone.getUnitCollection().getUnits(), Matches.unitIsOfType(transport)));
     assertNull(results);
     // Perform the first unload
     final Route unload = new Route();
     unload.setStart(japanSeaZone);
     unload.add(manchuria);
     results = delegate.move(
-        CollectionUtils.getNMatches(japanSeaZone.getUnits().getUnits(), 1, Matches.unitIsOfType(infantry)), unload);
+        CollectionUtils.getNMatches(japanSeaZone.getUnitCollection().getUnits(), 1, Matches.unitIsOfType(infantry)),
+        unload);
     assertNull(results);
     // Load another trn
     final Route route2 = new Route();
     route2.setStart(japan);
     route2.add(japanSeaZone);
-    results = delegate.move(CollectionUtils.getNMatches(japan.getUnits().getUnits(), 1, Matches.unitIsOfType(infantry)),
-        route2, CollectionUtils.getMatches(japanSeaZone.getUnits().getUnits(), Matches.unitIsOfType(transport)));
+    results = delegate.move(
+        CollectionUtils.getNMatches(japan.getUnitCollection().getUnits(), 1, Matches.unitIsOfType(infantry)),
+        route2,
+        CollectionUtils.getMatches(japanSeaZone.getUnitCollection().getUnits(), Matches.unitIsOfType(transport)));
     assertNull(results);
     // Move remaining units
     final Route route3 = new Route();
     route3.setStart(japanSeaZone);
     route3.add(sfeSeaZone);
-    final Collection<Unit> remainingTrns = CollectionUtils.getMatches(japanSeaZone.getUnits().getUnits(),
+    final Collection<Unit> remainingTrns = CollectionUtils.getMatches(japanSeaZone.getUnitCollection().getUnits(),
         Matches.unitHasNotMoved().and(Matches.unitWasNotLoadedThisTurn()));
     results = delegate.move(remainingTrns, route3);
     assertNull(results);
@@ -609,7 +616,8 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     IntegerMap<UnitType> map = new IntegerMap<>();
     map.put(armour, 1);
     String results =
-        delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
+        delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route,
+            route.getEnd().getUnitCollection().getUnits());
     assertValid(results);
     // move two infantry to red sea
     route = new Route();
@@ -618,7 +626,8 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     map = new IntegerMap<>();
     map.put(infantry, 2);
     results =
-        delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
+        delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route,
+            route.getEnd().getUnitCollection().getUnits());
     assertValid(results);
     // try to move 1 transport to indian ocean with 1 tank
     route = new Route();
@@ -810,7 +819,8 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     route.add(westAfricaSea);
     route.add(northAtlantic);
     Collection<Unit> units = new ArrayList<>(CollectionUtils.getMatches(
-        gameData.getMap().getTerritory(congoSeaZone.toString()).getUnits().getUnits(), Matches.unitIsCarrier()));
+        gameData.getMap().getTerritory(congoSeaZone.toString()).getUnitCollection().getUnits(),
+        Matches.unitIsCarrier()));
     results = delegate.move(units, route);
     assertValid(results);
     // move carriers to ensure they can't go anywhere
@@ -819,7 +829,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     route.add(eastMediteranean);
     route.add(blackSea);
     units = new ArrayList<>(CollectionUtils.getMatches(
-        gameData.getMap().getTerritory(redSea.toString()).getUnits().getUnits(), Matches.unitIsCarrier()));
+        gameData.getMap().getTerritory(redSea.toString()).getUnitCollection().getUnits(), Matches.unitIsCarrier()));
     results = delegate.move(units, route);
     assertValid(results);
     // make sure the place cant use it to land
@@ -955,14 +965,14 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     assertValid(results);
     // Get the attacking sea units that will retreat
     final List<Unit> retreatingSeaUnits =
-        new ArrayList<>(balticSeaZone.getUnits().getMatches(Matches.enemyUnit(germans, gameData)));
+        new ArrayList<>(balticSeaZone.getUnitCollection().getMatches(Matches.enemyUnit(germans, gameData)));
     // Get the attacking land units that will retreat and their number
     final List<Unit> retreatingLandUnits =
-        new ArrayList<>(finlandNorway.getUnits().getMatches(Matches.enemyUnit(germans, gameData)));
+        new ArrayList<>(finlandNorway.getUnitCollection().getMatches(Matches.enemyUnit(germans, gameData)));
     final int retreatingLandSizeInt = retreatingLandUnits.size();
     // Get the defending land units that and their number
     final List<Unit> defendingLandUnits =
-        new ArrayList<>(finlandNorway.getUnits().getMatches(Matches.enemyUnit(british, gameData)));
+        new ArrayList<>(finlandNorway.getUnitCollection().getMatches(Matches.enemyUnit(british, gameData)));
     final int defendingLandSizeInt = defendingLandUnits.size();
     // Set up the battles and the dependent battles
     final IBattle inFinlandNorway =
@@ -985,7 +995,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
         TerritoryEffectHelper.getEffects(balticSeaZone), null);
     assertEquals(0, roll.getHits());
     // Get total number of units in Finland before the retreat
-    final int preCountInt = finlandNorway.getUnits().size();
+    final int preCountInt = finlandNorway.getUnitCollection().size();
     // Retreat from the Baltic
     ((MustFightBattle) inBalticSeaZone).externalRetreat(retreatingSeaUnits, northSea, false, bridge);
     // Get the total number of units that should be left
@@ -1017,14 +1027,14 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     assertValid(results);
     // Get the attacking sea units that will retreat
     final List<Unit> retreatingSeaUnits =
-        new ArrayList<>(balticSeaZone.getUnits().getMatches(Matches.enemyUnit(germans, gameData)));
+        new ArrayList<>(balticSeaZone.getUnitCollection().getMatches(Matches.enemyUnit(germans, gameData)));
     // Get the attacking land units that will retreat and their number
     final List<Unit> retreatingLandUnits =
-        new ArrayList<>(finlandNorway.getUnits().getMatches(Matches.enemyUnit(germans, gameData)));
+        new ArrayList<>(finlandNorway.getUnitCollection().getMatches(Matches.enemyUnit(germans, gameData)));
     final int retreatingLandSizeInt = retreatingLandUnits.size();
     // Get the defending land units that and their number
     final List<Unit> defendingLandUnits =
-        new ArrayList<>(finlandNorway.getUnits().getMatches(Matches.enemyUnit(british, gameData)));
+        new ArrayList<>(finlandNorway.getUnitCollection().getMatches(Matches.enemyUnit(british, gameData)));
     final int defendingLandSizeInt = defendingLandUnits.size();
     // Set up the battles and the dependent battles
     final IBattle inFinlandNorway =
@@ -1047,7 +1057,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
         TerritoryEffectHelper.getEffects(balticSeaZone), null);
     assertEquals(1, roll.getHits());
     // Get total number of units in Finland before the retreat
-    final int preCountInt = finlandNorway.getUnits().size();
+    final int preCountInt = finlandNorway.getUnitCollection().size();
     // Retreat from the Baltic
     ((MustFightBattle) inBalticSeaZone).externalRetreat(retreatingSeaUnits, northSea, false, bridge);
     // Get the total number of units that should be left
@@ -1079,13 +1089,13 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     assertValid(results);
     // Get the attacking sea units that will retreat
     final List<Unit> retreatingSeaUnits =
-        new ArrayList<>(balticSeaZone.getUnits().getMatches(Matches.enemyUnit(germans, gameData)));
+        new ArrayList<>(balticSeaZone.getUnitCollection().getMatches(Matches.enemyUnit(germans, gameData)));
     // Get the attacking land units that will retreat and their number
     final List<Unit> retreatingLandUnits =
-        new ArrayList<>(karelia.getUnits().getMatches(Matches.isUnitAllied(russians, gameData)));
+        new ArrayList<>(karelia.getUnitCollection().getMatches(Matches.isUnitAllied(russians, gameData)));
     final int retreatingLandSizeInt = retreatingLandUnits.size();
     // Get the defending land units that and their number
-    retreatingLandUnits.addAll(karelia.getUnits().getMatches(Matches.isUnitAllied(british, gameData)));
+    retreatingLandUnits.addAll(karelia.getUnitCollection().getMatches(Matches.isUnitAllied(british, gameData)));
     final List<Unit> defendingLandUnits = new ArrayList<>();
     final int defendingLandSizeInt = defendingLandUnits.size();
     // Set up the battles and the dependent battles
@@ -1103,7 +1113,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
         TerritoryEffectHelper.getEffects(balticSeaZone), null);
     assertEquals(0, roll.getHits());
     // Get total number of units in Finland before the retreat
-    final int preCountInt = karelia.getUnits().size();
+    final int preCountInt = karelia.getUnitCollection().size();
     // Retreat from the Baltic
     ((MustFightBattle) inBalticSeaZone).externalRetreat(retreatingSeaUnits, northSea, false, bridge);
     // Get the total number of units that should be left
@@ -1135,14 +1145,14 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     assertValid(results);
     // Get the attacking sea units that will retreat
     final List<Unit> retreatingSeaUnits =
-        new ArrayList<>(balticSeaZone.getUnits().getMatches(Matches.enemyUnit(germans, gameData)));
+        new ArrayList<>(balticSeaZone.getUnitCollection().getMatches(Matches.enemyUnit(germans, gameData)));
     // Get the attacking land units that will retreat and their number
     final List<Unit> retreatingLandUnits =
-        new ArrayList<>(karelia.getUnits().getMatches(Matches.isUnitAllied(russians, gameData)));
+        new ArrayList<>(karelia.getUnitCollection().getMatches(Matches.isUnitAllied(russians, gameData)));
     final int retreatingLandSizeInt = retreatingLandUnits.size();
     // Get the defending land units that and their number
     final List<Unit> defendingLandUnits = new ArrayList<>();
-    retreatingLandUnits.addAll(karelia.getUnits().getMatches(Matches.isUnitAllied(british, gameData)));
+    retreatingLandUnits.addAll(karelia.getUnitCollection().getMatches(Matches.isUnitAllied(british, gameData)));
     final int defendingLandSizeInt = defendingLandUnits.size();
     // Set up the battles and the dependent battles
     final IBattle inBalticSeaZone =
@@ -1159,7 +1169,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
         TerritoryEffectHelper.getEffects(balticSeaZone), null);
     assertEquals(1, roll.getHits());
     // Get total number of units in Finland before the retreat
-    final int preCountInt = karelia.getUnits().size();
+    final int preCountInt = karelia.getUnitCollection().size();
     // Retreat from the Baltic
     ((MustFightBattle) inBalticSeaZone).externalRetreat(retreatingSeaUnits, northSea, false, bridge);
     // Get the total number of units that should be left

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
@@ -131,14 +131,14 @@ public class MoveValidatorTest extends AbstractDelegateTestCase {
     final Territory berlin = territory("Berlin", twwGameData);
     final Territory easternGermany = territory("Eastern Germany", twwGameData);
     final Route r = new Route(berlin, easternGermany);
-    List<Unit> toMove = berlin.getUnits().getMatches(Matches.unitCanMove());
+    List<Unit> toMove = berlin.getUnitCollection().getMatches(Matches.unitCanMove());
     MoveValidationResult results = MoveValidator.validateMove(toMove, r, germans, Collections.emptyList(),
         new HashMap<>(), false, null, twwGameData);
     assertTrue(results.isMoveValid());
 
     // Add germanTrain to units which fails since it requires germainRail
     addTo(berlin, GameDataTestUtil.germanTrain(twwGameData).create(1, germans));
-    toMove = berlin.getUnits().getMatches(Matches.unitCanMove());
+    toMove = berlin.getUnitCollection().getMatches(Matches.unitCanMove());
     results = MoveValidator.validateMove(toMove, r, germans, Collections.emptyList(),
         new HashMap<>(), false, null, twwGameData);
     assertFalse(results.isMoveValid());
@@ -181,40 +181,41 @@ public class MoveValidatorTest extends AbstractDelegateTestCase {
     final Territory easternGermany = territory("Eastern Germany", twwGameData);
     final Territory poland = territory("Poland", twwGameData);
     final Route r = new Route(berlin, easternGermany, poland);
-    berlin.getUnits().clear();
+    berlin.getUnitCollection().clear();
     GameDataTestUtil.truck(twwGameData).create(1, germans);
     addTo(berlin, GameDataTestUtil.truck(twwGameData).create(1, germans));
-    MoveValidationResult results = MoveValidator.validateMove(berlin.getUnits(), r, germans, Collections.emptyList(),
-        new HashMap<>(), true, null, twwGameData);
+    MoveValidationResult results =
+        MoveValidator.validateMove(berlin.getUnitCollection(), r, germans, Collections.emptyList(),
+            new HashMap<>(), true, null, twwGameData);
     assertTrue(results.isMoveValid());
 
     // Add an infantry for truck to transport
     addTo(berlin, GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
-    results = MoveValidator.validateMove(berlin.getUnits(), r, germans, Collections.emptyList(),
+    results = MoveValidator.validateMove(berlin.getUnitCollection(), r, germans, Collections.emptyList(),
         new HashMap<>(), true, null, twwGameData);
     assertTrue(results.isMoveValid());
 
     // Add an infantry and the truck can't transport both
     addTo(berlin, GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
-    results = MoveValidator.validateMove(berlin.getUnits(), r, germans, Collections.emptyList(),
+    results = MoveValidator.validateMove(berlin.getUnitCollection(), r, germans, Collections.emptyList(),
         new HashMap<>(), true, null, twwGameData);
     assertFalse(results.isMoveValid());
 
     // Add a large truck (has capacity for 2 infantry) to transport second infantry
     addTo(berlin, GameDataTestUtil.largeTruck(twwGameData).create(1, germans));
-    results = MoveValidator.validateMove(berlin.getUnits(), r, germans, Collections.emptyList(),
+    results = MoveValidator.validateMove(berlin.getUnitCollection(), r, germans, Collections.emptyList(),
         new HashMap<>(), true, null, twwGameData);
     assertTrue(results.isMoveValid());
 
     // Add an infantry that the large truck can also transport
     addTo(berlin, GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
-    results = MoveValidator.validateMove(berlin.getUnits(), r, germans, Collections.emptyList(),
+    results = MoveValidator.validateMove(berlin.getUnitCollection(), r, germans, Collections.emptyList(),
         new HashMap<>(), true, null, twwGameData);
     assertTrue(results.isMoveValid());
 
     // Add an infantry that can't be transported
     addTo(berlin, GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
-    results = MoveValidator.validateMove(berlin.getUnits(), r, germans, Collections.emptyList(),
+    results = MoveValidator.validateMove(berlin.getUnitCollection(), r, germans, Collections.emptyList(),
         new HashMap<>(), true, null, twwGameData);
     assertFalse(results.isMoveValid());
   }
@@ -229,23 +230,23 @@ public class MoveValidatorTest extends AbstractDelegateTestCase {
     final Territory northernGermany = territory("Northern Germany", twwGameData);
     final Territory sz27 = territory("27 Sea Zone", twwGameData);
     final Route r = new Route(northernGermany, sz27);
-    northernGermany.getUnits().clear();
+    northernGermany.getUnitCollection().clear();
     addTo(northernGermany, GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
-    final List<Unit> transport = sz27.getUnits().getMatches(Matches.unitIsTransport());
-    MoveValidationResult results = MoveValidator.validateMove(northernGermany.getUnits(), r, germans,
+    final List<Unit> transport = sz27.getUnitCollection().getMatches(Matches.unitIsTransport());
+    MoveValidationResult results = MoveValidator.validateMove(northernGermany.getUnitCollection(), r, germans,
         transport, new HashMap<>(), false, null, twwGameData);
     assertTrue(results.isMoveValid());
 
     // Add USA ship to transport sea zone
     final PlayerId usa = GameDataTestUtil.usa(twwGameData);
     addTo(sz27, GameDataTestUtil.americanCruiser(twwGameData).create(1, usa));
-    results = MoveValidator.validateMove(northernGermany.getUnits(), r, germans,
+    results = MoveValidator.validateMove(northernGermany.getUnitCollection(), r, germans,
         transport, new HashMap<>(), false, null, twwGameData);
     assertFalse(results.isMoveValid());
 
     // Set 'Units Can Load In Hostile Sea Zones' to true
     twwGameData.getProperties().set(Constants.UNITS_CAN_LOAD_IN_HOSTILE_SEA_ZONES, true);
-    results = MoveValidator.validateMove(northernGermany.getUnits(), r, germans,
+    results = MoveValidator.validateMove(northernGermany.getUnitCollection(), r, germans,
         transport, new HashMap<>(), false, null, twwGameData);
     assertTrue(results.isMoveValid());
   }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MustFightBattleTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MustFightBattleTest.java
@@ -37,7 +37,7 @@ public class MustFightBattleTest extends AbstractDelegateTestCase {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(twwGameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(twwGameData).start();
-    move(sz33.getUnitCollection().getUnits(), new Route(sz33, sz40));
+    move(sz33.getUnits(), new Route(sz33, sz40));
     moveDelegate(twwGameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(twwGameData).getPendingBattle(sz40, false, null);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MustFightBattleTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MustFightBattleTest.java
@@ -37,7 +37,7 @@ public class MustFightBattleTest extends AbstractDelegateTestCase {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(twwGameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(twwGameData).start();
-    move(sz33.getUnits().getUnits(), new Route(sz33, sz40));
+    move(sz33.getUnitCollection().getUnits(), new Route(sz33, sz40));
     moveDelegate(twwGameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(twwGameData).getPendingBattle(sz40, false, null);
@@ -45,7 +45,7 @@ public class MustFightBattleTest extends AbstractDelegateTestCase {
     // Set first roll to hit (mine AA) and check that both units are killed
     whenGetRandom(bridge).thenAnswer(withValues(0));
     battle.fight(bridge);
-    assertEquals(0, sz40.getUnits().size());
+    assertEquals(0, sz40.getUnitCollection().size());
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
   }
 
@@ -57,7 +57,7 @@ public class MustFightBattleTest extends AbstractDelegateTestCase {
     final PlayerId usa = GameDataTestUtil.usa(twwGameData);
     final PlayerId germany = GameDataTestUtil.germany(twwGameData);
     final Territory celebes = territory("Celebes", twwGameData);
-    celebes.getUnits().clear();
+    celebes.getUnitCollection().clear();
     addTo(celebes, GameDataTestUtil.americanStrategicBomber(twwGameData).create(1, usa));
     addTo(celebes, GameDataTestUtil.germanInfantry(twwGameData).create(1, germany));
     final IDelegateBridge bridge = MockDelegateBridge.newInstance(twwGameData, germany);
@@ -68,7 +68,7 @@ public class MustFightBattleTest extends AbstractDelegateTestCase {
 
     // Ensure battle ends, both units remain, and has 0 rolls
     battle.fight(bridge);
-    assertEquals(2, celebes.getUnits().size());
+    assertEquals(2, celebes.getUnitCollection().size());
     thenGetRandomShouldHaveBeenCalled(bridge, times(0));
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
@@ -247,14 +247,15 @@ public class PacificTest extends AbstractDelegateTestCase {
     // movement to force boarding
     route.add(sz24);
     // verify unit counts before move
-    assertEquals(2, bonin.getUnits().size());
-    assertEquals(1, sz24.getUnits().size());
+    assertEquals(2, bonin.getUnitCollection().size());
+    assertEquals(1, sz24.getUnitCollection().size());
     // validate movement
     final String results =
-        delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route, route.getEnd().getUnits().getUnits());
+        delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route,
+            route.getEnd().getUnitCollection().getUnits());
     assertValid(results);
     // verify unit counts after move
-    assertEquals(1, bonin.getUnits().size());
-    assertEquals(2, sz24.getUnits().size());
+    assertEquals(1, bonin.getUnitCollection().size());
+    assertEquals(2, sz24.getUnitCollection().size());
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
@@ -252,7 +252,7 @@ public class PacificTest extends AbstractDelegateTestCase {
     // validate movement
     final String results =
         delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route,
-            route.getEnd().getUnitCollection().getUnits());
+            route.getEnd().getUnits());
     assertValid(results);
     // verify unit counts after move
     assertEquals(1, bonin.getUnitCollection().size());

--- a/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -135,7 +135,7 @@ public class RevisedTest {
     advanceToStep(bridge, "NonCombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    final String error = moveDelegate(gameData).move(sz1.getUnitCollection().getUnits(), new Route(sz1, sz11, sz9));
+    final String error = moveDelegate(gameData).move(sz1.getUnits(), new Route(sz1, sz11, sz9));
     assertNotNull(error);
   }
 
@@ -181,7 +181,7 @@ public class RevisedTest {
     // the transport can enter sz 8
     // since the sub is submerged
     final Route m1 = new Route(sz1, sz8);
-    assertNull(moveDelegate.move(sz1.getUnitCollection().getUnits(), m1));
+    assertNull(moveDelegate.move(sz1.getUnits(), m1));
     // the transport can now leave sz8
     final Route m2 = new Route(sz8, sz7);
     final String error = moveDelegate.move(sz8.getUnitCollection().getMatches(Matches.unitIsOwnedBy(british)), m2);
@@ -201,7 +201,7 @@ public class RevisedTest {
     initDel.end();
     // make sinkian japanese owned, put one infantry in it
     final Territory sinkiang = gameData.getMap().getTerritory("Sinkiang");
-    gameData.performChange(ChangeFactory.removeUnits(sinkiang, sinkiang.getUnitCollection().getUnits()));
+    gameData.performChange(ChangeFactory.removeUnits(sinkiang, sinkiang.getUnits()));
     final PlayerId japanese = GameDataTestUtil.japanese(gameData);
     sinkiang.setOwner(japanese);
     final UnitType infantryType = infantry(gameData);
@@ -212,7 +212,7 @@ public class RevisedTest {
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
     final Territory novo = gameData.getMap().getTerritory("Novosibirsk");
-    moveDelegate.move(novo.getUnitCollection().getUnits(), gameData.getMap().getRoute(novo, sinkiang));
+    moveDelegate.move(novo.getUnits(), gameData.getMap().getRoute(novo, sinkiang));
     moveDelegate.end();
     final BattleDelegate battle = (BattleDelegate) gameData.getDelegateList().getDelegate("battle");
     battle.setDelegateBridgeAndPlayer(bridge);
@@ -254,7 +254,7 @@ public class RevisedTest {
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final Territory karelia = gameData.getMap().getTerritory("Karelia S.S.R.");
     final Territory sz5 = gameData.getMap().getTerritory("5 Sea Zone");
-    gameData.performChange(ChangeFactory.removeUnits(sz5, sz5.getUnitCollection().getUnits()));
+    gameData.performChange(ChangeFactory.removeUnits(sz5, sz5.getUnits()));
     final UnitType infantryType = infantry(gameData);
     final UnitType subType = submarine(gameData);
     final UnitType trnType = transport(gameData);
@@ -263,17 +263,17 @@ public class RevisedTest {
     gameData.performChange(ChangeFactory.addUnits(sz5, subType.create(1, russians)));
     // submerge the russian sub
     final TripleAUnit sub = (TripleAUnit) CollectionUtils
-        .getMatches(sz5.getUnitCollection().getUnits(), Matches.unitIsOwnedBy(russians)).iterator().next();
+        .getMatches(sz5.getUnits(), Matches.unitIsOwnedBy(russians)).iterator().next();
     sub.setSubmerged(true);
     // now move an infantry through the sz
     String results = moveDelegate.move(
-        CollectionUtils.getNMatches(germany.getUnitCollection().getUnits(), 1, Matches.unitIsOfType(infantryType)),
+        CollectionUtils.getNMatches(germany.getUnits(), 1, Matches.unitIsOfType(infantryType)),
         gameData.getMap().getRoute(germany, sz5),
-        CollectionUtils.getMatches(sz5.getUnitCollection().getUnits(), Matches.unitIsOfType(trnType)));
+        CollectionUtils.getMatches(sz5.getUnits(), Matches.unitIsOfType(trnType)));
     assertNull(results);
     results =
         moveDelegate.move(
-            CollectionUtils.getNMatches(sz5.getUnitCollection().getUnits(), 1, Matches.unitIsOfType(infantryType)),
+            CollectionUtils.getNMatches(sz5.getUnits(), 1, Matches.unitIsOfType(infantryType)),
             gameData.getMap().getRoute(sz5, karelia));
     assertNull(results);
     moveDelegate.end();
@@ -316,7 +316,7 @@ public class RevisedTest {
     // create 20 british infantry
     addTo(british(gameData), infantry(gameData).create(20, british(gameData)), gameData);
     final Territory uk = territory("United Kingdom", gameData);
-    final Collection<Unit> units = british(gameData).getUnitCollection().getUnits();
+    final Collection<Unit> units = british(gameData).getUnits();
     final PlaceableUnits placeable = bidPlaceDelegate(gameData).getPlaceableUnits(units, uk);
     assertEquals(20, placeable.getMaxUnits());
     assertNull(placeable.getErrorMessage());
@@ -670,7 +670,7 @@ public class RevisedTest {
     advanceToStep(bridge, "NonCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    final String error = moveDelegate(gameData).move(sz8.getUnitCollection().getUnits(), new Route(sz8, sz1));
+    final String error = moveDelegate(gameData).move(sz8.getUnits(), new Route(sz8, sz1));
     assertError(error);
   }
 
@@ -686,7 +686,7 @@ public class RevisedTest {
     advanceToStep(bridge, "NonCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    final String error = moveDelegate(gameData).move(sz8.getUnitCollection().getUnits(), new Route(sz8, sz2));
+    final String error = moveDelegate(gameData).move(sz8.getUnits(), new Route(sz8, sz2));
     assertError(error);
   }
 
@@ -702,7 +702,7 @@ public class RevisedTest {
     advanceToStep(bridge, "NonCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    final String error = moveDelegate(gameData).move(sz8.getUnitCollection().getUnits(), new Route(sz1, sz8));
+    final String error = moveDelegate(gameData).move(sz8.getUnits(), new Route(sz1, sz8));
     assertError(error);
   }
 
@@ -763,7 +763,7 @@ public class RevisedTest {
     // Preset units in FIC
     final UnitType infType = infantry(gameData);
     // UnitType aaType = GameDataTestUtil.aaGun(gameData);
-    removeFrom(fic, fic.getUnitCollection().getUnits());
+    removeFrom(fic, fic.getUnits());
     addTo(fic, aaGun(gameData).create(1, japanese));
     addTo(fic, infantry(gameData).create(1, japanese));
     assertEquals(2, fic.getUnitCollection().getUnitCount());
@@ -961,7 +961,7 @@ public class RevisedTest {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(from.getUnitCollection().getUnits(), new Route(from, attacked));
+    move(from.getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
@@ -983,7 +983,7 @@ public class RevisedTest {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(from.getUnitCollection().getUnits(), new Route(from, attacked));
+    move(from.getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
@@ -1005,7 +1005,7 @@ public class RevisedTest {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(from.getUnitCollection().getUnits(), new Route(from, attacked));
+    move(from.getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
@@ -1042,7 +1042,7 @@ public class RevisedTest {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(from.getUnitCollection().getUnits(), new Route(from, attacked));
+    move(from.getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
@@ -1096,7 +1096,7 @@ public class RevisedTest {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(from.getUnitCollection().getUnits(), new Route(from, attacked));
+    move(from.getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
@@ -1152,7 +1152,7 @@ public class RevisedTest {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(from.getUnitCollection().getUnits(), new Route(from, attacked));
+    move(from.getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
@@ -1192,7 +1192,7 @@ public class RevisedTest {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(from.getUnitCollection().getUnits(), new Route(from, attacked));
+    move(from.getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
@@ -1249,7 +1249,7 @@ public class RevisedTest {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(from.getUnitCollection().getUnits(), new Route(from, attacked));
+    move(from.getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
@@ -1407,7 +1407,7 @@ public class RevisedTest {
     final MoveDelegate moveDelegate = moveDelegate(gameData);
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    final String error = moveDelegate.move(sz15.getUnitCollection().getUnits(), new Route(sz15, sz34));
+    final String error = moveDelegate.move(sz15.getUnits(), new Route(sz15, sz34));
     assertValid(error);
   }
 
@@ -1417,13 +1417,13 @@ public class RevisedTest {
     final Territory sz15 = territory("15 Sea Zone", gameData);
     final Territory sz34 = territory("34 Sea Zone", gameData);
     // clear the british in sz 15
-    removeFrom(sz15, sz15.getUnitCollection().getUnits());
+    removeFrom(sz15, sz15.getUnits());
     final IDelegateBridge bridge = newDelegateBridge(germans(gameData));
     advanceToStep(bridge, "CombatMove");
     final MoveDelegate moveDelegate = moveDelegate(gameData);
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    final String error = moveDelegate.move(sz14.getUnitCollection().getUnits(), new Route(sz14, sz15, sz34));
+    final String error = moveDelegate.move(sz14.getUnits(), new Route(sz14, sz15, sz34));
     assertError(error);
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -135,7 +135,7 @@ public class RevisedTest {
     advanceToStep(bridge, "NonCombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    final String error = moveDelegate(gameData).move(sz1.getUnits().getUnits(), new Route(sz1, sz11, sz9));
+    final String error = moveDelegate(gameData).move(sz1.getUnitCollection().getUnits(), new Route(sz1, sz11, sz9));
     assertNotNull(error);
   }
 
@@ -170,7 +170,7 @@ public class RevisedTest {
     final Territory sz1 = gameData.getMap().getTerritory("1 Sea Zone");
     final Territory sz7 = gameData.getMap().getTerritory("7 Sea Zone");
     final Territory sz8 = gameData.getMap().getTerritory("8 Sea Zone");
-    final TripleAUnit sub = (TripleAUnit) sz8.getUnits().iterator().next();
+    final TripleAUnit sub = (TripleAUnit) sz8.getUnitCollection().iterator().next();
     sub.setSubmerged(true);
     // now move to attack it
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegateList().getDelegate("move");
@@ -181,10 +181,10 @@ public class RevisedTest {
     // the transport can enter sz 8
     // since the sub is submerged
     final Route m1 = new Route(sz1, sz8);
-    assertNull(moveDelegate.move(sz1.getUnits().getUnits(), m1));
+    assertNull(moveDelegate.move(sz1.getUnitCollection().getUnits(), m1));
     // the transport can now leave sz8
     final Route m2 = new Route(sz8, sz7);
-    final String error = moveDelegate.move(sz8.getUnits().getMatches(Matches.unitIsOwnedBy(british)), m2);
+    final String error = moveDelegate.move(sz8.getUnitCollection().getMatches(Matches.unitIsOwnedBy(british)), m2);
     assertNull(error, error);
   }
 
@@ -201,7 +201,7 @@ public class RevisedTest {
     initDel.end();
     // make sinkian japanese owned, put one infantry in it
     final Territory sinkiang = gameData.getMap().getTerritory("Sinkiang");
-    gameData.performChange(ChangeFactory.removeUnits(sinkiang, sinkiang.getUnits().getUnits()));
+    gameData.performChange(ChangeFactory.removeUnits(sinkiang, sinkiang.getUnitCollection().getUnits()));
     final PlayerId japanese = GameDataTestUtil.japanese(gameData);
     sinkiang.setOwner(japanese);
     final UnitType infantryType = infantry(gameData);
@@ -212,7 +212,7 @@ public class RevisedTest {
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
     final Territory novo = gameData.getMap().getTerritory("Novosibirsk");
-    moveDelegate.move(novo.getUnits().getUnits(), gameData.getMap().getRoute(novo, sinkiang));
+    moveDelegate.move(novo.getUnitCollection().getUnits(), gameData.getMap().getRoute(novo, sinkiang));
     moveDelegate.end();
     final BattleDelegate battle = (BattleDelegate) gameData.getDelegateList().getDelegate("battle");
     battle.setDelegateBridgeAndPlayer(bridge);
@@ -232,11 +232,11 @@ public class RevisedTest {
     r.setStart(russia);
     r.add(novo);
     r.add(sinkiang);
-    assertNull(moveDelegate.move(russia.getUnits().getMatches(Matches.unitCanBlitz()), r));
+    assertNull(moveDelegate.move(russia.getUnitCollection().getMatches(Matches.unitCanBlitz()), r));
     moveDelegate.undoMove(0);
     assertTrue(battle.getBattleTracker().wasConquered(sinkiang));
     // now move the planes into the territory
-    assertNull(moveDelegate.move(russia.getUnits().getMatches(Matches.unitIsAir()), r));
+    assertNull(moveDelegate.move(russia.getUnitCollection().getMatches(Matches.unitIsAir()), r));
     // make sure they can't land, they can't because the territory was conquered
     assertEquals(1, moveDelegate.getTerritoriesWhereAirCantLand().size());
   }
@@ -254,7 +254,7 @@ public class RevisedTest {
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final Territory karelia = gameData.getMap().getTerritory("Karelia S.S.R.");
     final Territory sz5 = gameData.getMap().getTerritory("5 Sea Zone");
-    gameData.performChange(ChangeFactory.removeUnits(sz5, sz5.getUnits().getUnits()));
+    gameData.performChange(ChangeFactory.removeUnits(sz5, sz5.getUnitCollection().getUnits()));
     final UnitType infantryType = infantry(gameData);
     final UnitType subType = submarine(gameData);
     final UnitType trnType = transport(gameData);
@@ -263,16 +263,17 @@ public class RevisedTest {
     gameData.performChange(ChangeFactory.addUnits(sz5, subType.create(1, russians)));
     // submerge the russian sub
     final TripleAUnit sub = (TripleAUnit) CollectionUtils
-        .getMatches(sz5.getUnits().getUnits(), Matches.unitIsOwnedBy(russians)).iterator().next();
+        .getMatches(sz5.getUnitCollection().getUnits(), Matches.unitIsOwnedBy(russians)).iterator().next();
     sub.setSubmerged(true);
     // now move an infantry through the sz
     String results = moveDelegate.move(
-        CollectionUtils.getNMatches(germany.getUnits().getUnits(), 1, Matches.unitIsOfType(infantryType)),
+        CollectionUtils.getNMatches(germany.getUnitCollection().getUnits(), 1, Matches.unitIsOfType(infantryType)),
         gameData.getMap().getRoute(germany, sz5),
-        CollectionUtils.getMatches(sz5.getUnits().getUnits(), Matches.unitIsOfType(trnType)));
+        CollectionUtils.getMatches(sz5.getUnitCollection().getUnits(), Matches.unitIsOfType(trnType)));
     assertNull(results);
     results =
-        moveDelegate.move(CollectionUtils.getNMatches(sz5.getUnits().getUnits(), 1, Matches.unitIsOfType(infantryType)),
+        moveDelegate.move(
+            CollectionUtils.getNMatches(sz5.getUnitCollection().getUnits(), 1, Matches.unitIsOfType(infantryType)),
             gameData.getMap().getRoute(sz5, karelia));
     assertNull(results);
     moveDelegate.end();
@@ -299,8 +300,9 @@ public class RevisedTest {
     addTo(uk, infantry(gameData).create(2, americans));
     // try to load them on the british players turn
     final Territory sz2 = territory("2 Sea Zone", gameData);
-    final String error = moveDelegate(gameData).move(uk.getUnits().getMatches(Matches.unitIsOwnedBy(americans)),
-        new Route(uk, sz2), sz2.getUnits().getMatches(Matches.unitIsTransport()));
+    final String error =
+        moveDelegate(gameData).move(uk.getUnitCollection().getMatches(Matches.unitIsOwnedBy(americans)),
+            new Route(uk, sz2), sz2.getUnitCollection().getMatches(Matches.unitIsTransport()));
     // should not be able to load on british turn, only on american turn
     assertNotNull(error);
   }
@@ -314,7 +316,7 @@ public class RevisedTest {
     // create 20 british infantry
     addTo(british(gameData), infantry(gameData).create(20, british(gameData)), gameData);
     final Territory uk = territory("United Kingdom", gameData);
-    final Collection<Unit> units = british(gameData).getUnits().getUnits();
+    final Collection<Unit> units = british(gameData).getUnitCollection().getUnits();
     final PlaceableUnits placeable = bidPlaceDelegate(gameData).getPlaceableUnits(units, uk);
     assertEquals(20, placeable.getMaxUnits());
     assertNull(placeable.getErrorMessage());
@@ -336,11 +338,11 @@ public class RevisedTest {
     final Territory we = territory("Western Europe", gameData);
     final Territory se = territory("Southern Europe", gameData);
     final Route route = new Route(uk, territory("7 Sea Zone", gameData), we, se);
-    move(uk.getUnits().getMatches(Matches.unitIsStrategicBomber()), route);
+    move(uk.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()), route);
     // the aa gun should have fired. the bomber no longer exists
-    assertTrue(se.getUnits().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
-    assertTrue(we.getUnits().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
-    assertTrue(uk.getUnits().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
+    assertTrue(se.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
+    assertTrue(we.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
+    assertTrue(uk.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
   }
 
   @Test
@@ -362,12 +364,12 @@ public class RevisedTest {
     final Territory balk = territory("Balkans", gameData);
     addTo(uk, bomber(gameData).create(1, british));
     final Route route = new Route(uk, sz7, we, se, balk);
-    move(uk.getUnits().getMatches(Matches.unitIsStrategicBomber()), route);
+    move(uk.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()), route);
     // the aa gun should have fired (one hit, one miss in each territory overflown). the bombers no longer exists
-    assertTrue(uk.getUnits().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
-    assertTrue(we.getUnits().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
-    assertTrue(se.getUnits().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
-    assertTrue(balk.getUnits().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
+    assertTrue(uk.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
+    assertTrue(we.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
+    assertTrue(se.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
+    assertTrue(balk.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
   }
 
   @Test
@@ -386,11 +388,11 @@ public class RevisedTest {
     final Territory we = territory("Western Europe", gameData);
     final Territory se = territory("Southern Europe", gameData);
     final Route route = new Route(uk, territory("7 Sea Zone", gameData), we, se);
-    move(uk.getUnits().getMatches(Matches.unitIsStrategicBomber()), route);
+    move(uk.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()), route);
     // the aa gun should have fired and hit
-    assertTrue(se.getUnits().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
-    assertTrue(we.getUnits().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
-    assertTrue(uk.getUnits().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
+    assertTrue(se.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
+    assertTrue(we.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
+    assertTrue(uk.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()).isEmpty());
   }
 
   @Test
@@ -406,7 +408,7 @@ public class RevisedTest {
     final Route sz14To13 = new Route();
     sz14To13.setStart(sz14);
     sz14To13.add(sz13);
-    final List<Unit> transports = sz14.getUnits().getMatches(Matches.unitIsTransport());
+    final List<Unit> transports = sz14.getUnitCollection().getMatches(Matches.unitIsTransport());
     assertEquals(1, transports.size());
     final String error = moveDelegate.move(transports, sz14To13);
     assertNull(error, error);
@@ -427,9 +429,9 @@ public class RevisedTest {
     eeToSz5.setStart(eastEurope);
     eeToSz5.add(sz5);
     // load the transport in the baltic
-    final List<Unit> infantry = eastEurope.getUnits().getMatches(Matches.unitIsOfType(infantryType));
+    final List<Unit> infantry = eastEurope.getUnitCollection().getMatches(Matches.unitIsOfType(infantryType));
     assertEquals(2, infantry.size());
-    final TripleAUnit transport = (TripleAUnit) sz5.getUnits().getMatches(Matches.unitIsTransport()).get(0);
+    final TripleAUnit transport = (TripleAUnit) sz5.getUnitCollection().getMatches(Matches.unitIsTransport()).get(0);
     final String error = moveDelegate.move(infantry, eeToSz5, Collections.singletonList(transport));
     assertNull(error, error);
     // make sure the transport was loaded
@@ -460,9 +462,9 @@ public class RevisedTest {
     eeToSz5.setStart(eastEurope);
     eeToSz5.add(sz5);
     // load the transport in the baltic
-    final List<Unit> infantry = eastEurope.getUnits().getMatches(Matches.unitIsOfType(infantryType));
+    final List<Unit> infantry = eastEurope.getUnitCollection().getMatches(Matches.unitIsOfType(infantryType));
     assertEquals(2, infantry.size());
-    final TripleAUnit transport = (TripleAUnit) sz5.getUnits().getMatches(Matches.unitIsTransport()).get(0);
+    final TripleAUnit transport = (TripleAUnit) sz5.getUnitCollection().getMatches(Matches.unitIsTransport()).get(0);
     // load the transport
     String error = moveDelegate.move(infantry, eeToSz5, Collections.singletonList(transport));
     assertNull(error, error);
@@ -506,9 +508,9 @@ public class RevisedTest {
     eeToSz5.setStart(eastEurope);
     eeToSz5.add(sz5);
     // load the transport in the baltic
-    final List<Unit> infantry = eastEurope.getUnits().getMatches(Matches.unitIsOfType(infantryType));
+    final List<Unit> infantry = eastEurope.getUnitCollection().getMatches(Matches.unitIsOfType(infantryType));
     assertEquals(2, infantry.size());
-    final TripleAUnit transport = (TripleAUnit) sz5.getUnits().getMatches(Matches.unitIsTransport()).get(0);
+    final TripleAUnit transport = (TripleAUnit) sz5.getUnitCollection().getMatches(Matches.unitIsTransport()).get(0);
     // load the transports
     // in two moves
     String error = moveDelegate.move(infantry.subList(0, 1), eeToSz5, Collections.singletonList(transport));
@@ -545,10 +547,10 @@ public class RevisedTest {
     eeToSz5.setStart(eastEurope);
     eeToSz5.add(sz5);
     // load the transport in the baltic
-    final List<Unit> infantry = eastEurope.getUnits()
+    final List<Unit> infantry = eastEurope.getUnitCollection()
         .getMatches(Matches.unitIsOfType(infantryType).and(Matches.unitIsOwnedBy(japanese)));
     assertEquals(1, infantry.size());
-    final TripleAUnit transport = (TripleAUnit) sz5.getUnits().getMatches(Matches.unitIsTransport()).get(0);
+    final TripleAUnit transport = (TripleAUnit) sz5.getUnitCollection().getMatches(Matches.unitIsTransport()).get(0);
     String error = moveDelegate.move(infantry, eeToSz5, Collections.singletonList(transport));
     assertNull(error, error);
     // try to unload
@@ -575,9 +577,9 @@ public class RevisedTest {
     eeToSz5.setStart(eastEurope);
     eeToSz5.add(sz5);
     // load the transport in the baltic
-    final List<Unit> infantry = eastEurope.getUnits().getMatches(Matches.unitIsOfType(infantryType));
+    final List<Unit> infantry = eastEurope.getUnitCollection().getMatches(Matches.unitIsOfType(infantryType));
     assertEquals(2, infantry.size());
-    final TripleAUnit transport = (TripleAUnit) sz5.getUnits().getMatches(Matches.unitIsTransport()).get(0);
+    final TripleAUnit transport = (TripleAUnit) sz5.getUnitCollection().getMatches(Matches.unitIsTransport()).get(0);
     String error = moveDelegate.move(infantry, eeToSz5, Collections.singletonList(transport));
     assertNull(error, error);
     // unload one infantry to Norway
@@ -628,9 +630,9 @@ public class RevisedTest {
     eeToSz5.setStart(eastEurope);
     eeToSz5.add(sz5);
     // load the transport in the baltic
-    final List<Unit> infantry = eastEurope.getUnits().getMatches(Matches.unitIsOfType(infantryType));
+    final List<Unit> infantry = eastEurope.getUnitCollection().getMatches(Matches.unitIsOfType(infantryType));
     assertEquals(2, infantry.size());
-    final TripleAUnit transport = (TripleAUnit) sz5.getUnits().getMatches(Matches.unitIsTransport()).get(0);
+    final TripleAUnit transport = (TripleAUnit) sz5.getUnitCollection().getMatches(Matches.unitIsTransport()).get(0);
     String error = moveDelegate.move(infantry, eeToSz5, Collections.singletonList(transport));
     assertNull(error, error);
     // unload one infantry to Norway
@@ -668,7 +670,7 @@ public class RevisedTest {
     advanceToStep(bridge, "NonCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    final String error = moveDelegate(gameData).move(sz8.getUnits().getUnits(), new Route(sz8, sz1));
+    final String error = moveDelegate(gameData).move(sz8.getUnitCollection().getUnits(), new Route(sz8, sz1));
     assertError(error);
   }
 
@@ -684,7 +686,7 @@ public class RevisedTest {
     advanceToStep(bridge, "NonCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    final String error = moveDelegate(gameData).move(sz8.getUnits().getUnits(), new Route(sz8, sz2));
+    final String error = moveDelegate(gameData).move(sz8.getUnitCollection().getUnits(), new Route(sz8, sz2));
     assertError(error);
   }
 
@@ -700,7 +702,7 @@ public class RevisedTest {
     advanceToStep(bridge, "NonCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    final String error = moveDelegate(gameData).move(sz8.getUnits().getUnits(), new Route(sz1, sz8));
+    final String error = moveDelegate(gameData).move(sz8.getUnitCollection().getUnits(), new Route(sz1, sz8));
     assertError(error);
   }
 
@@ -724,7 +726,7 @@ public class RevisedTest {
     final Route sz50To45 = new Route();
     sz50To45.setStart(sz50);
     sz50To45.add(sz45);
-    String error = moveDelegate.move(sz50.getUnits().getMatches(Matches.unitIsAir()), sz50To45);
+    String error = moveDelegate.move(sz50.getUnitCollection().getMatches(Matches.unitIsAir()), sz50To45);
     assertNull(error);
     assertEquals(1, AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattleSites(false).size());
     // we should be able to move the sub out of the sz
@@ -732,7 +734,7 @@ public class RevisedTest {
     sz45To50.setStart(sz45);
     sz45To50.add(sz50);
     final List<Unit> japSub =
-        sz45.getUnits().getMatches(Matches.unitIsSub().and(Matches.unitIsOwnedBy(japanese)));
+        sz45.getUnitCollection().getMatches(Matches.unitIsSub().and(Matches.unitIsOwnedBy(japanese)));
     error = moveDelegate.move(japSub, sz45To50);
     // make sure no error
     assertNull(error);
@@ -761,16 +763,16 @@ public class RevisedTest {
     // Preset units in FIC
     final UnitType infType = infantry(gameData);
     // UnitType aaType = GameDataTestUtil.aaGun(gameData);
-    removeFrom(fic, fic.getUnits().getUnits());
+    removeFrom(fic, fic.getUnitCollection().getUnits());
     addTo(fic, aaGun(gameData).create(1, japanese));
     addTo(fic, infantry(gameData).create(1, japanese));
-    assertEquals(2, fic.getUnits().getUnitCount());
+    assertEquals(2, fic.getUnitCollection().getUnitCount());
     // Get attacking units
-    final Collection<Unit> britishUnits = india.getUnits().getUnits(infType, 1);
-    final Collection<Unit> japaneseUnits = kwang.getUnits().getUnits(infType, 1);
-    final Collection<Unit> americanUnits = china.getUnits().getUnits(infType, 1);
+    final Collection<Unit> britishUnits = india.getUnitCollection().getUnits(infType, 1);
+    final Collection<Unit> japaneseUnits = kwang.getUnitCollection().getUnits(infType, 1);
+    final Collection<Unit> americanUnits = china.getUnitCollection().getUnits(infType, 1);
     // Get Owner prior to battle
-    assertTrue(fic.getUnits().allMatch(Matches.unitIsOwnedBy(japanese(gameData))));
+    assertTrue(fic.getUnitCollection().allMatch(Matches.unitIsOwnedBy(japanese(gameData))));
     final String preOwner = fic.getOwner().getName();
     assertEquals(Constants.PLAYER_NAME_JAPANESE, preOwner);
     // Set up the move delegate
@@ -794,7 +796,7 @@ public class RevisedTest {
         .thenAnswer(withValues(5));
     battle.fight(delegateBridge);
     // Get Owner after to battle
-    assertTrue(fic.getUnits().allMatch(Matches.unitIsOwnedBy(british(gameData))));
+    assertTrue(fic.getUnitCollection().allMatch(Matches.unitIsOwnedBy(british(gameData))));
     final String postOwner = fic.getOwner().getName();
     assertEquals(Constants.PLAYER_NAME_BRITISH, postOwner);
     /*
@@ -816,7 +818,7 @@ public class RevisedTest {
         .thenAnswer(withValues(5));
     battle.fight(delegateBridge);
     // Get Owner after to battle
-    assertTrue(fic.getUnits().allMatch(Matches.unitIsOwnedBy(japanese(gameData))));
+    assertTrue(fic.getUnitCollection().allMatch(Matches.unitIsOwnedBy(japanese(gameData))));
     final String midOwner = fic.getOwner().getName();
     assertEquals(Constants.PLAYER_NAME_JAPANESE, midOwner);
     /*
@@ -838,7 +840,7 @@ public class RevisedTest {
         .thenAnswer(withValues(5));
     battle.fight(delegateBridge);
     // Get Owner after to battle
-    assertTrue(fic.getUnits().allMatch(Matches.unitIsOwnedBy(americans(gameData))));
+    assertTrue(fic.getUnitCollection().allMatch(Matches.unitIsOwnedBy(americans(gameData))));
     final String endOwner = fic.getOwner().getName();
     assertEquals(Constants.PLAYER_NAME_AMERICANS, endOwner);
   }
@@ -851,7 +853,7 @@ public class RevisedTest {
     final PlayerId british = GameDataTestUtil.british(gameData);
     final BattleTracker tracker = new BattleTracker();
     final StrategicBombingRaidBattle battle = new StrategicBombingRaidBattle(germany, gameData, british, tracker);
-    final List<Unit> bombers = uk.getUnits().getMatches(Matches.unitIsStrategicBomber());
+    final List<Unit> bombers = uk.getUnitCollection().getMatches(Matches.unitIsStrategicBomber());
     addTo(germany, bombers);
     battle.addAttackChange(gameData.getMap().getRoute(uk, germany), bombers, null);
     tracker.getBattleRecords().addBattle(british, battle.getBattleId(), germany, battle.getBattleType());
@@ -862,7 +864,7 @@ public class RevisedTest {
     battle.fight(bridge);
     final int pusAfterRaid = germans.getResources().getQuantity(gameData.getResourceList().getResource(Constants.PUS));
     assertEquals(pusBeforeRaid, pusAfterRaid);
-    assertEquals(0, germany.getUnits().getMatches(Matches.unitIsOwnedBy(british)).size());
+    assertEquals(0, germany.getUnitCollection().getMatches(Matches.unitIsOwnedBy(british)).size());
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
   }
 
@@ -893,7 +895,7 @@ public class RevisedTest {
     battle.fight(bridge);
     final int pusAfterRaid = germans.getResources().getQuantity(gameData.getResourceList().getResource(Constants.PUS));
     assertEquals(pusBeforeRaid - 1, pusAfterRaid);
-    assertEquals(1, germany.getUnits().getMatches(Matches.unitIsOwnedBy(british)).size());
+    assertEquals(1, germany.getUnitCollection().getMatches(Matches.unitIsOwnedBy(british)).size());
     thenGetRandomShouldHaveBeenCalled(bridge, times(3));
   }
 
@@ -920,7 +922,7 @@ public class RevisedTest {
     final int pusAfterRaid = germans.getResources().getQuantity(gameData.getResourceList().getResource(Constants.PUS));
     assertEquals(pusBeforeRaid - 5, pusAfterRaid);
     // 2 bombers get hit
-    assertEquals(5, germany.getUnits().getMatches(Matches.unitIsOwnedBy(british)).size());
+    assertEquals(5, germany.getUnitCollection().getMatches(Matches.unitIsOwnedBy(british)).size());
     thenGetRandomShouldHaveBeenCalled(bridge, times(2));
   }
 
@@ -933,8 +935,8 @@ public class RevisedTest {
     final BattleTracker tracker = new BattleTracker();
     final StrategicBombingRaidBattle battle = new StrategicBombingRaidBattle(germany, gameData, british, tracker);
     battle.addAttackChange(gameData.getMap().getRoute(uk, germany),
-        uk.getUnits().getMatches(Matches.unitIsStrategicBomber()), null);
-    addTo(germany, uk.getUnits().getMatches(Matches.unitIsStrategicBomber()));
+        uk.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()), null);
+    addTo(germany, uk.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()));
     tracker.getBattleRecords().addBattle(british, battle.getBattleId(), germany, battle.getBattleType());
     final IDelegateBridge bridge = newDelegateBridge(british);
     TechTracker.addAdvance(british, bridge,
@@ -959,7 +961,7 @@ public class RevisedTest {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(from.getUnits().getUnits(), new Route(from, attacked));
+    move(from.getUnitCollection().getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
@@ -981,7 +983,7 @@ public class RevisedTest {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(from.getUnits().getUnits(), new Route(from, attacked));
+    move(from.getUnitCollection().getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
@@ -1003,7 +1005,7 @@ public class RevisedTest {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(from.getUnits().getUnits(), new Route(from, attacked));
+    move(from.getUnitCollection().getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
@@ -1023,7 +1025,7 @@ public class RevisedTest {
         .thenAnswer(withValues(0));
     battle.fight(bridge);
     thenGetRandomShouldHaveBeenCalled(bridge, times(2));
-    assertTrue(attacked.getUnits().isEmpty());
+    assertTrue(attacked.getUnitCollection().isEmpty());
   }
 
   @Test
@@ -1040,7 +1042,7 @@ public class RevisedTest {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(from.getUnits().getUnits(), new Route(from, attacked));
+    move(from.getUnitCollection().getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
@@ -1075,8 +1077,8 @@ public class RevisedTest {
         .thenAnswer(withValues(0));
     battle.fight(bridge);
     thenGetRandomShouldHaveBeenCalled(bridge, times(3));
-    assertTrue(attacked.getUnits().getMatches(Matches.unitIsOwnedBy(british(gameData))).isEmpty());
-    assertEquals(1, attacked.getUnits().size());
+    assertTrue(attacked.getUnitCollection().getMatches(Matches.unitIsOwnedBy(british(gameData))).isEmpty());
+    assertEquals(1, attacked.getUnitCollection().size());
   }
 
   @Test
@@ -1094,7 +1096,7 @@ public class RevisedTest {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(from.getUnits().getUnits(), new Route(from, attacked));
+    move(from.getUnitCollection().getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
@@ -1131,8 +1133,8 @@ public class RevisedTest {
         .thenAnswer(withValues(0, 0, 0));
     battle.fight(bridge);
     thenGetRandomShouldHaveBeenCalled(bridge, times(2));
-    assertTrue(attacked.getUnits().getMatches(Matches.unitIsOwnedBy(british(gameData))).isEmpty());
-    assertEquals(3, attacked.getUnits().size());
+    assertTrue(attacked.getUnitCollection().getMatches(Matches.unitIsOwnedBy(british(gameData))).isEmpty());
+    assertEquals(3, attacked.getUnitCollection().size());
   }
 
   @Test
@@ -1150,7 +1152,7 @@ public class RevisedTest {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(from.getUnits().getUnits(), new Route(from, attacked));
+    move(from.getUnitCollection().getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
@@ -1171,8 +1173,8 @@ public class RevisedTest {
         .thenAnswer(withValues(0));
     battle.fight(bridge);
     thenGetRandomShouldHaveBeenCalled(bridge, times(2));
-    assertTrue(attacked.getUnits().getMatches(Matches.unitIsOwnedBy(germans(gameData))).isEmpty());
-    assertEquals(1, attacked.getUnits().size());
+    assertTrue(attacked.getUnitCollection().getMatches(Matches.unitIsOwnedBy(germans(gameData))).isEmpty());
+    assertEquals(1, attacked.getUnitCollection().size());
   }
 
   @Test
@@ -1190,7 +1192,7 @@ public class RevisedTest {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(from.getUnits().getUnits(), new Route(from, attacked));
+    move(from.getUnitCollection().getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
@@ -1227,8 +1229,8 @@ public class RevisedTest {
         .thenAnswer(withValues(0));
     battle.fight(bridge);
     thenGetRandomShouldHaveBeenCalled(bridge, times(2));
-    assertTrue(attacked.getUnits().getMatches(Matches.unitIsOwnedBy(germans(gameData))).isEmpty());
-    assertEquals(3, attacked.getUnits().size());
+    assertTrue(attacked.getUnitCollection().getMatches(Matches.unitIsOwnedBy(germans(gameData))).isEmpty());
+    assertEquals(3, attacked.getUnitCollection().size());
   }
 
   @Test
@@ -1247,7 +1249,7 @@ public class RevisedTest {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(from.getUnits().getUnits(), new Route(from, attacked));
+    move(from.getUnitCollection().getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
@@ -1271,7 +1273,7 @@ public class RevisedTest {
         .thenAnswer(withValues(0));
     battle.fight(bridge);
     thenGetRandomShouldHaveBeenCalled(bridge, times(4));
-    assertEquals(0, attacked.getUnits().size());
+    assertEquals(0, attacked.getUnitCollection().size());
   }
 
   @Test
@@ -1282,7 +1284,7 @@ public class RevisedTest {
     addTo(british(gameData), transport(gameData).create(1, british(gameData)), gameData);
     del.end();
     // unplaced units die
-    assertTrue(british(gameData).getUnits().isEmpty());
+    assertTrue(british(gameData).getUnitCollection().isEmpty());
   }
 
   @Test
@@ -1294,10 +1296,10 @@ public class RevisedTest {
     move.start();
     // remove the russians units in caucasus so we can blitz
     final Territory cauc = territory("Caucasus", gameData);
-    removeFrom(cauc, cauc.getUnits().getMatches(Matches.unitIsNotAa()));
+    removeFrom(cauc, cauc.getUnitCollection().getMatches(Matches.unitIsNotAa()));
     // blitz
     final Territory wr = territory("West Russia", gameData);
-    move(wr.getUnits().getMatches(Matches.unitCanBlitz()), new Route(wr, cauc));
+    move(wr.getUnitCollection().getMatches(Matches.unitCanBlitz()), new Route(wr, cauc));
     final Set<Territory> fire = RocketsFireHelper.getTerritoriesWithRockets(gameData, germans(gameData));
     // germany, WE, SE, but not caucusus
     assertEquals(3, fire.size());
@@ -1369,18 +1371,18 @@ public class RevisedTest {
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
     // load two transports, 1 tank each
-    load(germany.getUnits().getMatches(Matches.unitCanBlitz()).subList(0, 1), new Route(germany, sz5));
-    load(germany.getUnits().getMatches(Matches.unitCanBlitz()).subList(0, 1), new Route(germany, sz5));
-    load(germany.getUnits().getMatches(Matches.unitCanBlitz()).subList(0, 1), new Route(germany, sz5));
+    load(germany.getUnitCollection().getMatches(Matches.unitCanBlitz()).subList(0, 1), new Route(germany, sz5));
+    load(germany.getUnitCollection().getMatches(Matches.unitCanBlitz()).subList(0, 1), new Route(germany, sz5));
+    load(germany.getUnitCollection().getMatches(Matches.unitCanBlitz()).subList(0, 1), new Route(germany, sz5));
     // attack sz 6
-    move(sz5.getUnits().getMatches(Matches.unitCanBlitz().or(Matches.unitIsTransport())),
+    move(sz5.getUnitCollection().getMatches(Matches.unitCanBlitz().or(Matches.unitIsTransport())),
         new Route(sz5, sz6));
     // unload transports, 1 each to a different country
     // this move is illegal now
-    assertMoveError(sz6.getUnits().getMatches(Matches.unitCanBlitz()).subList(0, 1), new Route(sz6, norway));
+    assertMoveError(sz6.getUnitCollection().getMatches(Matches.unitCanBlitz()).subList(0, 1), new Route(sz6, norway));
     // this move is illegal now
-    assertMoveError(sz6.getUnits().getMatches(Matches.unitCanBlitz()).subList(0, 1), new Route(sz6, we));
-    move(sz6.getUnits().getMatches(Matches.unitCanBlitz()).subList(0, 1), new Route(sz6, uk));
+    assertMoveError(sz6.getUnitCollection().getMatches(Matches.unitCanBlitz()).subList(0, 1), new Route(sz6, we));
+    move(sz6.getUnitCollection().getMatches(Matches.unitCanBlitz()).subList(0, 1), new Route(sz6, uk));
     // fight the battle
     moveDelegate(gameData).end();
     final MustFightBattle battle =
@@ -1391,9 +1393,9 @@ public class RevisedTest {
         .thenAnswer(withValues(0, 0));
     battle.fight(bridge);
     // the armour should have died
-    assertEquals(0, norway.getUnits().countMatches(Matches.unitCanBlitz()));
-    assertEquals(2, we.getUnits().countMatches(Matches.unitCanBlitz()));
-    assertEquals(0, uk.getUnits().countMatches(Matches.unitIsOwnedBy(germans)));
+    assertEquals(0, norway.getUnitCollection().countMatches(Matches.unitCanBlitz()));
+    assertEquals(2, we.getUnitCollection().countMatches(Matches.unitCanBlitz()));
+    assertEquals(0, uk.getUnitCollection().countMatches(Matches.unitIsOwnedBy(germans)));
   }
 
   @Test
@@ -1405,7 +1407,7 @@ public class RevisedTest {
     final MoveDelegate moveDelegate = moveDelegate(gameData);
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    final String error = moveDelegate.move(sz15.getUnits().getUnits(), new Route(sz15, sz34));
+    final String error = moveDelegate.move(sz15.getUnitCollection().getUnits(), new Route(sz15, sz34));
     assertValid(error);
   }
 
@@ -1415,13 +1417,13 @@ public class RevisedTest {
     final Territory sz15 = territory("15 Sea Zone", gameData);
     final Territory sz34 = territory("34 Sea Zone", gameData);
     // clear the british in sz 15
-    removeFrom(sz15, sz15.getUnits().getUnits());
+    removeFrom(sz15, sz15.getUnitCollection().getUnits());
     final IDelegateBridge bridge = newDelegateBridge(germans(gameData));
     advanceToStep(bridge, "CombatMove");
     final MoveDelegate moveDelegate = moveDelegate(gameData);
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();
-    final String error = moveDelegate.move(sz14.getUnits().getUnits(), new Route(sz14, sz15, sz34));
+    final String error = moveDelegate.move(sz14.getUnitCollection().getUnits(), new Route(sz14, sz15, sz34));
     assertError(error);
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/UnitComparatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/UnitComparatorTest.java
@@ -47,7 +47,7 @@ public final class UnitComparatorTest {
           .subList(0, 1);
       load(transportedUnits, new Route(germany, seaZone5));
 
-      final List<Unit> units = new ArrayList<>(seaZone5.getUnitCollection().getUnits());
+      final List<Unit> units = new ArrayList<>(seaZone5.getUnits());
       final List<Unit> sortedUnits = new ArrayList<>(units);
       sortedUnits.sort(UnitComparator.getUnloadableUnitsComparator(units, new Route(seaZone5, kareliaSsr), germans));
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/UnitComparatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/UnitComparatorTest.java
@@ -42,12 +42,12 @@ public final class UnitComparatorTest {
       final Territory seaZone5 = territory("5 Sea Zone", gameData);
       final Territory kareliaSsr = territory("Karelia S.S.R.", gameData);
       startCombatMoveFor(germans, gameData);
-      final List<Unit> transportedUnits = germany.getUnits()
+      final List<Unit> transportedUnits = germany.getUnitCollection()
           .getMatches(u -> armour(gameData).equals(u.getType()))
           .subList(0, 1);
       load(transportedUnits, new Route(germany, seaZone5));
 
-      final List<Unit> units = new ArrayList<>(seaZone5.getUnits().getUnits());
+      final List<Unit> units = new ArrayList<>(seaZone5.getUnitCollection().getUnits());
       final List<Unit> sortedUnits = new ArrayList<>(units);
       sortedUnits.sort(UnitComparator.getUnloadableUnitsComparator(units, new Route(seaZone5, kareliaSsr), germans));
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/VictoryTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/VictoryTest.java
@@ -86,7 +86,7 @@ public class VictoryTest {
     moveDelegate.setDelegateBridgeAndPlayer(testBridge);
     moveDelegate.start();
     final String error =
-        moveDelegate.move(libya.getUnitCollection().getUnits(), gameData.getMap().getRoute(libya, britishCongo));
+        moveDelegate.move(libya.getUnits(), gameData.getMap().getRoute(libya, britishCongo));
     moveDelegate.end();
     assertEquals(MoveValidator.NOT_ALL_UNITS_CAN_BLITZ, error);
   }
@@ -98,7 +98,7 @@ public class VictoryTest {
     moveDelegate.setDelegateBridgeAndPlayer(testBridge);
     moveDelegate.start();
     final String error =
-        moveDelegate.move(frenchWestAfrica.getUnitCollection().getUnits(),
+        moveDelegate.move(frenchWestAfrica.getUnits(),
             gameData.getMap().getRoute(frenchWestAfrica, britishCongo));
     moveDelegate.end();
     assertNull(error);
@@ -111,11 +111,11 @@ public class VictoryTest {
     moveDelegate.setDelegateBridgeAndPlayer(testBridge);
     moveDelegate.start();
     String error =
-        moveDelegate.move(libya.getUnitCollection().getUnits(), gameData.getMap().getRoute(libya, angloEgypt));
+        moveDelegate.move(libya.getUnits(), gameData.getMap().getRoute(libya, angloEgypt));
     // first step is legal
     assertNull(error);
     // second step isn't legal because we lost blitz even though we took the mountain
-    error = moveDelegate.move(angloEgypt.getUnitCollection().getUnits(),
+    error = moveDelegate.move(angloEgypt.getUnits(),
         gameData.getMap().getRoute(angloEgypt, britishCongo));
     moveDelegate.end();
     assertEquals(MoveValidator.NOT_ALL_UNITS_CAN_BLITZ, error);
@@ -127,10 +127,10 @@ public class VictoryTest {
     advanceToStep(testBridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(testBridge);
     moveDelegate.start();
-    String error = moveDelegate.move(frenchWestAfrica.getUnitCollection().getUnits(),
+    String error = moveDelegate.move(frenchWestAfrica.getUnits(),
         gameData.getMap().getRoute(frenchWestAfrica, frenchEastAfrica));
     assertNull(error);
-    error = moveDelegate.move(frenchEastAfrica.getUnitCollection().getUnits(),
+    error = moveDelegate.move(frenchEastAfrica.getUnits(),
         gameData.getMap().getRoute(frenchEastAfrica, britishCongo));
     moveDelegate.end();
     assertNull(error);
@@ -144,7 +144,7 @@ public class VictoryTest {
     moveDelegate.setDelegateBridgeAndPlayer(testBridge);
     moveDelegate.start();
     final String error =
-        moveDelegate.move(libya.getUnitCollection().getUnits(), gameData.getMap().getRoute(libya, britishCongo));
+        moveDelegate.move(libya.getUnits(), gameData.getMap().getRoute(libya, britishCongo));
     moveDelegate.end();
     assertEquals(MoveValidator.NOT_ALL_UNITS_CAN_BLITZ, error);
   }
@@ -158,12 +158,12 @@ public class VictoryTest {
     advanceToStep(testBridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(testBridge);
     moveDelegate.start();
-    String error = moveDelegate.move(frenchEastAfrica.getUnitCollection().getUnits(),
+    String error = moveDelegate.move(frenchEastAfrica.getUnits(),
         gameData.getMap().getRoute(frenchEastAfrica, britishCongo));
     assertNull(error);
-    error = moveDelegate.move(kenya.getUnitCollection().getUnits(), gameData.getMap().getRoute(kenya, britishCongo));
+    error = moveDelegate.move(kenya.getUnits(), gameData.getMap().getRoute(kenya, britishCongo));
     assertNull(error);
-    error = moveDelegate.move(britishCongo.getUnitCollection().getUnits(),
+    error = moveDelegate.move(britishCongo.getUnits(),
         gameData.getMap().getRoute(britishCongo, frenchEastAfrica));
     assertEquals(MoveValidator.NOT_ALL_UNITS_CAN_BLITZ, error);
     moveDelegate.end();
@@ -182,32 +182,32 @@ public class VictoryTest {
     final int oreAmount = italians.getResources().getQuantity("Ore");
 
     gameData.performChange(ChangeFactory.addUnits(kenya, motorized.create(1, italians)));
-    moveDelegate.move(kenya.getUnitCollection().getUnits(), gameData.getMap().getRoute(kenya, britishCongo));
+    moveDelegate.move(kenya.getUnits(), gameData.getMap().getRoute(kenya, britishCongo));
     assertEquals(fuelAmount - 2, italians.getResources().getQuantity("Fuel"));
     assertEquals(puAmount - 1, italians.getResources().getQuantity("PUs"));
     assertEquals(oreAmount - 2, italians.getResources().getQuantity("Ore"));
 
     gameData.performChange(ChangeFactory.addUnits(kenya, armour.create(1, italians)));
-    moveDelegate.move(kenya.getUnitCollection().getUnits(), gameData.getMap().getRoute(kenya, britishCongo));
+    moveDelegate.move(kenya.getUnits(), gameData.getMap().getRoute(kenya, britishCongo));
     assertEquals(fuelAmount - 2, italians.getResources().getQuantity("Fuel"));
     assertEquals(puAmount - 1, italians.getResources().getQuantity("PUs"));
     assertEquals(oreAmount - 2, italians.getResources().getQuantity("Ore"));
 
-    moveDelegate.move(britishCongo.getUnitCollection().getUnits(),
+    moveDelegate.move(britishCongo.getUnits(),
         gameData.getMap().getRoute(britishCongo, frenchEastAfrica));
     assertEquals(fuelAmount - 3, italians.getResources().getQuantity("Fuel"));
     assertEquals(puAmount - 2, italians.getResources().getQuantity("PUs"));
     assertEquals(oreAmount - 2, italians.getResources().getQuantity("Ore"));
 
     gameData.performChange(ChangeFactory.addUnits(kenya, motorized.create(5, italians)));
-    moveDelegate.move(kenya.getUnitCollection().getUnits(), gameData.getMap().getRoute(kenya, britishCongo));
+    moveDelegate.move(kenya.getUnits(), gameData.getMap().getRoute(kenya, britishCongo));
     assertEquals(fuelAmount - 13, italians.getResources().getQuantity("Fuel"));
     assertEquals(puAmount - 7, italians.getResources().getQuantity("PUs"));
     assertEquals(oreAmount - 12, italians.getResources().getQuantity("Ore"));
 
     gameData.performChange(ChangeFactory.addUnits(kenya, motorized.create(50, italians)));
     final String error =
-        moveDelegate.move(kenya.getUnitCollection().getUnits(), gameData.getMap().getRoute(kenya, britishCongo));
+        moveDelegate.move(kenya.getUnits(), gameData.getMap().getRoute(kenya, britishCongo));
     assertTrue(error.startsWith("Not enough resources to perform this move"));
     moveDelegate.end();
   }
@@ -222,7 +222,7 @@ public class VictoryTest {
     // Combat move where air is always charged fuel
     gameData.performChange(ChangeFactory.addUnits(sz29, carrier.create(1, italians)));
     gameData.performChange(ChangeFactory.addUnits(sz29, fighter.create(2, italians)));
-    moveDelegate.move(sz29.getUnitCollection().getUnits(), gameData.getMap().getRoute(sz29, sz30));
+    moveDelegate.move(sz29.getUnits(), gameData.getMap().getRoute(sz29, sz30));
     assertEquals(fuelAmount - 7, italians.getResources().getQuantity("Fuel"));
 
     // Rest of the cases use non-combat move
@@ -234,7 +234,7 @@ public class VictoryTest {
     // Non-combat move where air isn't charged fuel
     gameData.performChange(ChangeFactory.addUnits(sz29, carrier.create(1, italians)));
     gameData.performChange(ChangeFactory.addUnits(sz29, fighter.create(2, italians)));
-    moveDelegate.move(sz29.getUnitCollection().getUnits(), gameData.getMap().getRoute(sz29, sz30));
+    moveDelegate.move(sz29.getUnits(), gameData.getMap().getRoute(sz29, sz30));
     assertEquals(fuelAmount - 8, italians.getResources().getQuantity("Fuel"));
     gameData.performChange(ChangeFactory.removeUnits(sz30, sz30.getUnitCollection()));
 
@@ -242,9 +242,9 @@ public class VictoryTest {
     gameData.performChange(ChangeFactory.addUnits(sz29, carrier.create(1, italians)));
     gameData.performChange(ChangeFactory.addUnits(sz29, fighter.create(1, italians)));
     gameData.performChange(ChangeFactory.addUnits(sz30, fighter.create(1, italians)));
-    moveDelegate.move(sz30.getUnitCollection().getUnits(), gameData.getMap().getRoute(sz30, sz29));
+    moveDelegate.move(sz30.getUnits(), gameData.getMap().getRoute(sz30, sz29));
     assertEquals(fuelAmount - 11, italians.getResources().getQuantity("Fuel"));
-    moveDelegate.move(sz29.getUnitCollection().getUnits(), gameData.getMap().getRoute(sz29, sz30));
+    moveDelegate.move(sz29.getUnits(), gameData.getMap().getRoute(sz29, sz30));
     assertEquals(fuelAmount - 12, italians.getResources().getQuantity("Fuel"));
     moveDelegate.move(sz30.getUnitCollection().getMatches(Matches.unitIsAir()), gameData.getMap().getRoute(sz30, sz29));
     assertEquals(fuelAmount - 16, italians.getResources().getQuantity("Fuel"));
@@ -254,14 +254,14 @@ public class VictoryTest {
     // Too many fighters for carrier
     gameData.performChange(ChangeFactory.addUnits(sz29, carrier.create(1, italians)));
     gameData.performChange(ChangeFactory.addUnits(sz29, fighter.create(3, italians)));
-    moveDelegate.move(sz29.getUnitCollection().getUnits(), gameData.getMap().getRoute(sz29, sz30));
+    moveDelegate.move(sz29.getUnits(), gameData.getMap().getRoute(sz29, sz30));
     assertEquals(fuelAmount - 20, italians.getResources().getQuantity("Fuel"));
 
     // Allied and owned fighters
     gameData.performChange(ChangeFactory.addUnits(sz29, carrier.create(2, italians)));
     gameData.performChange(ChangeFactory.addUnits(sz29, fighter.create(2, italians)));
     gameData.performChange(ChangeFactory.addUnits(sz29, fighter.create(3, germans)));
-    moveDelegate.move(sz29.getUnitCollection().getUnits(), gameData.getMap().getRoute(sz29, sz30));
+    moveDelegate.move(sz29.getUnits(), gameData.getMap().getRoute(sz29, sz30));
     assertEquals(fuelAmount - 25, italians.getResources().getQuantity("Fuel"));
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/VictoryTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/VictoryTest.java
@@ -86,7 +86,7 @@ public class VictoryTest {
     moveDelegate.setDelegateBridgeAndPlayer(testBridge);
     moveDelegate.start();
     final String error =
-        moveDelegate.move(libya.getUnits().getUnits(), gameData.getMap().getRoute(libya, britishCongo));
+        moveDelegate.move(libya.getUnitCollection().getUnits(), gameData.getMap().getRoute(libya, britishCongo));
     moveDelegate.end();
     assertEquals(MoveValidator.NOT_ALL_UNITS_CAN_BLITZ, error);
   }
@@ -98,7 +98,7 @@ public class VictoryTest {
     moveDelegate.setDelegateBridgeAndPlayer(testBridge);
     moveDelegate.start();
     final String error =
-        moveDelegate.move(frenchWestAfrica.getUnits().getUnits(),
+        moveDelegate.move(frenchWestAfrica.getUnitCollection().getUnits(),
             gameData.getMap().getRoute(frenchWestAfrica, britishCongo));
     moveDelegate.end();
     assertNull(error);
@@ -110,11 +110,13 @@ public class VictoryTest {
     advanceToStep(testBridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(testBridge);
     moveDelegate.start();
-    String error = moveDelegate.move(libya.getUnits().getUnits(), gameData.getMap().getRoute(libya, angloEgypt));
+    String error =
+        moveDelegate.move(libya.getUnitCollection().getUnits(), gameData.getMap().getRoute(libya, angloEgypt));
     // first step is legal
     assertNull(error);
     // second step isn't legal because we lost blitz even though we took the mountain
-    error = moveDelegate.move(angloEgypt.getUnits().getUnits(), gameData.getMap().getRoute(angloEgypt, britishCongo));
+    error = moveDelegate.move(angloEgypt.getUnitCollection().getUnits(),
+        gameData.getMap().getRoute(angloEgypt, britishCongo));
     moveDelegate.end();
     assertEquals(MoveValidator.NOT_ALL_UNITS_CAN_BLITZ, error);
   }
@@ -125,10 +127,10 @@ public class VictoryTest {
     advanceToStep(testBridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(testBridge);
     moveDelegate.start();
-    String error = moveDelegate.move(frenchWestAfrica.getUnits().getUnits(),
+    String error = moveDelegate.move(frenchWestAfrica.getUnitCollection().getUnits(),
         gameData.getMap().getRoute(frenchWestAfrica, frenchEastAfrica));
     assertNull(error);
-    error = moveDelegate.move(frenchEastAfrica.getUnits().getUnits(),
+    error = moveDelegate.move(frenchEastAfrica.getUnitCollection().getUnits(),
         gameData.getMap().getRoute(frenchEastAfrica, britishCongo));
     moveDelegate.end();
     assertNull(error);
@@ -142,7 +144,7 @@ public class VictoryTest {
     moveDelegate.setDelegateBridgeAndPlayer(testBridge);
     moveDelegate.start();
     final String error =
-        moveDelegate.move(libya.getUnits().getUnits(), gameData.getMap().getRoute(libya, britishCongo));
+        moveDelegate.move(libya.getUnitCollection().getUnits(), gameData.getMap().getRoute(libya, britishCongo));
     moveDelegate.end();
     assertEquals(MoveValidator.NOT_ALL_UNITS_CAN_BLITZ, error);
   }
@@ -156,12 +158,12 @@ public class VictoryTest {
     advanceToStep(testBridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(testBridge);
     moveDelegate.start();
-    String error = moveDelegate.move(frenchEastAfrica.getUnits().getUnits(),
+    String error = moveDelegate.move(frenchEastAfrica.getUnitCollection().getUnits(),
         gameData.getMap().getRoute(frenchEastAfrica, britishCongo));
     assertNull(error);
-    error = moveDelegate.move(kenya.getUnits().getUnits(), gameData.getMap().getRoute(kenya, britishCongo));
+    error = moveDelegate.move(kenya.getUnitCollection().getUnits(), gameData.getMap().getRoute(kenya, britishCongo));
     assertNull(error);
-    error = moveDelegate.move(britishCongo.getUnits().getUnits(),
+    error = moveDelegate.move(britishCongo.getUnitCollection().getUnits(),
         gameData.getMap().getRoute(britishCongo, frenchEastAfrica));
     assertEquals(MoveValidator.NOT_ALL_UNITS_CAN_BLITZ, error);
     moveDelegate.end();
@@ -180,31 +182,32 @@ public class VictoryTest {
     final int oreAmount = italians.getResources().getQuantity("Ore");
 
     gameData.performChange(ChangeFactory.addUnits(kenya, motorized.create(1, italians)));
-    moveDelegate.move(kenya.getUnits().getUnits(), gameData.getMap().getRoute(kenya, britishCongo));
+    moveDelegate.move(kenya.getUnitCollection().getUnits(), gameData.getMap().getRoute(kenya, britishCongo));
     assertEquals(fuelAmount - 2, italians.getResources().getQuantity("Fuel"));
     assertEquals(puAmount - 1, italians.getResources().getQuantity("PUs"));
     assertEquals(oreAmount - 2, italians.getResources().getQuantity("Ore"));
 
     gameData.performChange(ChangeFactory.addUnits(kenya, armour.create(1, italians)));
-    moveDelegate.move(kenya.getUnits().getUnits(), gameData.getMap().getRoute(kenya, britishCongo));
+    moveDelegate.move(kenya.getUnitCollection().getUnits(), gameData.getMap().getRoute(kenya, britishCongo));
     assertEquals(fuelAmount - 2, italians.getResources().getQuantity("Fuel"));
     assertEquals(puAmount - 1, italians.getResources().getQuantity("PUs"));
     assertEquals(oreAmount - 2, italians.getResources().getQuantity("Ore"));
 
-    moveDelegate.move(britishCongo.getUnits().getUnits(), gameData.getMap().getRoute(britishCongo, frenchEastAfrica));
+    moveDelegate.move(britishCongo.getUnitCollection().getUnits(),
+        gameData.getMap().getRoute(britishCongo, frenchEastAfrica));
     assertEquals(fuelAmount - 3, italians.getResources().getQuantity("Fuel"));
     assertEquals(puAmount - 2, italians.getResources().getQuantity("PUs"));
     assertEquals(oreAmount - 2, italians.getResources().getQuantity("Ore"));
 
     gameData.performChange(ChangeFactory.addUnits(kenya, motorized.create(5, italians)));
-    moveDelegate.move(kenya.getUnits().getUnits(), gameData.getMap().getRoute(kenya, britishCongo));
+    moveDelegate.move(kenya.getUnitCollection().getUnits(), gameData.getMap().getRoute(kenya, britishCongo));
     assertEquals(fuelAmount - 13, italians.getResources().getQuantity("Fuel"));
     assertEquals(puAmount - 7, italians.getResources().getQuantity("PUs"));
     assertEquals(oreAmount - 12, italians.getResources().getQuantity("Ore"));
 
     gameData.performChange(ChangeFactory.addUnits(kenya, motorized.create(50, italians)));
     final String error =
-        moveDelegate.move(kenya.getUnits().getUnits(), gameData.getMap().getRoute(kenya, britishCongo));
+        moveDelegate.move(kenya.getUnitCollection().getUnits(), gameData.getMap().getRoute(kenya, britishCongo));
     assertTrue(error.startsWith("Not enough resources to perform this move"));
     moveDelegate.end();
   }
@@ -219,7 +222,7 @@ public class VictoryTest {
     // Combat move where air is always charged fuel
     gameData.performChange(ChangeFactory.addUnits(sz29, carrier.create(1, italians)));
     gameData.performChange(ChangeFactory.addUnits(sz29, fighter.create(2, italians)));
-    moveDelegate.move(sz29.getUnits().getUnits(), gameData.getMap().getRoute(sz29, sz30));
+    moveDelegate.move(sz29.getUnitCollection().getUnits(), gameData.getMap().getRoute(sz29, sz30));
     assertEquals(fuelAmount - 7, italians.getResources().getQuantity("Fuel"));
 
     // Rest of the cases use non-combat move
@@ -231,34 +234,34 @@ public class VictoryTest {
     // Non-combat move where air isn't charged fuel
     gameData.performChange(ChangeFactory.addUnits(sz29, carrier.create(1, italians)));
     gameData.performChange(ChangeFactory.addUnits(sz29, fighter.create(2, italians)));
-    moveDelegate.move(sz29.getUnits().getUnits(), gameData.getMap().getRoute(sz29, sz30));
+    moveDelegate.move(sz29.getUnitCollection().getUnits(), gameData.getMap().getRoute(sz29, sz30));
     assertEquals(fuelAmount - 8, italians.getResources().getQuantity("Fuel"));
-    gameData.performChange(ChangeFactory.removeUnits(sz30, sz30.getUnits()));
+    gameData.performChange(ChangeFactory.removeUnits(sz30, sz30.getUnitCollection()));
 
     // Move onto carrier, move with carrier, move off carrier
     gameData.performChange(ChangeFactory.addUnits(sz29, carrier.create(1, italians)));
     gameData.performChange(ChangeFactory.addUnits(sz29, fighter.create(1, italians)));
     gameData.performChange(ChangeFactory.addUnits(sz30, fighter.create(1, italians)));
-    moveDelegate.move(sz30.getUnits().getUnits(), gameData.getMap().getRoute(sz30, sz29));
+    moveDelegate.move(sz30.getUnitCollection().getUnits(), gameData.getMap().getRoute(sz30, sz29));
     assertEquals(fuelAmount - 11, italians.getResources().getQuantity("Fuel"));
-    moveDelegate.move(sz29.getUnits().getUnits(), gameData.getMap().getRoute(sz29, sz30));
+    moveDelegate.move(sz29.getUnitCollection().getUnits(), gameData.getMap().getRoute(sz29, sz30));
     assertEquals(fuelAmount - 12, italians.getResources().getQuantity("Fuel"));
-    moveDelegate.move(sz30.getUnits().getMatches(Matches.unitIsAir()), gameData.getMap().getRoute(sz30, sz29));
+    moveDelegate.move(sz30.getUnitCollection().getMatches(Matches.unitIsAir()), gameData.getMap().getRoute(sz30, sz29));
     assertEquals(fuelAmount - 16, italians.getResources().getQuantity("Fuel"));
-    gameData.performChange(ChangeFactory.removeUnits(sz29, sz29.getUnits()));
-    gameData.performChange(ChangeFactory.removeUnits(sz30, sz30.getUnits()));
+    gameData.performChange(ChangeFactory.removeUnits(sz29, sz29.getUnitCollection()));
+    gameData.performChange(ChangeFactory.removeUnits(sz30, sz30.getUnitCollection()));
 
     // Too many fighters for carrier
     gameData.performChange(ChangeFactory.addUnits(sz29, carrier.create(1, italians)));
     gameData.performChange(ChangeFactory.addUnits(sz29, fighter.create(3, italians)));
-    moveDelegate.move(sz29.getUnits().getUnits(), gameData.getMap().getRoute(sz29, sz30));
+    moveDelegate.move(sz29.getUnitCollection().getUnits(), gameData.getMap().getRoute(sz29, sz30));
     assertEquals(fuelAmount - 20, italians.getResources().getQuantity("Fuel"));
 
     // Allied and owned fighters
     gameData.performChange(ChangeFactory.addUnits(sz29, carrier.create(2, italians)));
     gameData.performChange(ChangeFactory.addUnits(sz29, fighter.create(2, italians)));
     gameData.performChange(ChangeFactory.addUnits(sz29, fighter.create(3, germans)));
-    moveDelegate.move(sz29.getUnits().getUnits(), gameData.getMap().getRoute(sz29, sz30));
+    moveDelegate.move(sz29.getUnitCollection().getUnits(), gameData.getMap().getRoute(sz29, sz30));
     assertEquals(fuelAmount - 25, italians.getResources().getQuantity("Fuel"));
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -167,7 +167,7 @@ public class WW2V3Year41Test {
     // don't allow rolling, 6 of each is deterministic
     final DiceRoll roll = DiceRoll.rollAa(CollectionUtils.getMatches(planes,
         Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(gameData))),
-        defendingAa, planes, territory("Germany", gameData).getUnitCollection().getUnits(), bridge,
+        defendingAa, planes, territory("Germany", gameData).getUnits(), bridge,
         territory("Germany", gameData), true);
     final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
         defendingAa, roll, bridge, null, null, territory("Germany", gameData), null, false, null).getKilled();
@@ -198,7 +198,7 @@ public class WW2V3Year41Test {
         .thenAnswer(withValues(1));
     final DiceRoll roll = DiceRoll.rollAa(CollectionUtils.getMatches(planes,
         Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(gameData))),
-        defendingAa, planes, territory("Germany", gameData).getUnitCollection().getUnits(), bridge,
+        defendingAa, planes, territory("Germany", gameData).getUnits(), bridge,
         territory("Germany", gameData), true);
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
@@ -232,7 +232,7 @@ public class WW2V3Year41Test {
     final DiceRoll roll = DiceRoll.rollAa(
         CollectionUtils.getMatches(planes,
             Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(gameData))),
-        defendingAa, planes, territory("Germany", gameData).getUnitCollection().getUnits(), bridge,
+        defendingAa, planes, territory("Germany", gameData).getUnits(), bridge,
         territory("Germany", gameData), true);
     assertEquals(2, roll.getHits());
     // make sure we rolled once
@@ -259,7 +259,7 @@ public class WW2V3Year41Test {
     final Route sz12To13 = new Route();
     sz12To13.setStart(sz12);
     sz12To13.add(sz13);
-    final String error = moveDelegate.move(sz12.getUnitCollection().getUnits(), sz12To13);
+    final String error = moveDelegate.move(sz12.getUnits(), sz12To13);
     assertNull(error);
     assertEquals(3, sz13.getUnitCollection().size());
     moveDelegate.end();
@@ -342,7 +342,7 @@ public class WW2V3Year41Test {
     // move the transport to attack, this is suicide but valid
     move(sz9.getUnitCollection().getMatches(Matches.unitIsTransport()), sz9ToSz13);
     // load the transport
-    load(gibraltar.getUnitCollection().getUnits(), new Route(gibraltar, sz13));
+    load(gibraltar.getUnits(), new Route(gibraltar, sz13));
     moveDelegate.end();
     advanceToStep(bridge, "britishBattle");
     final BattleDelegate battleDelegate = battleDelegate(gameData);
@@ -388,7 +388,7 @@ public class WW2V3Year41Test {
     final Territory ukraine = territory("Ukraine", gameData);
     final Territory poland = territory("Poland", gameData);
     // remove all units from east poland
-    removeFrom(eastPoland, eastPoland.getUnitCollection().getUnits());
+    removeFrom(eastPoland, eastPoland.getUnits());
     final MoveDelegate moveDelegate = moveDelegate(gameData);
     final IDelegateBridge delegateBridge = newDelegateBridge(germans(gameData));
     advanceToStep(delegateBridge, "CombatMove");
@@ -396,7 +396,7 @@ public class WW2V3Year41Test {
     moveDelegate.start();
     final Territory bulgaria = territory("Bulgaria Romania", gameData);
     // attack from bulgraia
-    move(bulgaria.getUnitCollection().getUnits(), new Route(bulgaria, ukraine));
+    move(bulgaria.getUnits(), new Route(bulgaria, ukraine));
     // add an air attack from east poland
     move(poland.getUnitCollection().getMatches(Matches.unitIsAir()), new Route(poland, eastPoland, ukraine));
     // we should not be able to retreat to east poland!
@@ -412,7 +412,7 @@ public class WW2V3Year41Test {
     final Territory ukraine = territory("Ukraine", gameData);
     final Territory poland = territory("Poland", gameData);
     // remove all units from east poland
-    removeFrom(eastPoland, eastPoland.getUnitCollection().getUnits());
+    removeFrom(eastPoland, eastPoland.getUnits());
     final MoveDelegate moveDelegate = moveDelegate(gameData);
     final IDelegateBridge delegateBridge = newDelegateBridge(germans(gameData));
     advanceToStep(delegateBridge, "CombatMove");
@@ -420,7 +420,7 @@ public class WW2V3Year41Test {
     moveDelegate.start();
     final Territory bulgaria = territory("Bulgaria Romania", gameData);
     // attack from bulgraia
-    move(bulgaria.getUnitCollection().getUnits(), new Route(bulgaria, ukraine));
+    move(bulgaria.getUnits(), new Route(bulgaria, ukraine));
     // add a blitz attack
     move(poland.getUnitCollection().getMatches(Matches.unitCanBlitz()), new Route(poland, eastPoland, ukraine));
     // we should not be able to retreat to east poland!
@@ -437,7 +437,7 @@ public class WW2V3Year41Test {
     final Territory eastPoland = territory("East Poland", gameData);
     final Territory ukraine = territory("Ukraine", gameData);
     // remove all units from east poland
-    removeFrom(eastPoland, eastPoland.getUnitCollection().getUnits());
+    removeFrom(eastPoland, eastPoland.getUnits());
     // Add a russian factory
     addTo(eastPoland, factory(gameData).create(1, russians(gameData)));
     MoveDelegate moveDelegate = moveDelegate(gameData);
@@ -454,7 +454,7 @@ public class WW2V3Year41Test {
      * Now try with an AA
      */
     // remove all units from east poland
-    removeFrom(eastPoland, eastPoland.getUnitCollection().getUnits());
+    removeFrom(eastPoland, eastPoland.getUnits());
     // Add a russian factory
     addTo(eastPoland, aaGun(gameData).create(1, russians(gameData)));
     moveDelegate = moveDelegate(gameData);
@@ -549,7 +549,7 @@ public class WW2V3Year41Test {
     // Set up the unit types
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     // Remove all units from east poland
-    removeFrom(eastPoland, eastPoland.getUnitCollection().getUnits());
+    removeFrom(eastPoland, eastPoland.getUnits());
     // Get total number of units in territories to start
     final int preCountIntPoland = poland.getUnitCollection().size();
     final int preCountIntBelorussia = belorussia.getUnitCollection().size();
@@ -614,7 +614,7 @@ public class WW2V3Year41Test {
     // create 20 british infantry
     addTo(british(gameData), infantry(gameData).create(20, british(gameData)), gameData);
     final Territory uk = territory("United Kingdom", gameData);
-    final Collection<Unit> units = british(gameData).getUnitCollection().getUnits();
+    final Collection<Unit> units = british(gameData).getUnits();
     final PlaceableUnits placeable = bidPlaceDelegate(gameData).getPlaceableUnits(units, uk);
     assertEquals(20, placeable.getMaxUnits());
     assertNull(placeable.getErrorMessage());
@@ -670,9 +670,9 @@ public class WW2V3Year41Test {
     // Set up the unit types
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     // Remove all units
-    removeFrom(kiangsu, kiangsu.getUnitCollection().getUnits());
+    removeFrom(kiangsu, kiangsu.getUnits());
     // add a VALID attack
-    final Collection<Unit> moveUnits = hupeh.getUnitCollection().getUnits();
+    final Collection<Unit> moveUnits = hupeh.getUnits();
     final String validResults = moveDelegate.move(moveUnits, new Route(hupeh, kiangsu));
     assertValid(validResults);
     /*
@@ -730,7 +730,7 @@ public class WW2V3Year41Test {
     final IDelegateBridge delegateBridge = newDelegateBridge(germans);
     // Clear all units from the SZ and add an enemy unit
     final Territory sz5 = territory("5 Sea Zone", gameData);
-    removeFrom(sz5, sz5.getUnitCollection().getUnits());
+    removeFrom(sz5, sz5.getUnits());
     addTo(sz5, destroyer(gameData).create(1, british(gameData)));
     // Set up the unit types
     final UnitType transportType = GameDataTestUtil.transport(gameData);
@@ -756,7 +756,7 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).start();
     final Territory sz6 = territory("6 Sea Zone", gameData);
     final Route route = new Route(sz6, territory("7 Sea Zone", gameData), territory("8 Sea Zone", gameData));
-    final String error = moveDelegate(gameData).move(sz6.getUnitCollection().getUnits(), route);
+    final String error = moveDelegate(gameData).move(sz6.getUnits(), route);
     assertNull(error, error);
   }
 
@@ -768,7 +768,7 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).start();
     final Territory sz12 = territory("12 Sea Zone", gameData);
     final Route route = new Route(sz12, territory("13 Sea Zone", gameData), territory("14 Sea Zone", gameData));
-    final String error = moveDelegate(gameData).move(sz12.getUnitCollection().getUnits(), route);
+    final String error = moveDelegate(gameData).move(sz12.getUnits(), route);
     assertNull(error, error);
   }
 
@@ -780,9 +780,9 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).start();
     final Territory sz12 = territory("12 Sea Zone", gameData);
     final Territory sz14 = territory("14 Sea Zone", gameData);
-    removeFrom(sz14, sz14.getUnitCollection().getUnits());
+    removeFrom(sz14, sz14.getUnits());
     final Route route = new Route(sz12, territory("13 Sea Zone", gameData), sz14);
-    final String error = moveDelegate(gameData).move(sz12.getUnitCollection().getUnits(), route);
+    final String error = moveDelegate(gameData).move(sz12.getUnits(), route);
     assertNull(error, error);
   }
 
@@ -800,7 +800,7 @@ public class WW2V3Year41Test {
     // add a transport
     addTo(sz8, transport(gameData).create(1, british(gameData)));
     // move the transport where to the sub is
-    assertValid(moveDelegate.move(sz8.getUnitCollection().getUnits(), new Route(sz8, sz7)));
+    assertValid(moveDelegate.move(sz8.getUnits(), new Route(sz8, sz7)));
     // load the transport
     load(uk.getUnitCollection().getMatches(Matches.unitIsLandTransportable()), new Route(uk, sz7));
     // move the transport out
@@ -848,7 +848,7 @@ public class WW2V3Year41Test {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(from.getUnitCollection().getUnits(), new Route(from, attacked));
+    move(from.getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
@@ -883,7 +883,7 @@ public class WW2V3Year41Test {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(from.getUnitCollection().getUnits(), new Route(from, attacked));
+    move(from.getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
@@ -917,7 +917,7 @@ public class WW2V3Year41Test {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(from.getUnitCollection().getUnits(), new Route(from, attacked));
+    move(from.getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
@@ -952,7 +952,7 @@ public class WW2V3Year41Test {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(from.getUnitCollection().getUnits(), new Route(from, attacked));
+    move(from.getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
@@ -992,14 +992,14 @@ public class WW2V3Year41Test {
     final Territory li = territory("Libya", gameData);
     final Territory balkans = territory("Balkans", gameData);
     // Clear all units from the attacked terr
-    removeFrom(eg, eg.getUnitCollection().getUnits());
+    removeFrom(eg, eg.getUnits());
     // Add 2 inf
     final PlayerId british = GameDataTestUtil.british(gameData);
     addTo(eg, infantry(gameData).create(2, british));
     // load the transports
     load(balkans.getUnitCollection().getMatches(Matches.unitIsLandTransportable()), new Route(balkans, sz14));
     // move the fleet
-    move(sz14.getUnitCollection().getUnits(), new Route(sz14, sz15));
+    move(sz14.getUnits(), new Route(sz14, sz15));
     // move troops from Libya
     move(li.getUnitCollection().getMatches(Matches.unitOwnedBy(italians(gameData))), new Route(li, eg));
     // unload the transports
@@ -1039,8 +1039,8 @@ public class WW2V3Year41Test {
     final Territory eg = territory("Egypt", gameData);
     final Territory balkans = territory("Balkans", gameData);
     // Clear all units
-    removeFrom(eg, eg.getUnitCollection().getUnits());
-    removeFrom(sz14, sz14.getUnitCollection().getUnits());
+    removeFrom(eg, eg.getUnits());
+    removeFrom(sz14, sz14.getUnits());
     // Add 2 inf to the attacked terr
     final PlayerId british = GameDataTestUtil.british(gameData);
     addTo(eg, infantry(gameData).create(2, british));
@@ -1051,7 +1051,7 @@ public class WW2V3Year41Test {
     // load the transports
     load(balkans.getUnitCollection().getMatches(Matches.unitIsLandTransportable()), new Route(balkans, sz14));
     // move the fleet
-    move(sz14.getUnitCollection().getUnits(), new Route(sz14, sz15));
+    move(sz14.getUnits(), new Route(sz14, sz15));
     // unload the transports
     move(sz15.getUnitCollection().getMatches(Matches.unitIsLand()), new Route(sz15, eg));
     move.end();
@@ -1061,7 +1061,7 @@ public class WW2V3Year41Test {
     UnitAttachment.get(destroyer(gameData)).setCanBombard("true");
     // Set the bombard strength for the DDs
     final Collection<Unit> dds =
-        CollectionUtils.getMatches(sz15.getUnitCollection().getUnits(), Matches.unitIsDestroyer());
+        CollectionUtils.getMatches(sz15.getUnits(), Matches.unitIsDestroyer());
     final Iterator<Unit> ddIter = dds.iterator();
     while (ddIter.hasNext()) {
       final Unit unit = ddIter.next();
@@ -1107,7 +1107,7 @@ public class WW2V3Year41Test {
     // load the transports
     load(balkans.getUnitCollection().getMatches(Matches.unitIsLandTransportable()), new Route(balkans, sz14));
     // move the fleet
-    move(sz14.getUnitCollection().getUnits(), new Route(sz14, sz15));
+    move(sz14.getUnits(), new Route(sz14, sz15));
     // move troops from Libya
     move(li.getUnitCollection().getMatches(Matches.unitOwnedBy(italians(gameData))), new Route(li, eg));
     // unload the transports
@@ -1138,9 +1138,9 @@ public class WW2V3Year41Test {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(sz8.getUnitCollection().getUnits(), route);
+    move(sz8.getUnits(), route);
     // make sure the fighter moved
-    assertTrue(sz8.getUnitCollection().getUnits().isEmpty());
+    assertTrue(sz8.getUnits().isEmpty());
     assertFalse(sz1.getUnitCollection().getMatches(Matches.unitIsAir()).isEmpty());
   }
 
@@ -1163,7 +1163,7 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
     // don't allow kamikaze
-    final String error = moveDelegate(gameData).move(madagascar.getUnitCollection().getUnits(), route);
+    final String error = moveDelegate(gameData).move(madagascar.getUnits(), route);
     assertError(error);
   }
 
@@ -1202,7 +1202,7 @@ public class WW2V3Year41Test {
         new Route(germany, france));
     // try to move all the units in france, the infantry should not be able to move
     final Route r = new Route(france, germany);
-    final String error = moveDelegate(gameData).move(france.getUnitCollection().getUnits(), r);
+    final String error = moveDelegate(gameData).move(france.getUnits(), r);
     assertNotNull(error);
   }
 
@@ -1394,7 +1394,7 @@ public class WW2V3Year41Test {
     final Territory eastPoland = territory("East Poland", gameData);
     final Territory beloRussia = territory("Belorussia", gameData);
     // Clear East Poland
-    removeFrom(eastPoland, eastPoland.getUnitCollection().getUnits());
+    removeFrom(eastPoland, eastPoland.getUnits());
     // Set up test
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
@@ -1504,7 +1504,7 @@ public class WW2V3Year41Test {
     IntegerMap<RepairRule> repairs = new IntegerMap<>();
     repairs.put(repair, 1);
     String error = del.purchaseRepair(Collections.singletonMap(
-        CollectionUtils.getMatches(germany.getUnitCollection().getUnits(), Matches.unitCanBeDamaged()).iterator()
+        CollectionUtils.getMatches(germany.getUnits(), Matches.unitCanBeDamaged()).iterator()
             .next(),
         repairs));
     assertValid(error);
@@ -1528,7 +1528,7 @@ public class WW2V3Year41Test {
     repairs = new IntegerMap<>();
     repairs.put(repair, 2);
     error = del.purchaseRepair(Collections.singletonMap(
-        CollectionUtils.getMatches(germany.getUnitCollection().getUnits(), Matches.unitCanBeDamaged()).iterator()
+        CollectionUtils.getMatches(germany.getUnits(), Matches.unitCanBeDamaged()).iterator()
             .next(),
         repairs));
     assertValid(error);
@@ -1555,7 +1555,7 @@ public class WW2V3Year41Test {
     // we have 1 damaged marker, but trying to repair 2
     repairs.put(repair, 2);
     final String error = del.purchaseRepair(Collections.singletonMap(
-        CollectionUtils.getMatches(germany.getUnitCollection().getUnits(), Matches.unitCanBeDamaged()).iterator()
+        CollectionUtils.getMatches(germany.getUnits(), Matches.unitCanBeDamaged()).iterator()
             .next(),
         repairs));
     // it is no longer an error, we just math max 0 it
@@ -1577,12 +1577,12 @@ public class WW2V3Year41Test {
     final Territory hupeh = territory("Hupeh", gameData);
     final Territory kiangsu = territory("Kiangsu", gameData);
     // Remove all units
-    removeFrom(kiangsu, kiangsu.getUnitCollection().getUnits());
-    removeFrom(hupeh, hupeh.getUnitCollection().getUnits());
+    removeFrom(kiangsu, kiangsu.getUnits());
+    removeFrom(hupeh, hupeh.getUnits());
     // Set up the unit types
     addTo(hupeh, infantry(gameData).create(1, british));
     // Get units
-    final Collection<Unit> moveUnits = hupeh.getUnitCollection().getUnits();
+    final Collection<Unit> moveUnits = hupeh.getUnits();
     // Get Owner prior to battle
     final String preOwner = kiangsu.getOwner().getName();
     assertEquals(Constants.PLAYER_NAME_JAPANESE, preOwner);
@@ -1617,12 +1617,12 @@ public class WW2V3Year41Test {
     // Set as NEW capital
     taKiangsu.setCapital(Constants.PLAYER_NAME_CHINESE);
     // Remove all units
-    removeFrom(kiangsu, kiangsu.getUnitCollection().getUnits());
-    removeFrom(hupeh, hupeh.getUnitCollection().getUnits());
+    removeFrom(kiangsu, kiangsu.getUnits());
+    removeFrom(hupeh, hupeh.getUnits());
     // Set up the unit types
     addTo(hupeh, infantry(gameData).create(1, british));
     // Get units
-    final Collection<Unit> moveUnits = hupeh.getUnitCollection().getUnits();
+    final Collection<Unit> moveUnits = hupeh.getUnits();
     // Get Owner prior to battle
     final String preOwner = kiangsu.getOwner().getName();
     assertEquals(Constants.PLAYER_NAME_JAPANESE, preOwner);
@@ -1643,7 +1643,7 @@ public class WW2V3Year41Test {
     final Territory libya = territory("Libya", gameData);
     final Territory egypt = territory("Egypt", gameData);
     final Territory morrocco = territory("Morocco Algeria", gameData);
-    removeFrom(libya, libya.getUnitCollection().getUnits());
+    removeFrom(libya, libya.getUnits());
     // Set up the move delegate
     final MoveDelegate moveDelegate = moveDelegate(gameData);
     advanceToStep(delegateBridge, "CombatMove");

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -163,11 +163,11 @@ public class WW2V3Year41Test {
     final Collection<Unit> planes = bomber(gameData).create(3, british(gameData));
     planes.addAll(fighter(gameData).create(3, british(gameData)));
     final Collection<Unit> defendingAa =
-        territory("Germany", gameData).getUnits().getMatches(Matches.unitIsAaForAnything());
+        territory("Germany", gameData).getUnitCollection().getMatches(Matches.unitIsAaForAnything());
     // don't allow rolling, 6 of each is deterministic
     final DiceRoll roll = DiceRoll.rollAa(CollectionUtils.getMatches(planes,
         Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(gameData))),
-        defendingAa, planes, territory("Germany", gameData).getUnits().getUnits(), bridge,
+        defendingAa, planes, territory("Germany", gameData).getUnitCollection().getUnits(), bridge,
         territory("Germany", gameData), true);
     final Collection<Unit> casualties = BattleCalculator.getAaCasualties(false, planes, planes, defendingAa,
         defendingAa, roll, bridge, null, null, territory("Germany", gameData), null, false, null).getKilled();
@@ -190,7 +190,7 @@ public class WW2V3Year41Test {
     final Collection<Unit> planes = bomber(gameData).create(4, british(gameData));
     planes.addAll(fighter(gameData).create(4, british(gameData)));
     final Collection<Unit> defendingAa =
-        territory("Germany", gameData).getUnits().getMatches(Matches.unitIsAaForAnything());
+        territory("Germany", gameData).getUnitCollection().getMatches(Matches.unitIsAaForAnything());
     // 1 roll, a hit
     // then a dice to select the casualty
     whenGetRandom(bridge)
@@ -198,7 +198,7 @@ public class WW2V3Year41Test {
         .thenAnswer(withValues(1));
     final DiceRoll roll = DiceRoll.rollAa(CollectionUtils.getMatches(planes,
         Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(gameData))),
-        defendingAa, planes, territory("Germany", gameData).getUnits().getUnits(), bridge,
+        defendingAa, planes, territory("Germany", gameData).getUnitCollection().getUnits(), bridge,
         territory("Germany", gameData), true);
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
@@ -222,7 +222,7 @@ public class WW2V3Year41Test {
     final Collection<Unit> planes = bomber(gameData).create(4, british(gameData));
     planes.addAll(fighter(gameData).create(4, british(gameData)));
     final Collection<Unit> defendingAa =
-        territory("Germany", gameData).getUnits().getMatches(Matches.unitIsAaForAnything());
+        territory("Germany", gameData).getUnitCollection().getMatches(Matches.unitIsAaForAnything());
     // 1 roll, a miss
     // then a dice to select the casualty
     whenGetRandom(bridge)
@@ -232,7 +232,7 @@ public class WW2V3Year41Test {
     final DiceRoll roll = DiceRoll.rollAa(
         CollectionUtils.getMatches(planes,
             Matches.unitIsOfTypes(UnitAttachment.get(defendingAa.iterator().next().getType()).getTargetsAa(gameData))),
-        defendingAa, planes, territory("Germany", gameData).getUnits().getUnits(), bridge,
+        defendingAa, planes, territory("Germany", gameData).getUnitCollection().getUnits(), bridge,
         territory("Germany", gameData), true);
     assertEquals(2, roll.getHits());
     // make sure we rolled once
@@ -259,12 +259,12 @@ public class WW2V3Year41Test {
     final Route sz12To13 = new Route();
     sz12To13.setStart(sz12);
     sz12To13.add(sz13);
-    final String error = moveDelegate.move(sz12.getUnits().getUnits(), sz12To13);
+    final String error = moveDelegate.move(sz12.getUnitCollection().getUnits(), sz12To13);
     assertNull(error);
-    assertEquals(3, sz13.getUnits().size());
+    assertEquals(3, sz13.getUnitCollection().size());
     moveDelegate.end();
     // the transport was not removed automatically
-    assertEquals(3, sz13.getUnits().size());
+    assertEquals(3, sz13.getUnitCollection().size());
     final BattleDelegate bd = battleDelegate(gameData);
     assertFalse(bd.getBattleTracker().getPendingBattleSites(false).isEmpty());
   }
@@ -277,7 +277,7 @@ public class WW2V3Year41Test {
     addTo(british(gameData), transport(gameData).create(1, british(gameData)), gameData);
     del.end();
     // unplaced units die
-    assertEquals(1, british(gameData).getUnits().size());
+    assertEquals(1, british(gameData).getUnitCollection().size());
   }
 
   @Test
@@ -340,9 +340,9 @@ public class WW2V3Year41Test {
     final Territory sz13 = territory("13 Sea Zone", gameData);
     final Route sz9ToSz13 = new Route(sz9, territory("12 Sea Zone", gameData), sz13);
     // move the transport to attack, this is suicide but valid
-    move(sz9.getUnits().getMatches(Matches.unitIsTransport()), sz9ToSz13);
+    move(sz9.getUnitCollection().getMatches(Matches.unitIsTransport()), sz9ToSz13);
     // load the transport
-    load(gibraltar.getUnits().getUnits(), new Route(gibraltar, sz13));
+    load(gibraltar.getUnitCollection().getUnits(), new Route(gibraltar, sz13));
     moveDelegate.end();
     advanceToStep(bridge, "britishBattle");
     final BattleDelegate battleDelegate = battleDelegate(gameData);
@@ -365,10 +365,10 @@ public class WW2V3Year41Test {
     final Territory uk = territory("United Kingdom", gameData);
     final Route sz9ToSz7 = new Route(sz9, territory("8 Sea Zone", gameData), sz7);
     // move the transport to attack, this is suicide but valid
-    final List<Unit> transports = sz9.getUnits().getMatches(Matches.unitIsTransport());
+    final List<Unit> transports = sz9.getUnitCollection().getMatches(Matches.unitIsTransport());
     move(transports, sz9ToSz7);
     // load the transport
-    load(uk.getUnits().getMatches(Matches.unitIsLandTransportable()), new Route(uk, sz7));
+    load(uk.getUnitCollection().getMatches(Matches.unitIsLandTransportable()), new Route(uk, sz7));
     moveDelegate(gameData).end();
     whenGetRandom(bridge).thenAnswer(withValues(0, 1));
     advanceToStep(bridge, "britishBattle");
@@ -378,7 +378,8 @@ public class WW2V3Year41Test {
     battleDelegate.start();
     // battle already fought
     // make sure the infantry die with the transport
-    assertTrue(sz7.getUnits().getMatches(Matches.unitOwnedBy(british)).isEmpty(), sz7.getUnits().toString());
+    assertTrue(sz7.getUnitCollection().getMatches(Matches.unitOwnedBy(british)).isEmpty(),
+        sz7.getUnitCollection().toString());
   }
 
   @Test
@@ -387,7 +388,7 @@ public class WW2V3Year41Test {
     final Territory ukraine = territory("Ukraine", gameData);
     final Territory poland = territory("Poland", gameData);
     // remove all units from east poland
-    removeFrom(eastPoland, eastPoland.getUnits().getUnits());
+    removeFrom(eastPoland, eastPoland.getUnitCollection().getUnits());
     final MoveDelegate moveDelegate = moveDelegate(gameData);
     final IDelegateBridge delegateBridge = newDelegateBridge(germans(gameData));
     advanceToStep(delegateBridge, "CombatMove");
@@ -395,9 +396,9 @@ public class WW2V3Year41Test {
     moveDelegate.start();
     final Territory bulgaria = territory("Bulgaria Romania", gameData);
     // attack from bulgraia
-    move(bulgaria.getUnits().getUnits(), new Route(bulgaria, ukraine));
+    move(bulgaria.getUnitCollection().getUnits(), new Route(bulgaria, ukraine));
     // add an air attack from east poland
-    move(poland.getUnits().getMatches(Matches.unitIsAir()), new Route(poland, eastPoland, ukraine));
+    move(poland.getUnitCollection().getMatches(Matches.unitIsAir()), new Route(poland, eastPoland, ukraine));
     // we should not be able to retreat to east poland!
     // that territory is still owned by the enemy
     final MustFightBattle battle =
@@ -411,7 +412,7 @@ public class WW2V3Year41Test {
     final Territory ukraine = territory("Ukraine", gameData);
     final Territory poland = territory("Poland", gameData);
     // remove all units from east poland
-    removeFrom(eastPoland, eastPoland.getUnits().getUnits());
+    removeFrom(eastPoland, eastPoland.getUnitCollection().getUnits());
     final MoveDelegate moveDelegate = moveDelegate(gameData);
     final IDelegateBridge delegateBridge = newDelegateBridge(germans(gameData));
     advanceToStep(delegateBridge, "CombatMove");
@@ -419,9 +420,9 @@ public class WW2V3Year41Test {
     moveDelegate.start();
     final Territory bulgaria = territory("Bulgaria Romania", gameData);
     // attack from bulgraia
-    move(bulgaria.getUnits().getUnits(), new Route(bulgaria, ukraine));
+    move(bulgaria.getUnitCollection().getUnits(), new Route(bulgaria, ukraine));
     // add a blitz attack
-    move(poland.getUnits().getMatches(Matches.unitCanBlitz()), new Route(poland, eastPoland, ukraine));
+    move(poland.getUnitCollection().getMatches(Matches.unitCanBlitz()), new Route(poland, eastPoland, ukraine));
     // we should not be able to retreat to east poland!
     // that territory was just conquered
     final MustFightBattle battle =
@@ -436,7 +437,7 @@ public class WW2V3Year41Test {
     final Territory eastPoland = territory("East Poland", gameData);
     final Territory ukraine = territory("Ukraine", gameData);
     // remove all units from east poland
-    removeFrom(eastPoland, eastPoland.getUnits().getUnits());
+    removeFrom(eastPoland, eastPoland.getUnitCollection().getUnits());
     // Add a russian factory
     addTo(eastPoland, factory(gameData).create(1, russians(gameData)));
     MoveDelegate moveDelegate = moveDelegate(gameData);
@@ -446,13 +447,14 @@ public class WW2V3Year41Test {
     moveDelegate.start();
     // add a blitz attack
     String errorResults =
-        moveDelegate.move(poland.getUnits().getMatches(Matches.unitCanBlitz()), new Route(poland, eastPoland, ukraine));
+        moveDelegate.move(poland.getUnitCollection().getMatches(Matches.unitCanBlitz()),
+            new Route(poland, eastPoland, ukraine));
     assertError(errorResults);
     /*
      * Now try with an AA
      */
     // remove all units from east poland
-    removeFrom(eastPoland, eastPoland.getUnits().getUnits());
+    removeFrom(eastPoland, eastPoland.getUnitCollection().getUnits());
     // Add a russian factory
     addTo(eastPoland, aaGun(gameData).create(1, russians(gameData)));
     moveDelegate = moveDelegate(gameData);
@@ -462,7 +464,8 @@ public class WW2V3Year41Test {
     moveDelegate.start();
     // add a blitz attack
     errorResults =
-        moveDelegate.move(poland.getUnits().getMatches(Matches.unitCanBlitz()), new Route(poland, eastPoland, ukraine));
+        moveDelegate.move(poland.getUnitCollection().getMatches(Matches.unitCanBlitz()),
+            new Route(poland, eastPoland, ukraine));
     assertError(errorResults);
   }
 
@@ -478,14 +481,15 @@ public class WW2V3Year41Test {
     advanceToStep(delegateBridge, "NonCombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     moveDelegate.start();
-    final int preCount = germany.getUnits().getUnitCount();
+    final int preCount = germany.getUnitCollection().getUnitCount();
     /*
      * Move one
      */
     String errorResults =
-        moveDelegate.move(poland.getUnits().getMatches(Matches.unitIsAaForAnything()), new Route(poland, germany));
+        moveDelegate.move(poland.getUnitCollection().getMatches(Matches.unitIsAaForAnything()),
+            new Route(poland, germany));
     assertValid(errorResults);
-    assertEquals(germany.getUnits().getUnitCount(), preCount + 1);
+    assertEquals(germany.getUnitCollection().getUnitCount(), preCount + 1);
     /*
      * Test unloading TRN
      */
@@ -498,13 +502,14 @@ public class WW2V3Year41Test {
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     moveDelegate.start();
     // load the trn
-    errorResults = moveDelegate.move(finland.getUnits().getMatches(Matches.unitIsAaForAnything()),
-        new Route(finland, sz5), sz5.getUnits().getMatches(Matches.unitIsTransport()));
+    errorResults = moveDelegate.move(finland.getUnitCollection().getMatches(Matches.unitIsAaForAnything()),
+        new Route(finland, sz5), sz5.getUnitCollection().getMatches(Matches.unitIsTransport()));
     assertValid(errorResults);
     // unload the trn
-    errorResults = moveDelegate.move(sz5.getUnits().getMatches(Matches.unitIsAaForAnything()), new Route(sz5, germany));
+    errorResults =
+        moveDelegate.move(sz5.getUnitCollection().getMatches(Matches.unitIsAaForAnything()), new Route(sz5, germany));
     assertValid(errorResults);
-    assertEquals(germany.getUnits().getUnitCount(), preCount + 2);
+    assertEquals(germany.getUnitCollection().getUnitCount(), preCount + 2);
     /*
      * Test Building one
      */
@@ -522,7 +527,7 @@ public class WW2V3Year41Test {
     errorResults = placeDelegate.placeUnits(GameDataTestUtil.getUnits(map, germans), germany,
         IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertValid(errorResults);
-    assertEquals(germany.getUnits().getUnitCount(), preCount + 3);
+    assertEquals(germany.getUnitCollection().getUnitCount(), preCount + 3);
   }
 
   @Test
@@ -544,26 +549,26 @@ public class WW2V3Year41Test {
     // Set up the unit types
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     // Remove all units from east poland
-    removeFrom(eastPoland, eastPoland.getUnits().getUnits());
+    removeFrom(eastPoland, eastPoland.getUnitCollection().getUnits());
     // Get total number of units in territories to start
-    final int preCountIntPoland = poland.getUnits().size();
-    final int preCountIntBelorussia = belorussia.getUnits().size();
+    final int preCountIntPoland = poland.getUnitCollection().size();
+    final int preCountIntBelorussia = belorussia.getUnitCollection().size();
     // Get units
-    final Collection<Unit> moveUnits = poland.getUnits().getUnits(infantryType, 3);
-    moveUnits.addAll(poland.getUnits().getMatches(Matches.unitCanBlitz()));
+    final Collection<Unit> moveUnits = poland.getUnitCollection().getUnits(infantryType, 3);
+    moveUnits.addAll(poland.getUnitCollection().getMatches(Matches.unitCanBlitz()));
     // add a INVALID blitz attack
     final String errorResults = moveDelegate.move(moveUnits, new Route(poland, eastPoland, belorussia));
     assertError(errorResults);
     // Fix the number of units
     moveUnits.clear();
-    moveUnits.addAll(poland.getUnits().getUnits(infantryType, 2));
-    moveUnits.addAll(poland.getUnits().getMatches(Matches.unitCanBlitz()));
+    moveUnits.addAll(poland.getUnitCollection().getUnits(infantryType, 2));
+    moveUnits.addAll(poland.getUnitCollection().getMatches(Matches.unitCanBlitz()));
     // add a VALID blitz attack
     final String validResults = moveDelegate.move(moveUnits, new Route(poland, eastPoland, belorussia));
     assertValid(validResults);
     // Get number of units in territories after move (adjusted for movement)
-    final int postCountIntPoland = poland.getUnits().size() + 4;
-    final int postCountIntBelorussia = belorussia.getUnits().size() - 4;
+    final int postCountIntPoland = poland.getUnitCollection().size() + 4;
+    final int postCountIntBelorussia = belorussia.getUnitCollection().size() - 4;
     // Compare the number of units before and after
     assertEquals(preCountIntPoland, postCountIntPoland);
     assertEquals(preCountIntBelorussia, postCountIntBelorussia);
@@ -586,7 +591,7 @@ public class WW2V3Year41Test {
       gameData.getSequence().next();
     }
     final Collection<TerritoryEffect> territoryEffects = TerritoryEffectHelper.getEffects(eastPoland);
-    final List<Unit> germanFighter = (List<Unit>) poland.getUnits().getUnits(fighterType, 1);
+    final List<Unit> germanFighter = (List<Unit>) poland.getUnitCollection().getUnits(fighterType, 1);
     whenGetRandom(delegateBridge)
         .thenAnswer(withValues(3)) // With JET_POWER attacking fighter hits on 4 (0 base)
         .thenAnswer(withValues(4)); // With JET_POWER defending fighter misses on 5 (0 base)
@@ -609,7 +614,7 @@ public class WW2V3Year41Test {
     // create 20 british infantry
     addTo(british(gameData), infantry(gameData).create(20, british(gameData)), gameData);
     final Territory uk = territory("United Kingdom", gameData);
-    final Collection<Unit> units = british(gameData).getUnits().getUnits();
+    final Collection<Unit> units = british(gameData).getUnitCollection().getUnits();
     final PlaceableUnits placeable = bidPlaceDelegate(gameData).getPlaceableUnits(units, uk);
     assertEquals(20, placeable.getMaxUnits());
     assertNull(placeable.getErrorMessage());
@@ -665,9 +670,9 @@ public class WW2V3Year41Test {
     // Set up the unit types
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
     // Remove all units
-    removeFrom(kiangsu, kiangsu.getUnits().getUnits());
+    removeFrom(kiangsu, kiangsu.getUnitCollection().getUnits());
     // add a VALID attack
-    final Collection<Unit> moveUnits = hupeh.getUnits().getUnits();
+    final Collection<Unit> moveUnits = hupeh.getUnitCollection().getUnits();
     final String validResults = moveDelegate.move(moveUnits, new Route(hupeh, kiangsu));
     assertValid(validResults);
     /*
@@ -682,12 +687,12 @@ public class WW2V3Year41Test {
     map.add(infantryType, 3);
     addTo(chinese(gameData), infantry(gameData).create(1, chinese(gameData)), gameData);
     // Get the number of units before placing
-    int preCount = kiangsu.getUnits().getUnitCount();
+    int preCount = kiangsu.getUnitCollection().getUnitCount();
     // Place the infantry
     String response = placeDelegate.placeUnits(GameDataTestUtil.getUnits(map, chinese), kiangsu,
         IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertValid(response);
-    assertEquals(preCount + 1, kiangsu.getUnits().getUnitCount());
+    assertEquals(preCount + 1, kiangsu.getUnitCollection().getUnitCount());
     /*
      * Place units in a territory with up to 3 Chinese units
      */
@@ -696,12 +701,12 @@ public class WW2V3Year41Test {
     map.add(infantryType, 3);
     addTo(chinese(gameData), infantry(gameData).create(3, chinese(gameData)), gameData);
     // Get the number of units before placing
-    preCount = yunnan.getUnits().getUnitCount();
+    preCount = yunnan.getUnitCollection().getUnitCount();
     // Place the infantry
     response = placeDelegate.placeUnits(GameDataTestUtil.getUnits(map, chinese), yunnan,
         IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertValid(response);
-    final int midCount = yunnan.getUnits().getUnitCount();
+    final int midCount = yunnan.getUnitCollection().getUnitCount();
     // Make sure they were all placed
     assertEquals(preCount, midCount - 3);
     /*
@@ -714,7 +719,7 @@ public class WW2V3Year41Test {
         IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertError(response);
     // Make sure none were placed
-    final int postCount = yunnan.getUnits().getUnitCount();
+    final int postCount = yunnan.getUnitCollection().getUnitCount();
     assertEquals(midCount, postCount);
   }
 
@@ -725,7 +730,7 @@ public class WW2V3Year41Test {
     final IDelegateBridge delegateBridge = newDelegateBridge(germans);
     // Clear all units from the SZ and add an enemy unit
     final Territory sz5 = territory("5 Sea Zone", gameData);
-    removeFrom(sz5, sz5.getUnits().getUnits());
+    removeFrom(sz5, sz5.getUnitCollection().getUnits());
     addTo(sz5, destroyer(gameData).create(1, british(gameData)));
     // Set up the unit types
     final UnitType transportType = GameDataTestUtil.transport(gameData);
@@ -751,7 +756,7 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).start();
     final Territory sz6 = territory("6 Sea Zone", gameData);
     final Route route = new Route(sz6, territory("7 Sea Zone", gameData), territory("8 Sea Zone", gameData));
-    final String error = moveDelegate(gameData).move(sz6.getUnits().getUnits(), route);
+    final String error = moveDelegate(gameData).move(sz6.getUnitCollection().getUnits(), route);
     assertNull(error, error);
   }
 
@@ -763,7 +768,7 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).start();
     final Territory sz12 = territory("12 Sea Zone", gameData);
     final Route route = new Route(sz12, territory("13 Sea Zone", gameData), territory("14 Sea Zone", gameData));
-    final String error = moveDelegate(gameData).move(sz12.getUnits().getUnits(), route);
+    final String error = moveDelegate(gameData).move(sz12.getUnitCollection().getUnits(), route);
     assertNull(error, error);
   }
 
@@ -775,9 +780,9 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).start();
     final Territory sz12 = territory("12 Sea Zone", gameData);
     final Territory sz14 = territory("14 Sea Zone", gameData);
-    removeFrom(sz14, sz14.getUnits().getUnits());
+    removeFrom(sz14, sz14.getUnitCollection().getUnits());
     final Route route = new Route(sz12, territory("13 Sea Zone", gameData), sz14);
-    final String error = moveDelegate(gameData).move(sz12.getUnits().getUnits(), route);
+    final String error = moveDelegate(gameData).move(sz12.getUnitCollection().getUnits(), route);
     assertNull(error, error);
   }
 
@@ -795,12 +800,13 @@ public class WW2V3Year41Test {
     // add a transport
     addTo(sz8, transport(gameData).create(1, british(gameData)));
     // move the transport where to the sub is
-    assertValid(moveDelegate.move(sz8.getUnits().getUnits(), new Route(sz8, sz7)));
+    assertValid(moveDelegate.move(sz8.getUnitCollection().getUnits(), new Route(sz8, sz7)));
     // load the transport
-    load(uk.getUnits().getMatches(Matches.unitIsLandTransportable()), new Route(uk, sz7));
+    load(uk.getUnitCollection().getMatches(Matches.unitIsLandTransportable()), new Route(uk, sz7));
     // move the transport out
     assertValid(
-        moveDelegate.move(sz7.getUnits().getMatches(Matches.unitOwnedBy(british(gameData))), new Route(sz7, sz6)));
+        moveDelegate.move(sz7.getUnitCollection().getMatches(Matches.unitOwnedBy(british(gameData))),
+            new Route(sz7, sz6)));
   }
 
   @Test
@@ -815,13 +821,13 @@ public class WW2V3Year41Test {
     final Territory sz12 = territory("12 Sea Zone", gameData);
     final Route r = new Route(sz14, sz13, sz12);
     // move the battleship
-    move(sz14.getUnits().getMatches(Matches.unitHasMoreThanOneHitPointTotal()), r);
+    move(sz14.getUnitCollection().getMatches(Matches.unitHasMoreThanOneHitPointTotal()), r);
     // move everything
-    move(sz14.getUnits().getMatches(Matches.unitIsNotTransport()), r);
+    move(sz14.getUnitCollection().getMatches(Matches.unitIsNotTransport()), r);
     // undo it
     move.undoMove(1);
     // move again
-    move(sz14.getUnits().getMatches(Matches.unitIsNotTransport()), r);
+    move(sz14.getUnitCollection().getMatches(Matches.unitIsNotTransport()), r);
     final MustFightBattle mfb =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(sz12, false, null);
     // only 3 attacking units
@@ -842,7 +848,7 @@ public class WW2V3Year41Test {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(from.getUnits().getUnits(), new Route(from, attacked));
+    move(from.getUnitCollection().getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
@@ -859,7 +865,7 @@ public class WW2V3Year41Test {
         .thenAnswer(withValues(0));
     battle.fight(bridge);
     thenGetRandomShouldHaveBeenCalled(bridge, times(2));
-    assertTrue(attacked.getUnits().isEmpty());
+    assertTrue(attacked.getUnitCollection().isEmpty());
   }
 
   @Test
@@ -877,7 +883,7 @@ public class WW2V3Year41Test {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(from.getUnits().getUnits(), new Route(from, attacked));
+    move(from.getUnitCollection().getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
@@ -892,8 +898,8 @@ public class WW2V3Year41Test {
     whenGetRandom(bridge).thenAnswer(withValues(0));
     battle.fight(bridge);
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
-    assertTrue(attacked.getUnits().getMatches(Matches.unitIsOwnedBy(british(gameData))).isEmpty());
-    assertEquals(2, attacked.getUnits().size());
+    assertTrue(attacked.getUnitCollection().getMatches(Matches.unitIsOwnedBy(british(gameData))).isEmpty());
+    assertEquals(2, attacked.getUnitCollection().size());
   }
 
   @Test
@@ -911,7 +917,7 @@ public class WW2V3Year41Test {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(from.getUnits().getUnits(), new Route(from, attacked));
+    move(from.getUnitCollection().getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
@@ -926,8 +932,8 @@ public class WW2V3Year41Test {
     whenGetRandom(bridge).thenAnswer(withValues(0));
     battle.fight(bridge);
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
-    assertTrue(attacked.getUnits().getMatches(Matches.unitIsOwnedBy(germans(gameData))).isEmpty());
-    assertEquals(2, attacked.getUnits().size());
+    assertTrue(attacked.getUnitCollection().getMatches(Matches.unitIsOwnedBy(germans(gameData))).isEmpty());
+    assertEquals(2, attacked.getUnitCollection().size());
   }
 
   @Test
@@ -946,7 +952,7 @@ public class WW2V3Year41Test {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(from.getUnits().getUnits(), new Route(from, attacked));
+    move(from.getUnitCollection().getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
         (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
@@ -969,7 +975,7 @@ public class WW2V3Year41Test {
         .thenAnswer(withValues(0));
     battle.fight(bridge);
     thenGetRandomShouldHaveBeenCalled(bridge, times(4));
-    assertEquals(0, attacked.getUnits().size());
+    assertEquals(0, attacked.getUnitCollection().size());
   }
 
   @Test
@@ -986,18 +992,18 @@ public class WW2V3Year41Test {
     final Territory li = territory("Libya", gameData);
     final Territory balkans = territory("Balkans", gameData);
     // Clear all units from the attacked terr
-    removeFrom(eg, eg.getUnits().getUnits());
+    removeFrom(eg, eg.getUnitCollection().getUnits());
     // Add 2 inf
     final PlayerId british = GameDataTestUtil.british(gameData);
     addTo(eg, infantry(gameData).create(2, british));
     // load the transports
-    load(balkans.getUnits().getMatches(Matches.unitIsLandTransportable()), new Route(balkans, sz14));
+    load(balkans.getUnitCollection().getMatches(Matches.unitIsLandTransportable()), new Route(balkans, sz14));
     // move the fleet
-    move(sz14.getUnits().getUnits(), new Route(sz14, sz15));
+    move(sz14.getUnitCollection().getUnits(), new Route(sz14, sz15));
     // move troops from Libya
-    move(li.getUnits().getMatches(Matches.unitOwnedBy(italians(gameData))), new Route(li, eg));
+    move(li.getUnitCollection().getMatches(Matches.unitOwnedBy(italians(gameData))), new Route(li, eg));
     // unload the transports
-    move(sz15.getUnits().getMatches(Matches.unitIsLand()), new Route(sz15, eg));
+    move(sz15.getUnitCollection().getMatches(Matches.unitIsLand()), new Route(sz15, eg));
     move.end();
     // start the battle phase, this will ask the user to bombard
     battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
@@ -1017,7 +1023,7 @@ public class WW2V3Year41Test {
     battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     battleDelegate(gameData).start();
     // end result should be 2 italian infantry.
-    assertEquals(3, eg.getUnits().size());
+    assertEquals(3, eg.getUnitCollection().size());
   }
 
   @Test
@@ -1033,8 +1039,8 @@ public class WW2V3Year41Test {
     final Territory eg = territory("Egypt", gameData);
     final Territory balkans = territory("Balkans", gameData);
     // Clear all units
-    removeFrom(eg, eg.getUnits().getUnits());
-    removeFrom(sz14, sz14.getUnits().getUnits());
+    removeFrom(eg, eg.getUnitCollection().getUnits());
+    removeFrom(sz14, sz14.getUnitCollection().getUnits());
     // Add 2 inf to the attacked terr
     final PlayerId british = GameDataTestUtil.british(gameData);
     addTo(eg, infantry(gameData).create(2, british));
@@ -1043,18 +1049,19 @@ public class WW2V3Year41Test {
     addTo(sz14, transport(gameData).create(1, italians));
     addTo(sz14, destroyer(gameData).create(2, italians));
     // load the transports
-    load(balkans.getUnits().getMatches(Matches.unitIsLandTransportable()), new Route(balkans, sz14));
+    load(balkans.getUnitCollection().getMatches(Matches.unitIsLandTransportable()), new Route(balkans, sz14));
     // move the fleet
-    move(sz14.getUnits().getUnits(), new Route(sz14, sz15));
+    move(sz14.getUnitCollection().getUnits(), new Route(sz14, sz15));
     // unload the transports
-    move(sz15.getUnits().getMatches(Matches.unitIsLand()), new Route(sz15, eg));
+    move(sz15.getUnitCollection().getMatches(Matches.unitIsLand()), new Route(sz15, eg));
     move.end();
     // Set the tech for DDs bombard
     // ww2v3 doesn't have this tech, so this does nothing...
     // TechAttachment.get(italians).setDestroyerBombard("true");
     UnitAttachment.get(destroyer(gameData)).setCanBombard("true");
     // Set the bombard strength for the DDs
-    final Collection<Unit> dds = CollectionUtils.getMatches(sz15.getUnits().getUnits(), Matches.unitIsDestroyer());
+    final Collection<Unit> dds =
+        CollectionUtils.getMatches(sz15.getUnitCollection().getUnits(), Matches.unitIsDestroyer());
     final Iterator<Unit> ddIter = dds.iterator();
     while (ddIter.hasNext()) {
       final Unit unit = ddIter.next();
@@ -1081,7 +1088,7 @@ public class WW2V3Year41Test {
     battleDelegate(gameData).addBombardmentSources();
     fight(battleDelegate(gameData), eg);
     // 1 defending inf remaining
-    assertEquals(1, eg.getUnits().size());
+    assertEquals(1, eg.getUnitCollection().size());
   }
 
   @Test
@@ -1098,17 +1105,17 @@ public class WW2V3Year41Test {
     final Territory li = territory("Libya", gameData);
     final Territory balkans = territory("Balkans", gameData);
     // load the transports
-    load(balkans.getUnits().getMatches(Matches.unitIsLandTransportable()), new Route(balkans, sz14));
+    load(balkans.getUnitCollection().getMatches(Matches.unitIsLandTransportable()), new Route(balkans, sz14));
     // move the fleet
-    move(sz14.getUnits().getUnits(), new Route(sz14, sz15));
+    move(sz14.getUnitCollection().getUnits(), new Route(sz14, sz15));
     // move troops from Libya
-    move(li.getUnits().getMatches(Matches.unitOwnedBy(italians(gameData))), new Route(li, eg));
+    move(li.getUnitCollection().getMatches(Matches.unitOwnedBy(italians(gameData))), new Route(li, eg));
     // unload the transports
-    move(sz15.getUnits().getMatches(Matches.unitIsLand()), new Route(sz15, eg));
+    move(sz15.getUnitCollection().getMatches(Matches.unitIsLand()), new Route(sz15, eg));
     // undo amphibious landing
     move.undoMove(move.getMovesMade().size() - 1);
     // move again
-    move(sz15.getUnits().getMatches(Matches.unitIsLand()), new Route(sz15, eg));
+    move(sz15.getUnitCollection().getMatches(Matches.unitIsLand()), new Route(sz15, eg));
     move.end();
     // start the battle phase, this will ask the user to bombard
     battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
@@ -1131,10 +1138,10 @@ public class WW2V3Year41Test {
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
-    move(sz8.getUnits().getUnits(), route);
+    move(sz8.getUnitCollection().getUnits(), route);
     // make sure the fighter moved
-    assertTrue(sz8.getUnits().getUnits().isEmpty());
-    assertFalse(sz1.getUnits().getMatches(Matches.unitIsAir()).isEmpty());
+    assertTrue(sz8.getUnitCollection().getUnits().isEmpty());
+    assertFalse(sz1.getUnitCollection().getMatches(Matches.unitIsAir()).isEmpty());
   }
 
   @Test
@@ -1156,7 +1163,7 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
     // don't allow kamikaze
-    final String error = moveDelegate(gameData).move(madagascar.getUnits().getUnits(), route);
+    final String error = moveDelegate(gameData).move(madagascar.getUnitCollection().getUnits(), route);
     assertError(error);
   }
 
@@ -1173,8 +1180,8 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).start();
     final Route r = new Route(france, germany, poland);
     // 1 armour and 1 infantry
-    final List<Unit> toMove = new ArrayList<>(france.getUnits().getMatches(Matches.unitCanBlitz()));
-    toMove.add(france.getUnits().getMatches(Matches.unitIsLandTransportable()).get(0));
+    final List<Unit> toMove = new ArrayList<>(france.getUnitCollection().getMatches(Matches.unitCanBlitz()));
+    toMove.add(france.getUnitCollection().getMatches(Matches.unitIsLandTransportable()).get(0));
     move(toMove, r);
   }
 
@@ -1189,12 +1196,13 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
     // get rid of the infantry in france
-    removeFrom(france, france.getUnits().getMatches(Matches.unitIsLandTransportable()));
+    removeFrom(france, france.getUnitCollection().getMatches(Matches.unitIsLandTransportable()));
     // move an infantry from germany to france
-    move(germany.getUnits().getMatches(Matches.unitIsLandTransportable()).subList(0, 1), new Route(germany, france));
+    move(germany.getUnitCollection().getMatches(Matches.unitIsLandTransportable()).subList(0, 1),
+        new Route(germany, france));
     // try to move all the units in france, the infantry should not be able to move
     final Route r = new Route(france, germany);
-    final String error = moveDelegate(gameData).move(france.getUnits().getUnits(), r);
+    final String error = moveDelegate(gameData).move(france.getUnitCollection().getUnits(), r);
     assertNotNull(error);
   }
 
@@ -1204,7 +1212,7 @@ public class WW2V3Year41Test {
     final Territory france = territory("France", gameData);
     TechAttachment.get(germans).setParatroopers("true");
     final Route r = gameData.getMap().getRoute(france, territory("7 Sea Zone", gameData));
-    final Collection<Unit> paratroopers = france.getUnits().getMatches(Matches.unitIsAirTransportable());
+    final Collection<Unit> paratroopers = france.getUnitCollection().getMatches(Matches.unitIsAirTransportable());
     assertFalse(paratroopers.isEmpty());
     final MoveValidationResult results = MoveValidator.validateMove(paratroopers, r, germans,
         Collections.emptyList(), new HashMap<>(), false, null, gameData);
@@ -1224,8 +1232,8 @@ public class WW2V3Year41Test {
     final Territory karelia = territory("Karelia S.S.R.", gameData);
     addTo(germany, armour(gameData).create(1, germans));
     final Route r = new Route(germany, sz5, karelia);
-    final Collection<Unit> toMove = germany.getUnits().getMatches(Matches.unitCanBlitz());
-    toMove.addAll(germany.getUnits().getMatches(Matches.unitIsStrategicBomber()));
+    final Collection<Unit> toMove = germany.getUnitCollection().getMatches(Matches.unitCanBlitz());
+    toMove.addAll(germany.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()));
     assertEquals(2, toMove.size());
     final MoveValidationResult results = MoveValidator.validateMove(toMove, r, germans, Collections.emptyList(),
         new HashMap<>(), false, null, gameData);
@@ -1245,8 +1253,8 @@ public class WW2V3Year41Test {
     final Territory karelia = territory("Karelia S.S.R.", gameData);
     addTo(germany, armour(gameData).create(1, germans));
     final Route r = new Route(germany, sz5, karelia);
-    final Collection<Unit> toMove = germany.getUnits().getMatches(Matches.unitCanBlitz());
-    toMove.addAll(germany.getUnits().getMatches(Matches.unitIsStrategicBomber()));
+    final Collection<Unit> toMove = germany.getUnitCollection().getMatches(Matches.unitCanBlitz());
+    toMove.addAll(germany.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()));
     assertEquals(2, toMove.size());
     final MoveValidationResult results = MoveValidator.validateMove(toMove, r, germans, Collections.emptyList(),
         new HashMap<>(), false, null, gameData);
@@ -1265,10 +1273,10 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
     TechAttachment.get(germans).setParatroopers("true");
-    List<Unit> paratrooper = germany.getUnits().getMatches(Matches.unitIsAirTransportable());
+    List<Unit> paratrooper = germany.getUnitCollection().getMatches(Matches.unitIsAirTransportable());
     paratrooper = paratrooper.subList(0, 1);
     final List<Unit> bomberAndParatroop = new ArrayList<>(paratrooper);
-    bomberAndParatroop.addAll(germany.getUnits().getMatches(Matches.unitIsAirTransport()));
+    bomberAndParatroop.addAll(germany.getUnitCollection().getMatches(Matches.unitIsAirTransport()));
     // move to nwe, this is a valid move, and it not a partroop move
     move(bomberAndParatroop, new Route(germany, nwe));
   }
@@ -1286,10 +1294,10 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
     TechAttachment.get(germans).setParatroopers("true");
-    final List<Unit> paratrooper = nwe.getUnits().getMatches(Matches.unitIsAirTransportable());
+    final List<Unit> paratrooper = nwe.getUnitCollection().getMatches(Matches.unitIsAirTransportable());
     move(paratrooper, new Route(nwe, germany));
     final List<Unit> bomberAndParatroop = new ArrayList<>(paratrooper);
-    bomberAndParatroop.addAll(germany.getUnits().getMatches(Matches.unitIsAirTransport()));
+    bomberAndParatroop.addAll(germany.getUnitCollection().getMatches(Matches.unitIsAirTransport()));
     // move the units to east poland
     final String error = moveDelegate(gameData).move(bomberAndParatroop, new Route(germany, poland, eastPoland));
     assertError(error);
@@ -1309,11 +1317,11 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).start();
     TechAttachment.get(germans).setParatroopers("true");
     // Move the bomber first
-    final List<Unit> bomber = germany.getUnits().getMatches(Matches.unitIsAirTransport());
+    final List<Unit> bomber = germany.getUnitCollection().getMatches(Matches.unitIsAirTransport());
     move(bomber, new Route(germany, poland));
     // Pick up a paratrooper
     final List<Unit> bomberAndParatroop = new ArrayList<>(bomber);
-    bomberAndParatroop.addAll(poland.getUnits().getUnits(GameDataTestUtil.infantry(gameData), 1));
+    bomberAndParatroop.addAll(poland.getUnitCollection().getUnits(GameDataTestUtil.infantry(gameData), 1));
     // move them
     final String error = moveDelegate(gameData).move(bomberAndParatroop, new Route(poland, bulgaria, ukraine));
     assertError(error);
@@ -1333,9 +1341,9 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).start();
     TechAttachment.get(germans).setParatroopers("true");
     final List<Unit> bomberAndParatroop = new ArrayList<>();
-    bomberAndParatroop.addAll(germany.getUnits().getMatches(Matches.unitIsAirTransport()));
+    bomberAndParatroop.addAll(germany.getUnitCollection().getMatches(Matches.unitIsAirTransport()));
     // add 2 infantry
-    bomberAndParatroop.addAll(germany.getUnits().getUnits(GameDataTestUtil.infantry(gameData), 2));
+    bomberAndParatroop.addAll(germany.getUnitCollection().getUnits(GameDataTestUtil.infantry(gameData), 2));
     // move the units to east poland
     final String error = moveDelegate(gameData).move(bomberAndParatroop, new Route(germany, poland, eastPoland));
     assertError(error);
@@ -1356,12 +1364,12 @@ public class WW2V3Year41Test {
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
     TechAttachment.get(germans).setParatroopers("true");
-    List<Unit> paratroopers = germany.getUnits().getMatches(Matches.unitIsAirTransportable());
+    List<Unit> paratroopers = germany.getUnitCollection().getMatches(Matches.unitIsAirTransportable());
     paratroopers = paratroopers.subList(0, 1);
     final List<Unit> bomberAndParatroop = new ArrayList<>(paratroopers);
-    bomberAndParatroop.addAll(germany.getUnits().getMatches(Matches.unitIsAirTransport()));
+    bomberAndParatroop.addAll(germany.getUnitCollection().getMatches(Matches.unitIsAirTransport()));
     final Route route = new Route(germany, poland, eastPoland);
-    final List<Unit> airTransports = germany.getUnits().getMatches(Matches.unitIsAirTransport());
+    final List<Unit> airTransports = germany.getUnitCollection().getMatches(Matches.unitIsAirTransport());
     for (final Unit airTransport : airTransports) {
       for (final Unit unit : paratroopers) {
         final Change change = TransportTracker.loadTransportChange((TripleAUnit) airTransport, unit);
@@ -1386,18 +1394,18 @@ public class WW2V3Year41Test {
     final Territory eastPoland = territory("East Poland", gameData);
     final Territory beloRussia = territory("Belorussia", gameData);
     // Clear East Poland
-    removeFrom(eastPoland, eastPoland.getUnits().getUnits());
+    removeFrom(eastPoland, eastPoland.getUnitCollection().getUnits());
     // Set up test
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
     TechAttachment.get(germans).setParatroopers("true");
-    List<Unit> paratrooper = germany.getUnits().getMatches(Matches.unitIsAirTransportable());
+    List<Unit> paratrooper = germany.getUnitCollection().getMatches(Matches.unitIsAirTransportable());
     paratrooper = paratrooper.subList(0, 1);
     final List<Unit> bomberAndParatroop = new ArrayList<>(paratrooper);
-    bomberAndParatroop.addAll(germany.getUnits().getMatches(Matches.unitIsAirTransport()));
-    final List<Unit> tanks = poland.getUnits().getMatches(Matches.unitCanBlitz());
+    bomberAndParatroop.addAll(germany.getUnitCollection().getMatches(Matches.unitIsAirTransport()));
+    final List<Unit> tanks = poland.getUnitCollection().getMatches(Matches.unitCanBlitz());
     move(tanks, new Route(poland, eastPoland, beloRussia));
     final List<Unit> airTransports = CollectionUtils.getMatches(bomberAndParatroop, Matches.unitIsAirTransport());
     for (final Unit airTransport : airTransports) {
@@ -1422,9 +1430,9 @@ public class WW2V3Year41Test {
     final Territory uk = territory("United Kingdom", gameData);
     final Territory sz5 = territory("5 Sea Zone", gameData);
     // remove the sub
-    removeFrom(sz5, sz5.getUnits().getMatches(Matches.unitIsSub()));
+    removeFrom(sz5, sz5.getUnitCollection().getMatches(Matches.unitIsSub()));
 
-    move(uk.getUnits().getMatches(Matches.unitIsAir()), gameData.getMap().getRoute(uk, sz5));
+    move(uk.getUnitCollection().getMatches(Matches.unitIsAir()), gameData.getMap().getRoute(uk, sz5));
     // move units for amphib assault
     moveDelegate(gameData).end();
     advanceToStep(bridge, "Combat");
@@ -1436,7 +1444,7 @@ public class WW2V3Year41Test {
     battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     battleDelegate(gameData).start();
     // make sure the transports died
-    assertTrue(sz5.getUnits().getMatches(Matches.unitIsOwnedBy(germans(gameData))).isEmpty());
+    assertTrue(sz5.getUnitCollection().getMatches(Matches.unitIsOwnedBy(germans(gameData))).isEmpty());
     thenRemotePlayerShouldNotBeAskedToRetreat(bridge);
   }
 
@@ -1456,7 +1464,7 @@ public class WW2V3Year41Test {
     final Route route = new Route(neEurope, territory("Germany", gameData), territory("Poland", gameData),
         territory("Baltic States", gameData), territory("5 Sea Zone", gameData));
     // the fighter should be able to move, and hover in the sea zone until the carrier is placed
-    move(neEurope.getUnits().getMatches(Matches.unitIsAir()), route);
+    move(neEurope.getUnitCollection().getMatches(Matches.unitIsAir()), route);
   }
 
   @Test
@@ -1472,14 +1480,15 @@ public class WW2V3Year41Test {
     final Territory neEurope = territory("Northwestern Europe", gameData);
     final Route route = new Route(neEurope, territory("Germany", gameData), territory("Poland", gameData),
         territory("Baltic States", gameData), territory("5 Sea Zone", gameData));
-    final String error = moveDelegate(gameData).move(neEurope.getUnits().getMatches(Matches.unitIsAir()), route);
+    final String error =
+        moveDelegate(gameData).move(neEurope.getUnitCollection().getMatches(Matches.unitIsAir()), route);
     assertNotNull(error);
   }
 
   @Test
   public void testRepair() {
     final Territory germany = territory("Germany", gameData);
-    final Unit factory = germany.getUnits().getMatches(Matches.unitCanBeDamaged()).get(0);
+    final Unit factory = germany.getUnitCollection().getMatches(Matches.unitCanBeDamaged()).get(0);
     final PurchaseDelegate del = purchaseDelegate(gameData);
     del.setDelegateBridgeAndPlayer(newDelegateBridge(germans(gameData)));
     del.start();
@@ -1495,7 +1504,8 @@ public class WW2V3Year41Test {
     IntegerMap<RepairRule> repairs = new IntegerMap<>();
     repairs.put(repair, 1);
     String error = del.purchaseRepair(Collections.singletonMap(
-        CollectionUtils.getMatches(germany.getUnits().getUnits(), Matches.unitCanBeDamaged()).iterator().next(),
+        CollectionUtils.getMatches(germany.getUnitCollection().getUnits(), Matches.unitCanBeDamaged()).iterator()
+            .next(),
         repairs));
     assertValid(error);
     assertEquals(0, ((TripleAUnit) factory).getUnitDamage());
@@ -1518,7 +1528,8 @@ public class WW2V3Year41Test {
     repairs = new IntegerMap<>();
     repairs.put(repair, 2);
     error = del.purchaseRepair(Collections.singletonMap(
-        CollectionUtils.getMatches(germany.getUnits().getUnits(), Matches.unitCanBeDamaged()).iterator().next(),
+        CollectionUtils.getMatches(germany.getUnitCollection().getUnits(), Matches.unitCanBeDamaged()).iterator()
+            .next(),
         repairs));
     assertValid(error);
     assertEquals(0, ((TripleAUnit) factory).getUnitDamage());
@@ -1530,7 +1541,7 @@ public class WW2V3Year41Test {
   @Test
   public void testRepairMoreThanDamaged() {
     final Territory germany = territory("Germany", gameData);
-    final Unit factory = germany.getUnits().getMatches(Matches.unitCanBeDamaged()).get(0);
+    final Unit factory = germany.getUnitCollection().getMatches(Matches.unitCanBeDamaged()).get(0);
     final PurchaseDelegate del = purchaseDelegate(gameData);
     del.setDelegateBridgeAndPlayer(newDelegateBridge(germans(gameData)));
     del.start();
@@ -1544,7 +1555,8 @@ public class WW2V3Year41Test {
     // we have 1 damaged marker, but trying to repair 2
     repairs.put(repair, 2);
     final String error = del.purchaseRepair(Collections.singletonMap(
-        CollectionUtils.getMatches(germany.getUnits().getUnits(), Matches.unitCanBeDamaged()).iterator().next(),
+        CollectionUtils.getMatches(germany.getUnitCollection().getUnits(), Matches.unitCanBeDamaged()).iterator()
+            .next(),
         repairs));
     // it is no longer an error, we just math max 0 it
     assertValid(error);
@@ -1565,12 +1577,12 @@ public class WW2V3Year41Test {
     final Territory hupeh = territory("Hupeh", gameData);
     final Territory kiangsu = territory("Kiangsu", gameData);
     // Remove all units
-    removeFrom(kiangsu, kiangsu.getUnits().getUnits());
-    removeFrom(hupeh, hupeh.getUnits().getUnits());
+    removeFrom(kiangsu, kiangsu.getUnitCollection().getUnits());
+    removeFrom(hupeh, hupeh.getUnitCollection().getUnits());
     // Set up the unit types
     addTo(hupeh, infantry(gameData).create(1, british));
     // Get units
-    final Collection<Unit> moveUnits = hupeh.getUnits().getUnits();
+    final Collection<Unit> moveUnits = hupeh.getUnitCollection().getUnits();
     // Get Owner prior to battle
     final String preOwner = kiangsu.getOwner().getName();
     assertEquals(Constants.PLAYER_NAME_JAPANESE, preOwner);
@@ -1605,12 +1617,12 @@ public class WW2V3Year41Test {
     // Set as NEW capital
     taKiangsu.setCapital(Constants.PLAYER_NAME_CHINESE);
     // Remove all units
-    removeFrom(kiangsu, kiangsu.getUnits().getUnits());
-    removeFrom(hupeh, hupeh.getUnits().getUnits());
+    removeFrom(kiangsu, kiangsu.getUnitCollection().getUnits());
+    removeFrom(hupeh, hupeh.getUnitCollection().getUnits());
     // Set up the unit types
     addTo(hupeh, infantry(gameData).create(1, british));
     // Get units
-    final Collection<Unit> moveUnits = hupeh.getUnits().getUnits();
+    final Collection<Unit> moveUnits = hupeh.getUnitCollection().getUnits();
     // Get Owner prior to battle
     final String preOwner = kiangsu.getOwner().getName();
     assertEquals(Constants.PLAYER_NAME_JAPANESE, preOwner);
@@ -1631,14 +1643,14 @@ public class WW2V3Year41Test {
     final Territory libya = territory("Libya", gameData);
     final Territory egypt = territory("Egypt", gameData);
     final Territory morrocco = territory("Morocco Algeria", gameData);
-    removeFrom(libya, libya.getUnits().getUnits());
+    removeFrom(libya, libya.getUnitCollection().getUnits());
     // Set up the move delegate
     final MoveDelegate moveDelegate = moveDelegate(gameData);
     advanceToStep(delegateBridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(delegateBridge);
     moveDelegate.start();
     // blitz in two steps
-    final Collection<Unit> armour = egypt.getUnits().getMatches(Matches.unitCanBlitz());
+    final Collection<Unit> armour = egypt.getUnitCollection().getMatches(Matches.unitCanBlitz());
     move(armour, new Route(egypt, libya));
     assertEquals(libya.getOwner(), british(gameData));
     move(armour, new Route(libya, morrocco));

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
@@ -103,7 +103,7 @@ public class WW2V3Year42Test {
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
     // attack with a german sub
-    move(sz7.getUnitCollection().getUnits(), new Route(sz7, sz6, sz5));
+    move(sz7.getUnits(), new Route(sz7, sz6, sz5));
     moveDelegate(gameData).end();
     // adding of lingering units was moved from end of combat-move phase, to start of battle phase
     battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
@@ -129,7 +129,7 @@ public class WW2V3Year42Test {
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
     // attack with a german sub
-    move(sz7.getUnitCollection().getUnits(), new Route(sz7, sz6, sz5));
+    move(sz7.getUnits(), new Route(sz7, sz6, sz5));
     moveDelegate(gameData).end();
     // adding of lingering units was moved from end of combat-move phase, to start of battle phase
     battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
@@ -152,7 +152,7 @@ public class WW2V3Year42Test {
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
     // attack with a german sub
-    move(sz7.getUnitCollection().getUnits(), new Route(sz7, sz6, sz5));
+    move(sz7.getUnits(), new Route(sz7, sz6, sz5));
     // move the transport away
     move(sz5.getUnitCollection().getMatches(Matches.unitIsTransport()), new Route(sz5, sz6));
     moveDelegate(gameData).end();

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
@@ -58,7 +58,7 @@ public class WW2V3Year42Test {
     final Route sz13To12 = new Route();
     sz13To12.setStart(sz13);
     sz13To12.add(sz12);
-    final List<Unit> transports = sz13.getUnits().getMatches(Matches.unitIsTransport());
+    final List<Unit> transports = sz13.getUnitCollection().getMatches(Matches.unitIsTransport());
     assertEquals(1, transports.size());
     final String error = moveDelegate.move(transports, sz13To12);
     assertNull(error);
@@ -78,11 +78,11 @@ public class WW2V3Year42Test {
     moveDelegate.start();
     when(withRemotePlayer(bridge).shouldBomberBomb(any())).thenReturn(true);
     // remove the russian units
-    removeFrom(karrelia, karrelia.getUnits().getMatches(Matches.unitCanBeDamaged().negate()));
+    removeFrom(karrelia, karrelia.getUnitCollection().getMatches(Matches.unitCanBeDamaged().negate()));
     // move the bomber to attack
-    move(germany.getUnits().getMatches(Matches.unitIsStrategicBomber()), new Route(germany, sz5, karrelia));
+    move(germany.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()), new Route(germany, sz5, karrelia));
     // move an infantry to invade
-    move(baltic.getUnits().getMatches(Matches.unitIsLandTransportable()), new Route(baltic, karrelia));
+    move(baltic.getUnitCollection().getMatches(Matches.unitIsLandTransportable()), new Route(baltic, karrelia));
     final BattleTracker battleTracker = MoveDelegate.getBattleTracker(gameData);
     // we should have a pending land battle, and a pending bombing raid
     assertNotNull(battleTracker.getPendingBattle(karrelia, false, null));
@@ -103,7 +103,7 @@ public class WW2V3Year42Test {
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
     // attack with a german sub
-    move(sz7.getUnits().getUnits(), new Route(sz7, sz6, sz5));
+    move(sz7.getUnitCollection().getUnits(), new Route(sz7, sz6, sz5));
     moveDelegate(gameData).end();
     // adding of lingering units was moved from end of combat-move phase, to start of battle phase
     battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
@@ -129,7 +129,7 @@ public class WW2V3Year42Test {
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
     // attack with a german sub
-    move(sz7.getUnits().getUnits(), new Route(sz7, sz6, sz5));
+    move(sz7.getUnitCollection().getUnits(), new Route(sz7, sz6, sz5));
     moveDelegate(gameData).end();
     // adding of lingering units was moved from end of combat-move phase, to start of battle phase
     battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
@@ -152,9 +152,9 @@ public class WW2V3Year42Test {
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
     // attack with a german sub
-    move(sz7.getUnits().getUnits(), new Route(sz7, sz6, sz5));
+    move(sz7.getUnitCollection().getUnits(), new Route(sz7, sz6, sz5));
     // move the transport away
-    move(sz5.getUnits().getMatches(Matches.unitIsTransport()), new Route(sz5, sz6));
+    move(sz5.getUnitCollection().getMatches(Matches.unitIsTransport()), new Route(sz5, sz6));
     moveDelegate(gameData).end();
     // adding of lingering units was moved from end of combat-move phase, to start of battle phase
     battleDelegate(gameData).setDelegateBridgeAndPlayer(bridge);

--- a/game-core/src/test/java/games/strategy/triplea/odds/calculator/OddsCalculatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/odds/calculator/OddsCalculatorTest.java
@@ -35,7 +35,7 @@ public class OddsCalculatorTest {
   @Test
   public void testUnbalancedFight() {
     final Territory germany = gameData.getMap().getTerritory("Germany");
-    final Collection<Unit> defendingUnits = new ArrayList<>(germany.getUnitCollection().getUnits());
+    final Collection<Unit> defendingUnits = new ArrayList<>(germany.getUnits());
     final PlayerId russians = GameDataTestUtil.russians(gameData);
     final PlayerId germans = GameDataTestUtil.germans(gameData);
     final List<Unit> attackingUnits = GameDataTestUtil.infantry(gameData).create(100, russians);

--- a/game-core/src/test/java/games/strategy/triplea/odds/calculator/OddsCalculatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/odds/calculator/OddsCalculatorTest.java
@@ -35,7 +35,7 @@ public class OddsCalculatorTest {
   @Test
   public void testUnbalancedFight() {
     final Territory germany = gameData.getMap().getTerritory("Germany");
-    final Collection<Unit> defendingUnits = new ArrayList<>(germany.getUnits().getUnits());
+    final Collection<Unit> defendingUnits = new ArrayList<>(germany.getUnitCollection().getUnits());
     final PlayerId russians = GameDataTestUtil.russians(gameData);
     final PlayerId germans = GameDataTestUtil.germans(gameData);
     final List<Unit> attackingUnits = GameDataTestUtil.infantry(gameData).create(100, russians);

--- a/game-core/src/test/java/games/strategy/triplea/util/UnitSeparatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/util/UnitSeparatorTest.java
@@ -32,7 +32,7 @@ public class UnitSeparatorTest {
   public void testGetSortedUnitCategories() throws Exception {
     final GameData data = TestMapGameData.TWW.getGameData();
     final Territory northernGermany = territory("Northern Germany", data);
-    northernGermany.getUnits().clear();
+    northernGermany.getUnitCollection().clear();
     final List<Unit> units = new ArrayList<>();
     final PlayerId italians = GameDataTestUtil.italy(data);
     units.addAll(GameDataTestUtil.italianInfantry(data).create(1, italians));
@@ -66,7 +66,7 @@ public class UnitSeparatorTest {
   public void testGetSortedUnitCategoriesDontDrawUnit() throws Exception {
     final GameData data = TestMapGameData.TWW.getGameData();
     final Territory northernGermany = territory("Northern Germany", data);
-    northernGermany.getUnits().clear();
+    northernGermany.getUnitCollection().clear();
     final PlayerId italians = GameDataTestUtil.italy(data);
     final List<Unit> units = new ArrayList<>(GameDataTestUtil.italianInfantry(data).create(1, italians));
     GameDataTestUtil.addTo(northernGermany, units);


### PR DESCRIPTION
## Overview
Refactor to:
1. convert examples of: `getUnits().getUnits()` to `getUnits()`
2. Rename method so the name is more canonical and matches return value, `getUnits()` -> `getUnitCollection`

## Functional Changes
none

## Manual Testing Performed
none