### PR TITLE
Add Http LobbyLogin client with stubbed server controller

### DIFF
--- a/lobby-client-http/src/main/java/org/triplea/http/client/lobby/login/LobbyLoginClient.java
+++ b/lobby-client-http/src/main/java/org/triplea/http/client/lobby/login/LobbyLoginClient.java
@@ -1,0 +1,72 @@
+package org.triplea.http.client.lobby.login;
+
+import java.net.URI;
+
+import org.triplea.http.client.HttpClient;
+
+import feign.Headers;
+import feign.RequestLine;
+
+/**
+ * Http client to authenticate a user with the http(s)-lobby.
+ * Both registered and anonymous users use this to gain a single-use
+ * token that can be used to establish a non-https socket connection.
+ */
+@SuppressWarnings("InterfaceNeverImplemented")
+public interface LobbyLoginClient {
+
+  String LOGIN_PATH = "/login";
+  String ANONYMOUS_LOGIN_PATH = "/anonymous-login";
+
+  static LobbyLoginClient newClient(final URI uri) {
+    return new HttpClient<>(LobbyLoginClient.class, uri).get();
+  }
+
+  /**
+   * Http client method to do username and password verification.
+   * Example usage:
+   *
+   * <pre>
+   * LobbyLoginClient client = LobbyLoginClient.newClient(uri);
+   * try {
+   *   String token = client.login(name, password);
+   *   if (!token.isPresent()) {
+   *     // login failed, bad credentials
+   *   }
+   * } catch (FeignException e) {
+   *   // communication or server error
+   * }
+   * </pre>
+   */
+  @RequestLine("POST " + LOGIN_PATH)
+  @Headers({
+      "Content-Type: application/json",
+      "Accept: application/json"
+  })
+  LobbyLoginResponse login(RegisteredUserLoginRequest loginRequest);
+
+
+  /**
+   * Http client method to for anonymous login, should only check that a given username is not reserved
+   * nor violates any rules.
+   * Example usage:
+   *
+   * <pre>
+   * LobbyLoginClient client = LobbyLoginClient.newClient(uri);
+   * try {
+   *   String token = client.anonymousLogin(name);
+   *   if (!token.isPresent()) {
+   *     // login failed, bad credentials
+   *   }
+   * } catch (FeignException e) {
+   *   // communication or server error
+   * }
+   * </pre>
+   */
+  @RequestLine("POST " + ANONYMOUS_LOGIN_PATH)
+  @Headers({
+      "Content-Type: application/json",
+      "Accept: application/json"
+  })
+  LobbyLoginResponse anonymousLogin(String name);
+}

--- a/lobby-client-http/src/main/java/org/triplea/http/client/lobby/login/LobbyLoginResponse.java
+++ b/lobby-client-http/src/main/java/org/triplea/http/client/lobby/login/LobbyLoginResponse.java
@@ -1,0 +1,50 @@
+package org.triplea.http.client.lobby.login;
+
+import java.util.Optional;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+/** Represents data that would be uploaded to a server. */
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@EqualsAndHashCode
+public class LobbyLoginResponse {
+  private final String loginToken;
+  private final String failReason;
+
+  /**
+   * Factory method for creating login responses where login was not successful.
+   *
+   * @param reason A reason for why login failed, to be shown to user.
+   */
+  public static LobbyLoginResponse newFailResponse(final String reason) {
+    return new LobbyLoginResponse(null, reason);
+  }
+
+  /**
+   * Factory method for creating login response where login was successful.
+   *
+   * @param token Single-use token that can be used to establish a socket connection.
+   */
+  public static LobbyLoginResponse newSuccessResponse(final String token) {
+    return new LobbyLoginResponse(token, null);
+  }
+
+  /**
+   * If present, indicates login was success.
+   */
+  public Optional<String> getLoginToken() {
+    return Optional.ofNullable(loginToken);
+  }
+
+  /**
+   * If login fails, this will return a 'reason' string that can be shown to the user. This is here
+   * so we can tell a user that they were banned or if they simply got the wrong password.
+   */
+  public Optional<String> getFailReason() {
+    return Optional.ofNullable(failReason);
+  }
+}

