### PR TITLE
 Trim requested user names

### DIFF
--- a/game-core/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
+++ b/game-core/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
@@ -58,12 +58,10 @@ public class ServerQuarantineConversation extends QuarantineConversation {
     try {
       switch (step) {
         case READ_NAME:
-          // read name, send challenge
           remoteName = ((String) serializable).trim();
           step = Step.READ_MAC;
           return Action.NONE;
         case READ_MAC:
-          // read name, send challenge
           remoteMac = (String) serializable;
           if (validator != null) {
             challenge = validator.getChallengeProperties(remoteName);

--- a/game-core/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
+++ b/game-core/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
@@ -59,7 +59,7 @@ public class ServerQuarantineConversation extends QuarantineConversation {
       switch (step) {
         case READ_NAME:
           // read name, send challenge
-          remoteName = (String) serializable;
+          remoteName = ((String) serializable).trim();
           step = Step.READ_MAC;
           return Action.NONE;
         case READ_MAC:


### PR DESCRIPTION
## Overview

Leading or trailing whitespace on requested user names is chopped off with this update. Avoids a user from
creating a same nickname by adding spaces to the end of an existing name.

Typical clients cannot add whitespace to the end of a username, disallowed by UI. If a motivated user were
to create a custom/hacked client, then they could send such a username.

## Functional Changes
Usernames will be trimmed on server side.

## Manual Testing Performed
Attempted the non-trimmed login with a standard client, the non-trimmed whitespace was rejected by UI.

Did not try a hacked client to verify this.

## Additional Review Notes
While doing small updates, the comments removed are copy/pasted and the second one is incorrect. The first one is already pretty obvious from the code and restates the code.
