### PR TITLE
Muted_macs remove columns

### DIFF
--- a/lobby-db/src/main/resources/db/migration/V1.10.00.201903131400__drop_muted_mac_columns.sql
+++ b/lobby-db/src/main/resources/db/migration/V1.10.00.201903131400__drop_muted_mac_columns.sql
@@ -1,0 +1,6 @@
+alter table muted_macs
+  drop column username;
+alter table muted_macs
+  drop column mod_mac;
+alter table muted_macs
+  drop column mod_ip;

--- a/lobby/src/main/java/org/triplea/lobby/server/ModeratorController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/ModeratorController.java
@@ -156,17 +156,12 @@ final class ModeratorController implements IModeratorController {
       throw new IllegalStateException("Can't mute an admin");
     }
 
-    final User mutedUser = getUserForNode(node);
-    final User moderator = getUserForNode(MessageContext.getSender());
-
-    database.getMutedMacDao().addMutedMac(mutedUser, muteExpires, moderator);
-    serverMessenger.notifyMacMutingOfPlayer(mutedUser.getHashedMacAddress(), muteExpires);
+    final String hashedMac = getNodeMacAddress(node);
+    database.getMutedMacDao().addMutedMac(
+        node.getAddress(), hashedMac, muteExpires, MessageContext.getSender().getName());
+    serverMessenger.notifyMacMutingOfPlayer(hashedMac, muteExpires);
     log.info(String.format(
-        "User was muted in the lobby (by MAC); "
-            + "Username: %s, IP: %s, MAC: %s, Mod Username: %s, Mod IP: %s, Mod MAC: %s, Expires: %s",
-        mutedUser.getUsername(), mutedUser.getInetAddress().getHostAddress(), mutedUser.getHashedMacAddress(),
-        moderator.getUsername(), moderator.getInetAddress().getHostAddress(), moderator.getHashedMacAddress(),
-        muteExpires == null ? "forever" : muteExpires.toString()));
+        "Node was muted: %s, until: %s, by: %s", node, muteExpires, MessageContext.getSender().getName()));
   }
 
   @Override

--- a/lobby/src/main/java/org/triplea/lobby/server/db/MutedMacDao.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/MutedMacDao.java
@@ -1,15 +1,20 @@
 package org.triplea.lobby.server.db;
 
+import java.net.InetAddress;
 import java.time.Instant;
 import java.util.Optional;
 
-import org.triplea.lobby.server.User;
+import javax.annotation.Nullable;
 
 /**
  * Utility to create/read/delete muted macs (there is no update).
  */
 public interface MutedMacDao {
-  void addMutedMac(User mutedUser, Instant muteExpires, User moderator);
+  void addMutedMac(
+      InetAddress netAddress,
+      String hashedMac,
+      @Nullable Instant muteTill,
+      String moderatorName);
 
   Optional<Instant> getMacUnmuteTime(String mac);
 

--- a/lobby/src/test/java/org/triplea/lobby/server/db/MutedMacControllerIntegrationTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/db/MutedMacControllerIntegrationTest.java
@@ -8,7 +8,6 @@ import java.time.Instant;
 import java.util.Optional;
 
 import org.junit.jupiter.api.Test;
-import org.triplea.lobby.server.User;
 import org.triplea.lobby.server.config.TestLobbyConfigurations;
 
 final class MutedMacControllerIntegrationTest extends AbstractModeratorServiceControllerTestCase {
@@ -26,7 +25,6 @@ final class MutedMacControllerIntegrationTest extends AbstractModeratorServiceCo
   void testMuteMac() {
     final Instant muteUntil = Instant.now().plusSeconds(100L);
     muteMac(muteUntil);
-    assertMutedUserEquals(user);
     assertTrue(isMacMuted(Instant.now()));
     assertEquals(Optional.of(muteUntil), getMacUnmuteTime());
 
@@ -62,19 +60,12 @@ final class MutedMacControllerIntegrationTest extends AbstractModeratorServiceCo
     assertEquals(Optional.of(muteUntil), getMacUnmuteTime());
   }
 
-  @Test
-  void testMuteMacUpdatesMutedUserAndModerator() {
-    muteMac();
-
-    assertModeratorEquals(moderator);
-  }
-
   private void muteMac() {
     muteMac(null);
   }
 
   private void muteMac(final Instant expiry) {
-    controller.addMutedMac(user, expiry, moderator);
+    controller.addMutedMac(user.getInetAddress(), user.getHashedMacAddress(), expiry, moderator.getUsername());
   }
 
   private Optional<Instant> getMacUnmuteTime() {
@@ -83,21 +74,5 @@ final class MutedMacControllerIntegrationTest extends AbstractModeratorServiceCo
 
   private boolean isMacMuted(final Instant checkTime) {
     return controller.isMacMuted(checkTime, user.getHashedMacAddress());
-  }
-
-  private void assertMutedUserEquals(final User expected) {
-    assertUserEquals(
-        expected,
-        "select username, ip, mac from muted_macs where mac=?",
-        ps -> ps.setString(1, user.getHashedMacAddress()),
-        "unknown muted hashed MAC address: " + user.getHashedMacAddress());
-  }
-
-  private void assertModeratorEquals(final User expected) {
-    assertUserEquals(
-        expected,
-        "select mod_username, mod_ip, mod_mac from muted_macs where mac=?",
-        ps -> ps.setString(1, user.getHashedMacAddress()),
-        "unknown muted hashed MAC address: " + user.getHashedMacAddress());
   }
 }


### PR DESCRIPTION
## Overview
Removes columns and associated APIs for muted_macs table:
- username: simply not needed when a player is muted by network IDs
- Moderator mac and IP: a moderator name identifies a mod uniquely
    
One note, this update helps remove TripleA game-core data types from the lobby/db layer.

## Manual Testing Performed
- none
