### PR TITLE
Adds unit tests to all trigger methods in TriggerAttachment; minor other refactoring.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -19,6 +19,7 @@ import javax.annotation.Nullable;
 
 import org.triplea.java.collections.IntegerMap;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
 
@@ -67,7 +68,9 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
         .noneMatch(i -> coordinate[i] >= gridDimensions[i] || coordinate[i] < 0);
   }
 
-  protected void addTerritory(final Territory t1) {
+  // TODO: Adding a lot of 'VisibleForTesting'. Is this a good idea?
+  @VisibleForTesting
+  public void addTerritory(final Territory t1) {
     if (territories.contains(t1)) {
       throw new IllegalArgumentException("Map already contains " + t1.getName());
     }

--- a/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -68,7 +68,6 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
         .noneMatch(i -> coordinate[i] >= gridDimensions[i] || coordinate[i] < 0);
   }
 
-  // TODO: Adding a lot of 'VisibleForTesting'. Is this a good idea?
   @VisibleForTesting
   public void addTerritory(final Territory t1) {
     if (territories.contains(t1)) {

--- a/game-core/src/main/java/games/strategy/engine/data/ResourceList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/ResourceList.java
@@ -5,6 +5,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.google.common.annotations.VisibleForTesting;
+
 /**
  * A collection of {@link Resource}s keyed on the resource name.
  */
@@ -17,7 +19,8 @@ public class ResourceList extends GameDataComponent {
     super(data);
   }
 
-  protected void addResource(final Resource resource) {
+  @VisibleForTesting
+  public void addResource(final Resource resource) {
     resources.put(resource.getName(), resource);
   }
 

--- a/game-core/src/main/java/games/strategy/engine/data/UnitTypeList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitTypeList.java
@@ -7,6 +7,8 @@ import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.annotations.VisibleForTesting;
+
 /**
  * A collection of unit types.
  */
@@ -19,7 +21,8 @@ public class UnitTypeList extends GameDataComponent implements Iterable<UnitType
     super(data);
   }
 
-  protected void addUnitType(final UnitType type) {
+  @VisibleForTesting
+  public void addUnitType(final UnitType type) {
     unitTypes.put(type.getName(), type);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -1441,6 +1441,22 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   public static void triggerNotifications(final Set<TriggerAttachment> satisfiedTriggers, final IDelegateBridge bridge,
       final String beforeOrAfter, final String stepName, final boolean useUses, final boolean testUses,
       final boolean testChance, final boolean testWhen) {
+
+    // TODO: This check is currently (2019-04-28) needed due to another test failing otherwise, namely
+    // MustFightBattleTest, reg. property files. That may or may not indicate a bug and/or other.
+    if (satisfiedTriggers.stream().anyMatch(t -> t.getNotification() != null)) {
+      triggerNotifications(
+          satisfiedTriggers, bridge, beforeOrAfter, stepName, useUses, testUses, testChance, testWhen,
+          NotificationMessages.getInstance());
+    }
+  }
+
+  @VisibleForTesting
+  static void triggerNotifications(final Set<TriggerAttachment> satisfiedTriggers, final IDelegateBridge bridge,
+      final String beforeOrAfter, final String stepName, final boolean useUses, final boolean testUses,
+      final boolean testChance, final boolean testWhen,
+      final NotificationMessages notificationMessages) {
+
     final GameData data = bridge.getData();
     Collection<TriggerAttachment> trigs = CollectionUtils.getMatches(satisfiedTriggers, notificationMatch());
     if (testWhen) {
@@ -1460,14 +1476,14 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       if (!notifications.contains(t.getNotification())) {
         notifications.add(t.getNotification());
         final String notificationMessageKey = t.getNotification().trim();
-        final String sounds = NotificationMessages.getInstance().getSoundsKey(notificationMessageKey);
+        final String sounds = notificationMessages.getSoundsKey(notificationMessageKey);
         if (sounds != null) {
           // play to observers if we are playing to everyone
           bridge.getSoundChannelBroadcaster().playSoundToPlayers(
               SoundPath.CLIP_TRIGGERED_NOTIFICATION_SOUND + sounds.trim(), t.getPlayers(), null,
               t.getPlayers().containsAll(data.getPlayerList().getPlayers()));
         }
-        final String message = NotificationMessages.getInstance().getMessage(notificationMessageKey);
+        final String message = notificationMessages.getMessage(notificationMessageKey);
         if (message != null) {
           String messageForRecord = message.trim();
           if (messageForRecord.length() > 190) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -1434,7 +1434,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
 
     // TODO: This check is currently (2019-04-28) needed due to another test failing otherwise, namely
     // MustFightBattleTest, reg. property files. That may or may not indicate a bug and/or other.
-    if (satisfiedTriggers.stream().anyMatch(t -> notificationMatch().test(t))) {
+    if (satisfiedTriggers.stream().anyMatch(notificationMatch())) {
       triggerNotifications(
           satisfiedTriggers, bridge, beforeOrAfter, stepName, useUses, testUses, testChance, testWhen,
           NotificationMessages.getInstance());
@@ -2318,7 +2318,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
 
     // TODO: This check is currently (2019-05-01) needed due to other tests failing reg. property files.
     // That may or may not indicate a bug and/or other.
-    if (satisfiedTriggers.stream().anyMatch(t -> victoryMatch().test(t))) {
+    if (satisfiedTriggers.stream().anyMatch(victoryMatch())) {
       triggerVictory(
           satisfiedTriggers, bridge, beforeOrAfter, stepName, useUses, testUses, testChance, testWhen,
           NotificationMessages.getInstance());

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -616,7 +616,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     relationshipChange = value;
   }
 
-  private List<String> getRelationshipChange() {
+  @VisibleForTesting
+  List<String> getRelationshipChange() {
     return relationshipChange;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -616,8 +616,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     relationshipChange = value;
   }
 
-  @VisibleForTesting
-  List<String> getRelationshipChange() {
+  private List<String> getRelationshipChange() {
     return relationshipChange;
   }
 
@@ -640,8 +639,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     unitTypes = value;
   }
 
-  @VisibleForTesting
-  List<UnitType> getUnitType() {
+  private List<UnitType> getUnitType() {
     return unitTypes;
   }
 
@@ -711,8 +709,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     unitProperty = value;
   }
 
-  @VisibleForTesting
-  List<Tuple<String, String>> getUnitProperty() {
+  private List<Tuple<String, String>> getUnitProperty() {
     return unitProperty;
   }
 
@@ -735,8 +732,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     territories = value;
   }
 
-  @VisibleForTesting
-  List<Territory> getTerritories() {
+  private List<Territory> getTerritories() {
     return territories;
   }
 
@@ -806,8 +802,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     territoryProperty = value;
   }
 
-  @VisibleForTesting
-  List<Tuple<String, String>> getTerritoryProperty() {
+  private List<Tuple<String, String>> getTerritoryProperty() {
     return territoryProperty;
   }
 
@@ -916,8 +911,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     playerProperty = value;
   }
 
-  @VisibleForTesting
-  List<Tuple<String, String>> getPlayerProperty() {
+  private List<Tuple<String, String>> getPlayerProperty() {
     return playerProperty;
   }
 
@@ -940,8 +934,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     relationshipTypes = value;
   }
 
-  @VisibleForTesting
-  List<RelationshipType> getRelationshipTypes() {
+  private List<RelationshipType> getRelationshipTypes() {
     return relationshipTypes;
   }
 
@@ -1010,8 +1003,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     relationshipTypeProperty = value;
   }
 
-  @VisibleForTesting
-  List<Tuple<String, String>> getRelationshipTypeProperty() {
+  private List<Tuple<String, String>> getRelationshipTypeProperty() {
     return relationshipTypeProperty;
   }
 
@@ -1034,8 +1026,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     territoryEffects = value;
   }
 
-  @VisibleForTesting
-  List<TerritoryEffect> getTerritoryEffects() {
+  private List<TerritoryEffect> getTerritoryEffects() {
     return territoryEffects;
   }
 
@@ -1104,8 +1095,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     territoryEffectProperty = value;
   }
 
-  @VisibleForTesting
-  List<Tuple<String, String>> getTerritoryEffectProperty() {
+  private List<Tuple<String, String>> getTerritoryEffectProperty() {
     return territoryEffectProperty;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -830,8 +830,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     players = value;
   }
 
-  @VisibleForTesting
-  List<PlayerId> getPlayers() {
+  private List<PlayerId> getPlayers() {
     return players.isEmpty() ? new ArrayList<>(Collections.singletonList((PlayerId) getAttachedTo())) : players;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -1445,7 +1445,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
 
     // TODO: This check is currently (2019-04-28) needed due to another test failing otherwise, namely
     // MustFightBattleTest, reg. property files. That may or may not indicate a bug and/or other.
-    if (satisfiedTriggers.stream().anyMatch(t -> t.getNotification() != null)) {
+    if (satisfiedTriggers.stream().anyMatch(t -> notificationMatch().test(t))) {
       triggerNotifications(
           satisfiedTriggers, bridge, beforeOrAfter, stepName, useUses, testUses, testChance, testWhen,
           NotificationMessages.getInstance());
@@ -2326,6 +2326,21 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   public static void triggerVictory(final Set<TriggerAttachment> satisfiedTriggers, final IDelegateBridge bridge,
       final String beforeOrAfter, final String stepName, final boolean useUses, final boolean testUses,
       final boolean testChance, final boolean testWhen) {
+
+    // TODO: This check is currently (2019-05-01) needed due to other tests failing reg. property files.
+    // That may or may not indicate a bug and/or other.
+    if (satisfiedTriggers.stream().anyMatch(t -> victoryMatch().test(t))) {
+      triggerVictory(
+          satisfiedTriggers, bridge, beforeOrAfter, stepName, useUses, testUses, testChance, testWhen,
+          NotificationMessages.getInstance());
+    }
+  }
+
+  @VisibleForTesting
+  static void triggerVictory(final Set<TriggerAttachment> satisfiedTriggers, final IDelegateBridge bridge,
+      final String beforeOrAfter, final String stepName, final boolean useUses, final boolean testUses,
+      final boolean testChance, final boolean testWhen,
+      final NotificationMessages notificationMessages) {
     final GameData data = bridge.getData();
     Collection<TriggerAttachment> trigs = CollectionUtils.getMatches(satisfiedTriggers, victoryMatch());
     if (testWhen) {
@@ -2344,8 +2359,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       if (t.getVictory() == null || t.getPlayers() == null) {
         continue;
       }
-      final String victoryMessage = NotificationMessages.getInstance().getMessage(t.getVictory().trim());
-      final String sounds = NotificationMessages.getInstance().getSoundsKey(t.getVictory().trim());
+      final String victoryMessage = notificationMessages.getMessage(t.getVictory().trim());
+      final String sounds = notificationMessages.getSoundsKey(t.getVictory().trim());
       if (victoryMessage != null) {
         if (sounds != null) { // only play the sound if we are also notifying everyone
           bridge.getSoundChannelBroadcaster().playSoundToPlayers(

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -1432,8 +1432,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       final String beforeOrAfter, final String stepName, final boolean useUses, final boolean testUses,
       final boolean testChance, final boolean testWhen) {
 
-    // TODO: This check is currently (2019-04-28) needed due to another test failing otherwise, namely
-    // MustFightBattleTest, reg. property files. That may or may not indicate a bug and/or other.
+    // NOTE: The check is needed to ensure that UI-related code (namely 'NotificationMessages.getInstance()') is
+    // not executed when unit testing non-UI related code such as 'MustFightBattleTest'.
     if (satisfiedTriggers.stream().anyMatch(notificationMatch())) {
       triggerNotifications(
           satisfiedTriggers, bridge, beforeOrAfter, stepName, useUses, testUses, testChance, testWhen,
@@ -2316,8 +2316,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       final String beforeOrAfter, final String stepName, final boolean useUses, final boolean testUses,
       final boolean testChance, final boolean testWhen) {
 
-    // TODO: This check is currently (2019-05-01) needed due to other tests failing reg. property files.
-    // That may or may not indicate a bug and/or other.
+    // NOTE: The check is needed to ensure that UI-related code (namely 'NotificationMessages.getInstance()') is
+    // not executed when unit testing non-UI related code such as 'MustFightBattleTest'.
     if (satisfiedTriggers.stream().anyMatch(victoryMatch())) {
       triggerVictory(
           satisfiedTriggers, bridge, beforeOrAfter, stepName, useUses, testUses, testChance, testWhen,

--- a/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
@@ -485,8 +485,6 @@ class TriggerAttachmentTest {
       verify(bridge).addChange(not(argThat(Change::isEmpty)));
     }
 
-    // TODO: Too little/much usage of mocking in the various added unit tests? Poor usage of mocking?
-
     @Test
     void testTriggerChangeOwnership() throws Exception {
       final GameData gameData = bridge.getData();
@@ -622,8 +620,6 @@ class TriggerAttachmentTest {
           false); // testWhen
       verify(bridge, times(3)).addChange(not(argThat(Change::isEmpty)));
     }
-
-    // TODO: Refactor and maybe update some of the test methods.
 
     @Test
     void testTriggerUnitPlacement() throws Exception {

--- a/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
@@ -54,6 +54,7 @@ import games.strategy.engine.history.IDelegateHistoryWriter;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.delegate.BattleDelegate;
 import games.strategy.triplea.delegate.BattleTracker;
+import games.strategy.triplea.delegate.EndRoundDelegate;
 import games.strategy.triplea.delegate.TechAdvance;
 import games.strategy.triplea.ui.NotificationMessages;
 import games.strategy.triplea.ui.display.ITripleADisplay;
@@ -748,6 +749,39 @@ class TriggerAttachmentTest {
           false, // testChance
           false); // testWhen
       verify(bridge, times(2)).addChange(not(argThat(Change::isEmpty)));
+    }
+
+    @Test
+    void testTriggerVictory() throws Exception {
+      final GameData gameData = bridge.getData();
+
+      final PlayerId player = new PlayerId("somePlayer", gameData);
+      final TriggerAttachment triggerAttachment =
+          new TriggerAttachment("triggerAttachment", player, gameData);
+      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+
+      final String notificationMessageKey = "IndomitableCenterVictory";
+      final String notificationMessage = "<body><h2>Victory!<br>The Indomitable Center Has Conquered!</h2>...</body>";
+      triggerAttachment.getPropertyMap().get("victory").setValue(notificationMessageKey);
+
+      final EndRoundDelegate endRoundDelegate = mock(EndRoundDelegate.class);
+      when(endRoundDelegate.getName()).thenReturn("endRound");
+      gameData.addDelegate(endRoundDelegate);
+
+      final NotificationMessages notificationMessages = mock(NotificationMessages.class);
+      when(notificationMessages.getMessage(notificationMessageKey)).thenReturn(notificationMessage);
+
+      TriggerAttachment.triggerVictory(
+          satisfiedTriggers,
+          bridge,
+          "beforeOrAfter",
+          "stepName",
+          false, // useUses
+          false, // testUses
+          false, // testChance
+          false, // testWhen
+          notificationMessages);
+      verify(endRoundDelegate).signalGameOver(any(), any(), any());
     }
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
@@ -528,6 +528,37 @@ class TriggerAttachmentTest {
           false); // testWhen
       verify(bridge, times(2)).addChange(not(argThat(Change::isEmpty)));
     }
+
+    @Test
+    void testTriggerPurchase() throws Exception {
+      final GameData gameData = bridge.getData();
+
+      final PlayerId playerId = new PlayerId("somePlayer", gameData);
+
+      final TriggerAttachment triggerAttachment =
+          new TriggerAttachment("triggerAttachment", playerId, gameData);
+      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+
+      gameData.getUnitTypeList().addUnitType(new UnitType("brigantine", gameData));
+      gameData.getUnitTypeList().addUnitType(new UnitType("sellsword", gameData));
+      gameData.getUnitTypeList().addUnitType(new UnitType("skirmisher", gameData));
+
+      final MutableProperty<?> purchase = triggerAttachment.getPropertyMap().get("purchase");
+      // NOTE: The 'count' part is prepended in the game parser.
+      purchase.setValue("1:brigantine");
+      purchase.setValue("2:sellsword:skirmisher");
+
+      TriggerAttachment.triggerPurchase(
+          satisfiedTriggers,
+          bridge,
+          "beforeOrAfter",
+          "stepName",
+          false, // useUses
+          false, // testUses
+          false, // testChance
+          false); // testWhen
+      verify(bridge).addChange(not(argThat(Change::isEmpty)));
+    }
   }
 
   @Nested

--- a/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
@@ -142,7 +142,6 @@ class TriggerAttachmentTest {
           any());
     }
 
-    // TODO: Should this be moved down so as to fit with the order of definition of methods in TriggerAttachment?
     @Test
     void testTriggerProductionFrontierEditChange() throws Exception {
       final GameData gameData = bridge.getData();

--- a/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
@@ -42,6 +42,7 @@ import games.strategy.engine.data.ProductionRule;
 import games.strategy.engine.data.ProductionRuleList;
 import games.strategy.engine.data.RelationshipTracker;
 import games.strategy.engine.data.RelationshipType;
+import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.TechnologyFrontier;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.TerritoryEffect;
@@ -667,6 +668,32 @@ class TriggerAttachmentTest {
           false, // testChance
           false); // testWhen
       verify(bridge, times(3)).addChange(not(argThat(Change::isEmpty)));
+    }
+
+    @Test
+    void testTriggerResourceChange() throws Exception {
+      final GameData gameData = bridge.getData();
+
+      final PlayerId player = new PlayerId("somePlayer", gameData);
+      final TriggerAttachment triggerAttachment =
+          new TriggerAttachment("triggerAttachment", player, gameData);
+      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+
+      gameData.getResourceList().addResource(new Resource(Constants.PUS, gameData));
+
+      triggerAttachment.getPropertyMap().get("resource").setValue(Constants.PUS);
+      triggerAttachment.getPropertyMap().get("resourceCount").setValue("23");
+
+      TriggerAttachment.triggerResourceChange(
+          satisfiedTriggers,
+          bridge,
+          "beforeOrAfter",
+          "stepName",
+          false, // useUses
+          false, // testUses
+          false, // testChance
+          false); // testWhen
+      verify(bridge, times(1)).addChange(not(argThat(Change::isEmpty)));
     }
   }
 


### PR DESCRIPTION
## Overview

The changes adds somewhat superficial unit tests to all the trigger methods in TriggerAttachment, partially to help increase test coverage, and partially to enable making further refactorings in TriggerAttachment in future pull requests, such as the minor amount of duplicated code across the 19 "trigger methods" in TriggerAttachment. Another potential refactoring might be to create an immutable parameter object that only contains the fields `beforeOrAfter, stepName, useUses, testUses, testChance, testWhen`, and then change the parameters of the trigger methods to use that parameter object instead, though that would require updating other parts of the codebase that uses those methods.

I have updated and changed some tests to use less mocking as I got more experience with the code base, mocking as well as Mockito.

## Functional Changes

Hopefully none.

## Manual Testing Performed

Played through a single game, no manual testing apart from that.

## Before & After Screen Shots

## Additional Review Notes

There are several questions and issues:
- Many of the unit tests are somewhat superficial, are the introduced tests valuable enough to keep as is?
- Both `triggerNotifications()` and `triggerVictory()` were changed to support passing in `NotificationMessages`, since it otherwise would not be easy to mock in the unit tests. However, partially that is less nice, and partially a duplicated test is currently used for both of them to prevent test failures in other tests. The relevant parts are currently covered with TODOs.
- There is also a very minor TODO reg. moving a test down such that its definition order fits with the corresponding methods under test order in TriggerAttachment.
- The usage of mocking has been decreased. I have only limited experience with Mockito as well as best practices reg. mocking, so I am in doubt about whether I have used mocking well reg. the tests.