### PR TITLE
Allow non-sea subs and destroyers

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -860,7 +860,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
             taa = new TechAbilityAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, ta, data);
             ta.addAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, taa);
             final List<UnitType> allDestroyers =
-                CollectionUtils.getMatches(data.getUnitTypeList().getAllUnitTypes(), Matches.unitTypeIsDestroyer());
+                CollectionUtils.getMatches(data.getUnitTypeList().getAllUnitTypes(),
+                    Matches.unitTypeIsDestroyer().and(Matches.unitTypeIsSea()));
             for (final UnitType destroyer : allDestroyers) {
               taa.setUnitAbilitiesGained(destroyer.getName() + ":" + ABILITY_CAN_BOMBARD);
             }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -2439,7 +2439,7 @@ public class UnitAttachment extends DefaultAttachment {
   @Override
   public void validate(final GameData data) throws GameParseException {
     if (isAir) {
-      if (isSea || isSub || transportCost != -1 || carrierCapacity != -1 || canBlitz
+      if (isSea || transportCost != -1 || carrierCapacity != -1 || canBlitz
           || canBombard || isMarine != 0 || isLandTransportable || isLandTransport
           || isAirTransportable || isCombatTransport) {
         throw new GameParseException("air units cannot have certain properties, " + thisErrorMsg());
@@ -2451,7 +2451,7 @@ public class UnitAttachment extends DefaultAttachment {
         throw new GameParseException("sea units cannot have certain properties, " + thisErrorMsg());
       }
     } else { // if land
-      if (canBombard || isSub || carrierCapacity != -1 || bombard != -1
+      if (canBombard || carrierCapacity != -1 || bombard != -1
           || isAirTransport || isCombatTransport || isKamikaze) {
         throw new GameParseException("land units cannot have certain properties, " + thisErrorMsg());
       }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -330,8 +330,7 @@ public class MovePerformer implements Serializable {
             .anyMatch(Matches.unitIsEnemyOf(data, id).and(Matches.unitIsDestroyer()))) {
       // if we are allowed to have our subs enter any sea zone with enemies during noncombat, we want to make sure we
       // can't keep moving them if there is an enemy destroyer there
-      for (final Unit unit : CollectionUtils.getMatches(units,
-          Matches.unitIsSub().and(Matches.unitIsAir().negate()))) {
+      for (final Unit unit : CollectionUtils.getMatches(units, Matches.unitIsSub())) {
         change.add(ChangeFactory.markNoMovementChange(Collections.singleton(unit)));
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -1784,7 +1784,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   private boolean canAirAttackSubs(final Collection<Unit> firedAt, final Collection<Unit> firing) {
-    return !(firedAt.stream().anyMatch(Matches.unitIsSub()) && firing.stream().noneMatch(Matches.unitIsDestroyer()));
+    return firedAt.stream().noneMatch(Matches.unitIsSub()) || firing.stream().anyMatch(Matches.unitIsDestroyer());
   }
 
   private void defendAirOnNonSubs() {

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyPlayer.java
@@ -117,7 +117,6 @@ class DummyPlayer extends AbstractAi {
     }
     if (submerge) {
       // submerge if all air vs subs
-      final Predicate<Unit> seaSub = Matches.unitIsSea().and(Matches.unitIsSub());
       final Predicate<Unit> planeNotDestroyer = Matches.unitIsAir().and(Matches.unitIsDestroyer().negate());
       final List<Unit> ourUnits = getOurUnits();
       final List<Unit> enemyUnits = getEnemyUnits();
@@ -125,7 +124,7 @@ class DummyPlayer extends AbstractAi {
         return null;
       }
       if (!enemyUnits.isEmpty() && enemyUnits.stream().allMatch(planeNotDestroyer) && !ourUnits.isEmpty()
-          && ourUnits.stream().allMatch(seaSub)) {
+          && ourUnits.stream().allMatch(Matches.unitIsSub())) {
         return possibleTerritories.iterator().next();
       }
       return null;


### PR DESCRIPTION
## Overview
- Begin implementing non-sea sub functionality: https://forums.triplea-game.org/topic/328/unit-option-can-submerge-hide-for-land-units-partisan-guerrilla-spy-diplomat-munition
- This is just part 1 of the changes

## Functional Changes
- Remove checks not allowing air/land units to have `isSub`
- Remove some logic that only checks for sub functionality for sea territories
- Fix existing bug where REMOVE_SNEAK_ATTACK_CASUALTIES battle step is shown for battles that don't have any subs

## Manual Testing Performed
- Tested that sea subs still work properly
- Updated ww2v3 41 infantry to have `isSub` and check that basic sub functionality works as intended (infantry fire before other units and can submerge):
```
    <attachment name="unitAttachment" attachTo="infantry" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
      <option name="movement" value="1"/>
      <option name="transportCost" value="2"/>
      <option name="isInfantry" value="true"/>
      <option name="isAirTransportable" value="true"/>
      <option name="attack" value="1"/>
      <option name="defense" value="2"/>
      <option name="artillerySupportable" value="true"/>
      <option name="isSub" value="true"/>
    </attachment>
```
