### PR TITLE
Bring in Toast.java class to show pop-up toasts

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/MessagePopup.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/MessagePopup.java
@@ -1,0 +1,34 @@
+package games.strategy.engine.lobby.moderator.toolbox;
+
+import java.time.Duration;
+
+import javax.swing.JFrame;
+
+import org.triplea.swing.SwingComponents;
+import org.triplea.swing.Toast;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * Utility class to show 'toast' pop-ups that are used to confirm
+ * success actions have been executed on the server.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class MessagePopup {
+  public static void showMessage(final JFrame frame, final String message) {
+    Toast.builder()
+        .parent(frame)
+        .message(message)
+        .sleepTime(Duration.ofMillis(350))
+        .build()
+        .showtoast();
+  }
+
+  public static void showServerError(final RuntimeException e) {
+    SwingComponents.showDialog(
+        "Server Error",
+        "Http server operation failed. Report this to TripleA support if it keeps happening."
+            + " Error:\n" + e.getMessage());
+  }
+}

--- a/swing-lib/src/main/java/org/triplea/swing/Toast.java
+++ b/swing-lib/src/main/java/org/triplea/swing/Toast.java
@@ -1,0 +1,100 @@
+package org.triplea.swing;
+
+import java.awt.Color;
+import java.awt.Graphics;
+import java.time.Duration;
+
+import javax.annotation.Nonnull;
+import javax.swing.JFrame;
+import javax.swing.JPanel;
+import javax.swing.JWindow;
+import javax.swing.SwingUtilities;
+
+import lombok.Builder;
+
+/**
+ * Toast message is a popup window that disappears slowly.
+ * Code is based on: https://www.geeksforgeeks.org/java-swing-creating-toast-message/
+ */
+@Builder
+public class Toast {
+
+  @Nonnull
+  private final String message;
+  @Nonnull
+  private final Duration sleepTime;
+  @Nonnull
+  private final JFrame parent;
+
+  private final int windowHeight = 75;
+  private final int windowWidth = 200;
+
+  public void showtoast() {
+    SwingUtilities.invokeLater(this::showInBackground);
+  }
+
+  private void showInBackground() {
+    final JWindow window = new JWindow(parent);
+
+    window.setLocationRelativeTo(parent);
+    // make the background transparent
+    window.setBackground(Color.DARK_GRAY);
+
+    // create a panel
+    final JPanel panel = new JPanel() {
+      @Override
+      public void paintComponent(final Graphics g) {
+        final int width = g.getFontMetrics().stringWidth(message);
+        final int height = g.getFontMetrics().getHeight();
+
+        // draw the boundary of the toast and fill it
+        g.setColor(Color.DARK_GRAY);
+        g.fillRect(10, 10, width + 30, height + 10);
+        // g.setColor(Color.black);
+        g.drawRect(10, 10, width + 30, height + 10);
+
+        // set the color of text
+        g.setColor(new Color(255, 255, 255, 240));
+        g.drawString(message, 25, 27);
+        int t = 250;
+
+        // draw the shadow of the toast
+        for (int i = 0; i < 4; i++) {
+          t -= 60;
+          g.setColor(new Color(0, 0, 0, t));
+          g.drawRect(10 - i, 10 - i, width + 30 + i * 2,
+              height + 10 + i * 2);
+        }
+      }
+    };
+
+    window.add(panel);
+    window.setSize(windowWidth, windowHeight);
+
+    window.setOpacity(1);
+    window.setVisible(true);
+
+    new Thread(() -> {
+      // wait for some time
+      try {
+        Thread.sleep(sleepTime.toMillis());
+      } catch (final InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return;
+      }
+      // make the message disappear slowly
+      for (double d = 1.0; d > 0.2; d -= 0.1) {
+        try {
+          Thread.sleep(100);
+        } catch (final InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return;
+        }
+        final float newOpacity = (float) d;
+        SwingUtilities.invokeLater(() -> window.setOpacity(newOpacity));
+      }
+
+      SwingUtilities.invokeLater(window::dispose);
+    }).start();
+  }
+}


### PR DESCRIPTION
## Overview

Toast.java is a copy/paste from: https://www.geeksforgeeks.org/java-swing-creating-toast-message/
It has been modified slightly to fit our coding style and for some minor improvement like parameterized
window height and width and some spelled out variable names.

To make use of this class, MessagePopup.java is introduced which provides a simplified API to launch
the toast window.

The toast window will eventually be used with moderator-toolbox-2.0 to show action confirmations. For example, when values are added or removed from database the confirmation message will be in a toast message rather than a confirmation dialog.

For reference, Toast is a UI widget, a small window that appears that is not clickable and pop-ups and then slowly fades away informing a user of a message.

## Additional Review Notes
- Emphasis that Toast.java is a copy/paste, please do not review it in too much detail as I will be reluctant to change it too much. 
- Toast.java and the message pop-up are not yet used, this PR is a carve-off from moderator-toolbox-2.0 branch which is still a WIP and makes use to the toast pop-up.