### PR TITLE
Add onlyRepairIfDisabled phase option

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameStep.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameStep.java
@@ -44,6 +44,7 @@ public class GameStep extends GameDataComponent {
     String BID = "bid";
     String COMBINED_TURNS = "combinedTurns";
     String REPAIR_PLAYERS = "repairPlayers";
+    String ONLY_REPAIR_IF_DISABLED = "onlyRepairIfDisabled";
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
@@ -274,7 +274,8 @@ public final class GameStepPropertiesHelper {
     data.acquireReadLock();
     try {
       return Boolean.parseBoolean(
-          data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.SKIP_POSTING, "false"));
+          data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.ONLY_REPAIR_IF_DISABLED,
+              "false"));
     } finally {
       data.releaseReadLock();
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
@@ -265,6 +265,21 @@ public final class GameStepPropertiesHelper {
     return getPlayersFromProperty(data, GameStep.PropertyKeys.REPAIR_PLAYERS, player);
   }
 
+  /**
+   * Allow a purchase phase which only occurs if infrastructure is disabled and allows repairing it.
+   * This is useful for when combat move is before main purchase phase but want to allow repairing
+   * infrastructure that provides movement bonus or repairs unit HP.
+   */
+  public static boolean isOnlyRepairIfDisabled(final GameData data) {
+    data.acquireReadLock();
+    try {
+      return Boolean.parseBoolean(
+          data.getSequence().getStep().getProperties().getProperty(GameStep.PropertyKeys.SKIP_POSTING, "false"));
+    } finally {
+      data.releaseReadLock();
+    }
+  }
+
   // private static members for testing default situation based on name of delegate
   private static boolean isNonCombatDelegate(final GameData data) {
     return data.getSequence().getStep().getName().endsWith("NonCombatMove");

--- a/game-core/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
@@ -39,6 +39,7 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.TechAbilityAttachment;
+import games.strategy.triplea.delegate.GameStepPropertiesHelper;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.ui.ScrollableTextField;
 import games.strategy.ui.ScrollableTextFieldListener;
@@ -122,8 +123,11 @@ class ProductionRepairPanel extends JPanel {
     try {
       this.id = player;
       this.allowedPlayersToRepair = allowedPlayersToRepair;
-      final Predicate<Unit> myDamagedUnits = Matches.unitIsOwnedByOfAnyOfThesePlayers(this.allowedPlayersToRepair)
+      Predicate<Unit> myDamagedUnits = Matches.unitIsOwnedByOfAnyOfThesePlayers(this.allowedPlayersToRepair)
           .and(Matches.unitHasTakenSomeBombingUnitDamage());
+      if (GameStepPropertiesHelper.isOnlyRepairIfDisabled(data)) {
+        myDamagedUnits = myDamagedUnits.and(Matches.unitIsDisabled());
+      }
       final Collection<Territory> terrsWithPotentiallyDamagedUnits = CollectionUtils
           .getMatches(data.getMap().getTerritories(), Matches.territoryHasUnitsThatMatch(myDamagedUnits));
       for (final RepairRule repairRule : player.getRepairFrontier()) {


### PR DESCRIPTION
## Overview
- Slightly different approach to #4769

## Functional Changes
- Add new purchase phase option `onlyRepairIfDisabled` which makes it so a purchase phase only occurs if there is a disabled unit and only repairs disabled units. This can be used to have a very minimal repair phase before combat move when doing combat move before main purchase.
Example:
```
      <step name="japaneseDisabledPurchase" delegate="purchase" player="Japanese">
        <stepProperty name="onlyRepairIfDisabled" value="true"/>
      </step>
```

