### PR TITLE
Simplify getGameIcon

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -73,7 +73,7 @@ public class DownloadMapsWindow extends JFrame {
     setLocationRelativeTo(null);
     setMinimumSize(new Dimension(200, 200));
 
-    setIconImage(JFrameBuilder.getGameIcon(this));
+    setIconImage(JFrameBuilder.getGameIcon());
     progressPanel = new MapDownloadProgressPanel();
 
     final Set<DownloadFileDescription> pendingDownloads = new HashSet<>();

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -57,7 +57,7 @@ public class LobbyFrame extends JFrame {
   public LobbyFrame(final LobbyClient client, final LobbyServerProperties lobbyServerProperties) {
     super("TripleA Lobby");
     setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-    setIconImage(JFrameBuilder.getGameIcon(this));
+    setIconImage(JFrameBuilder.getGameIcon());
     this.client = client;
     setJMenuBar(new LobbyMenu(this));
     final Chat chat = new Chat(this.client.getMessenger(), LobbyConstants.LOBBY_CHAT,

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -373,7 +373,7 @@ public final class TripleAFrame extends JFrame {
     super("TripleA - " + game.getData().getGameName());
 
     localPlayers = players;
-    setIconImage(JFrameBuilder.getGameIcon(this));
+    setIconImage(JFrameBuilder.getGameIcon());
     // 200 size is pretty arbitrary, goal is to not allow users to shrink window down to nothing.
     setMinimumSize(new Dimension(200, 200));
 

--- a/swing-lib/src/main/java/org/triplea/swing/JFrameBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/JFrameBuilder.java
@@ -4,16 +4,16 @@ import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Image;
 import java.awt.LayoutManager;
-import java.awt.MediaTracker;
-import java.awt.Window;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.logging.Level;
 
 import javax.annotation.Nullable;
+import javax.imageio.ImageIO;
 import javax.swing.JFrame;
 
 import lombok.extern.java.Log;
@@ -77,7 +77,7 @@ public class JFrameBuilder {
         }));
 
     frame.setMinimumSize(new Dimension(minWidth, minHeight));
-    frame.setIconImage(getGameIcon(frame));
+    frame.setIconImage(getGameIcon());
     frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
 
     if ((width > 0) || (height > 0)) {
@@ -102,21 +102,13 @@ public class JFrameBuilder {
   /**
    * Returns the standard application icon typically displayed in a window's title bar.
    */
-  public static Image getGameIcon(final Window frame) {
-    Image img = null;
+  public static Image getGameIcon() {
     try {
-      img = frame.getToolkit().getImage(JFrameBuilder.class.getResource("ta_icon.png"));
-    } catch (final Exception ex) {
-      log.log(Level.SEVERE, "ta_icon.png not loaded", ex);
+      return ImageIO.read(JFrameBuilder.class.getResource("ta_icon.png"));
+    } catch (final IOException e) {
+      log.log(Level.SEVERE, "ta_icon.png not loaded", e);
     }
-    final MediaTracker tracker = new MediaTracker(frame);
-    tracker.addImage(img, 0);
-    try {
-      tracker.waitForAll();
-    } catch (final InterruptedException ex) {
-      Thread.currentThread().interrupt();
-    }
-    return img;
+    return null;
   }
 
   public JFrameBuilder escapeKeyClosesFrame() {


### PR DESCRIPTION
## Overview
Use `ImageIO` to simplify image loading code.

Following up to CR suggestion: https://github.com/triplea-game/triplea/pull/4651#pullrequestreview-201900992

## Functional Changes
None - refactor only

## Manual Testing Performed
- launched headed game client and verified window icons loaded
