### PR TITLE
Convert UrlConstants from enum to strings

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/ClientContext.java
+++ b/game-core/src/main/java/games/strategy/engine/ClientContext.java
@@ -61,6 +61,6 @@ public final class ClientContext {
   public static List<DownloadFileDescription> getMapDownloadList() {
     return ClientSetting.mapListOverride.getValue()
         .map(DownloadRunnable::readLocalFile)
-        .orElseGet(() -> DownloadRunnable.download(UrlConstants.MAP_DOWNLOAD_LIST.toString()));
+        .orElseGet(() -> DownloadRunnable.download(UrlConstants.MAP_DOWNLOAD_LIST));
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/auto/update/EngineVersionProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/update/EngineVersionProperties.java
@@ -36,10 +36,9 @@ class EngineVersionProperties {
   private EngineVersionProperties(final Properties props) {
     latestVersionOut =
         new Version(props.getProperty("LATEST", ClientContext.engineVersion().toStringFull()));
-    link = props.getProperty("LINK", UrlConstants.DOWNLOAD_WEBSITE.toString());
-    changelogLink = props.getProperty("CHANGELOG", UrlConstants.RELEASE_NOTES.toString());
+    link = props.getProperty("LINK", UrlConstants.DOWNLOAD_WEBSITE);
+    changelogLink = props.getProperty("CHANGELOG", UrlConstants.RELEASE_NOTES);
   }
-
 
   private static Properties getProperties() {
     final Properties props = new Properties();

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -132,11 +132,11 @@ public class MetaSetupPanel extends SetupPanel {
   }
 
   private static void ruleBook() {
-    SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.RULE_BOOK.toString());
+    SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.RULE_BOOK);
   }
 
   private static void helpPage() {
-    SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_HELP.toString());
+    SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_HELP);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -78,7 +78,7 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
           if (JOptionPane.showConfirmDialog(parentComponent,
               message + "\nDo you want to view the tutorial on how to host? This will open in your internet browser.",
               "View Help Website?", JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION) {
-            OpenFileUtility.openUrl(UrlConstants.HOSTING_GUIDE.toString());
+            OpenFileUtility.openUrl(UrlConstants.HOSTING_GUIDE);
           }
           ExitStatus.FAILURE.exit();
         });

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcher.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcher.java
@@ -93,20 +93,16 @@ public final class LobbyServerPropertiesFetcher {
   }
 
   private Optional<LobbyServerProperties> getRemoteProperties() {
-    final String lobbyPropsUrl = UrlConstants.LOBBY_PROPS.toString();
-
-    final Version currentVersion = ClientContext.engineVersion();
-
-    final Optional<LobbyServerProperties> lobbyProps = downloadAndParseRemoteFile(lobbyPropsUrl, currentVersion,
+    final Optional<LobbyServerProperties> lobbyProps = downloadAndParseRemoteFile(
+        UrlConstants.LOBBY_PROPS,
+        ClientContext.engineVersion(),
         LobbyPropertyFileParser::parse);
-
     lobbyProps.ifPresent(props -> {
       ClientSetting.lobbyLastUsedHost.setValue(props.getHost());
       ClientSetting.lobbyLastUsedPort.setValue(props.getPort());
       ClientSetting.lobbyLastUsedHttpHostUri.setValue(props.getHttpServerUri());
       ClientSetting.flush();
     });
-
     return lobbyProps;
   }
 

--- a/game-core/src/main/java/games/strategy/engine/pbem/AxisAndAlliesForumPoster.java
+++ b/game-core/src/main/java/games/strategy/engine/pbem/AxisAndAlliesForumPoster.java
@@ -18,7 +18,7 @@ class AxisAndAlliesForumPoster extends NodeBbForumPoster {
 
   @Override
   String getForumUrl() {
-    return UrlConstants.AXIS_AND_ALLIES_FORUM.toString();
+    return UrlConstants.AXIS_AND_ALLIES_FORUM;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/pbem/TripleAForumPoster.java
+++ b/game-core/src/main/java/games/strategy/engine/pbem/TripleAForumPoster.java
@@ -18,7 +18,7 @@ class TripleAForumPoster extends NodeBbForumPoster {
 
   @Override
   String getForumUrl() {
-    return UrlConstants.TRIPLEA_FORUM.toString();
+    return UrlConstants.TRIPLEA_FORUM;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/UrlConstants.java
+++ b/game-core/src/main/java/games/strategy/triplea/UrlConstants.java
@@ -2,56 +2,28 @@ package games.strategy.triplea;
 
 /**
  * Grouping of hardcoded URL constants.
- *
- * <p>
- * Typical usage:
- * </p>
- * <code><pre>
- *   String someUrl = UrlConstants.toString();
- * </pre></code>
  */
-public enum UrlConstants {
-  GITHUB_ISSUES("https://github.com/triplea-game/triplea/issues/new"),
+public final class UrlConstants {
+  public static final String GITHUB_ISSUES = "https://github.com/triplea-game/triplea/issues/new";
+  public static final String RULE_BOOK = "http://www.triplea-game.org/files/TripleA_RuleBook.pdf";
+  public static final String LOBBY_PROPS =
+      "https://raw.githubusercontent.com/triplea-game/triplea/master/lobby_server.yaml";
+  public static final String PAYPAL_DONATE =
+      "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=GKZL7598EDZLN";
+  public static final String GITHUB_HELP = "http://www.triplea-game.org/help/";
+  public static final String HOSTING_GUIDE = "https://forums.triplea-game.org/topic/100";
+  public static final String TRIPLEA_FORUM = "https://forums.triplea-game.org/";
+  public static final String AXIS_AND_ALLIES_FORUM = "https://www.axisandallies.org/forums";
+  public static final String TRIPLEA_LOBBY_RULES = "https://forums.triplea-game.org/topic/4";
+  public static final String LATEST_GAME_DOWNLOAD_WEBSITE = "http://www.triplea-game.org/download/";
+  public static final String TRIPLEA_WEBSITE = "http://www.triplea-game.org/";
+  public static final String DOWNLOAD_WEBSITE = "http://www.triplea-game.org/download/";
+  public static final String RELEASE_NOTES = "http://www.triplea-game.org/release_notes/";
+  public static final String MAP_DOWNLOAD_LIST =
+      "https://raw.githubusercontent.com/triplea-game/triplea/master/triplea_maps.yaml";
+  public static final String MAP_MAKER_HELP =
+      "https://github.com/triplea-game/triplea/blob/master/docs/map_making/map_and_map_skin_making_overview.md";
+  public static final String LICENSE_NOTICE = "https://github.com/triplea-game/triplea/blob/master/README.md#license";
 
-  RULE_BOOK("http://www.triplea-game.org/files/TripleA_RuleBook.pdf"),
-
-  LOBBY_PROPS("https://raw.githubusercontent.com/triplea-game/triplea/master/lobby_server.yaml"),
-
-  PAYPAL_DONATE("https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=GKZL7598EDZLN"),
-
-  GITHUB_HELP("http://www.triplea-game.org/help/"),
-
-  HOSTING_GUIDE("https://forums.triplea-game.org/topic/100"),
-
-  TRIPLEA_FORUM("https://forums.triplea-game.org/"),
-
-  AXIS_AND_ALLIES_FORUM("https://www.axisandallies.org/forums"),
-
-  TRIPLEA_LOBBY_RULES("https://forums.triplea-game.org/topic/4"),
-
-  LATEST_GAME_DOWNLOAD_WEBSITE("http://www.triplea-game.org/download/"),
-
-  TRIPLEA_WEBSITE("http://www.triplea-game.org/"),
-
-  DOWNLOAD_WEBSITE("http://www.triplea-game.org/download/"),
-
-  RELEASE_NOTES("http://www.triplea-game.org/release_notes/"),
-
-  MAP_DOWNLOAD_LIST("https://raw.githubusercontent.com/triplea-game/triplea/master/triplea_maps.yaml"),
-
-  MAP_MAKER_HELP(
-      "https://github.com/triplea-game/triplea/blob/master/docs/map_making/map_and_map_skin_making_overview.md"),
-
-  LICENSE_NOTICE("https://github.com/triplea-game/triplea/blob/master/README.md#license");
-
-  private final String urlString;
-
-  UrlConstants(final String value) {
-    this.urlString = value;
-  }
-
-  @Override
-  public String toString() {
-    return urlString;
-  }
+  private UrlConstants() {}
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -335,7 +335,6 @@ public final class HelpMenu extends JMenu {
 
   private void addReportBugsMenu() {
     add(SwingAction.of("Send Bug Report",
-        e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_ISSUES.toString())))
-            .setMnemonic(KeyEvent.VK_B);
+        e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_ISSUES))).setMnemonic(KeyEvent.VK_B);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -283,22 +283,19 @@ public final class LobbyMenu extends JMenuBar {
 
   private static void addHelpMenu(final JMenu parentMenu) {
     final JMenuItem hostingLink = new JMenuItem("How to host");
-    hostingLink
-        .addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.HOSTING_GUIDE.toString()));
+    hostingLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.HOSTING_GUIDE));
     parentMenu.add(hostingLink);
 
     final JMenuItem helpPageLink = new JMenuItem("Help Page");
-    helpPageLink
-        .addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_HELP.toString()));
+    helpPageLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_HELP));
     parentMenu.add(helpPageLink);
 
     final JMenuItem lobbyRules = new JMenuItem("Lobby Rules");
