### PR TITLE
Simplify Network Serialization of MessageHeader

### DIFF
--- a/game-core/src/main/java/games/strategy/net/MessageHeader.java
+++ b/game-core/src/main/java/games/strategy/net/MessageHeader.java
@@ -13,7 +13,8 @@ import lombok.Getter;
  */
 @Getter
 @AllArgsConstructor
-public class MessageHeader {
+public class MessageHeader implements Serializable {
+  private static final long serialVersionUID = -2854966142411168305L;
   // to can be null if we are a broadcast
   @Nullable
   private final INode to;

--- a/game-core/src/main/java/games/strategy/net/nio/Decoder.java
+++ b/game-core/src/main/java/games/strategy/net/nio/Decoder.java
@@ -1,24 +1,15 @@
 package games.strategy.net.nio;
 
-import java.io.Externalizable;
 import java.io.IOException;
-import java.io.ObjectInputStream;
-import java.io.Serializable;
 import java.net.Socket;
 import java.nio.channels.SocketChannel;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 
-import games.strategy.engine.message.HubInvocationResults;
-import games.strategy.engine.message.HubInvoke;
-import games.strategy.engine.message.SpokeInvocationResults;
-import games.strategy.engine.message.SpokeInvoke;
 import games.strategy.io.IoUtils;
 import games.strategy.net.CouldNotLogInException;
-import games.strategy.net.INode;
 import games.strategy.net.IObjectStreamFactory;
 import games.strategy.net.MessageHeader;
-import games.strategy.net.Node;
 import games.strategy.net.nio.QuarantineConversation.Action;
 import lombok.extern.java.Log;
 
@@ -66,7 +57,7 @@ class Decoder {
         try {
           final MessageHeader header = IoUtils.readFromMemory(data.getData(), is -> {
             try {
-              return readMessageHeader(data.getChannel(), objectStreamFactory.create(is));
+              return (MessageHeader) objectStreamFactory.create(is).readObject();
             } catch (final ClassNotFoundException e) {
               throw new IOException(e);
             }
@@ -115,75 +106,6 @@ class Decoder {
       nioSocket.unquarantine(channel, conversation);
       quarantine.remove(channel);
     }
-  }
-
-  private MessageHeader readMessageHeader(final SocketChannel channel, final ObjectInputStream objectInput)
-      throws IOException, ClassNotFoundException {
-    final INode to;
-    if (objectInput.read() == 1) {
-      to = null;
-    } else {
-      if (objectInput.read() == 1) {
-        // this may be null if we have not yet fully joined the network
-        to = nioSocket.getLocalNode();
-      } else {
-        to = new Node();
-        ((Node) to).readExternal(objectInput);
-      }
-    }
-    final INode from;
-    final int readMark = objectInput.read();
-    if (readMark == 1) {
-      from = nioSocket.getRemoteNode(channel);
-    } else if (readMark == 2) {
-      from = null;
-    } else {
-      from = new Node();
-      ((Node) from).readExternal(objectInput);
-    }
-    final Serializable message;
-    final byte type = (byte) objectInput.read();
-    if (type != Byte.MAX_VALUE) {
-      final Externalizable template = getTemplate(type);
-      template.readExternal(objectInput);
-      message = template;
-    } else {
-      message = (Serializable) objectInput.readObject();
-    }
-    return new MessageHeader(to, from, message);
-  }
-
-  private static Externalizable getTemplate(final byte type) {
-    switch (type) {
-      case 1:
-        return new HubInvoke();
-      case 2:
-        return new SpokeInvoke();
-      case 3:
-        return new HubInvocationResults();
-      case 4:
-        return new SpokeInvocationResults();
-      default:
-        throw new IllegalStateException("not recognized, " + type);
-    }
-  }
-
-  /**
-   * Most messages we pass will be one of the types below.
-   * Since each of these is externalizable, we can reduce network traffic considerably by skipping the writing of the
-   * full identifiers, and simply write a single byte to show the type.
-   */
-  static byte getType(final Object msg) {
-    if (msg instanceof HubInvoke) {
-      return 1;
-    } else if (msg instanceof SpokeInvoke) {
-      return 2;
-    } else if (msg instanceof HubInvocationResults) {
-      return 3;
-    } else if (msg instanceof SpokeInvocationResults) {
-      return 4;
-    }
-    return Byte.MAX_VALUE;
   }
 
   void add(final SocketChannel channel, final QuarantineConversation conversation) {

--- a/game-core/src/main/java/games/strategy/net/nio/Encoder.java
+++ b/game-core/src/main/java/games/strategy/net/nio/Encoder.java
@@ -2,32 +2,27 @@ package games.strategy.net.nio;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.io.Externalizable;
 import java.io.IOException;
 import java.io.ObjectOutputStream;
 import java.nio.channels.SocketChannel;
 import java.util.logging.Level;
 
+import com.google.common.base.Preconditions;
+
 import games.strategy.io.IoUtils;
 import games.strategy.net.IObjectStreamFactory;
 import games.strategy.net.MessageHeader;
-import games.strategy.net.Node;
+import lombok.AllArgsConstructor;
 import lombok.extern.java.Log;
 
 /**
  * Encodes data to be written by a writer.
  */
 @Log
+@AllArgsConstructor
 class Encoder {
   private final NioWriter writer;
   private final IObjectStreamFactory objectStreamFactory;
-  private final NioSocket nioSocket;
-
-  Encoder(final NioSocket nioSocket, final NioWriter writer, final IObjectStreamFactory objectStreamFactory) {
-    this.nioSocket = nioSocket;
-    this.writer = writer;
-    this.objectStreamFactory = objectStreamFactory;
-  }
 
   void write(final SocketChannel to, final MessageHeader header) {
     checkNotNull(to);
@@ -35,7 +30,7 @@ class Encoder {
       throw new IllegalArgumentException("No from node");
     }
     try {
-      final byte[] bytes = IoUtils.writeToMemory(os -> write(header, objectStreamFactory.create(os), to));
+      final byte[] bytes = IoUtils.writeToMemory(os -> write(header, objectStreamFactory.create(os)));
       final SocketWriteData data = new SocketWriteData(bytes, bytes.length);
       writer.enque(data, to);
     } catch (final IOException e) {
@@ -44,41 +39,9 @@ class Encoder {
     }
   }
 
-  private void write(final MessageHeader header, final ObjectOutputStream out, final SocketChannel remote)
-      throws IOException {
-    if (header.getFrom() == null) {
-      throw new IllegalArgumentException("null from");
-    }
-    // a broadcast
-    if (header.getTo() == null) {
-      out.write(1);
-    } else {
-      // to a node
-      out.write(0);
-      // the common case, skip writing the address
-      if (header.getTo().equals(nioSocket.getRemoteNode(remote))) {
-        out.write(1);
-      } else {
-        // this message is going to be relayed, write the destination
-        out.write(0);
-        ((Node) header.getTo()).writeExternal(out);
-      }
-    }
-    if (header.getFrom().equals(nioSocket.getLocalNode())) {
-      out.write(1);
-    } else if (nioSocket.getLocalNode() == null) {
-      out.write(2);
-    } else {
-      out.write(0);
-      ((Node) header.getFrom()).writeExternal(out);
-    }
-    final byte type = Decoder.getType(header.getMessage());
-    out.write(type);
-    if (type != Byte.MAX_VALUE) {
-      ((Externalizable) header.getMessage()).writeExternal(out);
-    } else {
-      out.writeObject(header.getMessage());
-    }
+  private void write(final MessageHeader header, final ObjectOutputStream out) throws IOException {
+    Preconditions.checkNotNull(header.getFrom());
+    out.writeObject(header);
     out.reset();
   }
 }

--- a/game-core/src/main/java/games/strategy/net/nio/NioSocket.java
+++ b/game-core/src/main/java/games/strategy/net/nio/NioSocket.java
@@ -31,7 +31,7 @@ public class NioSocket implements ErrorReporter {
     writer = new NioWriter(this);
     reader = new NioReader(this);
     decoder = new Decoder(this, reader, this, factory);
-    encoder = new Encoder(this, writer, factory);
+    encoder = new Encoder(writer, factory);
   }
 
   INode getLocalNode() {


### PR DESCRIPTION
## Overview
This is a simplification where we serialize the MessageHeader object directly rather than serialize its components to reconstruct it. This removes custom network efficiency code in favor of simpler code.

## Manual Testing Performed
- launched two local games, one hosted, the other connected, started a game, chatted
- launched a local lobby, launched bot, launched 2 headed game clients and started a network game on the local bot. Checked chat that it worked both in game and lobby.

## Additional Review Notes
- This update is to a pretty deep part of networking
- `INode` is `Serializable`