### PR TITLE
Add slf4j dependency for feign logging

### DIFF
--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -11,6 +11,8 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'com.sparkjava:spark-core:2.8.0'
 
+    runtimeOnly 'org.slf4j:slf4j-simple:1.7.21'
+
     testImplementation project(':test-common')
     testImplementation 'uk.co.datumedge:hamcrest-json:0.2'
 }


### PR DESCRIPTION
## Overview
Adds slf4j dependency to 'http-server', without 'http-client' error logging goes to a no-op logger.

## Functional Changes
- fixes http-server no-op logger: https://github.com/triplea-game/triplea/issues/4675

## Manual Testing Performed
- launched http-server to verify warning message went away.

## Before & After Screen Shots

### Before
Launch http-server:
```
SLF4J: Failed to load class "org.slf4j.impl.StaticLoggerBinder".
SLF4J: Defaulting to no-operation (NOP) logger implementation
SLF4J: See http://www.slf4j.org/codes.html#StaticLoggerBinder for further details.
```


### After
Launch http-server:
```
[Thread-1] INFO org.eclipse.jetty.util.log - Logging initialized @374ms to org.eclipse.jetty.util.log.Slf4jLog
[Thread-1] WARN org.eclipse.jetty.server.AbstractConnector - Ignoring deprecated socket close linger time
[Thread-1] INFO spark.embeddedserver.jetty.EmbeddedJettyServer - == Spark has ignited ...
[Thread-1] INFO spark.embeddedserver.jetty.EmbeddedJettyServer - >> Listening on 0.0.0.0:4567
```