### PR TITLE
Swap AND order

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -110,7 +110,6 @@ import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.data.events.GameDataChangeListener;
-import games.strategy.engine.data.events.GameStepListener;
 import games.strategy.engine.framework.ClientGame;
 import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.GameDataUtils;

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -298,9 +298,6 @@ public final class TripleAFrame extends JFrame {
     }
   };
 
-  private final GameStepListener stepListener =
-      (stepName, delegateName, player1, round1, stepDisplayName) -> updateStep();
-
   private final GameDataChangeListener dataChangeListener = new GameDataChangeListener() {
     @Override
     public void gameDataChanged(final Change change) {
@@ -586,7 +583,7 @@ public final class TripleAFrame extends JFrame {
     // force a data change event to update the UI for edit mode
     dataChangeListener.gameDataChanged(ChangeFactory.EMPTY_CHANGE);
     data.addDataChangeListener(dataChangeListener);
-    game.addGameStepListener(stepListener);
+    game.addGameStepListener((stepName, delegateName, player1, round1, stepDisplayName) -> updateStep());
     uiContext.addShutdownWindow(this);
   }
 
@@ -1649,7 +1646,7 @@ public final class TripleAFrame extends JFrame {
           showGame();
         }
       } else {
-        if (inHistory.compareAndSet(false, true) && !uiContext.getShowMapOnly()) {
+        if (!uiContext.getShowMapOnly() && inHistory.compareAndSet(false, true)) {
           showHistory();
         }
       }


### PR DESCRIPTION
## Overview
This PR swappes the order of arguments in an AND operation to ensure the atomic boolean is only updated when the other argument is true as well.
Also a variable is inlined.

## Functional Changes
Precaution to prevent messing up bool logic.

## Manual Testing Performed
None.