### PR TITLE
Return immutable view of collection

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/properties/ComboProperty.java
+++ b/game-core/src/main/java/games/strategy/engine/data/properties/ComboProperty.java
@@ -2,6 +2,7 @@ package games.strategy.engine.data.properties;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 
 import javax.swing.JComboBox;
 import javax.swing.JComponent;
@@ -31,7 +32,7 @@ public class ComboProperty<T> extends AbstractEditableProperty<T> {
       final T defaultValue,
       final Collection<T> possibleValues) {
     super(name, description);
-    this.possibleValues = new ArrayList<>(possibleValues);
+    this.possibleValues = Collections.unmodifiableCollection(new ArrayList<>(possibleValues));
     if (defaultValue != null && !possibleValues.contains(defaultValue)) {
       throw new IllegalStateException("possible values does not contain default");
     }
@@ -61,7 +62,10 @@ public class ComboProperty<T> extends AbstractEditableProperty<T> {
     return possibleValues != null && possibleValues.contains(value);
   }
 
+  /**
+   * Returns an immutable view of the possible values for the property.
+   */
   public Collection<T> getPossibleValues() {
-    return new ArrayList<>(possibleValues);
+    return possibleValues;
   }
 }


### PR DESCRIPTION
## Overview

As requested in https://github.com/triplea-game/triplea/pull/4642#discussion_r252884015.

Since `ComboProperty#possibleValues` is never modified after construction, I simply made the collection itself immutable rather than just returning an immutable wrapper from `getPossibleValues()`.  This will guard against any future change that may alter the immutability assumption.

I considered changing the type of `possibleValues` to Guava's `ImmutableCollection`.  However, the enclosing type is serializable, and since we've experienced issues in the past serializing the Guava immutable collection types, I didn't want to risk introducing a regression.

## Functional Changes

None.

## Manual Testing Performed

None.