-    lobbyRules.addActionListener(
-        e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_LOBBY_RULES.toString()));
+    lobbyRules.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_LOBBY_RULES));
     parentMenu.add(lobbyRules);
 
     final JMenuItem warClub = new JMenuItem("TripleA Forum");
-    warClub.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_FORUM.toString()));
+    warClub.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_FORUM));
     parentMenu.add(warClub);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/WebHelpMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/WebHelpMenu.java
@@ -23,36 +23,32 @@ final class WebHelpMenu extends JMenu {
   private void addWebMenu() {
     final JMenuItem hostingLink = new JMenuItem("How to Host");
     hostingLink.setMnemonic(KeyEvent.VK_H);
-    hostingLink
-        .addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_HELP.toString()));
+    hostingLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_HELP));
     add(hostingLink);
 
     final JMenuItem lobbyRules = new JMenuItem("Lobby Rules");
     lobbyRules.setMnemonic(KeyEvent.VK_L);
-    lobbyRules.addActionListener(
-        e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_LOBBY_RULES.toString()));
+    lobbyRules.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_LOBBY_RULES));
     add(lobbyRules);
 
     final JMenuItem warClub = new JMenuItem("TripleA Forum");
     warClub.setMnemonic(KeyEvent.VK_W);
-    warClub.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_FORUM.toString()));
+    warClub.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_FORUM));
     add(warClub);
 
     final JMenuItem donateLink = new JMenuItem("Donate");
     donateLink.setMnemonic(KeyEvent.VK_O);
