### PR TITLE
Rename ta_users table to 'lobby_user' and add moderator audit table

### DIFF
--- a/lobby-db/src/main/resources/db/migration/V1.10.00.20190330__lobby_user_table.sql
+++ b/lobby-db/src/main/resources/db/migration/V1.10.00.20190330__lobby_user_table.sql
@@ -32,6 +32,8 @@ insert into lobby_user (username, password, email, date_created, last_login, adm
 select username, password, email, joined, lastLogin, admin
 from ta_users;
 
+drop table ta_users;
+
 create table moderator_action_history
 (
     id            serial primary key,

--- a/lobby-db/src/main/resources/db/migration/V1.10.00.20190330__lobby_user_table.sql
+++ b/lobby-db/src/main/resources/db/migration/V1.10.00.20190330__lobby_user_table.sql
@@ -1,0 +1,54 @@
+create table lobby_user
+(
+    id              serial primary key,
+    username        character varying(40) not null unique,
+    password        character varying(60),
+    email           character varying(40) not null,
+    date_created    timestamptz           not null default current_timestamp,
+    last_login      timestamptz,
+    admin           boolean               not null default false,
+    bcrypt_password character(60) check (char_length(bcrypt_password) = 60)
+);
+
+-- alter table user owner to triplea_lobby;
+alter table lobby_user
+    owner to postgres;
+alter table lobby_user
+    add constraint lobby_user_pass_check check (password IS NOT NULL OR bcrypt_password IS NOT NULL);
+
+
+comment on table lobby_user is 'The table storing all the information about Lobby TripleA users.';
+comment on column lobby_user.id is 'Synthetic PK column';
+comment on column lobby_user.username is 'Defines the in-game username of everyone.';
+comment on column lobby_user.password is 'The legacy MD5Crypt hash of the password. The length of the hash must always be 34 chars. Either password or bcrypt_password must be not null.';
+comment on column lobby_user.email is 'Email storage of every user. Large size to match the maximum email length. More information here: https://stackoverflow.com/a/574698.';
+comment on column lobby_user.date_created is 'The timestamp of the creation of the account.';
+comment on column lobby_user.last_login is 'The timestamp of the last successful login.';
+comment on column lobby_user.admin is 'The role of the user, controls privileges. If true the user is able to ban and mute other people.';
+comment on column lobby_user.bcrypt_password is 'The BCrypt-Hashed password of the user, should be the same as the md5 password but in another form. The length of the hash must always be 60 chars. Either password or bcrypt_password must be not null.';
+
+
+insert into lobby_user (username, password, email, date_created, last_login, admin)
+select username, password, email, joined, lastLogin, admin
+from ta_users;
+
+create table moderator_action_history
+(
+    id            serial primary key,
+    lobby_user_id int         not null references lobby_user (id),
+    date_created  timestamptz not null default current_timestamp,
+    action_name   varchar(64) not null,
+    action_target varchar(40) not null
+);
+
+-- alter table moderator_action_history owner to triplea_lobby;
+alter table moderator_action_history
+    owner to postgres;
+
+comment on table moderator_action_history is 'Table storing an audit history of actions taken by moderators';
+comment on column moderator_action_history.id is 'Table storing an audit history of actions taken by moderators';
+
+comment on column moderator_action_history.lobby_user_id is 'FK to lobby_user table, this is the moderator that initiated an action.';
+comment on column moderator_action_history.date_created is 'Row creation timestamp, when the action was taken.';
+comment on column moderator_action_history.action_name is 'Specifier of what action the moderator took, eg: ban|mute';
+comment on column moderator_action_history.action_target is 'The target of the action, eg: banned player name, banned mac address';

--- a/lobby/src/main/java/org/triplea/lobby/server/ModeratorController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/ModeratorController.java
@@ -8,6 +8,7 @@ import javax.annotation.Nullable;
 import org.triplea.lobby.common.IModeratorController;
 import org.triplea.lobby.common.IRemoteHostUtils;
 import org.triplea.lobby.server.db.DatabaseDao;
+import org.triplea.lobby.server.db.ModeratorAuditHistoryDao;
 
 import games.strategy.engine.lobby.server.userDB.DBUser;
 import games.strategy.engine.message.IRemoteMessenger;
@@ -124,6 +125,11 @@ final class ModeratorController implements IModeratorController {
         "User was booted from the lobby. Username: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s",
         node.getName(), node.getAddress().getHostAddress(), mac, modNode.getName(),
         modNode.getAddress().getHostAddress(), getNodeMacAddress(modNode)));
+    database.getModeratorAuditHistoryDao().addAuditRecord(ModeratorAuditHistoryDao.AuditArgs.builder()
+        .moderatorName(modNode.getName())
+        .actionName(ModeratorAuditHistoryDao.AuditAction.BOOT_USER_FROM_LOBBY)
+        .actionTarget(node.getName())
+        .build());
   }
 
   @Override
