### PR TITLE
Update default http server port to 8080

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcher.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcher.java
@@ -22,7 +22,7 @@ import games.strategy.triplea.settings.GameSetting;
 public final class LobbyServerPropertiesFetcher {
 
   public static final int TEST_LOBBY_DEFAULT_PORT = 3304;
-  public static final int TEST_LOBBY_DEFAULT_HTTPS_PORT = 4567;
+  public static final int TEST_LOBBY_DEFAULT_HTTPS_PORT = 8080;
 
   private final BiFunction<String, Function<InputStream, LobbyServerProperties>,
       Optional<LobbyServerProperties>> fileDownloader;


### PR DESCRIPTION
## Overview
The previous default was appropriate for java Spark server. Now
that we on DropWizard, the correct port number for http server is 8080.
