### PR TITLE
Add DB Rider & Update BadWordDao 'list' API to be a 'contains'

### DIFF
--- a/lobby/build.gradle
+++ b/lobby/build.gradle
@@ -15,6 +15,7 @@ dependencies {
     runtimeOnly "org.postgresql:postgresql:$postgresqlVersion"
 
     testImplementation project(':test-common')
+    testImplementation 'com.github.database-rider:rider-junit5:1.5.2'
 }
 
 jar {

--- a/lobby/src/main/java/org/triplea/lobby/server/db/BadWordController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/BadWordController.java
@@ -38,13 +38,12 @@ final class BadWordController implements BadWordDao {
     final String sql =
         "select count(bw.word) "
             + "from bad_words bw "
-            + "where ? like '%' || lower(bw.word) || '%' "
-            + "limit 1";
+            + "where lower(?) like '%' || lower(bw.word) || '%'";
 
     try (Connection con = connection.get();
         PreparedStatement ps = con.prepareStatement(sql)) {
 
-      ps.setString(1, testString.toLowerCase());
+      ps.setString(1, testString);
 
       try (ResultSet rs = ps.executeQuery()) {
         rs.next();

--- a/lobby/src/main/java/org/triplea/lobby/server/db/BadWordController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/BadWordController.java
@@ -4,8 +4,6 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.function.Supplier;
 
 import lombok.AllArgsConstructor;
@@ -31,17 +29,27 @@ final class BadWordController implements BadWordDao {
   }
 
   @Override
-  public List<String> list() {
-    final String sql = "select word from bad_words";
+  public boolean containsBadWord(final String testString) {
+    if (testString.isEmpty()) {
+      return false;
+    }
+
+    // Query to count if at least one bad word value is contained in the testString.
+    final String sql =
+        "select count(bw.word) "
+            + "from bad_words bw "
+            + "where ? like '%' || lower(bw.word) || '%' "
+            + "limit 1";
 
     try (Connection con = connection.get();
-        PreparedStatement ps = con.prepareStatement(sql);
-        ResultSet rs = ps.executeQuery()) {
-      final List<String> badWords = new ArrayList<>();
-      while (rs.next()) {
-        badWords.add(rs.getString(1));
+        PreparedStatement ps = con.prepareStatement(sql)) {
+
+      ps.setString(1, testString.toLowerCase());
+
+      try (ResultSet rs = ps.executeQuery()) {
+        rs.next();
+        return rs.getInt(1) > 0;
       }
-      return badWords;
     } catch (final SQLException e) {
       throw new DatabaseException("Error reading bad words", e);
     }

--- a/lobby/src/main/java/org/triplea/lobby/server/db/BadWordDao.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/BadWordDao.java
@@ -1,7 +1,5 @@
 package org.triplea.lobby.server.db;
 
-import java.util.List;
-
 /**
  * Data access object for the bad word table.
  */
@@ -14,9 +12,11 @@ public interface BadWordDao {
   void addBadWord(String word);
 
   /**
-   * Returns a collection of all bad words in the table.
+   * Checks if a given string contains a bad word.
    *
-   * @return A collection of all bad words in the table.
+   * @param testString The value to check for a bad word
+   *
+   * @return Returns true if the parameter contains a bad word (case insensitive).
    */
-  List<String> list();
+  boolean containsBadWord(String testString);
 }

--- a/lobby/src/main/java/org/triplea/lobby/server/login/LobbyLoginValidator.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/login/LobbyLoginValidator.java
@@ -6,7 +6,6 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
@@ -110,10 +109,8 @@ public final class LobbyLoginValidator implements ILoginValidator {
       return "Wrong version, we require " + LobbyConstants.LOBBY_VERSION.toString() + " but trying to log in with "
           + clientVersionString;
     }
-    for (final String s : getBadWords()) {
-      if (user.getUsername().toLowerCase().contains(s.toLowerCase())) {
-        return ErrorMessages.THATS_NOT_A_NICE_NAME;
-      }
+    if (database.getBadWordDao().containsBadWord(user.getUsername())) {
+      return ErrorMessages.THATS_NOT_A_NICE_NAME;
     }
     if (!MacFinder.isValidHashedMacAddress(user.getHashedMacAddress())) {
       // Must have been tampered with
@@ -188,10 +185,6 @@ public final class LobbyLoginValidator implements ILoginValidator {
     }
     sb.append(minutes).append(" Minutes");
     return sb.toString();
-  }
-
-  private List<String> getBadWords() {
-    return database.getBadWordDao().list();
   }
 
   private @Nullable String authenticateRegisteredUser(final Map<String, String> response, final User user) {

--- a/lobby/src/test/resources/datasets/badwords/bad.yml
+++ b/lobby/src/test/resources/datasets/badwords/bad.yml
@@ -1,0 +1,2 @@
+bad_words:
+  - word: bad

--- a/lobby/src/test/resources/datasets/badwords/post-insert.yml
+++ b/lobby/src/test/resources/datasets/badwords/post-insert.yml
@@ -1,0 +1,3 @@
+bad_words:
+  - word: first
+  - word: second

--- a/lobby/src/test/resources/datasets/badwords/pre-insert.yml
+++ b/lobby/src/test/resources/datasets/badwords/pre-insert.yml
@@ -1,0 +1,2 @@
+bad_words:
+  - word: first

--- a/lobby/src/test/resources/dbunit.yml
+++ b/lobby/src/test/resources/dbunit.yml
@@ -1,0 +1,7 @@
+leakHunter: true
+caseInsensitiveStrategy: !!com.github.database.rider.core.api.configuration.Orthography 'LOWERCASE'
+connectionConfig:
+  driver: "org.postgresql.Driver"
+  url: "jdbc:postgresql://localhost:5432/ta_users"
+  user: "postgres"
+  password: "postgres"


### PR DESCRIPTION
## Overview
- Update BadWordDao test to use DB rider.
  DB rider is first discussed in:
      https://github.com/triplea-game/triplea/issues/4735
  Of note, all SQL is now removed from the test class.
- Update BadWordDao to have a 'contains' API instead of list.
  As part of this, update the query to do a contains query instead
  of reading full table.

## Functional Changes
- none

## Manual Testing Performed
- none

