### PR TITLE
Update integration test to not depend on hardcoded version number

### DIFF
--- a/game-core/src/test/java/org/triplea/config/product/ProductConfigurationIntegrationTest.java
+++ b/game-core/src/test/java/org/triplea/config/product/ProductConfigurationIntegrationTest.java
@@ -14,6 +14,6 @@ final class ProductConfigurationIntegrationTest {
   void shouldReadPropertiesFromResource() {
     assertThat(
         productConfiguration.getVersion().getExactVersion(),
-        matchesPattern("1\\.10\\.(@buildId@|dev|\\d+)"));
+        matchesPattern("\\d+\\.\\d+\\.(@buildId@|dev|\\d+)"));
   }
 }


### PR DESCRIPTION
## Overview
It was a surprise to see a test failure after an explicit version
update. This can be fixed by removing the hard-coded "1" and "10"
version numbers from an integration test check and instead just look for
numbers.

## Functional Changes
- none, remove version number dependency in test code.
