### PR TITLE
BattleTracker API simplifications

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -338,7 +338,7 @@ public class AirBattle extends AbstractBattle {
                 bridge, null, null, targets, true);
           }
         }
-        final IBattle battle = battleTracker.getPendingBattle(battleSite, true, null);
+        final IBattle battle = battleTracker.getPendingBombingBattle(battleSite);
         final IBattle dependent = battleTracker.getPendingBattle(battleSite, false, BattleType.NORMAL);
         if (dependent != null) {
           battleTracker.addDependency(dependent, battle);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -436,7 +436,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       // add the dependants to the attacking list
       attackingUnits.addAll(dependants);
       final List<Unit> enemyUnits = territory.getUnitCollection().getMatches(Matches.enemyUnit(player, data));
-      final IBattle bombingBattle = battleTracker.getPendingBattle(territory, true, null);
+      final IBattle bombingBattle = battleTracker.getPendingBombingBattle(territory);
       if (bombingBattle != null) {
         // we need to remove any units which are participating in bombing raids
         attackingUnits.removeAll(bombingBattle.getAttackingUnits());
@@ -587,7 +587,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
           .flatMap(Collection::stream)
           .collect(Collectors.toSet());
       // only look at bombing battles, because otherwise the normal attack will determine the ownership of the territory
-      final IBattle bombingBattle = battleTracker.getPendingBattle(territory, true, null);
+      final IBattle bombingBattle = battleTracker.getPendingBombingBattle(territory);
       if (bombingBattle != null) {
         enemyUnitsOfAbandonedToUnits.removeAll(bombingBattle.getAttackingUnits());
       }
@@ -833,7 +833,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         continue;
       }
       // make sure the units join the battle, or create a new battle.
-      final IBattle bombing = battleTracker.getPendingBattle(to, true, null);
+      final IBattle bombing = battleTracker.getPendingBombingBattle(to);
       IBattle battle = battleTracker.getPendingBattle(to, false, BattleType.NORMAL);
       if (battle == null) {
         final List<Unit> attackingUnits = to.getUnitCollection().getMatches(Matches.unitIsOwnedBy(player));

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -948,12 +948,11 @@ public class BattleTracker implements Serializable {
     if (guid == null) {
       return null;
     }
-    for (final IBattle battle : pendingBattles) {
-      if (guid.equals(battle.getBattleId())) {
-        return battle;
-      }
-    }
-    return null;
+
+    return pendingBattles.stream()
+        .filter(b -> b.getBattleId().equals(guid))
+        .findAny()
+        .orElse(null);
   }
 
   Collection<IBattle> getPendingBattles(final Territory t) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -956,10 +956,10 @@ public class BattleTracker implements Serializable {
     return null;
   }
 
-  Collection<IBattle> getPendingBattles(final Territory t, final BattleType type) {
+  Collection<IBattle> getPendingBattles(final Territory t) {
     final Collection<IBattle> battles = new HashSet<>();
     for (final IBattle battle : pendingBattles) {
-      if (battle.getTerritory().equals(t) && (type == null || type == battle.getBattleType())) {
+      if (battle.getTerritory().equals(t)) {
         battles.add(battle);
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -96,7 +96,7 @@ public class MovePerformer implements Serializable {
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
         // if we are moving out of a battle zone, mark it
         // this can happen for air units moving out of a battle zone
-        for (final IBattle battle : getBattleTracker().getPendingBattles(route.getStart(), null)) {
+        for (final IBattle battle : getBattleTracker().getPendingBattles(route.getStart())) {
           for (final Unit unit : units) {
             final Route routeUnitUsedToMove = moveDelegate.getRouteUsedToMoveInto(unit, route.getStart());
             if (battle != null) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
@@ -100,7 +100,7 @@ public class UndoableMove extends AbstractUndoableMove {
     }
     // if we are moving out of a battle zone, mark it
     // this can happen for air units moving out of a battle zone
-    for (final IBattle battle : battleTracker.getPendingBattles(route.getStart(), null)) {
+    for (final IBattle battle : battleTracker.getPendingBattles(route.getStart())) {
       if (battle == null || battle.isOver()) {
         continue;
       }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -933,9 +933,9 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     results = delegate.move(GameDataTestUtil.getUnits(map, route.getStart()), route);
     assertValid(results);
     final IBattle inBrazil =
-        DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(brazil, false, null);
+        DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(brazil);
     final IBattle inBrazilSea =
-        DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(southBrazilSeaZone, false, null);
+        DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(southBrazilSeaZone);
     assertNotNull(inBrazilSea);
     assertNotNull(inBrazil);
     assertEquals(DelegateFinder.battleDelegate(gameData).getBattleTracker().getDependentOn(inBrazil).iterator().next(),
@@ -976,9 +976,9 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     final int defendingLandSizeInt = defendingLandUnits.size();
     // Set up the battles and the dependent battles
     final IBattle inFinlandNorway =
-        DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(finlandNorway, false, null);
+        DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(finlandNorway);
     final IBattle inBalticSeaZone =
-        DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(balticSeaZone, false, null);
+        DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(balticSeaZone);
     assertNotNull(balticSeaZone);
     assertNotNull(finlandNorway);
     assertEquals(
@@ -1038,9 +1038,9 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     final int defendingLandSizeInt = defendingLandUnits.size();
     // Set up the battles and the dependent battles
     final IBattle inFinlandNorway =
-        DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(finlandNorway, false, null);
+        DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(finlandNorway);
     final IBattle inBalticSeaZone =
-        DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(balticSeaZone, false, null);
+        DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(balticSeaZone);
     assertNotNull(balticSeaZone);
     assertNotNull(finlandNorway);
     assertEquals(
@@ -1100,7 +1100,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     final int defendingLandSizeInt = defendingLandUnits.size();
     // Set up the battles and the dependent battles
     final IBattle inBalticSeaZone =
-        DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(balticSeaZone, false, null);
+        DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(balticSeaZone);
     assertNotNull(balticSeaZone);
     // Add some defending units in case there aren't any
     final List<Unit> defendList = transport.create(1, germans);
@@ -1156,7 +1156,7 @@ public class MoveDelegateTest extends AbstractDelegateTestCase {
     final int defendingLandSizeInt = defendingLandUnits.size();
     // Set up the battles and the dependent battles
     final IBattle inBalticSeaZone =
-        DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(balticSeaZone, false, null);
+        DelegateFinder.battleDelegate(gameData).getBattleTracker().getPendingBattle(balticSeaZone);
     assertNotNull(balticSeaZone);
     // Add some defending units in case there aren't any
     final List<Unit> defendList = transport.create(1, germans);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MustFightBattleTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MustFightBattleTest.java
@@ -40,7 +40,7 @@ public class MustFightBattleTest extends AbstractDelegateTestCase {
     move(sz33.getUnits(), new Route(sz33, sz40));
     moveDelegate(twwGameData).end();
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(twwGameData).getPendingBattle(sz40, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(twwGameData).getPendingBattle(sz40);
 
     // Set first roll to hit (mine AA) and check that both units are killed
     whenGetRandom(bridge).thenAnswer(withValues(0));
@@ -64,7 +64,7 @@ public class MustFightBattleTest extends AbstractDelegateTestCase {
     battleDelegate(twwGameData).setDelegateBridgeAndPlayer(bridge);
     BattleDelegate.doInitialize(battleDelegate(twwGameData).getBattleTracker(), bridge);
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(twwGameData).getPendingBattle(celebes, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(twwGameData).getPendingBattle(celebes);
 
     // Ensure battle ends, both units remain, and has 0 rolls
     battle.fight(bridge);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -283,7 +283,7 @@ public class RevisedTest {
     final BattleTracker tracker = AbstractMoveDelegate.getBattleTracker(gameData);
     // The battle should NOT be empty
     assertTrue(tracker.hasPendingBattle(sz5, false));
-    assertFalse(tracker.getPendingBattle(sz5, false, null).isEmpty());
+    assertFalse(tracker.getPendingBattle(sz5).isEmpty());
     battle.end();
   }
 
@@ -789,7 +789,7 @@ public class RevisedTest {
     moveDelegate(gameData).end();
     // Set up battle
     MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(fic, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(fic);
     // fight
     whenGetRandom(delegateBridge)
         .thenAnswer(withValues(0))
@@ -811,7 +811,7 @@ public class RevisedTest {
     validResults = moveDelegate.move(japaneseUnits, new Route(kwang, fic));
     assertValid(validResults);
     moveDelegate(gameData).end();
-    battle = (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(fic, false, null);
+    battle = (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(fic);
     // fight
     whenGetRandom(delegateBridge)
         .thenAnswer(withValues(0))
@@ -833,7 +833,7 @@ public class RevisedTest {
     validResults = moveDelegate.move(americanUnits, new Route(china, fic));
     assertValid(validResults);
     moveDelegate(gameData).end();
-    battle = (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(fic, false, null);
+    battle = (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(fic);
     // fight
     whenGetRandom(delegateBridge)
         .thenAnswer(withValues(0))
@@ -964,7 +964,7 @@ public class RevisedTest {
     move(from.getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings(true);
     assertEquals(Arrays.asList(attacker + FIRE, defender + SELECT_CASUALTIES, defender + FIRE,
         attacker + SELECT_CASUALTIES, REMOVE_CASUALTIES, attacker + ATTACKER_WITHDRAW).toString(), steps.toString());
@@ -986,7 +986,7 @@ public class RevisedTest {
     move(from.getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings(true);
     assertEquals(Arrays.asList(attacker + FIRE, defender + SELECT_CASUALTIES, defender + FIRE,
         attacker + SELECT_CASUALTIES, REMOVE_CASUALTIES, attacker + ATTACKER_WITHDRAW).toString(), steps.toString());
@@ -1008,7 +1008,7 @@ public class RevisedTest {
     move(from.getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings(true);
     assertEquals(
         Arrays.asList(attacker + SUBS_FIRE, defender + SELECT_SUB_CASUALTIES, defender + SUBS_FIRE,
@@ -1045,7 +1045,7 @@ public class RevisedTest {
     move(from.getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings(true);
     /*
      * Here are the exact errata clarifications on how REVISED rules subs work:
@@ -1099,7 +1099,7 @@ public class RevisedTest {
     move(from.getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings(true);
     /*
      * Here are the exact errata clarifications on how REVISED rules subs work:
@@ -1155,7 +1155,7 @@ public class RevisedTest {
     move(from.getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings(true);
     assertEquals(Arrays.asList(attacker + SUBS_FIRE, defender + SELECT_SUB_CASUALTIES, defender + SUBS_FIRE,
         attacker + SELECT_SUB_CASUALTIES, REMOVE_SNEAK_ATTACK_CASUALTIES, attacker + FIRE, defender + SELECT_CASUALTIES,
@@ -1195,7 +1195,7 @@ public class RevisedTest {
     move(from.getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings(true);
     /*
      * Here are the exact errata clarifications on how REVISED rules subs work:
@@ -1252,7 +1252,7 @@ public class RevisedTest {
     move(from.getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings(true);
     assertEquals(Arrays.asList(attacker + SUBS_FIRE, defender + SELECT_SUB_CASUALTIES, defender + SUBS_FIRE,
         attacker + SELECT_SUB_CASUALTIES, attacker + FIRE, defender + SELECT_CASUALTIES, defender + FIRE,
@@ -1386,7 +1386,7 @@ public class RevisedTest {
     // fight the battle
     moveDelegate(gameData).end();
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(sz6, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(sz6);
     // everything hits, this will kill both transports
     whenGetRandom(bridge)
         .thenAnswer(withValues(0, 0))

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -402,7 +402,7 @@ public class WW2V3Year41Test {
     // we should not be able to retreat to east poland!
     // that territory is still owned by the enemy
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(ukraine, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(ukraine);
     assertFalse(battle.getAttackerRetreatTerritories().contains(eastPoland));
   }
 
@@ -426,7 +426,7 @@ public class WW2V3Year41Test {
     // we should not be able to retreat to east poland!
     // that territory was just conquered
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(ukraine, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(ukraine);
     assertTrue(battle.getAttackerRetreatTerritories().contains(eastPoland));
   }
 
@@ -829,7 +829,7 @@ public class WW2V3Year41Test {
     // move again
     move(sz14.getUnitCollection().getMatches(Matches.unitIsNotTransport()), r);
     final MustFightBattle mfb =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(sz12, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(sz12);
     // only 3 attacking units
     // the battleship and the two cruisers
     assertEquals(3, mfb.getAttackingUnits().size());
@@ -851,7 +851,7 @@ public class WW2V3Year41Test {
     move(from.getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings(true);
     assertEquals(
         Arrays.asList(attacker + SUBS_SUBMERGE, defender + SUBS_SUBMERGE, attacker + SUBS_FIRE,
@@ -886,7 +886,7 @@ public class WW2V3Year41Test {
     move(from.getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings(true);
     assertEquals(
         Arrays.asList(defender + SUBS_SUBMERGE, defender + SUBS_FIRE, attacker + SELECT_SUB_CASUALTIES,
@@ -920,7 +920,7 @@ public class WW2V3Year41Test {
     move(from.getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings(true);
     assertEquals(
         Arrays.asList(attacker + SUBS_SUBMERGE, attacker + SUBS_FIRE, defender + SELECT_SUB_CASUALTIES,
@@ -955,7 +955,7 @@ public class WW2V3Year41Test {
     move(from.getUnits(), new Route(from, attacked));
     moveDelegate(gameData).end();
     final MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings(true);
     assertEquals(
         Arrays.asList(attacker + SUBS_FIRE, defender + SELECT_SUB_CASUALTIES, attacker + FIRE,
@@ -1010,7 +1010,7 @@ public class WW2V3Year41Test {
     BattleDelegate.doInitialize(battleDelegate(gameData).getBattleTracker(), bridge);
     battleDelegate(gameData).addBombardmentSources();
     final MustFightBattle mfb =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(eg, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(eg);
     // only 2 ships are allowed to bombard (there are 1 battleship and 2 cruisers that COULD bombard, but only 2 ships
     // may bombard total)
     assertEquals(2, mfb.getBombardingUnits().size());
@@ -1073,7 +1073,7 @@ public class WW2V3Year41Test {
     BattleDelegate.doInitialize(battleDelegate(gameData).getBattleTracker(), bridge);
     battleDelegate(gameData).addBombardmentSources();
     final MustFightBattle mfb =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(eg, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(eg);
     assertNotNull(mfb);
     // Show that bombard casualties can return fire
     // destroyer bombard hit/miss on rolls of 4 & 3
@@ -1122,7 +1122,7 @@ public class WW2V3Year41Test {
     BattleDelegate.doInitialize(battleDelegate(gameData).getBattleTracker(), bridge);
     battleDelegate(gameData).addBombardmentSources();
     final MustFightBattle mfb =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(eg, false, null);
+        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(eg);
     // only 2 battleships are allowed to bombard
     assertEquals(2, mfb.getBombardingUnits().size());
   }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
@@ -85,8 +85,8 @@ public class WW2V3Year42Test {
     move(baltic.getUnitCollection().getMatches(Matches.unitIsLandTransportable()), new Route(baltic, karrelia));
     final BattleTracker battleTracker = MoveDelegate.getBattleTracker(gameData);
     // we should have a pending land battle, and a pending bombing raid
-    assertNotNull(battleTracker.getPendingBattle(karrelia, false, null));
-    assertNotNull(battleTracker.getPendingBattle(karrelia, true, null));
+    assertNotNull(battleTracker.getPendingBattle(karrelia));
+    assertNotNull(battleTracker.getPendingBombingBattle(karrelia));
     // the territory should not be conquered
     assertEquals(karrelia.getOwner(), russians(gameData));
   }
@@ -110,7 +110,7 @@ public class WW2V3Year42Test {
     BattleDelegate.doInitialize(battleDelegate(gameData).getBattleTracker(), bridge);
     // all units in sz5 should be involved in the battle
     final MustFightBattle mfb =
-        (MustFightBattle) MoveDelegate.getBattleTracker(gameData).getPendingBattle(sz5, false, null);
+        (MustFightBattle) MoveDelegate.getBattleTracker(gameData).getPendingBattle(sz5);
     assertEquals(5, mfb.getAttackingUnits().size());
   }
 
@@ -136,7 +136,7 @@ public class WW2V3Year42Test {
     BattleDelegate.doInitialize(battleDelegate(gameData).getBattleTracker(), bridge);
     // all units in sz5 should be involved in the battle except the italian carrier
     final MustFightBattle mfb =
-        (MustFightBattle) MoveDelegate.getBattleTracker(gameData).getPendingBattle(sz5, false, null);
+        (MustFightBattle) MoveDelegate.getBattleTracker(gameData).getPendingBattle(sz5);
     assertEquals(6, mfb.getAttackingUnits().size());
   }
 
@@ -161,7 +161,7 @@ public class WW2V3Year42Test {
     BattleDelegate.doInitialize(battleDelegate(gameData).getBattleTracker(), bridge);
     // all units in sz5 should be involved in the battle
     final MustFightBattle mfb =
-        (MustFightBattle) MoveDelegate.getBattleTracker(gameData).getPendingBattle(sz5, false, null);
+        (MustFightBattle) MoveDelegate.getBattleTracker(gameData).getPendingBattle(sz5);
     assertEquals(4, mfb.getAttackingUnits().size());
   }
 }


### PR DESCRIPTION
## Overview
- couple simplifications in battle tracker

## Functional Changes
None, refactor only

## Additional Review Notes
Most of these changes are these conversions:
`getPendingBattle(territory, true, null)` => `getPendingBombingBattle(territory)`
`getPendingBattle(territory, false, null)` => `getPendingBattle(territory)`
