### PR TITLE
Encoded value fix for empty string

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/settings/IntegerClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/IntegerClientSetting.java
@@ -1,5 +1,7 @@
 package games.strategy.triplea.settings;
 
+import javax.annotation.Nullable;
+
 final class IntegerClientSetting extends ClientSetting<Integer> {
   IntegerClientSetting(final String name) {
     super(Integer.class, name);
@@ -15,8 +17,12 @@ final class IntegerClientSetting extends ClientSetting<Integer> {
   }
 
   @Override
+  @Nullable
   protected Integer decodeValue(final String encodedValue) throws ValueEncodingException {
     try {
+      if (encodedValue.isEmpty()) {
+        return null;
+      }
       return Integer.valueOf(encodedValue);
     } catch (final NumberFormatException e) {
       throw new ValueEncodingException(e);

--- a/game-core/src/test/java/games/strategy/triplea/settings/IntegerClientSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/IntegerClientSettingTest.java
@@ -2,6 +2,7 @@ package games.strategy.triplea.settings;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Nested;
@@ -35,8 +36,12 @@ final class IntegerClientSettingTest {
 
     @Test
     void shouldThrowExceptionWhenEncodedValueIsIllegal() {
-      assertThrows(ClientSetting.ValueEncodingException.class, () -> clientSetting.decodeValue(""));
       assertThrows(ClientSetting.ValueEncodingException.class, () -> clientSetting.decodeValue("a123"));
+    }
+
+    @Test
+    void emptyStringValuesAreDecodedToNull() throws Exception {
+      assertThat(clientSetting.decodeValue(""), nullValue());
     }
   }
 }


### PR DESCRIPTION
## Overview
After setting test value for lobby server port and then unsetting, this code can throw an integer parse exception trying to parse an empty string. This simple fix checks for an empty string and returns null skipping the integer parsing.

## Manual Testing Performed
-I'm not 100% sure of the repro case, though when I hit this error, this update fixed the situation. Otherwise, the error occurs on game launch and prevents the main window from loading.