--- a/lobby-client-http/src/main/java/org/triplea/http/client/lobby/login/RegisteredUserLoginRequest.java
+++ b/lobby-client-http/src/main/java/org/triplea/http/client/lobby/login/RegisteredUserLoginRequest.java
@@ -1,0 +1,18 @@
+package org.triplea.http.client.lobby.login;
+
+import javax.annotation.Nonnull;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+/** Represents data that would be uploaded to a server. */
+@Getter
+@Builder
+@EqualsAndHashCode
+public class RegisteredUserLoginRequest {
+  @Nonnull
+  private final String name;
+  @Nonnull
+  private final String password;
+}

--- a/lobby-client-http/src/test/java/org/triplea/http/client/lobby/login/LobbyLoginClientTest.java
+++ b/lobby-client-http/src/test/java/org/triplea/http/client/lobby/login/LobbyLoginClientTest.java
@@ -1,0 +1,131 @@
+package org.triplea.http.client.lobby.login;
+
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import java.net.URI;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.triplea.http.client.HttpClientTesting;
+import org.triplea.http.client.error.report.ErrorUploadClient;
+import org.triplea.test.common.Integration;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.google.gson.Gson;
+
+import ru.lanwen.wiremock.ext.WiremockResolver;
+import ru.lanwen.wiremock.ext.WiremockUriResolver;
+
+@ExtendWith({
+    WiremockResolver.class,
+    WiremockUriResolver.class
+})
+@Integration
+class LobbyLoginClientTest {
+  private static final LobbyLoginResponse SUCCESS_LOGIN = LobbyLoginResponse.newSuccessResponse("success");
+  private static final LobbyLoginResponse FAILED_LOGIN = LobbyLoginResponse.newFailResponse("fail-reason");
+  private static final String LOGIN_NAME = "example";
+  private static final RegisteredUserLoginRequest REGISTERED_USER_LOGIN_REQUEST =
+      RegisteredUserLoginRequest.builder()
+          .name("example")
+          .password("password")
+          .build();
+
+  @Nested
+  final class LoginTestCases {
+    @Test
+    void loginSuccess(@WiremockResolver.Wiremock final WireMockServer server) {
+      final LobbyLoginResponse response =
+          HttpClientTesting.sendServiceCallToWireMock(
+              HttpClientTesting.ServiceCallArgs.<LobbyLoginResponse>builder()
+                  .wireMockServer(server)
+                  .expectedRequestPath(LobbyLoginClient.LOGIN_PATH)
+                  .expectedBodyContents(
+                      Arrays.asList(
+                          REGISTERED_USER_LOGIN_REQUEST.getName(),
+                          REGISTERED_USER_LOGIN_REQUEST.getPassword()))
+                  .serverReturnValue(new Gson().toJson(SUCCESS_LOGIN))
+                  .serviceCall(this::doServiceCall)
+                  .build());
+
+      assertThat(response, is(SUCCESS_LOGIN));
+    }
+
+    private LobbyLoginResponse doServiceCall(final URI hostUri) {
+      return LobbyLoginClient.newClient(hostUri)
+          .login(REGISTERED_USER_LOGIN_REQUEST);
+    }
+
+    @Test
+    void loginFailure(@WiremockResolver.Wiremock final WireMockServer server) {
+      final LobbyLoginResponse response =
+          HttpClientTesting.sendServiceCallToWireMock(
+              HttpClientTesting.ServiceCallArgs.<LobbyLoginResponse>builder()
+                  .wireMockServer(server)
+                  .expectedRequestPath(LobbyLoginClient.LOGIN_PATH)
+                  .expectedBodyContents(
+                      Arrays.asList(
+                          REGISTERED_USER_LOGIN_REQUEST.getName(),
+                          REGISTERED_USER_LOGIN_REQUEST.getPassword()))
+                  .serverReturnValue(new Gson().toJson(FAILED_LOGIN))
+                  .serviceCall(this::doServiceCall)
+                  .build());
+
+      assertThat(response, is(FAILED_LOGIN));
+    }
+
+    @Test
+    void errorHandling(@WiremockResolver.Wiremock final WireMockServer wireMockServer) {
+      HttpClientTesting.verifyErrorHandling(
+          wireMockServer, ErrorUploadClient.ERROR_REPORT_PATH, this::doServiceCall);
+    }
+  }
+
+  @Nested
+  final class AnonymousLoginCases {
+    @Test
+    void loginSuccess(@WiremockResolver.Wiremock final WireMockServer server) {
+      final LobbyLoginResponse response =
+          HttpClientTesting.sendServiceCallToWireMock(
+              HttpClientTesting.ServiceCallArgs.<LobbyLoginResponse>builder()
+                  .wireMockServer(server)
+                  .expectedRequestPath(LobbyLoginClient.ANONYMOUS_LOGIN_PATH)
+                  .expectedBodyContents(singletonList(LOGIN_NAME))
+                  .serverReturnValue(new Gson().toJson(SUCCESS_LOGIN))
+                  .serviceCall(this::doServiceCall)
+                  .build());
+
+      assertThat(response, is(SUCCESS_LOGIN));
+    }
+
+    private LobbyLoginResponse doServiceCall(final URI hostUri) {
+      return LobbyLoginClient.newClient(hostUri)
+          .anonymousLogin(LOGIN_NAME);
+    }
+
+    @Test
+    void loginFailure(@WiremockResolver.Wiremock final WireMockServer server) {
+      final LobbyLoginResponse response =
+          HttpClientTesting.sendServiceCallToWireMock(
+              HttpClientTesting.ServiceCallArgs.<LobbyLoginResponse>builder()
+                  .wireMockServer(server)
+                  .expectedRequestPath(LobbyLoginClient.ANONYMOUS_LOGIN_PATH)
+                  .expectedBodyContents(singletonList(LOGIN_NAME))
+                  .serverReturnValue(new Gson().toJson(FAILED_LOGIN))
+                  .serviceCall(this::doServiceCall)
+                  .build());
+
+      assertThat(response, is(FAILED_LOGIN));
+    }
+
+    @Test
+    void errorHandling(@WiremockResolver.Wiremock final WireMockServer wireMockServer) {
+      HttpClientTesting.verifyErrorHandling(
+          wireMockServer, ErrorUploadClient.ERROR_REPORT_PATH, this::doServiceCall);
+    }
+  }
+}

