### PR TITLE
Add support for a move phase which only posts. 

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameStep.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameStep.java
@@ -35,6 +35,7 @@ public class GameStep extends GameDataComponent {
     String AIRBORNE_MOVE = "airborneMove";
     String COMBAT_MOVE = "combatMove";
     String NON_COMBAT_MOVE = "nonCombatMove";
+    String POST_ONLY_MOVE = "postOnlyMove";
     String FIRE_ROCKETS = "fireRockets";
     String REPAIR_UNITS = "repairUnits";
     String GIVE_BONUS_MOVEMENT = "giveBonusMovement";

--- a/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -132,7 +132,9 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer implements ITrip
       purchase(GameStepPropertiesHelper.isBid(getGameData()));
     } else if (name.endsWith("Move")) {
       final boolean nonCombat = GameStepPropertiesHelper.isNonCombatMove(getGameData(), false);
-      move(nonCombat, name);
+      if (!GameStepPropertiesHelper.isPostOnlyMove(getGameData())) {
+        move(nonCombat, name);
+      }
       if (!nonCombat) {
         ui.waitForMoveForumPoster(getPlayerId(), getPlayerBridge());
         // TODO only do forum post if there is a combat

--- a/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
@@ -137,6 +137,20 @@ public final class GameStepPropertiesHelper {
   }
 
   /**
+   * For various things related to movement validation.
+   * Specifically is it a PBF/PBEM post only delegate - no movement allowed.
+   */
+  public static boolean isPostOnlyMove(final GameData data) {
+    data.acquireReadLock();
+    try {
+      final String prop = data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.POST_ONLY_MOVE);
+      // If post only not specified, assume it to be false
+      return prop != null && Boolean.parseBoolean(prop);
+    } finally {
+      data.releaseReadLock();
+    }
+  }
+  /**
    * Repairs damaged units. Normally would occur at either start of combat move or end of turn, depending.
    */
   static boolean isRepairUnits(final GameData data) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
@@ -143,13 +143,15 @@ public final class GameStepPropertiesHelper {
   public static boolean isPostOnlyMove(final GameData data) {
     data.acquireReadLock();
     try {
-      final String prop = data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.POST_ONLY_MOVE);
+      final String prop =
+          data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.POST_ONLY_MOVE);
       // If post only not specified, assume it to be false
       return prop != null && Boolean.parseBoolean(prop);
     } finally {
       data.releaseReadLock();
     }
   }
+
   /**
    * Repairs damaged units. Normally would occur at either start of combat move or end of turn, depending.
    */


### PR DESCRIPTION
For PBF/PBEM with combat move first

## Overview
One of the limitations of combat move before purchase is that you can't use the forum poster at the end of combat move. Defenders should be able to see purchases before making decisions.

## Functional Changes
Adds "postOnly" option to move phases. "skipPosting" already exists. So this will allow an additional move phase to be inserted after purchase which does nothing but posting.


## Manual Testing Performed
- ..
Ran through several scenarios including adding airborne combat move phases, after updating German XML to use the new options. Appeared to work correctly and posted correctly on axisandallies.org.
## Before & After Screen Shots
<!-- Leave blank if no UI changes -->
### Before

### After


## Additional Review Notes
<!-- Add here any extra notes that would be helpful to reviewers -->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->
