### PR TITLE
Add travis java-ea (java12) build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ matrix:
   include:
   - jdk: openjdk11
     env: TRIPLEA_RELEASE=true
+  - jdk: openjdk-ea
+    env: TRIPLEA_RELEASE=false
 addons:
   postgresql: "10"
   apt:


### PR DESCRIPTION
List of supported builds was found at: https://sormuras.github.io/blog/2018-05-31-jdk-matrix.html

## Manual Testing Performed
- none, PR branch build should be able to test this out adequately

