### PR TITLE
Separate territory effect images

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/image/AbstractImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/AbstractImageFactory.java
@@ -1,10 +1,7 @@
 package games.strategy.triplea.image;
 
-import java.awt.Graphics2D;
 import java.awt.Image;
-import java.awt.RenderingHints;
 import java.awt.Toolkit;
-import java.awt.image.BufferedImage;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
@@ -56,23 +53,10 @@ public abstract class AbstractImageFactory {
     if (icons.containsKey(fullName)) {
       return icons.get(fullName);
     }
-    // we draw the icon size to fit in the lower window bar
-    final int imageDimension = 32;
-    final Image img = getScaledImage(getBaseImage(fullName), imageDimension, imageDimension);
+    final Image img = getBaseImage(fullName);
     final ImageIcon icon = new ImageIcon(img);
     icons.put(fullName, icon);
     return icon;
-  }
-
-  private static Image getScaledImage(final Image srcImg, final int width, final int height) {
-    final BufferedImage resizedImg = new BufferedImage(width, height, BufferedImage.TYPE_INT_ARGB);
-    final Graphics2D g2 = resizedImg.createGraphics();
-
-    g2.setRenderingHint(RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BILINEAR);
-    g2.drawImage(srcImg, 0, 0, width, height, null);
-    g2.dispose();
-
-    return resizedImg;
   }
 
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -807,7 +807,10 @@ public class MapData implements Closeable {
     if (effectImages.get(effectName) != null) {
       return Optional.of(effectImages.get(effectName));
     }
-    final Optional<Image> effectImage = loadImage("territoryEffects/" + effectName + ".png");
+    Optional<Image> effectImage = loadImage("territoryEffects/" + effectName + "_large.png");
+    if (!effectImage.isPresent()) {
+      effectImage = loadImage("territoryEffects/" + effectName + ".png");
+    }
     effectImages.put(effectName, effectImage.orElse(null));
     return effectImage;
   }

--- a/game-core/src/main/java/tools/image/DecorationPlacer.java
+++ b/game-core/src/main/java/tools/image/DecorationPlacer.java
@@ -889,9 +889,9 @@ public final class DecorationPlacer {
             + "CTRL/SHIFT + Right Click = delete currently selected image point</html>"),
 
     territory_effects(
-        "territory_effects.txt", "territoryEffects", "mountain.png", false, false, false, false, true,
+        "territory_effects.txt", "territoryEffects", "mountain_large.png", false, false, false, false, true,
         "territory_effects.txt is the point where a territory effect image is shown,"
-            + " and it picks the <effect>.png image from the 'territoryEffects' folder",
+            + " and it picks the <effect>_large.png or <effect>.png image from the 'territoryEffects' folder",
         "<html>pu_place.txt will allow for multiple points per image. <br>"
             + "Left Click = select closest image  OR  place currently selected image <br>"
             + "Right click = copy selected image OR create an image for this territory<br>"


### PR DESCRIPTION
## Overview
- Revert #4623 
- Address #3396 

## Functional Changes
- Allow territory effect map decorations to use <effect>_large.png and if that isn't found then <effect>.png. This allows 2 different size images for territory effects: 1 for map and 1 for bottom bar. This makes it similar to how resource and flag images work.

## Manual Testing Performed
- Tested Another World with <effect>.png and <effect>_large.png
- Tested Dragon War and TWW to ensure their resource and territory effect images work as before

