### PR TITLE
Set product number early

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,10 +16,11 @@ install:
  - echo "create database lobby" | psql -h localhost -U postgres
  - ./.travis/setup_gradle
  - ./gradlew flywayMigrate
+ - ./gradlew shadowJar
+ - RELEASE_VERSION=$(sed "s/@buildId@/$TRAVIS_BUILD_NUMBER/" game-core/src/main/resources/META-INF/triplea/product.properties  | sed 's/version\s*=\s*//')
  # launch http server so that logged output will be displayed. This is to support eventual integration
  # testing of client/server interactions and allow for debugging in case of problems.
- - ./gradlew shadowJar
- - "java -jar http-server/build/libs/triplea-http-server-1.10.dev.jar server ./http-server/configuration-prerelease.yml &"
+ - "java -jar http-server/build/libs/triplea-http-server-${RELEASE_VERSION}.jar server ./http-server/configuration-prerelease.yml &"
 before_script:
 #- ./.travis/setup_gpg
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
  - ./gradlew flywayMigrate
  - ./gradlew shadowJar
  - RELEASE_VERSION=$(sed "s/@buildId@/$TRAVIS_BUILD_NUMBER/" game-core/src/main/resources/META-INF/triplea/product.properties  | sed 's/version\s*=\s*//')
+ - echo "Release version = $RELEASE_VERSION"
  # launch http server so that logged output will be displayed. This is to support eventual integration
  # testing of client/server interactions and allow for debugging in case of problems.
  - "java -jar http-server/build/libs/triplea-http-server-${RELEASE_VERSION}.jar server ./http-server/configuration-prerelease.yml &"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ addons:
       - python3-yaml
 install:
  - echo "create database lobby" | psql -h localhost -U postgres
+ - ./.travis/setup_gradle
  - ./gradlew flywayMigrate
  # launch http server so that logged output will be displayed. This is to support eventual integration
  # testing of client/server interactions and allow for debugging in case of problems.
@@ -21,7 +22,6 @@ install:
  - "java -jar http-server/build/libs/triplea-http-server-1.10.dev.jar server ./http-server/configuration-prerelease.yml &"
 before_script:
 #- ./.travis/setup_gpg
-- ./.travis/setup_gradle
 script:
 - ./gradlew --parallel check jacocoTestReport
 after_success:


### PR DESCRIPTION
## Overview
Should fix: https://github.com/triplea-game/triplea/issues/4891 (two jar files being packaged)

We were getting a *.dev jar file from the new task that launched an http server.
We could have cleaned up resources, but it adds a redundant step. The fix here is to move release number variable assignment up earlier so that gradle generates jar files with release numbers and not "1.10.dev"

Because we launch http server from jar file, we need to know the release number in travis now, a line of 'sed-fu' was added to scrap the release number and set it to variable. 

## Functional Changes
Jar files should be generated once now on build. The second 'shadowJar' execution should see that jar files already exist and be a no-op.