### PR TITLE
Parameterize http error testing HTTP method type

### DIFF
--- a/http-clients/src/test/java/org/triplea/http/client/error/report/ErrorReportClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/error/report/ErrorReportClientTest.java
@@ -58,7 +58,10 @@ class ErrorReportClientTest {
   @Test
   void errorHandling(@WiremockResolver.Wiremock final WireMockServer wireMockServer) {
     HttpClientTesting.verifyErrorHandling(
-        wireMockServer, ErrorUploadClient.ERROR_REPORT_PATH, ErrorReportClientTest::doServiceCall);
+        wireMockServer,
+        ErrorUploadClient.ERROR_REPORT_PATH,
+        HttpClientTesting.RequestType.POST,
+        ErrorReportClientTest::doServiceCall);
   }
 
 

--- a/http-clients/src/test/java/org/triplea/http/client/github/issues/GithubIssueClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/github/issues/GithubIssueClientTest.java
@@ -47,6 +47,7 @@ class GithubIssueClientTest {
         wireMockServer,
         String.format(
             "/repos/%s/%s/issues", GITHUB_ORG, GITHUB_REPO),
+        HttpClientTesting.RequestType.POST,
         GithubIssueClientTest::doServiceCall);
   }
 }

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/login/LobbyLoginClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/login/LobbyLoginClientTest.java
@@ -81,7 +81,10 @@ class LobbyLoginClientTest {
     @Test
     void errorHandling(@WiremockResolver.Wiremock final WireMockServer wireMockServer) {
       HttpClientTesting.verifyErrorHandling(
-          wireMockServer, ErrorUploadClient.ERROR_REPORT_PATH, this::doServiceCall);
+          wireMockServer,
+          ErrorUploadClient.ERROR_REPORT_PATH,
+          HttpClientTesting.RequestType.POST,
+          this::doServiceCall);
     }
   }
 
@@ -125,7 +128,10 @@ class LobbyLoginClientTest {
     @Test
     void errorHandling(@WiremockResolver.Wiremock final WireMockServer wireMockServer) {
       HttpClientTesting.verifyErrorHandling(
-          wireMockServer, ErrorUploadClient.ERROR_REPORT_PATH, this::doServiceCall);
+          wireMockServer,
+          ErrorUploadClient.ERROR_REPORT_PATH,
+          HttpClientTesting.RequestType.POST,
+          this::doServiceCall);
     }
   }
 }


### PR DESCRIPTION
## Overview
HttpClientTesting has some utilities to make fault testing easier. Currently it is only
for POST requests. This updates parameterizes the test to add support for GET requests.

## Functional Changes
- none

## Manual Testing Performed
- changes are in test-only

## Additional Review Notes
- Get methods are added in a different branch that is a WIP; otherwise we only test POST methods so far with the http client testing utility
