### PR TITLE
Improve: Error reporting user preview and help text

### DIFF
--- a/game-core/src/main/java/games/strategy/debug/error/reporting/ReportPreviewSwingView.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/ReportPreviewSwingView.java
@@ -1,0 +1,25 @@
+package games.strategy.debug.error.reporting;
+
+import java.util.function.Consumer;
+
+import javax.swing.JOptionPane;
+
+import org.triplea.http.client.error.report.create.ErrorReport;
+import org.triplea.swing.JTextAreaBuilder;
+import org.triplea.swing.SwingComponents;
+
+class ReportPreviewSwingView implements Consumer<ErrorReport> {
+  @Override
+  public void accept(final ErrorReport errorReport) {
+    JOptionPane.showMessageDialog(
+        null, SwingComponents.newJScrollPane(
+            JTextAreaBuilder.builder()
+                .columns(45)
+                .rows(12)
+                .readOnly()
+                .text(errorReport.getTitle() + "\n\n" + errorReport.getBody())
+                .build()),
+        "Preview - The Following Data Will Be Uploaded",
+        JOptionPane.INFORMATION_MESSAGE);
+  }
+}

--- a/game-core/src/main/java/games/strategy/debug/error/reporting/StackTraceReportModel.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/StackTraceReportModel.java
@@ -1,6 +1,7 @@
 package games.strategy.debug.error.reporting;
 
 import java.util.function.BiFunction;
+import java.util.function.Consumer;
 import java.util.function.Predicate;
 import java.util.logging.LogRecord;
 
