### PR TITLE
Remove unused method "isAcceptNewConnections"

### DIFF
--- a/game-core/src/main/java/games/strategy/net/AbstractServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/AbstractServerMessenger.java
@@ -551,11 +551,6 @@ public abstract class AbstractServerMessenger implements IServerMessenger, NioSo
   }
 
   @Override
-  public boolean isAcceptNewConnections() {
-    return acceptNewConnection;
-  }
-
-  @Override
   public INode getLocalNode() {
     return node;
   }

--- a/game-core/src/main/java/games/strategy/net/HeadlessServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/HeadlessServerMessenger.java
@@ -70,11 +70,6 @@ public class HeadlessServerMessenger implements IServerMessenger {
   public void setAcceptNewConnections(final boolean accept) {}
 
   @Override
-  public boolean isAcceptNewConnections() {
-    return false;
-  }
-
-  @Override
   public void setLoginValidator(final ILoginValidator loginValidator) {}
 
   @Override

--- a/game-core/src/main/java/games/strategy/net/IServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/IServerMessenger.java
@@ -13,8 +13,6 @@ import javax.annotation.Nullable;
 public interface IServerMessenger extends IMessenger {
   void setAcceptNewConnections(boolean accept);
 
-  boolean isAcceptNewConnections();
-
   void setLoginValidator(ILoginValidator loginValidator);
 
   ILoginValidator getLoginValidator();


### PR DESCRIPTION
## Overview
It appears that  `acceptNewConnection` the variable is used, but the getter method for it is no longer.


The method was added very long-ago in this context on `TripleAFrame.java`:

3a6587feed24990ea4ec8f7d529e1d9713f488cb

```
 
    /**
     * @param parentMenu
     */
    private void addAllowObserversToJoin(JMenu parentMenu)
    {
        if(!m_game.getMessenger().isServer())
            return;
        
        final IServerMessenger messeneger = (IServerMessenger) m_game.getMessenger();
        
        final JCheckBoxMenuItem allowObservers = new JCheckBoxMenuItem("Allow New Observers");
        allowObservers.setSelected(messeneger.isAcceptNewConnections());
        
        
        allowObservers.addActionListener(new AbstractAction()
        {
            public void actionPerformed(ActionEvent e)
            {
                messeneger.setAcceptNewConnections(allowObservers.isSelected());
            }
        });

        parentMenu.add(allowObservers);
        return;
    }
```


In this commit it was disabled with this commit, removing the one usage that had moved to `BasicGameMenuBar` (later renamed to TripleAMenuBar where you can find this commit: 4d01789)

    // People can use setpassword instead of this.  It is annoying joining a game only to get socket errors that confuse people and stuff. 
    // Either setup a new column or some kind of indicator to show that a lobby game isn't accepting new connections, or keep this off.

Then as part of mass commented code cleanup, I removed the commented out reference here: 3ce3bf4

## Functional Changes
none

