### PR TITLE
Update manual game post hotkey to avoid conflict with players tab

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
@@ -82,7 +82,7 @@ final class FileMenu extends JMenu {
     }));
     menuPbem.setMnemonic(KeyEvent.VK_P);
     menuPbem.setAccelerator(
-        KeyStroke.getKeyStroke(KeyEvent.VK_P, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
+        KeyStroke.getKeyStroke(KeyEvent.VK_M, Toolkit.getDefaultToolkit().getMenuShortcutKeyMask()));
     return menuPbem;
   }
 


### PR DESCRIPTION
## Overview
- Addresses https://github.com/triplea-game/triplea/issues/4815

## Functional Changes
- Manual game post is now mapped to CTRL+M instead of CTRL+P which conflicted with players tab hotkey
