### PR TITLE
LocalizeHtml refactoring

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
@@ -163,7 +163,11 @@ public class GameChooser extends JDialog {
   private void setupListeners() {
     okButton.addActionListener(e -> selectAndReturn());
     cancelButton.addActionListener(e -> cancelAndReturn());
-    gameList.addListSelectionListener(e -> updateInfoPanel());
+    gameList.addListSelectionListener(e -> {
+      if (!e.getValueIsAdjusting()) {
+        updateInfoPanel();
+      }
+    });
     gameList.addMouseListener(new MouseListener() {
       @Override
       public void mouseClicked(final MouseEvent event) {

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
@@ -138,7 +138,7 @@ public class GameChooser extends JDialog {
       if (!trimmedNotes.isEmpty()) {
         // AbstractUiContext resource loader should be null (or potentially is still the last game we played's loader),
         // so we send the map dir name so that our localizing of image links can get a new resource loader if needed
-        notes.append(LocalizeHtml.localizeImgLinksInHtml(trimmedNotes, null, mapNameDir));
+        notes.append(LocalizeHtml.localizeImgLinksInHtml(trimmedNotes, mapNameDir));
       }
       notesPanel.setText(notes.toString());
     } else {

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
@@ -134,11 +134,11 @@ public class GameChooser extends JDialog {
       appendListItem("Location", getSelected().getLocation() + "", notes);
       appendListItem("Version", data.getGameVersion() + "", notes);
       notes.append("<p></p>");
-      final String notesProperty = data.getProperties().get("notes", "");
-      if (notesProperty != null && notesProperty.trim().length() != 0) {
+      final String trimmedNotes = data.getProperties().get("notes", "").trim();
+      if (!trimmedNotes.isEmpty()) {
         // AbstractUiContext resource loader should be null (or potentially is still the last game we played's loader),
         // so we send the map dir name so that our localizing of image links can get a new resource loader if needed
-        notes.append(LocalizeHtml.localizeImgLinksInHtml(notesProperty.trim(), null, mapNameDir));
+        notes.append(LocalizeHtml.localizeImgLinksInHtml(trimmedNotes, null, mapNameDir));
       }
       notesPanel.setText(notes.toString());
     } else {

--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -40,6 +40,7 @@ public class ResourceLoader implements Closeable {
 
   private final URLClassLoader loader;
   private final ResourceLocationTracker resourceLocationTracker;
+  private final String mapName;
 
   private ResourceLoader(final String mapName, final String[] paths) {
     final URL[] urls = new URL[paths.length];
@@ -62,6 +63,7 @@ public class ResourceLoader implements Closeable {
     // To solve this we will get all matching paths and then filter by what matched
     // the assets folder.
     loader = new URLClassLoader(urls);
+    this.mapName = mapName;
   }
 
   public static ResourceLoader getGameEngineAssetLoader() {
@@ -259,5 +261,9 @@ public class ResourceLoader implements Closeable {
 
     return UrlStreams.openStream(url)
         .orElseThrow(() -> new IllegalStateException("Failed to open an input stream to: " + path));
+  }
+
+  public String getMapName() {
+    return mapName;
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -28,6 +28,7 @@ import games.strategy.engine.framework.map.download.DownloadMapsWindow;
 import games.strategy.engine.framework.startup.launcher.MapNotFoundException;
 import games.strategy.ui.SwingComponents;
 import games.strategy.util.UrlStreams;
+import lombok.Getter;
 import lombok.extern.java.Log;
 
 /**
@@ -40,6 +41,7 @@ public class ResourceLoader implements Closeable {
 
   private final URLClassLoader loader;
   private final ResourceLocationTracker resourceLocationTracker;
+  @Getter
   private final String mapName;
 
   private ResourceLoader(final String mapName, final String[] paths) {
@@ -261,9 +263,5 @@ public class ResourceLoader implements Closeable {
 
     return UrlStreams.openStream(url)
         .orElseThrow(() -> new IllegalStateException("Failed to open an input stream to: " + path));
-  }
-
-  public String getMapName() {
-    return mapName;
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -390,9 +390,10 @@ final class ExportMenu extends JMenu {
         return;
       }
       try (Writer writer = Files.newBufferedWriter(chooser.getSelectedFile().toPath(), StandardCharsets.UTF_8)) {
-        writer.write(
-            HelpMenu.getUnitStatsTable(gameData, uiContext).replaceAll("<p>", "<p>\r\n").replaceAll("</p>", "</p>\r\n")
-                .replaceAll("</tr>", "</tr>\r\n").replaceAll(LocalizeHtml.PATTERN_HTML_IMG_TAG, ""));
+        writer.write(HelpMenu
+            .getUnitStatsTable(gameData, uiContext)
+            .replaceAll("</?p>|</tr>", "$0\r\n")
+            .replaceAll(LocalizeHtml.PATTERN_HTML_IMG_TAG, ""));
       } catch (final IOException e1) {
         log.log(Level.SEVERE, "Failed to write unit stats: " + chooser.getSelectedFile().getAbsolutePath(), e1);
       }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -392,7 +392,7 @@ final class ExportMenu extends JMenu {
         writer.write(HelpMenu
             .getUnitStatsTable(gameData, uiContext)
             .replaceAll("</?p>|</tr>", "$0\r\n")
-            .replaceAll("(?i)<img([^>]+)/>", ""));
+            .replaceAll("(?i)<img[^>]+/>", ""));
       } catch (final IOException e1) {
         log.log(Level.SEVERE, "Failed to write unit stats: " + chooser.getSelectedFile().getAbsolutePath(), e1);
       }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -393,7 +393,7 @@ final class ExportMenu extends JMenu {
         writer.write(HelpMenu
             .getUnitStatsTable(gameData, uiContext)
             .replaceAll("</?p>|</tr>", "$0\r\n")
-            .replaceAll(LocalizeHtml.PATTERN_HTML_IMG_TAG, ""));
+            .replaceAll("(?i)<img([^>]+)/>", ""));
       } catch (final IOException e1) {
         log.log(Level.SEVERE, "Failed to write unit stats: " + chooser.getSelectedFile().getAbsolutePath(), e1);
       }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -54,7 +54,6 @@ import games.strategy.triplea.ui.history.HistoryPanel;
 import games.strategy.triplea.util.PlayerOrderComparator;
 import games.strategy.ui.SwingAction;
 import games.strategy.util.FileNameUtils;
-import games.strategy.util.LocalizeHtml;
 import lombok.extern.java.Log;
 
 @Log

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -182,7 +182,7 @@ public final class HelpMenu extends JMenu {
       return "no image";
     }
     final Optional<URL> imageUrl = unitImageFactory.getBaseImageUrl(unitType.getName(), player);
-    final String imageLocation = imageUrl.isPresent() ? imageUrl.get().toString() : "";
+    final String imageLocation = imageUrl.map(Object::toString).orElse("");
 
     return "<img src=\"" + imageLocation + "\" border=\"0\"/>";
   }

--- a/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
+++ b/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
@@ -77,11 +77,11 @@ public final class LocalizeHtml {
     final String firstOption = ASSET_IMAGE_FOLDER + imageFileName;
     URL replacementUrl = loader.getResource(firstOption);
 
-    if (replacementUrl == null || replacementUrl.toString().isEmpty()) {
+    if (replacementUrl == null) {
       log.severe(String.format("Could not find: %s/%s", loader.getMapName(), firstOption));
       final String secondFallback = ASSET_IMAGE_FOLDER + ASSET_IMAGE_NOT_FOUND;
       replacementUrl = loader.getResource(secondFallback);
-      if (replacementUrl == null || replacementUrl.toString().isEmpty()) {
+      if (replacementUrl == null) {
         log.severe(String.format("Could not find: %s", secondFallback));
         return link;
       }

--- a/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
+++ b/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
@@ -19,11 +19,11 @@ import lombok.extern.java.Log;
  */
 @Log
 public final class LocalizeHtml {
-  private static final String ASSET_IMAGE_FOLDER = "doc/images/";
-  private static final String ASSET_IMAGE_NOT_FOUND = "notFound.png";
-
   // Match the <img /> tag
   public static final String PATTERN_HTML_IMG_TAG = "(?i)<img([^>]+)/>";
+
+  private static final String ASSET_IMAGE_FOLDER = "doc/images/";
+  private static final String ASSET_IMAGE_NOT_FOUND = "notFound.png";
   // Match the <img> src
   private static final Pattern PATTERN_HTML_IMG_SRC_TAG = Pattern
       .compile("(<img[^>]*src\\s*=\\s*)(?:\"([^\"]*)\"|'([^']*)')([^>]*/?>)", Pattern.CASE_INSENSITIVE);

--- a/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
+++ b/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
@@ -55,7 +55,7 @@ public final class LocalizeHtml {
     final Matcher matcher = PATTERN_HTML_IMG_SRC_TAG.matcher(htmlText);
     while (matcher.find()) {
       final String link = Optional.ofNullable(matcher.group(2)).orElseGet(() -> matcher.group(3));
-      assert link != null && !link.isEmpty(): "RegEx is broken";
+      assert link != null && !link.isEmpty() : "RegEx is broken";
       final String localized = cache.computeIfAbsent(link, l -> getLocalizedLink(l, loader));
       final char quote = matcher.group(2) != null ? '"' : '\'';
       matcher.appendReplacement(result, matcher.group(1) + quote + localized + quote + matcher.group(4));

--- a/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
+++ b/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
@@ -23,7 +23,7 @@ public final class LocalizeHtml {
   private static final String ASSET_IMAGE_NOT_FOUND = "notFound.png";
   // Match the <img> src
   private static final Pattern PATTERN_HTML_IMG_SRC_TAG = Pattern
-      .compile("(<img[^>]*src\\s*=\\s*)(?:\"([^\"]*)\"|'([^']*)')([^>]*/?>)", Pattern.CASE_INSENSITIVE);
+      .compile("(<img[^>]*src\\s*=\\s*)(?:\"([^\"]+)\"|'([^']+)')([^>]*/?>)", Pattern.CASE_INSENSITIVE);
 
   private LocalizeHtml() {}
 
@@ -55,11 +55,10 @@ public final class LocalizeHtml {
     final Matcher matcher = PATTERN_HTML_IMG_SRC_TAG.matcher(htmlText);
     while (matcher.find()) {
       final String link = Optional.ofNullable(matcher.group(2)).orElseGet(() -> matcher.group(3));
-      if (link != null && !link.isEmpty()) {
-        final String localized = cache.computeIfAbsent(link, l -> getLocalizedLink(l, loader));
-        final char quote = matcher.group(2) != null ? '"' : '\'';
-        matcher.appendReplacement(result, matcher.group(1) + quote + localized + quote + matcher.group(4));
-      }
+      assert link != null && !link.isEmpty(): "RegEx is broken";
+      final String localized = cache.computeIfAbsent(link, l -> getLocalizedLink(l, loader));
+      final char quote = matcher.group(2) != null ? '"' : '\'';
+      matcher.appendReplacement(result, matcher.group(1) + quote + localized + quote + matcher.group(4));
     }
     matcher.appendTail(result);
 

--- a/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
+++ b/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
@@ -7,6 +7,8 @@ import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import games.strategy.triplea.ResourceLoader;
 import games.strategy.triplea.ui.AbstractUiContext;
 import lombok.extern.java.Log;
@@ -47,7 +49,8 @@ public final class LocalizeHtml {
     return localizeImgLinksInHtml(htmlText, ResourceLoader.getMapResourceLoader(mapNameDir));
   }
 
-  private static String localizeImgLinksInHtml(final String htmlText, final ResourceLoader loader) {
+  @VisibleForTesting
+  static String localizeImgLinksInHtml(final String htmlText, final ResourceLoader loader) {
     final StringBuffer result = new StringBuffer();
     final Map<String, String> cache = new HashMap<>();
     final Matcher matcher = PATTERN_HTML_IMG_SRC_TAG.matcher(htmlText);
@@ -55,7 +58,8 @@ public final class LocalizeHtml {
       final String link = Optional.ofNullable(matcher.group(2)).orElseGet(() -> matcher.group(3));
       if (link != null && !link.isEmpty()) {
         final String localized = cache.computeIfAbsent(link, l -> getLocalizedLink(l, loader));
-        matcher.appendReplacement(result, matcher.group(1) + '"' + localized + '"' + matcher.group(4));
+        final char quote = matcher.group(2) != null ? '"' : '\'';
+        matcher.appendReplacement(result, matcher.group(1) + quote + localized + quote + matcher.group(4));
       }
     }
     matcher.appendTail(result);

--- a/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
+++ b/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
@@ -19,19 +19,12 @@ import lombok.extern.java.Log;
 public final class LocalizeHtml {
   private static final String ASSET_IMAGE_FOLDER = "doc/images/";
   private static final String ASSET_IMAGE_NOT_FOUND = "notFound.png";
-  /*
-   * You would think that there would be a single standardized REGEX for pulling html links out of <img> tags and <a>
-   * tags.
-   * But there isn't, and the internet seems to give million different answers, none of which work perfectly.
-   * So here are the best one I could find.
-   * Regex's found at http://www.mkyong.com/
-   */
 
   // Match the <img /> tag
   public static final String PATTERN_HTML_IMG_TAG = "(?i)<img([^>]+)/>";
   // Match the <img> src
   private static final Pattern PATTERN_HTML_IMG_SRC_TAG = Pattern
-      .compile("s(?<=<img[^>]{0,99})rc\\s*=\\s*(?:\"([^\"]*)\"|'([^']*)')(?=[^>]*/?>)", Pattern.CASE_INSENSITIVE);
+      .compile("(<img[^>]*src\\s*=\\s*)(?:\"([^\"]*)\"|'([^']*)')([^>]*/?>)", Pattern.CASE_INSENSITIVE);
 
   private LocalizeHtml() {}
 
@@ -59,10 +52,10 @@ public final class LocalizeHtml {
     final Map<String, String> cache = new HashMap<>();
     final Matcher matcher = PATTERN_HTML_IMG_SRC_TAG.matcher(htmlText);
     while (matcher.find()) {
-      final String link = Optional.ofNullable(matcher.group(1)).orElseGet(() -> matcher.group(2));
+      final String link = Optional.ofNullable(matcher.group(2)).orElseGet(() -> matcher.group(3));
       if (link != null && !link.isEmpty()) {
         final String localized = cache.computeIfAbsent(link, l -> getLocalizedLink(l, loader, mapNameDir));
-        matcher.appendReplacement(result, "src=\"" + localized + '"');
+        matcher.appendReplacement(result, matcher.group(1) + '"' + localized + '"' + matcher.group(4));
       }
     }
     matcher.appendTail(result);

--- a/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
+++ b/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
@@ -19,9 +19,6 @@ import lombok.extern.java.Log;
  */
 @Log
 public final class LocalizeHtml {
-  // Match the <img /> tag
-  public static final String PATTERN_HTML_IMG_TAG = "(?i)<img([^>]+)/>";
-
   private static final String ASSET_IMAGE_FOLDER = "doc/images/";
   private static final String ASSET_IMAGE_NOT_FOUND = "notFound.png";
   // Match the <img> src

--- a/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
+++ b/game-core/src/main/java/games/strategy/util/LocalizeHtml.java
@@ -48,6 +48,8 @@ public final class LocalizeHtml {
 
   @VisibleForTesting
   static String localizeImgLinksInHtml(final String htmlText, final ResourceLoader loader) {
+    // StringBuffer is required here, because Matcher.appendReplacement
+    // doesn't support StringBuilder until Java 9
     final StringBuffer result = new StringBuffer();
     final Map<String, String> cache = new HashMap<>();
     final Matcher matcher = PATTERN_HTML_IMG_SRC_TAG.matcher(htmlText);

--- a/game-core/src/test/java/games/strategy/util/LocalizeHtmlTest.java
+++ b/game-core/src/test/java/games/strategy/util/LocalizeHtmlTest.java
@@ -73,4 +73,11 @@ class LocalizeHtmlTest {
     LocalizeHtml.localizeImgLinksInHtml(testHtml, loader);
     verify(loader, times(1)).getResource(any());
   }
+
+  @Test
+  void testStrictHtml() {
+    final String testHtml = "<img src=\"test\"";
+    assertThat(LocalizeHtml.localizeImgLinksInHtml(testHtml, loader), is(equalTo(testHtml)));
+    verify(loader, never()).getResource(any());
+  }
 }

--- a/game-core/src/test/java/games/strategy/util/LocalizeHtmlTest.java
+++ b/game-core/src/test/java/games/strategy/util/LocalizeHtmlTest.java
@@ -47,9 +47,7 @@ class LocalizeHtmlTest {
   void testFallbackLink() throws Exception {
     when(loader.getResource("doc/images/actual-link")).thenReturn(null);
     when(loader.getResource("doc/images/another-link.png")).thenReturn(null);
-    when(loader.getResource("doc/images/notFound.png"))
-        .thenReturn(null)
-        .thenReturn(new URL("http://notFound.png"));
+    when(loader.getResource("doc/images/notFound.png")).thenReturn(null, new URL("http://notFound.png"));
     final String result = LocalizeHtml.localizeImgLinksInHtml(testHtml, loader);
     assertThat(result, containsString("dir/actual-link"));
     assertThat(result, containsString("http://notFound.png"));
@@ -71,8 +69,8 @@ class LocalizeHtmlTest {
   @Test
   void testCaching() throws Exception {
     final String testHtml = "<img src='test'><img src='test'>";
-    LocalizeHtml.localizeImgLinksInHtml(testHtml, loader);
     when(loader.getResource("doc/images/test")).thenReturn(new URL("http://test"));
-    verify(loader).getResource("doc/images/test");
+    LocalizeHtml.localizeImgLinksInHtml(testHtml, loader);
+    verify(loader, times(1)).getResource(any());
   }
 }

--- a/game-core/src/test/java/games/strategy/util/LocalizeHtmlTest.java
+++ b/game-core/src/test/java/games/strategy/util/LocalizeHtmlTest.java
@@ -1,0 +1,57 @@
+package games.strategy.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URL;
+
+import org.junit.jupiter.api.Test;
+
+import games.strategy.triplea.ResourceLoader;
+
+class LocalizeHtmlTest {
+  private final ResourceLoader loader = mock(ResourceLoader.class);
+  private final String testHtml = "<audio src='test-audio'> &lt;img src=&quot;test&quot;&gt;"
+      + "<img useless fill src=\"dir/actual-link\" alt='Alternative Text' > <p>  Placeholder </P> <img\n"
+      + " src='another-link.png' />";
+
+  @Test
+  void testLocalizeHtml() throws Exception {
+
+    when(loader.getResource("doc/images/actual-link")).thenReturn(new URL("http://local-link-1"));
+    when(loader.getResource("doc/images/another-link.png")).thenReturn(new URL("http://local-link-2"));
+
+    final String result = LocalizeHtml.localizeImgLinksInHtml(testHtml, loader);
+
+    assertThat(result, not(containsString("dir/actual-link")));
+    assertThat(result, not(containsString("another-link.png")));
+
+    assertThat(result, containsString("http://local-link-1"));
+    assertThat(result, containsString("http://local-link-2"));
+
+    assertThat(result, containsString("test-audio"));
+  }
+
+  @Test
+  void testFallbackLink() throws Exception {
+    when(loader.getResource("doc/images/actual-link")).thenReturn(null);
+    when(loader.getResource("doc/images/another-link.png")).thenReturn(null);
+    when(loader.getResource("doc/images/notFound.png"))
+        .thenReturn(null)
+        .thenReturn(new URL("http://notFound.png"));
+    final String result = LocalizeHtml.localizeImgLinksInHtml(testHtml, loader);
+    assertThat(result, containsString("dir/actual-link"));
+    assertThat(result, containsString("http://notFound.png"));
+    assertThat(result, not(containsString("another-link.png")));
+  }
+
+  @Test
+  void testDoNothingWithoutResources() {
+    assertThat(LocalizeHtml.localizeImgLinksInHtml(testHtml, loader), is(equalTo(testHtml)));
+  }
+}

--- a/game-core/src/test/java/games/strategy/util/LocalizeHtmlTest.java
+++ b/game-core/src/test/java/games/strategy/util/LocalizeHtmlTest.java
@@ -5,7 +5,11 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.net.URL;
@@ -35,6 +39,8 @@ class LocalizeHtmlTest {
     assertThat(result, containsString("http://local-link-2"));
 
     assertThat(result, containsString("test-audio"));
+
+    verify(loader, times(2)).getResource(any());
   }
 
   @Test
@@ -53,5 +59,20 @@ class LocalizeHtmlTest {
   @Test
   void testDoNothingWithoutResources() {
     assertThat(LocalizeHtml.localizeImgLinksInHtml(testHtml, loader), is(equalTo(testHtml)));
+  }
+
+  @Test
+  void testDoNothingWithoutTag() {
+    final String testHtml = "<p>Paragraph</p>";
+    assertThat(LocalizeHtml.localizeImgLinksInHtml(testHtml, loader), is(equalTo(testHtml)));
+    verify(loader, never()).getResource(any());
+  }
+
+  @Test
+  void testCaching() throws Exception {
+    final String testHtml = "<img src='test'><img src='test'>";
+    LocalizeHtml.localizeImgLinksInHtml(testHtml, loader);
+    when(loader.getResource("doc/images/test")).thenReturn(new URL("http://test"));
+    verify(loader).getResource("doc/images/test");
   }
 }


### PR DESCRIPTION
## Overview
This aims to make `LocalizeHtml` a little bit less resource hungry by reducing the amount of nested regexes into a single one. At least on my machine this reduced the time to process the String by half for World at War (from 40ms to 20ms on average) and slightly increases the time for maps without images in the notes (from < 1ms to <= 3ms on average).
Also the required pattern is now being pre-compiled instead of being compiled for every instance that calls this method.
So the error reported in #3661 can't occur in the exact same way anymore, but it isn't really fixed either (Stackoverflow errors are nasty). Perhaps the likelyhood of it occuring decreased a little bit.
Also the probably biggest impact on memory usage is no longer repeatedly using replaceAll to replace all links in a document. So we no longer have multiple variations of the same html String in memory

## Functional Changes
None.

## Manual Testing Performed
I verified the links are correctly being replaced and display in the GameSelector screen.