### PR TITLE
Allow posting from after purchase phase

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -130,6 +130,10 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer implements ITrip
       tech();
     } else if (name.endsWith("Bid") || name.endsWith("Purchase")) { // the delegate handles everything
       purchase(GameStepPropertiesHelper.isBid(getGameData()));
+      if (!GameStepPropertiesHelper.isBid(getGameData())) {
+        ui.waitForMoveForumPoster(getPlayerId(), getPlayerBridge());
+        // TODO only do forum post if there is a combat
+      }
     } else if (name.endsWith("Move")) {
       final boolean nonCombat = GameStepPropertiesHelper.isNonCombatMove(getGameData(), false);
       move(nonCombat, name);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
@@ -25,13 +25,15 @@ public final class GameStepPropertiesHelper {
   private GameStepPropertiesHelper() {}
 
   /**
-   * Indicates we skip posting the game summary and save to a forum or email.
+   * Indicates we skip posting the game summary and save to a forum or email. Defaults to true for
+   * purchase phase and false for all others.
    */
   public static boolean isSkipPosting(final GameData data) {
     data.acquireReadLock();
     try {
-      return Boolean.parseBoolean(
-          data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.SKIP_POSTING, "false"));
+      final String defaultSkipPosting = isPurchaseDelegate(data) ? "true" : "false";
+      return Boolean.parseBoolean(data.getSequence().getStep().getProperties()
+          .getProperty(GameStep.PropertyKeys.SKIP_POSTING, defaultSkipPosting));
     } finally {
       data.releaseReadLock();
     }
@@ -285,4 +287,9 @@ public final class GameStepPropertiesHelper {
   private static boolean isBidPlaceDelegate(final GameData data) {
     return data.getSequence().getStep().getName().endsWith("BidPlace");
   }
+
+  private static boolean isPurchaseDelegate(final GameData data) {
+    return data.getSequence().getStep().getName().endsWith("Purchase");
+  }
+
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -27,7 +27,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.changefactory.ChangeFactory;
-import games.strategy.engine.message.IRemote;
+import games.strategy.engine.pbem.PbemMessagePoster;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.AbstractTriggerAttachment;
@@ -37,6 +37,7 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.TriggerAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitTypeComparator;
+import games.strategy.triplea.delegate.remote.IAbstractForumPosterDelegate;
 import games.strategy.triplea.delegate.remote.IPurchaseDelegate;
 import games.strategy.triplea.formatter.MyFormatter;
 
@@ -46,7 +47,7 @@ import games.strategy.triplea.formatter.MyFormatter;
  * Subclasses can over ride addToPlayer(...) and removeFromPlayer(...) to change how
  * the adding or removing of resources is done.
  */
-public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDelegate {
+public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDelegate, IAbstractForumPosterDelegate {
   public static final String NOT_ENOUGH_RESOURCES = "Not enough resources";
   private static final Comparator<RepairRule> repairRuleComparator = Comparator.comparing(
       o -> (UnitType) o.getResults().keySet().iterator().next(),
@@ -329,7 +330,7 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
   }
 
   @Override
-  public Class<? extends IRemote> getRemoteType() {
+  public Class<IPurchaseDelegate> getRemoteType() {
     return IPurchaseDelegate.class;
   }
 
@@ -347,6 +348,21 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
       changes.add(change);
     }
     return returnString.toString();
+  }
+
+  @Override
+  public void setHasPostedTurnSummary(final boolean hasPostedTurnSummary) {
+    // nothing for now
+  }
+
+  @Override
+  public boolean getHasPostedTurnSummary() {
+    return false;
+  }
+
+  @Override
+  public boolean postTurnSummary(final PbemMessagePoster poster, final String title) {
+    return poster.post(bridge.getHistoryWriter(), title);
   }
 
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/remote/IPurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/remote/IPurchaseDelegate.java
@@ -7,13 +7,11 @@ import org.triplea.java.collections.IntegerMap;
 import games.strategy.engine.data.ProductionRule;
 import games.strategy.engine.data.RepairRule;
 import games.strategy.engine.data.Unit;
-import games.strategy.engine.delegate.IDelegate;
-import games.strategy.engine.message.IRemote;
 
 /**
  * Logic for purchasing and repairing units.
  */
-public interface IPurchaseDelegate extends IRemote, IDelegate {
+public interface IPurchaseDelegate extends IAbstractForumPosterDelegate {
   /**
    * Purchases the specified units.
    *


### PR DESCRIPTION
## Overview
- Alternative for #4768 

## Functional Changes
- Allow using the "skipPosting" step property for purchase phase so that for maps that are combat move then purchase they can post after purchase rather than after combat move.
- "skipPosting" defaults to true for purchase phase instead of false for other phases (move, endturn)
- Here is an example to achieve posting after purchase instead of combat move:
```
<step name="HumansCombatMove" delegate="move" player="Humans" display="Combat Move">
  <stepProperty name="skipPosting" value="true"/>
</step> 
<step name="HumansPurchase" delegate="purchase" player="Humans" display="Purchase Units">
  <stepProperty name="skipPosting" value="false"/>
</step>
```

## Manual Testing Performed
- Tested that this has no impact on existing maps
- Tested updating a map with the above configuration and seeing it successfully post after purchase and not after combat move

