### PR TITLE
Update logging levels of IOException

### DIFF
--- a/game-core/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ServerMessenger.java
@@ -311,13 +311,13 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
               socketChannel.configureBlocking(false);
               socketChannel.socket().setKeepAlive(true);
             } catch (final IOException e) {
-              log.log(Level.FINE, "Could not accept channel", e);
+              log.log(Level.SEVERE, "Could not accept channel", e);
               try {
                 if (socketChannel != null) {
                   socketChannel.close();
                 }
               } catch (final IOException e2) {
-                log.log(Level.FINE, "Could not close channel", e2);
+                log.log(Level.SEVERE, "Could not close channel", e2);
               }
               continue;
             }
@@ -326,7 +326,7 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
               try {
                 socketChannel.close();
               } catch (final IOException e) {
-                log.log(Level.FINE, "Could not close channel", e);
+                log.log(Level.SEVERE, "Could not close channel", e);
               }
               continue;
             }


### PR DESCRIPTION
## Overview
FINE may not be logged, we do not expect to get various IOExceptions with server sockets and should see the exception messages.


## Functional Changes
Upgrades logging levels, could cause multiple error pop-ups when hosting a game and encountering multiple exceptions.

## Manual Testing Performed
- none

## Additional Review Notes
I'm pretty sure these exceptions are really never expected, hence there is a desire to log them so we know we are hitting them in case we are. 
