### PR TITLE
Fix Battle Calc Retreat Missing Air Units

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -1388,11 +1388,11 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   @Override
   public List<Unit> getRemainingAttackingUnits() {
     final List<Unit> remaining = new ArrayList<>(attackingUnitsRetreated);
-    if (getWhoWon() != WhoWon.DEFENDER) {
-      final Collection<Unit> unitsLeftInTerritory = battleSite.getUnits();
-      unitsLeftInTerritory.removeAll(killed);
-      remaining.addAll(CollectionUtils.getMatches(unitsLeftInTerritory, Matches.unitOwnedBy(attacker)));
-    }
+    final Collection<Unit> unitsLeftInTerritory = battleSite.getUnits();
+    unitsLeftInTerritory.removeAll(killed);
+    remaining.addAll(CollectionUtils.getMatches(unitsLeftInTerritory, getWhoWon() != WhoWon.DEFENDER
+        ? Matches.unitOwnedBy(attacker)
+        : Matches.unitOwnedBy(attacker).and(Matches.unitIsAir()).and(Matches.unitIsNotInfrastructure())));
     return remaining;
   }
 


### PR DESCRIPTION
## Overview
- Addresses #4708

## Functional Changes
- Add in any remaining non-infra air units to remaining attackers (air units aren't part of the retreating units list) to fix TUV calc when using "retreat after round"

## Manual Testing Performed
- Tested battle calc using retreat on revised, dragon war, and house of hapsburg
