### PR TITLE
Add new canal option canNotMoveThroughDuringCombatMove

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/CanalAttachment.java
@@ -30,6 +30,7 @@ public class CanalAttachment extends DefaultAttachment {
   private String canalName = null;
   private Set<Territory> landTerritories = null;
   private Set<UnitType> excludedUnits = null;
+  private boolean canNotMoveThroughDuringCombatMove = false;
 
   public CanalAttachment(final String name, final Attachable attachable, final GameData gameData) {
     super(name, attachable, gameData);
@@ -154,6 +155,14 @@ public class CanalAttachment extends DefaultAttachment {
     excludedUnits = null;
   }
 
+  private void setCanNotMoveThroughDuringCombatMove(final boolean value) {
+    canNotMoveThroughDuringCombatMove = value;
+  }
+
+  public boolean getCanNotMoveThroughDuringCombatMove() {
+    return canNotMoveThroughDuringCombatMove;
+  }
+
   @Override
   public void validate(final GameData data) throws GameParseException {
     if (canalName == null) {
@@ -193,6 +202,12 @@ public class CanalAttachment extends DefaultAttachment {
                 this::setExcludedUnits,
                 this::getExcludedUnits,
                 this::resetExcludedUnits))
+        .put("canNotMoveThroughDuringCombatMove",
+            MutableProperty.ofMapper(
+                DefaultAttachment::getBool,
+                this::setCanNotMoveThroughDuringCombatMove,
+                this::getCanNotMoveThroughDuringCombatMove,
+                () -> false))
         .build();
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -1291,7 +1291,7 @@ public class MoveValidator {
     if (unit != null && Matches.unitIsOfTypes(canalAttachment.getExcludedUnits()).test(unit)) {
       return Optional.empty();
     }
-    return checkCanalOwnership(canalAttachment, player, data);
+    return checkCanalStepAndOwnership(canalAttachment, player, data);
   }
 
   private static Optional<String> canAnyPassThroughCanal(final CanalAttachment canalAttachment,
@@ -1299,11 +1299,14 @@ public class MoveValidator {
     if (units.stream().anyMatch(Matches.unitIsOfTypes(canalAttachment.getExcludedUnits()))) {
       return Optional.empty();
     }
-    return checkCanalOwnership(canalAttachment, player, data);
+    return checkCanalStepAndOwnership(canalAttachment, player, data);
   }
 
-  private static Optional<String> checkCanalOwnership(final CanalAttachment canalAttachment,
+  private static Optional<String> checkCanalStepAndOwnership(final CanalAttachment canalAttachment,
       final PlayerId player, final GameData data) {
+    if (GameStepPropertiesHelper.isCombatMove(data) && canalAttachment.getCanNotMoveThroughDuringCombatMove()) {
+      return Optional.of("Can only move through " + canalAttachment.getCanalName() + " during non-combat move");
+    }
     for (final Territory borderTerritory : canalAttachment.getLandTerritories()) {
       if (!data.getRelationshipTracker().canMoveThroughCanals(player, borderTerritory.getOwner())) {
         return Optional.of("Must control " + canalAttachment.getCanalName() + " to move through");


### PR DESCRIPTION
## Overview
- FR: https://forums.triplea-game.org/topic/1300/add-new-canal-option-to-not-allow-movement-through-during-combat-move
- Add new canal option: `canNotMoveThroughDuringCombatMove`

## Functional Changes
- New canal option allows canals to only be moved through during non-combat move which can be very useful for simulating these types of connections take more time to pass through. Here is an XML example:
```
        <attachment name="canalAttachmentPanama" attachTo="SZ1" javaClass="CanalAttachment" type="territory">
            <option name="canalName" value="Panama Canal"/>
            <option name="landTerritories" value="Panama"/>
            <option name="canNotMoveThroughDuringCombatMove" value="true"/>
        </attachment>
        <attachment name="canalAttachmentPanama" attachTo="SZ2" javaClass="CanalAttachment" type="territory">
            <option name="canalName" value="Panama Canal"/>
            <option name="landTerritories" value="Panama"/>
            <option name="canNotMoveThroughDuringCombatMove" value="true"/>
        </attachment>
```

## Manual Testing Performed
- Tested updating XML for a few maps and being able to move through only during NCM not CM
