### PR TITLE
Plumb error correctly when yaml decoding fails.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/ContentReader.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/ContentReader.java
@@ -41,7 +41,7 @@ public final class ContentReader {
    * @param uri The resource URI; must not be {@code null}.
    * @param action The action to perform using the give InputStream; must not be {@code null}.
    */
-  public <T> Optional<T> download(final String uri, final Function<InputStream, T> action) {
+  public <T> Optional<T> download(final String uri, final ThrowingFunction<InputStream, T, IOException> action) {
     checkNotNull(uri);
     checkNotNull(action);
 

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
@@ -3,12 +3,14 @@ package games.strategy.engine.framework.map.download;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.InputStream;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
 import org.snakeyaml.engine.v1.api.Load;
 import org.snakeyaml.engine.v1.api.LoadSettingsBuilder;
+import org.snakeyaml.engine.v1.exceptions.YamlEngineException;
 import org.triplea.util.Version;
 
 import com.google.common.base.Preconditions;
@@ -26,7 +28,15 @@ final class DownloadFileParser {
     url, mapType, version, mapName, description, mapCategory, img
   }
 
-  public static List<DownloadFileDescription> parse(final InputStream is) {
+  public static List<DownloadFileDescription> parse(final InputStream is) throws IOException {
+    try {
+      return parseImpl(is);
+    } catch (final YamlEngineException e) {
+      throw new IOException(e);
+    }
+  }
+
+  private static List<DownloadFileDescription> parseImpl(final InputStream is) throws IOException {
     final Load load = new Load(new LoadSettingsBuilder().build());
     final List<?> yamlData = (List<?>) load.loadFromInputStream(is);
 

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
@@ -2,8 +2,8 @@ package games.strategy.engine.framework.map.download;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcher.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcher.java
@@ -1,10 +1,9 @@
 package games.strategy.engine.lobby.client.login;
 
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Optional;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 import javax.annotation.Nullable;
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcher.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcher.java
@@ -1,12 +1,14 @@
 package games.strategy.engine.lobby.client.login;
 
 import java.io.InputStream;
+import java.io.IOException;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
 import javax.annotation.Nullable;
 
+import org.triplea.java.function.ThrowingFunction;
 import org.triplea.util.Version;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -24,14 +26,14 @@ public final class LobbyServerPropertiesFetcher {
   public static final int TEST_LOBBY_DEFAULT_PORT = 3304;
   public static final int TEST_LOBBY_DEFAULT_HTTPS_PORT = 8080;
 
-  private final BiFunction<String, Function<InputStream, LobbyServerProperties>,
+  private final BiFunction<String, ThrowingFunction<InputStream, LobbyServerProperties, IOException>,
       Optional<LobbyServerProperties>> fileDownloader;
   @Nullable
   private LobbyServerProperties lobbyServerProperties;
 
 
   LobbyServerPropertiesFetcher(
-      final BiFunction<String, Function<InputStream, LobbyServerProperties>,
+      final BiFunction<String, ThrowingFunction<InputStream, LobbyServerProperties, IOException>,
           Optional<LobbyServerProperties>> fileDownloader) {
     this.fileDownloader = fileDownloader;
   }

--- a/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcherTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcherTest.java
@@ -13,7 +13,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
 import java.util.function.BiFunction;
-import java.util.function.Function;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -21,8 +20,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.triplea.java.function.ThrowingFunction;
 import org.triplea.java.OptionalUtils;
+import org.triplea.java.function.ThrowingFunction;
 import org.triplea.util.Version;
 
 import games.strategy.triplea.settings.GameSetting;
@@ -30,7 +29,7 @@ import games.strategy.triplea.settings.GameSetting;
 @ExtendWith(MockitoExtension.class)
 class LobbyServerPropertiesFetcherTest {
   @Mock
-  private BiFunction<String, ThrowingFunction<InputStream, LobbyServerProperties,IOException>,
+  private BiFunction<String, ThrowingFunction<InputStream, LobbyServerProperties, IOException>,
       Optional<LobbyServerProperties>> mockFileDownloader;
 
   private LobbyServerPropertiesFetcher testObj;

--- a/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcherTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/client/login/LobbyServerPropertiesFetcherTest.java
@@ -9,6 +9,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Optional;
 import java.util.function.BiFunction;
@@ -20,6 +21,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.java.function.ThrowingFunction;
 import org.triplea.java.OptionalUtils;
 import org.triplea.util.Version;
 
@@ -28,7 +30,7 @@ import games.strategy.triplea.settings.GameSetting;
 @ExtendWith(MockitoExtension.class)
 class LobbyServerPropertiesFetcherTest {
   @Mock
-  private BiFunction<String, Function<InputStream, LobbyServerProperties>,
+  private BiFunction<String, ThrowingFunction<InputStream, LobbyServerProperties,IOException>,
       Optional<LobbyServerProperties>> mockFileDownloader;
 
   private LobbyServerPropertiesFetcher testObj;


### PR DESCRIPTION
## Overview
If YAML parsing fails when trying to download maps, the underlying IOException message was not shown because the error thrown was not actually an IOException but a YamlEngineException wrapping it. This change fixes this by explicitly catching the YamlEngineException and rethrowing it as an IOException so it can be caught by higher level code expecting an IOException.

## Functional Changes
If you click "Download Maps" with your client set up such that "game-headed" is a directory (e.g. in a developer checkout), the error message will actually show the correct error message containing the path in question and not just the cryptic "Is a directory".

## Manual Testing Performed
- Click "Download Maps" in a developer instance and look at the error message shown.

## Before & After Screen Shots
<!-- Leave blank if no UI changes -->
### Before

### After


## Additional Review Notes
<!-- Add here any extra notes that would be helpful to reviewers -->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->
