### PR TITLE
Calc: Fix bombard value and handle limited bombard per land units

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -608,7 +608,7 @@ public class DiceRoll implements Externalizable {
             strength += ua.getIsMarine();
           }
         }
-        if (ua.getIsSea() && isAmphibiousBattle && Matches.territoryIsLand().test(location)) {
+        if (ua.getIsSea() && Matches.territoryIsLand().test(location)) {
           // Change the strength to be bombard, not attack/defense, because this is a bombarding naval unit
           strength = ua.getBombard();
         }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UnitComparator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UnitComparator.java
@@ -127,9 +127,9 @@ public final class UnitComparator {
         .thenComparing(getMovableUnitsComparator(units, route));
   }
 
-  static Comparator<Unit> getDecreasingAttackComparator(final PlayerId player) {
+  static Comparator<Unit> getDecreasingBombardComparator() {
     return Comparator.comparing(Unit::getType,
         Comparator.comparing(UnitAttachment::get,
-            Comparator.<UnitAttachment>comparingInt(u -> u.getAttack(player)).reversed()));
+            Comparator.<UnitAttachment>comparingInt(u -> u.getBombard()).reversed()));
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UnitComparator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UnitComparator.java
@@ -130,6 +130,6 @@ public final class UnitComparator {
   static Comparator<Unit> getDecreasingBombardComparator() {
     return Comparator.comparing(Unit::getType,
         Comparator.comparing(UnitAttachment::get,
-            Comparator.<UnitAttachment>comparingInt(u -> u.getBombard()).reversed()));
+            Comparator.comparingInt(UnitAttachment::getBombard).reversed()));
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
@@ -182,6 +182,7 @@ class OddsCalculatorPanel extends JPanel {
         + "does not include Bombarding sea units for land battles.");
     retreatWhenOnlyAirLeftCheckBox.setToolTipText("We retreat if only air is left, and if 'retreat when x units "
         + "left' is positive we will retreat when x of non-air is left too.");
+    amphibiousCheckBox.setToolTipText("Determines if isMarine bonus is applied for all attacking land units");
     attackerUnitsTotalNumber.setToolTipText("Totals do not include AA guns and other infrastructure, and does not "
         + "include Bombarding sea units for land battles.");
     defenderUnitsTotalNumber.setToolTipText("Totals do not include AA guns and other infrastructure, and does not "

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
@@ -79,8 +79,8 @@ class OddsCalculatorPanel extends JPanel {
   private final IntTextField retreatAfterXUnitsLeft = new IntTextField();
   private final JButton calculateButton = new JButton("Pls Wait, Copying Data...");
   private final JCheckBox keepOneAttackingLandUnitCheckBox = new JCheckBox("One attacking land must live");
-  private final JCheckBox amphibiousCheckBox = new JCheckBox("Battle is Amphibious");
-  private final JCheckBox landBattleCheckBox = new JCheckBox("Land Battle");
+  private final JCheckBox amphibiousCheckBox = new JCheckBox("Add amphibious attack modifiers");
+  private final JCheckBox landBattleCheckBox = new JCheckBox("Land battle");
   private final JCheckBox retreatWhenOnlyAirLeftCheckBox = new JCheckBox("Retreat when only air left");
   private final UiContext uiContext;
   private final GameData data;
@@ -182,7 +182,7 @@ class OddsCalculatorPanel extends JPanel {
         + "does not include Bombarding sea units for land battles.");
     retreatWhenOnlyAirLeftCheckBox.setToolTipText("We retreat if only air is left, and if 'retreat when x units "
         + "left' is positive we will retreat when x of non-air is left too.");
-    amphibiousCheckBox.setToolTipText("Determines if isMarine bonus is applied for all attacking land units");
+    amphibiousCheckBox.setToolTipText("Applies amphibious attack modifiers to all attacking land units");
     attackerUnitsTotalNumber.setToolTipText("Totals do not include AA guns and other infrastructure, and does not "
         + "include Bombarding sea units for land battles.");
     defenderUnitsTotalNumber.setToolTipText("Totals do not include AA guns and other infrastructure, and does not "

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
@@ -600,6 +600,7 @@ class OddsCalculatorPanel extends JPanel {
           final int numLandUnits = CollectionUtils.countMatches(attacking, Matches.unitIsLand());
           if (Properties.getShoreBombardPerGroundUnitRestricted(data) && numLandUnits < bombarding.size()) {
             BattleDelegate.sortUnitsToBombard(bombarding);
+            // Create new list as needs to be serializable which subList isn't
             bombarding = new ArrayList<>(bombarding.subList(0, numLandUnits));
           }
         }

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
@@ -50,6 +50,7 @@ import games.strategy.engine.framework.ui.background.WaitDialog;
 import games.strategy.engine.history.History;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.BattleCalculator;
+import games.strategy.triplea.delegate.BattleDelegate;
 import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
@@ -596,6 +597,11 @@ class OddsCalculatorPanel extends JPanel {
         if (isLand()) {
           bombarding = CollectionUtils.getMatches(attacking, Matches.unitCanBombard(getAttacker()));
           attacking.removeAll(bombarding);
+          final int numLandUnits = CollectionUtils.countMatches(attacking, Matches.unitIsLand());
+          if (Properties.getShoreBombardPerGroundUnitRestricted(data) && numLandUnits < bombarding.size()) {
+            BattleDelegate.sortUnitsToBombard(bombarding);
+            bombarding = new ArrayList<>(bombarding.subList(0, numLandUnits));
+          }
         }
         calculator.setRetreatAfterRound(retreatAfterXRounds.getValue());
         calculator.setRetreatAfterXUnitsLeft(retreatAfterXUnitsLeft.getValue());

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
@@ -598,21 +598,10 @@ class OddsCalculatorPanel extends JPanel {
         }
         calculator.setRetreatAfterRound(retreatAfterXRounds.getValue());
         calculator.setRetreatAfterXUnitsLeft(retreatAfterXUnitsLeft.getValue());
-        if (retreatWhenOnlyAirLeftCheckBox.isSelected()) {
-          calculator.setRetreatWhenOnlyAirLeft(true);
-        } else {
-          calculator.setRetreatWhenOnlyAirLeft(false);
-        }
-        if (landBattleCheckBox.isSelected() && keepOneAttackingLandUnitCheckBox.isSelected()) {
-          calculator.setKeepOneAttackingLandUnit(true);
-        } else {
-          calculator.setKeepOneAttackingLandUnit(false);
-        }
-        if (isAmphibiousBattle()) {
-          calculator.setAmphibious(true);
-        } else {
-          calculator.setAmphibious(false);
-        }
+        calculator.setRetreatWhenOnlyAirLeft(retreatWhenOnlyAirLeftCheckBox.isSelected());
+        calculator.setKeepOneAttackingLandUnit(
+            landBattleCheckBox.isSelected() && keepOneAttackingLandUnitCheckBox.isSelected());
+        calculator.setAmphibious(isAmphibiousBattle());
         calculator.setAttackerOrderOfLosses(attackerOrderOfLosses);
         calculator.setDefenderOrderOfLosses(defenderOrderOfLosses);
         final Collection<TerritoryEffect> territoryEffects = getTerritoryEffects();
@@ -756,21 +745,15 @@ class OddsCalculatorPanel extends JPanel {
       final int defenseHitPoints = BattleCalculator.getTotalHitpointsLeft(defenders);
       attackerUnitsTotalHitpoints.setText("HP: " + attackHitPoints);
       defenderUnitsTotalHitpoints.setText("HP: " + defenseHitPoints);
-      final boolean isAmphibiousBattle = isAmphibiousBattle();
       final Collection<TerritoryEffect> territoryEffects = getTerritoryEffects();
       final IntegerMap<UnitType> costs = TuvUtils.getCostsForTuv(getAttacker(), data);
       attackers.sort(new UnitBattleComparator(false, costs, territoryEffects, data, false, false));
       Collections.reverse(attackers);
       final int attackPower = DiceRoll.getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(attackers, defenders,
-          false, data, location, territoryEffects, isAmphibiousBattle,
-          (isAmphibiousBattle ? attackers : new ArrayList<>())), data);
+          false, data, location, territoryEffects, isAmphibiousBattle(), attackers), data);
       // defender is never amphibious
-      final int defensePower =
-          DiceRoll
-              .getTotalPower(
-                  DiceRoll.getUnitPowerAndRollsForNormalBattles(defenders, attackers, true,
-                      data, location, territoryEffects, isAmphibiousBattle, new ArrayList<>()),
-                  data);
+      final int defensePower = DiceRoll.getTotalPower(DiceRoll.getUnitPowerAndRollsForNormalBattles(defenders,
+          attackers, true, data, location, territoryEffects, false, new ArrayList<>()), data);
       attackerUnitsTotalPower.setText("Power: " + attackPower);
       defenderUnitsTotalPower.setText("Power: " + defensePower);
     } finally {

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -9,6 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -505,7 +506,9 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
     final List<Unit> attackList = bomber.create(2, russians);
     attackList.addAll(attackTrns);
     whenGetRandom(bridge).thenAnswer(withValues(1, 1));
-    final DiceRoll roll = DiceRoll.rollDice(attackList, false, russians, bridge, mock(IBattle.class), "",
+    final IBattle battle = mock(IBattle.class);
+    when(battle.getTerritory()).thenReturn(westEurope);
+    final DiceRoll roll = DiceRoll.rollDice(attackList, false, russians, bridge, battle, "",
         TerritoryEffectHelper.getEffects(balticSeaZone), null);
     assertEquals(2, roll.getHits());
     advanceToStep(bridge, "russianNonCombatMove");


### PR DESCRIPTION
## Overview
- Address bug found here: https://forums.triplea-game.org/topic/1454/battle-calc-not-accounting-for-limited-bombards/14
- Address unhandled property: https://forums.triplea-game.org/topic/1454/battle-calc-not-accounting-for-limited-bombards

## Functional Changes
- Remove check for isAmphibious when setting bombard unit value (if its a sea unit and land battle that is sufficient)
- Add logic to handle "Shore Bombard Per Ground Unit Restricted"

## Manual Testing Performed
- Tested that TWW battle calc now has same result whether Is Amphibious is checked or not in regards to bombarding units
- Tested that calc limits bombarding units by number of lands units if using "Shore Bombard Per Ground Unit Restricted"
