### PR TITLE
Allow custom hostnames for bots

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -280,7 +280,7 @@ public final class GameRunner {
     ProcessRunnerUtil.populateBasicJavaArgs(commands);
     final String prefix = "-D";
     commands.add(prefix + TRIPLEA_CLIENT + "=true");
-    commands.add(prefix + TRIPLEA_PORT + "=" + description.getHostedBy().getPort());
+    commands.add(prefix + TRIPLEA_PORT + "=" + description.getPort());
     commands.add(prefix + TRIPLEA_HOST + "=" + description.getHostedBy().getAddress().getHostAddress());
     commands.add(prefix + TRIPLEA_NAME + "=" + messengers.getMessenger().getLocalNode().getName());
     commands.add(Services.loadAny(ApplicationContext.class).getMainClass().getName());

--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -280,7 +280,7 @@ public final class GameRunner {
     ProcessRunnerUtil.populateBasicJavaArgs(commands);
     final String prefix = "-D";
     commands.add(prefix + TRIPLEA_CLIENT + "=true");
-    commands.add(prefix + TRIPLEA_PORT + "=" + description.getPort());
+    commands.add(prefix + TRIPLEA_PORT + "=" + description.getHostedBy().getPort());
     commands.add(prefix + TRIPLEA_HOST + "=" + description.getHostedBy().getAddress().getHostAddress());
     commands.add(prefix + TRIPLEA_NAME + "=" + messengers.getMessenger().getLocalNode().getName());
     commands.add(Services.loadAny(ApplicationContext.class).getMainClass().getName());

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -106,7 +106,7 @@ public class InGameLobbyWatcher {
     final INode publicNode = new Node(messenger.getLocalNode().getName(), publicView);
     gameDescription = GameDescription.builder()
         .hostedBy(publicNode)
-        .port(customPort.isPresent()? publicNode.getPort() : serverMessenger.getLocalNode().getPort())
+        .port(customPort.isPresent() ? publicNode.getPort() : serverMessenger.getLocalNode().getPort())
         .startDateTime(startDateTime)
         .gameName("???")
         .playerCount(playerCount)

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -99,13 +99,14 @@ public class InGameLobbyWatcher {
         (oldWatcher == null || oldWatcher.gameDescription == null || oldWatcher.gameDescription.getRound() == null)
             ? "-"
             : oldWatcher.gameDescription.getRound();
+    final Optional<Integer> customPort = Optional.ofNullable(Integer.getInteger("customPort"));
     final InetSocketAddress publicView = Optional.ofNullable(System.getProperty("customHost"))
-        .map(s -> new InetSocketAddress(s, Optional.ofNullable(Integer.getInteger("customPort")).orElse(3300)))
+        .map(s -> new InetSocketAddress(s, customPort.orElse(3300)))
         .orElse(messenger.getLocalNode().getSocketAddress());
     final INode publicNode = new Node(messenger.getLocalNode().getName(), publicView);
     gameDescription = GameDescription.builder()
         .hostedBy(publicNode)
-        .port(publicNode.getPort())
+        .port(customPort.isPresent()? publicNode.getPort() : serverMessenger.getLocalNode().getPort())
         .startDateTime(startDateTime)
         .gameName("???")
         .playerCount(playerCount)

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -7,10 +7,12 @@ import static games.strategy.engine.framework.CliProperties.SERVER_PASSWORD;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_NAME;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_PORT;
 
+import java.net.InetSocketAddress;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Observer;
+import java.util.Optional;
 import java.util.logging.Level;
 
 import javax.annotation.Nullable;
@@ -40,6 +42,7 @@ import games.strategy.net.IMessengerErrorListener;
 import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.MacFinder;
+import games.strategy.net.Node;
 import lombok.extern.java.Log;
 
 /**
@@ -96,9 +99,13 @@ public class InGameLobbyWatcher {
         (oldWatcher == null || oldWatcher.gameDescription == null || oldWatcher.gameDescription.getRound() == null)
             ? "-"
             : oldWatcher.gameDescription.getRound();
+    final InetSocketAddress publicView = Optional.ofNullable(System.getProperty("customHost"))
+        .map(s -> new InetSocketAddress(s, Optional.ofNullable(Integer.getInteger("customPort")).orElse(3300)))
+        .orElse(messenger.getLocalNode().getSocketAddress());
+    final INode publicNode = new Node(messenger.getLocalNode().getName(), publicView);
     gameDescription = GameDescription.builder()
-        .hostedBy(messenger.getLocalNode())
-        .port(serverMessenger.getLocalNode().getPort())
+        .hostedBy(publicNode)
+        .port(publicNode.getPort())
         .startDateTime(startDateTime)
         .gameName("???")
         .playerCount(playerCount)

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
@@ -59,8 +59,8 @@ class LobbyGameTableModel extends AbstractTableModel {
 
     final Map<GUID, GameDescription> games =
         ((ILobbyGameController) remoteMessenger.getRemote(ILobbyGameController.REMOTE_NAME)).listGames();
-    for (final GUID id : games.keySet()) {
-      updateGame(id, games.get(id));
+    for (final Map.Entry<GUID, GameDescription> entry : games.entrySet()) {
+      updateGame(entry.getKey(), entry.getValue());
     }
   }
 
@@ -102,11 +102,10 @@ class LobbyGameTableModel extends AbstractTableModel {
   }
 
   private void updateGame(final GUID gameId, final GameDescription description) {
+    if (gameId == null) {
+      return;
+    }
     SwingUtilities.invokeLater(() -> {
-      if (gameId == null) {
-        return;
-      }
-
       final Tuple<GUID, GameDescription> toReplace = findGame(gameId);
       if (toReplace == null) {
         gameList.add(Tuple.of(gameId, description));

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/GameDescription.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/GameDescription.java
@@ -47,6 +47,11 @@ public class GameDescription implements Externalizable, Cloneable {
   }
 
   private INode hostedBy;
+
+  /**
+   * @deprecated This method is obsolete, the Node stored in hostedBy is completely sufficient.
+   */
+  @Deprecated
   private int port;
 
   /**
@@ -137,6 +142,7 @@ public class GameDescription implements Externalizable, Cloneable {
     this.playerCount = playerCount;
   }
 
+  @Deprecated
   public void setPort(final int port) {
     version++;
     this.port = port;
@@ -205,6 +211,7 @@ public class GameDescription implements Externalizable, Cloneable {
     return playerCount;
   }
 
+  @Deprecated
   public int getPort() {
     return port;
   }

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/GameDescription.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/GameDescription.java
@@ -50,6 +50,7 @@ public class GameDescription implements Externalizable, Cloneable {
 
   /**
    * Kept for compatibility. Remove in the next lobby-incompatible release.
+   *
    * @deprecated This field is redundant, the Node stored in hostedBy is completely sufficient.
    */
   @Deprecated

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/GameDescription.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/GameDescription.java
@@ -213,6 +213,10 @@ public class GameDescription implements Externalizable, Cloneable {
     return playerCount;
   }
 
+  /**
+   * Kept for backwards compatibility. Should no longer be used.
+   * @deprecated Use {@link #getHostedBy()}{@code .getPort()} instead in the next incompatible lobby release.
+   */
   @Deprecated
   public int getPort() {
     return port;

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/GameDescription.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/GameDescription.java
@@ -215,6 +215,7 @@ public class GameDescription implements Externalizable, Cloneable {
 
   /**
    * Kept for backwards compatibility. Should no longer be used.
+   *
    * @deprecated Use {@link #getHostedBy()}{@code .getPort()} instead in the next incompatible lobby release.
    */
   @Deprecated

--- a/game-core/src/main/java/games/strategy/engine/lobby/server/GameDescription.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/server/GameDescription.java
@@ -49,7 +49,8 @@ public class GameDescription implements Externalizable, Cloneable {
   private INode hostedBy;
 
   /**
-   * @deprecated This method is obsolete, the Node stored in hostedBy is completely sufficient.
+   * Kept for compatibility. Remove in the next lobby-incompatible release.
+   * @deprecated This field is redundant, the Node stored in hostedBy is completely sufficient.
    */
   @Deprecated
   private int port;

--- a/game-core/src/main/java/games/strategy/net/Node.java
+++ b/game-core/src/main/java/games/strategy/net/Node.java
@@ -113,6 +113,8 @@ public class Node implements INode, Externalizable {
   public void writeExternal(final ObjectOutput out) throws IOException {
     out.writeUTF(name);
     out.writeInt(port);
+    // InetAddress is Serializable, we should use that instead of implementing our own logic
+    // in order to preserve the hostname if present in the next lobby-incompatible release
     out.write(address.getAddress().length);
     out.write(address.getAddress());
   }

--- a/lobby/src/main/java/org/triplea/lobby/server/LobbyGameController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/LobbyGameController.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -129,7 +130,7 @@ final class LobbyGameController implements ILobbyGameController {
     final INode sender = MessageContext.getSender();
     synchronized (mutex) {
       final Optional<Set<GUID>> allowedGames = Optional.ofNullable(hostToGame.get(sender));
-      if (!allowedGames.orElseGet(HashSet::new).contains(gameId)) {
+      if (!allowedGames.orElseGet(Collections::emptySet).contains(gameId)) {
         throw new IllegalStateException(String.format("Invalid Node %s tried accessing other game", sender));
       }
     }

--- a/lobby/src/main/java/org/triplea/lobby/server/LobbyGameController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/LobbyGameController.java
@@ -105,13 +105,12 @@ final class LobbyGameController implements ILobbyGameController {
       return "No such game found";
     }
     // make sure we are being tested from the right node
-    final int port = description.getPort();
-    final String host = description.getHostedBy().getAddress().getHostAddress();
+    final InetSocketAddress address = description.getHostedBy().getSocketAddress();
     try (Socket s = new Socket()) {
-      s.connect(new InetSocketAddress(host, port), 10 * 1000);
+      s.connect(address, 10 * 1000);
       return null;
     } catch (final IOException e) {
-      return "host:" + host + " " + " port:" + port;
+      return "host:" + address.getHostName() + " " + " port:" + address.getPort();
     }
   }
 }

--- a/lobby/src/main/java/org/triplea/lobby/server/LobbyGameController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/LobbyGameController.java
@@ -57,9 +57,9 @@ final class LobbyGameController implements ILobbyGameController {
         if (game.getHostedBy().equals(to)) {
           keys.remove();
           removed.add(key);
-          hostToGame.remove(to);
         }
       }
+      hostToGame.remove(to);
     }
     for (final GUID guid : removed) {
       broadcaster.gameRemoved(guid);

--- a/lobby/src/main/java/org/triplea/lobby/server/LobbyGameController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/LobbyGameController.java
@@ -60,8 +60,6 @@ final class LobbyGameController implements ILobbyGameController {
 
   @Override
   public void postGame(final GUID gameId, final GameDescription description) {
-    final INode from = MessageContext.getSender();
-    assertCorrectHost(description, from);
     log.info("Game added:" + description);
     synchronized (mutex) {
       allGames.put(gameId, description);
@@ -69,17 +67,8 @@ final class LobbyGameController implements ILobbyGameController {
     broadcaster.gameUpdated(gameId, description);
   }
 
-  private static void assertCorrectHost(final GameDescription description, final INode from) {
-    if (!from.getAddress().getHostAddress().equals(description.getHostedBy().getAddress().getHostAddress())) {
-      log.severe("Game modified from wrong host, from:" + from + " game host:" + description.getHostedBy());
-      throw new IllegalStateException("Game from the wrong host");
-    }
-  }
-
   @Override
   public void updateGame(final GUID gameId, final GameDescription description) {
-    final INode from = MessageContext.getSender();
-    assertCorrectHost(description, from);
     synchronized (mutex) {
       final GameDescription oldDescription = allGames.get(gameId);
       // out of order updates
@@ -116,8 +105,6 @@ final class LobbyGameController implements ILobbyGameController {
       return "No such game found";
     }
     // make sure we are being tested from the right node
-    final INode from = MessageContext.getSender();
-    assertCorrectHost(description, from);
     final int port = description.getPort();
     final String host = description.getHostedBy().getAddress().getHostAddress();
     try (Socket s = new Socket()) {

--- a/lobby/src/main/java/org/triplea/lobby/server/LobbyGameController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/LobbyGameController.java
@@ -104,12 +104,13 @@ final class LobbyGameController implements ILobbyGameController {
       return "No such game found";
     }
     // make sure we are being tested from the right node
-    final InetSocketAddress address = description.getHostedBy().getSocketAddress();
+    final int port = description.getPort();
+    final String host = description.getHostedBy().getAddress().getHostAddress();
     try (Socket s = new Socket()) {
-      s.connect(address, 10 * 1000);
+      s.connect(new InetSocketAddress(host, port), 10 * 1000);
       return null;
     } catch (final IOException e) {
-      return "host:" + address.getHostName() + " " + " port:" + address.getPort();
+      return "host:" + host + " " + " port:" + port;
     }
   }
 }

--- a/lobby/src/main/java/org/triplea/lobby/server/LobbyGameController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/LobbyGameController.java
@@ -14,7 +14,6 @@ import org.triplea.lobby.common.ILobbyGameController;
 
 import games.strategy.engine.lobby.server.GameDescription;
 import games.strategy.engine.message.IRemoteMessenger;
-import games.strategy.engine.message.MessageContext;
 import games.strategy.net.GUID;
 import games.strategy.net.IConnectionChangeListener;
 import games.strategy.net.INode;


### PR DESCRIPTION
## Overview
This should allow anyone to host bots without having to go through a process of opening ports etc.
Closes #3570
Note that this requires a lobby-update to work.

## Functional Changes
### General
~The INode is now the single source of truth for hostnames.~ The port field in GameDescription duplicating the port of this class has been deprecated, ~its reading usage removed~ and where it's written set to the same value as the Node.
### Lobby
No more server side check if the supplied endpoint matches the ip the server is communicating with. 
~Connection Testing is now done using the provided Node exclusively.~
Update: Instead we keep track which Node created which game and only allow the creator node to change it afterwards.
~### Headed~
~To join a bot now the port provided by the Node is used.~
### Headless
Headless clients now pass a custom Node to the lobby if certain command line params are set.

## Manual Testing Performed
I verified basic functionality using ngrok and a remote ip. ~I haven't done any edge case compatibility testing yet because of time reasons. I'd appreciate if you could help me out with that.~