### PR TITLE
Use IP address for lobby instead of host name

### DIFF
--- a/lobby_server.yaml
+++ b/lobby_server.yaml
@@ -1,5 +1,5 @@
 - version: 1.9.0.0
-  host: lobby.triplea-game.org
+  host: 45.79.144.53
   port: 3304
   https_port: 5432
   message: |


### PR DESCRIPTION
Prod DNS is not resolving, switching to use IP address.
Prod issue tracked in: https://github.com/triplea-game/triplea/issues/4904