-    donateLink
-        .addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.PAYPAL_DONATE.toString()));
+    donateLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.PAYPAL_DONATE));
     add(donateLink);
 
     final JMenuItem helpLink = new JMenuItem("Help");
     helpLink.setMnemonic(KeyEvent.VK_G);
-    helpLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_HELP.toString()));
+    helpLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_HELP));
     add(helpLink);
 
     final JMenuItem ruleBookLink = new JMenuItem("Rule Book");
     ruleBookLink.setMnemonic(KeyEvent.VK_K);
-    ruleBookLink
-        .addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.RULE_BOOK.toString()));
+    ruleBookLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.RULE_BOOK));
     add(ruleBookLink);
   }
 }

--- a/game-core/src/main/java/tools/map/making/MapCreator.java
+++ b/game-core/src/main/java/tools/map/making/MapCreator.java
@@ -150,7 +150,7 @@ public class MapCreator extends JFrame {
     panel1.add(Box.createVerticalStrut(30));
     panel1.add(new JLabel("Click button open up the readme file on how to make maps:"));
     final JButton helpButton = new JButton("Start Tutorial  /  Show Help Document");
-    helpButton.addActionListener(e -> OpenFileUtility.openUrl(UrlConstants.MAP_MAKER_HELP.toString()));
+    helpButton.addActionListener(e -> OpenFileUtility.openUrl(UrlConstants.MAP_MAKER_HELP));
     panel1.add(helpButton);
     panel1.add(Box.createVerticalStrut(30));
     panel1.add(new JLabel("Click button to select where your map folder is:"));

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/MainMenuPane.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/MainMenuPane.java
@@ -101,12 +101,12 @@ class MainMenuPane extends BorderPane {
 
   @FXML
   private void showHelp() {
-    triplea.open(UrlConstants.GITHUB_HELP.toString());
+    triplea.open(UrlConstants.GITHUB_HELP);
   }
 
   @FXML
   private void showRuleBook() {
-    triplea.open(UrlConstants.RULE_BOOK.toString());
+    triplea.open(UrlConstants.RULE_BOOK);
   }
 
   @FXML


### PR DESCRIPTION
## Overview

Removes the indirection of mapping an `UrlConstants` enum member to a string.  There is no longer any type usage of `UrlConstants` (e.g. a method parameter type), and all uses of the members of this type are always converted to strings anyway.

## Functional Changes

None.

## Manual Testing Performed

None.