### PR TITLE
Remove strategic bombing land unit limitation

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -2446,7 +2446,7 @@ public class UnitAttachment extends DefaultAttachment {
         throw new GameParseException("sea units cannot have certain properties, " + thisErrorMsg());
       }
     } else { // if land
-      if (canBombard || isStrategicBomber || isSub || carrierCapacity != -1 || bombard != -1
+      if (canBombard || isSub || carrierCapacity != -1 || bombard != -1
           || isAirTransport || isCombatTransport || isKamikaze) {
         throw new GameParseException("land units cannot have certain properties, " + thisErrorMsg());
       }


### PR DESCRIPTION
Allow land units to perform strategic bombing. I did some basic testing and it seems to work fine. Just appears to be a unnecessary parsing check.