### PR TITLE
Update to allow attacker to withdraw before defender submerges for revised rules

### DIFF
--- a/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -1013,7 +1013,7 @@ class RevisedTest {
     assertEquals(
         Arrays.asList(attacker + SUBS_FIRE, defender + SELECT_SUB_CASUALTIES, defender + SUBS_FIRE,
             attacker + SELECT_SUB_CASUALTIES, REMOVE_SNEAK_ATTACK_CASUALTIES, REMOVE_CASUALTIES,
-            attacker + SUBS_SUBMERGE, defender + SUBS_SUBMERGE, attacker + ATTACKER_WITHDRAW).toString(),
+            attacker + SUBS_SUBMERGE, attacker + ATTACKER_WITHDRAW, defender + SUBS_SUBMERGE).toString(),
         steps.toString());
     final List<IExecutable> execs = battle.getBattleExecutables(false);
     final int attackSubs = getIndex(execs, MustFightBattle.AttackSubs.class);
@@ -1062,7 +1062,7 @@ class RevisedTest {
      */
     assertEquals(Arrays.asList(attacker + SUBS_FIRE, defender + SELECT_SUB_CASUALTIES, defender + SUBS_FIRE,
         attacker + SELECT_SUB_CASUALTIES, REMOVE_SNEAK_ATTACK_CASUALTIES, defender + FIRE, attacker + SELECT_CASUALTIES,
-        REMOVE_CASUALTIES, attacker + SUBS_SUBMERGE, defender + SUBS_SUBMERGE, attacker + ATTACKER_WITHDRAW).toString(),
+        REMOVE_CASUALTIES, attacker + SUBS_SUBMERGE, attacker + ATTACKER_WITHDRAW, defender + SUBS_SUBMERGE).toString(),
         steps.toString());
     final List<IExecutable> execs = battle.getBattleExecutables(false);
     final int attackSubs = getIndex(execs, MustFightBattle.AttackSubs.class);
@@ -1118,7 +1118,7 @@ class RevisedTest {
         Arrays.asList(attacker + SUBS_FIRE, defender + SELECT_SUB_CASUALTIES, defender + SUBS_FIRE,
             attacker + SELECT_SUB_CASUALTIES, REMOVE_SNEAK_ATTACK_CASUALTIES, attacker + FIRE,
             defender + SELECT_CASUALTIES, defender + FIRE, attacker + SELECT_CASUALTIES, REMOVE_CASUALTIES,
-            attacker + SUBS_SUBMERGE, defender + SUBS_SUBMERGE, attacker + ATTACKER_WITHDRAW).toString(),
+            attacker + SUBS_SUBMERGE, attacker + ATTACKER_WITHDRAW, defender + SUBS_SUBMERGE).toString(),
         steps.toString());
     final List<IExecutable> execs = battle.getBattleExecutables(false);
     final int attackSubs = getIndex(execs, MustFightBattle.AttackSubs.class);
@@ -1159,7 +1159,7 @@ class RevisedTest {
     final List<String> steps = battle.determineStepStrings(true);
     assertEquals(Arrays.asList(attacker + SUBS_FIRE, defender + SELECT_SUB_CASUALTIES, defender + SUBS_FIRE,
         attacker + SELECT_SUB_CASUALTIES, REMOVE_SNEAK_ATTACK_CASUALTIES, attacker + FIRE, defender + SELECT_CASUALTIES,
-        REMOVE_CASUALTIES, attacker + SUBS_SUBMERGE, defender + SUBS_SUBMERGE, attacker + ATTACKER_WITHDRAW).toString(),
+        REMOVE_CASUALTIES, attacker + SUBS_SUBMERGE, attacker + ATTACKER_WITHDRAW, defender + SUBS_SUBMERGE).toString(),
         steps.toString());
     final List<IExecutable> execs = battle.getBattleExecutables(false);
     final int attackSubs = getIndex(execs, MustFightBattle.AttackSubs.class);
@@ -1214,7 +1214,7 @@ class RevisedTest {
         Arrays.asList(attacker + SUBS_FIRE, defender + SELECT_SUB_CASUALTIES, defender + SUBS_FIRE,
             attacker + SELECT_SUB_CASUALTIES, REMOVE_SNEAK_ATTACK_CASUALTIES, attacker + FIRE,
             defender + SELECT_CASUALTIES, defender + FIRE, attacker + SELECT_CASUALTIES, REMOVE_CASUALTIES,
-            attacker + SUBS_SUBMERGE, defender + SUBS_SUBMERGE, attacker + ATTACKER_WITHDRAW).toString(),
+            attacker + SUBS_SUBMERGE, attacker + ATTACKER_WITHDRAW, defender + SUBS_SUBMERGE).toString(),
         steps.toString());
     final List<IExecutable> execs = battle.getBattleExecutables(false);
     final int attackSubs = getIndex(execs, MustFightBattle.AttackSubs.class);
@@ -1256,8 +1256,8 @@ class RevisedTest {
     final List<String> steps = battle.determineStepStrings(true);
     assertEquals(Arrays.asList(attacker + SUBS_FIRE, defender + SELECT_SUB_CASUALTIES, defender + SUBS_FIRE,
         attacker + SELECT_SUB_CASUALTIES, attacker + FIRE, defender + SELECT_CASUALTIES, defender + FIRE,
-        attacker + SELECT_CASUALTIES, REMOVE_CASUALTIES, attacker + SUBS_SUBMERGE, defender + SUBS_SUBMERGE,
-        attacker + ATTACKER_WITHDRAW).toString(), steps.toString());
+        attacker + SELECT_CASUALTIES, REMOVE_CASUALTIES, attacker + SUBS_SUBMERGE, attacker + ATTACKER_WITHDRAW,
+        defender + SUBS_SUBMERGE).toString(), steps.toString());
     final List<IExecutable> execs = battle.getBattleExecutables(false);
     final int attackSubs = getIndex(execs, MustFightBattle.AttackSubs.class);
     final int defendSubs = getIndex(execs, MustFightBattle.DefendSubs.class);


### PR DESCRIPTION
## Overview
- Addresses: https://www.axisandallies.org/forums/topic/33353/revised-submerge-withdraw-order

## Functional Changes
- For revised sub rules (submerge after combat rolls), the attacker should get option to submerge, then option to withdraw, then defender option to submerge instead of attacker submerge, defender submerge, attacker withdraw

## Manual Testing Performed
- Tested revised and updated unit tests

