### PR TITLE
Allow specifying territory effects for unit placement restrictions

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -2578,7 +2578,7 @@ public class UnitAttachment extends DefaultAttachment {
         territories.add(territory);
       } else {
         // Check if its a territory effect and get all territories
-        if (getData().getTerritoryEffectList().keySet().contains(name)) {
+        if (getData().getTerritoryEffectList().containsKey(name)) {
           for (final Territory t : getData().getMap().getTerritories()) {
             for (final TerritoryEffect te : TerritoryEffectHelper.getEffects(t)) {
               if (name.equals(te.getName())) {


### PR DESCRIPTION
## Overview
- Addresses: https://forums.triplea-game.org/topic/1277/allow-territory-effects-for-unitplacementrestrictions-and-unitplacementonlyallowedin
- Allow unit properties `unitPlacementRestrictions` and `unitPlacementOnlyAllowedIn` to specify territory effects in addition to territory names. This is very useful for large maps that use territory effects and only want certain unit to be able to be produced in certain terrains. Otherwise you have to specify a list of every territory that has the territory effect in the XML.

## Functional Changes
- Added logic to check for territory effects for those 2 unit options if a territory isn't found.
- One important note is that any UnitAttachments that then specify territory effects must come after the TerritoryAttachments in the XML.

## Manual Testing Performed
- Updated TWW XML to have a UnitAttachment setting those properties that follows all the TerritoryAttachments and made sure the placement restriction works properly.

