### PR TITLE
Fix biggest leak

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeelSwingFrameListener.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeelSwingFrameListener.java
@@ -28,12 +28,12 @@ public final class LookAndFeelSwingFrameListener implements Consumer<GameSetting
 
   /**
    * Creates a look and feel update listener that will update the passed in JFrame
-   * component. Listener removal is also handled and is attached to the window close event.
+   * component. Listener removal is also handled and is attached to the window closed event.
    */
   public static void register(final JFrame component) {
     final Consumer<GameSetting<String>> listener = new LookAndFeelSwingFrameListener(component);
     ClientSetting.lookAndFeel.addListener(listener);
-    SwingComponents.addWindowClosingListener(component, () -> ClientSetting.lookAndFeel.removeListener(listener));
+    SwingComponents.addWindowClosedListener(component, () -> ClientSetting.lookAndFeel.removeListener(listener));
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -9,6 +9,7 @@ import java.awt.Dimension;
 import java.awt.Graphics;
 import java.awt.Graphics2D;
 import java.awt.Image;
+import java.awt.KeyboardFocusManager;
 import java.awt.MouseInfo;
 import java.awt.Point;
 import java.awt.PointerInfo;
@@ -267,6 +268,8 @@ public class MapPanel extends ImageScrollerLargeView {
       deactivate();
       clearPendingDrawOperations();
       executor.shutdown();
+      // Desperate attempt tp fix a memory leak
+      KeyboardFocusManager.getCurrentKeyboardFocusManager().focusNextComponent();
     });
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -268,7 +268,7 @@ public class MapPanel extends ImageScrollerLargeView {
       deactivate();
       clearPendingDrawOperations();
       executor.shutdown();
-      // Desperate attempt tp fix a memory leak
+      // Desperate attempt to fix a memory leak
       KeyboardFocusManager.getCurrentKeyboardFocusManager().focusNextComponent();
     });
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -264,7 +264,6 @@ public class MapPanel extends ImageScrollerLargeView {
     addScrollListener((x2, y2) -> SwingUtilities.invokeLater(this::repaint));
     executor.execute(() -> recreateTiles(data, uiContext));
     uiContext.addActive(() -> {
-      // super.deactivate
       deactivate();
       clearPendingDrawOperations();
       executor.shutdown();

--- a/game-core/src/main/java/games/strategy/triplea/ui/NotesPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/NotesPanel.java
@@ -7,33 +7,23 @@ import javax.swing.JEditorPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 
+import games.strategy.triplea.ui.menubar.HelpMenu;
+
 class NotesPanel extends JPanel {
   private static final long serialVersionUID = 2746643868463714526L;
-  protected final JEditorPane gameNotesPane;
+  private final JEditorPane gameNotesPane;
 
   // we now require passing a JEditorPane containing the notes in it, because we do not want to have multiple copies of
   // it in memory for all the different ways the user can access the game notes
   // so instead we keep the main copy in the TripleAMenuBar, and then give it to the notes tab. this prevents out of
   // memory errors for maps with large images in their games notes.
-  NotesPanel(final JEditorPane gameNotesPane) {
-    this.gameNotesPane = gameNotesPane;
+  NotesPanel(final String trimmedNotes) {
+    gameNotesPane = HelpMenu.createNotesPanel(trimmedNotes);
     initLayout();
   }
 
   protected void initLayout() {
     setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
-    removeNotes();
-  }
-
-  void removeNotes() {
-    removeAll();
-  }
-
-  void layoutNotes() {
-    if (gameNotesPane == null) {
-      return;
-    }
-    removeAll();
     final JScrollPane scroll = new JScrollPane(gameNotesPane);
     scroll.scrollRectToVisible(new Rectangle(0, 0, 0, 0));
     add(scroll);

--- a/game-core/src/main/java/games/strategy/triplea/ui/NotesPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/NotesPanel.java
@@ -7,6 +7,9 @@ import javax.swing.JScrollPane;
 
 import org.triplea.util.LocalizeHtml;
 
+/**
+ * Wrapper class to display game related notes in a swing component.
+ */
 public class NotesPanel extends JScrollPane {
   private static final long serialVersionUID = 2746643868463714526L;
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/NotesPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/NotesPanel.java
@@ -1,31 +1,24 @@
 package games.strategy.triplea.ui;
 
-import java.awt.Rectangle;
+import java.awt.Color;
 
-import javax.swing.BoxLayout;
 import javax.swing.JEditorPane;
-import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 
-import games.strategy.triplea.ui.menubar.HelpMenu;
+import org.triplea.util.LocalizeHtml;
 
-class NotesPanel extends JPanel {
+public class NotesPanel extends JScrollPane {
   private static final long serialVersionUID = 2746643868463714526L;
-  private final JEditorPane gameNotesPane;
 
-  // we now require passing a JEditorPane containing the notes in it, because we do not want to have multiple copies of
-  // it in memory for all the different ways the user can access the game notes
-  // so instead we keep the main copy in the TripleAMenuBar, and then give it to the notes tab. this prevents out of
-  // memory errors for maps with large images in their games notes.
-  NotesPanel(final String trimmedNotes) {
-    gameNotesPane = HelpMenu.createNotesPanel(trimmedNotes);
-    initLayout();
+  public NotesPanel(final String trimmedNotes) {
+    super(createNotesPane(LocalizeHtml.localizeImgLinksInHtml(trimmedNotes)));
   }
 
-  protected void initLayout() {
-    setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
-    final JScrollPane scroll = new JScrollPane(gameNotesPane);
-    scroll.scrollRectToVisible(new Rectangle(0, 0, 0, 0));
-    add(scroll);
+  private static JEditorPane createNotesPane(final String html) {
+    final JEditorPane gameNotesPane = new JEditorPane("text/html", html);
+    gameNotesPane.setEditable(false);
+    gameNotesPane.setForeground(Color.BLACK);
+    gameNotesPane.setCaretPosition(0);
+    return gameNotesPane;
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -162,7 +162,6 @@ import games.strategy.triplea.ui.export.ScreenshotExporter;
 import games.strategy.triplea.ui.history.HistoryDetailsPanel;
 import games.strategy.triplea.ui.history.HistoryLog;
 import games.strategy.triplea.ui.history.HistoryPanel;
-import games.strategy.triplea.ui.menubar.HelpMenu;
 import games.strategy.triplea.ui.menubar.TripleAMenuBar;
 import games.strategy.triplea.ui.screen.UnitsDrawer;
 import games.strategy.triplea.util.TuvUtils;

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -528,7 +528,7 @@ public final class TripleAFrame extends JFrame {
     } else {
       addTab(objectivePanel.getName(), objectivePanel, 'O');
     }
-    notesPanel = new NotesPanel(HelpMenu.gameNotesPane);
+    notesPanel = new NotesPanel(data.getProperties().get("notes", "").trim());
     addTab("Notes", notesPanel, 'N');
     details = new TerritoryDetailPanel(mapPanel, data, uiContext, this);
     addTab("Territory", details, 'T');
@@ -540,13 +540,6 @@ public final class TripleAFrame extends JFrame {
       final int sel = pane.getSelectedIndex();
       if (sel == -1) {
         return;
-      }
-      if (pane.getComponentAt(sel).equals(notesPanel)) {
-        notesPanel.layoutNotes();
-      } else {
-        // for memory management reasons the notes are in a SoftReference,
-        // so we must remove our hard reference link to them so it can be reclaimed if needed
-        notesPanel.removeNotes();
       }
       if (pane.getComponentAt(sel).equals(editPanel)) {
         data.acquireReadLock();

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -23,7 +23,6 @@ import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.awt.event.WindowListener;
 import java.awt.font.TextAttribute;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -377,14 +376,19 @@ public final class TripleAFrame extends JFrame {
     this.game = game;
     data = game.getData();
     addZoomKeyboardShortcuts();
-    this.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
-    final WindowListener windowListener = new WindowAdapter() {
+    setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
+    addWindowListener(new WindowAdapter() {
       @Override
       public void windowClosing(final WindowEvent e) {
         leaveGame();
       }
-    };
-    this.addWindowListener(windowListener);
+    });
+    addWindowFocusListener(new WindowAdapter() {
+      @Override
+      public void windowGainedFocus(final WindowEvent e) {
+        mapPanel.requestFocusInWindow();
+      }
+    });
     this.uiContext = uiContext;
     this.setCursor(uiContext.getCursor());
     editModeButtonModel = new JToggleButton.ToggleButtonModel();
@@ -493,7 +497,7 @@ public final class TripleAFrame extends JFrame {
       @Override
       public void focusGained(final FocusEvent e) {
         // give the focus back to the map panel
-        mapPanel.requestFocusInWindow();
+        mapPanel.requestFocus();
       }
     };
     rightHandSidePanel.addFocusListener(focusToMapPanelFocusListener);

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -12,7 +12,6 @@ import java.net.URL;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import java.util.concurrent.CompletableFuture;
 
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
@@ -28,7 +27,6 @@ import javax.swing.JScrollPane;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 
-import org.triplea.java.concurrency.CompletableFutureUtils;
 import org.triplea.swing.JLabelBuilder;
 import org.triplea.swing.SwingAction;
 import org.triplea.swing.SwingComponents;
@@ -285,13 +283,8 @@ public final class HelpMenu extends JMenu {
   }
 
   public static JEditorPane createNotesPanel(final String trimmedNotes) {
-    final JEditorPane gameNotesPane = new JEditorPane();
-    final CompletableFuture<?> future = CompletableFuture
-        .supplyAsync(() -> LocalizeHtml.localizeImgLinksInHtml(trimmedNotes))
-        .thenAccept(notes -> SwingUtilities.invokeLater(() -> gameNotesPane.setText(notes)));
-    CompletableFutureUtils.logExceptionWhenComplete(future, "Failed to set game notes text");
+    final JEditorPane gameNotesPane = new JEditorPane("text/html", LocalizeHtml.localizeImgLinksInHtml(trimmedNotes));
     gameNotesPane.setEditable(false);
-    gameNotesPane.setContentType("text/html");
     gameNotesPane.setForeground(Color.BLACK);
     return gameNotesPane;
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -188,28 +188,11 @@ public final class HelpMenu extends JMenu {
   private void addUnitHelpMenu() {
     final String unitHelpTitle = "Unit Help";
     final JMenuItem unitMenuItem = add(SwingAction.of(unitHelpTitle, e -> {
-      final JEditorPane editorPane = new JEditorPane();
+      final JEditorPane editorPane = new JEditorPane("text/html", getUnitStatsTable(gameData, uiContext));
       editorPane.setEditable(false);
-      editorPane.setContentType("text/html");
-      editorPane.setText(getUnitStatsTable(gameData, uiContext));
       editorPane.setCaretPosition(0);
       final JScrollPane scroll = new JScrollPane(editorPane);
       scroll.setBorder(BorderFactory.createEmptyBorder());
-      final Dimension screenResolution = Toolkit.getDefaultToolkit().getScreenSize();
-      // not only do we have a start bar, but we also have the message dialog to account for just the scroll bars plus
-      // the window sides
-      final int availHeight = screenResolution.height - 120;
-      final int availWidth = screenResolution.width - 40;
-      scroll
-          .setPreferredSize(new Dimension(
-              (scroll.getPreferredSize().width > availWidth ? availWidth
-                  : (scroll.getPreferredSize().height > availHeight
-                      ? Math.min(availWidth, scroll.getPreferredSize().width + 22)
-                      : scroll.getPreferredSize().width)),
-              (scroll.getPreferredSize().height > availHeight ? availHeight
-                  : (scroll.getPreferredSize().width > availWidth
-                      ? Math.min(availHeight, scroll.getPreferredSize().height + 22)
-                      : scroll.getPreferredSize().height))));
       createInformationDialog(scroll, unitHelpTitle).setVisible(true);
     }));
     unitMenuItem.setMnemonic(KeyEvent.VK_U);

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -1,9 +1,7 @@
 package games.strategy.triplea.ui.menubar;
 
 import java.awt.BorderLayout;
-import java.awt.Color;
 import java.awt.Dimension;
-import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 import java.awt.event.WindowAdapter;
@@ -30,7 +28,6 @@ import javax.swing.SwingUtilities;
 import org.triplea.swing.JLabelBuilder;
 import org.triplea.swing.SwingAction;
 import org.triplea.swing.SwingComponents;
-import org.triplea.util.LocalizeHtml;
 
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.data.GameData;
@@ -41,6 +38,7 @@ import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.ui.MacOsIntegration;
+import games.strategy.triplea.ui.NotesPanel;
 import games.strategy.triplea.ui.TooltipProperties;
 import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.util.TuvUtils;
@@ -245,10 +243,9 @@ public final class HelpMenu extends JMenu {
     if (!trimmedNotes.isEmpty()) {
       final String gameNotesTitle = "Game Notes";
       add(SwingAction.of(gameNotesTitle, e -> SwingUtilities.invokeLater(() -> {
-        final JScrollPane scroll = new JScrollPane(createNotesPanel(trimmedNotes));
-        scroll.scrollRectToVisible(new Rectangle(0, 0, 0, 0));
         final JDialog dialog = new JDialog((JFrame) null, gameNotesTitle);
-        dialog.add(scroll, BorderLayout.CENTER);
+        final NotesPanel notesPanel = new NotesPanel(trimmedNotes);
+        dialog.add(notesPanel, BorderLayout.CENTER);
         final JPanel buttons = new JPanel();
         final JButton button = new JButton(SwingAction.of("OK", event -> {
           dialog.setVisible(false);
@@ -280,13 +277,6 @@ public final class HelpMenu extends JMenu {
         dialog.setVisible(true);
       }))).setMnemonic(KeyEvent.VK_N);
     }
-  }
-
-  public static JEditorPane createNotesPanel(final String trimmedNotes) {
-    final JEditorPane gameNotesPane = new JEditorPane("text/html", LocalizeHtml.localizeImgLinksInHtml(trimmedNotes));
-    gameNotesPane.setEditable(false);
-    gameNotesPane.setForeground(Color.BLACK);
-    return gameNotesPane;
   }
 
   private void addAboutMenu() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 
 import javax.swing.BorderFactory;
 import javax.swing.JButton;
+import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JEditorPane;
 import javax.swing.JFrame;
@@ -209,27 +210,7 @@ public final class HelpMenu extends JMenu {
                   : (scroll.getPreferredSize().width > availWidth
                       ? Math.min(availHeight, scroll.getPreferredSize().height + 22)
                       : scroll.getPreferredSize().height))));
-      final JDialog dialog = new JDialog((JFrame) null, unitHelpTitle);
-      dialog.add(scroll, BorderLayout.CENTER);
-      final JPanel buttons = new JPanel();
-      final JButton button = new JButton(SwingAction.of("OK", event -> {
-        dialog.setVisible(false);
-        dialog.removeAll();
-        dialog.dispose();
-      }));
-      buttons.add(button);
-      dialog.getRootPane().setDefaultButton(button);
-      dialog.add(buttons, BorderLayout.SOUTH);
-      dialog.pack();
-      dialog.addWindowListener(new WindowAdapter() {
-        @Override
-        public void windowOpened(final WindowEvent e) {
-          scroll.getVerticalScrollBar().getModel().setValue(0);
-          scroll.getHorizontalScrollBar().getModel().setValue(0);
-          button.requestFocus();
-        }
-      });
-      dialog.setVisible(true);
+      createInformationDialog(scroll, unitHelpTitle).setVisible(true);
     }));
     unitMenuItem.setMnemonic(KeyEvent.VK_U);
     unitMenuItem.setAccelerator(
@@ -243,19 +224,7 @@ public final class HelpMenu extends JMenu {
     if (!trimmedNotes.isEmpty()) {
       final String gameNotesTitle = "Game Notes";
       add(SwingAction.of(gameNotesTitle, e -> SwingUtilities.invokeLater(() -> {
-        final JDialog dialog = new JDialog((JFrame) null, gameNotesTitle);
-        final NotesPanel notesPanel = new NotesPanel(trimmedNotes);
-        dialog.add(notesPanel, BorderLayout.CENTER);
-        final JPanel buttons = new JPanel();
-        final JButton button = new JButton(SwingAction.of("OK", event -> {
-          dialog.setVisible(false);
-          dialog.removeAll();
-          dialog.dispose();
-        }));
-        buttons.add(button);
-        dialog.getRootPane().setDefaultButton(button);
-        dialog.add(buttons, BorderLayout.SOUTH);
-        dialog.pack();
+        final JDialog dialog = createInformationDialog(new NotesPanel(trimmedNotes), gameNotesTitle);
         if (dialog.getWidth() < 400) {
           dialog.setSize(400, dialog.getHeight());
         }
@@ -268,12 +237,6 @@ public final class HelpMenu extends JMenu {
         if (dialog.getHeight() > 600) {
           dialog.setSize(dialog.getWidth(), 600);
         }
-        dialog.addWindowListener(new WindowAdapter() {
-          @Override
-          public void windowOpened(final WindowEvent e) {
-            button.requestFocus();
-          }
-        });
         dialog.setVisible(true);
       }))).setMnemonic(KeyEvent.VK_N);
     }
@@ -322,5 +285,27 @@ public final class HelpMenu extends JMenu {
   private void addReportBugsMenu() {
     add(SwingAction.of("Send Bug Report",
         e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_ISSUES))).setMnemonic(KeyEvent.VK_B);
+  }
+
+  private static JDialog createInformationDialog(final JComponent component, final String title) {
+    final JDialog dialog = new JDialog((JFrame) null, title);
+    dialog.add(component, BorderLayout.CENTER);
+    final JPanel buttons = new JPanel();
+    final JButton button = new JButton(SwingAction.of("OK", event -> {
+      dialog.setVisible(false);
+      dialog.removeAll();
+      dialog.dispose();
+    }));
+    buttons.add(button);
+    dialog.getRootPane().setDefaultButton(button);
+    dialog.add(buttons, BorderLayout.SOUTH);
+    dialog.pack();
+    dialog.addWindowListener(new WindowAdapter() {
+      @Override
+      public void windowOpened(final WindowEvent e) {
+        button.requestFocus();
+      }
+    });
+    return dialog;
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -1,7 +1,6 @@
 package games.strategy.triplea.ui.menubar;
 
 import java.awt.BorderLayout;
-import java.awt.Dimension;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 import java.awt.event.WindowAdapter;
@@ -26,6 +25,8 @@ import javax.swing.JScrollPane;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 
+import org.triplea.java.Interruptibles;
+import org.triplea.java.Interruptibles.Result;
 import org.triplea.swing.JLabelBuilder;
 import org.triplea.swing.SwingAction;
 import org.triplea.swing.SwingComponents;
@@ -35,6 +36,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.data.ResourceCollection;
 import games.strategy.engine.data.UnitType;
+import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.triplea.image.UnitImageFactory;
@@ -188,7 +190,10 @@ public final class HelpMenu extends JMenu {
   private void addUnitHelpMenu() {
     final String unitHelpTitle = "Unit Help";
     final JMenuItem unitMenuItem = add(SwingAction.of(unitHelpTitle, e -> {
-      final JEditorPane editorPane = new JEditorPane("text/html", getUnitStatsTable(gameData, uiContext));
+      final Result<String> result = Interruptibles.awaitResult(() -> GameRunner.newBackgroundTaskRunner()
+          .runInBackgroundAndReturn("Calculating Data", () -> getUnitStatsTable(gameData, uiContext)));
+      final JEditorPane editorPane = new JEditorPane("text/html",
+          result.result.orElse("Failed to calculate Data"));
       editorPane.setEditable(false);
       editorPane.setCaretPosition(0);
       final JScrollPane scroll = new JScrollPane(editorPane);

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -51,7 +51,6 @@ import games.strategy.triplea.util.TuvUtils;
  * The help menu.
  */
 public final class HelpMenu extends JMenu {
-  public static final JEditorPane gameNotesPane = new JEditorPane();
   private static final long serialVersionUID = 4070541434144687452L;
 
   private final UiContext uiContext;
@@ -246,17 +245,9 @@ public final class HelpMenu extends JMenu {
     // displays whatever is in the notes field in html
     final String trimmedNotes = gameData.getProperties().get("notes", "").trim();
     if (!trimmedNotes.isEmpty()) {
-      final CompletableFuture<?> future = CompletableFuture
-          .supplyAsync(() -> LocalizeHtml.localizeImgLinksInHtml(trimmedNotes))
-          .thenAccept(notes -> SwingUtilities.invokeLater(() -> gameNotesPane.setText(notes)));
-      CompletableFutureUtils.logExceptionWhenComplete(future, "Failed to set game notes text");
-      gameNotesPane.setEditable(false);
-      gameNotesPane.setContentType("text/html");
-      gameNotesPane.setForeground(Color.BLACK);
-
       final String gameNotesTitle = "Game Notes";
       add(SwingAction.of(gameNotesTitle, e -> SwingUtilities.invokeLater(() -> {
-        final JScrollPane scroll = new JScrollPane(gameNotesPane);
+        final JScrollPane scroll = new JScrollPane(createNotesPanel(trimmedNotes));
         scroll.scrollRectToVisible(new Rectangle(0, 0, 0, 0));
         final JDialog dialog = new JDialog((JFrame) null, gameNotesTitle);
         dialog.add(scroll, BorderLayout.CENTER);
@@ -291,6 +282,18 @@ public final class HelpMenu extends JMenu {
         dialog.setVisible(true);
       }))).setMnemonic(KeyEvent.VK_N);
     }
+  }
+
+  public static JEditorPane createNotesPanel(final String trimmedNotes) {
+    final JEditorPane gameNotesPane = new JEditorPane();
+    final CompletableFuture<?> future = CompletableFuture
+        .supplyAsync(() -> LocalizeHtml.localizeImgLinksInHtml(trimmedNotes))
+        .thenAccept(notes -> SwingUtilities.invokeLater(() -> gameNotesPane.setText(notes)));
+    CompletableFutureUtils.logExceptionWhenComplete(future, "Failed to set game notes text");
+    gameNotesPane.setEditable(false);
+    gameNotesPane.setContentType("text/html");
+    gameNotesPane.setForeground(Color.BLACK);
+    return gameNotesPane;
   }
 
   private void addAboutMenu() {


### PR DESCRIPTION
## Overview
So this is my attempt at #4798
While I haven't completely solved this problem I can at least say that this is a step in the right direction and that I learned a lot about when exactly a leak occurs.
After this PR, simply opening a Game and leaving it using Ctrl+Q or pressing the X in the upper right corner no longer causes a memory leak. Note that leaving via the File Menu ***will*** cause a memory leak for reasons I don't understand.
To be precise: Once one of the Menus in the Menu bar open, leaving the game will no longer free the MapPanel instance, even if then closed using the other methods.
There's a similar thing for the JEditorPanel (contains complete HTML parser) and probably a lot of less important cases where once opened/used a single time the memory is never being freed again.

I'm really out of ideas on this one, according to JProfiler the problem is that some sort of reference to the MapPanel is still in some `InputMap` (for keyboard shortcuts etc.) that I wasn't able to find.
I'm probably not going to touch this anymore for a couple of weeks in order to keep my sanity.

## Functional Changes
The JEditorPane for the notes panel is no longer used twice for 2 different nodes. (Might behave a little bit differently though, because the parsing is now done upon creation)

## Manual Testing Performed
Way too much opening the game, leaving in various ways and running the garbage collector in the profiler to see if the memory will be freed again.