### PR TITLE
Remove gitter notification webhook

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,10 +48,3 @@ deploy:
     condition: "$TRIPLEA_RELEASE = true"
     repo: triplea-game/triplea
     branch: master
-notifications:
-  webhooks:
-    urls:
-      - "https://webhooks.gitter.im/e/1b12bfcd765b19e2d59d"
-    on_success: always  # options: [always|never|change] default: always
-    on_failure: always  # options: [always|never|change] default: always
-    on_start: never     # options: [always|never|change] default: always


### PR DESCRIPTION
## Overview

We have these notifications heading to a gitter room, the notifications look nice but there are quite a lot of them and nobody seems to have a use for them. To reduce gitter footprint, let's turn this feed off.



## Additional Review Notes

After merge will drop the gitter room that this is connected to: https://gitter.im/triplea-game/travis-build