### PR TITLE
Add new player option giveUnitControlInAllTerritories

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -396,20 +396,12 @@ public class PlayerAttachment extends DefaultAttachment {
     giveUnitControl = new ArrayList<>();
   }
 
-  private void setGiveUnitControlInAllTerritories(final String value) throws GameParseException {
-    giveUnitControlInAllTerritories = getBool(value);
-  }
-
   private void setGiveUnitControlInAllTerritories(final boolean value) {
     giveUnitControlInAllTerritories = value;
   }
 
   public boolean getGiveUnitControlInAllTerritories() {
     return giveUnitControlInAllTerritories;
-  }
-
-  private void resetGiveUnitControlInAllTerritories() {
-    giveUnitControlInAllTerritories = false;
   }
 
   private void setCaptureUnitOnEnteringBy(final String value) throws GameParseException {
@@ -553,11 +545,11 @@ public class PlayerAttachment extends DefaultAttachment {
                 this::getGiveUnitControl,
                 this::resetGiveUnitControl))
         .put("giveUnitControlInAllTerritories",
-            MutableProperty.of(
-                this::setGiveUnitControlInAllTerritories,
+            MutableProperty.ofMapper(
+                DefaultAttachment::getBool,
                 this::setGiveUnitControlInAllTerritories,
                 this::getGiveUnitControlInAllTerritories,
-                this::resetGiveUnitControlInAllTerritories))
+                () -> false))
         .put("captureUnitOnEnteringBy",
             MutableProperty.of(
                 this::setCaptureUnitOnEnteringBy,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -40,6 +40,7 @@ public class PlayerAttachment extends DefaultAttachment {
   // number of capitals needed before we lose ability to gain money and produce units
   private int retainCapitalProduceNumber = 1;
   private List<PlayerId> giveUnitControl = new ArrayList<>();
+  private boolean giveUnitControlInAllTerritories = false;
   private List<PlayerId> captureUnitOnEnteringBy = new ArrayList<>();
   // gives any technology researched to this player automatically
   private List<PlayerId> shareTechnology = new ArrayList<>();
@@ -395,6 +396,22 @@ public class PlayerAttachment extends DefaultAttachment {
     giveUnitControl = new ArrayList<>();
   }
 
+  private void setGiveUnitControlInAllTerritories(final String value) throws GameParseException {
+    giveUnitControlInAllTerritories = getBool(value);
+  }
+
+  private void setGiveUnitControlInAllTerritories(final boolean value) {
+    giveUnitControlInAllTerritories = value;
+  }
+
+  public boolean getGiveUnitControlInAllTerritories() {
+    return giveUnitControlInAllTerritories;
+  }
+
+  private void resetGiveUnitControlInAllTerritories() {
+    giveUnitControlInAllTerritories = false;
+  }
+
   private void setCaptureUnitOnEnteringBy(final String value) throws GameParseException {
     final String[] temp = splitOnColon(value);
     for (final String name : temp) {
@@ -535,6 +552,12 @@ public class PlayerAttachment extends DefaultAttachment {
                 this::setGiveUnitControl,
                 this::getGiveUnitControl,
                 this::resetGiveUnitControl))
+        .put("giveUnitControlInAllTerritories",
+            MutableProperty.of(
+                this::setGiveUnitControlInAllTerritories,
+                this::setGiveUnitControlInAllTerritories,
+                this::getGiveUnitControlInAllTerritories,
+                this::resetGiveUnitControlInAllTerritories))
         .put("captureUnitOnEnteringBy",
             MutableProperty.of(
                 this::setCaptureUnitOnEnteringBy,


### PR DESCRIPTION
## Overview
- https://forums.triplea-game.org/topic/1288/add-option-for-major-minor-nation-system-for-all-territories
- Add new player attachment boolean option: giveUnitControlInAllTerritories. Setting this to true makes it so all territories will check if units should be given to another player. This is primarily just an XML short cut to avoid having to put the changeUnitOwners option on every territory when using major-minor nation system like in TWW.

## Example

Can do this:
```
        <attachment name="playerAttachment" attachTo="French_Africa" javaClass="PlayerAttachment" type="player">
            <option name="giveUnitControl" value="France"/>
            <option name="giveUnitControlInAllTerritories" value="true"/>
        </attachment>
```

Avoids having to have this on every territory:
```
        <attachment name="territoryAttachment" attachTo="Morocco" javaClass="TerritoryAttachment" type="territory">
            <option name="production" value="2"/>
            <option name="changeUnitOwners" value="France:Germany:Austria-Hungary:Ottomans:Italy:Usa"/>           
        </attachment>
```

## Manual Testing Performed
- Using for new WWI map: https://forums.triplea-game.org/topic/1063/power-of-politics-1914-a-wwi-scenario/
