### PR TITLE
Remove javadoc paragraph checkstyle.

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -231,7 +231,6 @@
         <module name="SummaryJavadoc">
             <property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
         </module>
-        <module name="JavadocParagraph"/>
         <module name="AtclauseOrder">
             <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
             <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>


### PR DESCRIPTION
## Overview

It does not matter if `<p>` is same line or next line. This rule conflicts with the checked-in formatter and IDEA will mangle this. Checkstyle should not be a verification that hand-formatting was done but instead that automatic formatting is done.

Had two failed builds today due to this, that's 10 minutes lost and context switch time. For something that is so pedantic and not automated, the ROI of this rule is  negative.