### PR TITLE
Add: Lobby Docker with Jib

### DIFF
--- a/lobby/README.md
+++ b/lobby/README.md
@@ -12,7 +12,13 @@ This is the well-known running TripleA lobby server.
 
 ## Run
 
+### With java -jar
 ```
 ../gradlew run
 ```
 
+### With docker
+```
+../gradlew jibDockerBuild
+docker run -d --name=dev-lobby -p 3304:3304 lobby:1.10.dev
+```

--- a/lobby/build.gradle
+++ b/lobby/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'application'
     id 'com.github.johnrengelman.shadow' version '4.0.4'
+    id 'com.google.cloud.tools.jib' version '1.0.2'
 }
 
 archivesBaseName = "$group-$name"


### PR DESCRIPTION
## Overview

Add [jib](https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin) plugin that can build a docker image from gradle. After that is done a docker
command can be run to launch a docker container running the lobby.


## Functional Changes
Dev facing changes, allows dev to launch a docker container running lobby


## Additional Review Notes
- README is updated with run commands.
