### PR TITLE
Update: Error Message window LogRecord print handling

### DIFF
--- a/game-core/src/main/java/games/strategy/debug/ErrorMessage.java
+++ b/game-core/src/main/java/games/strategy/debug/ErrorMessage.java
@@ -17,7 +17,6 @@ import org.triplea.swing.JLabelBuilder;
 import org.triplea.swing.JPanelBuilder;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 
 import games.strategy.triplea.settings.ClientSetting;
 
@@ -101,7 +100,7 @@ public enum ErrorMessage {
   public static void show(final LogRecord record) {
     if (INSTANCE.enableErrorPopup && INSTANCE.isVisible.compareAndSet(false, true)) {
       SwingUtilities.invokeLater(() -> {
-        INSTANCE.errorMessage.setText(TextUtils.textToHtml(Strings.nullToEmpty(record.getMessage())));
+        INSTANCE.errorMessage.setText(new ErrorMessageFormatter().apply(record));
         INSTANCE.windowReference.pack();
         INSTANCE.windowReference.setLocationRelativeTo(null);
         INSTANCE.windowReference.setVisible(true);

--- a/game-core/src/main/java/games/strategy/debug/ErrorMessageFormatter.java
+++ b/game-core/src/main/java/games/strategy/debug/ErrorMessageFormatter.java
@@ -9,10 +9,6 @@ import java.util.logging.LogRecord;
  * Converts a 'LogRecord' to the text that we display to a user in an alert pop-up.
  */
 class ErrorMessageFormatter implements Function<LogRecord, String> {
-  private static final String ERROR_LINE_PREFIX = "Error: ";
-  private static final String LOCATION_LINE_PREFIX = "Location: ";
-  private static final String DETAILS_LINE_PREFIX = "Details: ";
-
   private static final String BREAK = "\n\n";
 
   @Override
@@ -20,7 +16,7 @@ class ErrorMessageFormatter implements Function<LogRecord, String> {
     checkArgument(logRecord.getThrown() != null || logRecord.getMessage() != null,
         "LogRecord should have one or both, a message or exception: " + logRecord);
 
-    return TextUtils.textToHtml(format(logRecord) + BREAK + locationLine(logRecord));
+    return TextUtils.textToHtml(format(logRecord));
   }
 
   /**
@@ -30,9 +26,7 @@ class ErrorMessageFormatter implements Function<LogRecord, String> {
    *      LogRecord.getMessage() == null && LogRecord.getThrown().getMessage() == null
    * }
    * Return:
-   * * Error: {exception simple name}
-   * *
-   * * Location: {className}.{methodName}
+   * * {exception simple name}
    * <br/>
    * (2) uncaught exception with a message
    * {@code
@@ -42,9 +36,7 @@ class ErrorMessageFormatter implements Function<LogRecord, String> {
    * }
    * <br/>
    * Return:
-   * * Error: {exception simple name} - {exception message}
-   * *
-   * * Location: {className}.{methodName}
+   * * {exception simple name} - {exception message}
    * <br/>
    * (3) logging an error message
    * {@code
@@ -53,9 +45,7 @@ class ErrorMessageFormatter implements Function<LogRecord, String> {
    * }
    * <br/>
    * Return:
-   * * Error: {log message}
-   * *
-   * * Location: {className}.{methodName}
+   * * {log message}
    * <br/>
    * (4) logging an error message with exception that has no message</li>
    * {@code
@@ -63,11 +53,9 @@ class ErrorMessageFormatter implements Function<LogRecord, String> {
    *              LogRecord.getMessage() != null && LogRecord.getThrown().getMessage() == null
    * }
    * Return:
-   * * * Error: {log message}
+   * * * {log message}
    * * *
-   * * * Details: {exception simple name}
-   * * *
-   * * * Location: {className}.{methodName}
+   * * * {exception simple name}
    * <br/>
    * (5) logging an error message with exception that has a message
    * {@code
@@ -78,11 +66,9 @@ class ErrorMessageFormatter implements Function<LogRecord, String> {
    * }
    * <br/>
    * Return:
-   * * Error: {log message}
+   * * {log message}
    * *
-   * * Details: {exception simple name} - {exception message}
-   * *
-   * * Location: {className}.{methodName}
+   * * {exception simple name} - {exception message}
    */
   private static String format(final LogRecord logRecord) {
     if (logRecord.getThrown() == null) {
@@ -128,7 +114,7 @@ class ErrorMessageFormatter implements Function<LogRecord, String> {
     checkArgument(logRecord.getMessage() != null);
     checkArgument(logRecord.getThrown() == null);
 
-    return ERROR_LINE_PREFIX + logRecord.getMessage();
+    return logRecord.getMessage();
   }
 
 
@@ -141,7 +127,7 @@ class ErrorMessageFormatter implements Function<LogRecord, String> {
     checkArgument(logRecord.getThrown().getMessage() != null);
     checkArgument(logRecord.getMessage() != null);
     checkArgument(logRecord.getThrown().getMessage().equals(logRecord.getMessage()));
-    return ERROR_LINE_PREFIX + simpleName(logRecord) + " - " + logRecord.getThrown().getMessage();
+    return simpleName(logRecord) + " - " + logRecord.getThrown().getMessage();
   }
 
 
@@ -158,7 +144,7 @@ class ErrorMessageFormatter implements Function<LogRecord, String> {
     checkArgument(logRecord.getThrown().getMessage() == null);
     checkArgument(logRecord.getMessage() == null);
 
-    return ERROR_LINE_PREFIX + simpleName(logRecord);
+    return simpleName(logRecord);
   }
 
   /*
@@ -173,8 +159,7 @@ class ErrorMessageFormatter implements Function<LogRecord, String> {
     checkArgument(logRecord.getMessage() != null);
     checkArgument(!logRecord.getThrown().getMessage().equals(logRecord.getMessage()));
 
-    return ERROR_LINE_PREFIX + logRecord.getMessage() + BREAK
-        + DETAILS_LINE_PREFIX + simpleName(logRecord) + " - " + logRecord.getThrown().getMessage();
+    return logRecord.getMessage() + BREAK + simpleName(logRecord) + ": " + logRecord.getThrown().getMessage();
   }
 
 
@@ -189,16 +174,6 @@ class ErrorMessageFormatter implements Function<LogRecord, String> {
     checkArgument(logRecord.getThrown().getMessage() == null);
     checkArgument(logRecord.getMessage() != null);
 
-    return ERROR_LINE_PREFIX + logRecord.getMessage() + BREAK
-        + DETAILS_LINE_PREFIX + simpleName(logRecord);
-  }
-
-  /*
-   * <pre>
-   * Location: {class name}.{method name}
-   * </pre>
-   */
-  private static String locationLine(final LogRecord logRecord) {
-    return LOCATION_LINE_PREFIX + logRecord.getSourceClassName() + "." + logRecord.getSourceMethodName();
+    return logRecord.getMessage() + BREAK + simpleName(logRecord);
   }
 }

--- a/game-core/src/main/java/games/strategy/debug/ErrorMessageFormatter.java
+++ b/game-core/src/main/java/games/strategy/debug/ErrorMessageFormatter.java
@@ -1,0 +1,204 @@
+package games.strategy.debug;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.util.function.Function;
+import java.util.logging.LogRecord;
+
+/**
+ * Converts a 'LogRecord' to the text that we display to a user in an alert pop-up.
+ */
+class ErrorMessageFormatter implements Function<LogRecord, String> {
+  private static final String ERROR_LINE_PREFIX = "Error: ";
+  private static final String LOCATION_LINE_PREFIX = "Location: ";
+  private static final String DETAILS_LINE_PREFIX = "Details: ";
+
+  private static final String BREAK = "\n\n";
+
+  @Override
+  public String apply(final LogRecord logRecord) {
+    checkArgument(logRecord.getThrown() != null || logRecord.getMessage() != null,
+        "LogRecord should have one or both, a message or exception: " + logRecord);
+
+    return TextUtils.textToHtml(format(logRecord) + BREAK + locationLine(logRecord));
+  }
+
+  /**
+   * Five ways we will hit our logging handler.:<br/>
+   * (1) uncaught exception with no message
+   * {@code throw new NullPointerException() =>
+   *      LogRecord.getMessage() == null && LogRecord.getThrown().getMessage() == null
+   * }
+   * Return:
+   * * Error: {exception simple name}
+   * *
+   * * Location: {className}.{methodName}
+   * <br/>
+   * (2) uncaught exception with a message
+   * {@code
+   *         throw new NullPointerException("message") =>
+   *              // log record message will be populated with the exception message
+   *              LogRecord.getMessage().equals(LogRecord.getThrown().getMessage())}
+   * }
+   * <br/>
+   * Return:
+   * * Error: {exception simple name} - {exception message}
+   * *
+   * * Location: {className}.{methodName}
+   * <br/>
+   * (3) logging an error message
+   * {@code
+   *         log.severe("message") =>
+   *              LogRecord.getMessage() != null && LogRecord.getThrown() == null
+   * }
+   * <br/>
+   * Return:
+   * * Error: {log message}
+   * *
+   * * Location: {className}.{methodName}
+   * <br/>
+   * (4) logging an error message with exception that has no message</li>
+   * {@code
+   *        log.log(Level.SEVERE, "message", new NullPointerException()) =>
+   *              LogRecord.getMessage() != null && LogRecord.getThrown().getMessage() == null
+   * }
+   * Return:
+   * * * Error: {log message}
+   * * *
+   * * * Details: {exception simple name}
+   * * *
+   * * * Location: {className}.{methodName}
+   * <br/>
+   * (5) logging an error message with exception that has a message
+   * {@code
+   *        log.log(Level.SEVERE, "log-message", new NullPointerException("exception message")) =>
+   *              LogRecord.getMessage() != null
+   *                 && LogRecord.getThrown() != null
+   *                 && !LogRecord.getMessage().equals(LogRecord.getThrown().getMessage())
+   * }
+   * <br/>
+   * Return:
+   * * Error: {log message}
+   * *
+   * * Details: {exception simple name} - {exception message}
+   * *
+   * * Location: {className}.{methodName}
+   */
+  private static String format(final LogRecord logRecord) {
+    if (logRecord.getThrown() == null) {
+      return logMessageOnly(logRecord);
+    }
+
+    if (logRecord.getMessage() != null
+        && logRecord.getThrown() != null
+        && logRecord.getThrown().getMessage() != null
+        && !logRecord.getMessage().equals(logRecord.getThrown().getMessage())) {
+      return logMessageAndExceptionMessage(logRecord);
+    }
+
+    if (logRecord.getMessage() != null
+        && logRecord.getThrown() != null
+        && logRecord.getThrown().getMessage() == null) {
+      return logMessageAndExceptionWithoutMessage(logRecord);
+    }
+
+    if (logRecord.getMessage() == null
+        && logRecord.getThrown() != null
+        && logRecord.getThrown().getMessage() == null) {
+      return exceptionOnlyWithOutMessage(logRecord);
+    }
+
+    if (logRecord.getMessage() != null
+        && logRecord.getThrown() != null
+        && logRecord.getThrown().getMessage() != null
+        && logRecord.getMessage().equals(logRecord.getThrown().getMessage())) {
+      return exceptionOnlyWithMessage(logRecord);
+    }
+
+
+    throw new IllegalStateException("Unhandled: " + logRecord.getMessage() + ", exception: " + logRecord.getThrown());
+  }
+
+  /*
+   * <pre>
+   * Error: {log message}
+   * </pre>
+   */
+  private static String logMessageOnly(final LogRecord logRecord) {
+    checkArgument(logRecord.getMessage() != null);
+    checkArgument(logRecord.getThrown() == null);
+
+    return ERROR_LINE_PREFIX + logRecord.getMessage();
+  }
+
+
+  /*
+   * <pre>
+   * Error: {exception simple name} - {exception message}
+   * </pre>
+   */
+  private static String exceptionOnlyWithMessage(final LogRecord logRecord) {
+    checkArgument(logRecord.getThrown().getMessage() != null);
+    checkArgument(logRecord.getMessage() != null);
+    checkArgument(logRecord.getThrown().getMessage().equals(logRecord.getMessage()));
+    return ERROR_LINE_PREFIX + simpleName(logRecord) + " - " + logRecord.getThrown().getMessage();
+  }
+
+
+  private static String simpleName(final LogRecord logRecord) {
+    return logRecord.getThrown().getClass().getSimpleName();
+  }
+
+  /*
+   * <pre>
+   * Error: {exception simple name}
+   * </pre>
+   */
+  private static String exceptionOnlyWithOutMessage(final LogRecord logRecord) {
+    checkArgument(logRecord.getThrown().getMessage() == null);
+    checkArgument(logRecord.getMessage() == null);
+
+    return ERROR_LINE_PREFIX + simpleName(logRecord);
+  }
+
+  /*
+   * <pre>
+   * Error: {log message}
+   *
+   * Details: {exception simple name} - {exception message}
+   * </pre>
+   */
+  private static String logMessageAndExceptionMessage(final LogRecord logRecord) {
+    checkArgument(logRecord.getThrown().getMessage() != null);
+    checkArgument(logRecord.getMessage() != null);
+    checkArgument(!logRecord.getThrown().getMessage().equals(logRecord.getMessage()));
+
+    return ERROR_LINE_PREFIX + logRecord.getMessage() + BREAK
+        + DETAILS_LINE_PREFIX + simpleName(logRecord) + " - " + logRecord.getThrown().getMessage();
+  }
+
+
+  /*
+   * <pre>
+   * Error: {log message}
+   *
+   * Details: {exception simple name}
+   * </pre>
+   */
+  private static String logMessageAndExceptionWithoutMessage(final LogRecord logRecord) {
+    checkArgument(logRecord.getThrown().getMessage() == null);
+    checkArgument(logRecord.getMessage() != null);
+
+    return ERROR_LINE_PREFIX + logRecord.getMessage() + BREAK
+        + DETAILS_LINE_PREFIX + simpleName(logRecord);
+  }
+
+  /*
+   * <pre>
+   * Location: {class name}.{method name}
+   * </pre>
+   */
+  private static String locationLine(final LogRecord logRecord) {
+    return LOCATION_LINE_PREFIX + logRecord.getSourceClassName() + "." + logRecord.getSourceMethodName();
+  }
+}

--- a/game-core/src/test/java/games/strategy/debug/ErrorMessageFormatterTest.java
+++ b/game-core/src/test/java/games/strategy/debug/ErrorMessageFormatterTest.java
@@ -16,13 +16,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class ErrorMessageFormatterTest {
 
-  private static final String CLASS_NAME = "UserErrorReportSample";
-  private static final String METHOD_NAME = "formatSomething";
-  private static final String LOCATION_LINE = "Location: " + CLASS_NAME + "." + METHOD_NAME;
-
   private static final String LOG_MESSAGE = "Pants travel with power at the stormy madagascar!";
   private static final String EXCEPTION_MESSAGE = "Jolly, yer not trading me without a life!";
-
 
   private static final Exception EXCEPTION_WITHOUT_MESSAGE = new NullPointerException();
   private static final Exception EXCEPTION_WITH_MESSAGE = new NullPointerException(EXCEPTION_MESSAGE);
@@ -40,14 +35,11 @@ class ErrorMessageFormatterTest {
 
   /*
    * <pre>
-   * Error: {log message}
-   *
-   * Location: {className}.{methodName}
+   * {log message}
    * </pre>
    */
   @Test
   void logMessageOnly() {
-    givenSourceClassAndMethodName(logRecord);
     when(logRecord.getMessage()).thenReturn(LOG_MESSAGE);
     when(logRecord.getThrown()).thenReturn(null);
 
@@ -57,26 +49,17 @@ class ErrorMessageFormatterTest {
         result,
         is(
             "<html>"
-                + "Error: " + LOG_MESSAGE + "<br/><br/>"
-                + LOCATION_LINE
+                + LOG_MESSAGE
                 + "</html>"));
-  }
-
-  private static void givenSourceClassAndMethodName(final LogRecord logRecord) {
-    when(logRecord.getSourceClassName()).thenReturn(CLASS_NAME);
-    when(logRecord.getSourceMethodName()).thenReturn(METHOD_NAME);
   }
 
   /*
    * <pre>
-   * Error: {exception simple name} - {exception message}
-   *
-   * Location: {className}.{methodName}
+   * {exception simple name} - {exception message}
    * </pre>
    */
   @Test
   void exceptionOnlyWithMessage() {
-    givenSourceClassAndMethodName(logRecord);
     givenLogRecordWithNoMessageOnlyAnException(logRecord, EXCEPTION_WITH_MESSAGE);
 
     final String result = errorMessageFormatter.apply(logRecord);
@@ -85,9 +68,8 @@ class ErrorMessageFormatterTest {
         result,
         is(
             "<html>"
-                + "Error: " + EXCEPTION_WITH_MESSAGE.getClass().getSimpleName() + " - "
-                + EXCEPTION_WITH_MESSAGE.getMessage() + "<br/><br/>"
-                + LOCATION_LINE
+                + EXCEPTION_WITH_MESSAGE.getClass().getSimpleName() + " - "
+                + EXCEPTION_WITH_MESSAGE.getMessage()
                 + "</html>"));
   }
 
@@ -98,14 +80,11 @@ class ErrorMessageFormatterTest {
 
   /*
    * <pre>
-   * Error: {exception simple name}
-   *
-   * Location: {className}.{methodName}
+   * {exception simple name}
    * </pre>
    */
   @Test
   void exceptionOnlyWithNoMessage() {
-    givenSourceClassAndMethodName(logRecord);
     givenLogRecordWithNoMessageOnlyAnException(logRecord, EXCEPTION_WITHOUT_MESSAGE);
 
     final String result = errorMessageFormatter.apply(logRecord);
@@ -114,23 +93,19 @@ class ErrorMessageFormatterTest {
         result,
         is(
             "<html>"
-                + "Error: " + EXCEPTION_WITHOUT_MESSAGE.getClass().getSimpleName() + "<br/><br/>"
-                + LOCATION_LINE
+                + EXCEPTION_WITHOUT_MESSAGE.getClass().getSimpleName()
                 + "</html>"));
   }
 
   /*
    * <pre>
-   * Error: {log message}
+   * {log message}
    *
-   * Details: {exception simple name} - {exception message}
-   *
-   * Location: {className}.{methodName}
+   * {exception simple name} - {exception message}
    * </pre>
    */
   @Test
   void bothMessageAndExceptionWithExceptionMessage() {
-    givenSourceClassAndMethodName(logRecord);
     when(logRecord.getMessage()).thenReturn(LOG_MESSAGE);
     when(logRecord.getThrown()).thenReturn(EXCEPTION_WITH_MESSAGE);
 
@@ -140,25 +115,21 @@ class ErrorMessageFormatterTest {
         result,
         is(
             "<html>"
-                + "Error: " + LOG_MESSAGE + "<br/><br/>"
-                + "Details: " + EXCEPTION_WITH_MESSAGE.getClass().getSimpleName() + " - "
-                + EXCEPTION_WITH_MESSAGE.getMessage() + "<br/><br/>"
-                + LOCATION_LINE
+                + LOG_MESSAGE + "<br/><br/>"
+                + EXCEPTION_WITH_MESSAGE.getClass().getSimpleName() + ": "
+                + EXCEPTION_WITH_MESSAGE.getMessage()
                 + "</html>"));
   }
 
   /*
    * <pre>
-   * Error: {log message}
+   * {log message}
    *
-   * Details: {exception simple name}
-   *
-   * Location: {className}.{methodName}
+   * {exception simple name}
    * </pre>
    */
   @Test
   void messageAndExceptionWithoutExceptionMessage() {
-    givenSourceClassAndMethodName(logRecord);
     when(logRecord.getMessage()).thenReturn(LOG_MESSAGE);
     when(logRecord.getThrown()).thenReturn(EXCEPTION_WITHOUT_MESSAGE);
 
@@ -168,9 +139,8 @@ class ErrorMessageFormatterTest {
         result,
         is(
             "<html>"
-                + "Error: " + LOG_MESSAGE + "<br/><br/>"
-                + "Details: " + EXCEPTION_WITHOUT_MESSAGE.getClass().getSimpleName() + "<br/><br/>"
-                + LOCATION_LINE
+                + LOG_MESSAGE + "<br/><br/>"
+                + EXCEPTION_WITHOUT_MESSAGE.getClass().getSimpleName()
                 + "</html>"));
   }
 }

--- a/game-core/src/test/java/games/strategy/debug/ErrorMessageFormatterTest.java
+++ b/game-core/src/test/java/games/strategy/debug/ErrorMessageFormatterTest.java
@@ -1,0 +1,176 @@
+package games.strategy.debug;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Function;
+import java.util.logging.LogRecord;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ErrorMessageFormatterTest {
+
+  private static final String CLASS_NAME = "UserErrorReportSample";
+  private static final String METHOD_NAME = "formatSomething";
+  private static final String LOCATION_LINE = "Location: " + CLASS_NAME + "." + METHOD_NAME;
+
+  private static final String LOG_MESSAGE = "Pants travel with power at the stormy madagascar!";
+  private static final String EXCEPTION_MESSAGE = "Jolly, yer not trading me without a life!";
+
+
+  private static final Exception EXCEPTION_WITHOUT_MESSAGE = new NullPointerException();
+  private static final Exception EXCEPTION_WITH_MESSAGE = new NullPointerException(EXCEPTION_MESSAGE);
+
+  @Mock
+  private LogRecord logRecord;
+
+  private Function<LogRecord, String> errorMessageFormatter;
+
+  @BeforeEach
+  void setup() {
+    errorMessageFormatter = new ErrorMessageFormatter();
+  }
+
+
+  /*
+   * <pre>
+   * Error: {log message}
+   *
+   * Location: {className}.{methodName}
+   * </pre>
+   */
+  @Test
+  void logMessageOnly() {
+    givenSourceClassAndMethodName(logRecord);
+    when(logRecord.getMessage()).thenReturn(LOG_MESSAGE);
+    when(logRecord.getThrown()).thenReturn(null);
+
+    final String result = errorMessageFormatter.apply(logRecord);
+
+    assertThat(
+        result,
+        is(
+            "<html>"
+                + "Error: " + LOG_MESSAGE + "<br/><br/>"
+                + LOCATION_LINE
+                + "</html>"));
+  }
+
+  private static void givenSourceClassAndMethodName(final LogRecord logRecord) {
+    when(logRecord.getSourceClassName()).thenReturn(CLASS_NAME);
+    when(logRecord.getSourceMethodName()).thenReturn(METHOD_NAME);
+  }
+
+  /*
+   * <pre>
+   * Error: {exception simple name} - {exception message}
+   *
+   * Location: {className}.{methodName}
+   * </pre>
+   */
+  @Test
+  void exceptionOnlyWithMessage() {
+    givenSourceClassAndMethodName(logRecord);
+    givenLogRecordWithNoMessageOnlyAnException(logRecord, EXCEPTION_WITH_MESSAGE);
+
+    final String result = errorMessageFormatter.apply(logRecord);
+
+    assertThat(
+        result,
+        is(
+            "<html>"
+                + "Error: " + EXCEPTION_WITH_MESSAGE.getClass().getSimpleName() + " - "
+                + EXCEPTION_WITH_MESSAGE.getMessage() + "<br/><br/>"
+                + LOCATION_LINE
+                + "</html>"));
+  }
+
+  private static void givenLogRecordWithNoMessageOnlyAnException(final LogRecord logRecord, final Exception exception) {
+    when(logRecord.getMessage()).thenReturn(exception.getMessage());
+    when(logRecord.getThrown()).thenReturn(exception);
+  }
+
+  /*
+   * <pre>
+   * Error: {exception simple name}
+   *
+   * Location: {className}.{methodName}
+   * </pre>
+   */
+  @Test
+  void exceptionOnlyWithNoMessage() {
+    givenSourceClassAndMethodName(logRecord);
+    givenLogRecordWithNoMessageOnlyAnException(logRecord, EXCEPTION_WITHOUT_MESSAGE);
+
+    final String result = errorMessageFormatter.apply(logRecord);
+
+    assertThat(
+        result,
+        is(
+            "<html>"
+                + "Error: " + EXCEPTION_WITHOUT_MESSAGE.getClass().getSimpleName() + "<br/><br/>"
+                + LOCATION_LINE
+                + "</html>"));
+  }
+
+  /*
+   * <pre>
+   * Error: {log message}
+   *
+   * Details: {exception simple name} - {exception message}
+   *
+   * Location: {className}.{methodName}
+   * </pre>
+   */
+  @Test
+  void bothMessageAndExceptionWithExceptionMessage() {
+    givenSourceClassAndMethodName(logRecord);
+    when(logRecord.getMessage()).thenReturn(LOG_MESSAGE);
+    when(logRecord.getThrown()).thenReturn(EXCEPTION_WITH_MESSAGE);
+
+    final String result = errorMessageFormatter.apply(logRecord);
+
+    assertThat(
+        result,
+        is(
+            "<html>"
+                + "Error: " + LOG_MESSAGE + "<br/><br/>"
+                + "Details: " + EXCEPTION_WITH_MESSAGE.getClass().getSimpleName() + " - "
+                + EXCEPTION_WITH_MESSAGE.getMessage() + "<br/><br/>"
+                + LOCATION_LINE
+                + "</html>"));
+  }
+
+  /*
+   * <pre>
+   * Error: {log message}
+   *
+   * Details: {exception simple name}
+   *
+   * Location: {className}.{methodName}
+   * </pre>
+   */
+  @Test
+  void messageAndExceptionWithoutExceptionMessage() {
+    givenSourceClassAndMethodName(logRecord);
+    when(logRecord.getMessage()).thenReturn(LOG_MESSAGE);
+    when(logRecord.getThrown()).thenReturn(EXCEPTION_WITHOUT_MESSAGE);
+
+    final String result = errorMessageFormatter.apply(logRecord);
+
+    assertThat(
+        result,
+        is(
+            "<html>"
+                + "Error: " + LOG_MESSAGE + "<br/><br/>"
+                + "Details: " + EXCEPTION_WITHOUT_MESSAGE.getClass().getSimpleName() + "<br/><br/>"
+                + LOCATION_LINE
+                + "</html>"));
+  }
+}

--- a/game-core/src/test/java/games/strategy/debug/ErrorMessageFormatterTest.java
+++ b/game-core/src/test/java/games/strategy/debug/ErrorMessageFormatterTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.when;
 import java.util.function.Function;
 import java.util.logging.LogRecord;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -25,19 +24,9 @@ class ErrorMessageFormatterTest {
   @Mock
   private LogRecord logRecord;
 
-  private Function<LogRecord, String> errorMessageFormatter;
-
-  @BeforeEach
-  void setup() {
-    errorMessageFormatter = new ErrorMessageFormatter();
-  }
+  private final Function<LogRecord, String> errorMessageFormatter = new ErrorMessageFormatter();
 
 
-  /*
-   * <pre>
-   * {log message}
-   * </pre>
-   */
   @Test
   void logMessageOnly() {
     when(logRecord.getMessage()).thenReturn(LOG_MESSAGE);
@@ -53,11 +42,6 @@ class ErrorMessageFormatterTest {
                 + "</html>"));
   }
 
-  /*
-   * <pre>
-   * {exception simple name} - {exception message}
-   * </pre>
-   */
   @Test
   void exceptionOnlyWithMessage() {
     givenLogRecordWithNoMessageOnlyAnException(logRecord, EXCEPTION_WITH_MESSAGE);
@@ -78,11 +62,6 @@ class ErrorMessageFormatterTest {
     when(logRecord.getThrown()).thenReturn(exception);
   }
 
-  /*
-   * <pre>
-   * {exception simple name}
-   * </pre>
-   */
   @Test
   void exceptionOnlyWithNoMessage() {
     givenLogRecordWithNoMessageOnlyAnException(logRecord, EXCEPTION_WITHOUT_MESSAGE);
@@ -97,13 +76,6 @@ class ErrorMessageFormatterTest {
                 + "</html>"));
   }
 
-  /*
-   * <pre>
-   * {log message}
-   *
-   * {exception simple name} - {exception message}
-   * </pre>
-   */
   @Test
   void bothMessageAndExceptionWithExceptionMessage() {
     when(logRecord.getMessage()).thenReturn(LOG_MESSAGE);
@@ -121,13 +93,6 @@ class ErrorMessageFormatterTest {
                 + "</html>"));
   }
 
-  /*
-   * <pre>
-   * {log message}
-   *
-   * {exception simple name}
-   * </pre>
-   */
   @Test
   void messageAndExceptionWithoutExceptionMessage() {
     when(logRecord.getMessage()).thenReturn(LOG_MESSAGE);


### PR DESCRIPTION
## 1000ft overview
We extract error message formatting from a `LogRecord` to a new class that has one method to do a transformation of a `LogRecord` to a string which is shown to user, and there is a test added for this.

What makes things slightly complex is if there is an exception thrown with a message, then `LogRecord.getMessage()` will be populated with that exception message. If we log both `LogRecord.getMessage()` and `LogRecord.getThrown().geMessage()` (and they can be different), then we also have the potential to log duplicate messages. Sorting this out leads to 5 main use cases between uncaught exceptions and logging.

## Overview

Error message window was coded to expect LogRecord.getMessage() to
always contain a value. If we have an uncaught exception with no
message, eg: `new NullPointerException()`, then the error message window
is blank.

This update conditionally prints the log message if it is there, the
exception message if it is there, and will not double print the message
if the log message and exception message match (which happens in the
case of an uncaught exception with a message, eg: `new
NullPointerException("message")`.

In addition to message printing we'll always have a third line printed
'location' that will tell us where the occurred. This serves a few
purposes:
- nice for dev, we get a pretty complete picture of the error just from the messages
and where the error occurred
- for user, it is a way to give feedback in case of uncaught errors and
limited information whether we are serving the exact same error or
different.


## Functional Changes
- Error message handles null log message case
- Error message window prints exception message
- Error message window prints class and method name of exception or log statement


## Manual Testing Performed
- injected exceptions and various log statements to record screenshots below

## Before & After Screen Shots

### Exception with no message
#### Before
![before-exception-only-with-no-message](https://user-images.githubusercontent.com/12397753/52846668-1a525180-30bf-11e9-9a9d-0b4b1118b279.png)

#### After
![after-exception-only-with-no-message](https://user-images.githubusercontent.com/12397753/52846666-1a525180-30bf-11e9-9cd5-797bce00f367.png)

### Exception with message

#### Before
![before-exception-only-with-message](https://user-images.githubusercontent.com/12397753/52846890-a06e9800-30bf-11e9-80db-7451b53f37df.png)

#### After
![after-exception-only-with-message](https://user-images.githubusercontent.com/12397753/52846735-3e159780-30bf-11e9-84b7-8bfc5eb4c7ca.png)



### Log Message Only

#### Before
![before-log-message-only](https://user-images.githubusercontent.com/12397753/52846743-3eae2e00-30bf-11e9-8970-3b5ca9b86dc5.png)

#### After
![after-log-message-only](https://user-images.githubusercontent.com/12397753/52846738-3e159780-30bf-11e9-983e-de3259157fa6.png)

### Log Message + Exception With Message

#### Before
![before-log-message-only](https://user-images.githubusercontent.com/12397753/52846743-3eae2e00-30bf-11e9-8970-3b5ca9b86dc5.png)


#### After
![after-with-different-messages](https://user-images.githubusercontent.com/12397753/52846739-3e159780-30bf-11e9-8ec0-ce59dacfc909.png)

### Log Message + Exception With No Message

#### Before

![before-log-message-only](https://user-images.githubusercontent.com/12397753/52846743-3eae2e00-30bf-11e9-8970-3b5ca9b86dc5.png)

#### After
![after-with-message-and-exception-with-no-message](https://user-images.githubusercontent.com/12397753/52846740-3eae2e00-30bf-11e9-8fc0-cb632628eeae.png)

## Additional Review Notes

### Background-Context:
While working on error upload I hit the uncaught exception case with no error message and realized that ErrorMessage was not written to handle uncaught exceptions and assumed there to be a log message, eg: `log.severe("message")` vs `throw new NullPointerException()`.

### Likely Next Steps Post-Merge:
A very likely next step will be to replace the "View Details" button on the error message with a "Report to TripleA" button.