### PR TITLE
Let ErrorController throw errors

### DIFF
--- a/lobby/src/main/java/org/triplea/server/http/spark/controller/ErrorReportController.java
+++ b/lobby/src/main/java/org/triplea/server/http/spark/controller/ErrorReportController.java
@@ -6,7 +6,6 @@ import java.util.function.Function;
 
 import org.triplea.http.client.error.report.ErrorUploadRequest;
 import org.triplea.http.client.error.report.ErrorUploadResponse;
-import org.triplea.server.reporting.error.CreateErrorReportException;
 import org.triplea.server.reporting.error.ErrorReportRequest;
 
 import com.google.gson.Gson;
@@ -31,12 +30,8 @@ public class ErrorReportController implements Runnable {
 
   private String uploadErrorReport(final Request req) {
     final org.triplea.server.reporting.error.ErrorReportRequest errorReport = readErrorReport(req);
-    try {
-      final ErrorUploadResponse result = errorReportIngestion.apply(errorReport);
-      return new Gson().toJson(result);
-    } catch (final CreateErrorReportException e) {
-      return e.getMessage();
-    }
+    final ErrorUploadResponse result = errorReportIngestion.apply(errorReport);
+    return new Gson().toJson(result);
   }
 
   private static ErrorReportRequest readErrorReport(final Request request) {


### PR DESCRIPTION
## Overview
Previous and recent updates changed error handling so that http server or client would throw exceptions on errors. This update fixes a missed update in the error reporting controller. Previously the idea was to return a string representing an error message or to return a proper JSON response. This was a bit complex, and it turns out we can return an http 500 by throwing an exception.

This update fixes error report controller to throw an exception on error and return a 500 in those cases.


## Functional Changes
Fixes error controller error handling to conform to contract, error results will now yield a 500

## Manual Testing Performed
- none, automated
