### PR TITLE
Move chat panel to its own package

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/Chat.java
@@ -247,7 +247,7 @@ public class Chat {
     return tagText;
   }
 
-  String getNotesForNode(final INode node) {
+  public String getNotesForNode(final INode node) {
     final Set<String> notes = notesMap.get(node);
     if (notes == null) {
       return null;
@@ -260,24 +260,24 @@ public class Chat {
     return sb.toString();
   }
 
-  SentMessagesHistory getSentMessagesHistory() {
+  public SentMessagesHistory getSentMessagesHistory() {
     return sentMessages;
   }
 
-  void addChatListener(final IChatListener listener) {
+  public void addChatListener(final IChatListener listener) {
     listeners.add(listener);
     updateConnections();
   }
 
-  StatusManager getStatusManager() {
+  public StatusManager getStatusManager() {
     return statusManager;
   }
 
-  void removeChatListener(final IChatListener listener) {
+  public void removeChatListener(final IChatListener listener) {
     listeners.remove(listener);
   }
 
-  Object getMutex() {
+  public Object getMutex() {
     return mutexNodes;
   }
 
@@ -306,7 +306,7 @@ public class Chat {
     }
   }
 
-  void sendSlap(final String playerName) {
+  public void sendSlap(final String playerName) {
     final IChatChannel remote = (IChatChannel) messengers.getChannelBroadcaster(
         new RemoteName(chatChannelName, IChatChannel.class));
     remote.slapOccured(playerName);
@@ -323,7 +323,7 @@ public class Chat {
     sentMessages.append(message);
   }
 
-  void setIgnored(final INode node, final boolean isIgnored) {
+  public void setIgnored(final INode node, final boolean isIgnored) {
     if (isIgnored) {
       ignoreList.add(node.getName());
     } else {
@@ -331,7 +331,7 @@ public class Chat {
     }
   }
 
-  boolean isIgnored(final INode node) {
+  public boolean isIgnored(final INode node) {
     return ignoreList.shouldIgnore(node.getName());
   }
 
@@ -356,7 +356,7 @@ public class Chat {
    *
    * @return the messages that have occurred so far.
    */
-  List<ChatMessage> getChatHistory() {
+  public List<ChatMessage> getChatHistory() {
     return chatHistory;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatFloodControl.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatFloodControl.java
@@ -7,7 +7,7 @@ import java.util.Map;
  * Simple flood control, only allow so many events per window of time. During each rolling time window, anyone that
  * sends more than "N" messages will be filtered until the next time window begins.
  */
-class ChatFloodControl {
+public class ChatFloodControl {
   static final int EVENTS_PER_WINDOW = 20;
   private static final int ONE_MINUTE = 60 * 1000;
   static final int WINDOW = ONE_MINUTE;
@@ -16,7 +16,7 @@ class ChatFloodControl {
   private final Map<String, Integer> messageCount = new HashMap<>();
   private long clearTime;
 
-  ChatFloodControl() {
+  public ChatFloodControl() {
     this(System.currentTimeMillis());
   }
 
@@ -24,7 +24,7 @@ class ChatFloodControl {
     clearTime = initialClearTime;
   }
 
-  boolean allow(final String from, final long now) {
+  public boolean allow(final String from, final long now) {
     synchronized (lock) {
       // reset the window
       if (now > clearTime) {

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatMessage.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatMessage.java
@@ -1,6 +1,6 @@
 package games.strategy.engine.chat;
 
-class ChatMessage {
+public class ChatMessage {
   private final String message;
   private final String from;
   private final boolean isMyMessage;
@@ -11,15 +11,15 @@ class ChatMessage {
     this.isMyMessage = isMyMessage;
   }
 
-  String getFrom() {
+  public String getFrom() {
     return from;
   }
 
-  boolean isMyMessage() {
+  public boolean isMyMessage() {
     return isMyMessage;
   }
 
-  String getMessage() {
+  public String getMessage() {
     return message;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/chat/SentMessagesHistory.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/SentMessagesHistory.java
@@ -3,7 +3,7 @@ package games.strategy.engine.chat;
 import java.util.ArrayList;
 import java.util.List;
 
-class SentMessagesHistory {
+public class SentMessagesHistory {
   private final List<String> history = new ArrayList<>();
   private int historyPosition;
 

--- a/game-core/src/main/java/games/strategy/engine/chat/StatusManager.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/StatusManager.java
@@ -61,7 +61,7 @@ public class StatusManager {
     }
   }
 
-  void setStatus(final String status) {
+  public void setStatus(final String status) {
     ((IStatusController) messengers.getRemote(IStatusController.STATUS_CONTROLLER))
         .setStatus(status);
   }

--- a/game-core/src/main/java/games/strategy/engine/chat/ui/panel/ChatMessagePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ui/panel/ChatMessagePanel.java
@@ -1,4 +1,4 @@
-package games.strategy.engine.chat;
+package games.strategy.engine.chat.ui.panel;
 
 import java.awt.BorderLayout;
 import java.awt.Container;
@@ -33,6 +33,12 @@ import org.triplea.swing.SwingAction;
 
 import com.google.common.base.Ascii;
 
+import games.strategy.engine.chat.AdministrativeChatMessages;
+import games.strategy.engine.chat.Chat;
+import games.strategy.engine.chat.ChatFloodControl;
+import games.strategy.engine.chat.ChatMessage;
+import games.strategy.engine.chat.IChatListener;
+import games.strategy.engine.chat.SentMessagesHistory;
 import games.strategy.net.INode;
 import games.strategy.sound.ClipPlayer;
 import games.strategy.sound.SoundPath;

--- a/game-core/src/main/java/games/strategy/engine/chat/ui/panel/ChatPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ui/panel/ChatPanel.java
@@ -1,4 +1,4 @@
-package games.strategy.engine.chat;
+package games.strategy.engine.chat.ui.panel;
 
 import java.awt.BorderLayout;
 import java.awt.Container;
@@ -12,6 +12,7 @@ import org.triplea.game.chat.ChatModel;
 import org.triplea.java.Interruptibles;
 import org.triplea.swing.SwingAction;
 
+import games.strategy.engine.chat.Chat;
 import games.strategy.engine.chat.Chat.ChatSoundProfile;
 import games.strategy.net.Messengers;
 

--- a/game-core/src/main/java/games/strategy/engine/chat/ui/panel/ChatPlayerPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ui/panel/ChatPlayerPanel.java
@@ -1,4 +1,4 @@
-package games.strategy.engine.chat;
+package games.strategy.engine.chat.ui.panel;
 
 import java.awt.BorderLayout;
 import java.awt.Dimension;
@@ -32,6 +32,11 @@ import javax.swing.UIManager;
 
 import org.triplea.swing.SwingAction;
 
+import games.strategy.engine.chat.Chat;
+import games.strategy.engine.chat.IChatListener;
+import games.strategy.engine.chat.IPlayerActionFactory;
+import games.strategy.engine.chat.IStatusListener;
+import games.strategy.engine.chat.PlayerChatRenderer;
 import games.strategy.net.INode;
 
 /**

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -33,7 +33,7 @@ import org.triplea.swing.SwingAction;
 import com.google.common.base.Preconditions;
 
 import games.strategy.engine.chat.Chat;
-import games.strategy.engine.chat.ChatPanel;
+import games.strategy.engine.chat.ui.panel.ChatPanel;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.framework.ClientGame;
 import games.strategy.engine.framework.GameDataManager;

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -41,8 +41,8 @@ import com.google.common.base.Preconditions;
 
 import games.strategy.engine.chat.Chat;
 import games.strategy.engine.chat.ChatController;
-import games.strategy.engine.chat.ChatPanel;
 import games.strategy.engine.chat.HeadlessChat;
+import games.strategy.engine.chat.ui.panel.ChatPanel;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.data.properties.GameProperties;

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
@@ -24,7 +24,7 @@ import javax.swing.SwingUtilities;
 
 import org.triplea.swing.SwingAction;
 
-import games.strategy.engine.chat.ChatPanel;
+import games.strategy.engine.chat.ui.panel.ChatPanel;
 import games.strategy.engine.framework.HeadlessAutoSaveType;
 import games.strategy.engine.framework.startup.launcher.ILauncher;
 import games.strategy.engine.framework.startup.mc.ClientModel;

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -29,8 +29,8 @@ import org.triplea.swing.JFrameBuilder;
 import org.triplea.swing.SwingAction;
 
 import games.strategy.engine.chat.Chat;
-import games.strategy.engine.chat.ChatMessagePanel;
-import games.strategy.engine.chat.ChatPlayerPanel;
+import games.strategy.engine.chat.ui.panel.ChatMessagePanel;
+import games.strategy.engine.chat.ui.panel.ChatPlayerPanel;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.lobby.client.LobbyClient;
 import games.strategy.engine.lobby.client.login.LobbyServerProperties;

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -94,8 +94,8 @@ import org.triplea.util.Tuple;
 import com.google.common.base.Preconditions;
 
 import games.strategy.engine.chat.Chat;
-import games.strategy.engine.chat.ChatPanel;
 import games.strategy.engine.chat.PlayerChatRenderer;
+import games.strategy.engine.chat.ui.panel.ChatPanel;
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.DefaultNamed;
 import games.strategy.engine.data.GameData;

--- a/game-core/src/test/java/games/strategy/engine/chat/ChatPanelTest.java
+++ b/game-core/src/test/java/games/strategy/engine/chat/ChatPanelTest.java
@@ -7,6 +7,8 @@ import javax.swing.text.StyledDocument;
 
 import org.junit.jupiter.api.Test;
 
+import games.strategy.engine.chat.ui.panel.ChatMessagePanel;
+
 class ChatPanelTest {
 
   @Test


### PR DESCRIPTION
## Overview

- Moves UI related chat panel class to their own sub-package

This is done as a very first step before more fixes land. The goal here is to first isolate the classes in their own package scope. Once we have that we'll then remove all public access to these classes and extract a publicly accessible view-model.


## Functional Changes
- none, just moving files around

## Manual Testing Performed
- none

## Screenshot

The three classes below went from the `chat` package to this new sub-package, `chat.ui.panel`:
![Screenshot from 2019-03-20 13-40-22](https://user-images.githubusercontent.com/12397753/54717696-0fec0300-4b16-11e9-8fc7-1c721ff2d05a.png)

