### PR TITLE
NIO Cleanup Refactoring

### DIFF
--- a/game-core/src/main/java/games/strategy/net/AbstractServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/AbstractServerMessenger.java
@@ -77,7 +77,7 @@ public abstract class AbstractServerMessenger implements IServerMessenger, NioSo
     socketChannel.socket().setReuseAddress(true);
     socketChannel.socket().bind(new InetSocketAddress(port), 10);
     final int boundPort = socketChannel.socket().getLocalPort();
-    nioSocket = new NioSocket(objectStreamFactory, this, "Server");
+    nioSocket = new NioSocket(objectStreamFactory, this);
     acceptorSelector = Selector.open();
     node = new Node(name, IpFinder.findInetAddress(), boundPort);
     new Thread(new ConnectionHandler(), "Server Messenger Connection Handler").start();
@@ -138,12 +138,6 @@ public abstract class AbstractServerMessenger implements IServerMessenger, NioSo
       return;
     }
     nioSocket.send(socketChannel, new MessageHeader(to, node, msg));
-  }
-
-  @Override
-  public void broadcast(final Serializable msg) {
-    final MessageHeader header = new MessageHeader(node, msg);
-    forwardBroadcast(header);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/net/AbstractServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/AbstractServerMessenger.java
@@ -332,10 +332,10 @@ public abstract class AbstractServerMessenger implements IServerMessenger, NioSo
         }
       }
     }
