### PR TITLE
WIP: Add ModeratorToolbox http clients for API key validation and bad word management

### DIFF
--- a/http-clients/src/main/java/org/triplea/http/client/moderator/toolbox/AddBadWordArgs.java
+++ b/http-clients/src/main/java/org/triplea/http/client/moderator/toolbox/AddBadWordArgs.java
@@ -1,0 +1,16 @@
+package org.triplea.http.client.moderator.toolbox;
+
+import javax.annotation.Nonnull;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter(AccessLevel.PACKAGE)
+public class AddBadWordArgs {
+  @Nonnull
+  private final String apiKey;
+  @Nonnull
+  private final String badWord;
+}

--- a/http-clients/src/main/java/org/triplea/http/client/moderator/toolbox/ModeratorToolboxClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/moderator/toolbox/ModeratorToolboxClient.java
@@ -1,0 +1,98 @@
+package org.triplea.http.client.moderator.toolbox;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.triplea.http.client.HttpClient;
+import org.triplea.http.client.HttpCommunicationException;
+
+import com.google.common.annotations.VisibleForTesting;
+
+/**
+ * Wrapper around moderator toolbox feign client. This wrapper handles exceptions and returns
+ * a success string result for most methods, otherwise the return value is any error message
+ * returned back from the server.
+ */
+public final class ModeratorToolboxClient {
+
+  /**
+   * Success string, any simple GET/POST method returning a string value other than this
+   * value is returning an error message.
+   */
+  public static final String SUCCESS = "SUCCESS";
+
+  public static final String VALIDATE_API_KEY_PATH = "/moderator-toolbox/validate-api-key";
+  public static final String BAD_WORD_ADD_PATH = "/moderator-toolbox/bad-words/add";
+  public static final String BAD_WORD_REMOVE_PATH = "/moderator-toolbox/bad-words/remove";
+  public static final String BAD_WORD_GET_PATH = "/moderator-toolbox/bad-words/get";
+  public static final String MODERATOR_API_KEY_HEADER = "moderator-api-key";
+
+  private final ModeratorToolboxFeignClient client;
+
+  private ModeratorToolboxClient(final URI uri) {
+    this(new HttpClient<>(ModeratorToolboxFeignClient.class, uri).get());
+  }
+
+  @VisibleForTesting
+  ModeratorToolboxClient(final ModeratorToolboxFeignClient feignClient) {
+    client = feignClient;
+  }
+
+  /**
+   * Creates a ModeratorToolboxClient, used by moderators interact with the server
+   * to view/add/remove database data (eg: player bans, bad words table)
+   */
+  public static ModeratorToolboxClient newClient(final URI uri) {
+    return new ModeratorToolboxClient(uri);
+  }
+
+  public String validateApiKey(final String apiKey) {
+    checkArgument(apiKey != null && !apiKey.isEmpty());
+
+    try {
+      return client.validateApiKey(apiKey);
+    } catch (final RuntimeException e) {
+      return e.getMessage();
+    }
+  }
+
+  public String removeBadWord(final RemoveBadWordArgs badWordArgs) {
+    checkArgument(badWordArgs != null);
+    try {
+      return client.removeBadWord(createHeaders(badWordArgs.getApiKey()), badWordArgs.getBadWord());
+    } catch (final HttpCommunicationException e) {
+      return e.getMessage();
+    }
+  }
+
+  private static Map<String, Object> createHeaders(final String apiKey) {
+    final Map<String, Object> headerMap = new HashMap<>();
+    headerMap.put(MODERATOR_API_KEY_HEADER, apiKey);
+    return headerMap;
+  }
+
+  public String addBadWord(final AddBadWordArgs addBadWordArgs) {
+    checkArgument(addBadWordArgs != null);
+    try {
+      return client.addBadWord(createHeaders(addBadWordArgs.getApiKey()), addBadWordArgs.getBadWord());
+    } catch (final RuntimeException e) {
+      return e.getMessage();
+    }
+  }
+
+  /**
+   * Returns list of bad words present in the bad words table.
+   *
+   * @param apiKey Moderator API key used to validate request is from an authorized moderator user.
+   * @throws HttpCommunicationException thrown if there are any HTTP errors or a non-200 return code.
+   */
+  public List<String> getBadWords(final String apiKey) {
+    checkArgument(apiKey != null && !apiKey.isEmpty());
+
+    return client.getBadWords(createHeaders(apiKey));
+  }
+}

