### PR TITLE
Fix Transport Loading After Combat in v3+

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -60,6 +60,7 @@ public class MoveValidator {
   public static final String NOT_ALL_AIR_UNITS_CAN_LAND = "Not all air units can land";
   public static final String TRANSPORT_CANNOT_LOAD_AND_UNLOAD_AFTER_COMBAT =
       "Transport cannot both load AND unload after being in combat";
+  public static final String TRANSPORT_CANNOT_LOAD_AFTER_COMBAT = "Transport cannot load after being in combat";
   public static final String NOT_ALL_UNITS_CAN_BLITZ = "Not all units can blitz";
 
   private MoveValidator() {}
@@ -1116,6 +1117,8 @@ public class MoveValidator {
           }
           if (TransportTracker.hasTransportUnloadedInPreviousPhase(transport)) {
             result.addDisallowedUnit(TRANSPORT_HAS_ALREADY_UNLOADED_UNITS_IN_A_PREVIOUS_PHASE, unit);
+          } else if (TransportTracker.isTransportLoadRestrictedAfterCombat(transport)) {
+            result.addDisallowedUnit(TRANSPORT_CANNOT_LOAD_AFTER_COMBAT, unit);
           } else if (TransportTracker.isTransportUnloadRestrictedToAnotherTerritory(transport, route.getEnd())) {
             Territory alreadyUnloadedTo = getTerritoryTransportHasUnloadedTo(undoableMoves, transport);
             for (final Unit transportToLoad : transportsToLoad) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
@@ -231,14 +231,14 @@ public class TransportTracker {
     return Properties.getWW2V2(data);
   }
 
-  // TODO here's a bug COMCO
   private static boolean isTransportUnloadRestricted(final GameData data) {
     return Properties.getTransportUnloadRestricted(data);
   }
 
-  // In some versions, a transport can never unload into multiple territories in a given turn.
-  // In WW2V1 a transport can unload to multiple territories in
-  // non-combat phase, provided they are both adjacent to the sea zone.
+  /**
+   * In some versions, a transport can never unload into multiple territories in a given turn. In WW2V1 a transport can
+   * unload to multiple territories in non-combat phase, provided they are both adjacent to the sea zone.
+   */
   static boolean isTransportUnloadRestrictedToAnotherTerritory(final Unit transport, final Territory territory) {
     final Collection<Unit> unloaded = ((TripleAUnit) transport).getUnloaded();
     if (unloaded.isEmpty()) {
@@ -264,10 +264,12 @@ public class TransportTracker {
     return false;
   }
 
-  // This method should be called after isTransportUnloadRestrictedToAnotherTerritory() returns false, in order to
-  // populate the error message. However, we only need to call this method to determine why we can't unload an
-  // additional unit. Since transports only hold up to two units, we only need to return one territory, not multiple
-  // territories.
+  /**
+   * This method should be called after isTransportUnloadRestrictedToAnotherTerritory() returns false, in order to
+   * populate the error message. However, we only need to call this method to determine why we can't unload an
+   * additional unit. Since transports only hold up to two units, we only need to return one territory, not multiple
+   * territories.
+   */
   static Territory getTerritoryTransportHasUnloadedTo(final Unit transport) {
     final Collection<Unit> unloaded = ((TripleAUnit) transport).getUnloaded();
     if (unloaded.isEmpty()) {
@@ -277,7 +279,7 @@ public class TransportTracker {
   }
 
   /**
-   * If a transport has been in combat, it cannot load AND unload in non-combat.
+   * If a transport has been in combat, it cannot both load AND unload in NCM.
    */
   static boolean isTransportUnloadRestrictedInNonCombat(final Unit transport) {
     final TripleAUnit taUnit = (TripleAUnit) transport;
@@ -286,7 +288,7 @@ public class TransportTracker {
   }
 
   /**
-   * For ww2v3+, if a transport has been in combat then it can't load or unload in NCM.
+   * For ww2v3+, if a transport has been in combat then it can't load in NCM.
    */
   static boolean isTransportLoadRestrictedAfterCombat(final Unit transport) {
     final TripleAUnit taUnit = (TripleAUnit) transport;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
@@ -276,10 +276,21 @@ public class TransportTracker {
     return ((TripleAUnit) unloaded.iterator().next()).getUnloadedTo();
   }
 
-  // If a transport has been in combat, it cannot load AND unload in non-combat
+  /**
+   * If a transport has been in combat, it cannot load AND unload in non-combat.
+   */
   static boolean isTransportUnloadRestrictedInNonCombat(final Unit transport) {
     final TripleAUnit taUnit = (TripleAUnit) transport;
     return GameStepPropertiesHelper.isNonCombatMove(transport.getData(), true) && taUnit.getWasInCombat()
         && taUnit.getWasLoadedAfterCombat();
+  }
+
+  /**
+   * For ww2v3+, if a transport has been in combat then it can't load or unload in NCM.
+   */
+  static boolean isTransportLoadRestrictedAfterCombat(final Unit transport) {
+    final TripleAUnit taUnit = (TripleAUnit) transport;
+    return Properties.getWW2V3(transport.getData())
+        && GameStepPropertiesHelper.isNonCombatMove(transport.getData(), true) && taUnit.getWasInCombat();
   }
 }


### PR DESCRIPTION
## Overview
- Addresses #3162

## Functional Changes
- Add check if v3+ to prevent loading transports that were in combat

## Manual Testing Performed
- Tested v3 and global maps
