### PR TITLE
Simplify Chat class

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/Chat.java
@@ -98,13 +98,8 @@ public class Chat {
     @Override
     public void speakerAdded(final INode node, final Tag tag, final long version) {
       assertMessageFromServer();
-      // Wait for latch in different Thread if we're still initialising this instance.
-      if (nodes == null) {
-        new Thread(() -> speakerAdded(node, tag, version)).start();
-        return;
-      }
-      Interruptibles.await(latch);
-      if (version > chatInitVersion) {
+      if (version > chatInitVersion && chatInitVersion != 0) {
+        Interruptibles.await(latch);
         synchronized (mutexNodes) {
           nodes.add(node);
           addToNotesMap(node, tag);
@@ -122,8 +117,8 @@ public class Chat {
     @Override
     public void speakerRemoved(final INode node, final long version) {
       assertMessageFromServer();
-      Interruptibles.await(latch);
       if (version > chatInitVersion) {
+        Interruptibles.await(latch);
         synchronized (mutexNodes) {
           nodes.remove(node);
           notesMap.remove(node);


### PR DESCRIPTION
## Overview
During messing around with the code I realised that the first invocation of the speakerAdded function always causes the if check to fail, when delayed until the chatInitVersion is set because chatInitVersion is guaranteed to be at least 1 and the first message obviously has version 1 (I tested this to be sure).

## Functional Changes
None.

## Manual Testing Performed
I verified Chat functionality continues to work without any problems, even using multi client connections.