--- a/http-clients/src/main/java/org/triplea/http/client/moderator/toolbox/ModeratorToolboxFeignClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/moderator/toolbox/ModeratorToolboxFeignClient.java
@@ -1,0 +1,43 @@
+package org.triplea.http.client.moderator.toolbox;
+
+import java.util.List;
+import java.util.Map;
+
+import org.triplea.http.client.HttpConstants;
+
+import feign.HeaderMap;
+import feign.Headers;
+import feign.RequestLine;
+
+/**
+ * Http client for moderator 'toolbox' actions. The toolbox is essentially a set of windows
+ * that show lobby table data and provide CRUD operations to moderators. For example
+ * with the toolbox moderators should be able to update the list of restricted usernames,
+ * view players that have joined the lobby, add and remove player bans, etc.
+ * <p>
+ * This set of http methods should all require an API key passed via headers to authenticate
+ * the moderator issuing the request.
+ * </p>
+ * <p>
+ * Rate-limiting: of note, the backend implementation should be careful to apply rate limiting
+ * to any/all endpoints that take an API key so as to avoid brute-force attacks to try and crack
+ * an API key value.
+ * </p>
+ */
+interface ModeratorToolboxFeignClient {
+  @RequestLine("POST " + ModeratorToolboxClient.VALIDATE_API_KEY_PATH)
+  @Headers({HttpConstants.CONTENT_TYPE_TEXT, HttpConstants.ACCEPT_TEXT})
+  String validateApiKey(String apiKey);
+
+  @RequestLine("POST " + ModeratorToolboxClient.BAD_WORD_REMOVE_PATH)
+  @Headers({HttpConstants.CONTENT_TYPE_TEXT, HttpConstants.ACCEPT_TEXT})
+  String removeBadWord(@HeaderMap Map<String, Object> headerMap, String word);
+
+  @RequestLine("POST " + ModeratorToolboxClient.BAD_WORD_ADD_PATH)
+  @Headers({HttpConstants.CONTENT_TYPE_TEXT, HttpConstants.ACCEPT_TEXT})
+  String addBadWord(@HeaderMap Map<String, Object> headerMap, String word);
+
+  @RequestLine("GET " + ModeratorToolboxClient.BAD_WORD_GET_PATH)
+  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
+  List<String> getBadWords(@HeaderMap Map<String, Object> headerMap);
+}

--- a/http-clients/src/main/java/org/triplea/http/client/moderator/toolbox/RemoveBadWordArgs.java
+++ b/http-clients/src/main/java/org/triplea/http/client/moderator/toolbox/RemoveBadWordArgs.java
@@ -1,0 +1,16 @@
+package org.triplea.http.client.moderator.toolbox;
+
+import javax.annotation.Nonnull;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter(AccessLevel.PACKAGE)
+public class RemoveBadWordArgs {
+  @Nonnull
+  private final String apiKey;
+  @Nonnull
+  private final String badWord;
+}

