### PR TITLE
Deployable, tested HTTP Server & Finish Error Upload Feature

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,7 +98,6 @@ subprojects {
 
         testRuntimeOnly "org.junit.jupiter:junit-jupiter-engine:$junitJupiterVersion"
         testRuntimeOnly 'org.junit.platform:junit-platform-launcher:1.4.0'
-        testRuntimeOnly 'org.slf4j:slf4j-nop:1.7.25'
     }
 
     tasks.withType(JavaCompile).configureEach {

--- a/game-core/src/main/java/games/strategy/debug/ErrorMessage.java
+++ b/game-core/src/main/java/games/strategy/debug/ErrorMessage.java
@@ -17,6 +17,7 @@ import org.triplea.http.client.error.report.ErrorUploadClient;
 import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.JLabelBuilder;
 import org.triplea.swing.JPanelBuilder;
+import org.triplea.swing.SwingComponents;
 
 import com.google.common.base.Preconditions;
 
@@ -128,7 +129,14 @@ public enum ErrorMessage {
       }
       INSTANCE.uploadButton.addActionListener(e -> {
         hide();
-        StackTraceReportView.showWindow(windowReference, serviceClient, record);
+        if (serviceClient.canSubmitErrorReport()) {
+          StackTraceReportView.showWindow(windowReference, serviceClient, record);
+        } else {
+          SwingComponents.showDialog(
+              "Error Report Limit Reached",
+              "You have reached a daily limit for error uploads. "
+                  + "Please wait a day before submitting additional error reports.");
+        }
       });
     }
   }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerProperties.java
