### PR TITLE
Fix some mixed mutability error prones

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/Route.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Route.java
@@ -20,6 +20,8 @@ import javax.annotation.Nullable;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.util.Tuple;
 
+import com.google.common.collect.ImmutableList;
+
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.TripleAUnit;
@@ -252,7 +254,7 @@ public class Route implements Serializable, Iterable<Territory> {
    */
   public List<Territory> getSteps() {
     if (numberOfSteps() > 0) {
-      return new ArrayList<>(steps);
+      return ImmutableList.copyOf(steps);
     }
     return EMPTY_TERRITORY_LIST;
   }

--- a/game-core/src/main/java/games/strategy/engine/data/Route.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Route.java
@@ -20,8 +20,6 @@ import javax.annotation.Nullable;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.util.Tuple;
 
-import com.google.common.collect.ImmutableList;
-
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.TripleAUnit;
@@ -253,20 +251,19 @@ public class Route implements Serializable, Iterable<Territory> {
    * Returns collection of all territories in this route, without the start.
    */
   public List<Territory> getSteps() {
-    if (numberOfSteps() > 0) {
-      return ImmutableList.copyOf(steps);
-    }
-    return EMPTY_TERRITORY_LIST;
+
+    return numberOfSteps() > 0
+        ? steps
+        : new ArrayList<>();
   }
 
   /**
    * Returns collection of all territories in this route without the start or the end.
    */
   public List<Territory> getMiddleSteps() {
-    if (numberOfSteps() > 1) {
-      return new ArrayList<>(steps).subList(0, numberOfSteps() - 1);
-    }
-    return EMPTY_TERRITORY_LIST;
+    return numberOfSteps() > 1
+        ? new ArrayList<>(steps).subList(0, numberOfSteps() - 1)
+        : new ArrayList<>();
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/data/Route.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Route.java
@@ -43,7 +43,6 @@ import games.strategy.triplea.delegate.Matches;
  */
 public class Route implements Serializable, Iterable<Territory> {
   private static final long serialVersionUID = 8743882455488948557L;
-  private static final List<Territory> EMPTY_TERRITORY_LIST = Collections.emptyList();
 
   private final List<Territory> steps = new ArrayList<>();
   private @Nullable Territory start;

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/login/HmacSha512Authenticator.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/login/HmacSha512Authenticator.java
@@ -103,9 +103,10 @@ final class HmacSha512Authenticator {
     }
 
     try {
-      return Maps.newHashMap(ImmutableMap.<String, String>builder()
-          .put(encodeProperty(ResponsePropertyNames.DIGEST, digest(password, salt, nonce)))
-          .build());
+      return ImmutableMap.copyOf(
+          Maps.newHashMap(ImmutableMap.<String, String>builder()
+              .put(encodeProperty(ResponsePropertyNames.DIGEST, digest(password, salt, nonce)))
+              .build()));
     } catch (final GeneralSecurityException e) {
       throw new AuthenticationException("security framework failure when creating response", e);
     }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -38,6 +38,7 @@ import org.triplea.swing.SwingAction;
 import org.triplea.util.Version;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 
 import games.strategy.engine.chat.Chat;
 import games.strategy.engine.chat.ChatController;
@@ -555,7 +556,7 @@ public class ServerModel extends Observable implements IMessengerErrorListener, 
         localPlayerMappings.put(player, localPlayerTypes.getOrDefault(player, defaultLocalType));
       }
     }
-    return localPlayerMappings;
+    return ImmutableMap.copyOf(localPlayerMappings);
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -20,6 +20,8 @@ import org.triplea.swing.EventThreadJOptionPane;
 import org.triplea.swing.JFrameBuilder;
 import org.triplea.swing.SwingAction;
 
+import com.google.common.collect.ImmutableList;
+
 import games.strategy.engine.chat.Chat;
 import games.strategy.engine.chat.ChatMessagePanel;
 import games.strategy.engine.chat.ChatPlayerPanel;
@@ -117,7 +119,7 @@ public class LobbyFrame extends JFrame {
       textPane.setText(text);
       JOptionPane.showMessageDialog(null, textPane, "Player Info", JOptionPane.INFORMATION_MESSAGE);
     }));
-    return actions;
+    return ImmutableList.copyOf(actions);
   }
 
   private boolean confirm(final String question) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
@@ -12,6 +12,8 @@ import java.util.stream.Collectors;
 
 import org.triplea.java.collections.CollectionUtils;
 
+import com.google.common.collect.ImmutableList;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.data.Territory;
@@ -203,7 +205,7 @@ public final class ProTransportUtils {
   public static List<Unit> findBestUnitsToLandTransport(final Unit unit, final Territory t,
       final List<Unit> usedUnits) {
     if (usedUnits.contains(unit)) {
-      return new ArrayList<>();
+      return Collections.emptyList();
     }
     final PlayerId player = unit.getOwner();
     final List<Unit> units = t.getUnitCollection().getMatches(Matches.unitIsOwnedBy(player)
@@ -225,7 +227,7 @@ public final class ProTransportUtils {
           .thenComparing(getDecreasingAttackComparator(player)));
       results.addAll(selectUnitsToTransportFromList(unit, units));
     }
-    return results;
+    return ImmutableList.copyOf(results);
   }
 
   private static Comparator<Unit> getDecreasingAttackComparator(final PlayerId player) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
@@ -13,6 +13,8 @@ import java.util.function.Predicate;
 
 import org.triplea.java.collections.CollectionUtils;
 
+import com.google.common.collect.ImmutableList;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.data.Route;
@@ -222,7 +224,7 @@ class AaInMoveUtil implements Serializable {
         territoriesWhereAaWillFire.add(route.getStart());
       }
     }
