### PR TITLE
Fix build with JDK 12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ matrix:
   include:
   - jdk: openjdk11
     env: TRIPLEA_RELEASE=true
+  - jdk: openjdk12
+    env: TRIPLEA_RELEASE=true
 addons:
   postgresql: "10"
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
   - jdk: openjdk11
     env: TRIPLEA_RELEASE=true
   - jdk: openjdk12
-    env: TRIPLEA_RELEASE=true
+    env: TRIPLEA_RELEASE=false
 addons:
   postgresql: "10"
   apt:

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ plugins {
     id 'java'
     id 'com.github.ben-manes.versions' version '0.20.0'
     id 'io.franzbecker.gradle-lombok' version '2.0' apply false
-    id 'net.ltgt.errorprone' version '0.8' apply false
+    id 'net.ltgt.errorprone' version '0.8.1' apply false
     id 'com.diffplug.gradle.spotless' version '3.23.0' apply false
 }
 
@@ -130,6 +130,7 @@ subprojects {
             check 'WaitNotInLoop', CheckSeverity.ERROR
             disable 'UnusedVariable' // Workaround for https://github.com/google/error-prone/issues/1250
         }
+        options.errorprone.errorproneArgs = ['-Xep:Finally:OFF'] // Workaround for https://github.com/google/error-prone/issues/1257
         options.incremental = true
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ subprojects {
         hamcrestVersion = '2.0.0.0'
         jbcryptVersion = '0.4'
         junitJupiterVersion = '5.4.0'
-        mockitoVersion = '2.24.0'
+        mockitoVersion = '2.24.5'
         postgresqlVersion = '42.2.5'
         sonatypeGoodiesPrefsVersion = '2.2.5'
     }


### PR DESCRIPTION
Adds a workaround for a bug in the errorprone plugin whose fix isn't yet released.

Also adds JDK12 to the travis build config.