### PR TITLE
Divide isSub into Attributes

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/Properties.java
+++ b/game-core/src/main/java/games/strategy/triplea/Properties.java
@@ -291,7 +291,8 @@ public final class Properties implements Constants {
   }
 
   /**
-   * Subs do not restrict movement of other units.
+   * Subs do not restrict movement of other units. When 'isSub' unit option is used this
+   * sets 'canBeMovedThroughByEnemies' unit option to true.
    */
   public static boolean getIgnoreSubInMovement(final GameData data) {
     return data.getProperties().get(IGNORE_SUB_IN_MOVEMENT, false);
@@ -302,7 +303,8 @@ public final class Properties implements Constants {
   }
 
   /**
-   * Air restricted from attacking subs unless DD present.
+   * Air restricted from attacking subs unless DD present. When 'isSub' unit option is used this
+   * sets 'cantBeTargetedBy' unit option to all air units.
    */
   public static boolean getAirAttackSubRestricted(final GameData data) {
     return data.getProperties().get(AIR_ATTACK_SUB_RESTRICTED, false);

--- a/game-core/src/main/java/games/strategy/triplea/Properties.java
+++ b/game-core/src/main/java/games/strategy/triplea/Properties.java
@@ -304,7 +304,7 @@ public final class Properties implements Constants {
 
   /**
    * Air restricted from attacking subs unless DD present. When 'isSub' unit option is used this
-   * sets 'cantBeTargetedBy' unit option to all air units.
+   * sets 'canNotBeTargetedBy' unit option to all air units.
    */
   public static boolean getAirAttackSubRestricted(final GameData data) {
     return data.getProperties().get(AIR_ATTACK_SUB_RESTRICTED, false);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -1030,7 +1030,7 @@ class ProCombatMoveAi {
 
         // Add destroyer if territory has subs and a destroyer has been already added
         final List<Unit> defendingUnits = attackMap.get(t).getMaxEnemyDefenders(player, data);
-        if (defendingUnits.stream().anyMatch(Matches.unitIsSub())
+        if (defendingUnits.stream().anyMatch(Matches.unitHasSubBattleAbilities())
             && attackMap.get(t).getUnits().stream().noneMatch(Matches.unitIsDestroyer())) {
           attackMap.get(t).addUnit(unit);
           addedUnits.add(unit);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -1797,7 +1797,8 @@ class ProNonCombatMoveAi {
         final int numLandAttackTerritories = CollectionUtils.countMatches(possibleAttackTerritories,
             ProMatches.territoryIsEnemyOrCantBeHeldAndIsAdjacentToMyLandUnits(player, data, territoriesThatCantBeHeld));
         final int numSeaAttackTerritories = CollectionUtils.countMatches(possibleAttackTerritories, Matches
-            .territoryHasEnemySeaUnits(player, data).and(Matches.territoryHasUnitsThatMatch(Matches.unitIsNotSub())));
+            .territoryHasEnemySeaUnits(player, data)
+            .and(Matches.territoryHasUnitsThatMatch(Matches.unitHasSubBattleAbilities().negate())));
         final Set<Territory> possibleMoveTerritories =
             data.getMap().getNeighbors(t, range, ProMatches.territoryCanMoveAirUnits(player, data, true));
         final int numNearbyEnemyTerritories = CollectionUtils.countMatches(possibleMoveTerritories,

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -577,7 +577,7 @@ class ProPurchaseAi {
 
       // Determine if need destroyer
       boolean needDestroyer = false;
-      if (enemyAttackOptions.getMax(t).getMaxUnits().stream().anyMatch(Matches.unitIsSub())
+      if (enemyAttackOptions.getMax(t).getMaxUnits().stream().anyMatch(Matches.unitHasSubBattleAbilities())
           && ownedLocalUnits.stream().noneMatch(Matches.unitIsDestroyer())) {
         needDestroyer = true;
       }
@@ -1173,7 +1173,7 @@ class ProPurchaseAi {
       if (enemyAttackOptions.getMax(t) != null) {
 
         // Determine if need destroyer
-        if (enemyAttackOptions.getMax(t).getMaxUnits().stream().anyMatch(Matches.unitIsSub())
+        if (enemyAttackOptions.getMax(t).getMaxUnits().stream().anyMatch(Matches.unitHasSubBattleAbilities())
             && t.getUnitCollection().getMatches(Matches.unitIsOwnedBy(player)).stream()
                 .noneMatch(Matches.unitIsDestroyer())) {
           needDestroyer = true;
@@ -1186,7 +1186,7 @@ class ProPurchaseAi {
             initialDefendingUnits, enemyAttackOptions.getMax(t).getMaxBombardUnits());
         boolean hasOnlyRetreatingSubs =
             Properties.getSubRetreatBeforeBattle(data)
-                && !initialDefendingUnits.isEmpty() && initialDefendingUnits.stream().allMatch(Matches.unitIsSub())
+                && !initialDefendingUnits.isEmpty() && initialDefendingUnits.stream().allMatch(Matches.unitCanEvade())
                 && enemyAttackOptions.getMax(t).getMaxUnits().stream().noneMatch(Matches.unitIsDestroyer());
         final List<Unit> unitsToPlace = new ArrayList<>();
         for (final ProPurchaseTerritory purchaseTerritory : selectedPurchaseTerritories) {
@@ -1253,7 +1253,7 @@ class ProPurchaseAi {
                 defendingUnits, enemyAttackOptions.getMax(t).getMaxBombardUnits());
             hasOnlyRetreatingSubs =
                 Properties.getSubRetreatBeforeBattle(data) && !defendingUnits.isEmpty()
-                    && defendingUnits.stream().allMatch(Matches.unitIsSub())
+                    && defendingUnits.stream().allMatch(Matches.unitCanEvade())
                     && enemyAttackOptions.getMax(t).getMaxUnits().stream().noneMatch(Matches.unitIsDestroyer());
           }
         }
@@ -1324,7 +1324,8 @@ class ProPurchaseAi {
       }
 
       // Check if destroyer is needed
-      final int numEnemySubs = CollectionUtils.countMatches(enemyUnitsInSeaTerritories, Matches.unitIsSub());
+      final int numEnemySubs =
+          CollectionUtils.countMatches(enemyUnitsInSeaTerritories, Matches.unitHasSubBattleAbilities());
       final int numMyDestroyers = CollectionUtils.countMatches(myUnitsInSeaTerritories, Matches.unitIsDestroyer());
       if (numEnemySubs > 2 * numMyDestroyers) {
         needDestroyer = true;

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
@@ -520,12 +520,11 @@ final class ProTechAi {
     if (start == null || destination == null || !start.isWater() || !destination.isWater()) {
       return null;
     }
-    final Predicate<Unit> sub = Matches.unitIsSub().negate();
     final Predicate<Unit> transport = Matches.unitIsTransport().negate().and(Matches.unitIsLand().negate());
     final Predicate<Unit> unitCond = PredicateBuilder.of(Matches.unitIsInfrastructure().negate())
         .and(Matches.alliedUnit(player, data).negate())
+        .and(Matches.unitCanBeMovedThroughByEnemies().negate())
         .andIf(Properties.getIgnoreTransportInMovement(data), transport)
-        .andIf(Properties.getIgnoreSubInMovement(data), sub)
         .build();
     final Predicate<Territory> routeCond = Matches.territoryHasUnitsThatMatch(unitCond).negate()
         .and(Matches.territoryIsWater());

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
@@ -110,7 +110,7 @@ public class ProPurchaseOption {
     transportCost = unitAttachment.getTransportCost() * quantity;
     carrierCost = unitAttachment.getCarrierCost() * quantity;
     isAir = unitAttachment.getIsAir();
-    isSub = unitAttachment.getIsSub();
+    isSub = !unitAttachment.getCantTarget().isEmpty();
     isDestroyer = unitAttachment.getIsDestroyer();
     isTransport = unitAttachment.getTransportCapacity() > 0;
     isLandTransport = unitAttachment.isLandTransport();

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
@@ -110,7 +110,7 @@ public class ProPurchaseOption {
     transportCost = unitAttachment.getTransportCost() * quantity;
     carrierCost = unitAttachment.getCarrierCost() * quantity;
     isAir = unitAttachment.getIsAir();
-    isSub = !unitAttachment.getCantTarget().isEmpty();
+    isSub = !unitAttachment.getCanNotTarget().isEmpty();
     isDestroyer = unitAttachment.getIsDestroyer();
     isTransport = unitAttachment.getTransportCapacity() > 0;
     isLandTransport = unitAttachment.isLandTransport();

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -173,10 +173,9 @@ public final class ProMatches {
   private static Predicate<Territory> territoryHasOnlyIgnoredUnits(final PlayerId player, final GameData data) {
     return t -> {
       final Predicate<Unit> subOnly = Matches.unitIsInfrastructure()
-          .or(Matches.unitIsSub())
+          .or(Matches.unitCanBeMovedThroughByEnemies())
           .or(Matches.enemyUnit(player, data).negate());
-      return (Properties.getIgnoreSubInMovement(data) && t.getUnitCollection().allMatch(subOnly))
-          || Matches.territoryHasNoEnemyUnits(player, data).test(t);
+      return t.getUnitCollection().allMatch(subOnly) || Matches.territoryHasNoEnemyUnits(player, data).test(t);
     };
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProOddsCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProOddsCalculator.java
@@ -120,7 +120,7 @@ public class ProOddsCalculator {
       final double tuv = TuvUtils.getTuv(mainCombatDefenders, ProData.unitValueMap);
       return new ProBattleResult(100, 0.1 + tuv, true, attackingUnits, new ArrayList<>(), 0);
     } else if (checkSubmerge && Properties.getSubRetreatBeforeBattle(data) && !defendingUnits.isEmpty()
-        && defendingUnits.stream().allMatch(Matches.unitIsSub())
+        && defendingUnits.stream().allMatch(Matches.unitCanEvade())
         && attackingUnits.stream().noneMatch(Matches.unitIsDestroyer())) {
       return new ProBattleResult();
     }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -987,7 +987,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
           allUnits.retainAll(
               CollectionUtils.getMatches(allUnits, Matches.enemyUnitOfAnyOfThesePlayers(players, data)
                   .and(Matches.unitIsSea())
-                  .and(Matches.unitIsNotSub())
+                  .and(Matches.unitCanEvade().negate())
                   .and(Matches.unitIsNotTransportButCouldBeCombatTransport())));
           break;
         default:

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -806,7 +806,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
             taa = new TechAbilityAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, ta, data);
             ta.addAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME, taa);
             final List<UnitType> allSubs =
-                CollectionUtils.getMatches(data.getUnitTypeList().getAllUnitTypes(), Matches.unitTypeIsSub());
+                CollectionUtils.getMatches(data.getUnitTypeList().getAllUnitTypes(), Matches.unitTypeIsFirstStrike());
             for (final UnitType sub : allSubs) {
               taa.setAttackBonus("1:" + sub.getName());
             }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -83,8 +83,8 @@ public class UnitAttachment extends DefaultAttachment {
   // sub/destroyer related
   private boolean canEvade = false;
   private boolean isFirstStrike = false;
-  private Set<UnitType> cantTarget = new HashSet<>();
-  private Set<UnitType> cantBeTargetedBy = new HashSet<>();
+  private Set<UnitType> canNotTarget = new HashSet<>();
+  private Set<UnitType> canNotBeTargetedBy = new HashSet<>();
   private boolean canMoveThroughEnemies = false;
   private boolean canBeMovedThroughByEnemies = false;
   private boolean isDestroyer = false;
@@ -603,11 +603,11 @@ public class UnitAttachment extends DefaultAttachment {
     setCanMoveThroughEnemies(s && Properties.getSubmersibleSubs(getData()));
     setCanBeMovedThroughByEnemies(s && Properties.getIgnoreSubInMovement(getData()));
     if (s) {
-      cantTarget = null;
-      cantBeTargetedBy = Properties.getAirAttackSubRestricted(getData()) ? null : new HashSet<>();
+      canNotTarget = null;
+      canNotBeTargetedBy = Properties.getAirAttackSubRestricted(getData()) ? null : new HashSet<>();
     } else {
-      resetCantTarget();
-      resetCantBeTargetedBy();
+      resetCanNotTarget();
+      resetCanNotBeTargetedBy();
     }
   }
 
@@ -643,58 +643,58 @@ public class UnitAttachment extends DefaultAttachment {
     return canBeMovedThroughByEnemies;
   }
 
-  private void setCantTarget(final String value) throws GameParseException {
+  private void setCanNotTarget(final String value) throws GameParseException {
     final String[] s = splitOnColon(value);
     for (final String u : s) {
       final UnitType ut = getData().getUnitTypeList().getUnitType(u);
       if (ut == null) {
-        throw new GameParseException("cantTarget: no such unit type: " + u + thisErrorMsg());
+        throw new GameParseException("canNotTarget: no such unit type: " + u + thisErrorMsg());
       }
-      cantTarget.add(ut);
+      canNotTarget.add(ut);
     }
   }
 
-  private void setCantTarget(final Set<UnitType> value) {
-    cantTarget = value;
+  private void setCanNotTarget(final Set<UnitType> value) {
+    canNotTarget = value;
   }
 
-  public Set<UnitType> getCantTarget() {
-    if (cantTarget == null) {
-      cantTarget = new HashSet<>(
+  public Set<UnitType> getCanNotTarget() {
+    if (canNotTarget == null) {
+      canNotTarget = new HashSet<>(
           CollectionUtils.getMatches(getData().getUnitTypeList().getAllUnitTypes(), Matches.unitTypeIsAir()));
     }
-    return cantTarget;
+    return canNotTarget;
   }
 
-  private void resetCantTarget() {
-    cantTarget = new HashSet<>();
+  private void resetCanNotTarget() {
+    canNotTarget = new HashSet<>();
   }
 
-  private void setCantBeTargetedBy(final String value) throws GameParseException {
+  private void setCanNotBeTargetedBy(final String value) throws GameParseException {
     final String[] s = splitOnColon(value);
     for (final String u : s) {
       final UnitType ut = getData().getUnitTypeList().getUnitType(u);
       if (ut == null) {
-        throw new GameParseException("cantBeTargetedBy: no such unit type: " + u + thisErrorMsg());
+        throw new GameParseException("canNotBeTargetedBy: no such unit type: " + u + thisErrorMsg());
       }
-      cantBeTargetedBy.add(ut);
+      canNotBeTargetedBy.add(ut);
     }
   }
 
-  private void setCantBeTargetedBy(final Set<UnitType> value) {
-    cantBeTargetedBy = value;
+  private void setCanNotBeTargetedBy(final Set<UnitType> value) {
+    canNotBeTargetedBy = value;
   }
 
-  public Set<UnitType> getCantBeTargetedBy() {
-    if (cantBeTargetedBy == null) {
-      cantBeTargetedBy = new HashSet<>(
+  public Set<UnitType> getCanNotBeTargetedBy() {
+    if (canNotBeTargetedBy == null) {
+      canNotBeTargetedBy = new HashSet<>(
           CollectionUtils.getMatches(getData().getUnitTypeList().getAllUnitTypes(), Matches.unitTypeIsAir()));
     }
-    return cantBeTargetedBy;
+    return canNotBeTargetedBy;
   }
 
-  private void resetCantBeTargetedBy() {
-    cantBeTargetedBy = new HashSet<>();
+  private void resetCanNotBeTargetedBy() {
+    canNotBeTargetedBy = new HashSet<>();
   }
 
   private void setIsCombatTransport(final String s) {
@@ -2745,8 +2745,8 @@ public class UnitAttachment extends DefaultAttachment {
         + "  carrierCost:" + carrierCost
         + "  canEvade:" + canEvade
         + "  isFirstStrike:" + isFirstStrike
-        + "  cantTarget:" + (cantTarget.isEmpty() ? "empty" : cantTarget.toString())
-        + "  cantBeTargetedBy:" + (cantBeTargetedBy.isEmpty() ? "empty" : cantBeTargetedBy.toString())
+        + "  canNotTarget:" + (canNotTarget.isEmpty() ? "empty" : canNotTarget.toString())
+        + "  canNotBeTargetedBy:" + (canNotBeTargetedBy.isEmpty() ? "empty" : canNotBeTargetedBy.toString())
         + "  canMoveThroughEnemies:" + canMoveThroughEnemies
         + "  canBeMovedThroughByEnemies:" + canBeMovedThroughByEnemies
         + "  isDestroyer:" + isDestroyer
@@ -3042,16 +3042,16 @@ public class UnitAttachment extends DefaultAttachment {
     if (getCanBeMovedThroughByEnemies()) {
       tuples.add(Tuple.of("Can Be Moved Through By Enemies", ""));
     }
-    if (!getCantTarget().isEmpty()) {
-      if (getCantTarget().size() <= 4) {
-        tuples.add(Tuple.of("Can't Target: ", getCantTarget().toString()));
+    if (!getCanNotTarget().isEmpty()) {
+      if (getCanNotTarget().size() <= 4) {
+        tuples.add(Tuple.of("Can't Target: ", getCanNotTarget().toString()));
       } else {
         tuples.add(Tuple.of("Can't Target Some Units", ""));
       }
     }
-    if (!getCantBeTargetedBy().isEmpty()) {
-      if (getCantBeTargetedBy().size() <= 4) {
-        tuples.add(Tuple.of("Can't Be Targeted By: ", getCantBeTargetedBy().toString()));
+    if (!getCanNotBeTargetedBy().isEmpty()) {
+      if (getCanNotBeTargetedBy().size() <= 4) {
+        tuples.add(Tuple.of("Can't Be Targeted By: ", getCanNotBeTargetedBy().toString()));
       } else {
         tuples.add(Tuple.of("Can't Be Targeted By Some Units", ""));
       }
@@ -3411,18 +3411,18 @@ public class UnitAttachment extends DefaultAttachment {
                 this::setIsFirstStrike,
                 this::getIsFirstStrike,
                 () -> false))
-        .put("cantTarget",
+        .put("canNotTarget",
             MutableProperty.of(
-                this::setCantTarget,
-                this::setCantTarget,
-                this::getCantTarget,
-                this::resetCantTarget))
-        .put("cantBeTargetedBy",
+                this::setCanNotTarget,
+                this::setCanNotTarget,
+                this::getCanNotTarget,
+                this::resetCanNotTarget))
+        .put("canNotBeTargetedBy",
             MutableProperty.of(
-                this::setCantBeTargetedBy,
-                this::setCantBeTargetedBy,
-                this::getCantBeTargetedBy,
-                this::resetCantBeTargetedBy))
+                this::setCanNotBeTargetedBy,
+                this::setCanNotBeTargetedBy,
+                this::getCanNotBeTargetedBy,
+                this::resetCanNotBeTargetedBy))
         .put("canMoveThroughEnemies",
             MutableProperty.ofMapper(
                 DefaultAttachment::getBool,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -496,7 +496,7 @@ public class BattleTracker implements Serializable {
       // TODO check if istrn and NOT isDD
       // If subs are restricted from controlling sea zones, subtract them
       if (Properties.getSubControlSeaZoneRestricted(data)) {
-        totalMatches -= CollectionUtils.countMatches(arrivedUnits, Matches.unitIsSub());
+        totalMatches -= CollectionUtils.countMatches(arrivedUnits, Matches.unitCanBeMovedThroughByEnemies());
       }
       if (totalMatches == 0) {
         return;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -106,12 +106,36 @@ public final class Matches {
     return unit -> UnitAttachment.get(unit.getType()).getIsSea();
   }
 
-  public static Predicate<Unit> unitIsSub() {
-    return unit -> UnitAttachment.get(unit.getType()).getIsSub();
+  // public static Predicate<Unit> unitIsSub() {
+  // return unit -> UnitAttachment.get(unit.getType()).getIsSub();
+  // }
+
+  public static Predicate<Unit> unitHasSubBattleAbilities() {
+    return unitCanEvade().or(unitIsFirstStrike()).or(unitCantBeTargetedByAll());
   }
 
-  public static Predicate<Unit> unitIsNotSub() {
-    return unitIsSub().negate();
+  public static Predicate<Unit> unitCanEvade() {
+    return unit -> UnitAttachment.get(unit.getType()).getCanEvade();
+  }
+
+  public static Predicate<Unit> unitIsFirstStrike() {
+    return unit -> UnitAttachment.get(unit.getType()).getIsFirstStrike();
+  }
+
+  public static Predicate<Unit> unitCanMoveThroughEnemies() {
+    return unit -> UnitAttachment.get(unit.getType()).getCanMoveThroughEnemies();
+  }
+
+  public static Predicate<Unit> unitCanBeMovedThroughByEnemies() {
+    return unit -> UnitAttachment.get(unit.getType()).getCanBeMovedThroughByEnemies();
+  }
+
+  public static Predicate<Unit> unitCantTargetAll() {
+    return unit -> !UnitAttachment.get(unit.getType()).getCantBeTargetedBy().isEmpty();
+  }
+
+  public static Predicate<Unit> unitCantBeTargetedByAll() {
+    return unit -> !UnitAttachment.get(unit.getType()).getCantBeTargetedBy().isEmpty();
   }
 
   private static Predicate<Unit> unitIsCombatTransport() {
@@ -1414,8 +1438,8 @@ public final class Matches {
     return u -> TripleAUnit.get(u).getSubmerged();
   }
 
-  public static Predicate<UnitType> unitTypeIsSub() {
-    return type -> UnitAttachment.get(type).getIsSub();
+  public static Predicate<UnitType> unitTypeIsFirstStrike() {
+    return type -> UnitAttachment.get(type).getIsFirstStrike();
   }
 
   static Predicate<Unit> unitOwnerHasImprovedArtillerySupportTech() {
@@ -1433,8 +1457,8 @@ public final class Matches {
     final Predicate<Unit> unitCond = PredicateBuilder
         .of(unitIsInfrastructure().negate())
         .and(alliedUnit(player, data).negate())
+        .and(unitCanBeMovedThroughByEnemies().negate())
         .andIf(Properties.getIgnoreTransportInMovement(data), transport)
-        .andIf(Properties.getIgnoreSubInMovement(data), unitIsSub().negate())
         .build();
     return territoryHasUnitsThatMatch(unitCond).negate().and(territoryIsWater());
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -106,10 +106,6 @@ public final class Matches {
     return unit -> UnitAttachment.get(unit.getType()).getIsSea();
   }
 
-  // public static Predicate<Unit> unitIsSub() {
-  // return unit -> UnitAttachment.get(unit.getType()).getIsSub();
-  // }
-
   public static Predicate<Unit> unitHasSubBattleAbilities() {
     return unitCanEvade().or(unitIsFirstStrike()).or(unitCantBeTargetedByAll());
   }
@@ -131,7 +127,7 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitCantTargetAll() {
-    return unit -> !UnitAttachment.get(unit.getType()).getCantBeTargetedBy().isEmpty();
+    return unit -> !UnitAttachment.get(unit.getType()).getCantTarget().isEmpty();
   }
 
   public static Predicate<Unit> unitCantBeTargetedByAll() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -107,7 +107,7 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitHasSubBattleAbilities() {
-    return unitCanEvade().or(unitIsFirstStrike()).or(unitCantBeTargetedByAll());
+    return unitCanEvade().or(unitIsFirstStrike()).or(unitCanNotBeTargetedByAll());
   }
 
   public static Predicate<Unit> unitCanEvade() {
@@ -126,12 +126,12 @@ public final class Matches {
     return unit -> UnitAttachment.get(unit.getType()).getCanBeMovedThroughByEnemies();
   }
 
-  public static Predicate<Unit> unitCantTargetAll() {
-    return unit -> !UnitAttachment.get(unit.getType()).getCantTarget().isEmpty();
+  public static Predicate<Unit> unitCanNotTargetAll() {
+    return unit -> !UnitAttachment.get(unit.getType()).getCanNotTarget().isEmpty();
   }
 
-  public static Predicate<Unit> unitCantBeTargetedByAll() {
-    return unit -> !UnitAttachment.get(unit.getType()).getCantBeTargetedBy().isEmpty();
+  public static Predicate<Unit> unitCanNotBeTargetedByAll() {
+    return unit -> !UnitAttachment.get(unit.getType()).getCanNotBeTargetedBy().isEmpty();
   }
 
   private static Predicate<Unit> unitIsCombatTransport() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -330,7 +330,7 @@ public class MovePerformer implements Serializable {
             .anyMatch(Matches.unitIsEnemyOf(data, id).and(Matches.unitIsDestroyer()))) {
       // if we are allowed to have our subs enter any sea zone with enemies during noncombat, we want to make sure we
       // can't keep moving them if there is an enemy destroyer there
-      for (final Unit unit : CollectionUtils.getMatches(units, Matches.unitIsSub())) {
+      for (final Unit unit : CollectionUtils.getMatches(units, Matches.unitCanMoveThroughEnemies())) {
         change.add(ChangeFactory.markNoMovementChange(Collections.singleton(unit)));
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -544,7 +544,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
     // Air units can't attack subs without Destroyers present
     if (attackingUnits.stream().anyMatch(Matches.unitIsAir())
-        && defendingUnits.stream().anyMatch(Matches.unitCantBeTargetedByAll())
+        && defendingUnits.stream().anyMatch(Matches.unitCanNotBeTargetedByAll())
         && !canAirAttackSubs(defendingUnits, attackingUnits)) {
       steps.add(SUBMERGE_SUBS_VS_AIR_ONLY);
       steps.add(AIR_ATTACK_NON_SUBS);
@@ -557,14 +557,14 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // also, ww2v3/global rules, defending subs without sneak attack fire with all defenders
     final Collection<Unit> units = new ArrayList<>(defendingUnits);
     units.addAll(defendingWaitingToDie);
-    if (units.stream().anyMatch(Matches.unitCantTargetAll()) && !defenderSubsFireFirst
+    if (units.stream().anyMatch(Matches.unitCanNotTargetAll()) && !defenderSubsFireFirst
         && (defendingSubsFireWithAllDefenders || defendingSubsFireWithAllDefendersAlways)) {
       steps.add(defender.getName() + SUBS_FIRE);
       steps.add(attacker.getName() + SELECT_SUB_CASUALTIES);
     }
     // Air Units can't attack subs without Destroyers present
     if (defendingUnits.stream().anyMatch(Matches.unitIsAir())
-        && attackingUnits.stream().anyMatch(Matches.unitCantBeTargetedByAll())
+        && attackingUnits.stream().anyMatch(Matches.unitCanNotBeTargetedByAll())
         && !canAirAttackSubs(attackingUnits, units)) {
       steps.add(AIR_DEFEND_NON_SUBS);
     }
@@ -1715,7 +1715,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
    */
   private void submergeSubsVsOnlyAir(final IDelegateBridge bridge) {
     // if All attackers are AIR, submerge any defending subs
-    final Predicate<Unit> subMatch = Matches.unitCanEvade().and(Matches.unitCantBeTargetedByAll());
+    final Predicate<Unit> subMatch = Matches.unitCanEvade().and(Matches.unitCanNotBeTargetedByAll());
     if (!attackingUnits.isEmpty() && attackingUnits.stream().allMatch(Matches.unitIsAir())
         && defendingUnits.stream().anyMatch(subMatch)) {
       // Get all defending subs (including allies) in the territory
@@ -1768,7 +1768,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (!canAirAttackSubs(defendingUnits, units)) {
       units = CollectionUtils.getMatches(units, Matches.unitIsAir());
       final Collection<Unit> enemyUnitsNotSubs =
-          CollectionUtils.getMatches(defendingUnits, Matches.unitCantBeTargetedByAll().negate());
+          CollectionUtils.getMatches(defendingUnits, Matches.unitCanNotBeTargetedByAll().negate());
       final List<Unit> allEnemyUnitsAliveOrWaitingToDie = new ArrayList<>(defendingUnits);
       allEnemyUnitsAliveOrWaitingToDie.addAll(defendingWaitingToDie);
       fire(defender.getName() + SELECT_CASUALTIES, units, enemyUnitsNotSubs, allEnemyUnitsAliveOrWaitingToDie, false,
@@ -1777,7 +1777,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   private boolean canAirAttackSubs(final Collection<Unit> firedAt, final Collection<Unit> firing) {
-    return firedAt.stream().noneMatch(Matches.unitCantBeTargetedByAll())
+    return firedAt.stream().noneMatch(Matches.unitCanNotBeTargetedByAll())
         || firing.stream().anyMatch(Matches.unitIsDestroyer());
   }
 
@@ -1790,7 +1790,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (!canAirAttackSubs(attackingUnits, units)) {
       units = CollectionUtils.getMatches(units, Matches.unitIsAir());
       final Collection<Unit> enemyUnitsNotSubs =
-          CollectionUtils.getMatches(attackingUnits, Matches.unitCantBeTargetedByAll().negate());
+          CollectionUtils.getMatches(attackingUnits, Matches.unitCanNotBeTargetedByAll().negate());
       if (enemyUnitsNotSubs.isEmpty()) {
         return;
       }
@@ -1940,10 +1940,10 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // comparatively simple rules for isSuicide units. if AirAttackSubRestricted and you have no destroyers, you can't
     // attack subs with anything.
     if (attackingUnits.stream().noneMatch(Matches.unitIsDestroyer())
-        && attackedDefenders.stream().anyMatch(Matches.unitCantBeTargetedByAll())) {
-      attackedDefenders.removeAll(CollectionUtils.getMatches(attackedDefenders, Matches.unitCantBeTargetedByAll()));
+        && attackedDefenders.stream().anyMatch(Matches.unitCanNotBeTargetedByAll())) {
+      attackedDefenders.removeAll(CollectionUtils.getMatches(attackedDefenders, Matches.unitCanNotBeTargetedByAll()));
     }
-    if (!suicideAttackers.isEmpty() && suicideAttackers.stream().allMatch(Matches.unitCantTargetAll())) {
+    if (!suicideAttackers.isEmpty() && suicideAttackers.stream().allMatch(Matches.unitCanNotTargetAll())) {
       attackedDefenders.removeAll(CollectionUtils.getMatches(attackedDefenders, Matches.unitIsAir()));
     }
     if (suicideAttackers.size() == 0 || attackedDefenders.size() == 0) {
@@ -1969,10 +1969,10 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // comparatively simple rules for isSuicide units. if AirAttackSubRestricted and you have no destroyers, you can't
     // attack subs with anything.
     if (defendingUnits.stream().noneMatch(Matches.unitIsDestroyer())
-        && attackedAttackers.stream().anyMatch(Matches.unitCantBeTargetedByAll())) {
-      attackedAttackers.removeAll(CollectionUtils.getMatches(attackedAttackers, Matches.unitCantBeTargetedByAll()));
+        && attackedAttackers.stream().anyMatch(Matches.unitCanNotBeTargetedByAll())) {
+      attackedAttackers.removeAll(CollectionUtils.getMatches(attackedAttackers, Matches.unitCanNotBeTargetedByAll()));
     }
-    if (!suicideDefenders.isEmpty() && suicideDefenders.stream().allMatch(Matches.unitCantTargetAll())) {
+    if (!suicideDefenders.isEmpty() && suicideDefenders.stream().allMatch(Matches.unitCanNotTargetAll())) {
       suicideDefenders.removeAll(CollectionUtils.getMatches(suicideDefenders, Matches.unitIsAir()));
     }
     if (suicideDefenders.size() == 0 || attackedAttackers.size() == 0) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -341,9 +341,9 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       // play a sound
       if (attackingUnits.stream().anyMatch(Matches.unitIsSea())
           || defendingUnits.stream().anyMatch(Matches.unitIsSea())) {
-        if ((!attackingUnits.isEmpty() && attackingUnits.stream().allMatch(Matches.unitIsSub()))
-            || (attackingUnits.stream().anyMatch(Matches.unitIsSub())
-                && defendingUnits.stream().anyMatch(Matches.unitIsSub()))) {
+        if ((!attackingUnits.isEmpty() && attackingUnits.stream().allMatch(Matches.unitCanEvade()))
+            || (attackingUnits.stream().anyMatch(Matches.unitCanEvade())
+                && defendingUnits.stream().anyMatch(Matches.unitCanEvade()))) {
           bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_SEA_SUBS, attacker);
         } else {
           bridge.getSoundChannelBroadcaster().playSoundForAll(SoundPath.CLIP_BATTLE_SEA_NORMAL, attacker);
@@ -494,11 +494,11 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // Check if defending subs can submerge before battle
     if (isSubRetreatBeforeBattle()) {
       if (defendingUnits.stream().noneMatch(Matches.unitIsDestroyer())
-          && attackingUnits.stream().anyMatch(Matches.unitIsSub())) {
+          && attackingUnits.stream().anyMatch(Matches.unitCanEvade())) {
         steps.add(attacker.getName() + SUBS_SUBMERGE);
       }
       if (attackingUnits.stream().noneMatch(Matches.unitIsDestroyer())
-          && defendingUnits.stream().anyMatch(Matches.unitIsSub())) {
+          && defendingUnits.stream().anyMatch(Matches.unitCanEvade())) {
         steps.add(defender.getName() + SUBS_SUBMERGE);
       }
     }
@@ -511,7 +511,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
     // if attacker has no sneak attack subs, then defender sneak attack subs fire first and remove casualties
     final boolean defenderSubsFireFirst = defenderSubsFireFirst();
-    if (defenderSubsFireFirst && defendingUnits.stream().anyMatch(Matches.unitIsSub())) {
+    if (defenderSubsFireFirst && defendingUnits.stream().anyMatch(Matches.unitIsFirstStrike())) {
       steps.add(defender.getName() + SUBS_FIRE);
       steps.add(attacker.getName() + SELECT_SUB_CASUALTIES);
       steps.add(REMOVE_SNEAK_ATTACK_CASUALTIES);
@@ -519,7 +519,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final boolean onlyAttackerSneakAttack = !defenderSubsFireFirst
         && returnFireAgainstAttackingSubs() == ReturnFire.NONE && returnFireAgainstDefendingSubs() == ReturnFire.ALL;
     // attacker subs sneak attack, no sneak attack if destroyers are present
-    if (attackingUnits.stream().anyMatch(Matches.unitIsSub())) {
+    if (attackingUnits.stream().anyMatch(Matches.unitIsFirstStrike())) {
       steps.add(attacker.getName() + SUBS_FIRE);
       steps.add(defender.getName() + SELECT_SUB_CASUALTIES);
       if (onlyAttackerSneakAttack) {
@@ -532,49 +532,50 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // defender subs sneak attack, no sneak attack in Pacific/Europe Theaters or if destroyers are present
     final boolean defendingSubsFireWithAllDefendersAlways = !defendingSubsSneakAttack3();
     if (!defendingSubsFireWithAllDefendersAlways && !defendingSubsFireWithAllDefenders && !defenderSubsFireFirst
-        && defendingUnits.stream().anyMatch(Matches.unitIsSub())) {
+        && defendingUnits.stream().anyMatch(Matches.unitIsFirstStrike())) {
       steps.add(defender.getName() + SUBS_FIRE);
       steps.add(attacker.getName() + SELECT_SUB_CASUALTIES);
     }
-    if ((attackingUnits.stream().anyMatch(Matches.unitIsSub()) || defendingUnits.stream().anyMatch(Matches.unitIsSub()))
+    if ((attackingUnits.stream().anyMatch(Matches.unitIsFirstStrike())
+        || defendingUnits.stream().anyMatch(Matches.unitIsFirstStrike()))
         && !defenderSubsFireFirst && !onlyAttackerSneakAttack
         && (returnFireAgainstDefendingSubs() != ReturnFire.ALL || returnFireAgainstAttackingSubs() != ReturnFire.ALL)) {
       steps.add(REMOVE_SNEAK_ATTACK_CASUALTIES);
     }
     // Air units can't attack subs without Destroyers present
-    if (isAirAttackSubRestricted() && attackingUnits.stream().anyMatch(Matches.unitIsAir())
+    if (attackingUnits.stream().anyMatch(Matches.unitIsAir())
+        && defendingUnits.stream().anyMatch(Matches.unitCantBeTargetedByAll())
         && !canAirAttackSubs(defendingUnits, attackingUnits)) {
       steps.add(SUBMERGE_SUBS_VS_AIR_ONLY);
       steps.add(AIR_ATTACK_NON_SUBS);
     }
-    if (attackingUnits.stream().anyMatch(Matches.unitIsNotSub())) {
+    if (attackingUnits.stream().anyMatch(Matches.unitIsFirstStrike().negate())) {
       steps.add(attacker.getName() + FIRE);
       steps.add(defender.getName() + SELECT_CASUALTIES);
     }
     // classic rules, subs fire with all defenders
     // also, ww2v3/global rules, defending subs without sneak attack fire with all defenders
-    final Collection<Unit> units = new ArrayList<>(defendingUnits.size() + defendingWaitingToDie.size());
-    units.addAll(defendingUnits);
+    final Collection<Unit> units = new ArrayList<>(defendingUnits);
     units.addAll(defendingWaitingToDie);
-    if (units.stream().anyMatch(Matches.unitIsSub()) && !defenderSubsFireFirst
+    if (units.stream().anyMatch(Matches.unitCantTargetAll()) && !defenderSubsFireFirst
         && (defendingSubsFireWithAllDefenders || defendingSubsFireWithAllDefendersAlways)) {
       steps.add(defender.getName() + SUBS_FIRE);
       steps.add(attacker.getName() + SELECT_SUB_CASUALTIES);
     }
     // Air Units can't attack subs without Destroyers present
-    if (isAirAttackSubRestricted()) {
-      if (defendingUnits.stream().anyMatch(Matches.unitIsAir()) && !canAirAttackSubs(attackingUnits, units)) {
-        steps.add(AIR_DEFEND_NON_SUBS);
-      }
+    if (defendingUnits.stream().anyMatch(Matches.unitIsAir())
+        && attackingUnits.stream().anyMatch(Matches.unitCantBeTargetedByAll())
+        && !canAirAttackSubs(attackingUnits, units)) {
+      steps.add(AIR_DEFEND_NON_SUBS);
     }
-    if (defendingUnits.stream().anyMatch(Matches.unitIsNotSub())) {
+    if (defendingUnits.stream().anyMatch(Matches.unitIsFirstStrike().negate())) {
       steps.add(defender.getName() + FIRE);
       steps.add(attacker.getName() + SELECT_CASUALTIES);
     }
     // remove casualties
     steps.add(REMOVE_CASUALTIES);
     // retreat attacking subs
-    if (attackingUnits.stream().anyMatch(Matches.unitIsSub())) {
+    if (attackingUnits.stream().anyMatch(Matches.unitCanEvade())) {
       if (canSubsSubmerge()) {
         if (!isSubRetreatBeforeBattle()) {
           steps.add(attacker.getName() + SUBS_SUBMERGE);
@@ -596,7 +597,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       steps.add(attacker.getName() + ATTACKER_WITHDRAW);
     }
     // retreat defending subs
-    if (defendingUnits.stream().anyMatch(Matches.unitIsSub())) {
+    if (defendingUnits.stream().anyMatch(Matches.unitCanEvade())) {
       if (canSubsSubmerge()) {
         if (!isSubRetreatBeforeBattle()) {
           steps.add(defender.getName() + SUBS_SUBMERGE);
@@ -946,16 +947,14 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       });
     }
     // Submerge subs if -vs air only & air restricted from attacking subs
-    if (isAirAttackSubRestricted()) {
-      steps.add(new IExecutable() {
-        private static final long serialVersionUID = 99990L;
+    steps.add(new IExecutable() {
+      private static final long serialVersionUID = 99990L;
 
-        @Override
-        public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-          submergeSubsVsOnlyAir(bridge);
-        }
-      });
-    }
+      @Override
+      public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+        submergeSubsVsOnlyAir(bridge);
+      }
+    });
     final ReturnFire returnFireAgainstAttackingSubs = returnFireAgainstAttackingSubs();
     final ReturnFire returnFireAgainstDefendingSubs = returnFireAgainstDefendingSubs();
     if (defenderSubsFireFirst()) {
@@ -989,16 +988,14 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       });
     }
     // Attacker air fire on non-subs
-    if (isAirAttackSubRestricted()) {
-      steps.add(new IExecutable() {
-        private static final long serialVersionUID = 99993L;
+    steps.add(new IExecutable() {
+      private static final long serialVersionUID = 99993L;
 
-        @Override
-        public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-          attackAirOnNonSubs();
-        }
-      });
-    }
+      @Override
+      public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+        attackAirOnNonSubs();
+      }
+    });
     // Attacker fire remaining units
     steps.add(new IExecutable() {
       private static final long serialVersionUID = 99994L;
@@ -1019,16 +1016,14 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       });
     }
     // Defender air fire on non-subs
-    if (isAirAttackSubRestricted()) {
-      steps.add(new IExecutable() {
-        private static final long serialVersionUID = 1560702114917865123L;
+    steps.add(new IExecutable() {
+      private static final long serialVersionUID = 1560702114917865123L;
 
-        @Override
-        public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-          defendAirOnNonSubs();
-        }
-      });
-    }
+      @Override
+      public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+        defendAirOnNonSubs();
+      }
+    });
     steps.add(new IExecutable() {
       private static final long serialVersionUID = 1560702114917865290L;
 
@@ -1072,7 +1067,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   private boolean defendingSubsSneakAttack3() {
-    return isWW2V2() || isDefendingSubsSneakAttack();
+    return isWW2V2() || Properties.getDefendingSubsSneakAttack(gameData);
   }
 
   private boolean canAttackerRetreatPlanes() {
@@ -1111,7 +1106,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         .and(Matches.unitIsNotInfrastructure())
         .and(Matches.unitIsBeingTransported().negate())
         .and(Matches.unitIsSubmerged().negate())
-        .andIf(Properties.getIgnoreSubInMovement(gameData), Matches.unitIsNotSub())
+        .and(Matches.unitCanBeMovedThroughByEnemies().negate())
         .andIf(Properties.getIgnoreTransportInMovement(gameData), Matches.unitIsNotTransportButCouldBeCombatTransport())
         .build();
     Collection<Territory> possible = CollectionUtils.getMatches(attackingFrom,
@@ -1206,7 +1201,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
     return attackingWaitingToDie.stream().noneMatch(Matches.unitIsDestroyer())
         && (getEmptyOrFriendlySeaNeighbors(defender,
-            CollectionUtils.getMatches(defendingUnits, Matches.unitIsSub())).size() != 0
+            CollectionUtils.getMatches(defendingUnits, Matches.unitCanEvade())).size() != 0
             || canSubsSubmerge());
   }
 
@@ -1214,7 +1209,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (!canAttackerRetreatSubs()) {
       return;
     }
-    if (attackingUnits.stream().anyMatch(Matches.unitIsSub())) {
+    if (attackingUnits.stream().anyMatch(Matches.unitCanEvade())) {
       queryRetreat(false, RetreatType.SUBS, bridge, getAttackerRetreatTerritories());
     }
   }
@@ -1223,9 +1218,9 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (!canDefenderRetreatSubs()) {
       return;
     }
-    if (!isOver && defendingUnits.stream().anyMatch(Matches.unitIsSub())) {
+    if (!isOver && defendingUnits.stream().anyMatch(Matches.unitCanEvade())) {
       queryRetreat(true, RetreatType.SUBS, bridge, getEmptyOrFriendlySeaNeighbors(defender,
-          CollectionUtils.getMatches(defendingUnits, Matches.unitIsSub())));
+          CollectionUtils.getMatches(defendingUnits, Matches.unitCanEvade())));
     }
   }
 
@@ -1270,7 +1265,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       units.removeAll(killed);
     }
     if (subs) {
-      units = CollectionUtils.getMatches(units, Matches.unitIsSub());
+      units = CollectionUtils.getMatches(units, Matches.unitCanEvade());
     } else if (planes) {
       units = CollectionUtils.getMatches(units, Matches.unitIsAir());
     } else if (partialAmphib) {
@@ -1720,17 +1715,18 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
    */
   private void submergeSubsVsOnlyAir(final IDelegateBridge bridge) {
     // if All attackers are AIR, submerge any defending subs
+    final Predicate<Unit> subMatch = Matches.unitCanEvade().and(Matches.unitCantBeTargetedByAll());
     if (!attackingUnits.isEmpty() && attackingUnits.stream().allMatch(Matches.unitIsAir())
-        && defendingUnits.stream().anyMatch(Matches.unitIsSub())) {
+        && defendingUnits.stream().anyMatch(subMatch)) {
       // Get all defending subs (including allies) in the territory
-      final List<Unit> defendingSubs = CollectionUtils.getMatches(defendingUnits, Matches.unitIsSub());
+      final List<Unit> defendingSubs = CollectionUtils.getMatches(defendingUnits, subMatch);
       // submerge defending subs
       submergeUnits(defendingSubs, true, bridge);
       // checking defending air on attacking subs
     } else if (!defendingUnits.isEmpty() && defendingUnits.stream().allMatch(Matches.unitIsAir())
-        && attackingUnits.stream().anyMatch(Matches.unitIsSub())) {
+        && attackingUnits.stream().anyMatch(subMatch)) {
       // Get all attacking subs in the territory
-      final List<Unit> attackingSubs = CollectionUtils.getMatches(attackingUnits, Matches.unitIsSub());
+      final List<Unit> attackingSubs = CollectionUtils.getMatches(attackingUnits, subMatch);
       // submerge attacking subs
       submergeUnits(attackingSubs, false, bridge);
     }
@@ -1740,19 +1736,17 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (attackingUnits.size() == 0) {
       return;
     }
-    Collection<Unit> units = new ArrayList<>(defendingUnits.size() + defendingWaitingToDie.size());
-    units.addAll(defendingUnits);
+    Collection<Unit> units = new ArrayList<>(defendingUnits);
     units.addAll(defendingWaitingToDie);
-    units = CollectionUtils.getMatches(units, Matches.unitIsNotSub());
+    units = CollectionUtils.getMatches(units, Matches.unitIsFirstStrike().negate());
     // if restricted, remove aircraft from attackers
-    if (isAirAttackSubRestricted() && !canAirAttackSubs(attackingUnits, units)) {
+    if (!canAirAttackSubs(attackingUnits, units)) {
       units.removeAll(CollectionUtils.getMatches(units, Matches.unitIsAir()));
     }
     if (units.isEmpty()) {
       return;
     }
-    final List<Unit> allEnemyUnitsAliveOrWaitingToDie = new ArrayList<>();
-    allEnemyUnitsAliveOrWaitingToDie.addAll(attackingUnits);
+    final List<Unit> allEnemyUnitsAliveOrWaitingToDie = new ArrayList<>(attackingUnits);
     allEnemyUnitsAliveOrWaitingToDie.addAll(attackingWaitingToDie);
     fire(attacker.getName() + SELECT_CASUALTIES, units, attackingUnits, allEnemyUnitsAliveOrWaitingToDie, true,
         ReturnFire.ALL, "Defenders fire, ");
@@ -1765,8 +1759,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (defendingUnits.size() == 0) {
       return;
     }
-    Collection<Unit> units = new ArrayList<>(attackingUnits.size() + attackingWaitingToDie.size());
-    units.addAll(attackingUnits);
+    Collection<Unit> units = new ArrayList<>(attackingUnits);
     units.addAll(attackingWaitingToDie);
     // See if allied air can participate in combat
     if (!isAlliedAirIndependent()) {
@@ -1774,9 +1767,9 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
     if (!canAirAttackSubs(defendingUnits, units)) {
       units = CollectionUtils.getMatches(units, Matches.unitIsAir());
-      final Collection<Unit> enemyUnitsNotSubs = CollectionUtils.getMatches(defendingUnits, Matches.unitIsNotSub());
-      final List<Unit> allEnemyUnitsAliveOrWaitingToDie = new ArrayList<>();
-      allEnemyUnitsAliveOrWaitingToDie.addAll(defendingUnits);
+      final Collection<Unit> enemyUnitsNotSubs =
+          CollectionUtils.getMatches(defendingUnits, Matches.unitCantBeTargetedByAll().negate());
+      final List<Unit> allEnemyUnitsAliveOrWaitingToDie = new ArrayList<>(defendingUnits);
       allEnemyUnitsAliveOrWaitingToDie.addAll(defendingWaitingToDie);
       fire(defender.getName() + SELECT_CASUALTIES, units, enemyUnitsNotSubs, allEnemyUnitsAliveOrWaitingToDie, false,
           ReturnFire.ALL, "Attacker's aircraft fire,");
@@ -1784,25 +1777,24 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   }
 
   private boolean canAirAttackSubs(final Collection<Unit> firedAt, final Collection<Unit> firing) {
-    return firedAt.stream().noneMatch(Matches.unitIsSub()) || firing.stream().anyMatch(Matches.unitIsDestroyer());
+    return firedAt.stream().noneMatch(Matches.unitCantBeTargetedByAll())
+        || firing.stream().anyMatch(Matches.unitIsDestroyer());
   }
 
   private void defendAirOnNonSubs() {
     if (attackingUnits.size() == 0) {
       return;
     }
-    Collection<Unit> units = new ArrayList<>(defendingUnits.size() + defendingWaitingToDie.size());
-    units.addAll(defendingUnits);
+    Collection<Unit> units = new ArrayList<>(defendingUnits);
     units.addAll(defendingWaitingToDie);
-
     if (!canAirAttackSubs(attackingUnits, units)) {
       units = CollectionUtils.getMatches(units, Matches.unitIsAir());
-      final Collection<Unit> enemyUnitsNotSubs = CollectionUtils.getMatches(attackingUnits, Matches.unitIsNotSub());
+      final Collection<Unit> enemyUnitsNotSubs =
+          CollectionUtils.getMatches(attackingUnits, Matches.unitCantBeTargetedByAll().negate());
       if (enemyUnitsNotSubs.isEmpty()) {
         return;
       }
-      final List<Unit> allEnemyUnitsAliveOrWaitingToDie = new ArrayList<>();
-      allEnemyUnitsAliveOrWaitingToDie.addAll(attackingUnits);
+      final List<Unit> allEnemyUnitsAliveOrWaitingToDie = new ArrayList<>(attackingUnits);
       allEnemyUnitsAliveOrWaitingToDie.addAll(attackingWaitingToDie);
       fire(attacker.getName() + SELECT_CASUALTIES, units, enemyUnitsNotSubs, allEnemyUnitsAliveOrWaitingToDie, true,
           ReturnFire.ALL, "Defender's aircraft fire,");
@@ -1817,35 +1809,33 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (defendingUnits.size() == 0) {
       return;
     }
-    Collection<Unit> units = CollectionUtils.getMatches(attackingUnits, Matches.unitIsNotSub());
-    units.addAll(CollectionUtils.getMatches(attackingWaitingToDie, Matches.unitIsNotSub()));
+    Collection<Unit> units = CollectionUtils.getMatches(attackingUnits, Matches.unitIsFirstStrike().negate());
+    units.addAll(CollectionUtils.getMatches(attackingWaitingToDie, Matches.unitIsFirstStrike().negate()));
     // See if allied air can participate in combat
     if (!isAlliedAirIndependent()) {
       units = CollectionUtils.getMatches(units, Matches.unitIsOwnedBy(attacker));
     }
     // if restricted, remove aircraft from attackers
-    if (isAirAttackSubRestricted() && !canAirAttackSubs(defendingUnits, units)) {
+    if (!canAirAttackSubs(defendingUnits, units)) {
       units.removeAll(CollectionUtils.getMatches(units, Matches.unitIsAir()));
     }
     if (units.isEmpty()) {
       return;
     }
-    final List<Unit> allEnemyUnitsAliveOrWaitingToDie = new ArrayList<>();
-    allEnemyUnitsAliveOrWaitingToDie.addAll(defendingUnits);
+    final List<Unit> allEnemyUnitsAliveOrWaitingToDie = new ArrayList<>(defendingUnits);
     allEnemyUnitsAliveOrWaitingToDie.addAll(defendingWaitingToDie);
     fire(defender.getName() + SELECT_CASUALTIES, units, defendingUnits, allEnemyUnitsAliveOrWaitingToDie, false,
         ReturnFire.ALL, "Attackers fire,");
   }
 
   private void attackSubs(final ReturnFire returnFire) {
-    final Collection<Unit> firing = CollectionUtils.getMatches(attackingUnits, Matches.unitIsSub());
+    final Collection<Unit> firing = CollectionUtils.getMatches(attackingUnits, Matches.unitIsFirstStrike());
     if (firing.isEmpty()) {
       return;
     }
     final Collection<Unit> attacked = CollectionUtils.getMatches(defendingUnits, Matches.unitIsNotAir());
     // if there are destroyers in the attacked units, we can return fire.
-    final List<Unit> allEnemyUnitsAliveOrWaitingToDie = new ArrayList<>();
-    allEnemyUnitsAliveOrWaitingToDie.addAll(defendingUnits);
+    final List<Unit> allEnemyUnitsAliveOrWaitingToDie = new ArrayList<>(defendingUnits);
     allEnemyUnitsAliveOrWaitingToDie.addAll(defendingWaitingToDie);
     fire(defender.getName() + SELECT_SUB_CASUALTIES, firing, attacked, allEnemyUnitsAliveOrWaitingToDie, false,
         returnFire, "Subs fire,");
@@ -1855,10 +1845,9 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (attackingUnits.size() == 0) {
       return;
     }
-    Collection<Unit> firing = new ArrayList<>(defendingUnits.size() + defendingWaitingToDie.size());
-    firing.addAll(defendingUnits);
+    Collection<Unit> firing = new ArrayList<>(defendingUnits);
     firing.addAll(defendingWaitingToDie);
-    firing = CollectionUtils.getMatches(firing, Matches.unitIsSub());
+    firing = CollectionUtils.getMatches(firing, Matches.unitIsFirstStrike());
     if (firing.isEmpty()) {
       return;
     }
@@ -1866,8 +1855,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (attacked.isEmpty()) {
       return;
     }
-    final List<Unit> allEnemyUnitsAliveOrWaitingToDie = new ArrayList<>();
-    allEnemyUnitsAliveOrWaitingToDie.addAll(attackingUnits);
+    final List<Unit> allEnemyUnitsAliveOrWaitingToDie = new ArrayList<>(attackingUnits);
     allEnemyUnitsAliveOrWaitingToDie.addAll(attackingWaitingToDie);
     fire(attacker.getName() + SELECT_SUB_CASUALTIES, firing, attacked, allEnemyUnitsAliveOrWaitingToDie, true,
         returnFire, "Subs defend, ");
@@ -1897,11 +1885,11 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     } else if (returnFire == ReturnFire.SUBS) {
       // move to waiting to die
       if (defender) {
-        defendingWaitingToDie.addAll(CollectionUtils.getMatches(killed, Matches.unitIsSub()));
+        defendingWaitingToDie.addAll(CollectionUtils.getMatches(killed, Matches.unitIsFirstStrike()));
       } else {
-        attackingWaitingToDie.addAll(CollectionUtils.getMatches(killed, Matches.unitIsSub()));
+        attackingWaitingToDie.addAll(CollectionUtils.getMatches(killed, Matches.unitIsFirstStrike()));
       }
-      remove(CollectionUtils.getMatches(killed, Matches.unitIsNotSub()), bridge, battleSite, defender);
+      remove(CollectionUtils.getMatches(killed, Matches.unitIsFirstStrike().negate()), bridge, battleSite, defender);
     } else if (returnFire == ReturnFire.NONE) {
       remove(killed, bridge, battleSite, defender);
     }
@@ -1951,11 +1939,11 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final Collection<Unit> attackedDefenders = CollectionUtils.getMatches(defendingUnits, attackableUnits);
     // comparatively simple rules for isSuicide units. if AirAttackSubRestricted and you have no destroyers, you can't
     // attack subs with anything.
-    if (isAirAttackSubRestricted() && attackingUnits.stream().noneMatch(Matches.unitIsDestroyer())
-        && attackedDefenders.stream().anyMatch(Matches.unitIsSub())) {
-      attackedDefenders.removeAll(CollectionUtils.getMatches(attackedDefenders, Matches.unitIsSub()));
+    if (attackingUnits.stream().noneMatch(Matches.unitIsDestroyer())
+        && attackedDefenders.stream().anyMatch(Matches.unitCantBeTargetedByAll())) {
+      attackedDefenders.removeAll(CollectionUtils.getMatches(attackedDefenders, Matches.unitCantBeTargetedByAll()));
     }
-    if (!suicideAttackers.isEmpty() && suicideAttackers.stream().allMatch(Matches.unitIsSub())) {
+    if (!suicideAttackers.isEmpty() && suicideAttackers.stream().allMatch(Matches.unitCantTargetAll())) {
       attackedDefenders.removeAll(CollectionUtils.getMatches(attackedDefenders, Matches.unitIsAir()));
     }
     if (suicideAttackers.size() == 0 || attackedDefenders.size() == 0) {
@@ -1980,11 +1968,11 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final Collection<Unit> attackedAttackers = CollectionUtils.getMatches(attackingUnits, attackableUnits);
     // comparatively simple rules for isSuicide units. if AirAttackSubRestricted and you have no destroyers, you can't
     // attack subs with anything.
-    if (isAirAttackSubRestricted() && defendingUnits.stream().noneMatch(Matches.unitIsDestroyer())
-        && attackedAttackers.stream().anyMatch(Matches.unitIsSub())) {
-      attackedAttackers.removeAll(CollectionUtils.getMatches(attackedAttackers, Matches.unitIsSub()));
+    if (defendingUnits.stream().noneMatch(Matches.unitIsDestroyer())
+        && attackedAttackers.stream().anyMatch(Matches.unitCantBeTargetedByAll())) {
+      attackedAttackers.removeAll(CollectionUtils.getMatches(attackedAttackers, Matches.unitCantBeTargetedByAll()));
     }
-    if (!suicideDefenders.isEmpty() && suicideDefenders.stream().allMatch(Matches.unitIsSub())) {
+    if (!suicideDefenders.isEmpty() && suicideDefenders.stream().allMatch(Matches.unitCantTargetAll())) {
       suicideDefenders.removeAll(CollectionUtils.getMatches(suicideDefenders, Matches.unitIsAir()));
     }
     if (suicideDefenders.size() == 0 || attackedAttackers.size() == 0) {
@@ -2015,10 +2003,6 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     return Properties.getAlliedAirIndependent(gameData);
   }
 
-  private boolean isDefendingSubsSneakAttack() {
-    return Properties.getDefendingSubsSneakAttack(gameData);
-  }
-
   private boolean isAttackerRetreatPlanes() {
     return Properties.getAttackerRetreatPlanes(gameData);
   }
@@ -2033,10 +2017,6 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
   private boolean isDefendingSuicideAndMunitionUnitsDoNotFire() {
     return Properties.getDefendingSuicideAndMunitionUnitsDoNotFire(gameData);
-  }
-
-  private boolean isAirAttackSubRestricted() {
-    return Properties.getAirAttackSubRestricted(gameData);
   }
 
   private boolean isSubRetreatBeforeBattle() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UnitBattleComparator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UnitBattleComparator.java
@@ -69,8 +69,8 @@ public class UnitBattleComparator implements Comparator<Unit> {
         || (!transporting1 && Matches.unitIsTransport().test(u1));
     final boolean airOrCarrierOrTransport2 = Matches.unitIsAir().test(u2) || Matches.unitIsCarrier().test(u2)
         || (!transporting2 && Matches.unitIsTransport().test(u2));
-    final boolean subDestroyer1 = Matches.unitIsSub().test(u1) || Matches.unitIsDestroyer().test(u1);
-    final boolean subDestroyer2 = Matches.unitIsSub().test(u2) || Matches.unitIsDestroyer().test(u2);
+    final boolean subDestroyer1 = Matches.unitHasSubBattleAbilities().test(u1) || Matches.unitIsDestroyer().test(u1);
+    final boolean subDestroyer2 = Matches.unitHasSubBattleAbilities().test(u2) || Matches.unitIsDestroyer().test(u2);
     final boolean multiHpCanRepair1 = multiHitpointCanRepair.contains(u1.getType());
     final boolean multiHpCanRepair2 = multiHitpointCanRepair.contains(u2.getType());
     if (!ignorePrimaryPower) {

--- a/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -244,7 +244,7 @@ public class UnitImageFactory {
           name.append("_hb");
         }
       }
-      if (UnitAttachment.get(type).getIsSub()
+      if (UnitAttachment.get(type).getIsFirstStrike()
           && (UnitAttachment.get(type).getAttack(id) > 0 || UnitAttachment.get(type).getDefense(id) > 0)) {
         if (TechTracker.hasSuperSubs(id)) {
           name.append("_ss");

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyPlayer.java
@@ -124,7 +124,7 @@ class DummyPlayer extends AbstractAi {
         return null;
       }
       if (!enemyUnits.isEmpty() && enemyUnits.stream().allMatch(planeNotDestroyer) && !ourUnits.isEmpty()
-          && ourUnits.stream().allMatch(Matches.unitCantBeTargetedByAll())) {
+          && ourUnits.stream().allMatch(Matches.unitCanNotBeTargetedByAll())) {
         return possibleTerritories.iterator().next();
       }
       return null;

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyPlayer.java
@@ -124,7 +124,7 @@ class DummyPlayer extends AbstractAi {
         return null;
       }
       if (!enemyUnits.isEmpty() && enemyUnits.stream().allMatch(planeNotDestroyer) && !ourUnits.isEmpty()
-          && ourUnits.stream().allMatch(Matches.unitIsSub())) {
+          && ourUnits.stream().allMatch(Matches.unitCantBeTargetedByAll())) {
         return possibleTerritories.iterator().next();
       }
       return null;

--- a/game-core/src/main/java/games/strategy/triplea/printgenerator/UnitInformation.java
+++ b/game-core/src/main/java/games/strategy/triplea/printgenerator/UnitInformation.java
@@ -69,7 +69,7 @@ class UnitInformation {
             + (!currentAttachment.getIsSea() ? "-" : "true") + "," + currentAttachment.getHitPoints() + ","
             + (currentAttachment.getTransportCapacity() == -1 ? "-" : currentAttachment.getTransportCapacity()) + ","
             + (currentAttachment.getCarrierCapacity() == -1 ? "-" : currentAttachment.getCarrierCapacity()) + ","
-            + (!currentAttachment.getIsSub() ? "-" : "true") + ","
+            + (!(currentAttachment.getCanEvade() && currentAttachment.getIsFirstStrike()) ? "-" : "true") + ","
             + (!currentAttachment.getIsDestroyer() ? "-" : "true"));
         unitInformation.write("\r\n");
       }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -734,7 +734,7 @@ class RevisedTest {
     sz45To50.setStart(sz45);
     sz45To50.add(sz50);
     final List<Unit> japSub =
-        sz45.getUnitCollection().getMatches(Matches.unitIsSub().and(Matches.unitIsOwnedBy(japanese)));
+        sz45.getUnitCollection().getMatches(Matches.unitCanEvade().and(Matches.unitIsOwnedBy(japanese)));
     error = moveDelegate.move(japSub, sz45To50);
     // make sure no error
     assertNull(error);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -1450,7 +1450,7 @@ class WW2V3Year41Test {
     final Territory uk = territory("United Kingdom", gameData);
     final Territory sz5 = territory("5 Sea Zone", gameData);
     // remove the sub
-    removeFrom(sz5, sz5.getUnitCollection().getMatches(Matches.unitIsSub()));
+    removeFrom(sz5, sz5.getUnitCollection().getMatches(Matches.unitCanEvade()));
 
     move(uk.getUnitCollection().getMatches(Matches.unitIsAir()), gameData.getMap().getRoute(uk, sz5));
     // move units for amphib assault


### PR DESCRIPTION
## Overview
- Second part of https://forums.triplea-game.org/topic/328/unit-option-can-submerge-hide-for-land-units-partisan-guerrilla-spy-diplomat-munition
- Breaking isSub and isDestroyer into smaller attributes so more fine grained control can be achieved (canHide, firstStrike, canTarget, canBeTargetedBy, etc)
- This should have no impact on existing maps and sea subs. Most functionality will now work for land/air subs but there are still some further changes need especially for cantTarget and cantBeTargetedBy as these are hardcoded to just check if empty or not.

## Functional Changes
**Separate isSub Functions**
1. **canEvade** - submerge
2. **isFirstStrike** - roll and take casualties before regular units
3. **canNotTarget** - can't target specific units like air units
4. **canNotBeTargetedBy** - can't be targeted by specific units like air units
5. **canMoveThroughEnemies** - unblockable, Treat Hostile Territories as Friendly
6. **canBeMovedThroughByEnemies** - enemies can move through territories if only these types of units are present (would also need blitz for enemy land territories)

## Manual Testing Performed
- Launched a few maps including revised, ww2v3, and global to ensure games still work properly
