### PR TITLE
Enable loopback pinentry mode by adding a gpg-agent.conf line

### DIFF
--- a/.travis/generate_artifact_checksums
+++ b/.travis/generate_artifact_checksums
@@ -23,6 +23,10 @@ for engine in ${ENGINES[@]}; do
   mv ${checksum_files[$engine]} ./${engine}.txt
 done
 
+## Enable pinentry loopback mode: https://www.fluidkeys.com/tweak-gpg-2.1.11/
+echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
+gpgconf --reload gpg-agent
+
 # Sign checksum files
 #
 # We use detached signatures so that


### PR DESCRIPTION
## Overview
Add conf to see if error "gpg: setting pinentry mode 'loopback' failed: Not supported" can be fixed.


## Manual Testing Performed
- None, live testing, will revert all GPG changes if not successful.
