### PR TITLE
Refactors and tests TriggerAttachment.java reg. property change methods.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -722,7 +722,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     territories = value;
   }
 
-  private List<Territory> getTerritories() {
+  @VisibleForTesting
+  List<Territory> getTerritories() {
     return territories;
   }
 
@@ -792,7 +793,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     territoryProperty = value;
   }
 
-  private List<Tuple<String, String>> getTerritoryProperty() {
+  @VisibleForTesting
+  List<Tuple<String, String>> getTerritoryProperty() {
     return territoryProperty;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -1342,6 +1342,19 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     bridge.addChange(change);
   }
 
+  /**
+   * Test if we are resetting/clearing the variable first, and if so, remove the leading "-reset-" or "-clear-"
+   * from the new value.
+   */
+  public static Tuple<Boolean, String> getClearFirstNewValue(final String preNewValue) {
+    final boolean clearFirst = preNewValue.length() > 0
+        && (preNewValue.startsWith(PREFIX_CLEAR) || preNewValue.startsWith(PREFIX_RESET));
+    final String newValue = clearFirst
+        ? preNewValue.replaceFirst(PREFIX_CLEAR, "").replaceFirst(PREFIX_RESET, "")
+        : preNewValue;
+    return Tuple.of(clearFirst, newValue);
+  }
+
   // And now for the actual triggers, as called throughout the engine.
   // Each trigger should be called exactly twice, once in BaseDelegate (for use with 'when'), and a second time as the
   // default location for when 'when' is not used.
@@ -1434,13 +1447,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       }
       for (final Tuple<String, String> property : t.getPlayerProperty()) {
         for (final PlayerId player : t.getPlayers()) {
-          String newValue = property.getSecond();
-          boolean clearFirst = false;
-          // test if we are resetting the variable first, and if so, remove the leading "-reset-" or "-clear-"
-          if (newValue.length() > 0 && (newValue.startsWith(PREFIX_CLEAR) || newValue.startsWith(PREFIX_RESET))) {
-            newValue = newValue.replaceFirst(PREFIX_CLEAR, "").replaceFirst(PREFIX_RESET, "");
-            clearFirst = true;
-          }
+
+          final Tuple<Boolean, String> clearFirstNewValue = getClearFirstNewValue(property.getSecond());
+          final boolean clearFirst = clearFirstNewValue.getFirst();
+          final String newValue = clearFirstNewValue.getSecond();
+
           final String attachmentName = t.getPlayerAttachmentName().getFirst();
           if (attachmentNameToAttachmentGetter.containsKey(attachmentName)) {
             final DefaultAttachment attachment = attachmentNameToAttachmentGetter
@@ -1469,6 +1480,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
   }
 
+
   /**
    * Triggers all relationship type property changes associated with {@code satisfiedTriggers}. Only relationship type
    * property changes associated with the following attachments will be triggered: {@link RelationshipTypeAttachment}.
@@ -1494,13 +1506,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       }
       for (final Tuple<String, String> property : t.getRelationshipTypeProperty()) {
         for (final RelationshipType relationshipType : t.getRelationshipTypes()) {
-          String newValue = property.getSecond();
-          boolean clearFirst = false;
-          // test if we are resetting the variable first, and if so, remove the leading "-reset-" or "-clear-"
-          if (newValue.length() > 0 && (newValue.startsWith(PREFIX_CLEAR) || newValue.startsWith(PREFIX_RESET))) {
-            newValue = newValue.replaceFirst(PREFIX_CLEAR, "").replaceFirst(PREFIX_RESET, "");
-            clearFirst = true;
-          }
+
+          final Tuple<Boolean, String> clearFirstNewValue = getClearFirstNewValue(property.getSecond());
+          final boolean clearFirst = clearFirstNewValue.getFirst();
+          final String newValue = clearFirstNewValue.getSecond();
+
           // covers RelationshipTypeAttachment
           if (t.getRelationshipTypeAttachmentName().getFirst().equals("RelationshipTypeAttachment")) {
             final RelationshipTypeAttachment attachment =
@@ -1554,13 +1564,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       for (final Tuple<String, String> property : t.getTerritoryProperty()) {
         for (final Territory territory : t.getTerritories()) {
           territoriesNeedingReDraw.add(territory);
-          String newValue = property.getSecond();
-          boolean clearFirst = false;
-          // test if we are resetting the variable first, and if so, remove the leading "-reset-" or "-clear-"
-          if (newValue.length() > 0 && (newValue.startsWith(PREFIX_CLEAR) || newValue.startsWith(PREFIX_RESET))) {
-            newValue = newValue.replaceFirst(PREFIX_CLEAR, "").replaceFirst(PREFIX_RESET, "");
-            clearFirst = true;
-          }
+
+          final Tuple<Boolean, String> clearFirstNewValue = getClearFirstNewValue(property.getSecond());
+          final boolean clearFirst = clearFirstNewValue.getFirst();
+          final String newValue = clearFirstNewValue.getSecond();
+
           // covers TerritoryAttachment, CanalAttachment
           if (t.getTerritoryAttachmentName().getFirst().equals("TerritoryAttachment")) {
             final TerritoryAttachment attachment =
@@ -1635,13 +1643,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       }
       for (final Tuple<String, String> property : t.getTerritoryEffectProperty()) {
         for (final TerritoryEffect territoryEffect : t.getTerritoryEffects()) {
-          String newValue = property.getSecond();
-          boolean clearFirst = false;
-          // test if we are resetting the variable first, and if so, remove the leading "-reset-" or "-clear-"
-          if (newValue.length() > 0 && (newValue.startsWith(PREFIX_CLEAR) || newValue.startsWith(PREFIX_RESET))) {
-            newValue = newValue.replaceFirst(PREFIX_CLEAR, "").replaceFirst(PREFIX_RESET, "");
-            clearFirst = true;
-          }
+
+          final Tuple<Boolean, String> clearFirstNewValue = getClearFirstNewValue(property.getSecond());
+          final boolean clearFirst = clearFirstNewValue.getFirst();
+          final String newValue = clearFirstNewValue.getSecond();
+
           // covers TerritoryEffectAttachment
           if (t.getTerritoryEffectAttachmentName().getFirst().equals("TerritoryEffectAttachment")) {
             final TerritoryEffectAttachment attachment =
@@ -1693,13 +1699,11 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       }
       for (final Tuple<String, String> property : t.getUnitProperty()) {
         for (final UnitType unitType : t.getUnitType()) {
-          String newValue = property.getSecond();
-          boolean clearFirst = false;
-          // test if we are resetting the variable first, and if so, remove the leading "-reset-" or "-clear-"
-          if (newValue.length() > 0 && (newValue.startsWith(PREFIX_CLEAR) || newValue.startsWith(PREFIX_RESET))) {
-            newValue = newValue.replaceFirst(PREFIX_CLEAR, "").replaceFirst(PREFIX_RESET, "");
-            clearFirst = true;
-          }
+
+          final Tuple<Boolean, String> clearFirstNewValue = getClearFirstNewValue(property.getSecond());
+          final boolean clearFirst = clearFirstNewValue.getFirst();
+          final String newValue = clearFirstNewValue.getSecond();
+
           // covers UnitAttachment, UnitSupportAttachment
           if (t.getUnitAttachmentName().getFirst().equals("UnitAttachment")) {
             final UnitAttachment attachment = UnitAttachment.get(unitType, t.getUnitAttachmentName().getSecond());

--- a/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Set;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -37,91 +38,123 @@ import games.strategy.engine.history.IDelegateHistoryWriter;
 @ExtendWith(MockitoExtension.class)
 class TriggerAttachmentTest {
 
-  @Mock
-  private IDelegateBridge bridge;
-  @Mock
-  private IDelegateHistoryWriter historyWriter;
+  @Nested
+  class TriggerChangeTest {
 
-  @BeforeEach
-  void setUp() {
-    final GameData gameData = new GameData();
+    @Mock
+    private IDelegateBridge bridge;
+    @Mock
+    private IDelegateHistoryWriter historyWriter;
 
-    when(bridge.getData()).thenReturn(gameData);
-    when(bridge.getHistoryWriter()).thenReturn(historyWriter);
+    @BeforeEach
+    void setUp() {
+      final GameData gameData = new GameData();
+
+      when(bridge.getData()).thenReturn(gameData);
+      when(bridge.getHistoryWriter()).thenReturn(historyWriter);
+    }
+
+    @Test
+    void testTriggerProductionFrontierEditChange() {
+      final GameData gameData = bridge.getData();
+      final TriggerAttachment triggerAttachment = mock(TriggerAttachment.class);
+      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+
+      when(triggerAttachment.getProductionRule())
+          .thenReturn(Arrays.asList("frontier:rule1", "frontier:-rule2", "frontier:rule3"));
+      when(triggerAttachment.getName()).thenReturn("mockedTriggerAttachment");
+
+      final ProductionRuleList productionRuleList = gameData.getProductionRuleList();
+      productionRuleList.addProductionRule(new ProductionRule("rule1", gameData));
+      final ProductionRule productionRule2 = new ProductionRule("rule2", gameData);
+      productionRuleList.addProductionRule(productionRule2);
+      productionRuleList.addProductionRule(new ProductionRule("rule3", gameData));
+
+      final ProductionFrontierList productionFrontierList = gameData.getProductionFrontierList();
+      productionFrontierList
+          .addProductionFrontier(
+              new ProductionFrontier("frontier", gameData, Collections.singletonList(productionRule2)));
+
+      TriggerAttachment.triggerProductionFrontierEditChange(
+          satisfiedTriggers,
+          bridge,
+          "beforeOrAfter",
+          "stepName",
+          false, // useUses
+          false, // testUses
+          false, // testChance
+          false); // testWhen
+      final ArgumentCaptor<CompositeChange> argument = ArgumentCaptor.forClass(CompositeChange.class);
+      verify(bridge).addChange(argument.capture());
+      final CompositeChange change = argument.getValue();
+      assertFalse(change.isEmpty());
+      final ArgumentCaptor<String> ruleAddArgument = ArgumentCaptor.forClass(String.class);
+      verify(historyWriter, times(3)).startEvent(ruleAddArgument.capture());
+      final List<String> allValues = ruleAddArgument.getAllValues();
+      assertEquals(3, allValues.size());
+      assertTrue(allValues.stream().anyMatch(s -> s.contains("rule1") && s.contains("added")));
+      assertTrue(allValues.stream().anyMatch(s -> s.contains("rule2") && s.contains("removed")));
+      assertTrue(allValues.stream().anyMatch(s -> s.contains("rule3") && s.contains("added")));
+      assertTrue(allValues.stream().allMatch(s -> s.contains("frontier")));
+    }
+
+    @Test
+    void testTriggerPlayerPropertyChange() throws Exception {
+      final GameData gameData = bridge.getData();
+      final TriggerAttachment triggerAttachment = mock(TriggerAttachment.class);
+      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+
+      when(triggerAttachment.getPropertyMap()).thenCallRealMethod();
+      triggerAttachment.getPropertyMap().get("playerAttachmentName").setValue("rulesAttachment:RulesAttachment");
+      when(triggerAttachment.getPlayerProperty())
+          .thenReturn(Collections.singletonList(
+              Tuple.of("productionPerXTerritories", "someNewValue")));
+      when(triggerAttachment.getName()).thenReturn("mockedTriggerAttachment");
+
+      final PlayerId playerId = mock(PlayerId.class);
+      when(playerId.getAttachment("rulesAttachment"))
+          .thenReturn(new RulesAttachment(null, null, gameData));
+      when(triggerAttachment.getPlayers()).thenReturn(Collections.singletonList(playerId));
+
+
+      TriggerAttachment.triggerPlayerPropertyChange(
+          satisfiedTriggers,
+          bridge,
+          "beforeOrAfter",
+          "stepName",
+          false, // useUses
+          false, // testUses
+          false, // testChance
+          false); // testWhen
+      verify(bridge).addChange(not(argThat(Change::isEmpty)));
+    }
   }
 
   @Test
-  void testTriggerProductionFrontierEditChange() {
-    final GameData gameData = bridge.getData();
-    final TriggerAttachment triggerAttachment = mock(TriggerAttachment.class);
-    final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+  void testGetClearFirstNewValue() {
 
-    when(triggerAttachment.getProductionRule())
-        .thenReturn(Arrays.asList("frontier:rule1", "frontier:-rule2", "frontier:rule3"));
-    when(triggerAttachment.getName()).thenReturn("mockedTriggerAttachment");
+    {
+      final Tuple<Boolean, String> r = TriggerAttachment.getClearFirstNewValue("-clear-");
+      assertTrue(r.getFirst());
+      assertTrue(r.getSecond().isEmpty());
+    }
 
-    final ProductionRuleList productionRuleList = gameData.getProductionRuleList();
-    productionRuleList.addProductionRule(new ProductionRule("rule1", gameData));
-    final ProductionRule productionRule2 = new ProductionRule("rule2", gameData);
-    productionRuleList.addProductionRule(productionRule2);
-    productionRuleList.addProductionRule(new ProductionRule("rule3", gameData));
+    {
+      final Tuple<Boolean, String> r = TriggerAttachment.getClearFirstNewValue("-reset-");
+      assertTrue(r.getFirst());
+      assertTrue(r.getSecond().isEmpty());
+    }
 
-    final ProductionFrontierList productionFrontierList = gameData.getProductionFrontierList();
-    productionFrontierList
-        .addProductionFrontier(
-            new ProductionFrontier("frontier", gameData, Collections.singletonList(productionRule2)));
+    {
+      final Tuple<Boolean, String> r = TriggerAttachment.getClearFirstNewValue("-clear-4:conscript");
+      assertTrue(r.getFirst());
+      assertEquals(r.getSecond(), "4:conscript");
+    }
 
-    TriggerAttachment.triggerProductionFrontierEditChange(
-        satisfiedTriggers,
-        bridge,
-        "beforeOrAfter",
-        "stepName",
-        false, // useUses
-        false, // testUses
-        false, // testChance
-        false); // testWhen
-    final ArgumentCaptor<CompositeChange> argument = ArgumentCaptor.forClass(CompositeChange.class);
-    verify(bridge).addChange(argument.capture());
-    final CompositeChange change = argument.getValue();
-    assertFalse(change.isEmpty());
-    final ArgumentCaptor<String> ruleAddArgument = ArgumentCaptor.forClass(String.class);
-    verify(historyWriter, times(3)).startEvent(ruleAddArgument.capture());
-    final List<String> allValues = ruleAddArgument.getAllValues();
-    assertEquals(3, allValues.size());
-    assertTrue(allValues.stream().anyMatch(s -> s.contains("rule1") && s.contains("added")));
-    assertTrue(allValues.stream().anyMatch(s -> s.contains("rule2") && s.contains("removed")));
-    assertTrue(allValues.stream().anyMatch(s -> s.contains("rule3") && s.contains("added")));
-    assertTrue(allValues.stream().allMatch(s -> s.contains("frontier")));
-  }
-
-  @Test
-  void testTriggerPlayerPropertyChange() throws Exception {
-    final GameData gameData = bridge.getData();
-    final TriggerAttachment triggerAttachment = mock(TriggerAttachment.class);
-    final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
-
-    when(triggerAttachment.getPropertyMap()).thenCallRealMethod();
-    triggerAttachment.getPropertyMap().get("playerAttachmentName").setValue("rulesAttachment:RulesAttachment");
-    when(triggerAttachment.getPlayerProperty())
-        .thenReturn(Collections.singletonList(
-            Tuple.of("productionPerXTerritories", "someNewValue")));
-    when(triggerAttachment.getName()).thenReturn("mockedTriggerAttachment");
-
-    final PlayerId playerId = mock(PlayerId.class);
-    when(playerId.getAttachment("rulesAttachment"))
-        .thenReturn(new RulesAttachment(null, null, gameData));
-    when(triggerAttachment.getPlayers()).thenReturn(Collections.singletonList(playerId));
-
-
-    TriggerAttachment.triggerPlayerPropertyChange(
-        satisfiedTriggers,
-        bridge,
-        "beforeOrAfter",
-        "stepName",
-        false, // useUses
-        false, // testUses
-        false, // testChance
-        false); // testWhen
-    verify(bridge).addChange(not(argThat(Change::isEmpty)));
+    {
+      final Tuple<Boolean, String> r = TriggerAttachment.getClearFirstNewValue("clearValueWithoutDash");
+      assertFalse(r.getFirst());
+      assertEquals(r.getSecond(), "clearValueWithoutDash");
+    }
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
@@ -35,6 +35,7 @@ import games.strategy.engine.data.ProductionFrontier;
 import games.strategy.engine.data.ProductionFrontierList;
 import games.strategy.engine.data.ProductionRule;
 import games.strategy.engine.data.ProductionRuleList;
+import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.TestAttachment;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.engine.history.IDelegateHistoryWriter;
@@ -121,6 +122,39 @@ class TriggerAttachmentTest {
       when(triggerAttachment.getPlayers()).thenReturn(Collections.singletonList(playerId));
 
       TriggerAttachment.triggerPlayerPropertyChange(
+          satisfiedTriggers,
+          bridge,
+          "beforeOrAfter",
+          "stepName",
+          false, // useUses
+          false, // testUses
+          false, // testChance
+          false); // testWhen
+      verify(bridge).addChange(not(argThat(Change::isEmpty)));
+    }
+
+    // TODO: Any existing games using 'triggerRelationshipTypePropertyChange', to base the test parameters on?
+
+    @Test
+    void testTriggerTerritoryPropertyChange() throws Exception {
+      final GameData gameData = bridge.getData();
+      final TriggerAttachment triggerAttachment = mock(TriggerAttachment.class);
+      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+
+      when(triggerAttachment.getPropertyMap()).thenCallRealMethod();
+      triggerAttachment.getPropertyMap().get("territoryAttachmentName")
+          .setValue("territoryAttachment:TerritoryAttachment");
+      when(triggerAttachment.getTerritoryProperty())
+          .thenReturn(Collections.singletonList(
+              Tuple.of("kamikazeZone", "true")));
+      when(triggerAttachment.getName()).thenReturn("mockedTriggerAttachment");
+
+      final Territory territory = mock(Territory.class);
+      when(territory.getAttachment("territoryAttachment"))
+          .thenReturn(new TerritoryAttachment(null, null, gameData));
+      when(triggerAttachment.getTerritories()).thenReturn(Collections.singletonList(territory));
+
+      TriggerAttachment.triggerTerritoryPropertyChange(
           satisfiedTriggers,
           bridge,
           "beforeOrAfter",

--- a/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
@@ -33,6 +33,7 @@ import games.strategy.engine.data.ProductionFrontier;
 import games.strategy.engine.data.ProductionFrontierList;
 import games.strategy.engine.data.ProductionRule;
 import games.strategy.engine.data.ProductionRuleList;
+import games.strategy.engine.data.RelationshipType;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.TestAttachment;
@@ -130,7 +131,36 @@ class TriggerAttachmentTest {
       verify(bridge).addChange(not(argThat(Change::isEmpty)));
     }
 
-    // TODO: Any existing games using 'triggerRelationshipTypePropertyChange', to base the test parameters on?
+    @Test
+    void testTriggerRelationshipTypePropertyChange() throws Exception {
+      final GameData gameData = bridge.getData();
+      final TriggerAttachment triggerAttachment = mock(TriggerAttachment.class);
+      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+
+      when(triggerAttachment.getPropertyMap()).thenCallRealMethod();
+      triggerAttachment.getPropertyMap().get("relationshipTypeAttachmentName")
+          .setValue("relationshipTypeAttachment:RelationshipTypeAttachment");
+      when(triggerAttachment.getRelationshipTypeProperty())
+          .thenReturn(Collections.singletonList(
+              Tuple.of("canMoveLandUnitsOverOwnedLand", "true")));
+      when(triggerAttachment.getName()).thenReturn("mockedTriggerAttachment");
+
+      final RelationshipType relationshipType = mock(RelationshipType.class);
+      when(relationshipType.getAttachment("relationshipTypeAttachment"))
+          .thenReturn(new RelationshipTypeAttachment(null, null, gameData));
+      when(triggerAttachment.getRelationshipTypes()).thenReturn(Collections.singletonList(relationshipType));
+
+      TriggerAttachment.triggerRelationshipTypePropertyChange(
+          satisfiedTriggers,
+          bridge,
+          "beforeOrAfter",
+          "stepName",
+          false, // useUses
+          false, // testUses
+          false, // testChance
+          false); // testWhen
+      verify(bridge).addChange(not(argThat(Change::isEmpty)));
+    }
 
     @Test
     void testTriggerTerritoryPropertyChange() throws Exception {

--- a/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
@@ -34,7 +34,9 @@ import games.strategy.engine.data.ProductionFrontierList;
 import games.strategy.engine.data.ProductionRule;
 import games.strategy.engine.data.ProductionRuleList;
 import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.TestAttachment;
+import games.strategy.engine.data.UnitType;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.engine.history.IDelegateHistoryWriter;
 
@@ -161,9 +163,67 @@ class TriggerAttachmentTest {
       verify(bridge).addChange(not(argThat(Change::isEmpty)));
     }
 
-    // TODO: Any existing games using 'triggerTerritoryEffectPropertyChange', to base the test parameters on?
+    @Test
+    void testTriggerTerritoryEffectPropertyChange() throws Exception {
+      final GameData gameData = bridge.getData();
+      final TriggerAttachment triggerAttachment = mock(TriggerAttachment.class);
+      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
 
-    // TODO: Any existing games using 'triggerUnitPropertyChange', to base the test parameters on?
+      when(triggerAttachment.getPropertyMap()).thenCallRealMethod();
+      triggerAttachment.getPropertyMap().get("territoryEffectAttachmentName")
+          .setValue("territoryEffectAttachment:TerritoryEffectAttachment");
+      when(triggerAttachment.getTerritoryEffectProperty())
+          .thenReturn(Collections.singletonList(
+              Tuple.of("unitsNotAllowed", "conscript:veteran:champion")));
+      when(triggerAttachment.getName()).thenReturn("mockedTriggerAttachment");
+
+      final TerritoryEffect territoryEffect = mock(TerritoryEffect.class);
+      when(territoryEffect.getAttachment("territoryEffectAttachment"))
+          .thenReturn(new TerritoryEffectAttachment(null, null, gameData));
+      when(triggerAttachment.getTerritoryEffects()).thenReturn(Collections.singletonList(territoryEffect));
+
+      TriggerAttachment.triggerTerritoryEffectPropertyChange(
+          satisfiedTriggers,
+          bridge,
+          "beforeOrAfter",
+          "stepName",
+          false, // useUses
+          false, // testUses
+          false, // testChance
+          false); // testWhen
+      verify(bridge).addChange(not(argThat(Change::isEmpty)));
+    }
+
+    @Test
+    void testTriggerUnitPropertyChange() throws Exception {
+      final GameData gameData = bridge.getData();
+      final TriggerAttachment triggerAttachment = mock(TriggerAttachment.class);
+      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+
+      when(triggerAttachment.getPropertyMap()).thenCallRealMethod();
+      triggerAttachment.getPropertyMap().get("unitAttachmentName")
+          .setValue("unitAttachment:UnitAttachment");
+      when(triggerAttachment.getUnitProperty())
+          .thenReturn(Collections.singletonList(
+              Tuple.of("movement", "4")));
+      when(triggerAttachment.getName()).thenReturn("mockedTriggerAttachment");
+
+      final UnitType unitType = mock(UnitType.class);
+      when(unitType.getAttachment("unitAttachment"))
+          .thenReturn(new UnitAttachment(null, null, gameData));
+      when(triggerAttachment.getUnitType()).thenReturn(Collections.singletonList(unitType));
+
+      TriggerAttachment.triggerUnitPropertyChange(
+          satisfiedTriggers,
+          bridge,
+          "beforeOrAfter",
+          "stepName",
+          false, // useUses
+          false, // testUses
+          false, // testChance
+          false); // testWhen
+      verify(bridge).addChange(not(argThat(Change::isEmpty)));
+    }
   }
 
   @Nested

--- a/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
@@ -165,6 +165,10 @@ class TriggerAttachmentTest {
           false); // testWhen
       verify(bridge).addChange(not(argThat(Change::isEmpty)));
     }
+
+    // TODO: Any existing games using 'triggerTerritoryEffectPropertyChange', to base the test parameters on?
+
+    // TODO: Any existing games using 'triggerUnitPropertyChange', to base the test parameters on?
   }
 
   @Test


### PR DESCRIPTION
## Overview

Refactors and adds unit tests to TriggerAttachment.java. The changes refactors common code across the property change trigger methods into commonly called methods.

## Functional Changes

There should be none, it should be pure refactoring.

## Manual Testing Performed

~Not currently manually tested, though unit tests covers the refactored code somewhat.~
I tested the changes manually with a single game play somewhat on the surface, and unit tests covers the refactored code somewhat.

## Before & After Screen Shots

## Additional Review Notes

~Not all of the property change trigger methods have been refactored and made unit tests for, since it is easier for me to create unit tests based on existing usage in games, and I would like to hear if anyone would happen to know of any games using the following triggers that I have not yet added unit tests for and refactored:~
- ~`relationshipTypeAttachmentName`~
- ~`territoryEffectAttachmentName`~
- ~`unitAttachmentName`~

~If no one happens to know of any such games, that is OK, I will search myself and in any case create unit tests and refactor those methods as well.~

Another question is whether the refactorings are good or bad overall; if they are not good, I don't mind changing or dropping them and/or other if you think that would be the best approach.