@@ -182,6 +188,13 @@ final class ModeratorController implements IModeratorController {
             + " In Headless HostBot. Host: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s",
         node.getName(), node.getAddress().getHostAddress(), mac, modNode.getName(),
         modNode.getAddress().getHostAddress(), getNodeMacAddress(modNode)));
+
+    database.getModeratorAuditHistoryDao().addAuditRecord(ModeratorAuditHistoryDao.AuditArgs.builder()
+        .moderatorName(modNode.getName())
+        .actionName(ModeratorAuditHistoryDao.AuditAction.BOOT_USER_FROM_BOT)
+        .actionTarget(node.getName())
+        .build());
+
     return response;
   }
 
@@ -203,6 +216,13 @@ final class ModeratorController implements IModeratorController {
             + "' Host: %s IP: %s Mac: %s Mod Username: %s Mod IP: %s Mod Mac: %s",
         node.getName(), node.getAddress().getHostAddress(), mac, modNode.getName(),
         modNode.getAddress().getHostAddress(), getNodeMacAddress(modNode)));
+
+    database.getModeratorAuditHistoryDao().addAuditRecord(ModeratorAuditHistoryDao.AuditArgs.builder()
+        .moderatorName(modNode.getName())
+        .actionName(ModeratorAuditHistoryDao.AuditAction.BAN_PLAYER_FROM_BOT)
+        .actionTarget(node.getName())
+        .build());
+
     return response;
   }
 

--- a/lobby/src/main/java/org/triplea/lobby/server/db/BannedMacController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/BannedMacController.java
@@ -59,6 +59,12 @@ class BannedMacController implements BannedMacDao {
     } catch (final SQLException e) {
       throw new DatabaseException("Error inserting banned mac: " + bannedUser.getHashedMacAddress(), e);
     }
