### PR TITLE
Reduce DBUser usage in APIs, move 'MakeAdmin' to test-only

### DIFF
--- a/lobby/src/main/java/org/triplea/lobby/server/UserManager.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/UserManager.java
@@ -38,7 +38,9 @@ final class UserManager implements IUserManager {
     final HashedPassword password = new HashedPassword(hashedPassword);
 
     try {
-      database.getUserDao().updateUser(user,
+      database.getUserDao().updateUser(
+          user.getName(),
+          user.getEmail(),
           password.isHashedWithSalt() ? password : new HashedPassword(BCrypt.hashpw(hashedPassword, BCrypt.gensalt())));
     } catch (final IllegalStateException e) {
       return e.getMessage();

--- a/lobby/src/main/java/org/triplea/lobby/server/db/UserDao.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/UserDao.java
@@ -19,13 +19,11 @@ public interface UserDao {
 
   boolean doesUserExist(String username);
 
-  void updateUser(DBUser user, HashedPassword password);
+  void updateUser(String name, String email, HashedPassword password);
 
-  void createUser(DBUser user, HashedPassword password);
+  void createUser(String name, String email, HashedPassword password);
 
   boolean login(String username, HashedPassword password);
 
   DBUser getUserByName(String username);
-
-  void makeAdmin(DBUser dbUser);
 }

--- a/lobby/src/main/java/org/triplea/lobby/server/login/LobbyLoginValidator.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/login/LobbyLoginValidator.java
@@ -185,16 +185,24 @@ public final class LobbyLoginValidator implements ILoginValidator {
         if (hashedPassword.isBcrypted()) {
           if (database.getUserDao().login(username, new HashedPassword(pass))) {
             if (legacyHashedPassword != null && database.getUserDao().getLegacyPassword(username).value.isEmpty()) {
-              database.getUserDao().updateUser(database.getUserDao().getUserByName(username),
+              final DBUser dbUser = database.getUserDao().getUserByName(username);
+              database.getUserDao().updateUser(
+                  dbUser.getName(),
+                  dbUser.getEmail(),
                   new HashedPassword(legacyHashedPassword));
-              database.getUserDao().updateUser(database.getUserDao().getUserByName(username),
+              database.getUserDao().updateUser(
+                  dbUser.getName(),
+                  dbUser.getEmail(),
                   new HashedPassword(BCrypt.hashpw(pass, bcryptSaltGenerator.get())));
             }
             return null;
           }
           return errorMessage;
         } else if (database.getUserDao().login(username, new HashedPassword(legacyHashedPassword))) {
-          database.getUserDao().updateUser(database.getUserDao().getUserByName(username),
+          final DBUser dbUser = database.getUserDao().getUserByName(username);
+          database.getUserDao().updateUser(
+              dbUser.getName(),
+              dbUser.getEmail(),
               new HashedPassword(BCrypt.hashpw(pass, bcryptSaltGenerator.get())));
           return null;
         } else {
@@ -248,10 +256,10 @@ public final class LobbyLoginValidator implements ILoginValidator {
       return rsaAuthenticator.decryptPasswordForAction(response, pass -> {
         final HashedPassword newPass = new HashedPassword(BCrypt.hashpw(pass, bcryptSaltGenerator.get()));
         if (password.isHashedWithSalt()) {
-          database.getUserDao().createUser(dbUser, password);
-          database.getUserDao().updateUser(dbUser, newPass);
+          database.getUserDao().createUser(dbUser.getName(), dbUser.getEmail(), password);
+          database.getUserDao().updateUser(dbUser.getName(), dbUser.getEmail(), newPass);
         } else {
-          database.getUserDao().createUser(dbUser, newPass);
+          database.getUserDao().createUser(dbUser.getName(), dbUser.getEmail(), newPass);
         }
         return null;
       });
@@ -261,7 +269,7 @@ public final class LobbyLoginValidator implements ILoginValidator {
     }
 
     try {
-      database.getUserDao().createUser(dbUser, password);
+      database.getUserDao().createUser(dbUser.getName(), dbUser.getEmail(), password);
       return null;
     } catch (final Exception e) {
       return e.getMessage();

--- a/lobby/src/test/java/org/triplea/lobby/server/ModeratorControllerIntegrationTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/ModeratorControllerIntegrationTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
@@ -20,7 +19,6 @@ import org.triplea.lobby.server.db.HashedPassword;
 import org.triplea.lobby.server.db.UserDao;
 import org.triplea.test.common.Integration;
 
-import games.strategy.engine.lobby.server.userDB.DBUser;
 import games.strategy.engine.message.MessageContext;
 import games.strategy.net.IConnectionChangeListener;
 import games.strategy.net.INode;
@@ -42,23 +40,22 @@ class ModeratorControllerIntegrationTest {
   }
 
   @BeforeEach
-  void setUp() throws UnknownHostException {
+  void setUp() throws Exception {
     moderatorController = new ModeratorController(
         serverMessenger, null, TestLobbyConfigurations.INTEGRATION_TEST.getDatabaseDao());
     final String adminName = TestUserUtils.newUniqueTimestamp();
-
-    final DBUser dbUser = new DBUser(new DBUser.UserName(adminName), new DBUser.UserEmail("n@n.n"), DBUser.Role.ADMIN);
+    final String email = "n@n.n";
 
     final UserDao userController = TestLobbyConfigurations.INTEGRATION_TEST.getDatabaseDao().getUserDao();
-    userController.createUser(dbUser, new HashedPassword(BCrypt.hashpw(adminName, BCrypt.gensalt())));
-    userController.makeAdmin(dbUser);
+    userController.createUser(adminName, email, new HashedPassword(BCrypt.hashpw(adminName, BCrypt.gensalt())));
+    UserDaoTestSupport.makeAdmin(adminName);
 
     adminNode = new Node(adminName, InetAddress.getLocalHost(), 0);
     when(serverMessenger.getPlayerMac(adminName)).thenReturn(newHashedMacAddress());
   }
 
   @Test
-  void testBoot() throws UnknownHostException {
+  void testBoot() throws Exception {
     MessageContext.setSenderNodeForThread(adminNode);
     connectionChangeListener = new ConnectionChangeListener();
     final INode booted = new Node("foo", InetAddress.getByAddress(new byte[] {1, 2, 3, 4}), 0);

--- a/lobby/src/test/java/org/triplea/lobby/server/UserDaoTestSupport.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/UserDaoTestSupport.java
@@ -1,0 +1,25 @@
+package org.triplea.lobby.server;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import org.triplea.lobby.server.db.TestDatabase;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+final class UserDaoTestSupport {
+  /**
+   * A method to set a given user as admin.
+   */
+  static void makeAdmin(final String username) throws SQLException {
+    try (Connection con = TestDatabase.newConnection();
+        PreparedStatement ps = con.prepareStatement("update lobby_user set admin = true where username = ?")) {
+      ps.setString(1, username);
+      ps.execute();
+      con.commit();
+    }
+  }
+}

--- a/lobby/src/test/java/org/triplea/lobby/server/db/AbstractModeratorServiceControllerTestCase.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/db/AbstractModeratorServiceControllerTestCase.java
@@ -17,8 +17,6 @@ import org.triplea.lobby.server.config.TestLobbyConfigurations;
 import org.triplea.test.common.Integration;
 import org.triplea.util.Md5Crypt;
 
-import games.strategy.engine.lobby.server.userDB.DBUser;
-
 /**
  * Superclass for fixtures that test a moderator service controller.
  */
@@ -27,18 +25,15 @@ public abstract class AbstractModeratorServiceControllerTestCase {
   protected final User user = newUser();
   protected final User moderator = newUser();
 
-  protected AbstractModeratorServiceControllerTestCase() {}
-
 
   /**
    * Creates a new unique user.
    */
-  protected static User newUser() {
+  private static User newUser() {
     final User user = TestUserUtils.newUser();
     TestLobbyConfigurations.INTEGRATION_TEST.getDatabaseDao().getUserDao().createUser(
-        new DBUser(
-            new DBUser.UserName(user.getUsername()),
-            new DBUser.UserEmail("email@email.com")),
+        user.getUsername(),
+        "email@email.com",
         new HashedPassword(Md5Crypt.hash("pass", "salt")));
     return user;
   }
@@ -54,7 +49,7 @@ public abstract class AbstractModeratorServiceControllerTestCase {
    *        for the user.
    * @param unknownUserMessage The failure message to be used when the requested user does not exist.
    */
-  protected void assertUserEquals(
+  void assertUserEquals(
       final User expected,
       final String userQuerySql,
       final ThrowingConsumer<PreparedStatement, SQLException> preparedStatementInitializer,

--- a/lobby/src/test/java/org/triplea/lobby/server/db/TestDatabase.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/db/TestDatabase.java
@@ -5,27 +5,29 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Properties;
 
-final class TestDatabase {
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
 
-  private TestDatabase() {}
 
-  static Connection newConnection() {
-    try {
-      final Connection connection =
-          DriverManager.getConnection(getConnectionUrl(), getConnectionProperties());
-      connection.setAutoCommit(false);
-      return connection;
-    } catch (final SQLException e) {
-      throw new RuntimeException(e);
-    }
-  }
+/**
+ * Utility class for creating DB connections in test.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class TestDatabase {
+  private static final String CONNECTION_URL = String.format(
+      "jdbc:postgresql://%s:%d/%s",
+      "localhost",
+      5432,
+      "lobby");
 
-  private static String getConnectionUrl() {
-    return String.format(
-        "jdbc:postgresql://%s:%d/%s",
-        "localhost",
-        5432,
-        "lobby");
+  /**
+   * Creates a new DB connection to localhost.
+   */
+  public static Connection newConnection() throws SQLException {
+    final Connection connection =
+        DriverManager.getConnection(CONNECTION_URL, getConnectionProperties());
+    connection.setAutoCommit(false);
+    return connection;
   }
 
   private static Properties getConnectionProperties() {

--- a/lobby/src/test/java/org/triplea/lobby/server/db/UserControllerIntegrationTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/db/UserControllerIntegrationTest.java
@@ -52,8 +52,11 @@ final class UserControllerIntegrationTest {
 
   @Test
   void testCreateDupe() {
+    final DBUser user = newUserWithMd5CryptHash();
     assertThrows(Exception.class,
-        () -> controller.createUser(newUserWithMd5CryptHash(),
+        () -> controller.createUser(
+            user.getName(),
+            user.getEmail(),
             new HashedPassword(md5Crypt(TestUserUtils.newUniqueTimestamp()))),
         "Should not be allowed to create a dupe user");
   }
@@ -62,7 +65,7 @@ final class UserControllerIntegrationTest {
   void testLogin() {
     final String password = md5Crypt(TestUserUtils.newUniqueTimestamp());
     final DBUser user = newUserWithHash(password, Function.identity());
-    controller.updateUser(user, new HashedPassword(bcrypt(obfuscate(password))));
+    controller.updateUser(user.getName(), user.getEmail(), new HashedPassword(bcrypt(obfuscate(password))));
     assertTrue(controller.login(user.getName(), new HashedPassword(password)));
     assertTrue(controller.login(user.getName(), new HashedPassword(obfuscate(password))));
   }
@@ -74,10 +77,12 @@ final class UserControllerIntegrationTest {
     final String password2 = md5Crypt("foo");
     final String email2 = "foo@foo.foo";
     controller.updateUser(
-        new DBUser(new DBUser.UserName(user.getName()), new DBUser.UserEmail(email2)),
+        user.getName(),
+        email2,
         new HashedPassword(bcrypt(obfuscate(TestUserUtils.newUniqueTimestamp()))));
     controller.updateUser(
-        new DBUser(new DBUser.UserName(user.getName()), new DBUser.UserEmail(email2)),
+        user.getName(),
+        email2,
         new HashedPassword(password2));
     try (Connection con = TestDatabase.newConnection()) {
       final String sql = " select * from lobby_user where username = '" + user.getName() + "'";
@@ -102,7 +107,7 @@ final class UserControllerIntegrationTest {
     final DBUser user = new DBUser(
         new DBUser.UserName(name),
         new DBUser.UserEmail(name + "@none.none"));
-    controller.createUser(user, new HashedPassword(hashingMethod.apply(password)));
+    controller.createUser(user.getName(), user.getEmail(), new HashedPassword(hashingMethod.apply(password)));
     return user;
   }
 

--- a/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
@@ -27,7 +27,6 @@ import org.triplea.lobby.server.db.HashedPassword;
 import org.triplea.test.common.Integration;
 import org.triplea.util.Md5Crypt;
 
-import games.strategy.engine.lobby.server.userDB.DBUser;
 import games.strategy.net.ILoginValidator;
 import games.strategy.net.MacFinder;
 
@@ -73,9 +72,7 @@ class LobbyLoginValidatorIntegrationTest {
     TestLobbyConfigurations.INTEGRATION_TEST
         .getDatabaseDao()
         .getUserDao()
-        .createUser(
-            new DBUser(new DBUser.UserName(name), new DBUser.UserEmail(EMAIL)),
-            password);
+        .createUser(name, EMAIL, password);
   }
 
   @SuppressWarnings("deprecation") // required for testing; remove upon next lobby-incompatible release

--- a/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorTest.java
@@ -185,31 +185,33 @@ final class LobbyLoginValidatorTest {
     }
 
     final void thenUserShouldBeCreatedWithMd5CryptedPassword() {
-      verify(userDao).createUser(dbUser, new HashedPassword(md5Crypt(PASSWORD)));
+      verify(userDao).createUser(dbUser.getName(), dbUser.getEmail(), new HashedPassword(md5Crypt(PASSWORD)));
     }
 
     final void thenUserShouldBeUpdatedWithBcryptedPassword() {
-      verify(userDao).updateUser(dbUser, new HashedPassword(bcrypt(PASSWORD)));
+      verify(userDao).updateUser(dbUser.getName(), dbUser.getEmail(), new HashedPassword(bcrypt(PASSWORD)));
     }
 
     final void thenUserShouldBeUpdatedWithMd5CryptedPassword() {
-      verify(userDao).updateUser(dbUser, new HashedPassword(md5Crypt(PASSWORD)));
+      verify(userDao).updateUser(dbUser.getName(), dbUser.getEmail(), new HashedPassword(md5Crypt(PASSWORD)));
     }
 
     final void thenUserShouldNotBeCreated() {
-      verify(userDao, never()).createUser(any(DBUser.class), any(HashedPassword.class));
+      verify(userDao, never()).createUser(any(), any(), any());
     }
 
     final void thenUserShouldNotBeUpdatedWithBcryptedPassword() {
-      verify(userDao, never()).updateUser(eq(dbUser), argThat(HashedPassword::isBcrypted));
+      verify(userDao, never())
+          .updateUser(eq(dbUser.getName()), eq(dbUser.getEmail()), argThat(HashedPassword::isBcrypted));
     }
 
     final void thenUserShouldNotBeUpdatedWithMd5CryptedPassword() {
-      verify(userDao, never()).updateUser(eq(dbUser), argThat(HashedPassword::isMd5Crypted));
+      verify(userDao, never())
+          .updateUser(eq(dbUser.getName()), eq(dbUser.getEmail()), argThat(HashedPassword::isMd5Crypted));
     }
 
     final void thenUserShouldNotBeUpdated() {
-      verify(userDao, never()).updateUser(any(DBUser.class), any(HashedPassword.class));
+      verify(userDao, never()).updateUser(any(), any(), any());
     }
   }
 


### PR DESCRIPTION
## Overview
- DBUser is used in a number of places in lobby code and not just in DAO.
To help move DAO to the 'lobby-db-dao' subproject, the DBUser parameter
is removed from DAO APIs. This begins to decouples the DAOs from DBUser
and eventually would allow the DAOs to be moved to the dedicated sub-project.

- Second, 'makeAdmin' is a test-only method, the method is moved to test code
so that production code can no longer 'see' it.

## Functional Changes
None, refactor

## Manual Testing Performed
None
