### PR TITLE
Update DB user to 'lobby_user' and DB to 'lobby_db'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ addons:
       - python3
       - python3-yaml
 install:
- - echo "create database lobby" | psql -h localhost -U postgres
+ - echo "create database lobby" | psql -h localhost -U lobby_user -d postgres
  - ./.travis/setup_gradle
  - ./gradlew flywayMigrate
  - ./gradlew shadowJar

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,9 @@ addons:
       - python3
       - python3-yaml
 install:
- - echo "create database lobby" | psql -h localhost -U lobby_user -d postgres
+ - echo "create database lobby_db" | psql -h localhost -U postgres -d postgres
+ - echo "create user lobby_user with password 'postgres'" | psql -h localhost -U postgres -d postgres
+ - echo "alter database lobby_db owner to lobby_user" | psql -h localhost -U postgres -d postgres
  - ./.travis/setup_gradle
  - ./gradlew flywayMigrate
  - ./gradlew shadowJar

--- a/http-server/configuration-prerelease.yml
+++ b/http-server/configuration-prerelease.yml
@@ -9,10 +9,9 @@ bcryptSalt: $2a$10$IhIXWg4HkQRWrZqjj9kV0u
 
 database:
   driverClass: org.postgresql.Driver
-  ## TODO: change database user to triplea_lobby or create a user for use with the http_server
-  user: postgres
+  user: lobby_user
   password: ${POSTGRES_PASSWORD:-postgres}
-  url: jdbc:postgresql://localhost:5432/lobby
+  url: jdbc:postgresql://localhost:5432/lobby_db
   properties:
     charSet: UTF-8
   # the maximum amount of time to wait on an empty pool before throwing an exception

--- a/http-server/configuration-production.yml
+++ b/http-server/configuration-production.yml
@@ -9,10 +9,9 @@ bcryptSalt: ${BCRYPT_SALT}
 
 database:
   driverClass: org.postgresql.Driver
-  ## TODO: change database user to triplea_lobby or create a user for use with the http_server
-  user: postgres
+  user: lobby_user
   password: ${POSTGRES_PASSWORD}
-  url: jdbc:postgresql://localhost:5432/lobby
+  url: jdbc:postgresql://localhost:5432/lobby_db
   properties:
     charSet: UTF-8
   # the maximum amount of time to wait on an empty pool before throwing an exception

--- a/http-server/src/test/resources/dbunit.yml
+++ b/http-server/src/test/resources/dbunit.yml
@@ -1,6 +1,6 @@
 caseInsensitiveStrategy: !!com.github.database.rider.core.api.configuration.Orthography 'LOWERCASE'
 connectionConfig:
   driver: "org.postgresql.Driver"
-  url: "jdbc:postgresql://localhost:5432/lobby"
-  user: "postgres"
+  url: "jdbc:postgresql://localhost:5432/lobby_db"
+  user: "lobby_user"
   password: "postgres"

--- a/infrastructure/ansible/group_vars/all.yml
+++ b/infrastructure/ansible/group_vars/all.yml
@@ -3,8 +3,8 @@
 
 java_open_jdk_version_major: "11"
 
-lobby_db_name: lobby
-lobby_db_user: triplea_lobby
+lobby_db_name: lobby_db
+lobby_db_user: lobby_user
 lobby_db_password: "{{ lookup('ENV', 'POSTGRES_PASSWORD') }}"
 lobby_port: 3304
 bot_lobby_port: "{{ lobby_port }}"