+    new ModeratorAuditHistoryController(connection).addAuditRecord(
+        ModeratorAuditHistoryDao.AuditArgs.builder()
+            .moderatorName(moderator.getUsername())
+            .actionName(ModeratorAuditHistoryDao.AuditAction.BAN_MAC)
+            .actionTarget(bannedUser.getHashedMacAddress())
+            .build());
   }
 
   private void removeBannedMac(final String mac) {

--- a/lobby/src/main/java/org/triplea/lobby/server/db/DatabaseDao.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/DatabaseDao.java
@@ -12,4 +12,6 @@ public interface DatabaseDao {
   UserDao getUserDao();
 
   BadWordDao getBadWordDao();
+
+  ModeratorAuditHistoryDao getModeratorAuditHistoryDao();
 }

--- a/lobby/src/main/java/org/triplea/lobby/server/db/JdbcDatabaseDao.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/JdbcDatabaseDao.java
@@ -14,6 +14,7 @@ class JdbcDatabaseDao implements DatabaseDao {
   private final UsernameBlacklistDao usernameBlacklistDao;
   private final BannedMacDao bannedMacDao;
   private final UserDao userDao;
+  private final ModeratorAuditHistoryDao moderatorAuditHistoryDao;
 
   JdbcDatabaseDao(final Database database) {
     final Supplier<Connection> connection = connectionSupplier(database);
@@ -22,6 +23,7 @@ class JdbcDatabaseDao implements DatabaseDao {
     bannedMacDao = new BannedMacController(connection);
     usernameBlacklistDao = new UsernameBlacklistController(connection);
     userDao = new UserController(connection);
+    moderatorAuditHistoryDao = new ModeratorAuditHistoryController(connection);
   }
 
   private static Supplier<Connection> connectionSupplier(final Database database) {

--- a/lobby/src/main/java/org/triplea/lobby/server/db/ModeratorAuditHistoryController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/ModeratorAuditHistoryController.java
@@ -1,0 +1,56 @@
+package org.triplea.lobby.server.db;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.function.Supplier;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+final class ModeratorAuditHistoryController implements ModeratorAuditHistoryDao {
+
+  private final Supplier<Connection> connection;
+
+  @Override
+  public void addAuditRecord(final ModeratorAuditHistoryDao.AuditArgs auditArgs) {
+    final int moderatorId = lookupModeratorId(auditArgs);
+    insertAuditRecord(moderatorId, auditArgs);
+  }
+
+  // TODO: make method private, as a private method PMD thinks this method is unused.
+  int lookupModeratorId(final AuditArgs auditArgs) {
+    final String sql = "select id from lobby_user where username = ?";
+    try (Connection con = connection.get();
+        PreparedStatement ps = con.prepareStatement(sql)) {
+      ps.setString(1, auditArgs.getModeratorName());
+      try (ResultSet rs = ps.executeQuery()) {
+        if (!rs.next()) {
+          throw new IllegalStateException("Failed to find a moderator by name: " + auditArgs.getModeratorName());
+        }
+        return rs.getInt("id");
+      }
+    } catch (final SQLException e) {
+      throw new DatabaseException("DB error looking up moderator name", e);
+    }
+  }
+
+  // TODO: make method private, as a private method PMD thinks this method is unused.
+  void insertAuditRecord(final int moderatorId, final AuditArgs auditArgs) {
+    final String sql = ""
+        + "insert into moderator_action_history "
+        + "  (lobby_user_id, action_name, action_target) "
+        + "values (?, ?, ?)";
+    try (Connection con = connection.get();
+        PreparedStatement ps = con.prepareStatement(sql)) {
+      ps.setInt(1, moderatorId);
+      ps.setString(2, auditArgs.getActionName().name());
+      ps.setString(3, auditArgs.getActionTarget());
+      ps.execute();
+      con.commit();
+    } catch (final SQLException e) {
+      throw new DatabaseException("Error inserting audit record: " + auditArgs, e);
+    }
+  }
+}

--- a/lobby/src/main/java/org/triplea/lobby/server/db/ModeratorAuditHistoryDao.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/ModeratorAuditHistoryDao.java
@@ -1,0 +1,40 @@
+package org.triplea.lobby.server.db;
+
+import javax.annotation.Nonnull;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * Interface for adding new moderator audit records to database. These records
+ * keep track of which actions moderators have taken, who the target was and
+ * which moderator took the action.
+ */
+public interface ModeratorAuditHistoryDao {
+
+  void addAuditRecord(AuditArgs auditArgs);
+
+  /**
+   * Parameters needed when adding an audit record.
+   */
+  @Getter
+  @Builder
+  @ToString
+  final class AuditArgs {
+    @Nonnull
+    private final String moderatorName;
+    @Nonnull
+    private final AuditAction actionName;
+    @Nonnull
+    private final String actionTarget;
+  }
+
+
+  /**
+   * The set of moderator actions.
+   */
+  enum AuditAction {
+    BAN_MAC, BAN_USERNAME, BOOT_USER_FROM_BOT, BOOT_USER_FROM_LOBBY, BAN_PLAYER_FROM_BOT,
+  }
+}

--- a/lobby/src/main/java/org/triplea/lobby/server/db/UserController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/UserController.java
@@ -36,7 +36,7 @@ final class UserController implements UserDao {
     try (Connection con = connection.get();
         PreparedStatement ps = con
             .prepareStatement(
-                "select password, coalesce(bcrypt_password, password) from lobby_user where username=?")) {
+                "select password, coalesce(bcrypt_password, password) from lobby_user where username = ?")) {
       ps.setString(1, username);
       try (ResultSet rs = ps.executeQuery()) {
         if (rs.next()) {
@@ -76,7 +76,7 @@ final class UserController implements UserDao {
       ps.execute();
       if (!hashedPassword.isBcrypted()) {
         try (PreparedStatement ps2 =
-            con.prepareStatement("update lobby_user set bcrypt_password=null where username=?")) {
+            con.prepareStatement("update lobby_user set bcrypt_password = null where username=?")) {
           ps2.setString(1, user.getName());
           ps2.execute();
         }
@@ -106,7 +106,7 @@ final class UserController implements UserDao {
     Preconditions.checkArgument(user.isValid(), user.getValidationErrorMessage());
 
     try (Connection con = connection.get();
-        PreparedStatement ps = con.prepareStatement("update lobby_user set admin=? where username = ?")) {
+        PreparedStatement ps = con.prepareStatement("update lobby_user set admin = ? where username = ?")) {
       ps.setBoolean(1, user.isAdmin());
       ps.setString(2, user.getName());
       ps.execute();

--- a/lobby/src/main/java/org/triplea/lobby/server/db/UserController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/UserController.java
@@ -35,7 +35,8 @@ final class UserController implements UserDao {
   private HashedPassword getPassword(final String username, final boolean legacy) {
     try (Connection con = connection.get();
         PreparedStatement ps = con
-            .prepareStatement("select password, coalesce(bcrypt_password, password) from ta_users where username=?")) {
+            .prepareStatement(
+                "select password, coalesce(bcrypt_password, password) from lobby_user where username=?")) {
       ps.setString(1, username);
       try (ResultSet rs = ps.executeQuery()) {
         if (rs.next()) {
@@ -50,7 +51,7 @@ final class UserController implements UserDao {
 
   @Override
   public boolean doesUserExist(final String username) {
-    final String sql = "select username from ta_users where upper(username) = upper(?)";
+    final String sql = "select username from lobby_user where upper(username) = upper(?)";
     try (Connection con = connection.get();
         PreparedStatement ps = con.prepareStatement(sql)) {
       ps.setString(1, username);
@@ -68,14 +69,14 @@ final class UserController implements UserDao {
 
     try (Connection con = connection.get();
         PreparedStatement ps = con.prepareStatement(
-            String.format("update ta_users set %s=?, email=? where username=?", getPasswordColumn(hashedPassword)))) {
+            String.format("update lobby_user set %s=?, email=? where username=?", getPasswordColumn(hashedPassword)))) {
       ps.setString(1, hashedPassword.value);
       ps.setString(2, user.getEmail());
       ps.setString(3, user.getName());
       ps.execute();
       if (!hashedPassword.isBcrypted()) {
         try (PreparedStatement ps2 =
-            con.prepareStatement("update ta_users set bcrypt_password=null where username=?")) {
+            con.prepareStatement("update lobby_user set bcrypt_password=null where username=?")) {
           ps2.setString(1, user.getName());
           ps2.execute();
         }
@@ -105,7 +106,7 @@ final class UserController implements UserDao {
     Preconditions.checkArgument(user.isValid(), user.getValidationErrorMessage());
 
     try (Connection con = connection.get();
-        PreparedStatement ps = con.prepareStatement("update ta_users set admin=? where username = ?")) {
+        PreparedStatement ps = con.prepareStatement("update lobby_user set admin=? where username = ?")) {
       ps.setBoolean(1, user.isAdmin());
       ps.setString(2, user.getName());
       ps.execute();
@@ -122,7 +123,7 @@ final class UserController implements UserDao {
 
     try (Connection con = connection.get();
         PreparedStatement ps = con.prepareStatement(
-            "insert into ta_users (username, password, bcrypt_password, email) values (?, ?, ?, ?)")) {
+            "insert into lobby_user (username, password, bcrypt_password, email) values (?, ?, ?, ?)")) {
       ps.setString(1, user.getName());
       ps.setString(2, hashedPassword.isBcrypted() ? null : hashedPassword.value);
       ps.setString(3, hashedPassword.isBcrypted() ? hashedPassword.value : null);
@@ -140,7 +141,7 @@ final class UserController implements UserDao {
     try (Connection con = connection.get()) {
       if (hashedPassword.isHashedWithSalt()) {
         try (PreparedStatement ps =
-            con.prepareStatement("select username from  ta_users where username = ? and password = ?")) {
+            con.prepareStatement("select username from  lobby_user where username = ? and password = ?")) {
           ps.setString(1, username);
           ps.setString(2, hashedPassword.value);
           try (ResultSet rs = ps.executeQuery()) {
@@ -160,7 +161,7 @@ final class UserController implements UserDao {
         }
       }
       // update last login time
-      try (PreparedStatement ps = con.prepareStatement("update ta_users set lastLogin = ? where username = ?")) {
+      try (PreparedStatement ps = con.prepareStatement("update lobby_user set last_login = ? where username = ?")) {
         ps.setTimestamp(1, Timestamp.from(Instant.now()));
         ps.setString(2, username);
         ps.execute();
@@ -175,7 +176,7 @@ final class UserController implements UserDao {
 
   @Override
   public DBUser getUserByName(final String username) {
-    final String sql = "select * from ta_users where username = ?";
+    final String sql = "select * from lobby_user where username = ?";
     try (Connection con = connection.get();
         PreparedStatement ps = con.prepareStatement(sql)) {
       ps.setString(1, username);

--- a/lobby/src/main/java/org/triplea/lobby/server/db/UsernameBlacklistController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/UsernameBlacklistController.java
@@ -35,6 +35,13 @@ class UsernameBlacklistController implements UsernameBlacklistDao {
     } catch (final SQLException e) {
       throw new DatabaseException("Error inserting banned username: " + usernameToBan, e);
     }
+
+    new ModeratorAuditHistoryController(connection).addAuditRecord(
+        ModeratorAuditHistoryDao.AuditArgs.builder()
+            .moderatorName(moderatorName)
+            .actionName(ModeratorAuditHistoryDao.AuditAction.BAN_USERNAME)
+            .actionTarget(usernameToBan)
+            .build());
   }
 
   /**

--- a/lobby/src/test/java/org/triplea/lobby/server/db/AbstractModeratorServiceControllerTestCase.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/db/AbstractModeratorServiceControllerTestCase.java
@@ -13,7 +13,11 @@ import java.sql.SQLException;
 import org.triplea.java.function.ThrowingConsumer;
 import org.triplea.lobby.server.TestUserUtils;
 import org.triplea.lobby.server.User;
+import org.triplea.lobby.server.config.TestLobbyConfigurations;
 import org.triplea.test.common.Integration;
+import org.triplea.util.Md5Crypt;
+
+import games.strategy.engine.lobby.server.userDB.DBUser;
 
 /**
  * Superclass for fixtures that test a moderator service controller.
@@ -25,11 +29,18 @@ public abstract class AbstractModeratorServiceControllerTestCase {
 
   protected AbstractModeratorServiceControllerTestCase() {}
 
+
   /**
    * Creates a new unique user.
    */
   protected static User newUser() {
-    return TestUserUtils.newUser();
+    final User user = TestUserUtils.newUser();
+    TestLobbyConfigurations.INTEGRATION_TEST.getDatabaseDao().getUserDao().createUser(
+        new DBUser(
+            new DBUser.UserName(user.getUsername()),
+            new DBUser.UserEmail("email@email.com")),
+        new HashedPassword(Md5Crypt.hash("pass", "salt")));
+    return user;
   }
 
   /**

--- a/lobby/src/test/java/org/triplea/lobby/server/db/ModeratorAuditHistoryControllerTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/db/ModeratorAuditHistoryControllerTest.java
@@ -1,0 +1,45 @@
+package org.triplea.lobby.server.db;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.triplea.lobby.server.config.TestLobbyConfigurations;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.database.rider.junit5.DBUnitExtension;
+
+@ExtendWith(DBUnitExtension.class)
+class ModeratorAuditHistoryControllerTest {
+
+  // test constants that exist in 'pre-insert.yml'
+  private static final String MODERATOR_NAME = "moderator";
+  private static final String ACTION_TARGET = "ACTION_TARGET";
+
+  private final ModeratorAuditHistoryDao dao =
+      TestLobbyConfigurations.INTEGRATION_TEST.getDatabaseDao().getModeratorAuditHistoryDao();
+
+  @Test
+  @DataSet("moderator_audit/pre-insert.yml")
+  void addAuditRecordThrowsIfModeratorNameNotFound() {
+    assertThrows(
+        IllegalStateException.class,
+        () -> dao.addAuditRecord(ModeratorAuditHistoryDao.AuditArgs.builder()
+            .moderatorName("moderator-name-that-does-not-exist")
+            .actionTarget("any-value")
+            .actionName(ModeratorAuditHistoryDao.AuditAction.BAN_USERNAME)
+            .build()));
+  }
+
+  @Test
+  @DataSet("moderator_audit/pre-insert.yml")
+  @ExpectedDataSet("moderator_audit/post-insert.yml")
+  void addAuditRecord() {
+    dao.addAuditRecord(ModeratorAuditHistoryDao.AuditArgs.builder()
+        .moderatorName(MODERATOR_NAME)
+        .actionName(ModeratorAuditHistoryDao.AuditAction.BAN_USERNAME)
+        .actionTarget(ACTION_TARGET)
+        .build());
+  }
+}

--- a/lobby/src/test/java/org/triplea/lobby/server/db/UserControllerIntegrationTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/db/UserControllerIntegrationTest.java
@@ -80,7 +80,7 @@ final class UserControllerIntegrationTest {
         new DBUser(new DBUser.UserName(user.getName()), new DBUser.UserEmail(email2)),
         new HashedPassword(password2));
     try (Connection con = TestDatabase.newConnection()) {
-      final String sql = " select * from ta_users where username = '" + user.getName() + "'";
+      final String sql = " select * from lobby_user where username = '" + user.getName() + "'";
       final ResultSet rs = con.createStatement().executeQuery(sql);
       assertTrue(rs.next());
       assertEquals(email2, rs.getString("email"));
@@ -108,7 +108,7 @@ final class UserControllerIntegrationTest {
 
   private int getUserCount() throws Exception {
     try (Connection dbConnection = TestDatabase.newConnection()) {
-      final String sql = "select count(*) from TA_USERS";
+      final String sql = "select count(*) from lobby_user";
       final ResultSet rs = dbConnection.createStatement().executeQuery(sql);
       assertTrue(rs.next());
       return rs.getInt(1);

--- a/lobby/src/test/resources/datasets/moderator_audit/post-insert.yml
+++ b/lobby/src/test/resources/datasets/moderator_audit/post-insert.yml
@@ -1,0 +1,12 @@
+lobby_user:
+  - id: 900000
+    username: moderator
+    password: 12345678901234567890123456
+    email: email
+    admin: false
+
+moderator_action_history:
+  - id:  "regex:\\d+" #any number
+    lobby_user_id: 900000
+    action_name: "BAN_USERNAME"
+    action_target: "ACTION_TARGET"

--- a/lobby/src/test/resources/datasets/moderator_audit/pre-insert.yml
+++ b/lobby/src/test/resources/datasets/moderator_audit/pre-insert.yml
@@ -1,0 +1,8 @@
+moderator_action_history:
+
+lobby_user:
+  - id: 900000
+    username: moderator
+    password: 12345678901234567890123456
+    email: email
+    admin: false


### PR DESCRIPTION
## Overview

Change summary:
- Rename db table 'ta_users' to 'lobby_user'
- Rename column 'ta_users.lastLogin' to 'lobby_user.last_login' to conform with SQL column naming convention of lower_snake_case.
- Add an integer PK column to 'lobby_user'.
- Add a moderator audit history table to record moderator actions.
- Insert a record into the new moderator audit history table on mac bans or username bans

Motivation for changes:
- The 'ta_users' table name does not conform to convention of singular name and follows an old and needless naming pattern where all tables were prefixed 'ta'
- The new PK column added to 'lobby_user' lets us start adding new tables with numeric foreign keys. A first example is the moderator audit history.
- The moderator audit history will eventually be viewable from the moderator toolbox. It will also simplify life for moderators as they will no longer need to report all actions they take to the forum as there will be an audit trail. A secondary benefit is we will have a more reliable audit trail and perhaps increased accountability.

## Functional Changes
- No user facing changes
- New audit trail of moderator actions recorded in database

## Manual Testing Performed
- none, automated testing added
