### PR TITLE
Replace forum links with links to user-guide

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -33,7 +33,7 @@ public class MetaSetupPanel extends SetupPanel {
   private JButton connectToLobby;
   private JButton enginePreferences;
   private JButton ruleBook;
-  private JButton helpButton;
+  private JButton userGuideButton;
 
   private final SetupPanelModel model;
 
@@ -71,7 +71,7 @@ public class MetaSetupPanel extends SetupPanel {
     enginePreferences = new JButton("Engine Preferences");
     enginePreferences.setToolTipText("<html>Configure certain options related to the engine.");
     ruleBook = new JButton("Rule Book");
-    helpButton = new JButton("Help");
+    userGuideButton = new JButton("User Guide & Help");
     ruleBook.setToolTipText("Download a manual of how to play");
   }
 
@@ -103,7 +103,7 @@ public class MetaSetupPanel extends SetupPanel {
     add(mapCreator, new GridBagConstraints(0, 9, 1, 1, 0, 0, GridBagConstraints.CENTER, GridBagConstraints.NONE,
         new Insets(10, 0, 0, 0), 0, 0));
 
-    add(helpButton, new GridBagConstraints(0, 10, 1, 1, 0, 0, GridBagConstraints.CENTER, GridBagConstraints.NONE,
+    add(userGuideButton, new GridBagConstraints(0, 10, 1, 1, 0, 0, GridBagConstraints.CENTER, GridBagConstraints.NONE,
         new Insets(10, 0, 0, 0), 0, 0));
 
     // top space
@@ -119,15 +119,15 @@ public class MetaSetupPanel extends SetupPanel {
     connectToLobby.addActionListener(e -> model.login());
     enginePreferences.addActionListener(e -> ClientSetting.showSettingsWindow());
     ruleBook.addActionListener(e -> ruleBook());
-    helpButton.addActionListener(e -> helpPage());
+    userGuideButton.addActionListener(e -> userGuidePage());
   }
 
   private static void ruleBook() {
     SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.RULE_BOOK);
   }
 
-  private static void helpPage() {
-    SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_HELP);
+  private static void userGuidePage() {
+    SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.USER_GUIDE);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -77,7 +77,7 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
           if (JOptionPane.showConfirmDialog(parentComponent,
               message + "\nDo you want to view the tutorial on how to host? This will open in your internet browser.",
               "View Help Website?", JOptionPane.YES_NO_OPTION) == JOptionPane.YES_OPTION) {
-            OpenFileUtility.openUrl(UrlConstants.HOSTING_GUIDE);
+            OpenFileUtility.openUrl(UrlConstants.USER_GUIDE);
           }
           ExitStatus.FAILURE.exit();
         });

--- a/game-core/src/main/java/games/strategy/triplea/UrlConstants.java
+++ b/game-core/src/main/java/games/strategy/triplea/UrlConstants.java
@@ -1,8 +1,12 @@
 package games.strategy.triplea;
 
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
 /**
  * Grouping of hardcoded URL constants.
  */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class UrlConstants {
   public static final String GITHUB_ISSUES = "https://github.com/triplea-game/triplea/issues/new";
   public static final String RULE_BOOK = "http://www.triplea-game.org/files/TripleA_RuleBook.pdf";
@@ -10,11 +14,8 @@ public final class UrlConstants {
       "https://raw.githubusercontent.com/triplea-game/triplea/master/lobby_server.yaml";
   public static final String PAYPAL_DONATE =
       "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=GKZL7598EDZLN";
-  public static final String GITHUB_HELP = "http://www.triplea-game.org/help/";
-  public static final String HOSTING_GUIDE = "https://forums.triplea-game.org/topic/100";
   public static final String TRIPLEA_FORUM = "https://forums.triplea-game.org/";
   public static final String AXIS_AND_ALLIES_FORUM = "https://www.axisandallies.org/forums";
-  public static final String TRIPLEA_LOBBY_RULES = "https://forums.triplea-game.org/topic/4";
   public static final String LATEST_GAME_DOWNLOAD_WEBSITE = "http://www.triplea-game.org/download/";
   public static final String TRIPLEA_WEBSITE = "http://www.triplea-game.org/";
   public static final String DOWNLOAD_WEBSITE = "http://www.triplea-game.org/download/";
@@ -25,5 +26,5 @@ public final class UrlConstants {
       "https://github.com/triplea-game/triplea/blob/master/docs/map_making/map_and_map_skin_making_overview.md";
   public static final String LICENSE_NOTICE = "https://github.com/triplea-game/triplea/blob/master/README.md#license";
 
-  private UrlConstants() {}
+  public static final String USER_GUIDE = "https://triplea-game.org/user-guide/";
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -243,17 +243,9 @@ public final class LobbyMenu extends JMenuBar {
   }
 
   private static void addHelpMenu(final JMenu parentMenu) {
-    final JMenuItem hostingLink = new JMenuItem("How to host");
-    hostingLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.HOSTING_GUIDE));
+    final JMenuItem hostingLink = new JMenuItem("User Guide");
+    hostingLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.USER_GUIDE));
     parentMenu.add(hostingLink);
-
-    final JMenuItem helpPageLink = new JMenuItem("Help Page");
-    helpPageLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_HELP));
-    parentMenu.add(helpPageLink);
-
-    final JMenuItem lobbyRules = new JMenuItem("Lobby Rules");
-    lobbyRules.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_LOBBY_RULES));
-    parentMenu.add(lobbyRules);
 
     final JMenuItem warClub = new JMenuItem("TripleA Forum");
     warClub.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_FORUM));

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/WebHelpMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/WebHelpMenu.java
@@ -21,34 +21,24 @@ final class WebHelpMenu extends JMenu {
   }
 
   private void addWebMenu() {
-    final JMenuItem hostingLink = new JMenuItem("How to Host");
+    final JMenuItem hostingLink = new JMenuItem("User Guide");
     hostingLink.setMnemonic(KeyEvent.VK_H);
-    hostingLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_HELP));
+    hostingLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.USER_GUIDE));
     add(hostingLink);