--- a/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/DatabaseEnvironmentVariable.java
+++ b/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/DatabaseEnvironmentVariable.java
@@ -7,7 +7,7 @@ import lombok.AllArgsConstructor;
 /** Class that represent OS environment variable keys with default values. */
 @AllArgsConstructor
 public enum DatabaseEnvironmentVariable {
-  POSTGRES_USER("postgres"),
+  POSTGRES_USER("lobby_user"),
 
   POSTGRES_PASSWORD("postgres"),
 
@@ -15,7 +15,7 @@ public enum DatabaseEnvironmentVariable {
 
   POSTGRES_PORT("5432"),
 
-  POSTGRES_DATABASE("lobby");
+  POSTGRES_DATABASE("lobby_db");
 
   private final String defaultValue;
 

--- a/lobby-db-dao/src/test/resources/dbunit.yml
+++ b/lobby-db-dao/src/test/resources/dbunit.yml
@@ -1,6 +1,6 @@
 caseInsensitiveStrategy: !!com.github.database.rider.core.api.configuration.Orthography 'LOWERCASE'
 connectionConfig:
   driver: "org.postgresql.Driver"
-  url: "jdbc:postgresql://localhost:5432/lobby"
-  user: "postgres"
+  url: "jdbc:postgresql://localhost:5432/lobby_db"
+  user: "lobby_user"
   password: "postgres"

--- a/lobby-db/Dockerfile
+++ b/lobby-db/Dockerfile
@@ -5,7 +5,8 @@
 FROM postgres:9.5
 MAINTAINER "tripleabuilderbot@gmail.com"
 
-ENV POSTGRES_DB=lobby
+ENV POSTGRES_USER=lobby_user
+ENV POSTGRES_DB=lobby_db
 
 # TODO: Copy a production-like snapshot. Snapshots include the flyway tracking tables, 
 # running flyway would then be incremental and run only new migrations, better simulating

--- a/lobby-db/README.md
+++ b/lobby-db/README.md
@@ -11,6 +11,7 @@ is where we check-in SQL commands to update database. Any new files are run auto
 
 To launch a local dabase on Docker, run: `launch_db`
 
+
 ### Prerequisites
 - Docker
 - `psql` (postgres-client) command 
@@ -42,8 +43,12 @@ A lobby server running on the same host as the lobby database container may conn
 
 Property | Value | Notes
 :-- | :-- | :--
-User | `postgres` |
+User | `triplea-lobby` |
 Password | _&lt;any&gt;_ | The lobby database is configured with authentication disabled, thus any password may be used.
 Host | `localhost` |
 Port | `5432` |
+
+## Docker DB configuraton
+
+Configuration flags and other docker container configuration documentation can be found at: https://hub.docker.com/_/postgres
 

--- a/lobby-db/README.md
+++ b/lobby-db/README.md
@@ -11,7 +11,6 @@ is where we check-in SQL commands to update database. Any new files are run auto
 
 To launch a local dabase on Docker, run: `launch_db`
 
-
 ### Prerequisites
 - Docker
 - `psql` (postgres-client) command 
@@ -43,12 +42,12 @@ A lobby server running on the same host as the lobby database container may conn
 
 Property | Value | Notes
 :-- | :-- | :--
-User | `triplea-lobby` |
+User | `lobby_user` |
 Password | _&lt;any&gt;_ | The lobby database is configured with authentication disabled, thus any password may be used.
 Host | `localhost` |
 Port | `5432` |
 
 ## Docker DB configuraton
 
-Configuration flags and other docker container configuration documentation can be found at: https://hub.docker.com/_/postgres
+Docker container and Configuration flag documentation can be found at: https://hub.docker.com/_/postgres
 

--- a/lobby-db/build.gradle
+++ b/lobby-db/build.gradle
@@ -11,8 +11,8 @@ plugins {
 
 flyway {
     driver = 'org.postgresql.Driver'
-    url= 'jdbc:postgresql://localhost:5432/lobby'
-    user = 'postgres'
+    url= 'jdbc:postgresql://localhost:5432/lobby_db'
+    user = 'lobby_user'
     password = 'postgres'
 }
 

--- a/lobby-db/connect_to_db
+++ b/lobby-db/connect_to_db
@@ -1,11 +1,4 @@
 #!/bin/bash
 
-DB=lobby
-PSQL="psql -h localhost -U postgres -w $DB"
-
-if [[ "$OSTYPE" == darwin* ]]; then
-  PSQL="psql -h localhost -U postgres -w $DB"
-fi
-
-$PSQL
+psql -h localhost -U lobby_user -w -d lobby_db
 

--- a/lobby-db/drop_db
+++ b/lobby-db/drop_db
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-DB=lobby
-PSQL="psql -h localhost -U postgres -w"
+DB=lobby_db
+PSQL="psql -h localhost -U lobby_user -w -d postgres"
 echo "drop database $DB" | $PSQL
 echo "create database $DB" | $PSQL
 

--- a/lobby-db/src/main/resources/db/migration/V1.00.00__lobby.sql
+++ b/lobby-db/src/main/resources/db/migration/V1.00.00__lobby.sql
@@ -2,50 +2,43 @@
 create table bad_words (
     word character varying(40) not null primary key
 );
--- alter table bad_words owner to triplea_lobby;
-alter table bad_words owner to postgres;
+alter table bad_words owner to lobby_user;
 
 create table banned_ips (
     ip character varying(40) not null primary key,
     ban_till timestamp without time zone
 );
--- alter table banned_ips owner to triplea_lobby;
-alter table banned_ips owner to postgres;
+alter table banned_ips owner to lobby_user;
 
 create table banned_macs (
     mac character varying(40) not null primary key,
     ban_till timestamp without time zone
 );
--- alter table banned_macs owner to triplea_lobby;
-alter table banned_macs owner to postgres;
+alter table banned_macs owner to lobby_user;
 
 create table banned_usernames (
     username character varying(40) not null primary key,
     ban_till timestamp without time zone
 );
--- alter table banned_usernames owner to triplea_lobby;
-alter table banned_usernames owner to postgres;
+alter table banned_usernames owner to lobby_user;
 
 create table muted_ips (
     ip character varying(40) not null primary key,
     mute_till timestamp without time zone
 );
--- alter table muted_ips owner to triplea_lobby;
-alter table muted_ips owner to postgres;
+alter table muted_ips owner to lobby_user;
 
 create table muted_macs (
     mac character varying(40) not null primary key,
     mute_till timestamp without time zone
 );
--- alter table muted_macs owner to triplea_lobby;
-alter table muted_macs owner to postgres;
+alter table muted_macs owner to lobby_user;
 
 create table muted_usernames (
     username character varying(40) not null primary key,
     mute_till timestamp without time zone
 );
--- alter table muted_usernames owner to triplea_lobby;
-alter table muted_usernames owner to postgres;
+alter table muted_usernames owner to lobby_user;
 
 create table ta_users (
     username character varying(40) not null primary key,
@@ -55,5 +48,4 @@ create table ta_users (
     lastlogin timestamp without time zone not null,
     admin integer not null
 );
--- alter table ta_users owner to triplea_lobby;
-alter table ta_users owner to postgres;
+alter table ta_users owner to lobby_user;

--- a/lobby-db/src/main/resources/db/migration/V1.09.00__lobby.sql
+++ b/lobby-db/src/main/resources/db/migration/V1.09.00__lobby.sql
@@ -38,7 +38,7 @@ alter table muted_usernames
 
 
 -- Comments
-comment on database lobby is 'The Database of the TripleA Lobby';
+comment on database lobby_db is 'The Database of the TripleA Lobby';
 
 comment on table ta_users is 'The table storing all the information about TripleA users.';
 comment on column ta_users.username is 'Defines the in-game username of everyone. The primary key constraint should probably be moved to an id column, preferably using pseudo_encrypt(nextval(''something'')) as default value.';
@@ -216,6 +216,5 @@ comment on column access_log.ip is 'The IP address of the user accessing the lob
 comment on column access_log.mac is 'The hashed MAC address of the user accessing the lobby.';
 comment on column access_log.registered is 'True if the user was registered when accessing the lobby; otherwise false if the user was anonymous';
 
-alter table access_log owner to postgres;
--- alter table access_log owner to triplea_lobby;
+alter table access_log owner to lobby_user;
 

--- a/lobby-db/src/main/resources/db/migration/V1.10.00.20190330__lobby_user_table.sql
+++ b/lobby-db/src/main/resources/db/migration/V1.10.00.20190330__lobby_user_table.sql
@@ -10,9 +10,7 @@ create table lobby_user
     bcrypt_password character(60) check (char_length(bcrypt_password) = 60)
 );
 
--- alter table user owner to triplea_lobby;
-alter table lobby_user
-    owner to postgres;
+alter table lobby_user owner to lobby_user;
 alter table lobby_user
     add constraint lobby_user_pass_check check (password IS NOT NULL OR bcrypt_password IS NOT NULL);
 
@@ -43,9 +41,7 @@ create table moderator_action_history
     action_target varchar(40) not null
 );
 
--- alter table moderator_action_history owner to triplea_lobby;
-alter table moderator_action_history
-    owner to postgres;
+alter table moderator_action_history owner to lobby_user;
 
 comment on table moderator_action_history is 'Table storing an audit history of actions taken by moderators';
 comment on column moderator_action_history.id is 'Table storing an audit history of actions taken by moderators';

--- a/lobby-db/src/main/resources/db/migration/V1.10.00.20190527__error_reporting_record.sql
+++ b/lobby-db/src/main/resources/db/migration/V1.10.00.20190527__error_reporting_record.sql
@@ -4,8 +4,7 @@ create table error_report_history(
   date_created timestamp not null default now()
 );
 
--- alter table error_report_history owner to triplea_lobby;
-alter table error_report_history owner to postgres;
+alter table error_report_history owner to lobby_user;
 
 comment on table error_report_history is 'Table that stores timestamps by user IP address of when error reports were created. Used to do rate limiting.';
 comment on column error_report_history.id is 'Synthetic PK column';

--- a/lobby-db/src/main/resources/db/migration/V1.10.00.20190605__api_key.sql
+++ b/lobby-db/src/main/resources/db/migration/V1.10.00.20190605__api_key.sql
@@ -9,9 +9,7 @@ create table moderator_api_key
     api_key                character(128) not null unique
 );
 
--- alter table moderator_api_key owner to triplea_lobby;
-alter table moderator_api_key
-    owner to postgres;
+alter table moderator_api_key owner to lobby_user;
 
 comment on table moderator_api_key is
     'Stores api-keys used by moderators to authenticate http server requests';

--- a/lobby-db/src/main/resources/db/migration/V1.10.00.20190607__single_use_api_key.sql
+++ b/lobby-db/src/main/resources/db/migration/V1.10.00.20190607__single_use_api_key.sql
@@ -7,9 +7,7 @@ create table moderator_single_use_key
     api_key       varchar(128) not null unique
 );
 
