### PR TITLE
Refactor JavaFX code

### DIFF
--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/MainMenuPane.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/MainMenuPane.java
@@ -1,6 +1,5 @@
 package org.triplea.game.client.ui.javafx;
 
-import java.io.IOException;
 import java.text.MessageFormat;
 import java.util.function.Function;
 
@@ -10,8 +9,6 @@ import org.triplea.awt.OpenFileUtility;
 import org.triplea.game.client.ui.javafx.screen.ControlledScreen;
 import org.triplea.game.client.ui.javafx.screen.NavigationPane;
 import org.triplea.game.client.ui.javafx.screen.RootActionPane;
-import org.triplea.game.client.ui.javafx.screen.ScreenController;
-import org.triplea.game.client.ui.javafx.util.FxmlManager;
 
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.framework.map.download.DownloadMapsWindow;
@@ -19,7 +16,6 @@ import games.strategy.triplea.UrlConstants;
 import javafx.beans.binding.Bindings;
 import javafx.beans.binding.NumberBinding;
 import javafx.fxml.FXML;
-import javafx.fxml.FXMLLoader;
 import javafx.scene.Node;
 import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
@@ -31,9 +27,9 @@ import javafx.scene.layout.VBox;
 import lombok.extern.java.Log;
 
 @Log
-class MainMenuPane extends BorderPane implements ControlledScreen<NavigationPane> {
+public class MainMenuPane implements ControlledScreen<NavigationPane> {
 
-  private final RootActionPane actionPane;
+  private RootActionPane actionPane;
   private NavigationPane screenController;
 
   @FXML
@@ -51,19 +47,11 @@ class MainMenuPane extends BorderPane implements ControlledScreen<NavigationPane
   @FXML
   private VBox mainOptions;
 
-  /**
-   * Initializes a new instance of the MainMenuPane class.
-   *
-   * @param actionPane The root pane.
-   * @throws IOException If the FXML file is not present.
-   */
-  MainMenuPane(final RootActionPane actionPane)
-      throws IOException {
-    this.actionPane = actionPane;
-    final FXMLLoader loader = FxmlManager.getLoader(getClass().getResource(FxmlManager.MAIN_MENU_PANE.toString()));
-    loader.setRoot(this);
-    loader.setController(this);
-    loader.load();
+  @FXML
+  private BorderPane root;
+
+  @FXML
+  private void initialize() {
     version.setText(MessageFormat.format(version.getText(), ClientContext.engineVersion().getExactVersion()));
     applyFileSelectionAnimation();
   }
@@ -155,8 +143,12 @@ class MainMenuPane extends BorderPane implements ControlledScreen<NavigationPane
     this.screenController = screenController;
   }
 
+  void setRootActionPane(final RootActionPane actionPane) {
+    this.actionPane = actionPane;
+  }
+
   @Override
   public Node getNode() {
-    return this;
+    return root;
   }
 }

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/MainMenuPane.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/MainMenuPane.java
@@ -166,10 +166,4 @@ class MainMenuPane extends BorderPane {
   private void showExitConfirmDialog() {
     actionPane.promptExit();
   }
-
-  @FXML
-  private void startHover(@SuppressWarnings("unused") final MouseEvent e) {}
-
-  @FXML
-  private void endHover(@SuppressWarnings("unused") final MouseEvent e) {}
 }

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/MainMenuPane.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/MainMenuPane.java
@@ -25,9 +25,10 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
-import lombok.extern.java.Log;
 
-@Log
+/**
+ * Controller representing the MainMenu JavaFX implementation.
+ */
 public class MainMenuPane implements ControlledScreen<NavigationPane> {
 
   private RootActionPane actionPane;

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/MainMenuPane.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/MainMenuPane.java
@@ -9,6 +9,7 @@ import org.triplea.awt.OpenFileUtility;
 import org.triplea.game.client.ui.javafx.screen.ControlledScreen;
 import org.triplea.game.client.ui.javafx.screen.NavigationPane;
 import org.triplea.game.client.ui.javafx.screen.RootActionPane;
+import org.triplea.game.client.ui.javafx.util.FxmlManager;
 
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.framework.map.download.DownloadMapsWindow;
@@ -123,7 +124,7 @@ public class MainMenuPane implements ControlledScreen<NavigationPane> {
 
   @FXML
   private void showSettingsMenu() {
-    screenController.switchScreen(SettingsPane.class);
+    screenController.switchScreen(FxmlManager.SETTINGS_PANE);
   }
 
   @FXML

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/MainMenuPane.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/MainMenuPane.java
@@ -7,6 +7,8 @@ import java.util.function.Function;
 import javax.swing.SwingUtilities;
 
 import org.triplea.awt.OpenFileUtility;
+import org.triplea.game.client.ui.javafx.screen.ControlledScreen;
+import org.triplea.game.client.ui.javafx.screen.NavigationPane;
 import org.triplea.game.client.ui.javafx.screen.RootActionPane;
 import org.triplea.game.client.ui.javafx.screen.ScreenController;
 import org.triplea.game.client.ui.javafx.util.FxmlManager;
@@ -29,10 +31,10 @@ import javafx.scene.layout.VBox;
 import lombok.extern.java.Log;
 
 @Log
-class MainMenuPane extends BorderPane {
+class MainMenuPane extends BorderPane implements ControlledScreen<NavigationPane> {
 
   private final RootActionPane actionPane;
-  private final ScreenController<Class<? extends Node>> screenController;
+  private NavigationPane screenController;
 
   @FXML
   private Button buttonBack;
@@ -55,10 +57,9 @@ class MainMenuPane extends BorderPane {
    * @param actionPane The root pane.
    * @throws IOException If the FXML file is not present.
    */
-  MainMenuPane(final RootActionPane actionPane, final ScreenController<Class<? extends Node>> screenController)
+  MainMenuPane(final RootActionPane actionPane)
       throws IOException {
     this.actionPane = actionPane;
-    this.screenController = screenController;
     final FXMLLoader loader = FxmlManager.getLoader(getClass().getResource(FxmlManager.MAIN_MENU_PANE.toString()));
     loader.setRoot(this);
     loader.setController(this);
@@ -147,5 +148,15 @@ class MainMenuPane extends BorderPane {
   @FXML
   private void showExitConfirmDialog() {
     actionPane.promptExit();
+  }
+
+  @Override
+  public void connect(final NavigationPane screenController) {
+    this.screenController = screenController;
+  }
+
+  @Override
+  public Node getNode() {
+    return this;
   }
 }

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/MainMenuPane.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/MainMenuPane.java
@@ -23,9 +23,6 @@ import javafx.scene.control.Alert;
 import javafx.scene.control.Button;
 import javafx.scene.control.ButtonType;
 import javafx.scene.control.Label;
-import javafx.scene.control.PasswordField;
-import javafx.scene.control.TextField;
-import javafx.scene.input.MouseEvent;
 import javafx.scene.layout.BorderPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.VBox;
@@ -36,18 +33,6 @@ class MainMenuPane extends BorderPane {
 
   private final RootActionPane actionPane;
   private final ScreenController<Class<? extends Node>> screenController;
-
-  @FXML
-  private Label loggedIn;
-
-  @FXML
-  private HBox loginForm;
-
-  @FXML
-  private TextField username;
-
-  @FXML
-  private PasswordField password;
 
   @FXML
   private Button buttonBack;
@@ -93,9 +78,6 @@ class MainMenuPane extends BorderPane {
           : numberBinding);
     });
   }
-
-  @FXML
-  private void login() {}
 
   @FXML
   private void showLastMenu() {

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/SettingsPane.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/SettingsPane.java
@@ -69,7 +69,8 @@ public class SettingsPane implements ControlledScreen<NavigationPane> {
             final Tooltip tooltip =
                 new Tooltip(resources.getString("settings.tooltip." + entry.getKey().name().toLowerCase()));
             final Region element = entry.getValue().getUiComponent();
-            final Label description = new Label(resources.getString(getSettingLocalizationKey(element, entry.getKey())));
+            final Label description =
+                new Label(resources.getString(getSettingLocalizationKey(element, entry.getKey())));
             description.setTooltip(tooltip);
             addTooltipRecursively(element, tooltip);
             pane.addColumn(0, description);

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/SettingsPane.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/SettingsPane.java
@@ -34,6 +34,10 @@ import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 
+/**
+ * SettingsPane Controller class that represents the JavaFX implementation
+ * of our Settings framework.
+ */
 public class SettingsPane implements ControlledScreen<NavigationPane> {
   private NavigationPane navigationPane;
   private final Map<ClientSettingJavaFxUiBinding, SelectionComponent<Region>> selectionComponentsBySetting =

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/SettingsPane.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/SettingsPane.java
@@ -1,6 +1,5 @@
 package org.triplea.game.client.ui.javafx;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.EnumMap;
 import java.util.Map;
@@ -13,13 +12,11 @@ import javax.annotation.Nullable;
 import org.triplea.game.client.ui.javafx.screen.ControlledScreen;
 import org.triplea.game.client.ui.javafx.screen.NavigationPane;
 import org.triplea.game.client.ui.javafx.util.ClientSettingJavaFxUiBinding;
-import org.triplea.game.client.ui.javafx.util.FxmlManager;
 
 import games.strategy.triplea.settings.GameSetting;
 import games.strategy.triplea.settings.SelectionComponent;
 import games.strategy.triplea.settings.SettingType;
 import javafx.fxml.FXML;
-import javafx.fxml.FXMLLoader;
 import javafx.geometry.HPos;
 import javafx.geometry.Insets;
 import javafx.scene.Node;
@@ -36,7 +33,7 @@ import javafx.scene.layout.Priority;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 
-class SettingsPane extends StackPane implements ControlledScreen<NavigationPane> {
+public class SettingsPane implements ControlledScreen<NavigationPane> {
   private NavigationPane navigationPane;
   private final Map<ClientSettingJavaFxUiBinding, SelectionComponent<Region>> selectionComponentsBySetting =
       Arrays.stream(ClientSettingJavaFxUiBinding.values()).collect(Collectors.toMap(
@@ -51,19 +48,10 @@ class SettingsPane extends StackPane implements ControlledScreen<NavigationPane>
   private TabPane tabPane;
 
   @FXML
-  private ResourceBundle resources;
+  private StackPane root;
 
-  /**
-   * Initializes a new instance of the SettingsPane class.
-   *
-   * @throws IOException If the FXML file is not present.
-   */
-  SettingsPane() throws IOException {
-    final FXMLLoader loader = FxmlManager.getLoader(getClass().getResource(FxmlManager.SETTINGS_PANE.toString()));
-    loader.setRoot(this);
-    loader.setController(this);
-    loader.load();
-  }
+  @FXML
+  private ResourceBundle resources;
 
   @FXML
   private void initialize() {
@@ -155,6 +143,6 @@ class SettingsPane extends StackPane implements ControlledScreen<NavigationPane>
 
   @Override
   public Node getNode() {
-    return this;
+    return root;
   }
 }

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/SettingsPane.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/SettingsPane.java
@@ -12,6 +12,7 @@ import javax.annotation.Nullable;
 import org.triplea.game.client.ui.javafx.screen.ControlledScreen;
 import org.triplea.game.client.ui.javafx.screen.NavigationPane;
 import org.triplea.game.client.ui.javafx.util.ClientSettingJavaFxUiBinding;
+import org.triplea.game.client.ui.javafx.util.FxmlManager;
 
 import games.strategy.triplea.settings.GameSetting;
 import games.strategy.triplea.settings.SelectionComponent;
@@ -97,7 +98,7 @@ public class SettingsPane implements ControlledScreen<NavigationPane> {
 
   @FXML
   private void back() {
-    navigationPane.switchScreen(MainMenuPane.class);
+    navigationPane.switchScreen(FxmlManager.MAIN_MENU_PANE);
   }
 
   @FXML

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/TripleA.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/TripleA.java
@@ -39,12 +39,12 @@ public class TripleA extends Application {
     final MainMenuPane mainMenuPane = FxmlManager.MAIN_MENU_PANE.<MainMenuPane, Node>load().getController();
     mainMenuPane.setRootActionPane(loadedNode.getController());
 
-    navigationPane.registerScreen(mainMenuPane);
-    navigationPane.registerScreen(FxmlManager.SETTINGS_PANE.<SettingsPane, Node>load().getController());
+    navigationPane.registerScreen(FxmlManager.MAIN_MENU_PANE, mainMenuPane);
+    navigationPane.registerScreen(FxmlManager.SETTINGS_PANE);
 
     loadedNode.getController().setContent(navigationPane);
 
-    navigationPane.switchScreen(MainMenuPane.class);
+    navigationPane.switchScreen(FxmlManager.MAIN_MENU_PANE);
 
     setupStage(stage, scene, loadedNode.getController());
     // Don't invoke Swing if headless (for example in tests)

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/TripleA.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/TripleA.java
@@ -30,8 +30,8 @@ public class TripleA extends Application {
 
     final NavigationPane navigationPane = new NavigationPane();
 
-    navigationPane.registerScreen(new MainMenuPane(rootActionPane, navigationPane));
-    navigationPane.registerScreen(new SettingsPane(navigationPane));
+    navigationPane.registerScreen(new MainMenuPane(rootActionPane));
+    navigationPane.registerScreen(new SettingsPane());
 
     rootActionPane.setContent(navigationPane);
 

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/TripleA.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/TripleA.java
@@ -21,12 +21,15 @@ import javafx.stage.Stage;
  * It sets up the Stage accordingly.
  */
 public class TripleA extends Application {
+  private static final String STYLESHEET_MAIN = "/org/triplea/game/client/ui/javafx/css/main.css";
+  private static final String FONT_PATH = "/org/triplea/game/client/ui/javafx/css/fonts/1942-report.ttf";
+  private static final String ICON_LOCATION = "/org/triplea/swing/ta_icon.png";
 
   @Override
   public void start(final Stage stage) throws Exception {
     final RootActionPane rootActionPane = new RootActionPane();
     final Scene scene = new Scene(rootActionPane);
-    scene.getStylesheets().add(FxmlManager.STYLESHEET_MAIN.toString());
+    scene.getStylesheets().add(STYLESHEET_MAIN);
 
     final NavigationPane navigationPane = new NavigationPane();
 
@@ -48,9 +51,9 @@ public class TripleA extends Application {
     stage.setFullScreenExitKeyCombination(KeyCombination.NO_MATCH);
     stage.setFullScreen(true);
 
-    Font.loadFont(TripleA.class.getResourceAsStream(FxmlManager.FONT_PATH.toString()), 14);
+    Font.loadFont(TripleA.class.getResourceAsStream(FONT_PATH), 14);
     stage.setScene(scene);
-    stage.getIcons().add(new Image(getClass().getResourceAsStream(FxmlManager.ICON_LOCATION.toString())));
+    stage.getIcons().add(new Image(getClass().getResourceAsStream(ICON_LOCATION)));
     stage.setTitle("TripleA");
     stage.show();
     stage.setOnCloseRequest(e -> {

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/TripleA.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/TripleA.java
@@ -7,12 +7,15 @@ import javax.swing.SwingUtilities;
 import org.triplea.game.client.ui.javafx.screen.NavigationPane;
 import org.triplea.game.client.ui.javafx.screen.RootActionPane;
 import org.triplea.game.client.ui.javafx.util.FxmlManager;
+import org.triplea.game.client.ui.javafx.util.FxmlManager.LoadedNode;
 
 import games.strategy.engine.framework.GameRunner;
 import javafx.application.Application;
+import javafx.scene.Node;
 import javafx.scene.Scene;
 import javafx.scene.image.Image;
 import javafx.scene.input.KeyCombination;
+import javafx.scene.layout.StackPane;
 import javafx.scene.text.Font;
 import javafx.stage.Stage;
 
@@ -26,21 +29,24 @@ public class TripleA extends Application {
   private static final String ICON_LOCATION = "/org/triplea/swing/ta_icon.png";
 
   @Override
-  public void start(final Stage stage) throws Exception {
-    final RootActionPane rootActionPane = new RootActionPane();
-    final Scene scene = new Scene(rootActionPane);
+  public void start(final Stage stage) {
+    final LoadedNode<RootActionPane, StackPane> loadedNode = FxmlManager.ROOT_CONTAINER.load();
+    final Scene scene = new Scene(loadedNode.getNode());
     scene.getStylesheets().add(STYLESHEET_MAIN);
 
     final NavigationPane navigationPane = new NavigationPane();
 
-    navigationPane.registerScreen(new MainMenuPane(rootActionPane));
-    navigationPane.registerScreen(new SettingsPane());
+    final MainMenuPane mainMenuPane = FxmlManager.MAIN_MENU_PANE.<MainMenuPane, Node>load().getController();
+    mainMenuPane.setRootActionPane(loadedNode.getController());
 
-    rootActionPane.setContent(navigationPane);
+    navigationPane.registerScreen(mainMenuPane);
+    navigationPane.registerScreen(FxmlManager.SETTINGS_PANE.<SettingsPane, Node>load().getController());
+
+    loadedNode.getController().setContent(navigationPane);
 
     navigationPane.switchScreen(MainMenuPane.class);
 
-    setupStage(stage, scene, rootActionPane);
+    setupStage(stage, scene, loadedNode.getController());
     // Don't invoke Swing if headless (for example in tests)
     if (!GraphicsEnvironment.isHeadless()) {
       SwingUtilities.invokeLater(GameRunner::newMainFrame);

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/screen/ControlledScreen.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/screen/ControlledScreen.java
@@ -5,6 +5,7 @@ import javafx.scene.Node;
 /**
  * Interface that all Controllers should
  * implement that represent a screen that can be swapped out by another one.
+ *
  * @param <T> The Type of the {@link ScreenController}.
  */
 public interface ControlledScreen<T extends ScreenController<?>> {
@@ -12,6 +13,7 @@ public interface ControlledScreen<T extends ScreenController<?>> {
   /**
    * A method being called by the {@link ScreenController}
    * when this Screen is getting registered.
+   *
    * @param screenController The calling {@link ScreenController} instance.
    */
   void connect(T screenController);

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/screen/ControlledScreen.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/screen/ControlledScreen.java
@@ -1,0 +1,8 @@
+package org.triplea.game.client.ui.javafx.screen;
+
+import javafx.scene.Node;
+
+public interface ControlledScreen<T extends ScreenController<?>> {
+  void connect(T screenController);
+  Node getNode();
+}

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/screen/ControlledScreen.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/screen/ControlledScreen.java
@@ -4,5 +4,6 @@ import javafx.scene.Node;
 
 public interface ControlledScreen<T extends ScreenController<?>> {
   void connect(T screenController);
+
   Node getNode();
 }

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/screen/ControlledScreen.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/screen/ControlledScreen.java
@@ -2,8 +2,22 @@ package org.triplea.game.client.ui.javafx.screen;
 
 import javafx.scene.Node;
 
+/**
+ * Interface that all Controllers should
+ * implement that represent a screen that can be swapped out by another one.
+ * @param <T> The Type of the {@link ScreenController}.
+ */
 public interface ControlledScreen<T extends ScreenController<?>> {
+
+  /**
+   * A method being called by the {@link ScreenController}
+   * when this Screen is getting registered.
+   * @param screenController The calling {@link ScreenController} instance.
+   */
   void connect(T screenController);
 
+  /**
+   * A common method to retrieve the root Node to attach it to the Scene Graph.
+   */
   Node getNode();
 }

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/screen/NavigationPane.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/screen/NavigationPane.java
@@ -1,7 +1,9 @@
 package org.triplea.game.client.ui.javafx.screen;
 
-import java.util.HashMap;
+import java.util.EnumMap;
 import java.util.Map;
+
+import org.triplea.game.client.ui.javafx.util.FxmlManager;
 
 import com.google.common.base.Preconditions;
 
@@ -15,27 +17,25 @@ import javafx.scene.layout.StackPane;
  * call tree by using the class name as the identifier.
  * Make sure to register Screens before using them.
  */
-public class NavigationPane extends StackPane implements ScreenController<Class<? extends ControlledScreen<NavigationPane>>> {
-  private final Map<Class<? extends ControlledScreen<NavigationPane>>, Node> screens = new HashMap<>();
+public class NavigationPane extends StackPane implements ScreenController<FxmlManager> {
+  private final Map<FxmlManager, Node> screens = new EnumMap<>(FxmlManager.class);
 
-  public void registerScreen(final ControlledScreen<NavigationPane> screen) {
+  public void registerScreen(final FxmlManager manager, final ControlledScreen<NavigationPane> screen) {
     Preconditions.checkState(Platform.isFxApplicationThread());
+    Preconditions.checkNotNull(manager);
     Preconditions.checkNotNull(screen);
-    screens.put(unchecked(screen.getClass()), screen.getNode());
+    screens.put(manager, screen.getNode());
     screen.connect(this);
   }
 
-  /**
-   * This method exists because generics in Java are terrible to work with,
-   * you should probably not be using it.
-   */
-  @SuppressWarnings("unchecked")
-  private static Class<? extends ControlledScreen<NavigationPane>> unchecked(final Class<?> clazz) {
-    return (Class<? extends ControlledScreen<NavigationPane>>) clazz;
+  public void registerScreen(final FxmlManager manager) {
+    Preconditions.checkState(Platform.isFxApplicationThread());
+    Preconditions.checkNotNull(manager);
+    registerScreen(manager, manager.<ControlledScreen<NavigationPane>, Object>load().getController());
   }
 
   @Override
-  public void switchScreen(final Class<? extends ControlledScreen<NavigationPane>> identifier) {
+  public void switchScreen(final FxmlManager identifier) {
     Preconditions.checkNotNull(identifier);
     Preconditions.checkArgument(screens.containsKey(identifier), "Screen of Type " + identifier + " not present");
 

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/screen/NavigationPane.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/screen/NavigationPane.java
@@ -15,17 +15,27 @@ import javafx.scene.layout.StackPane;
  * call tree by using the class name as the identifier.
  * Make sure to register Screens before using them.
  */
-public class NavigationPane extends StackPane implements ScreenController<Class<? extends Node>> {
-  private final Map<Class<? extends Node>, Node> screens = new HashMap<>();
+public class NavigationPane extends StackPane implements ScreenController<Class<? extends ControlledScreen<NavigationPane>>> {
+  private final Map<Class<? extends ControlledScreen<NavigationPane>>, Node> screens = new HashMap<>();
 
-  public void registerScreen(final Node screen) {
+  public void registerScreen(final ControlledScreen<NavigationPane> screen) {
     Preconditions.checkState(Platform.isFxApplicationThread());
     Preconditions.checkNotNull(screen);
-    screens.put(screen.getClass(), screen);
+    screens.put(unchecked(screen.getClass()), screen.getNode());
+    screen.connect(this);
+  }
+
+  /**
+   * This method exists because generics in Java are terrible to work with,
+   * you should probably not be using it.
+   */
+  @SuppressWarnings("unchecked")
+  private static Class<? extends ControlledScreen<NavigationPane>> unchecked(final Class<?> clazz) {
+    return (Class<? extends ControlledScreen<NavigationPane>>) clazz;
   }
 
   @Override
-  public void switchScreen(final Class<? extends Node> identifier) {
+  public void switchScreen(final Class<? extends ControlledScreen<NavigationPane>> identifier) {
     Preconditions.checkNotNull(identifier);
     Preconditions.checkArgument(screens.containsKey(identifier), "Screen of Type " + identifier + " not present");
 

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/screen/RootActionPane.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/screen/RootActionPane.java
@@ -20,7 +20,7 @@ import javafx.scene.layout.VBox;
 import javafx.util.Duration;
 
 /**
- * Root JavaFX Panel that supports a variety of options
+ * Root JavaFX Panel Controller that supports a variety of options
  * such as prompting the user to exit the Application.
  */
 public class RootActionPane implements ScreenController<Screens> {

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/screen/RootActionPane.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/screen/RootActionPane.java
@@ -5,7 +5,6 @@ import java.awt.GraphicsEnvironment;
 import javax.swing.SwingUtilities;
 
 import org.triplea.game.client.ui.javafx.screen.RootActionPane.Screens;
-import org.triplea.game.client.ui.javafx.util.FxmlManager;
 
 import com.google.common.base.Preconditions;
 
@@ -15,7 +14,6 @@ import javafx.animation.KeyValue;
 import javafx.animation.Timeline;
 import javafx.application.Platform;
 import javafx.fxml.FXML;
-import javafx.fxml.FXMLLoader;
 import javafx.scene.Node;
 import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
@@ -25,7 +23,7 @@ import javafx.util.Duration;
  * Root JavaFX Panel that supports a variety of options
  * such as prompting the user to exit the Application.
  */
-public class RootActionPane extends StackPane implements ScreenController<Screens> {
+public class RootActionPane implements ScreenController<Screens> {
 
   enum Screens {
     EXIT,
@@ -46,13 +44,6 @@ public class RootActionPane extends StackPane implements ScreenController<Screen
 
   @FXML
   private VBox exitFrame;
-
-  public RootActionPane() throws Exception {
-    final FXMLLoader loader = FxmlManager.getLoader(getClass().getResource(FxmlManager.ROOT_CONTAINER.toString()));
-    loader.setRoot(this);
-    loader.setController(this);
-    loader.load();
-  }
 
   public void setContent(final Node node) {
     Preconditions.checkNotNull(node);

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/FxmlManager.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/FxmlManager.java
@@ -14,15 +14,9 @@ public enum FxmlManager {
 
   MAIN_MENU_PANE("/org/triplea/game/client/ui/javafx/fxml/TripleAMainMenu.fxml"),
 
-  SETTINGS_PANE("/org/triplea/game/client/ui/javafx/fxml/TripleASettings.fxml"),
+  SETTINGS_PANE("/org/triplea/game/client/ui/javafx/fxml/TripleASettings.fxml");
 
-  LANG_CLASS_BASENAME("org.triplea.game.client.ui.javafx.lang.TripleA"),
-
-  STYLESHEET_MAIN("/org/triplea/game/client/ui/javafx/css/main.css"),
-
-  FONT_PATH("/org/triplea/game/client/ui/javafx/css/fonts/1942-report.ttf"),
-
-  ICON_LOCATION("/org/triplea/swing/ta_icon.png");
+  private static final String LANG_CLASS_BASENAME = "org.triplea.game.client.ui.javafx.lang.TripleA";
 
   private final String value;
 
@@ -44,7 +38,7 @@ public enum FxmlManager {
   public static FXMLLoader getLoader(final URL location) {
     final FXMLLoader loader = new FXMLLoader(location);
     // TODO load locale based on user setting
-    loader.setResources(ResourceBundle.getBundle(LANG_CLASS_BASENAME.toString(), new Locale("en", "US")));
+    loader.setResources(ResourceBundle.getBundle(LANG_CLASS_BASENAME, new Locale("en", "US")));
     return loader;
   }
 }

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/FxmlManager.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/FxmlManager.java
@@ -1,10 +1,12 @@
 package org.triplea.game.client.ui.javafx.util;
 
-import java.net.URL;
+import java.io.IOException;
 import java.util.Locale;
 import java.util.ResourceBundle;
 
 import javafx.fxml.FXMLLoader;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
 /**
  * Enum with relative Paths to fxml-related resources.
@@ -29,16 +31,27 @@ public enum FxmlManager {
     return value;
   }
 
+  @AllArgsConstructor
+  @Getter
+  public static final class LoadedNode<C, N> {
+    private final C controller;
+    private final N node;
+  }
+
   /**
-   * Simplified way of getting an {@link FXMLLoader} with the default settings for TripleA.
+   * Simplified way to load a Node & Controller.
    *
-   * @param location The FXML File to load
-   * @return An FXMLLoader object
+   * @return A LoadedNode object
    */
-  public static FXMLLoader getLoader(final URL location) {
-    final FXMLLoader loader = new FXMLLoader(location);
-    // TODO load locale based on user setting
-    loader.setResources(ResourceBundle.getBundle(LANG_CLASS_BASENAME, new Locale("en", "US")));
-    return loader;
+  public <C, N> LoadedNode<C, N> load() {
+    try {
+      final FXMLLoader loader = new FXMLLoader(getClass().getResource(value));
+      // TODO load locale based on user setting
+      loader.setResources(ResourceBundle.getBundle(LANG_CLASS_BASENAME, new Locale("en", "US")));
+      loader.load();
+      return new LoadedNode<>(loader.getController(), loader.getRoot());
+    } catch (final IOException e) {
+      throw new IllegalStateException("Failed to load FXML " + value, e);
+    }
   }
 }

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/FxmlManager.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/FxmlManager.java
@@ -9,7 +9,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
- * Enum with relative Paths to fxml-related resources.
+ * Enum used to build Node instances from FXML files.
  */
 public enum FxmlManager {
   ROOT_CONTAINER("/org/triplea/game/client/ui/javafx/fxml/TripleAMain.fxml"),
@@ -31,6 +31,12 @@ public enum FxmlManager {
     return value;
   }
 
+  /**
+   * Helper class to wrap a controller and the root node in a single class.
+   *
+   * @param <C> Type of the controller.
+   * @param <N> Type of the root node.
+   */
   @AllArgsConstructor
   @Getter
   public static final class LoadedNode<C, N> {

--- a/game-headed/src/main/resources/org/triplea/game/client/ui/javafx/fxml/TripleAMain.fxml
+++ b/game-headed/src/main/resources/org/triplea/game/client/ui/javafx/fxml/TripleAMain.fxml
@@ -9,7 +9,7 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
-<fx:root maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="540.0" minWidth="960.0" type="StackPane" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
+<StackPane maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="540.0" minWidth="960.0" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.triplea.game.client.ui.javafx.screen.RootActionPane">
    <children>
       <StackPane fx:id="rootPane" />
       <VBox fx:id="loadingOverlay" alignment="CENTER" minWidth="200.0" style="-fx-background-color: rgba(0, 0, 0, 0.2);" visible="false" StackPane.alignment="CENTER">
@@ -50,4 +50,4 @@
          </children>
       </VBox>
    </children>
-</fx:root>
+</StackPane>

--- a/game-headed/src/main/resources/org/triplea/game/client/ui/javafx/fxml/TripleAMainMenu.fxml
+++ b/game-headed/src/main/resources/org/triplea/game/client/ui/javafx/fxml/TripleAMainMenu.fxml
@@ -12,7 +12,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Text?>
 
-<fx:root id="rootPane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="540.0" minWidth="960.0" prefHeight="540.0" prefWidth="960.0" style="-fx-background-color: #EEE;" type="BorderPane" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
+<BorderPane id="rootPane" fx:id="root" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="540.0" minWidth="960.0" prefHeight="540.0" prefWidth="960.0" style="-fx-background-color: #EEE;" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.triplea.game.client.ui.javafx.MainMenuPane">
    <top>
       <VBox alignment="CENTER" BorderPane.alignment="CENTER">
          <children>
@@ -226,4 +226,4 @@
          </children>
       </StackPane>
    </center>
-</fx:root>
+</BorderPane>

--- a/game-headed/src/main/resources/org/triplea/game/client/ui/javafx/fxml/TripleAMainMenu.fxml
+++ b/game-headed/src/main/resources/org/triplea/game/client/ui/javafx/fxml/TripleAMainMenu.fxml
@@ -42,7 +42,7 @@
             </VBox>
             <HBox fx:id="gameOptions" alignment="CENTER" prefHeight="100.0" prefWidth="200.0" visible="false">
                <children>
-                  <Button contentDisplay="TOP" disable="true" mnemonicParsing="false" onAction="#showLobbyMenu" prefWidth="168.0" styleClass="normal-font-size" text="%main.button.join_lobby">
+                  <Button contentDisplay="TOP" mnemonicParsing="false" onAction="#showLobbyMenu" prefWidth="168.0" styleClass="normal-font-size" text="%main.button.join_lobby">
                      <HBox.margin>
                         <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
                      </HBox.margin>

--- a/game-headed/src/main/resources/org/triplea/game/client/ui/javafx/fxml/TripleAMainMenu.fxml
+++ b/game-headed/src/main/resources/org/triplea/game/client/ui/javafx/fxml/TripleAMainMenu.fxml
@@ -3,8 +3,6 @@
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
-<?import javafx.scene.control.PasswordField?>
-<?import javafx.scene.control.TextField?>
 <?import javafx.scene.effect.DropShadow?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.image.ImageView?>
@@ -14,7 +12,7 @@
 <?import javafx.scene.layout.VBox?>
 <?import javafx.scene.text.Text?>
 
-<fx:root id="rootPane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="540.0" minWidth="960.0" prefHeight="540.0" prefWidth="960.0" style="-fx-background-color: #EEE;" type="BorderPane" xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root id="rootPane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="540.0" minWidth="960.0" prefHeight="540.0" prefWidth="960.0" style="-fx-background-color: #EEE;" type="BorderPane" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1">
    <top>
       <VBox alignment="CENTER" BorderPane.alignment="CENTER">
          <children>
@@ -44,7 +42,7 @@
             </VBox>
             <HBox fx:id="gameOptions" alignment="CENTER" prefHeight="100.0" prefWidth="200.0" visible="false">
                <children>
-                  <Button contentDisplay="TOP" disable="true" mnemonicParsing="false" onAction="#showLobbyMenu" onMouseEntered="#startHover" onMouseExited="#endHover" prefWidth="168.0" styleClass="normal-font-size" text="%main.button.join_lobby">
+                  <Button contentDisplay="TOP" disable="true" mnemonicParsing="false" onAction="#showLobbyMenu" prefWidth="168.0" styleClass="normal-font-size" text="%main.button.join_lobby">
                      <HBox.margin>
                         <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
                      </HBox.margin>
@@ -58,7 +56,7 @@
                         <DropShadow color="#00000080" offsetX="5.0" offsetY="10.0" />
                      </effect>
                   </Button>
-                  <Button contentDisplay="TOP" mnemonicParsing="false" onAction="#showLocalGameMenu" onMouseEntered="#startHover" onMouseExited="#endHover" prefWidth="168.0" styleClass="normal-font-size" text="%main.button.local_game">
+                  <Button contentDisplay="TOP" mnemonicParsing="false" onAction="#showLocalGameMenu" prefWidth="168.0" styleClass="normal-font-size" text="%main.button.local_game">
                      <HBox.margin>
                         <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
                      </HBox.margin>
@@ -72,7 +70,7 @@
                         <DropShadow color="#00000080" offsetX="5.0" offsetY="10.0" />
                      </effect>
                   </Button>
-                  <Button contentDisplay="TOP" layoutX="723.0" layoutY="85.0" mnemonicParsing="false" onAction="#showPlayByForumMenu" onMouseEntered="#startHover" onMouseExited="#endHover" prefWidth="168.0" styleClass="normal-font-size" text="%main.button.startPBF">
+                  <Button contentDisplay="TOP" layoutX="723.0" layoutY="85.0" mnemonicParsing="false" onAction="#showPlayByForumMenu" prefWidth="168.0" styleClass="normal-font-size" text="%main.button.startPBF">
                      <graphic>
                         <ImageView fitHeight="150.0" fitWidth="150.0" pickOnBounds="true" preserveRatio="true">
                            <image>
@@ -86,7 +84,7 @@
                         <DropShadow color="#00000080" offsetX="5.0" offsetY="10.0" />
                      </effect>
                   </Button>
-                  <Button contentDisplay="TOP" mnemonicParsing="false" onAction="#showPlayByEmailMenu" onMouseEntered="#startHover" onMouseExited="#endHover" prefWidth="168.0" styleClass="normal-font-size" text="%main.button.startPBEM">
+                  <Button contentDisplay="TOP" mnemonicParsing="false" onAction="#showPlayByEmailMenu" prefWidth="168.0" styleClass="normal-font-size" text="%main.button.startPBEM">
                      <graphic>
                         <ImageView fitHeight="150.0" fitWidth="150.0" pickOnBounds="true" preserveRatio="true">
                            <image>
@@ -101,7 +99,7 @@
                         <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
                      </HBox.margin>
                   </Button>
-                  <Button contentDisplay="TOP" mnemonicParsing="false" onAction="#showHostNetworkGameMenu" onMouseEntered="#startHover" onMouseExited="#endHover" prefWidth="168.0" styleClass="normal-font-size" text="%main.button.host_networked_game">
+                  <Button contentDisplay="TOP" mnemonicParsing="false" onAction="#showHostNetworkGameMenu" prefWidth="168.0" styleClass="normal-font-size" text="%main.button.host_networked_game">
                      <HBox.margin>
                         <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
                      </HBox.margin>
@@ -115,7 +113,7 @@
                         <DropShadow color="#00000080" offsetX="5.0" offsetY="10.0" />
                      </effect>
                   </Button>
-                  <Button contentDisplay="TOP" mnemonicParsing="false" onAction="#showJoinNetworkGameMenu" onMouseEntered="#startHover" onMouseExited="#endHover" prefWidth="168.0" styleClass="normal-font-size" text="%main.button.join_networked_game">
+                  <Button contentDisplay="TOP" mnemonicParsing="false" onAction="#showJoinNetworkGameMenu" prefWidth="168.0" styleClass="normal-font-size" text="%main.button.join_networked_game">
                      <HBox.margin>
                         <Insets bottom="5.0" left="5.0" right="5.0" top="5.0" />
                      </HBox.margin>
@@ -205,40 +203,22 @@
             </VBox>
             <VBox alignment="BOTTOM_CENTER" pickOnBounds="false">
                <children>
-                  <HBox prefHeight="35.0" prefWidth="600.0">
+                  <HBox alignment="BOTTOM_RIGHT">
                      <children>
-                        <StackPane>
+                        <VBox alignment="BOTTOM_RIGHT">
                            <children>
-                              <Label fx:id="loggedIn" text="%main.label.logged_in_as" />
-                              <HBox fx:id="loginForm" alignment="BOTTOM_LEFT" prefHeight="25.0" prefWidth="476.0" StackPane.alignment="BOTTOM_LEFT">
-                                 <children>
-                                    <TextField fx:id="username" promptText="%main.textfield.username" styleClass="normal-font-size" />
-                                    <PasswordField fx:id="password" promptText="%main.textfield.password" styleClass="normal-font-size" />
-                                    <Button mnemonicParsing="false" onAction="#login" styleClass="normal-font-size" text="%main.button.login" />
-                                 </children>
-                                 <padding>
-                                    <Insets bottom="10.0" left="10.0" />
-                                 </padding>
-                              </HBox>
+                              <Button fx:id="buttonBack" mnemonicParsing="false" onAction="#showLastMenu" text="%main.button.back" visible="false">
+                                 <VBox.margin>
+                                    <Insets bottom="10.0" right="10.0" />
+                                 </VBox.margin>
+                              </Button>
+                              <Label fx:id="version" text="%main.label.triplea_version">
+                                 <effect>
+                                    <DropShadow color="WHITE" spread="0.33" />
+                                 </effect>
+                              </Label>
                            </children>
-                        </StackPane>
-                        <HBox alignment="BOTTOM_RIGHT" HBox.hgrow="ALWAYS">
-                           <children>
-                              <VBox alignment="BOTTOM_RIGHT">
-                                 <children>
-                                    <Button fx:id="buttonBack" mnemonicParsing="false" onAction="#showLastMenu" text="%main.button.back" visible="false">
-                                       <VBox.margin>
-                                          <Insets bottom="10.0" right="10.0" />
-                                       </VBox.margin>
-                                    </Button>
-                                    <Label fx:id="version" text="%main.label.triplea_version">
-                                       <effect>
-                                          <DropShadow color="WHITE" spread="0.33" />
-                                       </effect></Label>
-                                 </children>
-                              </VBox>
-                           </children>
-                        </HBox>
+                        </VBox>
                      </children>
                   </HBox>
                </children>

--- a/game-headed/src/main/resources/org/triplea/game/client/ui/javafx/fxml/TripleASettings.fxml
+++ b/game-headed/src/main/resources/org/triplea/game/client/ui/javafx/fxml/TripleASettings.fxml
@@ -8,7 +8,7 @@
 <?import javafx.scene.layout.StackPane?>
 <?import javafx.scene.layout.VBox?>
 
-<fx:root alignment="TOP_LEFT" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" prefHeight="540.0" prefWidth="920.0" type="StackPane" xmlns="http://javafx.com/javafx/8.0.141" xmlns:fx="http://javafx.com/fxml/1">
+<StackPane fx:id="root" alignment="TOP_LEFT" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" prefHeight="540.0" prefWidth="920.0" xmlns="http://javafx.com/javafx/8.0.171" xmlns:fx="http://javafx.com/fxml/1" fx:controller="org.triplea.game.client.ui.javafx.SettingsPane">
 	<children>
 		<BorderPane style="-fx-background-color: #EEE;">
 			<center>
@@ -46,4 +46,4 @@
 			</bottom>
 		</BorderPane>
 	</children>
-</fx:root>
+</StackPane>


### PR DESCRIPTION
## Overview
This PR refactors the JavaFX codebase to be better suited for testing and tries to be easier to deal with in general.
The most notable change is that the controller is now seperate from the actual UI class and already defined in FXML. This allows for simple Unit Testing (will follow in the future)
This way IntelliJ and SceneBuilder provide support for JavaFX and don't just treat the controllers as unused code.

## Functional Changes
None. (I did remove the unused "Lobby Login fields", maybe they'll return in the future but they are just unecessary right now.)

## Manual Testing Performed
I verified I could click through all the menus without any problems.

## Before & After Screen Shots
### Before
![Before](https://user-images.githubusercontent.com/8350879/55902080-00b71d00-5bcb-11e9-83b8-3c22af5107e9.png)

### After
![After](https://user-images.githubusercontent.com/8350879/55902123-1a586480-5bcb-11e9-8465-7e3e20c17d57.png)

/cc @DanVanAtta This PR also provides a good solution to the class vs enum problem that came up in #4803 