### PR TITLE
Revert "Remove Access Log DAO (#4749)"

### DIFF
--- a/lobby/src/main/java/org/triplea/lobby/server/db/AccessLogController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/AccessLogController.java
@@ -1,0 +1,38 @@
+package org.triplea.lobby.server.db;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.function.Supplier;
+
+import org.triplea.lobby.server.User;
+import org.triplea.lobby.server.login.UserType;
+
+import lombok.AllArgsConstructor;
+
+/**
+ * Implementation of {@link AccessLogDao} for a Postgres database.
+ */
+@AllArgsConstructor
+final class AccessLogController implements AccessLogDao {
+  private final Supplier<Connection> connection;
+
+  @Override
+  public void insert(final User user, final UserType userType) throws SQLException {
+    checkNotNull(user);
+    checkNotNull(userType);
+
+    final String sql = "insert into access_log (username, ip, mac, registered) values (?, ?::inet, ?, ?)";
+    try (Connection conn = connection.get();
+        PreparedStatement ps = conn.prepareStatement(sql)) {
+      ps.setString(1, user.getUsername());
+      ps.setString(2, user.getInetAddress().getHostAddress());
+      ps.setString(3, user.getHashedMacAddress());
+      ps.setBoolean(4, userType == UserType.REGISTERED);
+      ps.execute();
+      conn.commit();
+    }
+  }
+}

--- a/lobby/src/main/java/org/triplea/lobby/server/db/AccessLogDao.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/AccessLogDao.java
@@ -1,0 +1,21 @@
+package org.triplea.lobby.server.db;
+
+import java.sql.SQLException;
+
+import org.triplea.lobby.server.User;
+import org.triplea.lobby.server.login.UserType;
+
+/**
+ * Data access object for the access log table.
+ */
+public interface AccessLogDao {
+  /**
+   * Inserts a new record in the access log table.
+   *
+   * @param user The user who accessed the lobby.
+   * @param userType The type of the user who accessed the lobby.
+   *
+   * @throws SQLException If an error occurs while logging the access.
+   */
+  void insert(User user, UserType userType) throws SQLException;
+}

