### PR TITLE
Fix updating of blends (#4929)

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/image/TileImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/TileImageFactory.java
@@ -31,6 +31,7 @@ import lombok.extern.java.Log;
 @Log
 public final class TileImageFactory {
   // one instance in the application
+  private static boolean isDirty = false;
   private static final String SHOW_RELIEF_IMAGES_PREFERENCE = "ShowRelief2";
   private static boolean showReliefImages;
   private static final String SHOW_MAP_BLENDS_PREFERENCE = "ShowBlends";
@@ -44,7 +45,6 @@ public final class TileImageFactory {
   // maps image name to ImageRef
   private final Map<String, SoftReference<Image>> imageCache = Collections.synchronizedMap(new HashMap<>());
   private ResourceLoader resourceLoader;
-  private static boolean isDirty = false;
 
   static {
     final Preferences prefs = Preferences.userNodeForPackage(TileImageFactory.class);

--- a/game-core/src/main/java/games/strategy/triplea/image/TileImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/TileImageFactory.java
@@ -13,6 +13,7 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.logging.Level;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
@@ -43,6 +44,7 @@ public final class TileImageFactory {
   // maps image name to ImageRef
   private final Map<String, SoftReference<Image>> imageCache = Collections.synchronizedMap(new HashMap<>());
   private ResourceLoader resourceLoader;
+  private static boolean isDirty = false;
 
   static {
     final Preferences prefs = Preferences.userNodeForPackage(TileImageFactory.class);
@@ -69,6 +71,7 @@ public final class TileImageFactory {
   }
 
   public static void setShowReliefImages(final boolean showReliefImages) {
+    isDirty |= TileImageFactory.showReliefImages != showReliefImages;
     TileImageFactory.showReliefImages = showReliefImages;
     final Preferences prefs = Preferences.userNodeForPackage(TileImageFactory.class);
     prefs.putBoolean(SHOW_RELIEF_IMAGES_PREFERENCE, TileImageFactory.showReliefImages);
@@ -80,6 +83,7 @@ public final class TileImageFactory {
   }
 
   public static void setShowMapBlends(final boolean showMapBlends) {
+    isDirty |= TileImageFactory.showMapBlends != showMapBlends;
     TileImageFactory.showMapBlends = showMapBlends;
     final Preferences prefs = Preferences.userNodeForPackage(TileImageFactory.class);
     prefs.putBoolean(SHOW_MAP_BLENDS_PREFERENCE, TileImageFactory.showMapBlends);
@@ -91,6 +95,7 @@ public final class TileImageFactory {
   }
 
   public static void setShowMapBlendMode(final String showMapBlendMode) {
+    isDirty |= !Objects.equals(TileImageFactory.showMapBlendMode, showMapBlendMode);
     TileImageFactory.showMapBlendMode = showMapBlendMode;
     final Preferences prefs = Preferences.userNodeForPackage(TileImageFactory.class);
     prefs.put(SHOW_MAP_BLEND_MODE, TileImageFactory.showMapBlendMode);
@@ -102,6 +107,7 @@ public final class TileImageFactory {
   }
 
   public static void setShowMapBlendAlpha(final float showMapBlendAlpha) {
+    isDirty |= TileImageFactory.showMapBlendAlpha != showMapBlendAlpha;
     TileImageFactory.showMapBlendAlpha = showMapBlendAlpha;
     final Preferences prefs = Preferences.userNodeForPackage(TileImageFactory.class);
     prefs.putFloat(SHOW_MAP_BLEND_ALPHA, TileImageFactory.showMapBlendAlpha);
@@ -138,6 +144,10 @@ public final class TileImageFactory {
   }
 
   private Image getImage(final String fileName, final boolean transparent) {
+    if (isDirty) {
+      isDirty = false;
+      imageCache.clear();
+    }
     final Image image = isImageLoaded(fileName);
     if (image != null) {
       return image;

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -260,7 +260,7 @@ final class ViewMenu extends JMenu {
       }
       TileImageFactory.setShowReliefImages(showMapDetails.isSelected());
       new Thread(() -> frame.getMapPanel().updateCountries(gameData.getMap().getTerritories()),
-          "Triplea : Show map details thread").start();
+          "Show map details thread").start();
     });
     add(showMapDetails);
   }
@@ -282,10 +282,7 @@ final class ViewMenu extends JMenu {
       TileImageFactory.setShowMapBlends(showMapBlends.isSelected());
       TileImageFactory.setShowMapBlendMode(uiContext.getMapData().getMapBlendMode());
       TileImageFactory.setShowMapBlendAlpha(uiContext.getMapData().getMapBlendAlpha());
-      new Thread(() -> {
-        frame.getMapPanel().setScale(uiContext.getScale());
-        frame.getMapPanel().updateCountries(gameData.getMap().getTerritories());
-      }, "Triplea : Show map Blends thread").start();
+      new Thread(() -> frame.getMapPanel().updateCountries(gameData.getMap().getTerritories()), "Show map Blends thread").start();
     });
     add(showMapBlends);
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -282,7 +282,8 @@ final class ViewMenu extends JMenu {
       TileImageFactory.setShowMapBlends(showMapBlends.isSelected());
       TileImageFactory.setShowMapBlendMode(uiContext.getMapData().getMapBlendMode());
       TileImageFactory.setShowMapBlendAlpha(uiContext.getMapData().getMapBlendAlpha());
-      new Thread(() -> frame.getMapPanel().updateCountries(gameData.getMap().getTerritories()), "Show map Blends thread").start();
+      new Thread(() -> frame.getMapPanel().updateCountries(gameData.getMap().getTerritories()),
+          "Show map Blends thread").start();
     });
     add(showMapBlends);
   }


### PR DESCRIPTION
## Overview
Fixes #4929
Turns out the blending code was setting the scale to itself in order to clear the image cache. From the seamless zoom change forward, changing the scale no longer triggered a cache clear and therefore this feature seemed to be broken, but actually worked when saving and reopening the game.

## Functional Changes
Bugfix.

## Manual Testing Performed
I verified the blends are now correctly getting updated.