--- a/http-clients/src/test/java/org/triplea/http/client/moderator/toolbox/ModeratorToolboxClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/moderator/toolbox/ModeratorToolboxClientTest.java
@@ -1,0 +1,130 @@
+package org.triplea.http.client.moderator.toolbox;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.StringContains.containsString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.http.client.HttpCommunicationException;
+
+@ExtendWith(MockitoExtension.class)
+class ModeratorToolboxClientTest {
+
+  private static final String TEST_VALUE = "test-value";
+  private static final String RETURN_VALUE = "return-value";
+  private static final String EXCEPTION_MESSAGE = "exception-message";
+  private static final HttpCommunicationException EXCEPTION = new HttpCommunicationException(500, EXCEPTION_MESSAGE);
+  private static final List<String> BAD_WORDS = Arrays.asList("word1", "word2");
+
+  private static final String API_KEY = "api-key";
+
+  private static final Map<String, Object> expectedHeader;
+
+  static {
+    expectedHeader = new HashMap<>();
+    expectedHeader.put(ModeratorToolboxClient.MODERATOR_API_KEY_HEADER, API_KEY);
+  }
+
+  @Mock
+  private ModeratorToolboxFeignClient moderatorToolboxFeignClient;
+
+  @InjectMocks
+  private ModeratorToolboxClient moderatorToolboxClient;
+
+  @Test
+  void validateApiKey() {
+    when(moderatorToolboxFeignClient.validateApiKey(TEST_VALUE))
+        .thenReturn(RETURN_VALUE);
+
+    assertThat(
+        moderatorToolboxClient.validateApiKey(TEST_VALUE),
+        is(RETURN_VALUE));
+  }
+
+  @Test
+  void validateApiKeyWithException() {
+    when(moderatorToolboxFeignClient.validateApiKey(TEST_VALUE)).thenThrow(EXCEPTION);
+
+    assertThat(
+        moderatorToolboxClient.validateApiKey(TEST_VALUE),
+        containsString(EXCEPTION_MESSAGE));
+  }
+
+  @Test
+  void addBadWord() {
+    when(moderatorToolboxFeignClient.addBadWord(expectedHeader, TEST_VALUE)).thenReturn(RETURN_VALUE);
+
+    assertThat(
+        moderatorToolboxClient.addBadWord(AddBadWordArgs.builder()
+            .apiKey(API_KEY)
+            .badWord(TEST_VALUE)
+            .build()),
+        is(RETURN_VALUE));
+  }
+
+
+  @Test
+  void addBadWordWithException() {
+    when(moderatorToolboxFeignClient.addBadWord(expectedHeader, TEST_VALUE)).thenThrow(EXCEPTION);
+
+    assertThat(
+        moderatorToolboxClient.addBadWord(AddBadWordArgs.builder()
+            .apiKey(API_KEY)
+            .badWord(TEST_VALUE)
+            .build()),
+        containsString(EXCEPTION_MESSAGE));
+  }
+
+
+  @Test
+  void removeBadWord() {
+    when(moderatorToolboxFeignClient.removeBadWord(expectedHeader, TEST_VALUE)).thenReturn(RETURN_VALUE);
+
+    assertThat(
+        moderatorToolboxClient.removeBadWord(RemoveBadWordArgs.builder()
+            .apiKey(API_KEY)
+            .badWord(TEST_VALUE)
+            .build()),
+        is(RETURN_VALUE));
+  }
+
+
+  @Test
+  void removeBadWordWithException() {
+    when(moderatorToolboxFeignClient.removeBadWord(expectedHeader, TEST_VALUE)).thenThrow(EXCEPTION);
+
+    assertThat(
+        moderatorToolboxClient.removeBadWord(RemoveBadWordArgs.builder()
+            .apiKey(API_KEY)
+            .badWord(TEST_VALUE)
+            .build()),
+        containsString(EXCEPTION_MESSAGE));
+  }
+
+  @Test
+  void getBadWords() {
+    when(moderatorToolboxFeignClient.getBadWords(expectedHeader)).thenReturn(BAD_WORDS);
+
+    assertThat(
+        moderatorToolboxClient.getBadWords(API_KEY),
+        is(BAD_WORDS));
+  }
+
+  @Test
+  void getBadWordsWithException() {
+    when(moderatorToolboxFeignClient.getBadWords(expectedHeader)).thenThrow(EXCEPTION);
+
+    assertThrows(EXCEPTION.getClass(), () -> moderatorToolboxClient.getBadWords(API_KEY));
+  }
+}

