### PR TITLE
Fix: Bots to detect no-op game load and trigger error handling.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -206,9 +206,7 @@ public class ServerLauncher extends AbstractLauncher<Void> {
         // then crashing out, then launching, etc.
         serverModel.setAllPlayersToNullNodes();
         final File f1 = AutoSaveFileUtils.getHeadlessAutoSaveFile();
-        if (f1.exists()) {
-          gameSelectorModel.load(f1);
-        } else {
+        if (!f1.exists() || !gameSelectorModel.load(f1)) {
           gameSelectorModel.resetGameDataToNull();
         }
       } catch (final Exception e1) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -65,8 +65,11 @@ public class GameSelectorModel extends Observable {
 
   /**
    * Loads game data by parsing a given file.
+   *
+   * @return True if file parsing was successful and an internal {@code GameData}
+   *         was set. Otherwise returns false and internal {@code GameData} is null.
    */
-  public void load(final File file) {
+  public boolean load(final File file) {
     Preconditions.checkArgument(file.exists() && file.isFile(),
         "File should exist at: " + file.getAbsolutePath());
 
@@ -84,8 +87,10 @@ public class GameSelectorModel extends Observable {
       if (newData != null) {
         load(newData, file.getName());
       }
+      return (newData != null);
     } catch (final Exception e) {
       log.log(Level.SEVERE, "Error loading game file: " + file.getAbsolutePath(), e);
+      return false;
     }
   }
 


### PR DESCRIPTION
## Overview

Current error handling code has bot 'GameData' being set to null
in case of error, except 'GameSelectorModel#load' handles its own errors
and will no-op (EOFException has been observed as an example).

This update adds a success flag so that the no-op event can be signalled
as a failure. 

## Functional Changes
This should have bots failing slightly more gracefully
when failing to load a file.


## Manual Testing Performed
- none

## Log Example

This update is to help address error handling for this kind of error (bots are at v1.9.0.0.12226):

> Feb 13 19:23:16 bot35_frankfurt_de run_bot.sh: Feb 13, 2019 7:23:16 PM games.strategy.engine.framework.startup.mc.GameSelectorModel load
Feb 13 19:23:16 bot35_frankfurt_de run_bot.sh: SEVERE: Error loading game file: /home/triplea/triplea/savedGames/autoSave/Bot303_FRANKFURT_DE_autosave.tsvg, null
Feb 13 19:23:16 bot35_frankfurt_de run_bot.sh: SEVERE: Error loading game file: /home/triplea/triplea/savedGames/autoSave/Bot303_FRANKFURT_DE_autosave.tsvg, null
Feb 13 19:23:16 bot35_frankfurt_de run_bot.sh: java.io.EOFException
Feb 13 19:23:16 bot35_frankfurt_de run_bot.sh: #011at java.util.zip.GZIPInputStream.readUByte(GZIPInputStream.java:268)
Feb 13 19:23:16 bot35_frankfurt_de run_bot.sh: #011at java.util.zip.GZIPInputStream.readUShort(GZIPInputStream.java:258)
Feb 13 19:23:16 bot35_frankfurt_de run_bot.sh: #011at java.util.zip.GZIPInputStream.readHeader(GZIPInputStream.java:164)
Feb 13 19:23:16 bot35_frankfurt_de run_bot.sh: #011at java.util.zip.GZIPInputStream.<init>(GZIPInputStream.java:79)
Feb 13 19:23:16 bot35_frankfurt_de run_bot.sh: #011at java.util.zip.GZIPInputStream.<init>(GZIPInputStream.java:91)
Feb 13 19:23:16 bot35_frankfurt_de run_bot.sh: #011at games.strategy.engine.framework.GameDataManager.loadGame(GameDataManager.java:75)
Feb 13 19:23:16 bot35_frankfurt_de run_bot.sh: #011at games.strategy.engine.framework.GameDataManager.loadGame(GameDataManager.java:58)
Feb 13 19:23:16 bot35_frankfurt_de run_bot.sh: #011at games.strategy.engine.framework.startup.mc.GameSelectorModel.load(GameSelectorModel.java:81)
Feb 13 19:23:16 bot35_frankfurt_de run_bot.sh: #011at games.strategy.engine.framework.startup.launcher.ServerLauncher.lambda$launchInNewThread$2(ServerLauncher.java:213)
Feb 13 19:23:16 bot35_frankfurt_de run_bot.sh: #011at java.lang.Thread.run(Thread.java:748)
Feb 13 19:23:17 bot35_frankfurt_de run_bot.sh: Feb 13, 2019 7:23:17 PM games.strategy.engine.framework.headlessGameServer.HeadlessGameServer log
Feb 13 19:23:17 bot35_frankfurt_de run_bot.sh: INFO: Game Status: In Progress 
