### PR TITLE
Object rename: 'ErrorReport*' to ErrorUpload*

### DIFF
--- a/game-core/src/main/java/games/strategy/debug/ErrorMessage.java
+++ b/game-core/src/main/java/games/strategy/debug/ErrorMessage.java
@@ -14,9 +14,9 @@ import javax.swing.JLabel;
 import javax.swing.SwingUtilities;
 
 import org.triplea.http.client.ServiceClient;
-import org.triplea.http.client.error.report.ErrorReportClientFactory;
-import org.triplea.http.client.error.report.create.ErrorReport;
-import org.triplea.http.client.error.report.create.ErrorReportResponse;
+import org.triplea.http.client.error.report.ErrorUploadClientFactory;
+import org.triplea.http.client.error.report.ErrorUploadRequest;
+import org.triplea.http.client.error.report.ErrorUploadResponse;
 import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.JLabelBuilder;
 import org.triplea.swing.JPanelBuilder;
@@ -117,7 +117,7 @@ public enum ErrorMessage {
 
   private void setUploadRecord(final LogRecord record) {
 
-    final ServiceClient<ErrorReport, ErrorReportResponse> serviceClient = serviceClient();
+    final ServiceClient<ErrorUploadRequest, ErrorUploadResponse> serviceClient = serviceClient();
 
     if (serviceClient == null) {
       // if no internet connection, do not show 'upload button' as it will not work anyways.
@@ -137,11 +137,11 @@ public enum ErrorMessage {
   }
 
 
-  private static ServiceClient<ErrorReport, ErrorReportResponse> serviceClient() {
+  private static ServiceClient<ErrorUploadRequest, ErrorUploadResponse> serviceClient() {
     return LobbyPropertyFetcherConfiguration.lobbyServerPropertiesFetcher()
         .fetchLobbyServerProperties()
         .map(LobbyServerProperties::getHttpServerUri)
-        .map(ErrorReportClientFactory::newErrorUploader)
+        .map(ErrorUploadClientFactory::newErrorUploader)
         .orElse(null);
   }
 

--- a/game-core/src/main/java/games/strategy/debug/error/reporting/ConfirmationDialogController.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/ConfirmationDialogController.java
@@ -11,7 +11,7 @@ import javax.swing.event.HyperlinkEvent;
 
 import org.triplea.awt.OpenFileUtility;
 import org.triplea.http.client.ServiceResponse;
-import org.triplea.http.client.error.report.create.ErrorReportResponse;
+import org.triplea.http.client.error.report.ErrorUploadResponse;
 import org.triplea.swing.JPanelBuilder;
 
 import games.strategy.triplea.UrlConstants;
@@ -23,11 +23,11 @@ import games.strategy.triplea.UrlConstants;
 final class ConfirmationDialogController {
   private ConfirmationDialogController() {}
 
-  static void showFailureConfirmation(final ServiceResponse<ErrorReportResponse> response) {
+  static void showFailureConfirmation(final ServiceResponse<ErrorUploadResponse> response) {
     SwingUtilities.invokeLater(() -> doShowFailureConfirmation(response));
   }
 
-  private static void doShowFailureConfirmation(final ServiceResponse<ErrorReportResponse> response) {
+  private static void doShowFailureConfirmation(final ServiceResponse<ErrorUploadResponse> response) {
     final JEditorPane editorPane = new JEditorPane("text/html",
         "Failure uploading report, please try again or <a href='" + UrlConstants.GITHUB_ISSUES
             + "'>contact support</a>.<br/><br/>"
@@ -36,7 +36,7 @@ final class ConfirmationDialogController {
             + response.getExceptionMessage()
                 .map(error -> "Errors reported: " + error)
                 .orElseGet(() -> response.getPayload()
-                    .map(ErrorReportResponse::getError)
+                    .map(ErrorUploadResponse::getError)
                     .map(e -> "<br/>Error reported from server:<br/>" + e)
                     .orElse("")));
     editorPane.setEditable(false);

--- a/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportUploadAction.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/ErrorReportUploadAction.java
@@ -9,8 +9,8 @@ import javax.annotation.Nonnull;
 import org.triplea.http.client.SendResult;
 import org.triplea.http.client.ServiceClient;
 import org.triplea.http.client.ServiceResponse;
-import org.triplea.http.client.error.report.create.ErrorReport;
-import org.triplea.http.client.error.report.create.ErrorReportResponse;
+import org.triplea.http.client.error.report.ErrorUploadRequest;
+import org.triplea.http.client.error.report.ErrorUploadResponse;
 
 import lombok.Builder;
 
@@ -18,19 +18,19 @@ import lombok.Builder;
  * Strategy object to upload an error report to http server.
  */
 @Builder
-class ErrorReportUploadAction implements Predicate<ErrorReport> {
+class ErrorReportUploadAction implements Predicate<ErrorUploadRequest> {
 
   @Nonnull
-  private final ServiceClient<ErrorReport, ErrorReportResponse> serviceClient;
+  private final ServiceClient<ErrorUploadRequest, ErrorUploadResponse> serviceClient;
   @Nonnull
   private final Consumer<URI> successConfirmation;
   @Nonnull
-  private final Consumer<ServiceResponse<ErrorReportResponse>> failureConfirmation;
+  private final Consumer<ServiceResponse<ErrorUploadResponse>> failureConfirmation;
 
 
   @Override
-  public boolean test(final ErrorReport errorReport) {
-    final ServiceResponse<ErrorReportResponse> response = serviceClient.apply(errorReport);
+  public boolean test(final ErrorUploadRequest errorReport) {
+    final ServiceResponse<ErrorUploadResponse> response = serviceClient.apply(errorReport);
     final URI githubLink =
         response.getPayload().map(pay -> pay.getGithubIssueLink().orElse(null)).orElse(null);
 

--- a/game-core/src/main/java/games/strategy/debug/error/reporting/ReportPreviewSwingView.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/ReportPreviewSwingView.java
@@ -4,13 +4,13 @@ import java.util.function.Consumer;
 
 import javax.swing.JOptionPane;
 
-import org.triplea.http.client.error.report.create.ErrorReport;
+import org.triplea.http.client.error.report.ErrorUploadRequest;
 import org.triplea.swing.JTextAreaBuilder;
 import org.triplea.swing.SwingComponents;
 
-class ReportPreviewSwingView implements Consumer<ErrorReport> {
+class ReportPreviewSwingView implements Consumer<ErrorUploadRequest> {
   @Override
-  public void accept(final ErrorReport errorReport) {
+  public void accept(final ErrorUploadRequest errorReport) {
     JOptionPane.showMessageDialog(
         null, SwingComponents.newJScrollPane(
             JTextAreaBuilder.builder()

--- a/game-core/src/main/java/games/strategy/debug/error/reporting/StackTraceErrorReportFormatter.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/StackTraceErrorReportFormatter.java
@@ -8,7 +8,7 @@ import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
-import org.triplea.http.client.error.report.create.ErrorReport;
+import org.triplea.http.client.error.report.ErrorUploadRequest;
 
 import com.google.common.base.Strings;
 
@@ -19,11 +19,11 @@ import games.strategy.engine.framework.system.SystemProperties;
  * Combines user description input with data from a {@code LogRecord} to create an {@code ErrorReport}
  * object that we can send to the HTTP server.
  */
-class StackTraceErrorReportFormatter implements BiFunction<String, LogRecord, ErrorReport> {
+class StackTraceErrorReportFormatter implements BiFunction<String, LogRecord, ErrorUploadRequest> {
 
   @Override
-  public ErrorReport apply(final String userDescription, final LogRecord logRecord) {
-    return ErrorReport.builder()
+  public ErrorUploadRequest apply(final String userDescription, final LogRecord logRecord) {
+    return ErrorUploadRequest.builder()
         .title(createTitle(logRecord))
         .body(buildBody(userDescription, logRecord))
         .build();

--- a/game-core/src/main/java/games/strategy/debug/error/reporting/StackTraceReportModel.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/StackTraceReportModel.java
@@ -7,7 +7,7 @@ import java.util.logging.LogRecord;
 
 import javax.annotation.Nonnull;
 
-import org.triplea.http.client.error.report.create.ErrorReport;
+import org.triplea.http.client.error.report.ErrorUploadRequest;
 
 import lombok.Builder;
 
@@ -19,11 +19,11 @@ class StackTraceReportModel {
   @Nonnull
   private final LogRecord stackTraceRecord;
   @Nonnull
-  private final BiFunction<String, LogRecord, ErrorReport> formatter;
+  private final BiFunction<String, LogRecord, ErrorUploadRequest> formatter;
   @Nonnull
-  private final Predicate<ErrorReport> uploader;
+  private final Predicate<ErrorUploadRequest> uploader;
   @Nonnull
-  private final Consumer<ErrorReport> preview;
+  private final Consumer<ErrorUploadRequest> preview;
 
   void submitAction() {
     if (uploader.test(readErrorReportFromUi())) {
@@ -31,7 +31,7 @@ class StackTraceReportModel {
     }
   }
 
-  private ErrorReport readErrorReportFromUi() {
+  private ErrorUploadRequest readErrorReportFromUi() {
     return formatter.apply(view.readUserDescription(), stackTraceRecord);
   }
 

--- a/game-core/src/main/java/games/strategy/debug/error/reporting/StackTraceReportView.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/StackTraceReportView.java
@@ -4,8 +4,8 @@ import java.awt.Component;
 import java.util.logging.LogRecord;
 
 import org.triplea.http.client.ServiceClient;
-import org.triplea.http.client.error.report.create.ErrorReport;
-import org.triplea.http.client.error.report.create.ErrorReportResponse;
+import org.triplea.http.client.error.report.ErrorUploadRequest;
+import org.triplea.http.client.error.report.ErrorUploadResponse;
 
 /**
  * Interface for interactions with the stack trace user-reporting window UI.
@@ -42,7 +42,7 @@ public interface StackTraceReportView {
    */
   static void showWindow(
       final Component parentWindow,
-      final ServiceClient<ErrorReport, ErrorReportResponse> uploader,
+      final ServiceClient<ErrorUploadRequest, ErrorUploadResponse> uploader,
       final LogRecord logRecord) {
 
     final StackTraceReportView window = new StackTraceReportSwingView(parentWindow);

--- a/game-core/src/test/java/games/strategy/debug/error/reporting/StackTraceErrorReportFormatterTest.java
+++ b/game-core/src/test/java/games/strategy/debug/error/reporting/StackTraceErrorReportFormatterTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.triplea.http.client.error.report.create.ErrorReport;
+import org.triplea.http.client.error.report.ErrorUploadRequest;
 
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.framework.system.SystemProperties;
@@ -48,7 +48,7 @@ class StackTraceErrorReportFormatterTest {
       when(logRecord.getMessage()).thenReturn(LOG_MESSAGE);
       when(logRecord.getThrown()).thenReturn(null);
 
-      final ErrorReport errorReportResult =
+      final ErrorUploadRequest errorReportResult =
           new StackTraceErrorReportFormatter().apply(SAMPLE_USER_DESCRIPTION, logRecord);
 
       assertThat(
@@ -61,7 +61,7 @@ class StackTraceErrorReportFormatterTest {
       when(logRecord.getMessage()).thenReturn(LOG_MESSAGE);
       when(logRecord.getThrown()).thenReturn(EXCEPTION_WITH_MESSAGE);
 
-      final ErrorReport errorReportResult =
+      final ErrorUploadRequest errorReportResult =
           new StackTraceErrorReportFormatter().apply(SAMPLE_USER_DESCRIPTION, logRecord);
 
       assertThat(
@@ -76,7 +76,7 @@ class StackTraceErrorReportFormatterTest {
     void handleNullLogMessageAndNullExceptionMessage() {
       when(logRecord.getThrown()).thenReturn(EXCEPTION_WITH_NO_MESSAGE);
 
-      final ErrorReport errorReportResult =
+      final ErrorUploadRequest errorReportResult =
           new StackTraceErrorReportFormatter().apply(SAMPLE_USER_DESCRIPTION, logRecord);
 
       assertThat(
@@ -91,7 +91,7 @@ class StackTraceErrorReportFormatterTest {
       when(logRecord.getSourceMethodName()).thenReturn(METHOD_NAME);
       when(logRecord.getSourceClassName()).thenReturn("ClassInDefaultPackage");
 
-      final ErrorReport errorReportResult =
+      final ErrorUploadRequest errorReportResult =
           new StackTraceErrorReportFormatter().apply(SAMPLE_USER_DESCRIPTION, logRecord);
 
       assertDoesNotThrow(errorReportResult::getTitle);
@@ -108,7 +108,7 @@ class StackTraceErrorReportFormatterTest {
 
     @Test
     void containsUseSuppliedData() {
-      final ErrorReport errorReportResult =
+      final ErrorUploadRequest errorReportResult =
           new StackTraceErrorReportFormatter().apply(SAMPLE_USER_DESCRIPTION, logRecord);
 
       assertThat(errorReportResult.getBody(), containsString(SAMPLE_USER_DESCRIPTION));
@@ -116,7 +116,7 @@ class StackTraceErrorReportFormatterTest {
 
     @Test
     void containsSystemData() {
-      final ErrorReport errorReportResult =
+      final ErrorUploadRequest errorReportResult =
           new StackTraceErrorReportFormatter().apply(SAMPLE_USER_DESCRIPTION, logRecord);
 
       assertThat(errorReportResult.getBody(), containsString(SAMPLE_USER_DESCRIPTION));
@@ -128,7 +128,7 @@ class StackTraceErrorReportFormatterTest {
     @Test
     void containsStackTraceData() {
       when(logRecord.getThrown()).thenReturn(EXCEPTION_WITH_NO_MESSAGE);
-      final ErrorReport errorReportResult =
+      final ErrorUploadRequest errorReportResult =
           new StackTraceErrorReportFormatter().apply(SAMPLE_USER_DESCRIPTION, logRecord);
 
       Arrays.stream(EXCEPTION_WITH_NO_MESSAGE.getStackTrace())
@@ -143,7 +143,7 @@ class StackTraceErrorReportFormatterTest {
       when(logRecord.getMessage()).thenReturn(LOG_MESSAGE);
       when(logRecord.getThrown()).thenReturn(EXCEPTION_WITH_MESSAGE);
 
-      final ErrorReport errorReportResult =
+      final ErrorUploadRequest errorReportResult =
           new StackTraceErrorReportFormatter().apply(SAMPLE_USER_DESCRIPTION, logRecord);
 
       assertThat(errorReportResult.getBody(), containsString(EXCEPTION_WITH_MESSAGE.getClass().getName()));
@@ -163,7 +163,7 @@ class StackTraceErrorReportFormatterTest {
     void nullLogMessage() {
       when(logRecord.getThrown()).thenReturn(EXCEPTION_WITH_NO_MESSAGE);
 
-      final ErrorReport errorReportResult =
+      final ErrorUploadRequest errorReportResult =
           new StackTraceErrorReportFormatter().apply(SAMPLE_USER_DESCRIPTION, logRecord);
 
       assertThat(errorReportResult.getBody(), containsString(EXCEPTION_WITH_NO_MESSAGE.getClass().getName()));

--- a/game-core/src/test/java/games/strategy/debug/error/reporting/StackTraceReportModelTest.java
+++ b/game-core/src/test/java/games/strategy/debug/error/reporting/StackTraceReportModelTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.triplea.http.client.error.report.create.ErrorReport;
+import org.triplea.http.client.error.report.ErrorUploadRequest;
 
 @ExtendWith(MockitoExtension.class)
 class StackTraceReportModelTest {
@@ -29,16 +29,16 @@ class StackTraceReportModelTest {
   private StackTraceReportView stackTraceReportView;
 
   @Mock
-  private Predicate<ErrorReport> uploader;
+  private Predicate<ErrorUploadRequest> uploader;
 
   @Mock
-  private Consumer<ErrorReport> preview;
+  private Consumer<ErrorUploadRequest> preview;
 
   @Mock
-  private BiFunction<String, LogRecord, ErrorReport> formatter;
+  private BiFunction<String, LogRecord, ErrorUploadRequest> formatter;
 
   @Mock
-  private ErrorReport errorReport;
+  private ErrorUploadRequest errorReport;
 
   private StackTraceReportModel viewModel;
 

--- a/lobby-client-http/src/main/java/org/triplea/http/client/error/report/ErrorUploadClient.java
+++ b/lobby-client-http/src/main/java/org/triplea/http/client/error/report/ErrorUploadClient.java
@@ -1,15 +1,12 @@
 package org.triplea.http.client.error.report;
 
-import org.triplea.http.client.error.report.create.ErrorReport;
-import org.triplea.http.client.error.report.create.ErrorReportResponse;
-
 import com.google.common.annotations.VisibleForTesting;
 
 import feign.Headers;
 import feign.RequestLine;
 
 @SuppressWarnings("InterfaceNeverImplemented")
-interface ErrorReportClient {
+interface ErrorUploadClient {
 
   @VisibleForTesting
   String ERROR_REPORT_PATH = "/error-report";
@@ -19,5 +16,5 @@ interface ErrorReportClient {
       "Content-Type: application/json",
       "Accept: application/json"
   })
-  ErrorReportResponse sendErrorReport(ErrorReport errorReport);
+  ErrorUploadResponse sendErrorReport(ErrorUploadRequest errorReport);
 }

--- a/lobby-client-http/src/main/java/org/triplea/http/client/error/report/ErrorUploadClientFactory.java
+++ b/lobby-client-http/src/main/java/org/triplea/http/client/error/report/ErrorUploadClientFactory.java
@@ -4,22 +4,20 @@ import java.net.URI;
 
 import org.triplea.http.client.HttpClient;
 import org.triplea.http.client.ServiceClient;
-import org.triplea.http.client.error.report.create.ErrorReport;
-import org.triplea.http.client.error.report.create.ErrorReportResponse;
 
 /**
  * Creates an http client that can be used to upload error reports to the TripleA server.
  */
-public final class ErrorReportClientFactory {
-  private ErrorReportClientFactory() {}
+public final class ErrorUploadClientFactory {
+  private ErrorUploadClientFactory() {}
 
   /**
    * Creates an error report uploader clients, sends error reports and gets a response back.
    */
-  public static ServiceClient<ErrorReport, ErrorReportResponse> newErrorUploader(final URI uri) {
+  public static ServiceClient<ErrorUploadRequest, ErrorUploadResponse> newErrorUploader(final URI uri) {
     return new ServiceClient<>(new HttpClient<>(
-        ErrorReportClient.class,
-        ErrorReportClient::sendErrorReport,
+        ErrorUploadClient.class,
+        ErrorUploadClient::sendErrorReport,
         uri));
   }
 }

--- a/lobby-client-http/src/main/java/org/triplea/http/client/error/report/ErrorUploadRequest.java
+++ b/lobby-client-http/src/main/java/org/triplea/http/client/error/report/ErrorUploadRequest.java
@@ -1,4 +1,4 @@
-package org.triplea.http.client.error.report.create;
+package org.triplea.http.client.error.report;
 
 import javax.annotation.Nonnull;
 
@@ -12,7 +12,7 @@ import lombok.ToString;
 @ToString
 @EqualsAndHashCode
 @Builder
-public class ErrorReport {
+public class ErrorUploadRequest {
   @Nonnull
   private final String title;
   @Nonnull

--- a/lobby-client-http/src/main/java/org/triplea/http/client/error/report/ErrorUploadResponse.java
+++ b/lobby-client-http/src/main/java/org/triplea/http/client/error/report/ErrorUploadResponse.java
@@ -1,4 +1,4 @@
-package org.triplea.http.client.error.report.create;
+package org.triplea.http.client.error.report;
 
 import java.net.URI;
 import java.util.Optional;
@@ -14,7 +14,7 @@ import lombok.ToString;
  */
 @ToString
 @Builder
-public class ErrorReportResponse {
+public class ErrorUploadResponse {
   /**
    * A link to the github issue created (empty if there were problems creating the link).
    */

--- a/lobby-client-http/src/main/java/org/triplea/http/client/github/issues/GithubIssueClient.java
+++ b/lobby-client-http/src/main/java/org/triplea/http/client/github/issues/GithubIssueClient.java
@@ -3,7 +3,7 @@ package org.triplea.http.client.github.issues;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.triplea.http.client.error.report.create.ErrorReport;
+import org.triplea.http.client.error.report.ErrorUploadRequest;
 import org.triplea.http.client.github.issues.create.CreateIssueResponse;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -28,12 +28,12 @@ interface GithubIssueClient {
       @HeaderMap Map<String, Object> headerMap,
       @Param("org") String org,
       @Param("repo") String repo,
-      ErrorReport errorReport);
+      ErrorUploadRequest errorReport);
 
 
   default CreateIssueResponse newIssue(
       final IssueClientParams params,
-      final ErrorReport errorReport) {
+      final ErrorUploadRequest errorReport) {
     final Map<String, Object> tokens = new HashMap<>();
     tokens.put("Authorization", "token " + params.getAuthToken());
     return newIssue(tokens, params.getGithubOrg(), params.getGithubRepo(), errorReport);

--- a/lobby-client-http/src/main/java/org/triplea/http/client/github/issues/GithubIssueClientFactory.java
+++ b/lobby-client-http/src/main/java/org/triplea/http/client/github/issues/GithubIssueClientFactory.java
@@ -2,7 +2,7 @@ package org.triplea.http.client.github.issues;
 
 import org.triplea.http.client.HttpClient;
 import org.triplea.http.client.ServiceClient;
-import org.triplea.http.client.error.report.create.ErrorReport;
+import org.triplea.http.client.error.report.ErrorUploadRequest;
 import org.triplea.http.client.github.issues.create.CreateIssueResponse;
 
 /** Creates an http client that can be used to interact with Github 'issues'. */
@@ -10,7 +10,7 @@ public final class GithubIssueClientFactory {
   private GithubIssueClientFactory() {}
 
   /** Creates an http client that can post a new github issue. */
-  public static ServiceClient<ErrorReport, CreateIssueResponse> newGithubIssueCreator(
+  public static ServiceClient<ErrorUploadRequest, CreateIssueResponse> newGithubIssueCreator(
       final IssueClientParams issueClientParams) {
     return new ServiceClient<>(
         new HttpClient<>(

--- a/lobby-client-http/src/test/java/org/triplea/http/client/error/report/ErrorReportResponseTest.java
+++ b/lobby-client-http/src/test/java/org/triplea/http/client/error/report/ErrorReportResponseTest.java
@@ -7,14 +7,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.net.URI;
 
 import org.junit.jupiter.api.Test;
-import org.triplea.http.client.error.report.create.ErrorReportResponse;
 
 class ErrorReportResponseTest {
 
   @Test
   void verifyErrorReportIdBehavior() {
     assertThat(
-        ErrorReportResponse.builder()
+        ErrorUploadResponse.builder()
             .githubIssueLink("")
             .build()
             .getGithubIssueLink(),
@@ -25,7 +24,7 @@ class ErrorReportResponseTest {
   void verify() {
     final String exampleValue = "https://myuri";
     assertThat(
-        ErrorReportResponse.builder()
+        ErrorUploadResponse.builder()
             .githubIssueLink(exampleValue)
             .build()
             .getGithubIssueLink(),

--- a/lobby-client-http/src/test/java/org/triplea/http/client/throttle/rate/RateLimitingThrottleTest.java
+++ b/lobby-client-http/src/test/java/org/triplea/http/client/throttle/rate/RateLimitingThrottleTest.java
@@ -10,12 +10,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.triplea.http.client.error.report.create.ErrorReport;
+import org.triplea.http.client.error.report.ErrorUploadRequest;
 
 @ExtendWith(MockitoExtension.class)
 class RateLimitingThrottleTest {
 
-  private static final ErrorReport ERROR_REPORT = ErrorReport.builder()
+  private static final ErrorUploadRequest ERROR_REPORT = ErrorUploadRequest.builder()
       .title("Hunger is a scurvy tuna.")
       .body("Woodchucks are the sails of the scrawny desolation.")
       .build();
@@ -30,7 +30,7 @@ class RateLimitingThrottleTest {
 
   @Test
   void throttleNumberOfRequestPer() {
-    final Consumer<ErrorReport> throttle =
+    final Consumer<ErrorUploadRequest> throttle =
         new RateLimitingThrottle<>(MIN_MILLIS_BETWEEN_REQUSETS, instantSupplier);
 
     Mockito.when(instantSupplier.get())

--- a/lobby-client-http/src/test/java/org/triplea/http/client/throttle/size/MessageSizeThrottleTest.java
+++ b/lobby-client-http/src/test/java/org/triplea/http/client/throttle/size/MessageSizeThrottleTest.java
@@ -4,11 +4,11 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
-import org.triplea.http.client.error.report.create.ErrorReport;
+import org.triplea.http.client.error.report.ErrorUploadRequest;
 
 class MessageSizeThrottleTest {
 
-  private static final ErrorReport ERROR_REPORT = ErrorReport.builder()
+  private static final ErrorUploadRequest ERROR_REPORT = ErrorUploadRequest.builder()
       .title("never drink a doubloons. ")
       .body("The corsair stutters malaria like a rainy dubloon.")
       .build();

--- a/lobby-engine/src/main/java/org/triplea/server/reporting/error/ErrorReportRequest.java
+++ b/lobby-engine/src/main/java/org/triplea/server/reporting/error/ErrorReportRequest.java
@@ -2,7 +2,7 @@ package org.triplea.server.reporting.error;
 
 import javax.annotation.Nonnull;
 
-import org.triplea.http.client.error.report.create.ErrorReport;
+import org.triplea.http.client.error.report.ErrorUploadRequest;
 
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -14,7 +14,7 @@ import lombok.Getter;
 @EqualsAndHashCode
 public class ErrorReportRequest {
   @Nonnull
-  private final ErrorReport errorReport;
+  private final ErrorUploadRequest errorReport;
   @Nonnull
   private final String clientIp;
 }

--- a/lobby-engine/src/main/java/org/triplea/server/reporting/error/ErrorReportResponseAdapter.java
+++ b/lobby-engine/src/main/java/org/triplea/server/reporting/error/ErrorReportResponseAdapter.java
@@ -3,15 +3,15 @@ package org.triplea.server.reporting.error;
 import java.util.function.Function;
 
 import org.triplea.http.client.ServiceResponse;
-import org.triplea.http.client.error.report.create.ErrorReportResponse;
+import org.triplea.http.client.error.report.ErrorUploadResponse;
 import org.triplea.http.client.github.issues.create.CreateIssueResponse;
 
 class ErrorReportResponseAdapter
-    implements Function<ServiceResponse<CreateIssueResponse>, ErrorReportResponse> {
+    implements Function<ServiceResponse<CreateIssueResponse>, ErrorUploadResponse> {
 
   @Override
-  public ErrorReportResponse apply(final ServiceResponse<CreateIssueResponse> response) {
-    return ErrorReportResponse.builder()
+  public ErrorUploadResponse apply(final ServiceResponse<CreateIssueResponse> response) {
+    return ErrorUploadResponse.builder()
         .error(response.getThrown()
             .map(Throwable::getMessage)
             .orElse(""))

--- a/lobby-engine/src/main/java/org/triplea/server/reporting/error/ErrorUploadConfiguration.java
+++ b/lobby-engine/src/main/java/org/triplea/server/reporting/error/ErrorUploadConfiguration.java
@@ -1,7 +1,7 @@
 package org.triplea.server.reporting.error;
 
 import org.triplea.http.client.ServiceClient;
-import org.triplea.http.client.error.report.create.ErrorReport;
+import org.triplea.http.client.error.report.ErrorUploadRequest;
 import org.triplea.http.client.github.issues.GithubIssueClientFactory;
 import org.triplea.http.client.github.issues.IssueClientParams;
 import org.triplea.http.client.github.issues.create.CreateIssueResponse;
@@ -14,7 +14,7 @@ public final class ErrorUploadConfiguration {
    * Factory method for {@code ErrorUploader}.
    */
   public static ErrorUploadStrategy newErrorUploader(final IssueClientParams issueClientParams) {
-    final ServiceClient<ErrorReport, CreateIssueResponse> createIssueClient =
+    final ServiceClient<ErrorUploadRequest, CreateIssueResponse> createIssueClient =
         GithubIssueClientFactory.newGithubIssueCreator(issueClientParams);
 
     return ErrorUploadStrategy.builder()

--- a/lobby-engine/src/main/java/org/triplea/server/reporting/error/ErrorUploadStrategy.java
+++ b/lobby-engine/src/main/java/org/triplea/server/reporting/error/ErrorUploadStrategy.java
@@ -7,32 +7,32 @@ import javax.annotation.Nonnull;
 
 import org.triplea.http.client.ServiceClient;
 import org.triplea.http.client.ServiceResponse;
-import org.triplea.http.client.error.report.create.ErrorReport;
-import org.triplea.http.client.error.report.create.ErrorReportResponse;
+import org.triplea.http.client.error.report.ErrorUploadRequest;
+import org.triplea.http.client.error.report.ErrorUploadResponse;
 import org.triplea.http.client.github.issues.create.CreateIssueResponse;
 
 import lombok.Builder;
 
 /** Performs the steps for uploading an error report from the point of view of the server. */
 @Builder
-public class ErrorUploadStrategy implements Function<ErrorReportRequest, ErrorReportResponse> {
+public class ErrorUploadStrategy implements Function<ErrorReportRequest, ErrorUploadResponse> {
 
   @Nonnull
-  private final Function<ServiceResponse<CreateIssueResponse>, ErrorReportResponse> responseAdapter;
+  private final Function<ServiceResponse<CreateIssueResponse>, ErrorUploadResponse> responseAdapter;
   @Nonnull
-  private final ServiceClient<ErrorReport, CreateIssueResponse> createIssueClient;
+  private final ServiceClient<ErrorUploadRequest, CreateIssueResponse> createIssueClient;
   @Nonnull
   private final Predicate<ErrorReportRequest> allowErrorReport;
 
   @Override
-  public ErrorReportResponse apply(final ErrorReportRequest errorReportRequest) {
+  public ErrorUploadResponse apply(final ErrorReportRequest errorReportRequest) {
     if (allowErrorReport.test(errorReportRequest)) {
       final ServiceResponse<CreateIssueResponse> response =
           createIssueClient.apply(errorReportRequest.getErrorReport());
       return responseAdapter.apply(response);
     }
 
-    return ErrorReportResponse.builder()
+    return ErrorUploadResponse.builder()
         .error("Too many requests, please wait before submitting another request")
         .build();
   }

--- a/lobby-engine/src/test/java/org/triplea/server/reporting/error/ErrorReportResponseAdapterTest.java
+++ b/lobby-engine/src/test/java/org/triplea/server/reporting/error/ErrorReportResponseAdapterTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.triplea.http.client.SendResult;
 import org.triplea.http.client.ServiceResponse;
-import org.triplea.http.client.error.report.create.ErrorReportResponse;
+import org.triplea.http.client.error.report.ErrorUploadResponse;
 import org.triplea.http.client.github.issues.create.CreateIssueResponse;
 
 class ErrorReportResponseAdapterTest {
@@ -44,7 +44,7 @@ class ErrorReportResponseAdapterTest {
 
   @Test
   void apply() {
-    final ErrorReportResponse errorReportResponse = errorReportResponseAdapter.apply(SERVICE_RESPONSE);
+    final ErrorUploadResponse errorReportResponse = errorReportResponseAdapter.apply(SERVICE_RESPONSE);
 
     assertThat(
         errorReportResponse.getGithubIssueLink(),
@@ -55,7 +55,7 @@ class ErrorReportResponseAdapterTest {
 
   @Test
   void applyWithErrorInput() {
-    final ErrorReportResponse errorReportResponse = errorReportResponseAdapter.apply(ERROR_RESPONSE);
+    final ErrorUploadResponse errorReportResponse = errorReportResponseAdapter.apply(ERROR_RESPONSE);
 
     assertThat(errorReportResponse.getGithubIssueLink(), isEmpty());
     assertThat(errorReportResponse.getError(), is(sampleException.getMessage()));

--- a/lobby-engine/src/test/java/org/triplea/server/reporting/error/ErrorUploadStrategyTest.java
+++ b/lobby-engine/src/test/java/org/triplea/server/reporting/error/ErrorUploadStrategyTest.java
@@ -17,13 +17,13 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.http.client.ServiceClient;
 import org.triplea.http.client.ServiceResponse;
-import org.triplea.http.client.error.report.create.ErrorReport;
-import org.triplea.http.client.error.report.create.ErrorReportResponse;
+import org.triplea.http.client.error.report.ErrorUploadRequest;
+import org.triplea.http.client.error.report.ErrorUploadResponse;
 import org.triplea.http.client.github.issues.create.CreateIssueResponse;
 
 @ExtendWith(MockitoExtension.class)
 class ErrorUploadStrategyTest {
-  private static final ErrorReport ERROR_REPORT = ErrorReport.builder()
+  private static final ErrorUploadRequest ERROR_REPORT = ErrorUploadRequest.builder()
       .title("Decors volare in amivadum!")
       .body("Brabeuta camerarius imber est.")
       .build();
@@ -33,13 +33,13 @@ class ErrorUploadStrategyTest {
       .build();
 
   @Mock
-  private ServiceClient<ErrorReport, CreateIssueResponse> serviceClient;
+  private ServiceClient<ErrorUploadRequest, CreateIssueResponse> serviceClient;
   @Mock
   private ServiceResponse<CreateIssueResponse> serviceResponse;
   @Mock
-  private ErrorReportResponse errorReportResponse;
+  private ErrorUploadResponse errorReportResponse;
   @Mock
-  private Function<ServiceResponse<CreateIssueResponse>, ErrorReportResponse> responseAdapter;
+  private Function<ServiceResponse<CreateIssueResponse>, ErrorUploadResponse> responseAdapter;
   @Mock
   private Predicate<ErrorReportRequest> allowErrorReport;
 
@@ -62,7 +62,7 @@ class ErrorUploadStrategyTest {
     when(responseAdapter.apply(serviceResponse)).thenReturn(errorReportResponse);
     when(serviceClient.apply(ERROR_REPORT)).thenReturn(serviceResponse);
 
-    final ErrorReportResponse response = errorUploadStrategy.apply(ERROR_REPORT_REQUEST);
+    final ErrorUploadResponse response = errorUploadStrategy.apply(ERROR_REPORT_REQUEST);
 
     assertThat(response, sameInstance(errorReportResponse));
   }
@@ -72,7 +72,7 @@ class ErrorUploadStrategyTest {
   void filterRejectsRequest() {
     when(allowErrorReport.test(ERROR_REPORT_REQUEST)).thenReturn(false);
 
-    final ErrorReportResponse response = errorUploadStrategy.apply(ERROR_REPORT_REQUEST);
+    final ErrorUploadResponse response = errorUploadStrategy.apply(ERROR_REPORT_REQUEST);
 
     assertThat(response.getError(), not(emptyString()));
     assertThat(response.getGithubIssueLink(), isEmpty());

--- a/lobby/src/main/java/org/triplea/server/http/spark/controller/ErrorReportController.java
+++ b/lobby/src/main/java/org/triplea/server/http/spark/controller/ErrorReportController.java
@@ -4,8 +4,8 @@ import static spark.Spark.post;
 
 import java.util.function.Function;
 
-import org.triplea.http.client.error.report.create.ErrorReport;
-import org.triplea.http.client.error.report.create.ErrorReportResponse;
+import org.triplea.http.client.error.report.ErrorUploadRequest;
+import org.triplea.http.client.error.report.ErrorUploadResponse;
 import org.triplea.server.reporting.error.ErrorReportRequest;
 
 import com.google.gson.Gson;
@@ -21,7 +21,7 @@ public class ErrorReportController implements Runnable {
 
   public static final String ERROR_REPORT_PATH = "/error-report";
 
-  private final Function<ErrorReportRequest, ErrorReportResponse> errorReportIngestion;
+  private final Function<ErrorReportRequest, ErrorUploadResponse> errorReportIngestion;
 
   @Override
   public void run() {
@@ -30,13 +30,13 @@ public class ErrorReportController implements Runnable {
 
   String uploadErrorReport(final Request req) {
     final ErrorReportRequest errorReport = readErrorReport(req);
-    final ErrorReportResponse result = errorReportIngestion.apply(errorReport);
+    final ErrorUploadResponse result = errorReportIngestion.apply(errorReport);
     return new Gson().toJson(result);
   }
 
   private static ErrorReportRequest readErrorReport(final Request request) {
     return ErrorReportRequest.builder()
-        .errorReport(new Gson().fromJson(request.body(), ErrorReport.class))
+        .errorReport(new Gson().fromJson(request.body(), ErrorUploadRequest.class))
         .clientIp(request.ip())
         .build();
   }

--- a/lobby/src/test/java/org/triplea/server/http/spark/SparkServerSystemTest.java
+++ b/lobby/src/test/java/org/triplea/server/http/spark/SparkServerSystemTest.java
@@ -17,9 +17,9 @@ import org.mockito.Mockito;
 import org.triplea.http.client.SendResult;
 import org.triplea.http.client.ServiceClient;
 import org.triplea.http.client.ServiceResponse;
-import org.triplea.http.client.error.report.ErrorReportClientFactory;
-import org.triplea.http.client.error.report.create.ErrorReport;
-import org.triplea.http.client.error.report.create.ErrorReportResponse;
+import org.triplea.http.client.error.report.ErrorUploadClientFactory;
+import org.triplea.http.client.error.report.ErrorUploadRequest;
+import org.triplea.http.client.error.report.ErrorUploadResponse;
 import org.triplea.server.ServerConfiguration;
 import org.triplea.server.reporting.error.ErrorReportRequest;
 import org.triplea.server.reporting.error.ErrorUploadStrategy;
@@ -41,7 +41,7 @@ class SparkServerSystemTest {
       ErrorReportRequest.builder()
           .clientIp("")
           .errorReport(
-              ErrorReport.builder()
+              ErrorUploadRequest.builder()
                   .title("Ah there's nothing like the salty endurance stuttering on the plunder.")
                   .body("Where is the shiny jack?")
                   .build())
@@ -70,15 +70,15 @@ class SparkServerSystemTest {
 
   @Test
   void errorReportEndpont() {
-    final ServiceClient<ErrorReport, ErrorReportResponse> client =
-        ErrorReportClientFactory.newErrorUploader(LOCAL_HOST);
+    final ServiceClient<ErrorUploadRequest, ErrorUploadResponse> client =
+        ErrorUploadClientFactory.newErrorUploader(LOCAL_HOST);
 
     when(errorUploadStrategy.apply(Mockito.any()))
-        .thenReturn(ErrorReportResponse.builder()
+        .thenReturn(ErrorUploadResponse.builder()
             .githubIssueLink(LINK)
             .build());
 
-    final ServiceResponse<ErrorReportResponse> response =
+    final ServiceResponse<ErrorUploadResponse> response =
         client.apply(ERROR_REPORT.getErrorReport());
 
     assertThat(response.getSendResult(), is(SendResult.SENT));


### PR DESCRIPTION
## Overview
Rename is to help distinguish from 'error report' objects that are handled by the server hafter having received an error upload payload.

- Also flattened packages by moving request+response objects up one level

## Functional Changes
None

## Manual Testing Performed
None
