### PR TITLE
Change: remove loader is ignored message and remove no-op method

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameParser.java
@@ -157,7 +157,6 @@ public final class GameParser {
 
     // test minimum engine version FIRST
     parseMinimumEngineVersionNumber(getSingleChild("triplea", root, true));
-    parseGameLoader(getSingleChild("loader", root, true));
     // if we manage to get this far, past the minimum engine version number test, AND we are still good, then check and
     // see if we have any SAX errors we need to show
     if (!errorsSax.isEmpty()) {
@@ -511,12 +510,6 @@ public final class GameParser {
     data.setGameName(gameName);
     final String version = ((Element) info).getAttribute("version");
     data.setGameVersion(new Version(version));
-  }
-
-  private static void parseGameLoader(final Node loader) {
-    if (loader != null) {
-      log.fine("Loader tag is being ignored");
-    }
   }
 
   private void parseMap(final Node map) throws GameParseException {


### PR DESCRIPTION
## Overview

1. With loader removed, it's noise to log that the loader is now
ignored, that is just how the game works now.
2. no-op method to log that something is ignored does not seem useful,
secondly the method is badly named now as it no longer does any kind of
parsing.

## Functional Changes
Remove noisy log statement:
![screenshot from 2019-02-14 11-43-27](https://user-images.githubusercontent.com/12397753/52813063-c8bdae80-304d-11e9-883e-b0e2709890c1.png)


## Manual Testing Performed
- verified log message no longer shows
