### PR TITLE
Extract http accept and content type headers to constant

### DIFF
--- a/http-clients/src/main/java/org/triplea/http/client/HttpConstants.java
+++ b/http-clients/src/main/java/org/triplea/http/client/HttpConstants.java
@@ -1,0 +1,15 @@
+package org.triplea.http.client;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * Utility class with constants for HTTP clients.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class HttpConstants {
+  public static final String ACCEPT_JSON = "Accept: application/json";
+  public static final String ACCEPT_TEXT = "Accept: text/plain";
+  public static final String CONTENT_TYPE_JSON = "Content-Type: application/json";
+  public static final String CONTENT_TYPE_TEXT = "Content-Type: text/plain";
+}

--- a/http-clients/src/main/java/org/triplea/http/client/error/report/ErrorUploadClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/error/report/ErrorUploadClient.java
@@ -3,6 +3,7 @@ package org.triplea.http.client.error.report;
 import java.net.URI;
 
 import org.triplea.http.client.HttpClient;
+import org.triplea.http.client.HttpConstants;
 
 import feign.FeignException;
 import feign.Headers;
@@ -23,10 +24,7 @@ public interface ErrorUploadClient {
    * @throws FeignException Thrown on non-2xx responses.
    */
   @RequestLine("POST " + ERROR_REPORT_PATH)
-  @Headers({
-      "Content-Type: application/json",
-      "Accept: application/json"
-  })
+  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   ErrorUploadResponse uploadErrorReport(ErrorUploadRequest request);
 
   @RequestLine("GET " + CAN_REPORT_PATH)

--- a/http-clients/src/main/java/org/triplea/http/client/github/issues/GithubClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/github/issues/GithubClient.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import java.util.Map;
 
 import org.triplea.http.client.HttpClient;
+import org.triplea.http.client.HttpConstants;
 import org.triplea.http.client.error.report.ErrorUploadRequest;
 import org.triplea.http.client.github.issues.create.CreateIssueResponse;
 
@@ -27,10 +28,7 @@ interface GithubClient {
    * @throws FeignException Thrown on non-2xx responses.
    */
   @RequestLine("POST " + CREATE_ISSUE_PATH)
-  @Headers({
-      "Content-Type: application/json",
-      "Accept: application/json"
-  })
+  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   CreateIssueResponse newIssue(
       @HeaderMap Map<String, Object> headerMap,
       @Param("org") String org,

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/login/LobbyLoginClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/login/LobbyLoginClient.java
@@ -3,6 +3,7 @@ package org.triplea.http.client.lobby.login;
 import java.net.URI;
 
 import org.triplea.http.client.HttpClient;
+import org.triplea.http.client.HttpConstants;
 
 import feign.Headers;
 import feign.RequestLine;
@@ -39,10 +40,7 @@ public interface LobbyLoginClient {
    * </pre>
    */
   @RequestLine("POST " + LOGIN_PATH)
-  @Headers({
-      "Content-Type: application/json",
-      "Accept: application/json"
-  })
+  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   LobbyLoginResponse login(RegisteredUserLoginRequest loginRequest);
 
 
@@ -64,9 +62,6 @@ public interface LobbyLoginClient {
    * </pre>
    */
   @RequestLine("POST " + ANONYMOUS_LOGIN_PATH)
-  @Headers({
-      "Content-Type: application/json",
-      "Accept: application/json"
-  })
+  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   LobbyLoginResponse anonymousLogin(String name);
 }


### PR DESCRIPTION
## Overview
Simple refactor to extract constants set on HTTP clients for header values to a constants class.

## Functional Changes
- none

## Additional Review Notes
Note: simple text type will be used in future updates and is not yet used.
