### PR TITLE
Rename lobby database 'ta_users' -> 'lobby'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ addons:
       - python3
       - python3-yaml
 install:
- - echo "create database ta_users" | psql -h localhost -U postgres
+ - echo "create database lobby" | psql -h localhost -U postgres
  - ./gradlew flywayMigrate
 before_script:
 - ./.travis/setup_gpg

--- a/infrastructure/ansible/roles/lobby/defaults/main.yml
+++ b/infrastructure/ansible/roles/lobby/defaults/main.yml
@@ -17,3 +17,6 @@ lobby_postgres_password: ""
 lobby_postgres_host: "10.0.2.2"
 
 lobby_postgres_port: "5432"
+
+lobby_postgres_database: "lobby"
+

--- a/infrastructure/ansible/roles/lobby/templates/lobby.service.j2
+++ b/infrastructure/ansible/roles/lobby/templates/lobby.service.j2
@@ -13,6 +13,7 @@ Environment="POSTGRES_USER={{ lobby_postgres_user }}"
 Environment="POSTGRES_PASSWORD={{ lobby_postgres_password }}"
 Environment="POSTGRES_HOST={{ lobby_postgres_host }}"
 Environment="POSTGRES_PORT={{ lobby_postgres_port }}"
+Environment="POSTGRES_DATABASE={{ lobby_postgres_database }}"
 
 [Install]
 WantedBy=multi-user.target

--- a/lobby-db/Dockerfile
+++ b/lobby-db/Dockerfile
@@ -5,7 +5,7 @@
 FROM postgres:9.5
 MAINTAINER "tripleabuilderbot@gmail.com"
 
-ENV POSTGRES_DB=ta_users
+ENV POSTGRES_DB=lobby
 
 # TODO: Copy a production-like snapshot. Snapshots include the flyway tracking tables, 
 # running flyway would then be incremental and run only new migrations, better simulating

--- a/lobby-db/build.gradle
+++ b/lobby-db/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 flyway {
     driver = 'org.postgresql.Driver'
-    url= 'jdbc:postgresql://localhost:5432/ta_users'
+    url= 'jdbc:postgresql://localhost:5432/lobby'
     user = 'postgres'
     password = 'postgres'
 }

--- a/lobby-db/connect_to_db
+++ b/lobby-db/connect_to_db
@@ -1,9 +1,10 @@
 #!/bin/bash
 
-PSQL="psql -h localhost -U postgres -w ta_users"
+DB=lobby
+PSQL="psql -h localhost -U postgres -w $DB"
 
 if [[ "$OSTYPE" == darwin* ]]; then
-  PSQL="psql -h localhost -U postgres -w ta_users"
+  PSQL="psql -h localhost -U postgres -w $DB"
 fi
 
 $PSQL

--- a/lobby-db/drop_db
+++ b/lobby-db/drop_db
@@ -1,6 +1,7 @@
 #!/bin/bash
 
+DB=lobby
 PSQL="psql -h localhost -U postgres -w"
-echo "drop database ta_users" | $PSQL
-echo "create database ta_users" | $PSQL
+echo "drop database $DB" | $PSQL
+echo "create database $DB" | $PSQL
 

--- a/lobby/src/main/java/org/triplea/lobby/server/EnvironmentVariable.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/EnvironmentVariable.java
@@ -15,7 +15,9 @@ public enum EnvironmentVariable {
 
   POSTGRES_HOST("localhost"),
 
-  POSTGRES_PORT("5432");
+  POSTGRES_PORT("5432"),
+
+  POSTGRES_DATABASE("lobby");
 
   private final String defaultValue;
 

--- a/lobby/src/main/java/org/triplea/lobby/server/config/LobbyConfiguration.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/config/LobbyConfiguration.java
@@ -18,7 +18,7 @@ public final class LobbyConfiguration {
   public LobbyConfiguration() {
     port = Integer.valueOf(EnvironmentVariable.PORT.getValue());
     databaseDao = Database.builder()
-        .postgresDatabase("ta_users")
+        .postgresDatabase(EnvironmentVariable.POSTGRES_DATABASE.getValue())
         .postgresHost(EnvironmentVariable.POSTGRES_HOST.getValue())
         .postgresPassword(EnvironmentVariable.POSTGRES_PASSWORD.getValue())
         .postgresUser(EnvironmentVariable.POSTGRES_USER.getValue())

--- a/lobby/src/test/java/org/triplea/lobby/server/db/TestDatabase.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/db/TestDatabase.java
@@ -25,7 +25,7 @@ final class TestDatabase {
         "jdbc:postgresql://%s:%d/%s",
         "localhost",
         5432,
-        "ta_users");
+        "lobby");
   }
 
   private static Properties getConnectionProperties() {

--- a/lobby/src/test/resources/dbunit.yml
+++ b/lobby/src/test/resources/dbunit.yml
@@ -1,6 +1,6 @@
 caseInsensitiveStrategy: !!com.github.database.rider.core.api.configuration.Orthography 'LOWERCASE'
 connectionConfig:
   driver: "org.postgresql.Driver"
-  url: "jdbc:postgresql://localhost:5432/ta_users"
+  url: "jdbc:postgresql://localhost:5432/lobby"
   user: "postgres"
   password: "postgres"


### PR DESCRIPTION
## Overview

This update supports the 1.10 release and changes the 1.9 to 1.10 migration strategy.
With a new DB name, we can keep 1.9 running and reading an untouched 'ta_users' database.
When releasing 1.10, we can copy 'ta_users' to 'lobby', deal with flyway baseline issues,
then migrate the new 'lobby' to latest and run a 1.10 lobby with a 1.9 lobby still running in parallel.

## Functional Changes
- No user facing changes

## Manual Testing Performed
- verified the flyway and connection scripts still ran ok 
