### PR TITLE
Add ansible http_server role

### DIFF
--- a/infrastructure/ansible/group_vars/lobbyHosts.yml
+++ b/infrastructure/ansible/group_vars/lobbyHosts.yml
@@ -2,3 +2,4 @@ ufw_allowed_ports:
   - "{{ lobby_port }}"
   - 80
   - 443
+  - 8080

--- a/infrastructure/ansible/group_vars/prerelease.yml
+++ b/infrastructure/ansible/group_vars/prerelease.yml
@@ -1,1 +1,2 @@
 bot_lobby_address: prerelease.triplea-game.org
+http_server_error_report_github_token: "{{ lookup('env', 'GITHUB_API_TOKEN') }}"

--- a/infrastructure/ansible/group_vars/production.yml
+++ b/infrastructure/ansible/group_vars/production.yml
@@ -1,2 +1,4 @@
-http_server_error_report_github_repo: "triplea"
 bot_lobby_address: production.triplea-game.org
+http_server_error_report_github_repo: "triplea"
+http_server_error_report_github_token: "{{ lookup('env', 'GITHUB_API_TOKEN') }}"
+http_server_config_file: configuration-production.yml

--- a/infrastructure/ansible/roles/http_server/defaults/main.yml
+++ b/infrastructure/ansible/roles/http_server/defaults/main.yml
@@ -1,0 +1,21 @@
+http_server_user: http_server
+
+http_server_folder: "/home/{{ http_server_user }}"
+
+http_server_jar: "http_server-{{ lookup('env', 'VERSION') }}.jar"
+
+http_server_port: "8080"
+
+http_server_postgres_password: "{{ lookup('env', 'POSTGRES_PASSWORD') }}"
+
+http_server_postgres_host: "127.0.0.1"
+
+http_server_postgres_port: "5432"
+
+http_server_error_report_github_org: "triplea-game"
+
+http_server_error_report_github_repo: "test"
+
+http_server_error_report_github_token: "test"
+
+http_server_config_file: configuration-prerelease.yml

--- a/infrastructure/ansible/roles/http_server/tasks/main.yml
+++ b/infrastructure/ansible/roles/http_server/tasks/main.yml
@@ -1,0 +1,42 @@
+- name: create service user
+  become: true
+  user:
+    name: "{{ http_server_user }}"
+    create_home: yes
+    system: yes
+
+- name: deploy jar file
+  become: true
+  copy:
+    src: "{{ http_server_jar }}"
+    dest: "{{ http_server_folder }}/{{ http_server_jar }}"
+    owner: "{{ http_server_user }}"
+    group: "{{ http_server_user }}"
+
+- name: install systemd service script
+  become: true
+  template:
+    src: http_server.service.j2
+    dest: /lib/systemd/system/http_server.service
+    mode: "644"
+
+- name: deploy run_server script
+  become: true
+  template:
+    src: run_server.j2
+    dest: "{{ http_server_folder }}/run_server"
+    mode: "755"
+    owner: "{{ http_server_user }}"
+    group: "{{ http_server_user }}"
+
+- name: reload systemd
+  become: true
+  systemd:
+    daemon_reload: yes
+
+- name: enable and start service
+  become: true
+  service:
+    name: http_server
+    state: started
+    enabled: yes

--- a/infrastructure/ansible/roles/http_server/templates/http_server.service.j2
+++ b/infrastructure/ansible/roles/http_server/templates/http_server.service.j2
@@ -1,0 +1,22 @@
+[Unit]
+Description=TripleA Http Server
+Documentation=
+
+[Service]
+WorkingDirectory={{ http_server_folder }}
+User={{ http_server_user }}
+Group={{ http_server_user }}
+ExecStart={{ http_server_folder }}/run_server
+Restart=always
+Environment="PORT={{ http_server_port }}"
+Environment="POSTGRES_USER={{ http_server_db_user }}"
+Environment="POSTGRES_PASSWORD={{ http_server_db_password }}"
+Environment="POSTGRES_HOST={{ http_server_postgres_host }}"
+Environment="POSTGRES_PORT={{ http_server_postgres_port }}"
+Environment="POSTGRES_DATABASE={{ lobby_db_name }}"
+Environment="ERROR_REPORTING_GITHUB_ORG={{ http_server_error_report_github_org }}"
+Environment="ERROR_REPORTING_GITHUB_REPO={{ http_server_error_report_github_repo }}"
+Environment="GITHUB_API_AUTH_TOKEN={{ http_server_error_report_github_token }}"
+
+[Install]
+WantedBy=multi-user.target

--- a/infrastructure/ansible/roles/http_server/templates/run_server.j2
+++ b/infrastructure/ansible/roles/http_server/templates/run_server.j2
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd $(dirname $0)
+java -jar -jar {{ http_server_jar }} -server {{ http_server_config_file }}

--- a/infrastructure/ansible/roles/lobby/defaults/main.yml
+++ b/infrastructure/ansible/roles/lobby/defaults/main.yml
@@ -15,9 +15,3 @@ lobby_postgres_password: "{{ lookup('env', 'POSTGRES_PASSWORD') }}"
 lobby_postgres_host: "127.0.0.1"  # For vagrant host machine, use: 10.0.2.2
 
 lobby_postgres_port: "5432"
-
-lobby_error_report_github_org: "triplea-game"
-
-lobby_error_report_github_repo: "test"
-
-lobby_error_report_github_token: "token"

--- a/infrastructure/ansible/roles/lobby/templates/lobby.service.j2
+++ b/infrastructure/ansible/roles/lobby/templates/lobby.service.j2
@@ -14,9 +14,6 @@ Environment="POSTGRES_PASSWORD={{ lobby_db_password }}"
 Environment="POSTGRES_HOST={{ lobby_postgres_host }}"
 Environment="POSTGRES_PORT={{ lobby_postgres_port }}"
 Environment="POSTGRES_DATABASE={{ lobby_db_name }}"
-Environment="ERROR_REPORTING_GITHUB_ORG={{ lobby_error_report_github_org }}"
-Environment="ERROR_REPORTING_GITHUB_REPO={{ lobby_error_report_github_repo }}"
-Environment="GITHUB_API_AUTH_TOKEN={{ lobby_error_report_github_token }}"
 
 [Install]
 WantedBy=multi-user.target

--- a/infrastructure/ansible/site.yml
+++ b/infrastructure/ansible/site.yml
@@ -33,6 +33,7 @@
     - java
     - lobby
     - nginx
+    - http_server
 
 - hosts: botHosts
   gather_facts: no


### PR DESCRIPTION
## Overview

Adds a role based on the lobby role to install and run http_server.
This update also cleans up the lobby role of unused properties
that are exclusive to http_server now.

## Manual Testing Performed
- none

## Additional Review Notes

Note: not well tested, there may be some issues in this config, for now
this lays down the obvious boiler plater in preparation for a more serious
effort to ensure that http server is deployed and working on at least
prerelease.