-    return territoriesWhereAaWillFire;
+    return ImmutableList.copyOf(territoriesWhereAaWillFire);
   }
 
   private BattleTracker getBattleTracker() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractBattle.java
@@ -12,6 +12,8 @@ import java.util.stream.Collectors;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 
+import com.google.common.collect.ImmutableList;
+
 import games.strategy.engine.data.CompositeChange;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerId;
@@ -113,12 +115,13 @@ abstract class AbstractBattle implements IBattle {
     if (headless) {
       return Collections.emptyList();
     } else if (targets.stream().noneMatch(Matches.unitCanTransport())) {
-      return new ArrayList<>();
+      return Collections.emptyList();
     }
-    return targets.stream()
-        .map(TransportTracker::transportingAndUnloaded)
-        .flatMap(Collection::stream)
-        .collect(Collectors.toList());
+    return ImmutableList.copyOf(
+        targets.stream()
+            .map(TransportTracker::transportingAndUnloaded)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList()));
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -17,6 +17,8 @@ import org.triplea.java.PredicateBuilder;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 
+import com.google.common.collect.ImmutableMap;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.data.ResourceCollection;
@@ -1410,7 +1412,7 @@ public class MoveValidator {
       alliedAir.removeAll(carrying);
       mapping.put(carrier, carrying);
     }
-    return mapping;
+    return ImmutableMap.copyOf(mapping);
   }
 
   private static Collection<Unit> getCanCarry(final Unit carrier, final Collection<Unit> selectFrom,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -15,6 +15,8 @@ import java.util.function.Predicate;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 
+import com.google.common.collect.ImmutableList;
+
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerId;
@@ -391,7 +393,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
       }
     }
     bridge.getHistoryWriter().startEvent("Rolls to resolve tech hits:" + MyFormatter.asDice(random));
-    return newAdvances;
+    return ImmutableList.copyOf(newAdvances);
   }
 
   private List<TechAdvance> getAvailableAdvances() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/data/MoveValidationResult.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/data/MoveValidationResult.java
@@ -6,6 +6,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
+
 import games.strategy.engine.data.Unit;
 
 /**
@@ -85,7 +87,7 @@ public class MoveValidationResult implements Serializable, Comparable<MoveValida
     if (index == -1) {
       return Collections.emptyList();
     }
-    return new ArrayList<>(unresolvedUnitsList.get(index));
+    return ImmutableList.copyOf(unresolvedUnitsList.get(index));
   }
 
   public String getDisallowedUnitWarning(final int index) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -28,6 +28,8 @@ import org.triplea.java.PredicateBuilder;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 
+import com.google.common.collect.ImmutableList;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.data.Route;
@@ -669,7 +671,7 @@ public class MovePanel extends AbstractMovePanel {
     final Collection<Unit> allUnits = getFirstSelectedTerritory().getUnits();
     final List<Unit> candidateUnits = CollectionUtils.getMatches(allUnits, getUnloadableMatch(route, unitsToUnload));
     if (unitsToUnload.size() == candidateUnits.size()) {
-      return unitsToUnload;
+      return ImmutableList.copyOf(unitsToUnload);
     }
     final List<Unit> candidateTransports =
         CollectionUtils.getMatches(allUnits, Matches.unitIsTransportingSomeCategories(candidateUnits));
@@ -684,14 +686,14 @@ public class MovePanel extends AbstractMovePanel {
 
     // Just one transport, don't bother to ask
     if (candidateTransports.size() == 1) {
-      return unitsToUnload;
+      return ImmutableList.copyOf(unitsToUnload);
     }
 
     // Are the transports all of the same type and if they are, then don't ask
     final Collection<UnitCategory> categories =
         UnitSeparator.categorize(candidateTransports, mustMoveWithDetails.getMustMoveWith(), true, false);
     if (categories.size() == 1) {
-      return unitsToUnload;
+      return ImmutableList.copyOf(unitsToUnload);
     }
     sortTransportsToUnload(candidateTransports, route);
 
@@ -815,7 +817,7 @@ public class MovePanel extends AbstractMovePanel {
         }
       }
     }
-    return selectedUnitsToUnload;
+    return ImmutableList.copyOf(selectedUnitsToUnload);
   }
 
   private Predicate<Unit> getUnloadableMatch(final Route route, final Collection<Unit> units) {

--- a/game-core/src/test/java/games/strategy/engine/framework/startup/login/HmacSha512AuthenticatorTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/startup/login/HmacSha512AuthenticatorTest.java
@@ -14,6 +14,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.junit.jupiter.api.Nested;
@@ -165,7 +166,7 @@ final class HmacSha512AuthenticatorTest {
     @Test
     void shouldThrowExceptionWhenResponseDoesNotContainDigest() throws Exception {
       final Map<String, String> challenge = HmacSha512Authenticator.newChallenge();
-      final Map<String, String> response = HmacSha512Authenticator.newResponse(PASSWORD, challenge);
+      final Map<String, String> response = new HashMap<>(HmacSha512Authenticator.newResponse(PASSWORD, challenge));
 
       response.remove(ResponsePropertyNames.DIGEST);
 


### PR DESCRIPTION

## Overview
Fix a number of error prone warnings for mixed mutability on return types:
```
warning: [MixedMutabilityReturnType] This method returns both mutable and immutable collections or maps from different paths. This may be confusing for users of the method.
```

It looks like a number of these are from returning Collections.emptyList() and also returning array list. The former is immutable and the latter mutable.


## Functional Changes
- none

## Manual Testing Performed
- launched and connected to a local lobby
- started an all Hard-AI game on WWII revised and let the AIs duke it out for a few rounds, no errors.