--- a/lobby/src/main/java/org/triplea/server/ServerConfiguration.java
+++ b/lobby/src/main/java/org/triplea/server/ServerConfiguration.java
@@ -52,7 +52,7 @@ public class ServerConfiguration {
 
   private static Function<RegisteredUserLoginRequest, LobbyLoginResponse> registeredUserLoginStrategy() {
     // TODO: stubbed value, implement this;
-    return loginRequset -> LobbyLoginResponse.newFailResponse("stubbed response");
+    return loginRequest -> LobbyLoginResponse.newFailResponse("stubbed response");
   }
 
   private static Function<String, LobbyLoginResponse> anonymousUserLoginStrategy() {

--- a/lobby/src/main/java/org/triplea/server/ServerConfiguration.java
+++ b/lobby/src/main/java/org/triplea/server/ServerConfiguration.java
@@ -1,11 +1,16 @@
 package org.triplea.server;
 
 import java.net.URI;
+import java.util.function.Function;
 
+import org.triplea.http.client.error.report.ErrorUploadResponse;
 import org.triplea.http.client.github.issues.GithubIssueClient;
+import org.triplea.http.client.lobby.login.LobbyLoginResponse;
+import org.triplea.http.client.lobby.login.RegisteredUserLoginRequest;
 import org.triplea.lobby.server.EnvironmentVariable;
 import org.triplea.server.reporting.error.CreateIssueStrategy;
 import org.triplea.server.reporting.error.ErrorReportGateKeeper;
+import org.triplea.server.reporting.error.ErrorReportRequest;
 import org.triplea.server.reporting.error.ErrorReportResponseConverter;
 
 import lombok.Builder;
@@ -18,13 +23,20 @@ import lombok.Getter;
 @Getter
 @Builder
 public class ServerConfiguration {
-  private final CreateIssueStrategy errorUploader;
+
+  private final Function<ErrorReportRequest, ErrorUploadResponse> errorUploader;
+  private final Function<RegisteredUserLoginRequest, LobbyLoginResponse> registeredUserLogin;
+  private final Function<String, LobbyLoginResponse> anonymousUserLogin;
 
   public static ServerConfiguration fromEnvironmentVariables() {
-    return builder().errorUploader(createIssueStrategy()).build();
+    return builder()
+        .errorUploader(createIssueStrategy())
+        .registeredUserLogin(registeredUserLoginStrategy())
+        .anonymousUserLogin(anonymousUserLoginStrategy())
+        .build();
   }
 
-  private static CreateIssueStrategy createIssueStrategy() {
+  private static Function<ErrorReportRequest, ErrorUploadResponse> createIssueStrategy() {
     return CreateIssueStrategy.builder()
         .createIssueClient(GithubIssueClient.builder()
             .authToken(EnvironmentVariable.GITHUB_API_AUTH_TOKEN.getValue())
@@ -35,5 +47,16 @@ public class ServerConfiguration {
         .responseAdapter(new ErrorReportResponseConverter())
         .allowErrorReport(new ErrorReportGateKeeper())
         .build();
+  }
+
+
+  private static Function<RegisteredUserLoginRequest, LobbyLoginResponse> registeredUserLoginStrategy() {
+    // TODO: stubbed value, implement this;
+    return loginRequset -> LobbyLoginResponse.newFailResponse("stubbed response");
+  }
+
+  private static Function<String, LobbyLoginResponse> anonymousUserLoginStrategy() {
+    // TODO: stubbed value, implement this;
+    return loginRequset -> LobbyLoginResponse.newFailResponse("stubbed response");
   }
 }

--- a/lobby/src/main/java/org/triplea/server/ServerConfiguration.java
+++ b/lobby/src/main/java/org/triplea/server/ServerConfiguration.java
@@ -57,6 +57,6 @@ public class ServerConfiguration {
 
   private static Function<String, LobbyLoginResponse> anonymousUserLoginStrategy() {
     // TODO: stubbed value, implement this;
-    return loginRequset -> LobbyLoginResponse.newFailResponse("stubbed response");
+    return loginRequest -> LobbyLoginResponse.newFailResponse("stubbed response");
   }
 }

--- a/lobby/src/main/java/org/triplea/server/http/spark/controller/AnonymousUserLoginController.java
+++ b/lobby/src/main/java/org/triplea/server/http/spark/controller/AnonymousUserLoginController.java
@@ -1,0 +1,37 @@
+package org.triplea.server.http.spark.controller;
+
+import static spark.Spark.post;
+
+import java.util.function.Function;
+
+import org.triplea.http.client.lobby.login.LobbyLoginResponse;
+
+import com.google.gson.Gson;
+
+import lombok.AllArgsConstructor;
+import spark.Request;
+
+/**
+ * Controller that routes requests to authenticate 'anonymous' users. An anonymous user login consists
+ * only of the desired username. The return value of the controller is a JSON with a 'login token'. If
+ * the token is missing then login for that username is denied. Otherwise the token can be used
+ * to establish a socket connection with the lobby.
+ */
+@AllArgsConstructor
+public class AnonymousUserLoginController implements Runnable {
+
+  private static final String ANONYMOUS_LOGIN_PATH = "/anonymous-login";
+
+  private final Function<String, LobbyLoginResponse> anonymousUserLogin;
+
+  @Override
+  public void run() {
+    post(ANONYMOUS_LOGIN_PATH, (req, res) -> doLogin(req));
+  }
+
+  private String doLogin(final Request request) {
+    final String loginName = new Gson().fromJson(request.body(), String.class);
+    final LobbyLoginResponse result = anonymousUserLogin.apply(loginName);
+    return new Gson().toJson(result);
+  }
+}

--- a/lobby/src/main/java/org/triplea/server/http/spark/controller/ControllerConfiguration.java
+++ b/lobby/src/main/java/org/triplea/server/http/spark/controller/ControllerConfiguration.java
@@ -1,6 +1,6 @@
 package org.triplea.server.http.spark.controller;
 
-import java.util.Collections;
+import java.util.Arrays;
 
 import org.triplea.server.ServerConfiguration;
 
@@ -11,7 +11,9 @@ import lombok.AllArgsConstructor;
 public class ControllerConfiguration {
 
   public static Iterable<Runnable> getControllers(final ServerConfiguration serverConfiguration) {
-    return Collections.singletonList(
-        new ErrorReportController(serverConfiguration.getErrorUploader()));
+    return Arrays.asList(
+        new ErrorReportController(serverConfiguration.getErrorUploader()),
+        new AnonymousUserLoginController(serverConfiguration.getAnonymousUserLogin()),
+        new RegisteredUserLoginController(serverConfiguration.getRegisteredUserLogin()));
   }
 }

--- a/lobby/src/main/java/org/triplea/server/http/spark/controller/RegisteredUserLoginController.java
+++ b/lobby/src/main/java/org/triplea/server/http/spark/controller/RegisteredUserLoginController.java
@@ -1,0 +1,42 @@
+package org.triplea.server.http.spark.controller;
+
+import static spark.Spark.post;
+
+import java.util.function.Function;
+
+import org.triplea.http.client.lobby.login.LobbyLoginResponse;
+import org.triplea.http.client.lobby.login.RegisteredUserLoginRequest;
+
+import com.google.gson.Gson;
+
+import lombok.AllArgsConstructor;
+import spark.Request;
+
+/**
+ * Controller that routes requests to authenticate 'registered' users. Registered users have previously added
+ * a password to their account, a registered login requests consists of username and password.
+ * Return value is a JSON with a 'login token'. If the token is missing then login for that username+password
+ * combination is denied. Otherwise, the token can be used to establish a socket connection with the lobby.
+ */
+@AllArgsConstructor
+public class RegisteredUserLoginController implements Runnable {
+
+  private static final String REGISTERED_LOGIN_PATH = "/login";
+
+  private final Function<RegisteredUserLoginRequest, LobbyLoginResponse> registeredUserLogin;
+
+  @Override
+  public void run() {
+    post(REGISTERED_LOGIN_PATH, (req, res) -> doLogin(req));
+  }
+
+  private String doLogin(final Request req) {
+    final RegisteredUserLoginRequest loginRequest = readLoginRequest(req);
+    final LobbyLoginResponse result = registeredUserLogin.apply(loginRequest);
+    return new Gson().toJson(result);
+  }
+
+  private static RegisteredUserLoginRequest readLoginRequest(final Request request) {
+    return new Gson().fromJson(request.body(), RegisteredUserLoginRequest.class);
+  }
+}

--- a/lobby/src/test/java/org/triplea/server/http/spark/AnonymousUserLoginControllerTest.java
+++ b/lobby/src/test/java/org/triplea/server/http/spark/AnonymousUserLoginControllerTest.java
@@ -1,0 +1,41 @@
+package org.triplea.server.http.spark;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.triplea.http.client.lobby.login.LobbyLoginClient;
+import org.triplea.http.client.lobby.login.LobbyLoginResponse;
+
+import feign.FeignException;
+
+class AnonymousUserLoginControllerTest extends SparkServerSystemTest {
+  private static final String LOGIN_NAME = "Ah, fine whale. Vandalize the lighthouse!";
+  private static final LobbyLoginResponse STUBBED_RESPONSE = LobbyLoginResponse.newSuccessResponse("token");
+
+  private final LobbyLoginClient client = LobbyLoginClient.newClient(LOCAL_HOST);
+
+
+  @Test
+  void login() {
+    when(anonymousUserLogin.apply(LOGIN_NAME)).thenReturn(STUBBED_RESPONSE);
+
+    final LobbyLoginResponse response = client.anonymousLogin(LOGIN_NAME);
+
+    assertThat(response, is(STUBBED_RESPONSE));
+  }
+
+
+  @Test
+  void errorCase() {
+    when(anonymousUserLogin.apply(Mockito.any()))
+        .thenThrow(new RuntimeException("simulated exception"));
+
+    assertThrows(
+        FeignException.class,
+        () -> client.anonymousLogin(LOGIN_NAME));
+  }
+}

--- a/lobby/src/test/java/org/triplea/server/http/spark/RegisteredUserLoginControllerTest.java
+++ b/lobby/src/test/java/org/triplea/server/http/spark/RegisteredUserLoginControllerTest.java
@@ -1,0 +1,45 @@
+package org.triplea.server.http.spark;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.triplea.http.client.lobby.login.LobbyLoginClient;
+import org.triplea.http.client.lobby.login.LobbyLoginResponse;
+import org.triplea.http.client.lobby.login.RegisteredUserLoginRequest;
+
+import feign.FeignException;
+
+class RegisteredUserLoginControllerTest extends SparkServerSystemTest {
+  private static final RegisteredUserLoginRequest REGISTERED_USER_LOGIN_REQUEST =
+      RegisteredUserLoginRequest.builder()
+          .name("Cannibals whine with death!")
+          .password("Scrawny desolations lead to the malaria.")
+          .build();
+
+  private static final LobbyLoginResponse STUBBED_RESPONSE = LobbyLoginResponse.newSuccessResponse("token");
+
+  private final LobbyLoginClient client = LobbyLoginClient.newClient(LOCAL_HOST);
+
+  @Test
+  void login() {
+    when(registeredUserLogin.apply(REGISTERED_USER_LOGIN_REQUEST)).thenReturn(STUBBED_RESPONSE);
+
+    final LobbyLoginResponse response = client.login(REGISTERED_USER_LOGIN_REQUEST);
+
+    assertThat(response, is(STUBBED_RESPONSE));
+  }
+
+  @Test
+  void errorCase() {
+    when(registeredUserLogin.apply(Mockito.any()))
+        .thenThrow(new RuntimeException("simulated exception"));
+
+    assertThrows(
+        FeignException.class,
+        () -> client.login(REGISTERED_USER_LOGIN_REQUEST));
+  }
+}

--- a/lobby/src/test/java/org/triplea/server/http/spark/SparkServerSystemTest.java
+++ b/lobby/src/test/java/org/triplea/server/http/spark/SparkServerSystemTest.java
@@ -3,11 +3,14 @@ package org.triplea.server.http.spark;
 import static org.mockito.Mockito.reset;
 
 import java.net.URI;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.mockito.Mockito;
+import org.triplea.http.client.lobby.login.LobbyLoginResponse;
+import org.triplea.http.client.lobby.login.RegisteredUserLoginRequest;
 import org.triplea.server.ServerConfiguration;
 import org.triplea.server.reporting.error.CreateIssueStrategy;
 import org.triplea.test.common.Integration;
@@ -15,10 +18,13 @@ import org.triplea.test.common.Integration;
 import spark.Spark;
 
 
+@SuppressWarnings("unchecked")
 @Integration
 class SparkServerSystemTest {
-
   static final CreateIssueStrategy errorUploadStrategy = Mockito.mock(CreateIssueStrategy.class);
+  static final Function<RegisteredUserLoginRequest, LobbyLoginResponse> registeredUserLogin =
+      Mockito.mock(Function.class);
+  static final Function<String, LobbyLoginResponse> anonymousUserLogin = Mockito.mock(Function.class);
 
   private static final int SPARK_PORT = 5000;
 
@@ -29,6 +35,8 @@ class SparkServerSystemTest {
     Spark.port(SPARK_PORT);
     SparkServer.start(ServerConfiguration.builder()
         .errorUploader(errorUploadStrategy)
+        .anonymousUserLogin(anonymousUserLogin)
+        .registeredUserLogin(registeredUserLogin)
         .build());
     Spark.awaitInitialization();
   }
@@ -41,5 +49,6 @@ class SparkServerSystemTest {
   @AfterAll
   static void stopServer() {
     Spark.stop();
+    Spark.awaitStop();
   }
 }


### PR DESCRIPTION
## Overview
- Adds a working http client to do lobby login.
- Adds lobby http controller to listen to login requests

Currently the lobby login component is stubbed and returns a hardcoded response. Next steps will be:
- begin implementing the stubbed logic
- migrate DB tables to new normalized schema
- migrate client code to use the new http endpoint and update socket QuarantineConversation.java to use the http endpoint single-use token.

## Functional Changes
- adds stand-alone components not yet integrated with the greater system, so none for now.

## Manual Testing Performed
- none, automated.

