### PR TITLE
Always create a non fighting battle.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -380,7 +380,6 @@ public class BattleTracker implements Serializable {
       presentFromStartTilEnd.removeAll(unitsNotUnloadedTilEndOfRoute);
     }
     final boolean canConquerMiddleSteps = presentFromStartTilEnd.stream().anyMatch(Matches.unitIsNotAir());
-    final boolean scramblingEnabled = Properties.getScrambleRulesInEffect(data);
     final Predicate<Territory> conquerable = Matches.territoryIsEmptyOfCombatUnits(data, id)
         .and(Matches.territoryIsOwnedByPlayerWhosRelationshipTypeCanTakeOverOwnedTerritoryAndPassableAndNotWater(id)
             .or(Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(id, data)));

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -420,44 +420,21 @@ public class BattleTracker implements Serializable {
       if (precede == null) {
         precede = getPendingBombingBattle(route.getEnd());
       }
-      // if we have a preceding battle, then we must use a non-fighting-battle
-      // if we have scrambling on, and this is an amphibious attack,
-      // we may wish to scramble to kill the transports, so must use non-fighting-battle also
-      if (precede != null || (scramblingEnabled && route.isUnload() && route.hasExactlyOneStep())) {
-        IBattle nonFight = getPendingBattle(route.getEnd(), false, BattleType.NORMAL);
-        if (nonFight == null) {
-          nonFight = new NonFightingBattle(route.getEnd(), id, this, data);
-          pendingBattles.add(nonFight);
-          getBattleRecords().addBattle(id, nonFight.getBattleId(), route.getEnd(), nonFight.getBattleType());
-        }
-        final Change change = nonFight.addAttackChange(route, units, null);
-        bridge.addChange(change);
-        if (changeTracker != null) {
-          changeTracker.addChange(change);
-        }
-        if (precede != null) {
-          addDependency(nonFight, precede);
-        }
-      } else {
-        if (Matches.isTerritoryEnemy(id, data).test(route.getEnd())) {
-          if (Matches.territoryIsBlitzable(id, data).test(route.getEnd())) {
-            this.blitzed.add(route.getEnd());
-          }
-          this.conquered.add(route.getEnd());
-        }
-        IBattle nonFight = getPendingBattle(route.getEnd(), false, BattleType.NORMAL);
-        if (nonFight == null) {
-          nonFight = new FinishedBattle(route.getEnd(), id, this, false, BattleType.NORMAL, data,
-              BattleRecord.BattleResultDescription.CONQUERED, WhoWon.ATTACKER);
-          pendingBattles.add(nonFight);
-          getBattleRecords().addBattle(id, nonFight.getBattleId(), route.getEnd(), nonFight.getBattleType());
-        }
-        final Change change = nonFight.addAttackChange(route, units, null);
-        bridge.addChange(change);
-        if (changeTracker != null) {
-          changeTracker.addChange(change);
-        }
-        takeOver(route.getEnd(), id, bridge, changeTracker, units);
+      // There is no reason to avoid a NonFightingBattle any more.
+      // If Combat Move is before Purchase, capital plunders have to be after purchase.
+      IBattle nonFight = getPendingBattle(route.getEnd(), false, BattleType.NORMAL);
+      if (nonFight == null) {
+        nonFight = new NonFightingBattle(route.getEnd(), id, this, data);
+        pendingBattles.add(nonFight);
+        getBattleRecords().addBattle(id, nonFight.getBattleId(), route.getEnd(), nonFight.getBattleType());
+      }
+      final Change change = nonFight.addAttackChange(route, units, null);
+      bridge.addChange(change);
+      if (changeTracker != null) {
+        changeTracker.addChange(change);
+      }
+      if (precede != null) {
+        addDependency(nonFight, precede);
       }
     }
     // TODO: else what?


### PR DESCRIPTION
Fixes bug with combat-move/purchase/battle where a capital is plundered with no defensive units.

Has no downsides any more.

## Overview
Creates NonFightingBattles which are fought automatically in BattleDelegate.start().

## Functional Changes
Only noticeable change is not getting the income and PUs from attacking defenseless territories immediately.

## Manual Testing Performed
Tried testing the several scenarios in this one. 
- ..

## Before & After Screen Shots
<!-- Leave blank if no UI changes -->
### Before

### After


## Additional Review Notes
<!-- Add here any extra notes that would be helpful to reviewers -->
Blitzed territories are still created as FinishedBattles.

This involves few functional differences but removes about 10 lines of code.
<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->