--- a/lobby/src/main/java/org/triplea/lobby/server/db/DatabaseDao.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/DatabaseDao.java
@@ -11,6 +11,8 @@ public interface DatabaseDao {
 
   UserDao getUserDao();
 
+  AccessLogDao getAccessLogDao();
+
   BadWordDao getBadWordDao();
 
   ModeratorAuditHistoryDao getModeratorAuditHistoryDao();

--- a/lobby/src/main/java/org/triplea/lobby/server/db/JdbcDatabaseDao.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/JdbcDatabaseDao.java
@@ -12,6 +12,7 @@ import lombok.Getter;
 @Getter(onMethod_ = {@Override})
 class JdbcDatabaseDao implements DatabaseDao {
 
+  private final AccessLogDao accessLogDao;
   private final BadWordDao badWordDao;
   private final UsernameBlacklistDao usernameBlacklistDao;
   private final BannedMacDao bannedMacDao;
@@ -23,6 +24,8 @@ class JdbcDatabaseDao implements DatabaseDao {
     moderatorAuditHistoryDao = jdbi.onDemand(ModeratorAuditHistoryDao.class);
 
     final Supplier<Connection> connection = connectionSupplier(database);
+
+    accessLogDao = new AccessLogController(connection);
     badWordDao = new BadWordController(connection);
     bannedMacDao = new BannedMacController(connection, moderatorAuditHistoryDao);
     usernameBlacklistDao = new UsernameBlacklistController(connection, moderatorAuditHistoryDao);

--- a/lobby/src/main/java/org/triplea/lobby/server/login/LobbyLoginValidator.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/login/LobbyLoginValidator.java
@@ -2,12 +2,14 @@ package org.triplea.lobby.server.login;
 
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
+import java.util.logging.Level;
 
 import javax.annotation.Nullable;
 
@@ -89,7 +91,9 @@ public final class LobbyLoginValidator implements ILoginValidator {
         .inetAddress(((InetSocketAddress) remoteAddress).getAddress())
         .hashedMacAddress(clientMac)
         .build();
-    return authenticateUser(response, user);
+    final @Nullable String errorMessage = authenticateUser(response, user);
+    logAuthenticationResult(user, getUserTypeFor(response), errorMessage);
+    return errorMessage;
   }
 
   private @Nullable String authenticateUser(final Map<String, String> response, final User user) {
@@ -140,6 +144,16 @@ public final class LobbyLoginValidator implements ILoginValidator {
 
   private static UserType getUserTypeFor(final Map<String, String> response) {
     return response.containsKey(LobbyLoginResponseKeys.ANONYMOUS_LOGIN) ? UserType.ANONYMOUS : UserType.REGISTERED;
+  }
+
+  private void logAuthenticationResult(final User user, final UserType userType, final @Nullable String errorMessage) {
+    if (errorMessage == null) {
+      try {
+        database.getAccessLogDao().insert(user, userType);
+      } catch (final SQLException e) {
+        log.log(Level.SEVERE, "failed to record successful authentication in database", e);
+      }
+    }
   }
 
   private static String getBanDurationBreakdown(final Timestamp stamp) {

--- a/lobby/src/test/java/org/triplea/lobby/server/db/AccessLogControllerIntegrationTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/db/AccessLogControllerIntegrationTest.java
@@ -1,0 +1,54 @@
+package org.triplea.lobby.server.db;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+
+import org.junit.jupiter.api.Test;
+import org.triplea.lobby.server.TestUserUtils;
+import org.triplea.lobby.server.User;
+import org.triplea.lobby.server.config.TestLobbyConfigurations;
+import org.triplea.lobby.server.login.UserType;
+import org.triplea.test.common.Integration;
+
+@Integration
+final class AccessLogControllerIntegrationTest {
+  private final AccessLogDao accessLogController =
+      TestLobbyConfigurations.INTEGRATION_TEST.getDatabaseDao().getAccessLogDao();
+
+  @Test
+  void insert_ShouldInsertNewRecord() throws Exception {
+    final User user = TestUserUtils.newUser();
+
+    for (final UserType userType : UserType.values()) {
+      accessLogController.insert(user, userType);
+
+      thenAccessLogRecordShouldExist(user, userType);
+    }
+  }
+
+  private void thenAccessLogRecordShouldExist(final User user, final UserType userType) throws Exception {
+    final String sql = "select access_time from access_log where username=? and ip=?::inet and mac=? and registered=?";
+    try (Connection conn = TestDatabase.newConnection();
+        PreparedStatement ps = conn.prepareStatement(sql)) {
+      ps.setString(1, user.getUsername());
+      ps.setString(2, user.getInetAddress().getHostAddress());
+      ps.setString(3, user.getHashedMacAddress());
+      ps.setBoolean(4, userType == UserType.REGISTERED);
+      try (ResultSet rs = ps.executeQuery()) {
+        assertThat("record should exist", rs.next(), is(true));
+        assertThat("access_time column should have a default value", rs.getTimestamp(1), is(not(nullValue())));
+        assertThat(
+            "only one record should exist "
+                + "(possible aliasing from another test run due to no control over access_time value)",
+            rs.next(),
+            is(false));
+      }
+    }
+  }
+}

--- a/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorTest.java
@@ -29,6 +29,7 @@ import org.triplea.lobby.common.login.LobbyLoginResponseKeys;
 import org.triplea.lobby.common.login.RsaAuthenticator;
 import org.triplea.lobby.server.TestUserUtils;
 import org.triplea.lobby.server.User;
+import org.triplea.lobby.server.db.AccessLogDao;
 import org.triplea.lobby.server.db.BadWordDao;
 import org.triplea.lobby.server.db.BannedMacDao;
 import org.triplea.lobby.server.db.DatabaseDao;
@@ -57,6 +58,9 @@ final class LobbyLoginValidatorTest {
 
     @Mock
     UsernameBlacklistDao bannedUsernameDao;
+
+    @Mock
+    AccessLogDao accessLog;
 
     @Mock
     BadWordDao badWordDao;
@@ -172,6 +176,10 @@ final class LobbyLoginValidatorTest {
           remoteAddress);
     }
 
+    final void thenAccessLogShouldReceiveSuccessfulAuthentication(final UserType userType) throws Exception {
+      verify(accessLog).insert(eq(user), eq(userType));
+    }
+
     final void thenAuthenticationShouldFail() {
       assertThat(authenticationErrorMessage, is(not(nullValue())));
     }
@@ -242,6 +250,7 @@ final class LobbyLoginValidatorTest {
       @Test
       void shouldNotCreateOrUpdateUserWhenAuthenticationSucceeds() {
         givenAnonymousAuthenticationWillSucceed();
+        when(databaseDao.getAccessLogDao()).thenReturn(accessLog);
 
         whenAuthenticating(givenAuthenticationResponse());
 
@@ -276,6 +285,7 @@ final class LobbyLoginValidatorTest {
         @Test
         void shouldCreateNewUserWithOnlyMd5CryptedPassword() {
           givenUserDoesNotExist();
+          when(databaseDao.getAccessLogDao()).thenReturn(accessLog);
 
           whenAuthenticating(givenAuthenticationResponse());
 
@@ -299,6 +309,7 @@ final class LobbyLoginValidatorTest {
         @Test
         void shouldCreateNewUserWithBothPasswords() {
           givenUserDoesNotExist();
+          when(databaseDao.getAccessLogDao()).thenReturn(accessLog);
 
           whenAuthenticating(givenAuthenticationResponse());
 
@@ -328,6 +339,7 @@ final class LobbyLoginValidatorTest {
         void shouldNotUpdatePasswordsWhenUserHasOnlyMd5CryptedPassword() {
           givenUserDoesNotHaveBcryptedPassword();
           givenAuthenticationWillUseMd5CryptedPasswordAndSucceed();
+          when(databaseDao.getAccessLogDao()).thenReturn(accessLog);
 
           whenAuthenticating(givenAuthenticationResponse());
 
@@ -340,6 +352,7 @@ final class LobbyLoginValidatorTest {
         void shouldNotUpdatePasswordsWhenUserHasBothPasswords() {
           givenUserHasBcryptedPassword();
           givenAuthenticationWillUseMd5CryptedPasswordAndSucceed();
+          when(databaseDao.getAccessLogDao()).thenReturn(accessLog);
 
           whenAuthenticating(givenAuthenticationResponse());
 
@@ -375,6 +388,7 @@ final class LobbyLoginValidatorTest {
           givenUserHasMd5CryptedPassword();
           givenUserHasBcryptedPassword();
           givenAuthenticationWillUseObfuscatedPasswordAndSucceed();
+          when(databaseDao.getAccessLogDao()).thenReturn(accessLog);
 
           whenAuthenticating(givenAuthenticationResponse());
 
@@ -389,6 +403,7 @@ final class LobbyLoginValidatorTest {
           givenUserHasMd5CryptedPassword();
           givenUserDoesNotHaveBcryptedPassword();
           givenAuthenticationWillUseMd5CryptedPasswordAndSucceed();
+          when(databaseDao.getAccessLogDao()).thenReturn(accessLog);
 
           whenAuthenticating(givenAuthenticationResponse());
 
@@ -404,6 +419,7 @@ final class LobbyLoginValidatorTest {
           givenUserDoesNotHaveMd5CryptedPassword();
           givenUserHasBcryptedPassword();
           givenAuthenticationWillUseObfuscatedPasswordAndSucceed();
+          when(databaseDao.getAccessLogDao()).thenReturn(accessLog);
 
           whenAuthenticating(givenAuthenticationResponse());
 
@@ -432,10 +448,12 @@ final class LobbyLoginValidatorTest {
       @Test
       void shouldLogSuccessfulAuthenticationWhenAuthenticationSucceeds() {
         givenAnonymousAuthenticationWillSucceed();
+        when(databaseDao.getAccessLogDao()).thenReturn(accessLog);
 
         whenAuthenticating(givenAuthenticationResponse());
 
         thenAuthenticationShouldSucceed();
+        thenAccessLogShouldReceiveSuccessfulAuthentication(UserType.ANONYMOUS);
       }
 
       @Test
@@ -461,10 +479,12 @@ final class LobbyLoginValidatorTest {
       void shouldLogSuccessfulAuthenticationWhenAuthenticationSucceeds() {
         givenUserHasBcryptedPassword();
         givenAuthenticationWillUseObfuscatedPasswordAndSucceed();
+        when(databaseDao.getAccessLogDao()).thenReturn(accessLog);
 
         whenAuthenticating(givenAuthenticationResponse());
 
         thenAuthenticationShouldSucceed();
+        thenAccessLogShouldReceiveSuccessfulAuthentication(UserType.REGISTERED);
       }
 
       @Test


### PR DESCRIPTION
This reverts commit 11d4daacf728263df8886e7961f755ae8d042582.

Turns out this table is still very useful and does not need to be re-created. Moderator Toolbox 2.0 can display this table and then eventually show buttons for adding username or player bans.
