### PR TITLE
Move test documentation to a README

### DIFF
--- a/lobby-client-http/src/test/java/org/triplea/http/client/README.md
+++ b/lobby-client-http/src/test/java/org/triplea/http/client/README.md
@@ -1,0 +1,5 @@
+Test that checks the http client works, we use wiremock to simulate a server so we are not coupled
+to any one server implementation. Server sub-projects should include the http-client as a test dependency
+to then create an integration test to be sure that everything would work. Meanwhile we can test here
+against a generic/stubbed server to be sure the client contract works as expected.
+

--- a/lobby-client-http/src/test/java/org/triplea/http/client/error/report/ErrorReportClientTest.java
+++ b/lobby-client-http/src/test/java/org/triplea/http/client/error/report/ErrorReportClientTest.java
@@ -17,12 +17,6 @@ import com.google.gson.Gson;
 import ru.lanwen.wiremock.ext.WiremockResolver;
 import ru.lanwen.wiremock.ext.WiremockUriResolver;
 
-/**
- * A test that checks the http client works, we use wiremock to simulate a server so we are not coupled
- * to any one server implementation. Server sub-projects should include the http-client as a test dependency
- * to then create an integration test to be sure that everything would work. Meanwhile we can test here
- * against a generic/stubbed server to be sure the client contract works as expected.
- */
 @ExtendWith({
     WiremockResolver.class,
     WiremockUriResolver.class
@@ -35,7 +29,6 @@ class ErrorReportClientTest {
   private static final ErrorUploadResponse SUCCESS_RESPONSE = ErrorUploadResponse.builder()
       .githubIssueLink(LINK)
       .build();
-
 
   @Test
   void sendErrorReportSuccessCase(@WiremockResolver.Wiremock final WireMockServer server) {


### PR DESCRIPTION
## Overview
The documentation is generic for any/all http tests, so instead of having this documentation on one test class, we can move to a README

