### PR TITLE
Cleanup: Use consistent "toolTip" spelling

### DIFF
--- a/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportWindow.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportWindow.java
@@ -107,7 +107,7 @@ public final class ErrorReportWindow {
 
       descriptionFieldLabel = JLabelBuilder.builder()
           .html("Please describe the problem:")
-          .tooltip("This information will be sent to the TripleA development team. Please "
+          .toolTip("This information will be sent to the TripleA development team. Please "
               + "describe as exactly as possible where the problem is and the events leading "
               + "up to it.")
           .border(5)

--- a/swing-lib/src/main/java/org/triplea/swing/JLabelBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/JLabelBuilder.java
@@ -31,7 +31,7 @@ public class JLabelBuilder {
   private @Nullable Integer iconTextGap;
   private Alignment alignment;
   private Dimension maxSize;
-  private String tooltip;
+  private String toolTip;
   private Border border;
   private Integer borderSize;
 
@@ -63,7 +63,7 @@ public class JLabelBuilder {
           }
         });
 
-    Optional.ofNullable(tooltip)
+    Optional.ofNullable(toolTip)
         .ifPresent(label::setToolTipText);
 
     Optional.ofNullable(maxSize)
@@ -118,8 +118,8 @@ public class JLabelBuilder {
     return this;
   }
 
-  public JLabelBuilder tooltip(final String tooltip) {
-    this.tooltip = tooltip;
+  public JLabelBuilder toolTip(final String tooltip) {
+    this.toolTip = tooltip;
     return this;
   }
 

--- a/swing-lib/src/main/java/org/triplea/swing/JLabelBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/JLabelBuilder.java
@@ -118,8 +118,8 @@ public class JLabelBuilder {
     return this;
   }
 
-  public JLabelBuilder toolTip(final String tooltip) {
-    this.toolTip = tooltip;
+  public JLabelBuilder toolTip(final String toolTip) {
+    this.toolTip = toolTip;
     return this;
   }
 


### PR DESCRIPTION
## Overview
Update for consistent spelling from 'tooltip' -> 'toolTip'
The latter matches javax.swing and other builders.


## Functional Changes
none

