### PR TITLE
Documentation: Add README to lobby-client-http sub-project

### DIFF
--- a/lobby-client-http/README.md
+++ b/lobby-client-http/README.md
@@ -1,0 +1,48 @@
+// TODO: rename this sub-project to http-clients
+## http-clients
+
+This sub-project contains all http-client libraries.
+We use Feign, client-server interactions are defined 
+by annotated interfaces. 
+
+Http-clients will typically be per set of related methods 
+between a given client and server.
+
+Http-clients will typically have 2 components:
+(1) Feign annotated interface. This will describe the http
+methods available, POST or GEt, which parameters and headers.
+(2) Request and response objects, these are converted to 
+JSON automatically.
+
+
+## Notes and Conventions
+
+ - each method in a feign interfaced will throw a `FeignException` if anything
+goes wrong, including http 500's or IOException
+ - Each feign interface should have a static convenience constructor
+ method, eg: `ExampleFeignInterface.newClient(hostUri)`
+
+
+## Testing notes
+
+We use WireMock to set up a fake http server. We then create feign clients
+to verify request/response sequences.
+
+
+# Http Client List Overview and Summary 
+
+## Githhub Issues
+
+API integration to create a github issue. We need an auth token for which we use 
+our bot account. Otherwise the API needs a title and body which we get from
+the game user. The response from github contains a link to the newly created
+issue.
+
+
+## Lobby: Error Reporting
+
+API that the lobby provides to accept data about exceptions. This lets users
+uploads description data of an error with stack trace data automatically attached.
+The lobby server in turn uploads this to github to create an issue ticket.
+
+

--- a/lobby-client-http/README.md
+++ b/lobby-client-http/README.md
@@ -10,7 +10,7 @@ between a given client and server.
 
 Http-clients will typically have 2 components:
 (1) Feign annotated interface. This will describe the http
-methods available, POST or GEt, which parameters and headers.
+methods available, POST or GET, which parameters and headers.
 (2) Request and response objects, these are converted to 
 JSON automatically.
 


### PR DESCRIPTION
## Overview
Of note, the subproject was intended to be the home of *all*
http-clients, not just the ones used to connect to the http-lobby.
A TODO is added noting a desired rename to match that.

