### PR TITLE
Parameterizer retry count and Use a feign custom JSON encoder to better encode Strings

### DIFF
--- a/http-clients/src/main/java/org/triplea/http/client/JsonEncoder.java
+++ b/http-clients/src/main/java/org/triplea/http/client/JsonEncoder.java
@@ -1,0 +1,26 @@
+package org.triplea.http.client;
+
+import java.lang.reflect.Type;
+
+import feign.RequestTemplate;
+import feign.codec.Encoder;
+import feign.gson.GsonEncoder;
+
+/**
+ * A custom encoder that will be a pass-thru to Jackson encoder when encoding JSON objects,
+ * and a pass-thru of simple String values. Without this, String values are encoded to have surrounding
+ * quotes, this custom encoder will fix that so that Strings are passed as simple string values without
+ * extra surrounding quotes.
+ */
+public class JsonEncoder implements Encoder {
+  private static final GsonEncoder gsonEncoder = new GsonEncoder();
+
+  @Override
+  public void encode(final Object object, final Type bodyType, final RequestTemplate template) {
+    if (bodyType.getTypeName().equals(String.class.getName())) {
+      template.body(object.toString());
+    } else {
+      gsonEncoder.encode(object, bodyType, template);
+    }
+  }
+}

--- a/http-clients/src/test/java/org/triplea/http/client/JsonEncoderTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/JsonEncoderTest.java
@@ -1,0 +1,60 @@
+package org.triplea.http.client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import org.junit.jupiter.api.Test;
+
+import feign.RequestTemplate;
+import feign.gson.GsonEncoder;
+import lombok.Getter;
+
+class JsonEncoderTest {
+
+  private static final JsonEncoder jsonEncoder = new JsonEncoder();
+
+  private RequestTemplate template = new RequestTemplate();
+
+  /**
+   * We verify here strings are encoded without any modification.
+   */
+  @Test
+  void encodeString() {
+    final String value = "value";
+
+    jsonEncoder.encode(value, String.class, template);
+
+    assertThat(
+        template.requestBody().asString(),
+        is(value));
+  }
+
+  /**
+   * Verify that a simple example object is converted to a JSON string.
+   * We rely on GSON to create a JSON form of the sample object and verify our
+   * custom encoder produces the same result.
+   */
+  @Test
+  void encodeObject() {
+    final SampleObject sampleObject = new SampleObject();
+
+    jsonEncoder.encode(sampleObject, SampleObject.class, template);
+
+    assertThat(
+        template.requestBody().asString(),
+        is(encodeWithGson(sampleObject).requestBody().asString()));
+  }
+
+  private static RequestTemplate encodeWithGson(final SampleObject sampleObject) {
+    final GsonEncoder gsonEncoder = new GsonEncoder();
+    final RequestTemplate templateForGsonEncoding = new RequestTemplate();
+    gsonEncoder.encode(sampleObject, SampleObject.class, templateForGsonEncoding);
+    return templateForGsonEncoding;
+  }
+
+  @Getter
+  private static final class SampleObject {
+    final String key = "key-value";
+    final int intValue = 1;
+  }
+}


### PR DESCRIPTION
## Overview
    
    _Parameterized retry count_
    
    This is added mainly so that test can reduce retries and speed up tests. When verifying error
    cases we do not need to retry when we expect all attempts to fail.
    
    _Custom JSON Encoder_
    
    Implementing a work-in-progress future http client that sends simple String parameters,
    the existing encoder will add surrounding quotes around these strings values. This means
    that instead of a server receiving for example "value", it will get "\"value\"".
    
    The custom JSON encoder is a "pass-thru" to skip encoding when we are encoding a string
    encoder, otherwise we use the (existing) GSON encoder to encode objects. This means string
    values are simply encoded as-is, and objects are otherwise rendered into JSON.

## Functional Changes
- none

## Manual Testing Performed
- some manual testing done in another branch as part of other work. Automated testing is in place to verify existing behavior.