@@ -21,13 +22,23 @@ class StackTraceReportModel {
   private final BiFunction<String, LogRecord, ErrorReport> formatter;
   @Nonnull
   private final Predicate<ErrorReport> uploader;
+  @Nonnull
+  private final Consumer<ErrorReport> preview;
 
   void submitAction() {
-    final ErrorReport data = formatter.apply(view.readUserDescription(), stackTraceRecord);
-    if (uploader.test(data)) {
+    if (uploader.test(readErrorReportFromUi())) {
       view.close();
     }
   }
+
+  private ErrorReport readErrorReportFromUi() {
+    return formatter.apply(view.readUserDescription(), stackTraceRecord);
+  }
+
+  void previewAction() {
+    preview.accept(readErrorReportFromUi());
+  }
+
 
   void cancelAction() {
     view.close();

--- a/game-core/src/main/java/games/strategy/debug/error/reporting/StackTraceReportSwingView.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/StackTraceReportSwingView.java
@@ -3,8 +3,10 @@ package games.strategy.debug.error.reporting;
 import java.awt.Component;
 
 import javax.annotation.Nullable;
+import javax.swing.Box;
 import javax.swing.JButton;
 import javax.swing.JFrame;
+import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextArea;
 
@@ -16,12 +18,11 @@ import org.triplea.swing.JTextAreaBuilder;
 
 class StackTraceReportSwingView implements StackTraceReportView {
 
-  private static final String TOOL_TIP =
-      "<html>This information is used by the TripleA support team to help pinpoint<br/>"
-          + "and solve the error that occurred.  Please describe the sequence of actions and<br/>"
-          + "game events leading up to the error and include any additional information that would<br/>"
-          + "be helpful for TripleA support to solve this problem.<br/><br/>"
-          + "For example: \"Game crashed during combat after rolling dice for defending subs.\"";
+  private static final String HELP_TEXT =
+      "<html>Any data entered is optional, please use<br/>"
+          + "this form to help TripleA support know<br/>"
+          + "where and how the error occurred.<br/><br/>"
+          + "Uploaded data is publicly visible.";
 
   private final JFrame window = JFrameBuilder.builder()
       .title("Upload Error Report to TripleA Support")
@@ -31,13 +32,18 @@ class StackTraceReportSwingView implements StackTraceReportView {
       .build();
 
   private final JTextArea userDescriptionField = JTextAreaBuilder.builder()
-      .toolTip(TOOL_TIP)
+      .toolTip(HELP_TEXT)
       .build();
 
   private final JButton submitButton = JButtonBuilder.builder()
       .title("Upload")
       .biggerFont()
       .toolTip("Uploads error report to TripleA support")
+      .build();
+
+  private final JButton previewButton = JButtonBuilder.builder()
+      .title("Preview")
+      .toolTip("Shows a preview of the error report")
       .build();
 
   private final JButton cancelButton = JButtonBuilder.builder()
@@ -49,12 +55,25 @@ class StackTraceReportSwingView implements StackTraceReportView {
     window.setLocationRelativeTo(parentWindow);
     window.getContentPane()
         .add(JPanelBuilder.builder()
-            .addNorth(JLabelBuilder.builder()
-                .border(5)
-                .html("Please describe when and where the error happened:<br/>"
-                    + "(Error message details will be included automatically in the upload)")
-                .toolTip(TOOL_TIP)
-                .build())
+            .addNorth(
+                JPanelBuilder.builder()
+                    .addWest(
+                        JLabelBuilder.builder()
+                            .border(5)
+                            .html("Please describe the error and where it happened:")
+                            .toolTip(HELP_TEXT)
+                            .build())
+                    .addEast(
+                        JPanelBuilder.builder()
+                            .add(
+                                JButtonBuilder.builder()
+                                    .title("(?)")
+                                    .actionListener(() -> JOptionPane.showMessageDialog(
+                                        window,
+                                        HELP_TEXT))
+                                    .build())
+                            .build())
+                    .build())
             .addCenter(userDescriptionField)
             .addSouth(buttonPanel())
             .build());
@@ -65,11 +84,19 @@ class StackTraceReportSwingView implements StackTraceReportView {
         .border(10)
         .add(
             JPanelBuilder.builder()
-                .borderLayout()
-                .addHorizontalStrut(10)
-                .addWest(submitButton)
-                .addHorizontalStrut(30)
-                .addEast(cancelButton)
+                .addWest(
+                    JPanelBuilder.builder()
+                        .horizontalBoxLayout()
+                        .add(submitButton)
+                        .add(Box.createHorizontalStrut(30))
+                        .add(previewButton)
+                        .build())
+                .addEast(
+                    JPanelBuilder.builder()
+                        .horizontalBoxLayout()
+                        .add(Box.createHorizontalStrut(70))
+                        .add(cancelButton)
+                        .build())
                 .build())
         .build();
   }
@@ -77,6 +104,7 @@ class StackTraceReportSwingView implements StackTraceReportView {
   @Override
   public void bindActions(final StackTraceReportModel viewModel) {
     submitButton.addActionListener(e -> viewModel.submitAction());
+    previewButton.addActionListener(e -> viewModel.previewAction());
     cancelButton.addActionListener(e -> viewModel.cancelAction());
   }
 

--- a/game-core/src/main/java/games/strategy/debug/error/reporting/StackTraceReportView.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/StackTraceReportView.java
@@ -57,6 +57,7 @@ public interface StackTraceReportView {
                 .successConfirmation(ConfirmationDialogController::showSuccessConfirmation)
                 .failureConfirmation(ConfirmationDialogController::showFailureConfirmation)
                 .build())
+        .preview(new ReportPreviewSwingView())
         .build();
 
     window.bindActions(viewModel);

--- a/swing-lib/src/main/java/org/triplea/swing/JPanelBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/JPanelBuilder.java
@@ -165,7 +165,7 @@ public class JPanelBuilder {
   /**
    * Toggles a border layout, adds a given component to the 'north' portion of the border layout.
    */
-  public JPanelBuilder addNorth(final JComponent child) {
+  public JPanelBuilder addNorth(final Component child) {
     layout = new BorderLayout();
     Preconditions.checkNotNull(child);
     panelComponents.add(new PanelComponent(child, new PanelProperties(BorderLayoutPosition.NORTH)));
@@ -175,7 +175,7 @@ public class JPanelBuilder {
   /**
    * Toggles a border layout, adds a given component to the 'east' portion of the border layout.
    */
-  public JPanelBuilder addEast(final JComponent child) {
+  public JPanelBuilder addEast(final Component child) {
     layout = new BorderLayout();
     Preconditions.checkNotNull(child);
     panelComponents.add(new PanelComponent(child, new PanelProperties(BorderLayoutPosition.EAST)));
@@ -185,7 +185,7 @@ public class JPanelBuilder {
   /**
    * Toggles a border layout, adds a given component to the 'west' portion of the border layout.
    */
-  public JPanelBuilder addWest(final JComponent child) {
+  public JPanelBuilder addWest(final Component child) {
     layout = new BorderLayout();
     Preconditions.checkNotNull(child);
     panelComponents.add(new PanelComponent(child, new PanelProperties(BorderLayoutPosition.WEST)));
@@ -195,7 +195,7 @@ public class JPanelBuilder {
   /**
    * Toggles a border layout, adds a given component to the 'center' portion of the border layout.
    */
-  public JPanelBuilder addCenter(final JComponent child) {
+  public JPanelBuilder addCenter(final Component child) {
     layout = new BorderLayout();
     panelComponents.add(new PanelComponent(child, new PanelProperties(BorderLayoutPosition.CENTER)));
     return this;


### PR DESCRIPTION
## Overview
- Add a preview button that displays a preview of the data that would be uploaded. This way a user can verify/confirm data before uploading.
- Improve help text to be a bit less wordy. Probably could still use some improvements.
- Add a '(?)' button to display the help text without relying on mouse-hover tool tip text.


## Functional Changes
- New UI elements to error reporting window (displayed when there is an error message and user clicks 'send to TripleA'

## Manual Testing Performed
- Injected an exception on game startup to preview the windows

## Before & After Screen Shots

### Before
![screenshot from 2019-02-25 08-57-44](https://user-images.githubusercontent.com/12397753/53354362-72692f00-38db-11e9-982b-89448a85bfa4.png)

### After
Example of report window, note the new '(?)' button in top right, the updated tooltip text, and the new  'preview' button next to the send button:
![screenshot from 2019-02-25 08-50-23](https://user-images.githubusercontent.com/12397753/53354173-1bfbf080-38db-11e9-928e-c65e3cb96a3b.png)

Example of clicking on the '(?)' button
![screenshot from 2019-02-25 08-50-28](https://user-images.githubusercontent.com/12397753/53354174-1bfbf080-38db-11e9-9288-8133fc741dd0.png)

Example of clicking on the preview button:
![screenshot from 2019-02-25 08-50-43](https://user-images.githubusercontent.com/12397753/53354175-1bfbf080-38db-11e9-8e72-bfb9cb209882.png)


## Additional Review Notes
- Certainly could use recommendation on any of the text, if and/or how it can be improved
- Should be a pretty straight-forward update where some new functionality is added

- Follows up on https://github.com/triplea-game/triplea/pull/4687#issuecomment-464543991 (cc: @tvleavitt)

