### PR TITLE
Remove unused BadWordController#add method

### DIFF
--- a/lobby/src/main/java/org/triplea/lobby/server/db/BadWordController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/BadWordController.java
@@ -16,19 +16,6 @@ final class BadWordController implements BadWordDao {
   private final Supplier<Connection> connection;
 
   @Override
-  public void addBadWord(final String word) {
-    try (Connection con = connection.get();
-        // If the word already is present we don't need to add it twice.
-        PreparedStatement ps = con.prepareStatement("insert into bad_word (word) values (?) on conflict do nothing")) {
-      ps.setString(1, word);
-      ps.execute();
-      con.commit();
-    } catch (final SQLException e) {
-      throw new DatabaseException("Error inserting banned word: " + word, e);
-    }
-  }
-
-  @Override
   public boolean containsBadWord(final String testString) {
     if (testString.isEmpty()) {
       return false;

--- a/lobby/src/main/java/org/triplea/lobby/server/db/BadWordDao.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/BadWordDao.java
@@ -5,13 +5,6 @@ package org.triplea.lobby.server.db;
  */
 public interface BadWordDao {
   /**
-   * Adds the specified bad word to the table.
-   *
-   * @param word The bad word to add.
-   */
-  void addBadWord(String word);
-
-  /**
    * Checks if a given string contains a bad word.
    *
    * @param testString The value to check for a bad word

--- a/lobby/src/test/java/org/triplea/lobby/server/db/BadWordControllerIntegrationTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/db/BadWordControllerIntegrationTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
 import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
@@ -12,7 +11,6 @@ import org.triplea.lobby.server.config.TestLobbyConfigurations;
 import org.triplea.test.common.Integration;
 
 import com.github.database.rider.core.api.dataset.DataSet;
-import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.junit5.DBUnitExtension;
 
 @ExtendWith(DBUnitExtension.class)
@@ -20,13 +18,6 @@ import com.github.database.rider.junit5.DBUnitExtension;
 final class BadWordControllerIntegrationTest {
   private final BadWordDao controller =
       TestLobbyConfigurations.INTEGRATION_TEST.getDatabaseDao().getBadWordDao();
-
-  @Test
-  @DataSet("badwords/pre-insert.yml")
-  @ExpectedDataSet("badwords/post-insert.yml")
-  void testAdd() {
-    controller.addBadWord("second");
-  }
 
   @Nested
   final class CaseInsensitiveContainsTest {

--- a/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
@@ -1,7 +1,6 @@
 package org.triplea.lobby.server.login;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -10,7 +9,6 @@ import static org.triplea.lobby.common.login.RsaAuthenticator.hashPasswordWithSa
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -125,20 +123,6 @@ class LobbyLoginValidatorIntegrationTest {
     // create a user, verify we can't login with a username that already exists
     // we should not be able to login now
     assertNotNull(generateChallenge(new HashedPassword(md5Crypt("foo"))).apply(challenge -> response));
-  }
-
-  @Test
-  void testAnonymousLoginBadName() {
-    final String name = "bitCh" + TestUserUtils.newUniqueTimestamp();
-    try {
-      TestLobbyConfigurations.INTEGRATION_TEST.getDatabaseDao().getBadWordDao().addBadWord("bitCh");
-    } catch (final Exception ignore) {
-      // this is probably a duplicate insertion error, we can ignore that as it only means we already added the bad
-      // word previously
-    }
-    assertEquals(LobbyLoginValidator.ErrorMessages.THATS_NOT_A_NICE_NAME,
-        generateChallenge(name, new HashedPassword(md5Crypt("foo"))).apply(challenge -> new HashMap<>(
-            Collections.singletonMap(LobbyLoginResponseKeys.ANONYMOUS_LOGIN, Boolean.TRUE.toString()))));
   }
 
   @Test

--- a/lobby/src/test/resources/datasets/badwords/post-insert.yml
+++ b/lobby/src/test/resources/datasets/badwords/post-insert.yml
@@ -1,3 +1,0 @@
-bad_word:
-  - word: first
-  - word: second

--- a/lobby/src/test/resources/datasets/badwords/pre-insert.yml
+++ b/lobby/src/test/resources/datasets/badwords/pre-insert.yml
@@ -1,2 +1,0 @@
-bad_word:
-  - word: first


### PR DESCRIPTION
## Overview

Bad words are added directly to DB (for better or worse), the method to add a bad word
is currently only used in test code.

## Functional Changes
None, code cleanup removing unused (dead) code

## Manual Testing Performed
None

## Additional Review Notes
Note: we introduce a test gap to verify that usernames do not contain 'bad words'. For now this is intentional as DB tests are in progress of being updated to use database-rider. With further work in the DB area with luck we'll fix this testing gap soon enough.