### PR TITLE
Fix datasets to remove data from tables with FKs

### DIFF
--- a/lobby-db-dao/src/test/resources/datasets/bad_words/integration.yml
+++ b/lobby-db-dao/src/test/resources/datasets/bad_words/integration.yml
@@ -1,4 +1,0 @@
-lobby_user:
-  - username: "moderator"
-    email: "email@email.com"
-    password: "1234567890"

--- a/lobby-db-dao/src/test/resources/datasets/moderator_audit/pre-insert.yml
+++ b/lobby-db-dao/src/test/resources/datasets/moderator_audit/pre-insert.yml
@@ -1,4 +1,5 @@
 moderator_action_history:
+moderator_api_key:
 
 lobby_user:
   - id: 900000

--- a/lobby/src/test/resources/datasets/moderator_audit/pre-insert.yml
+++ b/lobby/src/test/resources/datasets/moderator_audit/pre-insert.yml
@@ -1,3 +1,4 @@
+moderator_api_key:
 moderator_action_history:
 
 lobby_user:


### PR DESCRIPTION
## Overview

One downside of database-rider datasets is that tables with FKs are not automatically cleared.
Any new table with a FK needs to be added to any existing dataset where the primary key exists.
To explain that, if we have table A, and then a new table B with FK to A, then any existing dataset
that uses table A will delete it. If we have run a test that populates table B, then the deletion of
table A will cause a FK constraint violation. This introduces a non-determinism where tests can
fail simply depending on the order in which they are run.

This update fixes this whooopsie and deletes tables that have FKs into lobby_user
(notably the moderator api key table).

Second, integration.yml is simply not used and is being dropped.