-    if (msg.getFor() == null) {
+    if (msg.getTo() == null) {
       forwardBroadcast(msg);
       notifyListeners(msg);
-    } else if (msg.getFor().equals(node)) {
+    } else if (msg.getTo().equals(node)) {
       notifyListeners(msg);
     } else {
       forward(msg);
@@ -451,9 +451,9 @@ public abstract class AbstractServerMessenger implements IServerMessenger, NioSo
     if (shutdown) {
       return;
     }
-    final SocketChannel socketChannel = nodeToChannel.get(msg.getFor());
+    final SocketChannel socketChannel = nodeToChannel.get(msg.getTo());
     if (socketChannel == null) {
-      throw new IllegalStateException("No channel for:" + msg.getFor());
+      throw new IllegalStateException("No channel for:" + msg.getTo());
     }
     nioSocket.send(socketChannel, msg);
   }

--- a/game-core/src/main/java/games/strategy/net/ClientMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ClientMessenger.java
@@ -181,7 +181,7 @@ public class ClientMessenger implements IClientMessenger, NioSocketListener {
 
   @Override
   public void messageReceived(final MessageHeader msg, final SocketChannel channel) {
-    if (msg.getFor() != null && !msg.getFor().equals(node)) {
+    if (msg.getTo() != null && !msg.getTo().equals(node)) {
       throw new IllegalStateException("msg not for me:" + msg);
     }
     for (final IMessageListener listener : listeners) {

--- a/game-core/src/main/java/games/strategy/net/ClientMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ClientMessenger.java
@@ -104,7 +104,7 @@ public class ClientMessenger implements IClientMessenger, NioSocketListener {
     }
     final Socket socket = socketChannel.socket();
     socket.setKeepAlive(true);
-    nioSocket = new NioSocket(streamFact, this, name);
+    nioSocket = new NioSocket(streamFact, this);
     final ClientQuarantineConversation conversation =
         new ClientQuarantineConversation(login, socketChannel, nioSocket, name, mac);
     nioSocket.add(socketChannel, conversation);
@@ -143,12 +143,6 @@ public class ClientMessenger implements IClientMessenger, NioSocketListener {
   public synchronized void send(final Serializable msg, final INode to) {
     // use our nodes address, this is our network visible address
     final MessageHeader header = new MessageHeader(to, node, msg);
-    nioSocket.send(socketChannel, header);
-  }
-
-  @Override
-  public synchronized void broadcast(final Serializable msg) {
-    final MessageHeader header = new MessageHeader(node, msg);
     nioSocket.send(socketChannel, header);
   }
 

--- a/game-core/src/main/java/games/strategy/net/HeadlessServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/HeadlessServerMessenger.java
@@ -27,9 +27,6 @@ public class HeadlessServerMessenger implements IServerMessenger {
   public void send(final Serializable msg, final INode to) {}
 
   @Override
-  public void broadcast(final Serializable msg) {}
-
-  @Override
   public void addMessageListener(final IMessageListener listener) {}
 
   @Override

--- a/game-core/src/main/java/games/strategy/net/IMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/IMessenger.java
@@ -17,11 +17,6 @@ public interface IMessenger {
   void send(Serializable msg, INode to);
 
   /**
-   * Send a message to all nodes.
-   */
-  void broadcast(Serializable msg);
-
-  /**
    * Listen for messages.
    */
   void addMessageListener(IMessageListener listener);

--- a/game-core/src/main/java/games/strategy/net/MessageHeader.java
+++ b/game-core/src/main/java/games/strategy/net/MessageHeader.java
@@ -2,44 +2,23 @@ package games.strategy.net;
 
 import java.io.Serializable;
 
+import javax.annotation.Nullable;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
 /**
  * The envelope for a message consisting of both the header and payload. The header specifies the source and
  * destination nodes of the message.
  */
+@Getter
+@AllArgsConstructor
 public class MessageHeader {
-  // if null, then a broadcast
+  // to can be null if we are a broadcast
+  @Nullable
   private final INode to;
   private final Serializable message;
+  // from can be null if the sending node doesnt know its own address
+  @Nullable
   private final INode from;
-
-  /**
-   * Creates a broadcast message.
-   */
-  public MessageHeader(final INode to, final INode from, final Serializable message) {
-    // for can be null if we are a broadcast
-    this.to = to;
-    // from can be null if the sending node doesnt know its own address
-    this.from = from;
-    this.message = message;
-  }
-
-  /**
-   * null if a broadcast.
-   */
-  public INode getFor() {
-    return to;
-  }
-
-  public INode getFrom() {
-    return from;
-  }
-
-  public Serializable getMessage() {
-    return message;
-  }
-
-  @Override
-  public String toString() {
-    return "Message header. msg:" + message + " to:" + to + " from:" + from;
-  }
 }

--- a/game-core/src/main/java/games/strategy/net/MessageHeader.java
+++ b/game-core/src/main/java/games/strategy/net/MessageHeader.java
@@ -17,8 +17,8 @@ public class MessageHeader {
   // to can be null if we are a broadcast
   @Nullable
   private final INode to;
-  private final Serializable message;
   // from can be null if the sending node doesnt know its own address
   @Nullable
   private final INode from;
+  private final Serializable message;
 }

--- a/game-core/src/main/java/games/strategy/net/MessageHeader.java
+++ b/game-core/src/main/java/games/strategy/net/MessageHeader.java
@@ -15,10 +15,6 @@ public class MessageHeader {
   /**
    * Creates a broadcast message.
    */
-  public MessageHeader(final INode from, final Serializable message) {
-    this(null, from, message);
-  }
-
   public MessageHeader(final INode to, final INode from, final Serializable message) {
     // for can be null if we are a broadcast
     this.to = to;

--- a/game-core/src/main/java/games/strategy/net/nio/Decoder.java
+++ b/game-core/src/main/java/games/strategy/net/nio/Decoder.java
@@ -41,12 +41,12 @@ class Decoder {
   private final Thread thread;
 
   Decoder(final NioSocket nioSocket, final NioReader reader, final ErrorReporter reporter,
-      final IObjectStreamFactory objectStreamFactory, final String threadSuffix) {
+      final IObjectStreamFactory objectStreamFactory) {
     this.reader = reader;
     errorReporter = reporter;
     this.objectStreamFactory = objectStreamFactory;
     this.nioSocket = nioSocket;
-    thread = new Thread(this::loop, "Decoder -" + threadSuffix);
+    thread = new Thread(this::loop, "Decoder");
     thread.start();
   }
 
@@ -190,7 +190,7 @@ class Decoder {
     quarantine.put(channel, conversation);
   }
 
-  void closed(final SocketChannel channel) {
+  void close(final SocketChannel channel) {
     // remove if it exists
     final QuarantineConversation conversation = quarantine.remove(channel);
     if (conversation != null) {

--- a/game-core/src/main/java/games/strategy/net/nio/Encoder.java
+++ b/game-core/src/main/java/games/strategy/net/nio/Encoder.java
@@ -50,18 +50,18 @@ class Encoder {
       throw new IllegalArgumentException("null from");
     }
     // a broadcast
-    if (header.getFor() == null) {
+    if (header.getTo() == null) {
       out.write(1);
     } else {
       // to a node
       out.write(0);
       // the common case, skip writing the address
-      if (header.getFor().equals(nioSocket.getRemoteNode(remote))) {
+      if (header.getTo().equals(nioSocket.getRemoteNode(remote))) {
         out.write(1);
       } else {
         // this message is going to be relayed, write the destination
         out.write(0);
-        ((Node) header.getFor()).writeExternal(out);
+        ((Node) header.getTo()).writeExternal(out);
       }
     }
     if (header.getFrom().equals(nioSocket.getLocalNode())) {

--- a/game-core/src/main/java/games/strategy/net/nio/NioReader.java
+++ b/game-core/src/main/java/games/strategy/net/nio/NioReader.java
@@ -1,8 +1,6 @@
 package games.strategy.net.nio;
 
 import java.io.IOException;
-import java.net.Socket;
-import java.net.SocketAddress;
 import java.net.SocketException;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SelectionKey;
@@ -33,7 +31,6 @@ class NioReader {
   private final Selector selector;
   private final Object socketsToAddMutex = new Object();
   private final List<SocketChannel> socketsToAdd = new ArrayList<>();
-  private long totalBytes;
 
   NioReader(final ErrorReporter reporter) {
     errorReporter = reporter;
@@ -100,10 +97,6 @@ class NioReader {
             try {
               final boolean done = packet.read(channel);
               if (done) {
-                totalBytes += packet.size();
-                if (log.isLoggable(Level.FINE)) {
-                  logNetwork(channel, packet);
-                }
                 enque(packet);
               }
             } catch (final Exception e) {
@@ -122,20 +115,6 @@ class NioReader {
         log.log(Level.SEVERE, "error in reader", e);
       }
     }
-  }
-
-  private void logNetwork(final SocketChannel channel, final SocketReadData packet) {
-    final Socket s = channel.socket();
-    SocketAddress sa = null;
-    if (s != null) {
-      sa = s.getRemoteSocketAddress();
-    }
-    String remote = "null";
-    if (sa != null) {
-      remote = sa.toString();
-    }
-    log.fine(" done reading from:" + remote + " size:" + packet.size() + " readCalls;"
-        + packet.getReadCalls() + " total:" + totalBytes);
   }
 
   private void enque(final SocketReadData packet) {

--- a/game-core/src/main/java/games/strategy/net/nio/NioSocket.java
+++ b/game-core/src/main/java/games/strategy/net/nio/NioSocket.java
@@ -26,11 +26,11 @@ public class NioSocket implements ErrorReporter {
   private final NioReader reader;
   private final NioSocketListener listener;
 
-  public NioSocket(final IObjectStreamFactory factory, final NioSocketListener listener, final String name) {
+  public NioSocket(final IObjectStreamFactory factory, final NioSocketListener listener) {
     this.listener = listener;
-    writer = new NioWriter(this, name);
-    reader = new NioReader(this, name);
-    decoder = new Decoder(this, reader, this, factory, name);
+    writer = new NioWriter(this);
+    reader = new NioReader(this);
+    decoder = new Decoder(this, reader, this, factory);
     encoder = new Encoder(this, writer, factory);
   }
 
@@ -107,9 +107,9 @@ public class NioSocket implements ErrorReporter {
     } catch (final IOException e1) {
       log.log(Level.FINE, "error closing channel", e1);
     }
-    decoder.closed(channel);
-    writer.closed(channel);
-    reader.closed(channel);
+    decoder.close(channel);
+    writer.close(channel);
+    reader.close(channel);
   }
 
   void messageReceived(final MessageHeader header, final SocketChannel channel) {

--- a/game-core/src/main/java/games/strategy/net/nio/NioWriter.java
+++ b/game-core/src/main/java/games/strategy/net/nio/NioWriter.java
@@ -35,7 +35,7 @@ class NioWriter {
   private long totalBytes = 0;
   private volatile boolean running = true;
 
-  NioWriter(final ErrorReporter reporter, final String threadSuffix) {
+  NioWriter(final ErrorReporter reporter) {
     errorReporter = reporter;
     try {
       selector = Selector.open();
@@ -43,7 +43,7 @@ class NioWriter {
       log.log(Level.SEVERE, "Could not create Selector", e);
       throw new IllegalStateException(e);
     }
-    new Thread(this::loop, "NIO Writer - " + threadSuffix).start();
+    new Thread(this::loop, "NIO Writer").start();
   }
 
   void shutDown() {
@@ -135,7 +135,7 @@ class NioWriter {
   /**
    * Remove the data for this channel.
    */
-  void closed(final SocketChannel channel) {
+  void close(final SocketChannel channel) {
     removeAll(channel);
   }
 

--- a/game-core/src/main/java/games/strategy/net/nio/SocketReadData.java
+++ b/game-core/src/main/java/games/strategy/net/nio/SocketReadData.java
@@ -3,8 +3,8 @@ package games.strategy.net.nio;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.SocketChannel;
-import java.util.concurrent.atomic.AtomicInteger;
 
+import lombok.Getter;
 import lombok.extern.java.Log;
 
 /**
@@ -16,19 +16,19 @@ import lombok.extern.java.Log;
  */
 @Log
 class SocketReadData {
-  public static final int MAX_MESSAGE_SIZE = 1000 * 1000 * 10;
+  static final int MAX_MESSAGE_SIZE = 1000 * 1000 * 10;
   // as a sanity check to make sure we are talking to another triplea instance
   // that the upper bits of the packet size we send is 0x9b
-  public static final int MAGIC = 0x9b000000;
-  private static final AtomicInteger counter = new AtomicInteger();
+  static final int MAGIC = 0x9b000000;
 
   private int targetSize = -1;
   // we read into here the first four bytes to find out size
   private ByteBuffer sizeBuffer;
   // we read into here after knowing out size
   private ByteBuffer contentBuffer;
+  @Getter
   private final SocketChannel channel;
-  private final int number = counter.incrementAndGet();
+  @Getter
   private int readCalls;
 
   SocketReadData(final SocketChannel channel) {
@@ -84,10 +84,6 @@ class SocketReadData {
     return !contentBuffer.hasRemaining();
   }
 
-  public SocketChannel getChannel() {
-    return channel;
-  }
-
   /**
    * Get the data as a byte[].
    * This method can only be called once.
@@ -103,14 +99,5 @@ class SocketReadData {
   public int size() {
     // add 4 to count the bytes used to send our size
     return targetSize + 4;
-  }
-
-  public int getReadCalls() {
-    return readCalls;
-  }
-
-  @Override
-  public String toString() {
-    return "<id:" + number + " size:" + targetSize + ">";
   }
 }


### PR DESCRIPTION
## Overview
- Remove unused constructor
- Replace methods with equivalent lombok annotation
- Move logging of socket data to clear up high level flow.
- Rename method 'closed' -> 'close'
- Simplify: Remove threadSuffix name parameter
- Remove 'broadcast' method called in test-only


