### PR TITLE
Fix chat panel not rendering on game staging screen.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/ChatPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatPanel.java
@@ -106,4 +106,9 @@ public class ChatPanel extends JPanel implements ChatModel {
   public ChatMessagePanel getChatMessagePanel() {
     return chatMessagePanel;
   }
+
+  @Override
+  public boolean isHeadless() {
+    return false;
+  }
 }

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatPanel.java
@@ -1,8 +1,10 @@
 package games.strategy.engine.chat;
 
 import java.awt.BorderLayout;
+import java.awt.Component;
 import java.awt.Container;
 import java.awt.Dimension;
+import java.util.Optional;
 
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.JPanel;
@@ -108,7 +110,7 @@ public class ChatPanel extends JPanel implements ChatModel {
   }
 
   @Override
-  public boolean isHeadless() {
-    return false;
+  public Optional<Component> getViewComponent() {
+    return Optional.of(this);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/chat/HeadlessChat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/HeadlessChat.java
@@ -1,7 +1,9 @@
 package games.strategy.engine.chat;
 
+import java.awt.Component;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Optional;
 
 import org.triplea.game.chat.ChatModel;
 import org.triplea.java.TimeManager;
@@ -139,7 +141,7 @@ public class HeadlessChat implements IChatListener, ChatModel {
   }
 
   @Override
-  public boolean isHeadless() {
-    return true;
+  public Optional<Component> getViewComponent() {
+    return Optional.empty();
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/chat/HeadlessChat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/HeadlessChat.java
@@ -137,4 +137,9 @@ public class HeadlessChat implements IChatListener, ChatModel {
     }
     allText.append(fullMessage);
   }
+
+  @Override
+  public boolean isHeadless() {
+    return true;
+  }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
@@ -1,6 +1,7 @@
 package games.strategy.engine.framework.startup.ui.panels.main;
 
 import java.awt.BorderLayout;
+import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.FlowLayout;
 import java.util.List;
@@ -8,8 +9,8 @@ import java.util.Observable;
 import java.util.Observer;
 import java.util.Optional;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 
+import javax.annotation.Nullable;
 import javax.swing.Action;
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
@@ -26,7 +27,6 @@ import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.JPanelBuilder;
 import org.triplea.swing.SwingAction;
 
-import games.strategy.engine.chat.ChatPanel;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.startup.ui.SetupPanel;
 import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorPanel;
@@ -59,8 +59,6 @@ public class MainPanel extends JPanel implements Observer, Consumer<SetupPanel> 
       .preferredHeight(62)
       .build();
   private SetupPanel gameSetupPanel;
-  private boolean isChatShowing;
-  private final Supplier<Optional<ChatModel>> chatModelSupplier;
 
   /**
    * MainPanel is the full contents of the 'mainFrame'. This panel represents the welcome screen and subsequent screens.
@@ -68,9 +66,8 @@ public class MainPanel extends JPanel implements Observer, Consumer<SetupPanel> 
   MainPanel(
       final GameSelectorPanel gameSelectorPanel,
       final Consumer<MainPanel> launchAction,
-      final Supplier<Optional<ChatModel>> chatModelSupplier,
+      @Nullable final ChatModel chatModel,
       final Runnable cancelAction) {
-    this.chatModelSupplier = chatModelSupplier;
     playButton.addActionListener(e -> launchAction.accept(this));
     cancelButton.addActionListener(e -> cancelAction.run());
 
@@ -91,7 +88,16 @@ public class MainPanel extends JPanel implements Observer, Consumer<SetupPanel> 
         .build();
 
     setLayout(new BorderLayout());
-    addChat();
+
+    final Optional<Component> chatComponent =
+        Optional.ofNullable(chatModel)
+            .flatMap(ChatModel::getViewComponent);
+
+    if (chatComponent.isPresent()) {
+      addChat(chatComponent.get());
+    } else {
+      add(mainPanel, BorderLayout.CENTER);
+    }
 
     final JButton quitButton = JButtonBuilder.builder()
         .title("Quit")
@@ -109,20 +115,15 @@ public class MainPanel extends JPanel implements Observer, Consumer<SetupPanel> 
     setWidgetActivation();
   }
 
-  private void addChat() {
+  private void addChat(final Component chatComponent) {
     remove(mainPanel);
     remove(chatSplit);
     chatPanelHolder.removeAll();
-    final ChatModel chat = chatModelSupplier.get().orElse(null);
-    if ((chat != null) && !chat.isHeadless()) {
-      chatPanelHolder.add(new ChatPanel(chat.getChat()), BorderLayout.CENTER);
-      chatSplit.setTopComponent(mainPanel);
-      chatSplit.setBottomComponent(chatPanelHolder);
-      add(chatSplit, BorderLayout.CENTER);
-    } else {
-      add(mainPanel, BorderLayout.CENTER);
-    }
-    isChatShowing = chat != null;
+
+    chatPanelHolder.add(chatComponent, BorderLayout.CENTER);
+    chatSplit.setTopComponent(mainPanel);
+    chatSplit.setBottomComponent(chatPanelHolder);
+    add(chatSplit, BorderLayout.CENTER);
   }
 
   /**
@@ -146,10 +147,11 @@ public class MainPanel extends JPanel implements Observer, Consumer<SetupPanel> 
       cancelPanel.add(cancelButton);
       gameSetupPanelHolder.add(cancelPanel, BorderLayout.SOUTH);
     }
-    final boolean panelHasChat = chatModelSupplier.get().isPresent();
-    if (panelHasChat != isChatShowing) {
-      addChat();
-    }
+
+    Optional.ofNullable(panel.getChatModel())
+        .flatMap(ChatModel::getViewComponent)
+        .ifPresent(this::addChat);
+
     revalidate();
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
@@ -68,9 +68,9 @@ public class MainPanel extends JPanel implements Observer, Consumer<SetupPanel> 
   MainPanel(
       final GameSelectorPanel gameSelectorPanel,
       final Consumer<MainPanel> launchAction,
-      final Supplier<Optional<ChatModel>> chatPanelSupplier,
+      final Supplier<Optional<ChatModel>> chatModelSupplier,
       final Runnable cancelAction) {
-    this.chatModelSupplier = chatPanelSupplier;
+    this.chatModelSupplier = chatModelSupplier;
     playButton.addActionListener(e -> launchAction.accept(this));
     cancelButton.addActionListener(e -> cancelAction.run());
 

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
@@ -26,6 +26,7 @@ import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.JPanelBuilder;
 import org.triplea.swing.SwingAction;
 
+import games.strategy.engine.chat.ChatPanel;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.startup.ui.SetupPanel;
 import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorPanel;
@@ -59,7 +60,7 @@ public class MainPanel extends JPanel implements Observer, Consumer<SetupPanel> 
       .build();
   private SetupPanel gameSetupPanel;
   private boolean isChatShowing;
-  private final Supplier<Optional<ChatModel>> chatPanelSupplier;
+  private final Supplier<Optional<ChatModel>> chatModelSupplier;
 
   /**
    * MainPanel is the full contents of the 'mainFrame'. This panel represents the welcome screen and subsequent screens.
@@ -69,7 +70,7 @@ public class MainPanel extends JPanel implements Observer, Consumer<SetupPanel> 
       final Consumer<MainPanel> launchAction,
       final Supplier<Optional<ChatModel>> chatPanelSupplier,
       final Runnable cancelAction) {
-    this.chatPanelSupplier = chatPanelSupplier;
+    this.chatModelSupplier = chatPanelSupplier;
     playButton.addActionListener(e -> launchAction.accept(this));
     cancelButton.addActionListener(e -> cancelAction.run());
 
@@ -112,9 +113,9 @@ public class MainPanel extends JPanel implements Observer, Consumer<SetupPanel> 
     remove(mainPanel);
     remove(chatSplit);
     chatPanelHolder.removeAll();
-    final ChatModel chat = chatPanelSupplier.get().orElse(null);
-    if (chat instanceof SetupPanel) {
-      chatPanelHolder.add((SetupPanel) chat, BorderLayout.CENTER);
+    final ChatModel chat = chatModelSupplier.get().orElse(null);
+    if ((chat != null) && !chat.isHeadless()) {
+      chatPanelHolder.add(new ChatPanel(chat.getChat()), BorderLayout.CENTER);
       chatSplit.setTopComponent(mainPanel);
       chatSplit.setBottomComponent(chatPanelHolder);
       add(chatSplit, BorderLayout.CENTER);
@@ -145,7 +146,7 @@ public class MainPanel extends JPanel implements Observer, Consumer<SetupPanel> 
       cancelPanel.add(cancelButton);
       gameSetupPanelHolder.add(cancelPanel, BorderLayout.SOUTH);
     }
-    final boolean panelHasChat = chatPanelSupplier.get().isPresent();
+    final boolean panelHasChat = chatModelSupplier.get().isPresent();
     if (panelHasChat != isChatShowing) {
       addChat();
     }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanelBuilder.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanelBuilder.java
@@ -47,8 +47,9 @@ public class MainPanelBuilder {
               });
           setupPanelModel.getPanel().postStartGame();
         },
-        () -> Optional.ofNullable(setupPanelModel.getPanel())
-            .map(SetupModel::getChatModel),
+        Optional.ofNullable(setupPanelModel.getPanel())
+            .map(SetupModel::getChatModel)
+            .orElse(null),
         setupPanelModel::showSelectType);
     setupPanelModel.setPanelChangeListener(mainPanel);
     gameSelectorModel.addObserver(mainPanel);

--- a/game-core/src/main/java/org/triplea/game/chat/ChatModel.java
+++ b/game-core/src/main/java/org/triplea/game/chat/ChatModel.java
@@ -1,5 +1,8 @@
 package org.triplea.game.chat;
 
+import java.awt.Component;
+import java.util.Optional;
+
 import games.strategy.engine.chat.Chat;
 
 /**
@@ -16,5 +19,5 @@ public interface ChatModel {
 
   void setShowChatTime(boolean showTime);
 
-  boolean isHeadless();
+  Optional<Component> getViewComponent();
 }

--- a/game-core/src/main/java/org/triplea/game/chat/ChatModel.java
+++ b/game-core/src/main/java/org/triplea/game/chat/ChatModel.java
@@ -15,4 +15,6 @@ public interface ChatModel {
   String getAllText();
 
   void setShowChatTime(boolean showTime);
+
+  boolean isHeadless();
 }


### PR DESCRIPTION
## Overview
Fixes: https://github.com/triplea-game/triplea/issues/4761

Relatively surgical fix of an impossible `instanceof` check condition that prevented the chat panel from rendering The condition was impossible as the class hierarchies did not line up.

One fix considered was to update the instanceof check to check for presumably the right chat model type 'HeadlessChatModel', but this still would have left in the brittle instanceof check. The fix here rolls back to an explicit 'isHeadless' method that was previously used to do this check.


## Manual Testing Performed
- verified on a locally launched host game, connected to the same game with multiple clients and verified chat.