-
-    final JMenuItem lobbyRules = new JMenuItem("Lobby Rules");
-    lobbyRules.setMnemonic(KeyEvent.VK_L);
-    lobbyRules.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_LOBBY_RULES));
-    add(lobbyRules);
 
     final JMenuItem warClub = new JMenuItem("TripleA Forum");
     warClub.setMnemonic(KeyEvent.VK_W);
     warClub.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_FORUM));
     add(warClub);
 
-    final JMenuItem donateLink = new JMenuItem("Donate");
-    donateLink.setMnemonic(KeyEvent.VK_O);
-    donateLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.PAYPAL_DONATE));
-    add(donateLink);
-
-    final JMenuItem helpLink = new JMenuItem("Help");
-    helpLink.setMnemonic(KeyEvent.VK_G);
-    helpLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_HELP));
-    add(helpLink);
-
     final JMenuItem ruleBookLink = new JMenuItem("Rule Book");
     ruleBookLink.setMnemonic(KeyEvent.VK_K);
     ruleBookLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.RULE_BOOK));
     add(ruleBookLink);
+
+    final JMenuItem donateLink = new JMenuItem("Donate");
+    donateLink.setMnemonic(KeyEvent.VK_O);
+    donateLink.addActionListener(e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.PAYPAL_DONATE));
+    add(donateLink);
   }
 }

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/screens/AboutInformation.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/screens/AboutInformation.java
@@ -33,7 +33,7 @@ public class AboutInformation implements ControlledScreen<ScreenController<FxmlM
 
   @FXML
   private void showHelp() {
-    open(UrlConstants.GITHUB_HELP);
+    open(UrlConstants.USER_GUIDE);
   }
 
   @FXML


### PR DESCRIPTION
## Overview

As we have moved forum help content to the website 'user-guide', this change updates and consolidates the forum help links to instead to be a link to the 'user-guide'.

Of note, the github help page no longer exists (404), the link is also replaced with the 'user-guide'

