### PR TITLE
Revert "Use IP address for lobby instead of host name"

### DIFF
--- a/lobby_server.yaml
+++ b/lobby_server.yaml
@@ -1,5 +1,5 @@
 - version: 1.9.0.0
-  host: 45.79.144.53
+  host: lobby.triplea-game.org
   port: 3304
   https_port: 5432
   message: |


### PR DESCRIPTION
Reverts triplea-game/triplea#4905

DNS outage is over. @RoiEXLab noted that IPv6 users are locked out if we use an IPv4 address.

As discussed in: https://github.com/triplea-game/triplea/issues/4904, long term solution seems to be for clients to cache the resolved IP address and then use that as a fallback. Currently we cache the hostname as found in the property files, but we do not cache the actual host address once that is resolved. 