### PR TITLE
Update Feature: No time duration when banning on remote

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/network/ui/BanPlayerAction.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/network/ui/BanPlayerAction.java
@@ -51,9 +51,9 @@ public class BanPlayerAction extends AbstractAction {
         final String realName = IServerMessenger.getRealName(node.getName());
         final String ip = node.getAddress().getHostAddress();
         final String mac = messenger.getPlayerMac(node.getName());
-        messenger.notifyUsernameMiniBanningOfPlayer(realName, null);
-        messenger.notifyIpMiniBanningOfPlayer(ip, null);
-        messenger.notifyMacMiniBanningOfPlayer(mac, null);
+        messenger.notifyUsernameMiniBanningOfPlayer(realName);
+        messenger.notifyIpMiniBanningOfPlayer(ip);
+        messenger.notifyMacMiniBanningOfPlayer(mac);
         messenger.removeConnection(node);
         return;
       }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/RemoteHostUtils.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/RemoteHostUtils.java
@@ -77,8 +77,10 @@ final class RemoteHostUtils implements IRemoteHostUtils {
   }
 
   @Override
-  public String banPlayerHeadlessHostBot(final String playerNameToBeBanned, final int hours,
-      final String hashedPassword, final String salt) {
+  public String banPlayerHeadlessHostBot(
+      final String playerNameToBeBanned,
+      final String hashedPassword,
+      final String salt) {
     if (!MessageContext.getSender().equals(serverNode)) {
       return "Not accepted!";
     }
@@ -86,7 +88,7 @@ final class RemoteHostUtils implements IRemoteHostUtils {
     if (instance == null) {
       return "Not a headless host bot!";
     }
-    return instance.remoteBanPlayer(playerNameToBeBanned, hours, hashedPassword, salt);
+    return instance.remoteBanPlayer(playerNameToBeBanned, hashedPassword, salt);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -363,7 +363,7 @@ class LobbyGamePanel extends JPanel {
     final String response =
         controller.mutePlayerHeadlessHostBot(lobbyWatcherNode, playerToBeMuted, min, hashedPassword, salt);
     JOptionPane.showMessageDialog(null, (response == null
-        ? "Successfully attempted to mute player (" + playerToBeMuted + ") on host"
+        ? "Successfully muted player (" + playerToBeMuted + ") on host"
         : "Failed: " + response));
   }
 
@@ -423,18 +423,6 @@ class LobbyGamePanel extends JPanel {
     if (playerToBeBanned == null) {
       return;
     }
-    final Object hours = JOptionPane.showInputDialog(getTopLevelAncestor(),
-        "Hours to Ban for?  (between 0 and 720, this is permanent and only a restart of the host will undo it!)",
-        "Hours to Ban for?", JOptionPane.QUESTION_MESSAGE, null, null, 24);
-    if (hours == null) {
-      return;
-    }
-    final int hrs;
-    try {
-      hrs = Math.max(0, Math.min(24 * 30, Integer.parseInt((String) hours)));
-    } catch (final NumberFormatException e) {
-      return;
-    }
     final INode lobbyWatcherNode = getLobbyWatcherNodeForTableRow(selectedIndex);
     final IModeratorController controller =
         (IModeratorController) messengers.getRemote(IModeratorController.REMOTE_NAME);
@@ -453,9 +441,9 @@ class LobbyGamePanel extends JPanel {
     final String salt = controller.getHeadlessHostBotSalt(lobbyWatcherNode);
     final String hashedPassword = hashPassword(password, salt);
     final String response =
-        controller.banPlayerHeadlessHostBot(lobbyWatcherNode, playerToBeBanned, hrs, hashedPassword, salt);
+        controller.banPlayerHeadlessHostBot(lobbyWatcherNode, playerToBeBanned, hashedPassword, salt);
     JOptionPane.showMessageDialog(null, (response == null
-        ? "Successfully attempted banned player (" + playerToBeBanned + ") on host"
+        ? "Successfully banned player (" + playerToBeBanned + ") on host"
         : "Failed: " + response));
   }
 
@@ -489,7 +477,7 @@ class LobbyGamePanel extends JPanel {
     final String hashedPassword = hashPassword(password, salt);
     final String response = controller.stopGameHeadlessHostBot(lobbyWatcherNode, hashedPassword, salt);
     JOptionPane.showMessageDialog(null,
-        (response == null ? "Successfully attempted stop of current game on host" : "Failed: " + response));
+        (response == null ? "Successfully stopped current game on host" : "Failed: " + response));
   }
 
   private void shutDownHeadlessHostBot() {
@@ -522,7 +510,7 @@ class LobbyGamePanel extends JPanel {
     final String hashedPassword = hashPassword(password, salt);
     final String response = controller.shutDownHeadlessHostBot(lobbyWatcherNode, hashedPassword, salt);
     JOptionPane.showMessageDialog(null,
-        (response == null ? "Successfully attempted to shut down host" : "Failed: " + response));
+        (response == null ? "Host shut down successful" : "Failed: " + response));
   }
 
   private void setWidgetActivation() {

--- a/game-core/src/main/java/games/strategy/net/IServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/IServerMessenger.java
@@ -29,28 +29,25 @@ public interface IServerMessenger extends IMessenger {
   Set<INode> getNodes();
 
   /**
-   * Notifies the server that the specified IP address has been banned until the specified instant.
+   * Notifies the server that the specified IP address has been banned.
    *
    * @param ip The IP address to ban.
-   * @param expires The time at which the ban expires or {@code null} if the ban is indefinite.
    */
-  void notifyIpMiniBanningOfPlayer(String ip, @Nullable Instant expires);
+  void notifyIpMiniBanningOfPlayer(String ip);
 
   /**
-   * Notifies the server that the specified hashed MAC address has been banned until the specified instant.
+   * Notifies the server that the specified hashed MAC address has been banned.
    *
    * @param mac The hashed MAC address to ban.
-   * @param expires The time at which the ban expires or {@code null} if the ban is indefinite.
    */
-  void notifyMacMiniBanningOfPlayer(String mac, @Nullable Instant expires);
+  void notifyMacMiniBanningOfPlayer(String mac);
 
   /**
-   * Notifies the server that the specified username has been banned until the specified instant.
+   * Notifies the server that the specified username has been banned.
    *
    * @param username The username to ban.
-   * @param expires The time at which the ban expires or {@code null} if the ban is indefinite.
    */
-  void notifyUsernameMiniBanningOfPlayer(String username, @Nullable Instant expires);
+  void notifyUsernameMiniBanningOfPlayer(String username);
 
   /**
    * Returns the hashed MAC address for the user with the specified name or {@code null} if unknown.

--- a/game-core/src/main/java/games/strategy/net/LocalNoOpMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/LocalNoOpMessenger.java
@@ -89,13 +89,13 @@ public class LocalNoOpMessenger implements IServerMessenger {
   }
 
   @Override
-  public void notifyIpMiniBanningOfPlayer(final String ip, final @Nullable Instant expires) {}
+  public void notifyIpMiniBanningOfPlayer(final String ip) {}
 
   @Override
-  public void notifyMacMiniBanningOfPlayer(final String mac, final @Nullable Instant expires) {}
+  public void notifyMacMiniBanningOfPlayer(final String mac) {}
 
   @Override
-  public void notifyUsernameMiniBanningOfPlayer(final String username, final @Nullable Instant expires) {}
+  public void notifyUsernameMiniBanningOfPlayer(final String username) {}
 
   @Override
   public @Nullable String getPlayerMac(final String name) {

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -397,24 +397,21 @@ public class HeadlessGameServer {
   }
 
   /**
-   * Bans the specified player from this headless game server for the specified duration at the request of a remote
-   * moderator.
+   * Bans the specified player from this headless game server at the request of a remote moderator.
    *
    * @param playerName The name of the player to ban.
-   * @param hours The duration (in hours) of the ban.
    * @param hashedPassword The hashed server password provided by the remote moderator.
    * @param salt The salt used to hash the server password.
    *
    * @return {@code null} if the operation succeeded; otherwise an error message if the operation failed.
    */
-  public String remoteBanPlayer(final String playerName, final int hours, final String hashedPassword,
+  public String remoteBanPlayer(final String playerName, final String hashedPassword,
       final String salt) {
     final String password = System.getProperty(LOBBY_GAME_SUPPORT_PASSWORD, "");
     if (password.equals(NO_REMOTE_REQUESTS_ALLOWED)) {
       return "Host not accepting remote requests!";
     }
     // milliseconds (30 days max)
-    final Instant expire = Instant.now().plus(Duration.ofHours(Math.min(24 * 30, hours)));
     if (hashPassword(password, salt).equals(hashedPassword)) {
       new Thread(() -> {
         if (getServerModel() == null) {
@@ -436,17 +433,17 @@ public class HeadlessGameServer {
             if (realName.equals(playerName)) {
               log.info("Remote Ban of Player: " + playerName);
               try {
-                messenger.notifyUsernameMiniBanningOfPlayer(realName, expire);
+                messenger.notifyUsernameMiniBanningOfPlayer(realName);
               } catch (final Exception e) {
                 log.log(Level.SEVERE, "Failed to notify username ban of player", e);
               }
               try {
-                messenger.notifyIpMiniBanningOfPlayer(ip, expire);
+                messenger.notifyIpMiniBanningOfPlayer(ip);
               } catch (final Exception e) {
                 log.log(Level.SEVERE, "Failed to notify IP ban of player", e);
               }
               try {
-                messenger.notifyMacMiniBanningOfPlayer(mac, expire);
+                messenger.notifyMacMiniBanningOfPlayer(mac);
               } catch (final Exception e) {
                 log.log(Level.SEVERE, "Failed to notify MAC ban of player", e);
               }

--- a/game-core/src/main/java/org/triplea/lobby/common/IModeratorController.java
+++ b/game-core/src/main/java/org/triplea/lobby/common/IModeratorController.java
@@ -107,8 +107,7 @@ public interface IModeratorController extends IRemote {
   /**
    * Remote ban player in a headless host bot.
    */
-  String banPlayerHeadlessHostBot(INode node, String playerNameToBeBanned, int hours, String hashedPassword,
-      String salt);
+  String banPlayerHeadlessHostBot(INode node, String playerNameToBeBanned, String hashedPassword, String salt);
 
   /**
    * Remote stop game of a headless host bot.

--- a/game-core/src/main/java/org/triplea/lobby/common/IRemoteHostUtils.java
+++ b/game-core/src/main/java/org/triplea/lobby/common/IRemoteHostUtils.java
@@ -19,7 +19,7 @@ public interface IRemoteHostUtils extends IRemote {
 
   String bootPlayerHeadlessHostBot(String playerNameToBeBooted, String hashedPassword, String salt);
 
-  String banPlayerHeadlessHostBot(String playerNameToBeBanned, int hours, String hashedPassword, String salt);
+  String banPlayerHeadlessHostBot(String playerNameToBeBanned, String hashedPassword, String salt);
 
   String stopGameHeadlessHostBot(String hashedPassword, String salt);
 

--- a/lobby/src/main/java/org/triplea/lobby/server/ModeratorController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/ModeratorController.java
@@ -266,7 +266,7 @@ final class ModeratorController implements IModeratorController {
   }
 
   @Override
-  public String banPlayerHeadlessHostBot(final INode node, final String playerNameToBeBanned, final int hours,
+  public String banPlayerHeadlessHostBot(final INode node, final String playerNameToBeBanned,
       final String hashedPassword, final String salt) {
     assertUserIsAdmin();
     if (serverMessenger.getServerNode().equals(node)) {
@@ -275,11 +275,12 @@ final class ModeratorController implements IModeratorController {
     final INode modNode = MessageContext.getSender();
     final String mac = getNodeMacAddress(node);
     final IRemoteHostUtils remoteHostUtils = getRemoteHostUtilsForNode(node);
-    final String response = remoteHostUtils.banPlayerHeadlessHostBot(playerNameToBeBanned, hours, hashedPassword, salt);
+    final String response = remoteHostUtils.banPlayerHeadlessHostBot(playerNameToBeBanned, hashedPassword, salt);
     log.info(String.format(
-        (response == null ? "Successful" : "Failed (" + response + ")") + " Remote Ban of " + playerNameToBeBanned
-            + " for " + hours
-            + "hours  In Headless HostBot. Host: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s",
+        (response == null
+            ? "Successful"
+            : "Failed (" + response + ")") + " Remote Ban of " + playerNameToBeBanned
+            + "' Host: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s",
         node.getName(), node.getAddress().getHostAddress(), mac, modNode.getName(),
         modNode.getAddress().getHostAddress(), getNodeMacAddress(modNode)));
     return response;


### PR DESCRIPTION
## Overview
Instead of offering a ban duration on hosts or on bots, bans will be permanent. Given that we'll likely see a host restart, or would want a bot ban to be permanent, it is just as well. Dropping a ban expiry in this case allows both simpler UX and code.

While testing this I noted some odd text, and updated the text to read better.


## Functional Changes
- When doing moderator remote player bans on bots, the bans will no longer offer an expiration
- When banning players from hosted games, the ban will no longer offer an expiration.
- Slightly updated success message when executing moderator remote commands

## Manual Testing Performed
Steps:
- started local lobby+DB
- started headed game
- created account on lobby
- updated DB to grant moderator
- logged back in with same account
- started headless game
- started a second headed game with name 'laf'
- Joined headless game on lobby with 'laf'
- with first account, remote player banned 'laf'
- Disconnected with 'laf' account
- Attempted reconnect to bot with 'laf' account, verified it showed a ban

## Before & After Screen Shots

### After
![screenshot from 2019-03-06 21-55-16](https://user-images.githubusercontent.com/12397753/53935752-65c3a400-405c-11e9-8702-c95b54a97828.png)
