### PR TITLE
Ai improve large map performance

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -145,7 +145,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * @param distance maximal distance of the neighboring territories
    */
   public Set<Territory> getNeighbors(final Territory territory, final int distance) {
-    Preconditions.checkArgument(distance < 0, "Distance must be non-negative: " + distance);
+    Preconditions.checkArgument(distance >= 0, "Distance must be non-negative: " + distance);
     if (distance == 0) {
       return Collections.emptySet();
     }
@@ -163,7 +163,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * Does NOT include the original/starting territory in the returned Set.
    */
   public Set<Territory> getNeighbors(final Territory territory, final int distance, final Predicate<Territory> cond) {
-    Preconditions.checkArgument(distance < 0, "Distance must be non-negative: " + distance);
+    Preconditions.checkArgument(distance >= 0, "Distance must be non-negative: " + distance);
     if (distance == 0) {
       return Collections.emptySet();
     }
@@ -213,7 +213,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    */
   public Set<Territory> getNeighborsIgnoreEnd(final Territory territory, final int distance,
       final Predicate<Territory> cond) {
-    Preconditions.checkArgument(distance < 0, "Distance must be non-negative: " + distance);
+    Preconditions.checkArgument(distance >= 0, "Distance must be non-negative: " + distance);
     if (distance == 0) {
       return Collections.emptySet();
     }

--- a/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -19,6 +19,7 @@ import javax.annotation.Nullable;
 
 import org.triplea.java.collections.IntegerMap;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
 
 import games.strategy.triplea.delegate.Matches;
@@ -144,9 +145,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * @param distance maximal distance of the neighboring territories
    */
   public Set<Territory> getNeighbors(final Territory territory, final int distance) {
-    if (distance < 0) {
-      throw new IllegalArgumentException("Distance must be positive not: " + distance);
-    }
+    Preconditions.checkArgument(distance < 0, "Distance must be non-negative: " + distance);
     if (distance == 0) {
       return Collections.emptySet();
     }
@@ -164,9 +163,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    * Does NOT include the original/starting territory in the returned Set.
    */
   public Set<Territory> getNeighbors(final Territory territory, final int distance, final Predicate<Territory> cond) {
-    if (distance < 0) {
-      throw new IllegalArgumentException("Distance must be positive not: " + distance);
-    }
+    Preconditions.checkArgument(distance < 0, "Distance must be non-negative: " + distance);
     if (distance == 0) {
       return Collections.emptySet();
     }
@@ -216,9 +213,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    */
   public Set<Territory> getNeighborsIgnoreEnd(final Territory territory, final int distance,
       final Predicate<Territory> cond) {
-    if (distance < 0) {
-      throw new IllegalArgumentException("Distance must be positive not: " + distance);
-    }
+    Preconditions.checkArgument(distance < 0, "Distance must be non-negative: " + distance);
     if (distance == 0) {
       return Collections.emptySet();
     }

--- a/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -207,9 +207,9 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
   }
 
   /**
-   * Returns all neighbors within a certain distance of the starting territory that territories
-   * between the 2 match the condition. Does NOT include the original/starting territory in the
-   * returned Set.
+   * Returns all neighbors within a certain distance of the starting territory where all
+   * territories between the 2 match the condition. Does NOT include the original/starting
+   * territory in the returned Set.
    */
   public Set<Territory> getNeighborsIgnoreEnd(final Territory territory, final int distance,
       final Predicate<Territory> cond) {

--- a/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -231,8 +231,8 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
 
   private Set<Territory> getNeighborsIgnoreEnd(final Set<Territory> frontier, final Set<Territory> searched,
       final int distance, @Nullable final Predicate<Territory> cond) {
-    if (distance == 0) {
-      return searched;
+    if (distance == 0 || frontier.isEmpty()) {
+      return searched; // End condition for recursion
     }
     final Predicate<Territory> neighborCond = (distance == 1) ? Predicates.alwaysTrue() : cond;
     final Set<Territory> newFrontier = frontier.stream()

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -90,11 +90,7 @@ class ProCombatMoveAi {
       clearedTerritories.add(patd.getTerritory());
     }
     territoryManager.populateEnemyAttackOptions(clearedTerritories, clearedTerritories);
-    Set<Territory> territoriesToCheck = new HashSet<>(clearedTerritories);
-    territoriesToCheck.addAll(ProData.myUnitTerritories);
-    Map<Territory, Double> territoryValueMap =
-        ProTerritoryValueUtils.findTerritoryValues(player, new ArrayList<>(), clearedTerritories, territoriesToCheck);
-    determineTerritoriesThatCanBeHeld(attackOptions, territoryValueMap);
+    determineTerritoriesThatCanBeHeld(attackOptions, clearedTerritories);
     prioritizeAttackOptions(player, attackOptions);
     removeTerritoriesThatArentWorthAttacking(attackOptions);
 
@@ -113,11 +109,7 @@ class ProCombatMoveAi {
     }
     possibleTransportTerritories.addAll(clearedTerritories);
     territoryManager.populateEnemyAttackOptions(clearedTerritories, new ArrayList<>(possibleTransportTerritories));
-    territoriesToCheck = new HashSet<>(clearedTerritories);
-    territoriesToCheck.addAll(ProData.myUnitTerritories);
-    territoryValueMap =
-        ProTerritoryValueUtils.findTerritoryValues(player, new ArrayList<>(), clearedTerritories, territoriesToCheck);
-    determineTerritoriesThatCanBeHeld(attackOptions, territoryValueMap);
+    determineTerritoriesThatCanBeHeld(attackOptions, clearedTerritories);
     removeTerritoriesThatArentWorthAttacking(attackOptions);
 
     // Determine how many units to attack each territory with
@@ -375,7 +367,7 @@ class ProCombatMoveAi {
   }
 
   private void determineTerritoriesThatCanBeHeld(final List<ProTerritory> prioritizedTerritories,
-      final Map<Territory, Double> territoryValueMap) {
+      final List<Territory> clearedTerritories) {
 
     ProLogger.info("Check if we should try to hold attack territories");
 
@@ -383,6 +375,17 @@ class ProCombatMoveAi {
     final Map<Territory, ProTerritory> attackMap = territoryManager.getAttackOptions().getTerritoryMap();
 
     // Determine which territories to try and hold
+    final Set<Territory> territoriesToCheck = new HashSet<>();
+    for (final ProTerritory patd : prioritizedTerritories) {
+      final Territory t = patd.getTerritory();
+      territoriesToCheck.add(t);
+      final List<Unit> nonAirAttackers = CollectionUtils.getMatches(patd.getMaxUnits(), Matches.unitIsNotAir());
+      for (final Unit u : nonAirAttackers) {
+        territoriesToCheck.add(ProData.unitTerritoryMap.get(u));
+      }
+    }
+    final Map<Territory, Double> territoryValueMap =
+        ProTerritoryValueUtils.findTerritoryValues(player, new ArrayList<>(), clearedTerritories, territoriesToCheck);
     for (final ProTerritory patd : prioritizedTerritories) {
       final Territory t = patd.getTerritory();
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -411,7 +411,7 @@ class ProPurchaseAi {
     // Find strategic value for each territory
     ProLogger.info("Find strategic value for place territories");
     final Set<Territory> territoriesToCheck = new HashSet<>();
-    for (final ProPurchaseTerritory t : purchaseTerritories.values()) {
+    for (final ProPurchaseTerritory t : placeNonConstructionTerritories.values()) {
       for (final ProPlaceTerritory ppt : t.getCanPlaceTerritories()) {
         territoriesToCheck.add(ppt.getTerritory());
       }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -49,13 +49,6 @@ public final class ProTerritoryValueUtils {
     return value;
   }
 
-  public static Map<Territory, Double> findTerritoryValues(final PlayerId player,
-      final List<Territory> territoriesThatCantBeHeld, final List<Territory> territoriesToAttack) {
-
-    return findTerritoryValues(player, territoriesThatCantBeHeld, territoriesToAttack,
-        new HashSet<>(ProData.getData().getMap().getTerritories()));
-  }
-
   /**
    * Returns the value of each territory in {@code territoriesToCheck}.
    */
@@ -64,7 +57,6 @@ public final class ProTerritoryValueUtils {
       final Set<Territory> territoriesToCheck) {
 
     final int maxLandMassSize = findMaxLandMassSize(player);
-
     final Map<Territory, Double> enemyCapitalsAndFactoriesMap =
         findEnemyCapitalsAndFactoriesValue(player, maxLandMassSize, territoriesThatCantBeHeld, territoriesToAttack);
 
@@ -92,12 +84,12 @@ public final class ProTerritoryValueUtils {
    * Returns the value of each sea territory in {@link ProData#getData()}.
    */
   public static Map<Territory, Double> findSeaTerritoryValues(final PlayerId player,
-      final List<Territory> territoriesThatCantBeHeld) {
+      final List<Territory> territoriesThatCantBeHeld, final List<Territory> territoriesToCheck) {
 
     // Determine value for water territories
     final Map<Territory, Double> territoryValueMap = new HashMap<>();
     final GameData data = ProData.getData();
-    for (final Territory t : data.getMap().getTerritories()) {
+    for (final Territory t : territoriesToCheck) {
       if (!territoriesThatCantBeHeld.contains(t) && t.isWater()
           && !data.getMap().getNeighbors(t, Matches.territoryIsWater()).isEmpty()) {
 
@@ -302,7 +294,8 @@ public final class ProTerritoryValueUtils {
 
     // Determine value based on nearby territory production
     double nearbyLandValue = 0;
-    final Set<Territory> nearbyTerritories = data.getMap().getNeighbors(t, 3);
+    final Set<Territory> nearbyTerritories =
+        data.getMap().getNeighborsIgnoreEnd(t, 3, ProMatches.territoryCanMoveSeaUnits(player, data, true));
     final List<Territory> nearbyLandTerritories =
         CollectionUtils.getMatches(nearbyTerritories, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data));
     nearbyLandTerritories.removeAll(territoriesToAttack);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
@@ -92,7 +92,7 @@ public final class ProUtils {
     return true;
   }
 
-  private static List<PlayerId> getEnemyPlayers(final PlayerId player) {
+  public static List<PlayerId> getEnemyPlayers(final PlayerId player) {
     final GameData data = ProData.getData();
     final List<PlayerId> enemyPlayers = new ArrayList<>();
     for (final PlayerId players : data.getPlayerList().getPlayers()) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -95,7 +95,7 @@ public class RandomStartDelegate extends BaseTripleADelegate {
         currentPickingPlayer = playersCanPick.get(0);
       }
       if (!Interruptibles.sleep(10)) {
-        return;
+        return; // TODO: determine if this sleep is needed
       }
       Territory picked;
       if (randomTerritories) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -94,7 +94,7 @@ public class RandomStartDelegate extends BaseTripleADelegate {
       if (currentPickingPlayer == null || !playersCanPick.contains(currentPickingPlayer)) {
         currentPickingPlayer = playersCanPick.get(0);
       }
-      if (!Interruptibles.sleep(250)) {
+      if (!Interruptibles.sleep(10)) {
         return;
       }
       Territory picked;


### PR DESCRIPTION
## Overview
- Address really slow AI performance on new alpha map World of War Heroes: https://forums.triplea-game.org/topic/1031/world-of-war-heroes-official-thread/22

## Functional Changes
- Decrease random start delegate pause time from 250ms to 10ms
- Add new get neighbors ignoring end methods to reduce trying to find routes for sea territories that either don't have a valid route or have a very long route
- Update territory value utils to avoid ever checking every territory on the map and always pass in what territories to check. This essentially makes AI calculations more 'regional' instead of 'global' so that the AI only calculates things where it can move/place units. An example is avoid having Japan calculate a bunch of territory values for things in the European Theater when it doesn't have any units that can reach that.

## Manual Testing Performed
- Did functional and performance testing on World of War Heroes alpha, WaW, Dom NML, and Another World. Most large maps with Fast AI are about 2x as fast now but World of War or other sparse large maps are 5x-10x faster.
