### PR TITLE
Simplify: Remove legacy login password

### DIFF
--- a/lobby-db/src/main/resources/db/migration/V1.07__drop_legacy_password.sql
+++ b/lobby-db/src/main/resources/db/migration/V1.07__drop_legacy_password.sql
@@ -1,0 +1,2 @@
+/* 'ta_users.bcrypt_password' column is now used as a replacement. */
+alter table ta_users drop column password;

--- a/lobby/src/main/java/org/triplea/lobby/server/db/HashedPassword.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/HashedPassword.java
@@ -1,66 +1,25 @@
 package org.triplea.lobby.server.db;
 
-import java.util.Objects;
-
-import org.triplea.util.Md5Crypt;
-
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Strings;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 
 /**
  * A Wrapper class for salted password hashes.
  * If the given String is not matching the format of Md5Crypt or BCrypt hashes isValidSyntax returns false.
  */
+@AllArgsConstructor
+@EqualsAndHashCode
 public final class HashedPassword {
   public final String value;
-
-  public HashedPassword(final String hashedPassword) {
-    this.value = Strings.nullToEmpty(hashedPassword);
-  }
 
   /**
    * Returns true if the hashed password looks like it could be a hash.
    */
   public boolean isHashedWithSalt() {
-    return isMd5Crypted() || isBcrypted();
+    return isBcrypted();
   }
 
-  public boolean isBcrypted() {
-    return value.matches("^\\$2a\\$.{56}$");
-  }
-
-  public boolean isMd5Crypted() {
-    return Md5Crypt.isLegalHashedValue(value);
-  }
-
-  /**
-   * Returns the value of this HashedPassword object with all characters replaces with asterisks.
-   */
-  public String mask() {
-    return Strings.repeat("*", value.length());
-  }
-
-  @Override
-  public boolean equals(final Object obj) {
-    if (obj == this) {
-      return true;
-    } else if (!(obj instanceof HashedPassword)) {
-      return false;
-    }
-
-    final HashedPassword other = (HashedPassword) obj;
-    return Objects.equals(value, other.value);
-  }
-
-  @Override
-  public int hashCode() {
-    return Objects.hashCode(value);
-  }
-
-  @Override
-  public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("value", mask())
-        .toString();
+  boolean isBcrypted() {
+    return value != null && value.matches("^\\$2a\\$.{56}$");
   }
 }

--- a/lobby/src/main/java/org/triplea/lobby/server/db/UserDao.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/UserDao.java
@@ -12,11 +12,6 @@ public interface UserDao {
    */
   HashedPassword getPassword(String username);
 
-  /**
-   * Returns null if the user does not exist or the user has no legacy password stored.
-   */
-  HashedPassword getLegacyPassword(String username);
-
   boolean doesUserExist(String username);
 
   void updateUser(DBUser user, HashedPassword password);

--- a/lobby/src/test/java/org/triplea/lobby/server/db/HashedPasswordTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/db/HashedPasswordTest.java
@@ -9,25 +9,23 @@ import org.junit.jupiter.api.Test;
 
 import nl.jqno.equalsverifier.EqualsVerifier;
 
-public class HashedPasswordTest {
+class HashedPasswordTest {
   @Test
-  public void shouldBeEquatableAndHashable() {
+  void shouldBeEquatableAndHashable() {
     EqualsVerifier.forClass(HashedPassword.class).verify();
   }
 
   @Test
-  public void isValidSyntax() {
-    Arrays.asList(
-        "$1$wwmV2glD$J5dZUS3L8DAMUim4wdL/11",
-        "$2a$10$7v.RGs4Aw.cW8Hg1LGINQO/EKf47TAQDClHXkDAzx6HCuakrjBF7.")
-        .forEach(
-            value -> assertThat(
-                "Expecting this to look valid: " + value,
-                new HashedPassword(value).isHashedWithSalt(), is(true)));
+  void isValidSyntax() {
+    final String value = "$2a$10$7v.RGs4Aw.cW8Hg1LGINQO/EKf47TAQDClHXkDAzx6HCuakrjBF7.";
+    assertThat(
+        "Expecting this to look valid: " + value,
+        new HashedPassword(value).isHashedWithSalt(),
+        is(true));
   }
 
   @Test
-  public void isValidSyntaxInvalidCases() {
+  void isValidSyntaxInvalidCases() {
     Arrays.asList(
         "",
         "abc",


### PR DESCRIPTION
## Overview
We have code to support authenticating against either old or new
password columns (old is md5, new is bcrypt). This update drops the old
'password' column code and we use just the new bcrypt password column.


## Functional Changes
- none, we should be migrated to bcrypt entirely by now.  

## Manual Testing Performed
- using a local lobby + DB:
  - created a new account with current master, restarted lobby with this branch and verified could log in
  - created new account with this branch, verified could log in
  - created account with this branch, updated password, verified could log in with the updated password 


Checking on prod DB, we always have a bcrypt_password where we have a password:
```
# select count(*) from ta_users where password is null and bcrypt_password is null
 count 
-------
     0

# select count(*) from ta_users 
 count 
-------
11369
```

## Additional Review Notes
- removed 'mask' function on HashPassword, it was used for logging, we can not log the value at all and thereby not need to mask it.
