### PR TITLE
Fix undo blitz battles

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -209,7 +209,7 @@ public class BattleTracker implements Serializable {
   void undoBattle(final Route route, final Collection<Unit> units, final PlayerId player,
       final IDelegateBridge bridge) {
     for (final IBattle battle : new ArrayList<>(pendingBattles)) {
-      if (battle.getTerritory().equals(route.getEnd())) {
+      if (!battle.getTerritory().equals(route.getStart())) {
         battle.removeAttack(route, units);
         if (battle.isEmpty()) {
           removeBattleForUndo(player, battle);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -836,6 +836,26 @@ class WW2V3Year41Test {
   }
 
   @Test
+  void testAttackUndoAndBattlesCleared() {
+    final MoveDelegate move = moveDelegate(gameData);
+    final IDelegateBridge bridge = newDelegateBridge(germans(gameData));
+    advanceToStep(bridge, "CombatMove");
+    move.setDelegateBridgeAndPlayer(bridge);
+    move.start();
+    final Territory libya = territory("Libya", gameData);
+    final Territory egypt = territory("Egypt", gameData);
+    final Territory sudan = territory("Anglo-Egypt Sudan", gameData);
+    final Route r = new Route(libya, egypt, sudan);
+    egypt.getUnitCollection().clear();
+    // blitz tank
+    move(libya.getUnitCollection().getMatches(Matches.unitCanBlitz()), r);
+    // undo it
+    move.undoMove(0);
+    // verify both blitz battles were cleared
+    assertEquals(true, AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattleSites().isEmpty());
+  }
+
+  @Test
   void testAttackSubsOnSubs() {
     final String defender = "Germans";
     final String attacker = "British";


### PR DESCRIPTION
## Overview
- Addresses #4812 

## Functional Changes
- Check clearing intermediate battles when undoing blitz moves
- I'm not sure if starting territory should be considered as well but decided to only consider other territories in the route

## Testing Performed
- Tested Global 40 with steps from reported bug
- Added unit test to verify behavior