@@ -71,9 +71,10 @@ public final class LobbyServerProperties {
   public URI getHttpsServerUri() {
     try {
       return new URIBuilder()
+          // TODO: use https
           .setScheme(
               // allow env variable override of https so we can do local development with http
-              Optional.ofNullable(System.getenv("HTTP_SERVER_PROTOCOL")).orElse("https"))
+              Optional.ofNullable(System.getenv("HTTP_SERVER_PROTOCOL")).orElse("http"))
           .setHost(host)
           .setPort(httpsPort)
           .build();

--- a/http-clients/src/main/java/org/triplea/http/client/error/report/ErrorUploadClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/error/report/ErrorUploadClient.java
@@ -4,8 +4,6 @@ import java.net.URI;
 
 import org.triplea.http.client.HttpClient;
 
-import com.google.common.annotations.VisibleForTesting;
-
 import feign.FeignException;
 import feign.Headers;
 import feign.RequestLine;
@@ -16,8 +14,8 @@ import feign.RequestLine;
 @SuppressWarnings("InterfaceNeverImplemented")
 public interface ErrorUploadClient {
 
-  @VisibleForTesting
   String ERROR_REPORT_PATH = "/error-report";
+  String CAN_REPORT_PATH = "/can-submit-error-report";
 
   /**
    * API to upload an exception error report from a TripleA client to TripleA server.
@@ -30,6 +28,9 @@ public interface ErrorUploadClient {
       "Accept: application/json"
   })
   ErrorUploadResponse uploadErrorReport(ErrorUploadRequest request);
+
+  @RequestLine("GET " + CAN_REPORT_PATH)
+  boolean canSubmitErrorReport();
 
   /**
    * Creates an error report uploader clients, sends error reports and gets a response back.

--- a/http-clients/src/main/java/org/triplea/http/client/github/issues/GithubIssueClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/github/issues/GithubIssueClient.java
@@ -33,6 +33,13 @@ public class GithubIssueClient {
     this.authToken = authToken;
   }
 
+  /**
+   * For local or integration testing, we may want to have a fake that does not actually
+   * call github. This method returns true if we are doing a fake call to github.
+   */
+  public boolean isTest() {
+    return authToken.equalsIgnoreCase("test");
+  }
 
   /**
    * Invokes github web-API to create a github issue with the provided parameter data.

--- a/http-server/README.md
+++ b/http-server/README.md
@@ -42,7 +42,13 @@ Of note, a reference to `AppConfig` is passed to the main server application
 
 ```bash
 curl -X POST  -H "Content-Type: application/json" \
-  -d '{"title":"my-title", "body":"my-body"}' localhost:8080/error-report
+  -d '{"title":"my-title", "body":"my-body"}' \
+  localhost:8080/error-report
+```
+
+```bash
+curl -X GET -H "Content-Type: application/json" \
+  localhost:8080/can-submit-error-report
 ```
 
 
@@ -52,3 +58,16 @@ curl -X POST  -H "Content-Type: application/json" \
   valid configuration.
 - [ ] see if we can create an integration test with mocked out backend that
   can verify http server/client interactions
+
+# WARNINGS!
+
+## Multiple SLF4J Bindings Not Allowed
+
+Dropwizard uses Logback and has a binding with SLF4J baked in. Additional SLF4J bindings 
+should generate a warning, but will ultimately cause problems (when run from gradle) and drop 
+wizard may fail to start with this error:
+
+```bash
+java.lang.IllegalStateException: Unable to acquire the logger context
+    at io.dropwizard.logging.LoggingUtil.getLoggerContext(LoggingUtil.java:46)
+```

--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -37,8 +37,7 @@ dependencies {
 
     testImplementation project(':test-common')
     testImplementation 'com.github.database-rider:rider-junit5:1.5.2'
-
-    testCompile group: 'io.dropwizard', name: 'dropwizard-testing', version: '1.3.12'
+    testImplementation 'io.dropwizarddropwizard-testing:1.3.12'
 }
 
 jar {

--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -13,6 +13,8 @@ ext {
 
 configurations {
     testImplementation {
+        // database-rider brings in slf4j-simple as a transitive dependency
+        // DropWizard has logback baked in and cannot have multiple slf4j bindings.
         exclude group: 'org.slf4j', module: 'slf4j-simple'
     }
 }

--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -1,22 +1,42 @@
 plugins {
     id 'application'
     id 'com.github.johnrengelman.shadow' version '4.0.4'
-    id 'de.undercouch.download' version '3.4.3'
 }
 
 archivesBaseName = "$group-$name"
 description = 'TripleA DropWizard Http Server'
-mainClassName = '' // org.triplea.game.client.HeadedGameRunner'
-
+mainClassName = 'org.triplea.server.http.ServerApplication'
 ext {
     releasesDir = file("$buildDir/releases")
 }
 
+
+configurations {
+    testImplementation {
+        exclude group: 'org.slf4j', module: 'slf4j-simple'
+    }
+}
+
 dependencies {
-    implementation 'io.dropwizard:dropwizard-core:1.3.11'
     implementation project(':java-extras')
     implementation project(':http-clients')
+
+    implementation 'io.dropwizard:dropwizard-core:1.3.12'
+    implementation 'io.dropwizard:dropwizard-jdbi3:1.3.12'
+    implementation 'org.jdbi:jdbi3-core:3.8.2'
+    implementation 'org.jdbi:jdbi3-sqlobject:3.8.2'
+
+    implementation 'javax.xml.bind:jaxb-api:2.3.1'
+    implementation 'com.sun.xml.bind:jaxb-impl:2.3.2'
+    implementation 'com.sun.xml.bind:jaxb-core:2.3.0'
+    implementation 'javax.activation:activation:1.1.1'
+
+    runtimeOnly "org.postgresql:postgresql:$postgresqlVersion"
+
     testImplementation project(':test-common')
+    testImplementation 'com.github.database-rider:rider-junit5:1.5.2'
+
+    testCompile group: 'io.dropwizard', name: 'dropwizard-testing', version: '1.3.12'
 }
 
 jar {
@@ -26,6 +46,9 @@ jar {
 }
 
 task portableInstaller(type: Zip, group: 'release', dependsOn: shadowJar) {
+    from file('configuration-prerelease.yml')
+    from file('configuration-production.yml')
+
     from(shadowJar.outputs) {
         into 'bin'
     }

--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 
     testImplementation project(':test-common')
     testImplementation 'com.github.database-rider:rider-junit5:1.5.2'
-    testCompile group: 'io.dropwizard', name: 'dropwizard-testing', version: '1.3.12'
+    testImplementation 'io.dropwizard:dropwizard-testing:1.3.12'
 }
 
 jar {

--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -37,7 +37,7 @@ dependencies {
 
     testImplementation project(':test-common')
     testImplementation 'com.github.database-rider:rider-junit5:1.5.2'
-    testImplementation 'io.dropwizarddropwizard-testing:1.3.12'
+    testCompile group: 'io.dropwizard', name: 'dropwizard-testing', version: '1.3.12'
 }
 
 jar {

--- a/http-server/configuration-prerelease.yml
+++ b/http-server/configuration-prerelease.yml
@@ -1,5 +1,5 @@
 githubRepo: test
-githubApiToken: ${GITHUB_ISSUES_API_TOKEN:-test}
+githubApiToken: ${GITHUB_API_TOKEN:-test}
 # if we are using any stubbing, we'll assert that this value is false.
 # this is to help guarantee that we do not accidently use test configuration in prod.
 prod: false

--- a/http-server/configuration-prerelease.yml
+++ b/http-server/configuration-prerelease.yml
@@ -1,2 +1,34 @@
 githubRepo: test
-githubApiToken: ${GITHUB_ISSUES_API_TOKEN}
+githubApiToken: ${GITHUB_ISSUES_API_TOKEN:-test}
+# if we are using any stubbing, we'll assert that this value is false.
+# this is to help guarantee that we do not accidently use test configuration in prod.
+prod: false
+
+database:
+  driverClass: org.postgresql.Driver
+  ## TODO: change database user to triplea_lobby or create a user for use with the http_server
+  user: postgres
+  password: ${POSTGRES_PASSWORD:-postgres}
+  url: jdbc:postgresql://localhost:5432/lobby
+  properties:
+    charSet: UTF-8
+  # the maximum amount of time to wait on an empty pool before throwing an exception
+  maxWaitForConnection: 1s
+
+  # the SQL query to run when validating a connection's liveness
+  validationQuery: select 1
+
+  # the minimum number of connections to keep open
+  minSize: 8
+
+  # the maximum number of connections to keep open
+  maxSize: 32
+
+  # whether or not idle connections should be validated
+  checkConnectionWhileIdle: false
+
+  # the amount of time to sleep between runs of the idle connection validation, abandoned cleaner and idle pool resizing
+  evictionInterval: 10s
+
+  # the minimum amount of time an connection must sit idle in the pool before it is eligible for eviction
+  minIdleTime: 1 minute

--- a/http-server/configuration-production.yml
+++ b/http-server/configuration-production.yml
@@ -1,2 +1,34 @@
 githubRepo: triplea
 githubApiToken: ${GITHUB_ISSUES_API_TOKEN}
+# if we are using any stubbing, we'll assert that this value is false.
+# this is to help guarantee that we do not accidently use test configuration in prod.
+prod: true
+
+database:
+  driverClass: org.postgresql.Driver
+  ## TODO: change database user to triplea_lobby or create a user for use with the http_server
+  user: postgres
+  password: ${POSTGRES_PASSWORD}
+  url: jdbc:postgresql://localhost:5432/lobby
+  properties:
+    charSet: UTF-8
+  # the maximum amount of time to wait on an empty pool before throwing an exception
+  maxWaitForConnection: 1s
+
+  # the SQL query to run when validating a connection's liveness
+  validationQuery: select 1
+
+  # the minimum number of connections to keep open
+  minSize: 8
+
+  # the maximum number of connections to keep open
+  maxSize: 32
+
+  # whether or not idle connections should be validated
+  checkConnectionWhileIdle: false
+
+  # the amount of time to sleep between runs of the idle connection validation, abandoned cleaner and idle pool resizing
+  evictionInterval: 10s
+
+  # the minimum amount of time an connection must sit idle in the pool before it is eligible for eviction
+  minIdleTime: 1 minute

--- a/http-server/configuration-production.yml
+++ b/http-server/configuration-production.yml
@@ -1,5 +1,5 @@
 githubRepo: triplea
-githubApiToken: ${GITHUB_ISSUES_API_TOKEN}
+githubApiToken: ${GITHUB_API_TOKEN}
 # if we are using any stubbing, we'll assert that this value is false.
 # this is to help guarantee that we do not accidently use test configuration in prod.
 prod: true

--- a/http-server/src/main/java/org/triplea/server/error/reporting/CreateIssueStrategy.java
+++ b/http-server/src/main/java/org/triplea/server/error/reporting/CreateIssueStrategy.java
@@ -1,6 +1,6 @@
 package org.triplea.server.error.reporting;
 
-import java.time.Clock;
+import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -45,7 +45,7 @@ public class CreateIssueStrategy implements Function<ErrorReportRequest, ErrorUp
       final ErrorUploadResponse errorUploadResponse = sendRequest(errorReportRequest);
 
       errorReportingDao.insertHistoryRecord(errorReportRequest.getClientIp());
-      errorReportingDao.purgeOld(Clock.systemUTC().instant().minus(2, ChronoUnit.DAYS));
+      errorReportingDao.purgeOld(Instant.now().minus(2, ChronoUnit.DAYS));
 
       return errorUploadResponse;
     }

--- a/http-server/src/main/java/org/triplea/server/error/reporting/CreateIssueStrategy.java
+++ b/http-server/src/main/java/org/triplea/server/error/reporting/CreateIssueStrategy.java
@@ -1,5 +1,7 @@
 package org.triplea.server.error.reporting;
 
+import java.time.Clock;
+import java.time.temporal.ChronoUnit;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -9,27 +11,56 @@ import org.triplea.http.client.error.report.ErrorUploadResponse;
 import org.triplea.http.client.github.issues.GithubIssueClient;
 import org.triplea.http.client.github.issues.create.CreateIssueResponse;
 
+import com.google.common.annotations.VisibleForTesting;
+
 import lombok.Builder;
+import lombok.NonNull;
 
 /** Performs the steps for uploading an error report from the point of view of the server. */
 @Builder
 public class CreateIssueStrategy implements Function<ErrorReportRequest, ErrorUploadResponse> {
+
+  @VisibleForTesting
+  static final String STUBBED_RETURN_VALUE = "API-token==test--returned-a-stubbed-github-issue-link";
 
   @Nonnull
   private final Function<CreateIssueResponse, ErrorUploadResponse> responseAdapter;
   @Nonnull
   private final GithubIssueClient githubIssueClient;
   @Nonnull
-  private final Predicate<ErrorReportRequest> allowErrorReport;
+  private final Predicate<String> allowErrorReport;
+  /**
+   * The 'production' flag is to help us verify we are not in a 'test' mode and will not return
+   * stubbed values while in production.
+   */
+  @NonNull
+  private final Boolean isProduction;
+  @Nonnull
+  private final ErrorReportingDao errorReportingDao;
+
 
   @Override
   public ErrorUploadResponse apply(final ErrorReportRequest errorReportRequest) {
-    if (allowErrorReport.test(errorReportRequest)) {
-      final CreateIssueResponse response =
-          githubIssueClient.newIssue(errorReportRequest.getErrorReport());
-      return responseAdapter.apply(response);
+    if (allowErrorReport.test(errorReportRequest.getClientIp())) {
+      final ErrorUploadResponse errorUploadResponse = sendRequest(errorReportRequest);
+
+      errorReportingDao.insertHistoryRecord(errorReportRequest.getClientIp());
+      errorReportingDao.purgeOld(Clock.systemUTC().instant().minus(2, ChronoUnit.DAYS));
+
+      return errorUploadResponse;
     }
 
-    throw new CreateErrorReportException("Too many requests, please wait before submitting another request");
+    throw new CreateErrorReportException("Error report limit reached, please wait a day to submit more.");
+  }
+
+  private ErrorUploadResponse sendRequest(final ErrorReportRequest errorReportRequest) {
+    if (githubIssueClient.isTest()) {
+      return ErrorUploadResponse.builder()
+          .githubIssueLink(STUBBED_RETURN_VALUE)
+          .build();
+    }
+    final CreateIssueResponse response =
+        githubIssueClient.newIssue(errorReportRequest.getErrorReport());
+    return responseAdapter.apply(response);
   }
 }

--- a/http-server/src/main/java/org/triplea/server/error/reporting/ErrorReportGateKeeper.java
+++ b/http-server/src/main/java/org/triplea/server/error/reporting/ErrorReportGateKeeper.java
@@ -1,18 +1,41 @@
 package org.triplea.server.error.reporting;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.function.Predicate;
+
+import lombok.Builder;
+import lombok.NonNull;
 
 /**
  * An object to check if we should accept an error report request from our users and use that
  * request to create a bug tracking ticket. A reason to deny is if rate limit has been exceeded.
  */
-public class ErrorReportGateKeeper implements Predicate<ErrorReportRequest> {
+@Builder
+public class ErrorReportGateKeeper implements Predicate<String> {
 
-  /** True if we should allow the error request. */
+  @NonNull
+  private final ErrorReportingDao dao;
+  @NonNull
+  private final Clock clock;
+  @NonNull
+  private final Integer maxReportsPerDay;
+
+  /**
+   * True if we should allow the error request. False indicates
+   * the user has submitted too many error reports.
+   */
   @Override
-  public boolean test(final ErrorReportRequest errorReportRequest) {
-    // TODO: implement
-    // TODO: log a warning when we do a request reject and return false
-    return true;
+  public boolean test(final String clientIp) {
+    checkNotNull(clientIp);
+    checkArgument(!clientIp.isEmpty());
+
+    final Instant oneDayAgo = clock.instant().minus(1, ChronoUnit.DAYS);
+
+    return dao.countRecordsByIpSince(clientIp, oneDayAgo) < maxReportsPerDay;
   }
 }

--- a/http-server/src/main/java/org/triplea/server/error/reporting/ErrorReportingDao.java
+++ b/http-server/src/main/java/org/triplea/server/error/reporting/ErrorReportingDao.java
@@ -1,0 +1,46 @@
+package org.triplea.server.error.reporting;
+
+import java.time.Instant;
+
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+
+/**
+ * DAO class for error reporting functionality.
+ */
+public interface ErrorReportingDao {
+
+  /**
+   * Inserts a new record indicating a user has submitted an error report
+   * at a given date.
+   *
+   * @param userIp Ip host address of the user submitting an error report.
+   */
+  @SqlUpdate("insert into error_report_history(user_ip) values(:ip)")
+  void insertHistoryRecord(@Bind("ip") String userIp);
+
+
+  /**
+   * Counts how many records, how many error reports, a user has submitted
+   * since a given date.
+   *
+   * @param userIp Ip host address of the user submitting an error report.
+   * @param dateSince How far back to look, only records newer compared
+   *        to this date will be counted.
+   */
+  @SqlQuery("select count(*) from error_report_history "
+      + "where user_ip = :ip "
+      + "  and date_created > :dateSince")
+  int countRecordsByIpSince(
+      @Bind("ip") String userIp, @Bind("dateSince") Instant dateSince);
+
+  /**
+   * Method to clean up old records from the error report history table.
+   * This is to avoid the table from growing very large.
+   *
+   * @param purgeSinceDate Any records older than this date will be removed.
+   */
+  @SqlUpdate("delete from error_report_history where date_created < :purgeSinceDate")
+  void purgeOld(@Bind("purgeSinceDate") Instant purgeSinceDate);
+}

--- a/http-server/src/main/java/org/triplea/server/http/AppConfig.java
+++ b/http-server/src/main/java/org/triplea/server/http/AppConfig.java
@@ -2,9 +2,13 @@ package org.triplea.server.http;
 
 import java.net.URI;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.dropwizard.Configuration;
+import io.dropwizard.db.DataSourceFactory;
 import lombok.Getter;
 import lombok.Setter;
 
@@ -18,9 +22,10 @@ import lombok.Setter;
  * whether to use prerelease or production configuration by specifying the appropriate file.
  * In the YML files secret or sensitive values are defined by environment variables.
  */
-class AppConfig extends Configuration {
+public class AppConfig extends Configuration {
   static final String GITHUB_ORG = "triplea-game";
   static final URI GITHUB_WEB_SERVICE_API_URL = URI.create("https://api.github.com");
+  static final int MAX_ERROR_REPORTS_PER_DAY = 5;
 
   @Getter(onMethod_ = {@JsonProperty})
   @Setter(onMethod_ = {@JsonProperty})
@@ -29,4 +34,14 @@ class AppConfig extends Configuration {
   @Getter(onMethod_ = {@JsonProperty})
   @Setter(onMethod_ = {@JsonProperty})
   private String githubRepo;
+
+  @Getter(onMethod_ = {@JsonProperty})
+  @Setter(onMethod_ = {@JsonProperty})
+  private boolean prod;
+
+  @Valid
+  @NotNull
+  @JsonProperty
+  @Getter
+  private DataSourceFactory database = new DataSourceFactory();
 }

--- a/http-server/src/main/java/org/triplea/server/http/AppConfig.java
+++ b/http-server/src/main/java/org/triplea/server/http/AppConfig.java
@@ -24,19 +24,31 @@ import lombok.Setter;
  * whether to use prerelease or production configuration by specifying the appropriate file.
  * In the YML files secret or sensitive values are defined by environment variables.
  */
-public class AppConfig extends Configuration {
+class AppConfig extends Configuration {
   static final String GITHUB_ORG = "triplea-game";
   static final URI GITHUB_WEB_SERVICE_API_URL = URI.create("https://api.github.com");
   static final int MAX_ERROR_REPORTS_PER_DAY = 5;
 
+  /**
+   * Webservice token, should be an API token for the TripleA builder bot account.
+   */
   @Getter(onMethod_ = {@JsonProperty})
   @Setter(onMethod_ = {@JsonProperty})
   private String githubApiToken;
 
+  /**
+   * Repo where we will create github issues from bug report uploads.
+   */
   @Getter(onMethod_ = {@JsonProperty})
   @Setter(onMethod_ = {@JsonProperty})
   private String githubRepo;
 
+  /**
+   * Flag that indicates if we are running in production. This can be used to verify we do not have
+   * any magic stubbing and to do any additional configuration checks to be really sure production is
+   * well configured. Because we vary configuration values between prod and test, there can be prod-only
+   * cases where we perhaps have something misconfigured, hence the risk we are trying to defend against.
+   */
   @Getter(onMethod_ = {@JsonProperty})
   @Setter(onMethod_ = {@JsonProperty})
   private boolean prod;

--- a/http-server/src/main/java/org/triplea/server/http/AppConfig.java
+++ b/http-server/src/main/java/org/triplea/server/http/AppConfig.java
@@ -1,5 +1,7 @@
 package org.triplea.server.http;
 
+import static com.google.common.base.Preconditions.checkState;
+
 import java.net.URI;
 
 import javax.validation.Valid;
@@ -44,4 +46,25 @@ public class AppConfig extends Configuration {
   @JsonProperty
   @Getter
   private DataSourceFactory database = new DataSourceFactory();
+
+  /**
+   * Ensures that we have defined all values needed for running in production.
+   * To allow environment variables to be defaulted, we have to configure drop wizard to allow
+   * empty environment variable values. This opens up a vulnerability where in production we could
+   * incorrectly define, or forget to define an environment variable value. In that case we'd launch
+   * with an incorrect or incomplete configuration and might not know until that functionality is
+   * exercised.
+   */
+  void verifyProdEnvironmentVariables() {
+    checkState(prod);
+
+    checkEnvVariable(githubApiToken, "GITHUB_API_TOKEN");
+    checkEnvVariable(System.getenv("POSTGRES_PASSWORD"), "POSTGRES_PASSWORD");
+  }
+
+  private void checkEnvVariable(final String value, final String envVariableName) {
+    checkState(
+        value != null && !value.isEmpty(),
+        envVariableName + " environment variable must be set");
+  }
 }

--- a/http-server/src/main/java/org/triplea/server/http/ServerApplication.java
+++ b/http-server/src/main/java/org/triplea/server/http/ServerApplication.java
@@ -61,6 +61,10 @@ public class ServerApplication extends Application<AppConfig> {
   public void run(final AppConfig configuration, final Environment environment) {
     environment.jersey().register(new ClientExceptionMapper());
 
+    if(configuration.isProd()) {
+      configuration.verifyProdEnvironmentVariables();
+    }
+
     final JdbiFactory factory = new JdbiFactory();
     final Jdbi jdbi = factory.build(environment, configuration.getDatabase(), "postgresql-connection-pool");
 

--- a/http-server/src/main/java/org/triplea/server/http/ServerApplication.java
+++ b/http-server/src/main/java/org/triplea/server/http/ServerApplication.java
@@ -61,7 +61,7 @@ public class ServerApplication extends Application<AppConfig> {
   public void run(final AppConfig configuration, final Environment environment) {
     environment.jersey().register(new ClientExceptionMapper());
 
-    if(configuration.isProd()) {
+    if (configuration.isProd()) {
       configuration.verifyProdEnvironmentVariables();
     }
 

--- a/http-server/src/main/java/org/triplea/server/http/ServerApplication.java
+++ b/http-server/src/main/java/org/triplea/server/http/ServerApplication.java
@@ -1,14 +1,23 @@
 package org.triplea.server.http;
 
+import java.time.Clock;
+import java.util.function.Predicate;
+
+import org.jdbi.v3.core.Jdbi;
 import org.triplea.http.client.github.issues.GithubIssueClient;
 import org.triplea.server.error.reporting.CreateIssueStrategy;
 import org.triplea.server.error.reporting.ErrorReportController;
 import org.triplea.server.error.reporting.ErrorReportGateKeeper;
 import org.triplea.server.error.reporting.ErrorReportResponseConverter;
+import org.triplea.server.error.reporting.ErrorReportingDao;
+
+import com.google.common.base.Preconditions;
 
 import io.dropwizard.Application;
 import io.dropwizard.configuration.EnvironmentVariableSubstitutor;
 import io.dropwizard.configuration.SubstitutingSourceProvider;
+import io.dropwizard.jdbi3.JdbiFactory;
+import io.dropwizard.jdbi3.bundles.JdbiExceptionsBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 
@@ -18,12 +27,19 @@ import io.dropwizard.setup.Environment;
  * registering resources (controllers) and injecting those resources
  * with configuration properties from 'AppConfig'.
  */
-class ServerApplication extends Application<AppConfig> {
+public class ServerApplication extends Application<AppConfig> {
 
+  private static final String[] DEFAULT_ARGS =
+      new String[] {"server", "configuration-prerelease.yml"};
+
+  /**
+   * Main entry-point method, launches the drop-wizard http server.
+   * If no args are passed then will use default values suitable for local development.
+   */
   public static void main(final String[] args) throws Exception {
+    final ServerApplication application = new ServerApplication();
     // if no args are provided then we will use default values.
-    new ServerApplication().run(
-        args.length == 0 ? new String[] {"server", "configuration-prerelease.yml"} : args);
+    application.run(args.length == 0 ? DEFAULT_ARGS : args);
   }
 
   @Override
@@ -32,18 +48,29 @@ class ServerApplication extends Application<AppConfig> {
     // variable values. Without it, all values in the YML configuration are treated as literals.
     bootstrap.setConfigurationSourceProvider(
         new SubstitutingSourceProvider(bootstrap.getConfigurationSourceProvider(),
-            new EnvironmentVariableSubstitutor()));
+            new EnvironmentVariableSubstitutor(false)));
+
+    // From: https://www.dropwizard.io/0.7.1/docs/manual/jdbi.html
+    // By adding the JdbiExceptionsBundle to your application, Dropwizard will automatically unwrap any
+    // thrown SQLException or DBIException instances. This is critical for debugging, since otherwise
+    // only the common wrapper exception’s stack trace is logged.
+    bootstrap.addBundle(new JdbiExceptionsBundle());
   }
 
   @Override
   public void run(final AppConfig configuration, final Environment environment) {
     environment.jersey().register(new ClientExceptionMapper());
 
+    final JdbiFactory factory = new JdbiFactory();
+    final Jdbi jdbi = factory.build(environment, configuration.getDatabase(), "postgresql-connection-pool");
+
     // register all endpoint handlers here:
-    environment.jersey().register(errorReportController(configuration));
+    environment.jersey().register(errorReportController(configuration, jdbi));
   }
 
-  private static ErrorReportController errorReportController(final AppConfig configuration) {
+  private static ErrorReportController errorReportController(
+      final AppConfig configuration,
+      final Jdbi jdbi) {
     final GithubIssueClient githubIssueClient = GithubIssueClient.builder()
         .uri(AppConfig.GITHUB_WEB_SERVICE_API_URL)
         .authToken(configuration.getGithubApiToken())
@@ -51,10 +78,27 @@ class ServerApplication extends Application<AppConfig> {
         .githubRepo(configuration.getGithubRepo())
         .build();
 
-    return new ErrorReportController(CreateIssueStrategy.builder()
-        .githubIssueClient(githubIssueClient)
-        .allowErrorReport(new ErrorReportGateKeeper())
-        .responseAdapter(new ErrorReportResponseConverter())
-        .build());
+    final ErrorReportingDao errorReportingDao = jdbi.onDemand(ErrorReportingDao.class);
+    final Predicate<String> errorReportGateKeeper = ErrorReportGateKeeper.builder()
+        .maxReportsPerDay(AppConfig.MAX_ERROR_REPORTS_PER_DAY)
+        .dao(errorReportingDao)
+        .clock(Clock.systemUTC())
+        .build();
+
+
+    if (githubIssueClient.isTest()) {
+      Preconditions.checkState(!configuration.isProd());
+    }
+
+    return ErrorReportController.builder()
+        .errorReportIngestion(CreateIssueStrategy.builder()
+            .githubIssueClient(githubIssueClient)
+            .allowErrorReport(errorReportGateKeeper)
+            .responseAdapter(new ErrorReportResponseConverter())
+            .isProduction(configuration.isProd())
+            .errorReportingDao(errorReportingDao)
+            .build())
+        .errorReportRateChecker(errorReportGateKeeper)
+        .build();
   }
 }

--- a/http-server/src/test/java/org/triplea/server/error/reporting/CreateIssueStrategyTest.java
+++ b/http-server/src/test/java/org/triplea/server/error/reporting/CreateIssueStrategyTest.java
@@ -1,0 +1,106 @@
+package org.triplea.server.error.reporting;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsSame.sameInstance;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Function;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.http.client.error.report.ErrorUploadRequest;
+import org.triplea.http.client.error.report.ErrorUploadResponse;
+import org.triplea.http.client.github.issues.GithubIssueClient;
+import org.triplea.http.client.github.issues.create.CreateIssueResponse;
+
+@ExtendWith(MockitoExtension.class)
+class CreateIssueStrategyTest {
+
+  private static final ErrorReportRequest ERROR_REPORT_REQUEST = ErrorReportRequest.builder()
+      .errorReport(ErrorUploadRequest.builder()
+          .body("body")
+          .title("title")
+          .build())
+      .clientIp("ip")
+      .build();
+
+  private CreateIssueStrategy createIssueStrategy;
+
+  @Mock
+  private GithubIssueClient githubIssueClient;
+  @Mock
+  private ErrorUploadResponse errorUploadResponse;
+  @Mock
+  private CreateIssueResponse createIssueResponse;
+  @Mock
+  private Function<CreateIssueResponse, ErrorUploadResponse> responseAdapter;
+  @Mock
+  private ErrorReportingDao errorReportingDao;
+
+  @Test
+  void whenGithubServiceClientIsTestWillReturnStub() {
+    createIssueStrategy = CreateIssueStrategy.builder()
+        .githubIssueClient(githubIssueClient)
+        .allowErrorReport(value -> true)
+        .isProduction(false)
+        .responseAdapter(value -> null)
+        .errorReportingDao(errorReportingDao)
+        .build();
+    when(githubIssueClient.isTest()).thenReturn(true);
+
+    final ErrorUploadResponse response = createIssueStrategy.apply(ERROR_REPORT_REQUEST);
+
+    assertThat(
+        response.getGithubIssueLink(),
+        is(CreateIssueStrategy.STUBBED_RETURN_VALUE));
+
+    verify(errorReportingDao).insertHistoryRecord(ERROR_REPORT_REQUEST.getClientIp());
+    verify(errorReportingDao).purgeOld(any());
+  }
+
+  @Test
+  void willThrowIfReportingLimitIsReached() {
+    createIssueStrategy = CreateIssueStrategy.builder()
+        .githubIssueClient(githubIssueClient)
+        // key setting here is that allow error report is false
+        .allowErrorReport(value -> false)
+        .isProduction(false)
+        .responseAdapter(value -> null)
+        .errorReportingDao(errorReportingDao)
+        .build();
+
+    assertThrows(CreateErrorReportException.class, () -> createIssueStrategy.apply(ERROR_REPORT_REQUEST));
+
+    verify(errorReportingDao, never()).insertHistoryRecord(any());
+    verify(errorReportingDao, never()).purgeOld(any());
+  }
+
+  @Test
+  void verifyHappyCaseFlow() {
+    createIssueStrategy = CreateIssueStrategy.builder()
+        .githubIssueClient(githubIssueClient)
+        .allowErrorReport(value -> true)
+        .isProduction(true)
+        .responseAdapter(responseAdapter)
+        .errorReportingDao(errorReportingDao)
+        .build();
+
+    when(githubIssueClient.isTest()).thenReturn(false);
+    when(githubIssueClient.newIssue(ERROR_REPORT_REQUEST.getErrorReport()))
+        .thenReturn(createIssueResponse);
+    when(responseAdapter.apply(createIssueResponse)).thenReturn(errorUploadResponse);
+
+    final ErrorUploadResponse response = createIssueStrategy.apply(ERROR_REPORT_REQUEST);
+    assertThat(response, sameInstance(errorUploadResponse));
+
+    verify(errorReportingDao).insertHistoryRecord(ERROR_REPORT_REQUEST.getClientIp());
+    verify(errorReportingDao).purgeOld(any());
+  }
+}

--- a/http-server/src/test/java/org/triplea/server/error/reporting/Database.java
+++ b/http-server/src/test/java/org/triplea/server/error/reporting/Database.java
@@ -1,0 +1,20 @@
+package org.triplea.server.error.reporting;
+
+import org.jdbi.v3.core.Jdbi;
+import org.jdbi.v3.sqlobject.SqlObjectPlugin;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * Utility to get connections to the Postgres lobby database.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+final class Database {
+  static Jdbi newConnection() {
+    final Jdbi jdbi = Jdbi.create(
+        "jdbc:postgresql://localhost:5432/lobby", "postgres", "postgres");
+    jdbi.installPlugin(new SqlObjectPlugin());
+    return jdbi;
+  }
+}

--- a/http-server/src/test/java/org/triplea/server/error/reporting/ErrorReportGateKeeperTest.java
+++ b/http-server/src/test/java/org/triplea/server/error/reporting/ErrorReportGateKeeperTest.java
@@ -1,0 +1,79 @@
+package org.triplea.server.error.reporting;
+
+import static org.hamcrest.core.Is.is;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+import org.hamcrest.MatcherAssert;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * In this test we set up some mock objects to return a report
+ * count since yesterday that we will compare to a configurable
+ * max value. If at max or over, then we expect 'false', meaning
+ * an additional report is not allowed.
+ */
+@ExtendWith(MockitoExtension.class)
+class ErrorReportGateKeeperTest {
+  private static final int MAX_REPORTS_PER_DAY = 3;
+  private static final Instant INSTANT = Instant.now();
+  private static final String USER_IP = "user-ip-value";
+
+  @Mock
+  private Clock clock;
+
+  @Mock
+  private ErrorReportingDao dao;
+
+  private ErrorReportGateKeeper errorReportGateKeeper;
+
+  @BeforeEach
+  void setup() {
+    errorReportGateKeeper = ErrorReportGateKeeper.builder()
+        .clock(clock)
+        .dao(dao)
+        .maxReportsPerDay(MAX_REPORTS_PER_DAY)
+        .build();
+  }
+
+  @Test
+  void allowedIfUnderMax() {
+    givenErrorReportCount(MAX_REPORTS_PER_DAY - 1);
+    MatcherAssert.assertThat(
+        errorReportGateKeeper.test(USER_IP),
+        is(true));
+  }
+
+  private void givenErrorReportCount(final int count) {
+    Mockito.when(clock.instant()).thenReturn(INSTANT);
+
+    final Instant oneDayAgo = INSTANT.minus(1, ChronoUnit.DAYS);
+
+    Mockito.when(dao.countRecordsByIpSince(USER_IP, oneDayAgo))
+        .thenReturn(count);
+  }
+
+  @Test
+  void notAllowedIfAtMax() {
+    givenErrorReportCount(MAX_REPORTS_PER_DAY);
+    MatcherAssert.assertThat(
+        errorReportGateKeeper.test(USER_IP),
+        is(false));
+  }
+
+  @Test
+  void notAllowedIfExceedingMax() {
+    givenErrorReportCount(MAX_REPORTS_PER_DAY + 1);
+    MatcherAssert.assertThat(
+        errorReportGateKeeper.test(USER_IP),
+        is(false));
+  }
+
+}

--- a/http-server/src/test/java/org/triplea/server/error/reporting/ErrorReportGateKeeperTest.java
+++ b/http-server/src/test/java/org/triplea/server/error/reporting/ErrorReportGateKeeperTest.java
@@ -1,17 +1,17 @@
 package org.triplea.server.error.reporting;
 
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.when;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 
-import org.hamcrest.MatcherAssert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 /**
@@ -46,24 +46,23 @@ class ErrorReportGateKeeperTest {
   @Test
   void allowedIfUnderMax() {
     givenErrorReportCount(MAX_REPORTS_PER_DAY - 1);
-    MatcherAssert.assertThat(
+    assertThat(
         errorReportGateKeeper.test(USER_IP),
         is(true));
   }
 
   private void givenErrorReportCount(final int count) {
-    Mockito.when(clock.instant()).thenReturn(INSTANT);
+    when(clock.instant()).thenReturn(INSTANT);
 
     final Instant oneDayAgo = INSTANT.minus(1, ChronoUnit.DAYS);
 
-    Mockito.when(dao.countRecordsByIpSince(USER_IP, oneDayAgo))
-        .thenReturn(count);
+    when(dao.countRecordsByIpSince(USER_IP, oneDayAgo)).thenReturn(count);
   }
 
   @Test
   void notAllowedIfAtMax() {
     givenErrorReportCount(MAX_REPORTS_PER_DAY);
-    MatcherAssert.assertThat(
+    assertThat(
         errorReportGateKeeper.test(USER_IP),
         is(false));
   }
@@ -71,7 +70,7 @@ class ErrorReportGateKeeperTest {
   @Test
   void notAllowedIfExceedingMax() {
     givenErrorReportCount(MAX_REPORTS_PER_DAY + 1);
-    MatcherAssert.assertThat(
+    assertThat(
         errorReportGateKeeper.test(USER_IP),
         is(false));
   }

--- a/http-server/src/test/java/org/triplea/server/error/reporting/ErrorReportingDaoTest.java
+++ b/http-server/src/test/java/org/triplea/server/error/reporting/ErrorReportingDaoTest.java
@@ -1,0 +1,93 @@
+package org.triplea.server.error.reporting;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.triplea.test.common.Integration;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.database.rider.junit5.DBUnitExtension;
+
+@ExtendWith(DBUnitExtension.class)
+@Integration
+final class ErrorReportingDaoTest {
+  private static final ErrorReportingDao REPORTING_DAO = Database.newConnection().onDemand(ErrorReportingDao.class);
+
+  /**
+   * Simple check that if we insert a record we'll get a new record in the expected dataset.
+   */
+  @DataSet("error_reporting/pre-insert.yml")
+  @ExpectedDataSet(value = "error_reporting/post-insert.yml")
+  @Test
+  void insertRow() {
+    REPORTING_DAO.insertHistoryRecord("second");
+  }
+
+  /**
+   * Dates in dataset span from: 2016-01-01 23:59:20.0 to 2016-01-03 23:59:20.0.
+   * In this test we'll bisect the various date and verify we select the correct number of records.
+   */
+  @DataSet("error_reporting/select.yml")
+  @Test
+  void insertionsSince() {
+
+    Arrays.asList("first", "second").forEach(userIp -> assertThat(
+        "All records are dated 2016-01-xx, now should have no records",
+        REPORTING_DAO.countRecordsByIpSince(userIp, Instant.now()),
+        is(0)));
+
+    assertThat(
+        "All records are dated 2016-01-xx, now should have no records",
+        REPORTING_DAO.countRecordsByIpSince("first", Instant.now()),
+        is(0));
+
+    final Instant farPast = LocalDateTime.of(2000, 1, 1, 0, 0)
+        .toInstant(ZoneOffset.UTC);
+
+    assertThat(
+        "There is one record with 'second', we'll search for a date in far past",
+        REPORTING_DAO.countRecordsByIpSince("second", farPast),
+        is(1));
+
+    assertThat(
+        "should select only last record of first userIp",
+        REPORTING_DAO.countRecordsByIpSince(
+            "first",
+            LocalDateTime.of(2016, 1, 3, 23, 0, 0)
+                .toInstant(ZoneOffset.UTC)),
+        is(1));
+
+    assertThat(
+        "should select last two records of first userIp",
+        REPORTING_DAO.countRecordsByIpSince(
+            "first",
+            LocalDateTime.of(2016, 1, 2, 23, 0, 0)
+                .toInstant(ZoneOffset.UTC)),
+        is(2));
+
+    assertThat(
+        "should select all three records of first userIp",
+        REPORTING_DAO.countRecordsByIpSince(
+            "first",
+            LocalDateTime.of(2016, 1, 1, 23, 0, 0)
+                .toInstant(ZoneOffset.UTC)),
+        is(3));
+  }
+
+  @DataSet("error_reporting/pre-purge.yml")
+  @ExpectedDataSet(value = "error_reporting/post-purge.yml")
+  @Test
+  void purgeOld() {
+    REPORTING_DAO.purgeOld(
+        LocalDateTime.of(2016, 1, 3, 23, 0, 0)
+            .toInstant(ZoneOffset.UTC));
+  }
+}

--- a/http-server/src/test/java/org/triplea/server/http/HttpServerIntegrationTest.java
+++ b/http-server/src/test/java/org/triplea/server/http/HttpServerIntegrationTest.java
@@ -1,0 +1,57 @@
+package org.triplea.server.http;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.IsNull.notNullValue;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.triplea.http.client.error.report.ErrorUploadClient;
+import org.triplea.http.client.error.report.ErrorUploadRequest;
+import org.triplea.test.common.Integration;
+
+import io.dropwizard.testing.DropwizardTestSupport;
+
+/**
+ * Integration test launches a server and verifies we can
+ * access each endpoint. As this is an integrated test, we do
+ * not verify anything other than we receive a valid-looking
+ * response. Logic validation is left for unit tests.
+ */
+@Integration
+class HttpServerIntegrationTest {
+
+  private static final DropwizardTestSupport<AppConfig> SUPPORT =
+      new DropwizardTestSupport<>(ServerApplication.class, "configuration-prerelease.yml");
+
+  private static ErrorUploadClient client;
+
+
+  @BeforeAll
+  static void beforeClass() {
+    SUPPORT.before();
+    client = ErrorUploadClient.newClient(URI.create("http://localhost:8080"));
+  }
+
+  @AfterAll
+  static void afterClass() {
+    SUPPORT.after();
+  }
+
+  @Test
+  void canSubmitErrorReport() {
+    client.canSubmitErrorReport();
+  }
+
+  @Test
+  void uploadErrorReport() {
+    assertThat(
+        client.uploadErrorReport(ErrorUploadRequest.builder()
+            .body("body")
+            .title("title")
+            .build()),
+        notNullValue());
+  }
+}

--- a/http-server/src/test/resources/datasets/error_reporting/post-insert.yml
+++ b/http-server/src/test/resources/datasets/error_reporting/post-insert.yml
@@ -1,5 +1,3 @@
 error_report_history:
-  - id: 1
-    user_ip: first
   - id:  "regex:\\d+" #any number
     user_ip: second

--- a/http-server/src/test/resources/datasets/error_reporting/post-insert.yml
+++ b/http-server/src/test/resources/datasets/error_reporting/post-insert.yml
@@ -1,0 +1,5 @@
+error_report_history:
+  - id: 1
+    user_ip: first
+  - id:  "regex:\\d+" #any number
+    user_ip: second

--- a/http-server/src/test/resources/datasets/error_reporting/post-purge.yml
+++ b/http-server/src/test/resources/datasets/error_reporting/post-purge.yml
@@ -1,0 +1,7 @@
+error_report_history:
+  - id: 3
+    user_ip: first
+    date_created: 2016-01-03 23:59:20.0
+  - id: 4
+    user_ip: second
+    date_created: 2016-01-03 23:59:20.0

--- a/http-server/src/test/resources/datasets/error_reporting/post-purge.yml
+++ b/http-server/src/test/resources/datasets/error_reporting/post-purge.yml
@@ -1,7 +1,7 @@
 error_report_history:
-  - id: 3
+  - id: 900002
     user_ip: first
     date_created: 2016-01-03 23:59:20.0
-  - id: 4
+  - id: 900003
     user_ip: second
     date_created: 2016-01-03 23:59:20.0

--- a/http-server/src/test/resources/datasets/error_reporting/pre-insert.yml
+++ b/http-server/src/test/resources/datasets/error_reporting/pre-insert.yml
@@ -1,0 +1,3 @@
+error_report_history:
+  - id: 1
+    user_ip: first

--- a/http-server/src/test/resources/datasets/error_reporting/pre-insert.yml
+++ b/http-server/src/test/resources/datasets/error_reporting/pre-insert.yml
@@ -1,3 +1,1 @@
 error_report_history:
-  - id: 1
-    user_ip: first

--- a/http-server/src/test/resources/datasets/error_reporting/pre-purge.yml
+++ b/http-server/src/test/resources/datasets/error_reporting/pre-purge.yml
@@ -1,0 +1,13 @@
+error_report_history:
+  - id: 1
+    user_ip: first
+    date_created: 2016-01-01 23:59:20.0
+  - id: 2
+    user_ip: first
+    date_created: 2016-01-02 23:59:20.0
+  - id: 3
+    user_ip: first
+    date_created: 2016-01-03 23:59:20.0
+  - id: 4
+    user_ip: second
+    date_created: 2016-01-03 23:59:20.0

--- a/http-server/src/test/resources/datasets/error_reporting/pre-purge.yml
+++ b/http-server/src/test/resources/datasets/error_reporting/pre-purge.yml
@@ -1,13 +1,13 @@
 error_report_history:
-  - id: 1
+  - id: 900000
     user_ip: first
     date_created: 2016-01-01 23:59:20.0
-  - id: 2
+  - id: 900001
     user_ip: first
     date_created: 2016-01-02 23:59:20.0
-  - id: 3
+  - id: 900002
     user_ip: first
     date_created: 2016-01-03 23:59:20.0
-  - id: 4
+  - id: 900003
     user_ip: second
     date_created: 2016-01-03 23:59:20.0

--- a/http-server/src/test/resources/datasets/error_reporting/select.yml
+++ b/http-server/src/test/resources/datasets/error_reporting/select.yml
@@ -1,0 +1,13 @@
+error_report_history:
+  - id: 1
+    user_ip: first
+    date_created: 2016-01-01 23:59:20.0
+  - id: 2
+    user_ip: first
+    date_created: 2016-01-02 23:59:20.0
+  - id: 3
+    user_ip: first
+    date_created: 2016-01-03 23:59:20.0
+  - id: 4
+    user_ip: second
+    date_created: 2016-01-03 23:59:20.0

--- a/http-server/src/test/resources/datasets/error_reporting/select.yml
+++ b/http-server/src/test/resources/datasets/error_reporting/select.yml
@@ -1,13 +1,13 @@
 error_report_history:
-  - id: 1
+  - id: 800001
     user_ip: first
     date_created: 2016-01-01 23:59:20.0
-  - id: 2
+  - id: 800002
     user_ip: first
     date_created: 2016-01-02 23:59:20.0
-  - id: 3
+  - id: 800003
     user_ip: first
     date_created: 2016-01-03 23:59:20.0
-  - id: 4
+  - id: 800004
     user_ip: second
     date_created: 2016-01-03 23:59:20.0

--- a/http-server/src/test/resources/dbunit.yml
+++ b/http-server/src/test/resources/dbunit.yml
@@ -1,0 +1,6 @@
+caseInsensitiveStrategy: !!com.github.database.rider.core.api.configuration.Orthography 'LOWERCASE'
+connectionConfig:
+  driver: "org.postgresql.Driver"
+  url: "jdbc:postgresql://localhost:5432/lobby"
+  user: "postgres"
+  password: "postgres"

--- a/lobby-db/src/main/resources/db/migration/V1.10.00.20190527__error_reporting_record.sql
+++ b/lobby-db/src/main/resources/db/migration/V1.10.00.20190527__error_reporting_record.sql
@@ -1,0 +1,13 @@
+create table error_report_history(
+  id       serial primary key,
+  user_ip  character varying(30) not null,
+  date_created timestamp not null default now()
+);
+
+-- alter table error_report_history owner to triplea_lobby;
+alter table error_report_history owner to postgres;
+
+comment on table error_report_history is 'Table that stores timestamps by user IP address of when error reports were created. Used to do rate limiting.';
+comment on column error_report_history.id is 'Synthetic PK column';
+comment on column error_report_history.user_ip is 'IP address of a user that has submitted an error report';
+comment on column error_report_history.date_created is 'Timestamp when error report was created in DB';


### PR DESCRIPTION
## Overview
- Fix up gradle config for http-server to create a launchable artifact.
- Add an integration test for drop wizard http server, fires up the http server and verifies http client code can connect.
- Add database support to http server (per drop wizard recommendation, using JDBI framework)
- Add rate limiting for error report upload. Except for http server deployment, this completes the error report upload feature. For server side rate limiting we add a simple history table and update it on the server side when error reports are submitted. Of note, whenever we add to the history table we'll also purge any records older than two days to prevent the table from growing. An initial rate limit of 5 error reports per day has been configured.
- Update headed-client to have a 'fail-early' check if upload limit has been reached. If so we'll show a dialog explaining this to the user instead of showing the upload-error-report form. To enable this a new GET endpoint was added: '/can-submit-error-report'
- Set a default value for 'github API token' to be 'test'. This is used as a magic value to trigger a stubbed response when creating github issues. To safeguard against using a stub in production, a 'prod' flag is added which will crash the application if we are configured to use a stub response.

## Functional Changes
- Error report upload now has a server side rate limit, 5 per day
- Client side error report upload will tell the user when they hit the limit if they click "report to triplea" when seeing errors

## Manual Testing Performed
- fired up a local http server and tested out the endpoints with curl. (Note, the new integration tests really helped quite a lot, like most automated testing, that testing was more valuable and replaced any curl testing, but it's not bad to have curl testing nonetheless)
- fired up a local http server, lobby, and added a "generate error button" to the homepage that threw an exception. I clicked this to verify the DB data was as expected and that the rate limit dialog appeared. Also was able to verify the DB pruning manually in this fashion and saw old records drop away from the DB.
