### PR TITLE
Encapsulate access to battle frame window

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -52,7 +52,7 @@ import lombok.extern.java.Log;
  * UI for fighting battles.
  */
 @Log
-public class BattlePanel extends ActionPanel {
+public final class BattlePanel extends ActionPanel {
   private static final long serialVersionUID = 5304208569738042592L;
   private final JLabel actionLabel = new JLabel();
   private FightBattleDetails fightBattleMessage;
@@ -172,8 +172,8 @@ public class BattlePanel extends ActionPanel {
     return true;
   }
 
-  protected JFrame getBattleFrame() {
-    return battleFrame;
+  boolean isBattleShowing() {
+    return battleFrame.isVisible();
   }
 
   public void listBattle(final List<String> steps) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -828,7 +828,7 @@ public final class TripleAFrame extends JFrame {
     messageAndDialogThreadPool.waitForAll();
     actionButtons.changeToMove(player, nonCombat, stepName);
     // workaround for panel not receiving focus at beginning of n/c move phase
-    if (!getBattlePanel().getBattleFrame().isVisible()) {
+    if (!getBattlePanel().isBattleShowing()) {
       requestWindowFocus();
     }
     return actionButtons.waitForMove(bridge);


### PR DESCRIPTION
## Overview

Saw this while I was fiddling with `BattlePanel` yesterday.  There's no reason to let the battle frame window escape outside of `BattlePanel`, and so this PR simply tightens things up a bit.

## Functional Changes

None.

## Manual Testing Performed

None.