### PR TITLE
Remove pauses from RandomStartDelegate

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
@@ -292,7 +292,6 @@ public abstract class AbstractAi extends AbstractBasePlayer implements ITripleAP
   @Override
   public Tuple<Territory, Set<Unit>> pickTerritoryAndUnits(final List<Territory> territoryChoices,
       final List<Unit> unitChoices, final int unitsPerPick) {
-    pause();
     final GameData data = getGameData();
     final PlayerId me = getPlayerId();
     final Territory picked;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -9,7 +9,6 @@ import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
 
-import org.triplea.java.Interruptibles;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.util.Tuple;
@@ -93,9 +92,6 @@ public class RandomStartDelegate extends BaseTripleADelegate {
     while (!allPickableTerritories.isEmpty() && !playersCanPick.isEmpty()) {
       if (currentPickingPlayer == null || !playersCanPick.contains(currentPickingPlayer)) {
         currentPickingPlayer = playersCanPick.get(0);
-      }
-      if (!Interruptibles.sleep(10)) {
-        return; // TODO: determine if this sleep is needed
       }
       Territory picked;
       if (randomTerritories) {


### PR DESCRIPTION
## Overview
- Remove pauses for RandomStartDelegate as I can't see any reason that they are needed and for large maps make the initial set up very slow