--- a/http-clients/src/test/java/org/triplea/http/client/moderator/toolbox/ModeratorToolboxFeignClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/moderator/toolbox/ModeratorToolboxFeignClientTest.java
@@ -1,0 +1,161 @@
+package org.triplea.http.client.moderator.toolbox;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
+
+import javax.annotation.Nonnull;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.triplea.http.client.HttpClient;
+import org.triplea.http.client.HttpClientTesting;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+
+import lombok.Builder;
+import ru.lanwen.wiremock.ext.WiremockResolver;
+import ru.lanwen.wiremock.ext.WiremockUriResolver;
+
+@ExtendWith({
+    WiremockResolver.class,
+    WiremockUriResolver.class
+})
+class ModeratorToolboxFeignClientTest {
+
+  private static final String SUCCESS_JSON = "SUCCESS";
+  private static final String INPUT_JSON = "word";
+
+  private static final Map<String, Object> headerMap;
+
+  private static final String HEADER_KEY = "key";
+  private static final String HEADER_VALUE = "value";
+
+  static {
+    headerMap = new HashMap<>();
+    headerMap.put(HEADER_KEY, HEADER_VALUE);
+  }
+
+  @Test
+  void validateApiKey(@WiremockResolver.Wiremock final WireMockServer wireMockServer) {
+    wireMockServer.stubFor(
+        WireMock.post(ModeratorToolboxClient.VALIDATE_API_KEY_PATH)
+            .willReturn(
+                WireMock.aResponse()
+                    .withStatus(200)
+                    .withBody(SUCCESS_JSON)));
+
+    final ModeratorToolboxFeignClient client = newClient(wireMockServer);
+
+    assertThat(
+        client.validateApiKey("apiKey"),
+        is(ModeratorToolboxClient.SUCCESS));
+  }
+
+  private static ModeratorToolboxFeignClient newClient(final WireMockServer wireMockServer) {
+    final URI hostUri = URI.create(wireMockServer.url(""));
+    final int maxAttempts = 1;
+    return new HttpClient<>(ModeratorToolboxFeignClient.class, hostUri, maxAttempts).get();
+  }
+
+  @Test
+  void addBadWord(@WiremockResolver.Wiremock final WireMockServer wireMockServer) {
+    expectPost(wireMockServer, ModeratorToolboxClient.BAD_WORD_ADD_PATH);
+    final ModeratorToolboxFeignClient client = newClient(wireMockServer);
+
+    assertThat(
+        client.addBadWord(headerMap, "word"),
+        is(ModeratorToolboxClient.SUCCESS));
+  }
+
+  private void expectPost(final WireMockServer wireMockServer, final String path) {
+    wireMockServer.stubFor(
+        WireMock.post(path)
+            .withHeader(HEADER_KEY, equalTo(HEADER_VALUE))
+            .willReturn(
+                WireMock.aResponse()
+                    .withStatus(200)
+                    .withBody(SUCCESS_JSON)));
+  }
+
+  @Test
+  void removeBadWord(@WiremockResolver.Wiremock final WireMockServer wireMockServer) {
+    expectPost(wireMockServer, ModeratorToolboxClient.BAD_WORD_REMOVE_PATH);
+    final ModeratorToolboxFeignClient client = newClient(wireMockServer);
+
+    assertThat(
+        client.removeBadWord(headerMap, INPUT_JSON),
+        is(ModeratorToolboxClient.SUCCESS));
+  }
+
+  @Test
+  void getBadWords(@WiremockResolver.Wiremock final WireMockServer server) {
+    final ModeratorToolboxFeignClient client = newClient(server);
+    stubForGetBadWods(server);
+
+    assertThat(
+        client.getBadWords(headerMap),
+        is(asList("value", "value2")));
+  }
+
+  private void stubForGetBadWods(final WireMockServer wireMockServer) {
+    wireMockServer.stubFor(
+        WireMock.get(ModeratorToolboxClient.BAD_WORD_GET_PATH)
+            .withHeader(HEADER_KEY, equalTo(HEADER_VALUE))
+            .willReturn(
+                WireMock.aResponse()
+                    .withStatus(200)
+                    .withBody("[ \"value\", \"value2\" ]")));
+  }
+
+
+  @Test
+  void verifyErrorHandling(@WiremockResolver.Wiremock final WireMockServer server) {
+    final ModeratorToolboxFeignClient client = newClient(server);
+
+    asList(
+        ErrorHandlingArg.builder()
+            .path(ModeratorToolboxClient.VALIDATE_API_KEY_PATH)
+            .requestType(HttpClientTesting.RequestType.POST)
+            .serviceCall(uri -> client.validateApiKey("key"))
+            .build(),
+        ErrorHandlingArg.builder()
+            .path(ModeratorToolboxClient.BAD_WORD_ADD_PATH)
+            .requestType(HttpClientTesting.RequestType.POST)
+            .serviceCall(uri -> client.addBadWord(new HashMap<>(), "word"))
+            .build(),
+        ErrorHandlingArg.builder()
+            .path(ModeratorToolboxClient.BAD_WORD_GET_PATH)
+            .requestType(HttpClientTesting.RequestType.GET)
+            .serviceCall(uri -> client.getBadWords(new HashMap<>()))
+            .build(),
+        ErrorHandlingArg.builder()
+            .path(ModeratorToolboxClient.BAD_WORD_REMOVE_PATH)
+            .requestType(HttpClientTesting.RequestType.POST)
+            .serviceCall(uri -> client.removeBadWord(new HashMap<>(), "word"))
+            .build())
+                .forEach(arg -> HttpClientTesting.verifyErrorHandling(
+                    server,
+                    arg.path,
+                    arg.requestType,
+                    arg.serviceCall));
+  }
+
+  @Builder
+  private static final class ErrorHandlingArg<T> {
+    @Nonnull
+    private final String path;
+    @Nonnull
+    private final HttpClientTesting.RequestType requestType;
+    @Nonnull
+    private final Function<URI, T> serviceCall;
+  }
+
+}


### PR DESCRIPTION
## Overview

This update adds http clients that will be used for the moderator-toolbox-2.0.
The initial features supported are for API key validation and for bad word management
(CRUD operations for the bad-word table).

Currently this http client is not currently used outside of in-flight work that is not
yet checked in.

One important design decision taken is that all moderator toolbox operations are grouped
under one http client. The controller methods servicing these methods will on the other
hand be broken up by moderator toolbox tab. For example there will be a dedicated controller
for API key validation and another for bad-word management, and as a further example
yet another server controller for user ban management.

API-key note:
- The http client and server is designed so that we will pass an api-key from client to the server.
It is intended that we will issue each moderator a unique and lengthy api-key that will they
enter into the TripleA UI on an admin screen that will then be saved in client settings. This key
will then be sent to the server for any moderator related actions. The server side will for any
moderator endpoint verify this key and do rate limiting to ensure brute-force attacks cannot occur.


## Additional Review Notes
This will need: https://github.com/triplea-game/triplea/pull/4861 to be merged before the build passes.