--- alter table moderator_single_use_key owner to triplea_lobby;
-alter table moderator_single_use_key
-    owner to postgres;
+alter table moderator_single_use_key owner to lobby_user;
 
 comment on table moderator_single_use_key is $$Stores single use api-keys used by moderators. The single-use
   key is provided to a moderator at which point they use it to do an initial authentication. If successful

--- a/lobby-db/src/main/resources/db/migration/V1.10.00.20190610__moderator_toolbox_support.sql
+++ b/lobby-db/src/main/resources/db/migration/V1.10.00.20190610__moderator_toolbox_support.sql
@@ -16,9 +16,7 @@ create table banned_user
     date_created timestamptz   not null default now()
 );
 
-alter table banned_user
-    owner to postgres;
--- alter table banned_user owner to triplea_lobby;
+alter table banned_user owner to lobby_user;
 
 -- migrate existing data to the new table name
 insert into banned_user(public_id, username, hashed_mac, ip, ban_expiry)

--- a/lobby/src/test/java/org/triplea/lobby/server/db/TestDatabase.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/db/TestDatabase.java
@@ -18,7 +18,7 @@ public final class TestDatabase {
       "jdbc:postgresql://%s:%d/%s",
       "localhost",
       5432,
-      "lobby");
+      "lobby_db");
 
   /**
    * Creates a new DB connection to localhost.
@@ -32,7 +32,7 @@ public final class TestDatabase {
 
   private static Properties getConnectionProperties() {
     final Properties props = new Properties();
-    props.put("user", "postgres");
+    props.put("user", "lobby_user");
     props.put("password", "postgres");
     return props;
   }

--- a/lobby/src/test/resources/dbunit.yml
+++ b/lobby/src/test/resources/dbunit.yml
@@ -1,6 +1,6 @@
 caseInsensitiveStrategy: !!com.github.database.rider.core.api.configuration.Orthography 'LOWERCASE'
 connectionConfig:
   driver: "org.postgresql.Driver"
-  url: "jdbc:postgresql://localhost:5432/lobby"
-  user: "postgres"
+  url: "jdbc:postgresql://localhost:5432/lobby_db"
+  user: "lobby_user"
   password: "postgres"


### PR DESCRIPTION
## Overview

- Changes lobby user name from postgres to 'lobby_user'. This is done so we are not using the postgres super user account for application connectivity. This does collide with the name of the 'lobby_user' table, but ultimately that should be okay..
- Changes lobby DB name from 'lobby' to 'lobby_db'. Mainly this is to disambiguate between user and lobby so we don't have both DB and user both named 'lobby'.
- Update documentation to include postgres docker documentation link

## Functional Changes
- none

## Manual Testing Performed
- verified scripts in 'lobby-db' continue to work, notably the connect to db script and the drop db script and the docker build and run scripts
- verified gradle integration tests work
- launched a local lobby and local headed game and connected to the local lobby

## Additional Review Notes

- next release will be against a clean DB, so we are free to update the existing flyway migration scripts
