### PR TITLE
Fix current player logic in battle simulator when history is open.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/PlayerId.java
+++ b/game-core/src/main/java/games/strategy/engine/data/PlayerId.java
@@ -6,9 +6,10 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Optional;
 
+import javax.annotation.Nullable;
+
 import com.google.common.base.Splitter;
 
-import javax.annotation.Nullable;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.RulesAttachment;

--- a/game-core/src/main/java/games/strategy/engine/data/PlayerId.java
+++ b/game-core/src/main/java/games/strategy/engine/data/PlayerId.java
@@ -4,9 +4,11 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Optional;
 
 import com.google.common.base.Splitter;
 
+import javax.annotation.Nullable;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.RulesAttachment;
@@ -193,6 +195,13 @@ public class PlayerId extends NamedAttachable implements NamedUnitHolder {
       currentPlayers.put(player.getName(), player.getPlayerType().name);
     }
     return currentPlayers;
+  }
+
+  public static Optional<PlayerId> asOptional(@Nullable final PlayerId player) {
+    if (player.isNull()) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(player);
   }
 
   public boolean isDefaultTypeAi() {

--- a/game-core/src/main/java/games/strategy/engine/data/PlayerId.java
+++ b/game-core/src/main/java/games/strategy/engine/data/PlayerId.java
@@ -199,10 +199,10 @@ public class PlayerId extends NamedAttachable implements NamedUnitHolder {
   }
 
   public static Optional<PlayerId> asOptional(@Nullable final PlayerId player) {
-    if (player.isNull()) {
+    if (player == null || player.isNull()) {
       return Optional.empty();
     }
-    return Optional.ofNullable(player);
+    return Optional.of(player);
   }
 
   public boolean isDefaultTypeAi() {

--- a/game-core/src/main/java/games/strategy/engine/history/History.java
+++ b/game-core/src/main/java/games/strategy/engine/history/History.java
@@ -3,8 +3,8 @@ package games.strategy.engine.history;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
+import java.util.Optional;
 
-import javax.annotation.Nullable;
 import javax.swing.SwingUtilities;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
@@ -61,11 +61,11 @@ public class History extends DefaultTreeModel {
     }
   }
 
-  public @Nullable PlayerId getActivePlayer() {
+  public Optional<PlayerId> getActivePlayer() {
     if (currentNode instanceof Step) {
-      return ((Step) currentNode).getPlayerId();
+      return PlayerId.asOptional(((Step) currentNode).getPlayerId());
     }
-    return null;
+    return Optional.empty();
   }
 
   public HistoryNode getLastNode() {

--- a/game-core/src/main/java/games/strategy/engine/history/History.java
+++ b/game-core/src/main/java/games/strategy/engine/history/History.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 
+import javax.annotation.Nullable;
 import javax.swing.SwingUtilities;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
@@ -11,6 +12,7 @@ import javax.swing.tree.DefaultTreeModel;
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.CompositeChange;
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.PlayerId;
 import games.strategy.triplea.ui.history.HistoryPanel;
 
 /**
@@ -57,6 +59,13 @@ public class History extends DefaultTreeModel {
     if (panel != null) {
       panel.goToEnd();
     }
+  }
+
+  public @Nullable PlayerId getActivePlayer() {
+    if (currentNode instanceof Step) {
+      return ((Step) currentNode).getPlayerId();
+    }
+    return null;
   }
 
   public HistoryNode getLastNode() {

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorDialog.java
@@ -16,12 +16,10 @@ import javax.swing.WindowConstants;
 
 import org.triplea.swing.SwingComponents;
 
-import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.history.History;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.ui.TripleAFrame;
-import games.strategy.triplea.ui.UiContext;
 
 /**
  * A dialog that allows the user to set up an arbitrary battle and calculate the attacker's odds of successfully winning

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorDialog.java
@@ -18,6 +18,7 @@ import org.triplea.swing.SwingComponents;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Territory;
+import games.strategy.engine.history.History;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.ui.TripleAFrame;
 import games.strategy.triplea.ui.UiContext;
@@ -32,9 +33,9 @@ public class OddsCalculatorDialog extends JDialog {
   private static List<OddsCalculatorDialog> instances = new ArrayList<>();
   private final OddsCalculatorPanel panel;
 
-  OddsCalculatorDialog(final GameData data, final UiContext uiContext, final JFrame parent, final Territory location) {
+  OddsCalculatorDialog(final OddsCalculatorPanel panel, final JFrame parent) {
     super(parent, "Odds Calculator");
-    panel = new OddsCalculatorPanel(data, uiContext, location, this);
+    this.panel = panel;
     getContentPane().setLayout(new BorderLayout());
     getContentPane().add(panel, BorderLayout.CENTER);
     pack();
@@ -43,9 +44,13 @@ public class OddsCalculatorDialog extends JDialog {
   /**
    * Shows the Odds Calculator dialog and initializes it using the current state of the specified territory.
    */
-  public static void show(final TripleAFrame taFrame, final Territory t) {
-    final OddsCalculatorDialog dialog =
-        new OddsCalculatorDialog(taFrame.getGame().getData(), taFrame.getUiContext(), taFrame, t);
+  public static void show(final TripleAFrame taFrame, final Territory t, final History history) {
+    // Note: The history param may not be the same as taFrame.getGame().getData().getHistory() as GameData
+    // gets cloned when showing history with a different History instance that doesn't correspond to what's
+    // shown.
+    final OddsCalculatorPanel panel =
+        new OddsCalculatorPanel(taFrame.getGame().getData(), history, taFrame.getUiContext(), t);
+    final OddsCalculatorDialog dialog = new OddsCalculatorDialog(panel, taFrame);
     dialog.pack();
 
     dialog.addWindowListener(new WindowAdapter() {

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
@@ -19,7 +19,6 @@ import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.logging.Level;
 
-import javax.annotation.Nullable;
 import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
 import javax.swing.DefaultListCellRenderer;
@@ -446,16 +445,16 @@ class OddsCalculatorPanel extends JPanel {
         landBattleCheckBox.setSelected(!location.isWater());
 
         // Default attacker to current player
-        final PlayerId currentPlayer = getCurrentPlayer(history);
-        if (currentPlayer != null) {
-          attackerCombo.setSelectedItem(currentPlayer);
+        final Optional<PlayerId> currentPlayer = getCurrentPlayer(history);
+        if (currentPlayer.isPresent()) {
+          attackerCombo.setSelectedItem(currentPlayer.get());
         }
 
         // Get players with units sorted
         final List<PlayerId> players = location.getUnitCollection().getPlayersByUnitCount();
-        if (players.contains(currentPlayer)) {
-          players.remove(currentPlayer);
-          players.add(0, currentPlayer);
+        if (currentPlayer.isPresent() && players.contains(currentPlayer.get())) {
+          players.remove(currentPlayer.get());
+          players.add(0, currentPlayer.get());
         }
 
         // Check location to determine optimal attacker and defender
@@ -506,15 +505,12 @@ class OddsCalculatorPanel extends JPanel {
     revalidate();
   }
 
-  private @Nullable PlayerId getCurrentPlayer(final History history) {
-    PlayerId player = history.getActivePlayer();
-    if (player == null || player.isNull()) {
-      player = data.getSequence().getStep().getPlayerId();
-    }
-    if (!player.isNull()) {
+  private Optional<PlayerId> getCurrentPlayer(final History history) {
+    Optional<PlayerId> player = history.getActivePlayer();
+    if (player.isPresent()) {
       return player;
     }
-    return null;
+    return PlayerId.asOptional(data.getSequence().getStep().getPlayerId());
   }
 
   void shutdown() {

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
@@ -47,8 +47,8 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
-import games.strategy.engine.history.History;
 import games.strategy.engine.framework.ui.background.WaitDialog;
+import games.strategy.engine.history.History;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.BattleCalculator;
 import games.strategy.triplea.delegate.DiceRoll;
@@ -390,7 +390,7 @@ class OddsCalculatorPanel extends JPanel {
     closeButton.addActionListener(e -> {
       attackerOrderOfLosses = null;
       defenderOrderOfLosses = null;
-      Window parent = SwingUtilities.getWindowAncestor(OddsCalculatorPanel.this);
+      final Window parent = SwingUtilities.getWindowAncestor(OddsCalculatorPanel.this);
       if (parent != null) {
         parent.setVisible(false);
       }

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
@@ -506,7 +506,7 @@ class OddsCalculatorPanel extends JPanel {
   }
 
   private Optional<PlayerId> getCurrentPlayer(final History history) {
-    Optional<PlayerId> player = history.getActivePlayer();
+    final Optional<PlayerId> player = history.getActivePlayer();
     if (player.isPresent()) {
       return player;
     }

--- a/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -59,9 +59,9 @@ class TerritoryDetailPanel extends AbstractStatPanel {
     setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
     setBorder(new EmptyBorder(5, 5, 0, 0));
 
-    showOdds.addActionListener(e -> OddsCalculatorDialog.show(frame, currentTerritory));
+    showOdds.addActionListener(e -> OddsCalculatorDialog.show(frame, currentTerritory, gameData.getHistory()));
     SwingComponents.addKeyListenerWithMetaAndCtrlMasks(
-        frame, 'B', () -> OddsCalculatorDialog.show(frame, currentTerritory));
+        frame, 'B', () -> OddsCalculatorDialog.show(frame, currentTerritory, gameData.getHistory()));
 
     addAttackers.addActionListener(e -> OddsCalculatorDialog.addAttackers(currentTerritory));
     SwingComponents.addKeyListenerWithMetaAndCtrlMasks(

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -73,8 +73,8 @@ final class GameMenu extends JMenu {
     addNotificationSettings();
     addShowDiceStats();
     addRollDice();
-    addMenuItemWithHotkey(SwingAction.of("Battle Calculator", e -> OddsCalculatorDialog.show(frame, null, gameData.getHistory())),
-        KeyEvent.VK_B);
+    addMenuItemWithHotkey(SwingAction.of("Battle Calculator",
+        e -> OddsCalculatorDialog.show(frame, null, gameData.getHistory())), KeyEvent.VK_B);
   }
 
   private void addMenuItemWithHotkey(final Action action, final int keyCode) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -73,7 +73,7 @@ final class GameMenu extends JMenu {
     addNotificationSettings();
     addShowDiceStats();
     addRollDice();
-    addMenuItemWithHotkey(SwingAction.of("Battle Calculator", e -> OddsCalculatorDialog.show(frame, null)),
+    addMenuItemWithHotkey(SwingAction.of("Battle Calculator", e -> OddsCalculatorDialog.show(frame, null, gameData.getHistory())),
         KeyEvent.VK_B);
   }
 


### PR DESCRIPTION
## Overview
When using the battle simulator while history is open, the attacking player was not being properly selected.

## Functional Changes
The logic for choosing the attacking player has been adjusted to take into account the selected history node, when viewing a past battle.

## Manual Testing Performed
- In a game, play several turns.
- Open history viewer and select a past combat step.
- Mouse over a territory where battle is taking place and open the Battle Simulator.
- The correct active player for that history turn should be set.

## Before & After Screen Shots
<!-- Leave blank if no UI changes -->
### Before

### After


## Additional Review Notes
<!-- Add here any extra notes that would be helpful to reviewers -->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->
