### PR TITLE
Repair bases

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameStep.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameStep.java
@@ -37,6 +37,7 @@ public class GameStep extends GameDataComponent {
     String NON_COMBAT_MOVE = "nonCombatMove";
     String FIRE_ROCKETS = "fireRockets";
     String REPAIR_UNITS = "repairUnits";
+    String REPAIR_ON_INOPERATIVE = "repairOnInoperative";
     String GIVE_BONUS_MOVEMENT = "giveBonusMovement";
     String REMOVE_AIR_THAT_CAN_NOT_LAND = "removeAirThatCanNotLand";
     String RESET_UNIT_STATE_AT_START = "resetUnitStateAtStart";

--- a/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
@@ -40,6 +40,21 @@ public final class GameStepPropertiesHelper {
   }
 
   /**
+   * Allow a purchase step which only repairs. Does not actually purchase.
+   * Triggered if a base is inoperative.
+   */
+  public static boolean isRepairOnInoperative(final GameData data) {
+    data.acquireReadLock();
+    try {
+      final String prop = data.getSequence().getStep().getProperties()
+          .getProperty(GameStep.PropertyKeys.REPAIR_ON_INOPERATIVE);
+      return prop != null && Boolean.parseBoolean(prop);  // default to false
+    } finally {
+      data.releaseReadLock();
+    }
+  }
+
+  /**
    * What players is this turn summary for? If more than 1 player, whose phases are touching or intermeshed, then we
    * will summarize for all those phases.
    *

--- a/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
@@ -48,7 +48,7 @@ public final class GameStepPropertiesHelper {
     try {
       final String prop = data.getSequence().getStep().getProperties()
           .getProperty(GameStep.PropertyKeys.REPAIR_ON_INOPERATIVE);
-      return prop != null && Boolean.parseBoolean(prop);  // default to false
+      return prop != null && Boolean.parseBoolean(prop); // default to false
     } finally {
       data.releaseReadLock();
     }


### PR DESCRIPTION
## Overview
Allows a phase to be added which only repairs, and only when bases (naval and air in Global 1940) are inoperative.

## Functional Changes
As above

## Manual Testing Performed
Ran through most imaginable scenarios.

Not completely perfect - if you have an inoperative base you are offered a chance to repair everything which is damaged, and you will get a second bite at the cherry when the normal repair/purchase phase comes around. Still doesn't cause harm to the existing games, unless I'm really missing something.

## Before & After Screen Shots
<!-- Leave blank if no UI changes -->
### Before

### After


## Additional Review Notes
<!-- Add here any extra notes that would be helpful to reviewers -->
Accidentally made this change on top of my previous PR so I'd advise that to be merged first. Was supposed to be two distinct PRs with a merge.

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->
