### PR TITLE
Don't allow transports to load after being in battle if LHTR

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/Constants.java
+++ b/game-core/src/main/java/games/strategy/triplea/Constants.java
@@ -44,7 +44,7 @@ public interface Constants {
   String FACTORIES_PER_COUNTRY_PROPERTY = "maxFactoriesPerTerritory";
   String TWO_HIT_BATTLESHIP_PROPERTY = "Two hit battleship";
   String ALWAYS_ON_AA_PROPERTY = "Always on AA";
-  // allows lhtr carrier/fighter production
+  // allows lhtr carrier/fighter production and not loading transports that were in a battle
   String LHTR_CARRIER_PRODUCTION_RULES = "LHTR Carrier production rules";
   // Break up fighter/carrier production into atomic units
   // allow fighters to be placed on newly produced carriers

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
@@ -306,12 +306,13 @@ public class TransportTracker {
   }
 
   /**
-   * For ww2v3+, if a transport has been in combat then it can't load in NCM.
+   * For ww2v3+ and LHTR, if a transport has been in combat then it can't load in NCM.
    */
   static boolean isTransportLoadRestrictedAfterCombat(final Unit transport) {
     final TripleAUnit taUnit = (TripleAUnit) transport;
-    return Properties.getWW2V3(transport.getData())
-        && GameStepPropertiesHelper.isNonCombatMove(transport.getData(), true) && taUnit.getWasInCombat();
+    final GameData data = transport.getData();
+    return (Properties.getWW2V3(data) || Properties.getLhtrCarrierProductionRules(data))
+        && GameStepPropertiesHelper.isNonCombatMove(data, true) && taUnit.getWasInCombat();
   }
 
   static CompositeChange clearTransportedByForAlliedAirOnCarrier(final Collection<Unit> attackingUnits,


### PR DESCRIPTION
## Overview
- Address LHTR portion of #3162

## Functional Changes
- If property "LHTR Carrier production rules" is true then don't allow transports to load after being in a battle

## Manual Testing Performed
- Tested revised LHTR
