### PR TITLE
Refactors trigger attachment and related.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/FireTriggerParams.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/FireTriggerParams.java
@@ -1,0 +1,75 @@
+package games.strategy.triplea.attachments;
+
+
+/**
+ * Parameter object for fire trigger methods, first and foremost in {@link TriggerAttachment}.
+ */
+public class FireTriggerParams {
+
+  /**
+   * Filter value for before or after a given step.
+   *
+   * <p>
+   * See {@link #testWhen}, documentation for trigger attachment option "when" as well as
+   * {@link AbstractTriggerAttachment#whenOrDefaultMatch} .
+   * </p>
+   */
+  public final String beforeOrAfter;
+
+  /**
+   * Filter value for a specific step/phase (like "russianPolitics" step).
+   *
+   * <p>
+   * See {@link #testWhen}, documentation for trigger attachment option "when" as well as
+   * {@link AbstractTriggerAttachment#whenOrDefaultMatch} .
+   * </p>
+   */
+  public final String stepName;
+
+  /**
+   * TODO: Document.
+   *
+   * <p>
+   * See documentation for trigger attachment option "uses".
+   * </p>
+   */
+  public final boolean useUses;
+
+  /**
+   * TODO: Document.
+   *
+   * <p>
+   * See documentation for trigger attachment option "uses".
+   * </p>
+   */
+  public final boolean testUses;
+
+  /**
+   * TODO: Document.
+   *
+   * <p>
+   * See documentation for trigger attachment option "chance".
+   * </p>
+   */
+  public final boolean testChance;
+
+  /**
+   * Whether to filter for "when".
+   *
+   * <p>
+   * See documentation for trigger attachment option "when" as well as
+   * {@link AbstractTriggerAttachment#whenOrDefaultMatch} .
+   * </p>
+   */
+  public final boolean testWhen;
+
+  public FireTriggerParams(final String beforeOrAfter, final String stepName,
+      final boolean useUses, final boolean testUses, final boolean testChance, final boolean testWhen) {
+    this.beforeOrAfter = beforeOrAfter;
+    this.stepName = stepName;
+    this.useUses = useUses;
+    this.testUses = testUses;
+    this.testChance = testChance;
+    this.testWhen = testWhen;
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/attachments/FireTriggerParams.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/FireTriggerParams.java
@@ -1,9 +1,14 @@
 package games.strategy.triplea.attachments;
 
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Value;
 
 /**
  * Parameter object for fire trigger methods, first and foremost in {@link TriggerAttachment}.
  */
+@Value
+@Getter(AccessLevel.NONE)
 public class FireTriggerParams {
 
   /**
@@ -27,29 +32,17 @@ public class FireTriggerParams {
   public final String stepName;
 
   /**
-   * TODO: Document.
-   *
-   * <p>
    * See documentation for trigger attachment option "uses".
-   * </p>
    */
   public final boolean useUses;
 
   /**
-   * TODO: Document.
-   *
-   * <p>
    * See documentation for trigger attachment option "uses".
-   * </p>
    */
   public final boolean testUses;
 
   /**
-   * TODO: Document.
-   *
-   * <p>
    * See documentation for trigger attachment option "chance".
-   * </p>
    */
   public final boolean testChance;
 
@@ -62,14 +55,4 @@ public class FireTriggerParams {
    * </p>
    */
   public final boolean testWhen;
-
-  public FireTriggerParams(final String beforeOrAfter, final String stepName,
-      final boolean useUses, final boolean testUses, final boolean testChance, final boolean testWhen) {
-    this.beforeOrAfter = beforeOrAfter;
-    this.stepName = stepName;
-    this.useUses = useUses;
-    this.testUses = testUses;
-    this.testChance = testChance;
-    this.testWhen = testWhen;
-  }
 }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -1494,8 +1494,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
           String messageForRecord = message.trim();
           if (messageForRecord.length() > 190) {
             // We don't want to record a giant string in the history panel, so just put a shortened version in instead.
-            messageForRecord = messageForRecord.replaceAll("\\<br.*?>", " ");
-            messageForRecord = messageForRecord.replaceAll("\\<.*?>", "");
+            messageForRecord = messageForRecord.replaceAll("<br.*?>", " ");
+            messageForRecord = messageForRecord.replaceAll("<.*?>", "");
             if (messageForRecord.length() > 195) {
               messageForRecord = messageForRecord.substring(0, 190) + "....";
             }
@@ -2267,8 +2267,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
         }
         String messageForRecord = victoryMessage.trim();
         if (messageForRecord.length() > 150) {
-          messageForRecord = messageForRecord.replaceAll("\\<br.*?>", " ");
-          messageForRecord = messageForRecord.replaceAll("\\<.*?>", "");
+          messageForRecord = messageForRecord.replaceAll("<br.*?>", " ");
+          messageForRecord = messageForRecord.replaceAll("<.*?>", "");
           if (messageForRecord.length() > 155) {
             messageForRecord = messageForRecord.substring(0, 150) + "....";
           }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -18,6 +18,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.triplea.java.ObjectUtils;
+import org.triplea.java.PredicateBuilder;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.util.Tuple;
@@ -1434,14 +1435,12 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   private static Collection<TriggerAttachment> filterSatisfiedTriggers(
       final Set<TriggerAttachment> satisfiedTriggers, final Predicate<TriggerAttachment> customPredicate,
       final FireTriggerParams fireTriggerParams) {
-    Predicate<TriggerAttachment> combinedPredicate = customPredicate;
-    if (fireTriggerParams.testWhen) {
-      combinedPredicate = combinedPredicate
-          .and(whenOrDefaultMatch(fireTriggerParams.beforeOrAfter, fireTriggerParams.stepName));
-    }
-    if (fireTriggerParams.testUses) {
-      combinedPredicate = combinedPredicate.and(availableUses);
-    }
+    final Predicate<TriggerAttachment> combinedPredicate = PredicateBuilder
+        .of(customPredicate)
+        .andIf(fireTriggerParams.testWhen,
+            whenOrDefaultMatch(fireTriggerParams.beforeOrAfter, fireTriggerParams.stepName))
+        .andIf(fireTriggerParams.testUses, availableUses)
+        .build();
     return CollectionUtils.getMatches(satisfiedTriggers, combinedPredicate);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -1420,6 +1420,28 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     };
   }
 
+  /**
+   * Filters the given satisfied triggers.
+   *
+   * <p>
+   * No side-effects.
+   * </p>
+   *
+   * @param customPredicate Must have no side-effects.
+   */
+  static Collection<TriggerAttachment> filterSatisfiedTriggers(
+      final Set<TriggerAttachment> satisfiedTriggers, final Predicate<TriggerAttachment> customPredicate,
+      final String beforeOrAfter, final String stepName, final boolean testUses, final boolean testWhen) {
+    Predicate<TriggerAttachment> combinedPredicate = customPredicate;
+    if (testWhen) {
+      combinedPredicate = combinedPredicate.and(whenOrDefaultMatch(beforeOrAfter, stepName));
+    }
+    if (testUses) {
+      combinedPredicate = combinedPredicate.and(availableUses);
+    }
+    return CollectionUtils.getMatches(satisfiedTriggers, combinedPredicate);
+  }
+
   // And now for the actual triggers, as called throughout the engine.
   // Each trigger should be called exactly twice, once in BaseDelegate (for use with 'when'), and a second time as the
   // default location for when 'when' is not used.
@@ -1448,13 +1470,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       final NotificationMessages notificationMessages) {
 
     final GameData data = bridge.getData();
-    Collection<TriggerAttachment> trigs = CollectionUtils.getMatches(satisfiedTriggers, notificationMatch());
-    if (testWhen) {
-      trigs = CollectionUtils.getMatches(trigs, whenOrDefaultMatch(beforeOrAfter, stepName));
-    }
-    if (testUses) {
-      trigs = CollectionUtils.getMatches(trigs, availableUses);
-    }
+    final Collection<TriggerAttachment> trigs = filterSatisfiedTriggers(
+        satisfiedTriggers, notificationMatch(), beforeOrAfter, stepName, testUses, testWhen);
     final Set<String> notifications = new HashSet<>();
     for (final TriggerAttachment t : trigs) {
       if (testChance && !t.testChance(bridge)) {
@@ -1502,13 +1519,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   public static void triggerPlayerPropertyChange(final Set<TriggerAttachment> satisfiedTriggers,
       final IDelegateBridge bridge, final String beforeOrAfter, final String stepName, final boolean useUses,
       final boolean testUses, final boolean testChance, final boolean testWhen) {
-    Collection<TriggerAttachment> trigs = CollectionUtils.getMatches(satisfiedTriggers, playerPropertyMatch());
-    if (testWhen) {
-      trigs = CollectionUtils.getMatches(trigs, whenOrDefaultMatch(beforeOrAfter, stepName));
-    }
-    if (testUses) {
-      trigs = CollectionUtils.getMatches(trigs, availableUses);
-    }
+    final Collection<TriggerAttachment> trigs = filterSatisfiedTriggers(
+        satisfiedTriggers, playerPropertyMatch(), beforeOrAfter, stepName, testUses, testWhen);
     final CompositeChange change = new CompositeChange();
     for (final TriggerAttachment t : trigs) {
       if (testChance && !t.testChance(bridge)) {
@@ -1549,14 +1561,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   public static void triggerRelationshipTypePropertyChange(final Set<TriggerAttachment> satisfiedTriggers,
       final IDelegateBridge bridge, final String beforeOrAfter, final String stepName, final boolean useUses,
       final boolean testUses, final boolean testChance, final boolean testWhen) {
-    Collection<TriggerAttachment> trigs =
-        CollectionUtils.getMatches(satisfiedTriggers, relationshipTypePropertyMatch());
-    if (testWhen) {
-      trigs = CollectionUtils.getMatches(trigs, whenOrDefaultMatch(beforeOrAfter, stepName));
-    }
-    if (testUses) {
-      trigs = CollectionUtils.getMatches(trigs, availableUses);
-    }
+    final Collection<TriggerAttachment> trigs = filterSatisfiedTriggers(
+        satisfiedTriggers, relationshipTypePropertyMatch(), beforeOrAfter, stepName, testUses, testWhen);
     final CompositeChange change = new CompositeChange();
     for (final TriggerAttachment t : trigs) {
       if (testChance && !t.testChance(bridge)) {
@@ -1597,13 +1603,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   public static void triggerTerritoryPropertyChange(final Set<TriggerAttachment> satisfiedTriggers,
       final IDelegateBridge bridge, final String beforeOrAfter, final String stepName, final boolean useUses,
       final boolean testUses, final boolean testChance, final boolean testWhen) {
-    Collection<TriggerAttachment> trigs = CollectionUtils.getMatches(satisfiedTriggers, territoryPropertyMatch());
-    if (testWhen) {
-      trigs = CollectionUtils.getMatches(trigs, whenOrDefaultMatch(beforeOrAfter, stepName));
-    }
-    if (testUses) {
-      trigs = CollectionUtils.getMatches(trigs, availableUses);
-    }
+    final Collection<TriggerAttachment> trigs = filterSatisfiedTriggers(
+        satisfiedTriggers, territoryPropertyMatch(), beforeOrAfter, stepName, testUses, testWhen);
     final CompositeChange change = new CompositeChange();
     final Set<Territory> territoriesNeedingReDraw = new HashSet<>();
     for (final TriggerAttachment t : trigs) {
@@ -1660,13 +1661,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   public static void triggerTerritoryEffectPropertyChange(final Set<TriggerAttachment> satisfiedTriggers,
       final IDelegateBridge bridge, final String beforeOrAfter, final String stepName, final boolean useUses,
       final boolean testUses, final boolean testChance, final boolean testWhen) {
-    Collection<TriggerAttachment> trigs = CollectionUtils.getMatches(satisfiedTriggers, territoryEffectPropertyMatch());
-    if (testWhen) {
-      trigs = CollectionUtils.getMatches(trigs, whenOrDefaultMatch(beforeOrAfter, stepName));
-    }
-    if (testUses) {
-      trigs = CollectionUtils.getMatches(trigs, availableUses);
-    }
+    final Collection<TriggerAttachment> trigs = filterSatisfiedTriggers(
+        satisfiedTriggers, territoryEffectPropertyMatch(), beforeOrAfter, stepName, testUses, testWhen);
     final CompositeChange change = new CompositeChange();
     for (final TriggerAttachment t : trigs) {
       if (testChance && !t.testChance(bridge)) {
@@ -1706,13 +1702,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   public static void triggerUnitPropertyChange(final Set<TriggerAttachment> satisfiedTriggers,
       final IDelegateBridge bridge, final String beforeOrAfter, final String stepName, final boolean useUses,
       final boolean testUses, final boolean testChance, final boolean testWhen) {
-    Collection<TriggerAttachment> trigs = CollectionUtils.getMatches(satisfiedTriggers, unitPropertyMatch());
-    if (testWhen) {
-      trigs = CollectionUtils.getMatches(trigs, whenOrDefaultMatch(beforeOrAfter, stepName));
-    }
-    if (testUses) {
-      trigs = CollectionUtils.getMatches(trigs, availableUses);
-    }
+    final Collection<TriggerAttachment> trigs = filterSatisfiedTriggers(
+        satisfiedTriggers, unitPropertyMatch(), beforeOrAfter, stepName, testUses, testWhen);
     final CompositeChange change = new CompositeChange();
     for (final TriggerAttachment t : trigs) {
       if (testChance && !t.testChance(bridge)) {
@@ -1752,13 +1743,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       final IDelegateBridge bridge, final String beforeOrAfter, final String stepName, final boolean useUses,
       final boolean testUses, final boolean testChance, final boolean testWhen) {
     final GameData data = bridge.getData();
-    Collection<TriggerAttachment> trigs = CollectionUtils.getMatches(satisfiedTriggers, relationshipChangeMatch());
-    if (testWhen) {
-      trigs = CollectionUtils.getMatches(trigs, whenOrDefaultMatch(beforeOrAfter, stepName));
-    }
-    if (testUses) {
-      trigs = CollectionUtils.getMatches(trigs, availableUses);
-    }
+    final Collection<TriggerAttachment> trigs = filterSatisfiedTriggers(
+        satisfiedTriggers, relationshipChangeMatch(), beforeOrAfter, stepName, testUses, testWhen);
     final CompositeChange change = new CompositeChange();
     for (final TriggerAttachment t : trigs) {
       if (testChance && !t.testChance(bridge)) {
@@ -1808,13 +1794,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   public static void triggerAvailableTechChange(final Set<TriggerAttachment> satisfiedTriggers,
       final IDelegateBridge bridge, final String beforeOrAfter, final String stepName, final boolean useUses,
       final boolean testUses, final boolean testChance, final boolean testWhen) {
-    Collection<TriggerAttachment> trigs = CollectionUtils.getMatches(satisfiedTriggers, techAvailableMatch());
-    if (testWhen) {
-      trigs = CollectionUtils.getMatches(trigs, whenOrDefaultMatch(beforeOrAfter, stepName));
-    }
-    if (testUses) {
-      trigs = CollectionUtils.getMatches(trigs, availableUses);
-    }
+    final Collection<TriggerAttachment> trigs = filterSatisfiedTriggers(
+        satisfiedTriggers, techAvailableMatch(), beforeOrAfter, stepName, testUses, testWhen);
     for (final TriggerAttachment t : trigs) {
       if (testChance && !t.testChance(bridge)) {
         continue;
@@ -1852,14 +1833,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   public static void triggerTechChange(final Set<TriggerAttachment> satisfiedTriggers, final IDelegateBridge bridge,
       final String beforeOrAfter, final String stepName, final boolean useUses, final boolean testUses,
       final boolean testChance, final boolean testWhen) {
-    // final GameData data = aBridge.getData();
-    Collection<TriggerAttachment> trigs = CollectionUtils.getMatches(satisfiedTriggers, techMatch());
-    if (testWhen) {
-      trigs = CollectionUtils.getMatches(trigs, whenOrDefaultMatch(beforeOrAfter, stepName));
-    }
-    if (testUses) {
-      trigs = CollectionUtils.getMatches(trigs, availableUses);
-    }
+    final Collection<TriggerAttachment> trigs = filterSatisfiedTriggers(
+        satisfiedTriggers, techMatch(), beforeOrAfter, stepName, testUses, testWhen);
     for (final TriggerAttachment t : trigs) {
       if (testChance && !t.testChance(bridge)) {
         continue;
@@ -1886,13 +1861,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   public static void triggerProductionChange(final Set<TriggerAttachment> satisfiedTriggers,
       final IDelegateBridge bridge, final String beforeOrAfter, final String stepName, final boolean useUses,
       final boolean testUses, final boolean testChance, final boolean testWhen) {
-    Collection<TriggerAttachment> trigs = CollectionUtils.getMatches(satisfiedTriggers, prodMatch());
-    if (testWhen) {
-      trigs = CollectionUtils.getMatches(trigs, whenOrDefaultMatch(beforeOrAfter, stepName));
-    }
-    if (testUses) {
-      trigs = CollectionUtils.getMatches(trigs, availableUses);
-    }
+    final Collection<TriggerAttachment> trigs = filterSatisfiedTriggers(
+        satisfiedTriggers, prodMatch(), beforeOrAfter, stepName, testUses, testWhen);
     final CompositeChange change = new CompositeChange();
     for (final TriggerAttachment t : trigs) {
       if (testChance && !t.testChance(bridge)) {
@@ -1919,13 +1889,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       final IDelegateBridge bridge, final String beforeOrAfter, final String stepName, final boolean useUses,
       final boolean testUses, final boolean testChance, final boolean testWhen) {
     final GameData data = bridge.getData();
-    Collection<TriggerAttachment> trigs = CollectionUtils.getMatches(satisfiedTriggers, prodFrontierEditMatch());
-    if (testWhen) {
-      trigs = CollectionUtils.getMatches(trigs, whenOrDefaultMatch(beforeOrAfter, stepName));
-    }
-    if (testUses) {
-      trigs = CollectionUtils.getMatches(trigs, availableUses);
-    }
+    final Collection<TriggerAttachment> trigs = filterSatisfiedTriggers(
+        satisfiedTriggers, prodFrontierEditMatch(), beforeOrAfter, stepName, testUses, testWhen);
     final CompositeChange change = new CompositeChange();
     for (final TriggerAttachment triggerAttachment : trigs) {
       if (testChance && !triggerAttachment.testChance(bridge)) {
@@ -1971,13 +1936,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       final String beforeOrAfter, final String stepName, final boolean useUses, final boolean testUses,
       final boolean testChance, final boolean testWhen) {
     final GameData data = bridge.getData();
-    Collection<TriggerAttachment> trigs = CollectionUtils.getMatches(satisfiedTriggers, supportMatch());
-    if (testWhen) {
-      trigs = CollectionUtils.getMatches(trigs, whenOrDefaultMatch(beforeOrAfter, stepName));
-    }
-    if (testUses) {
-      trigs = CollectionUtils.getMatches(trigs, availableUses);
-    }
+    final Collection<TriggerAttachment> trigs = filterSatisfiedTriggers(
+        satisfiedTriggers, supportMatch(), beforeOrAfter, stepName, testUses, testWhen);
     final CompositeChange change = new CompositeChange();
     for (final TriggerAttachment t : trigs) {
       if (testChance && !t.testChance(bridge)) {
@@ -2029,13 +1989,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       final IDelegateBridge bridge, final String beforeOrAfter, final String stepName, final boolean useUses,
       final boolean testUses, final boolean testChance, final boolean testWhen) {
     final GameData data = bridge.getData();
-    Collection<TriggerAttachment> trigs = CollectionUtils.getMatches(satisfiedTriggers, changeOwnershipMatch());
-    if (testWhen) {
-      trigs = CollectionUtils.getMatches(trigs, whenOrDefaultMatch(beforeOrAfter, stepName));
-    }
-    if (testUses) {
-      trigs = CollectionUtils.getMatches(trigs, availableUses);
-    }
+    final Collection<TriggerAttachment> trigs = filterSatisfiedTriggers(
+        satisfiedTriggers, changeOwnershipMatch(), beforeOrAfter, stepName, testUses, testWhen);
     final BattleTracker bt = DelegateFinder.battleDelegate(data).getBattleTracker();
     for (final TriggerAttachment t : trigs) {
       if (testChance && !t.testChance(bridge)) {
@@ -2084,13 +2039,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   public static void triggerPurchase(final Set<TriggerAttachment> satisfiedTriggers, final IDelegateBridge bridge,
       final String beforeOrAfter, final String stepName, final boolean useUses, final boolean testUses,
       final boolean testChance, final boolean testWhen) {
-    Collection<TriggerAttachment> trigs = CollectionUtils.getMatches(satisfiedTriggers, purchaseMatch());
-    if (testWhen) {
-      trigs = CollectionUtils.getMatches(trigs, whenOrDefaultMatch(beforeOrAfter, stepName));
-    }
-    if (testUses) {
-      trigs = CollectionUtils.getMatches(trigs, availableUses);
-    }
+    final Collection<TriggerAttachment> trigs = filterSatisfiedTriggers(
+        satisfiedTriggers, purchaseMatch(), beforeOrAfter, stepName, testUses, testWhen);
     for (final TriggerAttachment t : trigs) {
       if (testChance && !t.testChance(bridge)) {
         continue;
@@ -2123,13 +2073,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   public static void triggerUnitRemoval(final Set<TriggerAttachment> satisfiedTriggers, final IDelegateBridge bridge,
       final String beforeOrAfter, final String stepName, final boolean useUses, final boolean testUses,
       final boolean testChance, final boolean testWhen) {
-    Collection<TriggerAttachment> trigs = CollectionUtils.getMatches(satisfiedTriggers, removeUnitsMatch());
-    if (testWhen) {
-      trigs = CollectionUtils.getMatches(trigs, whenOrDefaultMatch(beforeOrAfter, stepName));
-    }
-    if (testUses) {
-      trigs = CollectionUtils.getMatches(trigs, availableUses);
-    }
+    final Collection<TriggerAttachment> trigs = filterSatisfiedTriggers(
+        satisfiedTriggers, removeUnitsMatch(), beforeOrAfter, stepName, testUses, testWhen);
     for (final TriggerAttachment t : trigs) {
       if (testChance && !t.testChance(bridge)) {
         continue;
@@ -2154,13 +2099,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   public static void triggerUnitPlacement(final Set<TriggerAttachment> satisfiedTriggers, final IDelegateBridge bridge,
       final String beforeOrAfter, final String stepName, final boolean useUses, final boolean testUses,
       final boolean testChance, final boolean testWhen) {
-    Collection<TriggerAttachment> trigs = CollectionUtils.getMatches(satisfiedTriggers, placeMatch());
-    if (testWhen) {
-      trigs = CollectionUtils.getMatches(trigs, whenOrDefaultMatch(beforeOrAfter, stepName));
-    }
-    if (testUses) {
-      trigs = CollectionUtils.getMatches(trigs, availableUses);
-    }
+    final Collection<TriggerAttachment> trigs = filterSatisfiedTriggers(
+        satisfiedTriggers, placeMatch(), beforeOrAfter, stepName, testUses, testWhen);
     for (final TriggerAttachment t : trigs) {
       if (testChance && !t.testChance(bridge)) {
         continue;
@@ -2203,13 +2143,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       final IDelegateBridge bridge, final String beforeOrAfter, final String stepName, final boolean useUses,
       final boolean testUses, final boolean testChance, final boolean testWhen, final StringBuilder endOfTurnReport) {
     final GameData data = bridge.getData();
-    Collection<TriggerAttachment> trigs = CollectionUtils.getMatches(satisfiedTriggers, resourceMatch());
-    if (testWhen) {
-      trigs = CollectionUtils.getMatches(trigs, whenOrDefaultMatch(beforeOrAfter, stepName));
-    }
-    if (testUses) {
-      trigs = CollectionUtils.getMatches(trigs, availableUses);
-    }
+    final Collection<TriggerAttachment> trigs = filterSatisfiedTriggers(
+        satisfiedTriggers, resourceMatch(), beforeOrAfter, stepName, testUses, testWhen);
     final IntegerMap<Resource> resources = new IntegerMap<>();
     for (final TriggerAttachment t : trigs) {
       if (testChance && !t.testChance(bridge)) {
@@ -2252,13 +2187,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       final String stepName, final boolean useUses, final boolean testUses, final boolean testChance,
       final boolean testWhen) {
     final GameData data = bridge.getData();
-    Collection<TriggerAttachment> trigs = CollectionUtils.getMatches(satisfiedTriggers, activateTriggerMatch());
-    if (testWhen) {
-      trigs = CollectionUtils.getMatches(trigs, whenOrDefaultMatch(beforeOrAfter, stepName));
-    }
-    if (testUses) {
-      trigs = CollectionUtils.getMatches(trigs, availableUses);
-    }
+    final Collection<TriggerAttachment> trigs = filterSatisfiedTriggers(
+        satisfiedTriggers, activateTriggerMatch(), beforeOrAfter, stepName, testUses, testWhen);
     for (final TriggerAttachment t : trigs) {
       if (testChance && !t.testChance(bridge)) {
         continue;
@@ -2331,13 +2261,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       final boolean testChance, final boolean testWhen,
       final NotificationMessages notificationMessages) {
     final GameData data = bridge.getData();
-    Collection<TriggerAttachment> trigs = CollectionUtils.getMatches(satisfiedTriggers, victoryMatch());
-    if (testWhen) {
-      trigs = CollectionUtils.getMatches(trigs, whenOrDefaultMatch(beforeOrAfter, stepName));
-    }
-    if (testUses) {
-      trigs = CollectionUtils.getMatches(trigs, availableUses);
-    }
+    final Collection<TriggerAttachment> trigs = filterSatisfiedTriggers(
+        satisfiedTriggers, victoryMatch(), beforeOrAfter, stepName, testUses, testWhen);
     for (final TriggerAttachment t : trigs) {
       if (testChance && !t.testChance(bridge)) {
         continue;
@@ -2345,7 +2270,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       if (useUses) {
         t.use(bridge);
       }
-      if (t.getVictory() == null || t.getPlayers() == null) {
+      if (t.getPlayers() == null) {
         continue;
       }
       final String victoryMessage = notificationMessages.getMessage(t.getVictory().trim());

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -134,11 +134,13 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
           continue;
         }
       }
+      final FireTriggerParams fireTriggerParams = new FireTriggerParams(
+          null, null, useUsesToFire,
+          testUsesToFire, testChanceToFire, false);
       for (int i = 0; i < numberOfTimesToFire; ++i) {
         bridge.getHistoryWriter().startEvent(MyFormatter.attachmentNameToText(actionAttachment.getName())
             + " activates a trigger called: " + MyFormatter.attachmentNameToText(toFire.getName()));
-        TriggerAttachment.fireTriggers(toFireSet, testedConditionsSoFar, bridge, null, null, useUsesToFire,
-            testUsesToFire, testChanceToFire, false);
+        TriggerAttachment.fireTriggers(toFireSet, testedConditionsSoFar, bridge, fireTriggerParams);
       }
     }
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -27,6 +27,7 @@ import games.strategy.sound.SoundPath;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.AbstractTriggerAttachment;
+import games.strategy.triplea.attachments.FireTriggerParams;
 import games.strategy.triplea.attachments.ICondition;
 import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
@@ -110,10 +111,12 @@ public class EndRoundDelegate extends BaseTripleADelegate {
         final Set<TriggerAttachment> toFireTestedAndSatisfied = new HashSet<>(
             CollectionUtils.getMatches(toFirePossible, AbstractTriggerAttachment.isSatisfiedMatch(testedConditions)));
         // now list out individual types to fire, once for each of the matches above.
-        TriggerAttachment.triggerActivateTriggerOther(testedConditions, toFireTestedAndSatisfied, bridge, null, null,
-            true, true, true, true);
+        final FireTriggerParams fireTriggerParams = new FireTriggerParams(
+            null, null, true, true, true, true);
+        TriggerAttachment.triggerActivateTriggerOther(testedConditions, toFireTestedAndSatisfied, bridge,
+            fireTriggerParams);
         // will call
-        TriggerAttachment.triggerVictory(toFireTestedAndSatisfied, bridge, null, null, true, true, true, true);
+        TriggerAttachment.triggerVictory(toFireTestedAndSatisfied, bridge, fireTriggerParams);
         // signalGameOver itself
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -32,6 +32,7 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.AbstractConditionsAttachment;
 import games.strategy.triplea.attachments.AbstractTriggerAttachment;
+import games.strategy.triplea.attachments.FireTriggerParams;
 import games.strategy.triplea.attachments.ICondition;
 import games.strategy.triplea.attachments.RulesAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
@@ -273,8 +274,10 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     if (useTriggers && !triggers.isEmpty()) {
       final Set<TriggerAttachment> toFireTestedAndSatisfied = new HashSet<>(
           CollectionUtils.getMatches(triggers, AbstractTriggerAttachment.isSatisfiedMatch(testedConditions)));
-      endTurnReport.append(TriggerAttachment.triggerResourceChange(toFireTestedAndSatisfied, bridge, null, null, true,
-          true, true, true)).append("<br />");
+      endTurnReport.append(TriggerAttachment.triggerResourceChange(toFireTestedAndSatisfied, bridge,
+          new FireTriggerParams(
+              null, null, true, true, true, true)))
+          .append("<br />");
     }
 
     // Execute national objectives

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -31,6 +31,7 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.AbstractTriggerAttachment;
+import games.strategy.triplea.attachments.FireTriggerParams;
 import games.strategy.triplea.attachments.ICondition;
 import games.strategy.triplea.attachments.TriggerAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
@@ -107,20 +108,16 @@ public class MoveDelegate extends AbstractMoveDelegate {
                 .getMatches(toFireBeforeBonus, AbstractTriggerAttachment.isSatisfiedMatch(testedConditions)));
 
             // now list out individual types to fire, once for each of the matches above.
-            TriggerAttachment.triggerNotifications(toFireTestedAndSatisfied, bridge, null, null, true, true, true,
-                true);
-            TriggerAttachment.triggerPlayerPropertyChange(toFireTestedAndSatisfied, bridge, null, null, true, true,
-                true, true);
-            TriggerAttachment.triggerRelationshipTypePropertyChange(toFireTestedAndSatisfied, bridge, null, null,
-                true, true, true, true);
-            TriggerAttachment.triggerTerritoryPropertyChange(toFireTestedAndSatisfied, bridge, null, null, true,
-                true, true, true);
-            TriggerAttachment.triggerTerritoryEffectPropertyChange(toFireTestedAndSatisfied, bridge, null, null,
-                true, true, true, true);
-            TriggerAttachment.triggerChangeOwnership(toFireTestedAndSatisfied, bridge, null, null, true, true, true,
-                true);
-            TriggerAttachment.triggerUnitRemoval(toFireTestedAndSatisfied, bridge, null, null, true, true, true,
-                true);
+            final FireTriggerParams fireTriggerParams = new FireTriggerParams(
+                null, null, true, true, true, true);
+            TriggerAttachment.triggerNotifications(toFireTestedAndSatisfied, bridge, fireTriggerParams);
+            TriggerAttachment.triggerPlayerPropertyChange(toFireTestedAndSatisfied, bridge, fireTriggerParams);
+            TriggerAttachment.triggerRelationshipTypePropertyChange(toFireTestedAndSatisfied, bridge,
+                fireTriggerParams);
+            TriggerAttachment.triggerTerritoryPropertyChange(toFireTestedAndSatisfied, bridge, fireTriggerParams);
+            TriggerAttachment.triggerTerritoryEffectPropertyChange(toFireTestedAndSatisfied, bridge, fireTriggerParams);
+            TriggerAttachment.triggerChangeOwnership(toFireTestedAndSatisfied, bridge, fireTriggerParams);
+            TriggerAttachment.triggerUnitRemoval(toFireTestedAndSatisfied, bridge, fireTriggerParams);
           }
         }
       }
@@ -151,8 +148,8 @@ public class MoveDelegate extends AbstractMoveDelegate {
               .getMatches(toFireAfterBonus, AbstractTriggerAttachment.isSatisfiedMatch(testedConditions)));
 
           // now list out individual types to fire, once for each of the matches above.
-          TriggerAttachment.triggerUnitPlacement(toFireTestedAndSatisfied, bridge, null, null, true, true, true,
-              true);
+          TriggerAttachment.triggerUnitPlacement(toFireTestedAndSatisfied, bridge, new FireTriggerParams(
+              null, null, true, true, true, true));
         }
       }
       if (GameStepPropertiesHelper.isResetUnitStateAtStart(data)) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -26,6 +26,7 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.engine.random.IRandomStats.DiceType;
 import games.strategy.sound.SoundPath;
 import games.strategy.triplea.Properties;
+import games.strategy.triplea.attachments.FireTriggerParams;
 import games.strategy.triplea.attachments.ICondition;
 import games.strategy.triplea.attachments.PoliticalActionAttachment;
 import games.strategy.triplea.attachments.RulesAttachment;
@@ -62,8 +63,8 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
         final Set<TriggerAttachment> toFireTestedAndSatisfied = new HashSet<>(
             CollectionUtils.getMatches(toFirePossible, TriggerAttachment.isSatisfiedMatch(testedConditions)));
         // now list out individual types to fire, once for each of the matches above.
-        TriggerAttachment.triggerRelationshipChange(toFireTestedAndSatisfied, bridge, null, null, true, true, true,
-            true);
+        TriggerAttachment.triggerRelationshipChange(toFireTestedAndSatisfied, bridge, new FireTriggerParams(
+            null, null, true, true, true, true));
       }
     }
     chainAlliancesTogether(bridge);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -31,6 +31,7 @@ import games.strategy.engine.pbem.PbemMessagePoster;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.AbstractTriggerAttachment;
+import games.strategy.triplea.attachments.FireTriggerParams;
 import games.strategy.triplea.attachments.ICondition;
 import games.strategy.triplea.attachments.TechAbilityAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
@@ -80,11 +81,11 @@ public class PurchaseDelegate extends BaseTripleADelegate implements IPurchaseDe
           final Set<TriggerAttachment> toFireTestedAndSatisfied = new HashSet<>(
               CollectionUtils.getMatches(toFirePossible, AbstractTriggerAttachment.isSatisfiedMatch(testedConditions)));
           // now list out individual types to fire, once for each of the matches above.
-          TriggerAttachment.triggerProductionChange(toFireTestedAndSatisfied, bridge, null, null, true, true, true,
-              true);
-          TriggerAttachment.triggerProductionFrontierEditChange(toFireTestedAndSatisfied, bridge, null, null, true,
-              true, true, true);
-          TriggerAttachment.triggerPurchase(toFireTestedAndSatisfied, bridge, null, null, true, true, true, true);
+          final FireTriggerParams fireTriggerParams = new FireTriggerParams(
+              null, null, true, true, true, true);
+          TriggerAttachment.triggerProductionChange(toFireTestedAndSatisfied, bridge, fireTriggerParams);
+          TriggerAttachment.triggerProductionFrontierEditChange(toFireTestedAndSatisfied, bridge, fireTriggerParams);
+          TriggerAttachment.triggerPurchase(toFireTestedAndSatisfied, bridge, fireTriggerParams);
         }
       }
       needToInitialize = false;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
@@ -14,6 +14,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.message.IRemote;
 import games.strategy.triplea.Properties;
+import games.strategy.triplea.attachments.FireTriggerParams;
 import games.strategy.triplea.attachments.ICondition;
 import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.TriggerAttachment;
@@ -68,10 +69,11 @@ public class TechActivationDelegate extends BaseTripleADelegate {
         final Set<TriggerAttachment> toFireTestedAndSatisfied = new HashSet<>(
             CollectionUtils.getMatches(toFirePossible, TriggerAttachment.isSatisfiedMatch(testedConditions)));
         // now list out individual types to fire, once for each of the matches above.
-        TriggerAttachment.triggerUnitPropertyChange(toFireTestedAndSatisfied, bridge, null, null, true, true, true,
-            true);
-        TriggerAttachment.triggerTechChange(toFireTestedAndSatisfied, bridge, null, null, true, true, true, true);
-        TriggerAttachment.triggerSupportChange(toFireTestedAndSatisfied, bridge, null, null, true, true, true, true);
+        final FireTriggerParams fireTriggerParams = new FireTriggerParams(
+            null, null, true, true, true, true);
+        TriggerAttachment.triggerUnitPropertyChange(toFireTestedAndSatisfied, bridge, fireTriggerParams);
+        TriggerAttachment.triggerTechChange(toFireTestedAndSatisfied, bridge, fireTriggerParams);
+        TriggerAttachment.triggerSupportChange(toFireTestedAndSatisfied, bridge, fireTriggerParams);
       }
     }
     shareTechnology();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -27,6 +27,7 @@ import games.strategy.sound.SoundPath;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.AbstractTriggerAttachment;
+import games.strategy.triplea.attachments.FireTriggerParams;
 import games.strategy.triplea.attachments.ICondition;
 import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
@@ -85,7 +86,8 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
             CollectionUtils.getMatches(toFirePossible, AbstractTriggerAttachment.isSatisfiedMatch(testedConditions));
         // now list out individual types to fire, once for each of the matches above.
         TriggerAttachment.triggerAvailableTechChange(new HashSet<>(toFireTestedAndSatisfied), bridge,
-            null, null, true, true, true, true);
+            new FireTriggerParams(
+                null, null, true, true, true, true));
       }
     }
     needToInitialize = false;

--- a/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
@@ -61,6 +61,15 @@ import games.strategy.triplea.ui.display.ITripleADisplay;
 @ExtendWith(MockitoExtension.class)
 class TriggerAttachmentTest {
 
+  private static final FireTriggerParams defaultFireTriggerParams =
+      new FireTriggerParams(
+          "beforeOrAfter",
+          "stepName",
+          false, // useUses
+          false, // testUses
+          false, // testChance
+          false); // testWhen
+
   private static BattleDelegate mockAddBattleDelegate(final GameData gameData) {
     final BattleDelegate battleDelegate = mock(BattleDelegate.class);
     when(battleDelegate.getName()).thenReturn("battle");
@@ -125,15 +134,7 @@ class TriggerAttachmentTest {
 
       triggerAttachment.getPropertyMap().get("notification").setValue(notificationMessageKey);
 
-      TriggerAttachment.triggerNotifications(
-          satisfiedTriggers,
-          bridge,
-          "beforeOrAfter",
-          "stepName",
-          false, // useUses
-          false, // testUses
-          false, // testChance
-          false, // testWhen
+      TriggerAttachment.triggerNotifications(satisfiedTriggers, bridge, defaultFireTriggerParams,
           notificationMessages);
       verify(display).reportMessageToPlayers(
           not(argThat(Collection::isEmpty)), // Players.
@@ -166,15 +167,7 @@ class TriggerAttachmentTest {
       productionRuleProperty.setValue("frontier:-rule2");
       productionRuleProperty.setValue("frontier:rule3");
 
-      TriggerAttachment.triggerProductionFrontierEditChange(
-          satisfiedTriggers,
-          bridge,
-          "beforeOrAfter",
-          "stepName",
-          false, // useUses
-          false, // testUses
-          false, // testChance
-          false); // testWhen
+      TriggerAttachment.triggerProductionFrontierEditChange(satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge).addChange(not(argThat(Change::isEmpty)));
       final ArgumentCaptor<String> ruleAddArgument = ArgumentCaptor.forClass(String.class);
       verify(historyWriter, times(3)).startEvent(ruleAddArgument.capture());
@@ -203,15 +196,7 @@ class TriggerAttachmentTest {
       propertyMap.get("playerProperty").setValue("someNewValue:productionPerXTerritories");
       propertyMap.get("players").setValue("somePlayer");
 
-      TriggerAttachment.triggerPlayerPropertyChange(
-          satisfiedTriggers,
-          bridge,
-          "beforeOrAfter",
-          "stepName",
-          false, // useUses
-          false, // testUses
-          false, // testChance
-          false); // testWhen
+      TriggerAttachment.triggerPlayerPropertyChange(satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge).addChange(not(argThat(Change::isEmpty)));
     }
 
@@ -234,15 +219,7 @@ class TriggerAttachmentTest {
       propertyMap.get("relationshipTypeProperty").setValue("true:canMoveLandUnitsOverOwnedLand");
       propertyMap.get("relationshipTypes").setValue("someRelationshipType");
 
-      TriggerAttachment.triggerRelationshipTypePropertyChange(
-          satisfiedTriggers,
-          bridge,
-          "beforeOrAfter",
-          "stepName",
-          false, // useUses
-          false, // testUses
-          false, // testChance
-          false); // testWhen
+      TriggerAttachment.triggerRelationshipTypePropertyChange(satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge).addChange(not(argThat(Change::isEmpty)));
     }
 
@@ -264,15 +241,7 @@ class TriggerAttachmentTest {
       propertyMap.get("territoryProperty").setValue("true:kamikazeZone");
       propertyMap.get("territories").setValue(territoryName);
 
-      TriggerAttachment.triggerTerritoryPropertyChange(
-          satisfiedTriggers,
-          bridge,
-          "beforeOrAfter",
-          "stepName",
-          false, // useUses
-          false, // testUses
-          false, // testChance
-          false); // testWhen
+      TriggerAttachment.triggerTerritoryPropertyChange(satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge).addChange(not(argThat(Change::isEmpty)));
     }
 
@@ -295,15 +264,7 @@ class TriggerAttachmentTest {
       propertyMap.get("territoryEffectProperty").setValue("conscript:veteran:champion:unitsNotAllowed");
       propertyMap.get("territoryEffects").setValue("someTerritoryEffect");
 
-      TriggerAttachment.triggerTerritoryEffectPropertyChange(
-          satisfiedTriggers,
-          bridge,
-          "beforeOrAfter",
-          "stepName",
-          false, // useUses
-          false, // testUses
-          false, // testChance
-          false); // testWhen
+      TriggerAttachment.triggerTerritoryEffectPropertyChange(satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge).addChange(not(argThat(Change::isEmpty)));
     }
 
@@ -323,15 +284,7 @@ class TriggerAttachmentTest {
       propertyMap.get("unitProperty").setValue("4:movement");
       propertyMap.get("unitType").setValue("someUnit");
 
-      TriggerAttachment.triggerUnitPropertyChange(
-          satisfiedTriggers,
-          bridge,
-          "beforeOrAfter",
-          "stepName",
-          false, // useUses
-          false, // testUses
-          false, // testChance
-          false); // testWhen
+      TriggerAttachment.triggerUnitPropertyChange(satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge).addChange(not(argThat(Change::isEmpty)));
     }
 
@@ -364,15 +317,7 @@ class TriggerAttachmentTest {
 
       triggerAttachment.getPropertyMap().get("relationshipChange").setValue("Keoland:Furyondy:any:allied");
 
-      TriggerAttachment.triggerRelationshipChange(
-          satisfiedTriggers,
-          bridge,
-          "beforeOrAfter",
-          "stepName",
-          false, // useUses
-          false, // testUses
-          false, // testChance
-          false); // testWhen
+      TriggerAttachment.triggerRelationshipChange(satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge).addChange(not(argThat(Change::isEmpty)));
     }
 
@@ -397,15 +342,7 @@ class TriggerAttachmentTest {
       triggerAttachment.getPropertyMap().get("availableTech")
           .setValue("airCategory:longRangeAir:jetPower:heavyBomber");
 
-      TriggerAttachment.triggerAvailableTechChange(
-          satisfiedTriggers,
-          bridge,
-          "beforeOrAfter",
-          "stepName",
-          false, // useUses
-          false, // testUses
-          false, // testChance
-          false); // testWhen
+      TriggerAttachment.triggerAvailableTechChange(satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge, times(3)).addChange(not(argThat(Change::isEmpty)));
     }
 
@@ -429,15 +366,7 @@ class TriggerAttachmentTest {
 
       triggerAttachment.getPropertyMap().get("tech").setValue("longRangeAir:heavyBomber");
 
-      TriggerAttachment.triggerTechChange(
-          satisfiedTriggers,
-          bridge,
-          "beforeOrAfter",
-          "stepName",
-          false, // useUses
-          false, // testUses
-          false, // testChance
-          false); // testWhen
+      TriggerAttachment.triggerTechChange(satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge, times(2)).addChange(not(argThat(Change::isEmpty)));
     }
 
@@ -461,15 +390,7 @@ class TriggerAttachmentTest {
 
       triggerAttachment.getPropertyMap().get("frontier").setValue("Americans_Super_Carrier_production");
 
-      TriggerAttachment.triggerProductionChange(
-          satisfiedTriggers,
-          bridge,
-          "beforeOrAfter",
-          "stepName",
-          false, // useUses
-          false, // testUses
-          false, // testChance
-          false); // testWhen
+      TriggerAttachment.triggerProductionChange(satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge).addChange(not(argThat(Change::isEmpty)));
     }
 
@@ -492,15 +413,7 @@ class TriggerAttachmentTest {
       triggerAttachment.getPropertyMap().get("support")
           .setValue("supportAttachmentBattlefleet_Support");
 
-      TriggerAttachment.triggerSupportChange(
-          satisfiedTriggers,
-          bridge,
-          "beforeOrAfter",
-          "stepName",
-          false, // useUses
-          false, // testUses
-          false, // testChance
-          false); // testWhen
+      TriggerAttachment.triggerSupportChange(satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge).addChange(not(argThat(Change::isEmpty)));
     }
 
@@ -531,15 +444,7 @@ class TriggerAttachmentTest {
       changeOwnership.setValue("Archangel:Russia:Britain:false"); // Belonging to non-Russia, so should not match.
       changeOwnership.setValue("Eastern Szechwan:any:China:false");
 
-      TriggerAttachment.triggerChangeOwnership(
-          satisfiedTriggers,
-          bridge,
-          "beforeOrAfter",
-          "stepName",
-          false, // useUses
-          false, // testUses
-          false, // testChance
-          false); // testWhen
+      TriggerAttachment.triggerChangeOwnership(satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge, times(2)).addChange(not(argThat(Change::isEmpty)));
     }
 
@@ -562,15 +467,7 @@ class TriggerAttachmentTest {
       purchase.setValue("1:brigantine");
       purchase.setValue("2:sellsword:skirmisher");
 
-      TriggerAttachment.triggerPurchase(
-          satisfiedTriggers,
-          bridge,
-          "beforeOrAfter",
-          "stepName",
-          false, // useUses
-          false, // testUses
-          false, // testChance
-          false); // testWhen
+      TriggerAttachment.triggerPurchase(satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge).addChange(not(argThat(Change::isEmpty)));
     }
 
@@ -610,15 +507,7 @@ class TriggerAttachmentTest {
       removeUnits.setValue("5:Hraak Pass:conscript");
       removeUnits.setValue("5:all:sellsword");
 
-      TriggerAttachment.triggerUnitRemoval(
-          satisfiedTriggers,
-          bridge,
-          "beforeOrAfter",
-          "stepName",
-          false, // useUses
-          false, // testUses
-          false, // testChance
-          false); // testWhen
+      TriggerAttachment.triggerUnitRemoval(satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge, times(3)).addChange(not(argThat(Change::isEmpty)));
     }
 
@@ -651,15 +540,7 @@ class TriggerAttachmentTest {
       placement.setValue("2:Hraak Pass:conscript:sellsword");
       placement.setValue("Soull Pass:sellsword");
 
-      TriggerAttachment.triggerUnitPlacement(
-          satisfiedTriggers,
-          bridge,
-          "beforeOrAfter",
-          "stepName",
-          false, // useUses
-          false, // testUses
-          false, // testChance
-          false); // testWhen
+      TriggerAttachment.triggerUnitPlacement(satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge, times(3)).addChange(not(argThat(Change::isEmpty)));
     }
 
@@ -677,15 +558,7 @@ class TriggerAttachmentTest {
       triggerAttachment.getPropertyMap().get("resource").setValue(Constants.PUS);
       triggerAttachment.getPropertyMap().get("resourceCount").setValue("23");
 
-      TriggerAttachment.triggerResourceChange(
-          satisfiedTriggers,
-          bridge,
-          "beforeOrAfter",
-          "stepName",
-          false, // useUses
-          false, // testUses
-          false, // testChance
-          false); // testWhen
+      TriggerAttachment.triggerResourceChange(satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge, times(1)).addChange(not(argThat(Change::isEmpty)));
     }
 
@@ -724,15 +597,7 @@ class TriggerAttachmentTest {
           String.format("%s:1:false:false:false:false", triggerToBeFiredTriggerAttachment.getName()));
 
       TriggerAttachment.triggerActivateTriggerOther(
-          Collections.emptyMap(),
-          satisfiedTriggers,
-          bridge,
-          "beforeOrAfter",
-          "stepName",
-          false, // useUses
-          false, // testUses
-          false, // testChance
-          false); // testWhen
+          Collections.emptyMap(), satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge, times(2)).addChange(not(argThat(Change::isEmpty)));
     }
 
@@ -756,16 +621,7 @@ class TriggerAttachmentTest {
       final NotificationMessages notificationMessages = mock(NotificationMessages.class);
       when(notificationMessages.getMessage(notificationMessageKey)).thenReturn(notificationMessage);
 
-      TriggerAttachment.triggerVictory(
-          satisfiedTriggers,
-          bridge,
-          "beforeOrAfter",
-          "stepName",
-          false, // useUses
-          false, // testUses
-          false, // testChance
-          false, // testWhen
-          notificationMessages);
+      TriggerAttachment.triggerVictory(satisfiedTriggers, bridge, defaultFireTriggerParams, notificationMessages);
       verify(endRoundDelegate).signalGameOver(any(), any(), any());
     }
   }


### PR DESCRIPTION
## Overview

The first commit refactors filtering in the different trigger methods, and the second commit refactors away the long parameter lists for the different trigger methods as well as elsewhere by using a parameter object.

## Functional Changes

It should only be refactoring.

## Manual Testing Performed

Played a simple game including Hard AI (Middle Earth).

## Before & After Screen Shots

### Before

### After

## Additional Review Notes

I believe the second commit is valuable, though while it overall seems like an improvement to me, parameter objects are in some ways less nice.

I have some TODOs reg. the documentation of the parameter object, since I am not quite certain where to find all the relevant documentation or what exactly they do (I have added some references I found).

I tried to refactor away the part reg.:

```java
if (fireTriggerParams.testChance && !t.testChance(bridge)) {
  continue;
}
if (fireTriggerParams.useUses) {
  t.use(bridge);
}
```

, but the code snippet has a fair bit of side-effects, and I did not find an approach that would preserve the order of statement execution while making the code seem better.