### PR TITLE
Disallow multiple names from same IP address

### DIFF
--- a/game-core/src/main/java/games/strategy/net/PlayerNameAssigner.java
+++ b/game-core/src/main/java/games/strategy/net/PlayerNameAssigner.java
@@ -49,16 +49,9 @@ public final class PlayerNameAssigner {
     if (currentName.length() < 2) {
       currentName = "aa" + currentName;
     }
-    if (isNameTaken(currentName, loggedInNodes)) {
-      int i = 1;
-      while (true) {
-        final String newName = currentName + " (" + i + ")";
-        if (!isNameTaken(newName, loggedInNodes)) {
-          currentName = newName;
-          break;
-        }
-        i++;
-      }
+    final String originalName = currentName;
+    for (int i = 1; isNameTaken(currentName, loggedInNodes); i++) {
+      currentName = originalName + " (" + i + ")";
     }
     return currentName;
   }

--- a/game-core/src/main/java/games/strategy/net/PlayerNameAssigner.java
+++ b/game-core/src/main/java/games/strategy/net/PlayerNameAssigner.java
@@ -47,9 +47,6 @@ public final class PlayerNameAssigner {
     if (currentName.length() > 50) {
       currentName = currentName.substring(0, 50);
     }
-    if (currentName.length() < 2) {
-      currentName = "aa" + currentName;
-    }
     final String originalName = currentName;
     for (int i = 1; isNameTaken(currentName, loggedInNodes); i++) {
       currentName = originalName + " (" + i + ")";

--- a/game-core/src/main/java/games/strategy/net/PlayerNameAssigner.java
+++ b/game-core/src/main/java/games/strategy/net/PlayerNameAssigner.java
@@ -69,7 +69,6 @@ public final class PlayerNameAssigner {
   private static boolean isNameTaken(final String nodeName, final Collection<INode> nodes) {
     return nodes
         .stream()
-        .sorted()
         .map(INode::getName)
         .anyMatch(nodeName::equalsIgnoreCase);
   }

--- a/game-core/src/main/java/games/strategy/net/PlayerNameAssigner.java
+++ b/game-core/src/main/java/games/strategy/net/PlayerNameAssigner.java
@@ -1,0 +1,83 @@
+package games.strategy.net;
+
+import java.net.InetAddress;
+import java.util.Collection;
+import java.util.Optional;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/**
+ * Utility class that will assign a name to a newly logging in player.
+ */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class PlayerNameAssigner {
+
+  /**
+   * Name string returned in the case of a hacked client sending us an invalid/unexpected name.
+   */
+  @VisibleForTesting
+  static final String DUMMY_NAME = "aa";
+
+  /**
+   * Returns a node name, based on the specified node name, that is unique across all nodes. The node name is made
+   * unique by adding a numbered suffix to the existing node name. For example, for the second node with the name "foo",
+   * this method will return "foo (1)".
+   *
+   * @param desiredName The name being requested by a new user joining.
+   * @param ipAddress The IP address of the user that is joining. Used to determine if the user
+   *        is already connected under a different name.
+   * @param loggedInNodes Collection of nodes that have already joined.
+   */
+  public static String assignName(
+      final String desiredName,
+      final InetAddress ipAddress,
+      final Collection<INode> loggedInNodes) {
+    Preconditions.checkNotNull(ipAddress);
+    Preconditions.checkNotNull(loggedInNodes);
+
+    String currentName =
+        (desiredName == null || desiredName.length() < 3)
+            ? DUMMY_NAME
+            : findLoggedInName(ipAddress, loggedInNodes).orElse(desiredName);
+    if (currentName.length() > 50) {
+      currentName = currentName.substring(0, 50);
+    }
+    if (currentName.length() < 2) {
+      currentName = "aa" + currentName;
+    }
+    if (isNameTaken(currentName, loggedInNodes)) {
+      int i = 1;
+      while (true) {
+        final String newName = currentName + " (" + i + ")";
+        if (!isNameTaken(newName, loggedInNodes)) {
+          currentName = newName;
+          break;
+        }
+        i++;
+      }
+    }
+    return currentName;
+  }
+
+  private static Optional<String> findLoggedInName(
+      final InetAddress socketAddress, final Collection<INode> nodes) {
+    return nodes
+        .stream()
+        .sorted()
+        .filter(node -> node.getAddress().equals(socketAddress))
+        .findFirst()
+        .map(INode::getName);
+  }
+
+  private static boolean isNameTaken(final String nodeName, final Collection<INode> nodes) {
+    return nodes
+        .stream()
+        .sorted()
+        .map(INode::getName)
+        .anyMatch(nodeName::equalsIgnoreCase);
+  }
+}

--- a/game-core/src/main/java/games/strategy/net/PlayerNameAssigner.java
+++ b/game-core/src/main/java/games/strategy/net/PlayerNameAssigner.java
@@ -2,6 +2,7 @@ package games.strategy.net;
 
 import java.net.InetAddress;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.Optional;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -60,9 +61,8 @@ public final class PlayerNameAssigner {
       final InetAddress socketAddress, final Collection<INode> nodes) {
     return nodes
         .stream()
-        .sorted()
         .filter(node -> node.getAddress().equals(socketAddress))
-        .findFirst()
+        .min(Comparator.naturalOrder())
         .map(INode::getName);
   }
 

--- a/game-core/src/main/java/games/strategy/net/PlayerNameAssigner.java
+++ b/game-core/src/main/java/games/strategy/net/PlayerNameAssigner.java
@@ -3,7 +3,9 @@ package games.strategy.net;
 import java.net.InetAddress;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
@@ -47,8 +49,13 @@ public final class PlayerNameAssigner {
     if (currentName.length() > 50) {
       currentName = currentName.substring(0, 50);
     }
+    final Collection<String> playerNames = new HashSet<>(
+        loggedInNodes.stream()
+            .map(INode::getName)
+            .parallel()
+            .collect(Collectors.toSet()));
     final String originalName = currentName;
-    for (int i = 1; isNameTaken(currentName, loggedInNodes); i++) {
+    for (int i = 1; playerNames.contains(currentName); i++) {
       currentName = originalName + " (" + i + ")";
     }
     return currentName;
@@ -61,12 +68,5 @@ public final class PlayerNameAssigner {
         .filter(node -> node.getAddress().equals(socketAddress))
         .min(Comparator.naturalOrder())
         .map(INode::getName);
-  }
-
-  private static boolean isNameTaken(final String nodeName, final Collection<INode> nodes) {
-    return nodes
-        .stream()
-        .map(INode::getName)
-        .anyMatch(nodeName::equalsIgnoreCase);
   }
 }

--- a/game-core/src/main/java/games/strategy/net/nio/ClientQuarantineConversation.java
+++ b/game-core/src/main/java/games/strategy/net/nio/ClientQuarantineConversation.java
@@ -8,6 +8,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.logging.Level;
 
 import org.triplea.java.Interruptibles;
+import org.triplea.swing.DialogBuilder;
 
 import games.strategy.net.IConnectionLogin;
 import games.strategy.net.MessageHeader;
@@ -114,6 +115,21 @@ public class ClientQuarantineConversation extends QuarantineConversation {
           return Action.NONE;
         case READ_NAMES:
           final String[] strings = ((String[]) serializable);
+          final String assignedName = strings[0];
+          // If the assigned name does not start with the desired local name,
+          // it means we are already connected and have been given our existing logged in name.
+          // We warn the user here to let them know explicitly so it does not look like
+          // a silent error.
+          if (!assignedName.startsWith(localName)) {
+            new Thread(() -> DialogBuilder.builder()
+                .parent(null)
+                .title("Already Logged In")
+                .infoMessage(
+                    "<html>Already logged in with another name, cannot use a different name.<br/>"
+                        + "Logging in as: " + assignedName)
+                .showDialog())
+                    .start();
+          }
           localName = strings[0];
           serverName = strings[1];
           step = Step.READ_ADDRESS;

--- a/game-core/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
+++ b/game-core/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
@@ -9,6 +9,7 @@ import java.util.logging.Level;
 import games.strategy.net.ILoginValidator;
 import games.strategy.net.MessageHeader;
 import games.strategy.net.Node;
+import games.strategy.net.PlayerNameAssigner;
 import games.strategy.net.ServerMessenger;
 import lombok.extern.java.Log;
 
@@ -85,9 +86,11 @@ public class ServerQuarantineConversation extends QuarantineConversation {
           } else {
             send(null);
           }
-          // get a unique name
-          remoteName = serverMessenger.getUniqueName(remoteName);
-          // send the node its name and our name
+          synchronized (serverMessenger.newNodeLock) {
+            remoteName = PlayerNameAssigner.assignName(
+                remoteName, channel.socket().getInetAddress(), serverMessenger.getNodes());
+          }
+          // send the node its assigned name and our name
           send(new String[] {remoteName, serverMessenger.getLocalNode().getName()});
           // send the node its and our address as we see it
           send(new InetSocketAddress[] {(InetSocketAddress) channel.socket().getRemoteSocketAddress(),

--- a/game-core/src/test/java/games/strategy/engine/message/unifiedmessenger/ChannelMessengerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/message/unifiedmessenger/ChannelMessengerTest.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.triplea.swing.DialogBuilder;
 
 import games.strategy.engine.message.ChannelMessenger;
 import games.strategy.engine.message.IChannelSubscriber;
@@ -31,6 +32,7 @@ class ChannelMessengerTest {
 
   @BeforeEach
   void setUp() throws IOException {
+    DialogBuilder.disableUi();
     serverMessenger = new TestServerMessenger();
     serverMessenger.setAcceptNewConnections(true);
     serverPort = serverMessenger.getLocalNode().getSocketAddress().getPort();

--- a/game-core/src/test/java/games/strategy/net/MessengerIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/net/MessengerIntegrationTest.java
@@ -17,6 +17,7 @@ import javax.annotation.concurrent.GuardedBy;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.triplea.swing.DialogBuilder;
 import org.triplea.test.common.Integration;
 
 @Integration
@@ -30,6 +31,7 @@ class MessengerIntegrationTest {
 
   @BeforeEach
   void setUp() throws Exception {
+    DialogBuilder.disableUi();
     serverMessenger = new TestServerMessenger();
     serverMessenger.setAcceptNewConnections(true);
     serverMessenger.addMessageListener(serverMessageListener);

--- a/game-core/src/test/java/games/strategy/net/PlayerNameAssignerTest.java
+++ b/game-core/src/test/java/games/strategy/net/PlayerNameAssignerTest.java
@@ -1,0 +1,251 @@
+package games.strategy.net;
+
+import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singleton;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.net.InetAddress;
+import java.util.Arrays;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PlayerNameAssignerTest {
+
+  private static final String name1 = "Never endure a plunder.";
+  private static final String name2 = "C'mon, never vandalize a gull";
+
+  @Mock
+  private InetAddress address1;
+
+  @Mock
+  private InetAddress address2;
+
+  @Nested
+  final class ErrorCases {
+    /**
+     * Null for IP address or node list means we have something wrong on the server side
+     * and should see an exception.
+     */
+    @Test
+    void nullArguments() {
+      assertThrows(
+          NullPointerException.class,
+          () -> PlayerNameAssigner.assignName(name1, null, emptyList()));
+
+      assertThrows(
+          NullPointerException.class,
+          () -> PlayerNameAssigner.assignName(name1, address1, null));
+    }
+
+    /**
+     * Short or bad name could be a custom (hacked) client.
+     */
+    @Test
+    void nameTooShort() {
+      Arrays.asList(null, "", "a", "_").forEach(nameTooShort -> assertThat(
+          "With a name too short, we could have a hacked client, should use a default "
+              + "dummy name and not error out on the server side.",
+          PlayerNameAssigner.assignName(
+              nameTooShort,
+              address1,
+              emptyList()),
+          is(PlayerNameAssigner.DUMMY_NAME)));
+    }
+
+    @Test
+    void badNamesPassedFromClientWithDuplicate() {
+      assertThat(
+          "We already have a dummy name, so we should see an increment to the name.",
+          PlayerNameAssigner.assignName(
+              null,
+              address1,
+              singleton(createNode(PlayerNameAssigner.DUMMY_NAME, address2))),
+          is(PlayerNameAssigner.DUMMY_NAME + " (1)"));
+
+      assertThat(
+          "We already have a couple dummy names, should see an increment to the name.",
+          PlayerNameAssigner.assignName(
+              null,
+              address1,
+              asList(
+                  createNode(PlayerNameAssigner.DUMMY_NAME, address2),
+                  createNode(PlayerNameAssigner.DUMMY_NAME + " (1)", address2))),
+          is(PlayerNameAssigner.DUMMY_NAME + " (2)"));
+    }
+  }
+
+
+  @Test
+  void assignNameShouldGetAssignedNameWhenNotTaken() {
+    assertThat(
+        "no nodes to match against, we should get the desired name",
+        PlayerNameAssigner.assignName(name1, address1, emptyList()),
+        is(name1));
+
+    assertThat(
+        "name and address do not match, should get the desired name",
+        PlayerNameAssigner.assignName(
+            name1, address1, singleton(createNode(name2, address2))),
+        is(name1));
+  }
+
+  @Test
+  void assignNameWithMatchingNames() {
+    assertThat(
+        "name match, should be assigned a numeral name",
+        PlayerNameAssigner.assignName(
+            name1, address1, singleton(createNode(name1, address2))),
+        is(name1 + " (1)"));
+
+    assertThat(
+        "name match, matching against multiple nodes",
+        PlayerNameAssigner.assignName(
+            name1, address1, asList(createNode(name2, address2), createNode(name1, address2))),
+        is(name1 + " (1)"));
+  }
+
+  /**
+   * Verifies that when we have multiple names differing by numeral that we'll get the next
+   * available numeral.
+   */
+  @Test
+  void assignNameMultipleNumerals() {
+    assertThat(
+        "name match, should get next sequential numeral appended",
+        PlayerNameAssigner.assignName(
+            name1, address1, asList(
+                createNode(name1, address2),
+                createNode(name1 + " (1)", address2))),
+        is(name1 + " (2)"));
+
+    assertThat(
+        "name match, should get next sequential numeral appended, "
+            + "ordering should not matter",
+        PlayerNameAssigner.assignName(
+            name1, address1, asList(
+                createNode(name1 + " (1)", address2),
+                createNode(name1, address2))),
+        is(name1 + " (2)"));
+  }
+
+  /**
+   * If we have "name", and "name (2)", the next value should be "name (1)" before
+   * we get "name (3)".
+   */
+  @Test
+  void assignNameShouldFillInMissingNumerals() {
+    assertThat(
+        "name does not actually match",
+        PlayerNameAssigner.assignName(
+            name1, address1, singleton(createNode(name1 + " (1)", address2))),
+        is(name1));
+
+    assertThat(
+        "name matches and there is gap in numbering",
+        PlayerNameAssigner.assignName(
+            name1, address1, asList(
+                createNode(name1, address2),
+                createNode(name1 + " (2)", address2))),
+        is(name1 + " (1)"));
+
+    assertThat(
+        "name matches and there is gap in numbering, ordering should not matter",
+        PlayerNameAssigner.assignName(
+            name1, address1, asList(
+                createNode(name1 + " (3)", address2),
+                createNode(name1 + " (1)", address2),
+                createNode(name1, address2))),
+        is(name1 + " (2)"));
+
+    assertThat(
+        "should get next ascending numeral",
+        PlayerNameAssigner.assignName(
+            name1, address1, asList(
+                createNode(name1 + " (2)", address2),
+                createNode(name1 + " (1)", address2),
+                createNode(name1, address2))),
+        is(name1 + " (3)"));
+  }
+
+  /**
+   * If a user choose a name like "name (1)", then the numeral append should still
+   * work and append to that name, eg: "name (1) (1)".
+   */
+  @Test
+  void doubleAppendCase() {
+    assertThat(
+        "if requesting a name ending in (1), and we have that already, then append again",
+        PlayerNameAssigner.assignName(
+            name1 + " (1)",
+            address1,
+            singleton(createNode(name1 + " (1)", address2))),
+        is(name1 + " (1) (1)"));
+
+    assertThat(
+        "if requesting a name ending in (1), and we have that already, then append again,"
+            + "and verify incrementing numerals",
+        PlayerNameAssigner.assignName(
+            name1 + " (1)",
+            address1,
+            asList(
+                createNode(name1 + " (1) (2)", address2),
+                createNode(name1 + " (1)", address2),
+                createNode(name1 + " (1) (1)", address2))),
+        is(name1 + " (1) (3)"));
+
+
+    assertThat(
+        "oddball case where there is a matching substring, we need a full match",
+        PlayerNameAssigner.assignName(
+            name1 + " (1)", address1, singleton(createNode(name1, address2))),
+        is(name1 + " (1)"));
+  }
+
+  /**
+   * Not only will matching names cause a numeral increment, but if we see the same address
+   * then we'll ignore the requested name and append a numeral increment.
+   */
+  @Test
+  void matchingAddressWillIncrementOriginalName() {
+    assertThat(
+        "addresses match",
+        PlayerNameAssigner.assignName(
+            name1,
+            address1,
+            singleton(createNode(name2, address1))),
+        is(name2 + " (1)"));
+
+    assertThat(
+        "addresses match, ordering should not matter",
+        PlayerNameAssigner.assignName(
+            name1,
+            address1,
+            asList(
+                createNode(name2 + " (1)", address1),
+                createNode(name2, address1))),
+        is(name2 + " (2)"));
+
+
+    assertThat(
+        "addresses match, should fill in gaps in the numerals",
+        PlayerNameAssigner.assignName(
+            name1,
+            address1,
+            asList(
+                createNode(name2 + " (2)", address1),
+                createNode(name2, address1))),
+        is(name2 + " (1)"));
+  }
+
+  private static INode createNode(final String name, final InetAddress inetAddress) {
+    return new Node(name, inetAddress, 1234);
+  }
+}


### PR DESCRIPTION
## Overview
Prevents users from logging in from the same computer with different names. Intended to prevent malicious users from creating 'sock puppet' accounts where they can appear as if they are different people but are actually the same. The typical TripleA user should be logging in just once from a given IP address.

## Functional Changes
users can no longer log in from the same computer with multiple names.


## Manual Testing Performed
- launched a local hosted game and logged in multiple times. Note, the host is not considered as a connected node, so someone could host and self connect with a new name. Any subsequent connections would not be allowed to have new names.
- launched a lobby and verified that only the first name is allowed, subsequent names get numerals appended to them.

## Screenshots
Error message when logged in under a different name:
![Screenshot from 2019-08-07 23-17-16](https://user-images.githubusercontent.com/12397753/62679855-99d42580-b96a-11e9-9d74-1e5dfda0abfb.png)

## Additional Review Notes
A good chunk of the code is existing. The code in `PlayerNamAssigner` is moved there and added the new method "findLoggedInName". 
There is then an update to use that method with an `Optional.ofNullable(..).orElse)` and second update to the existing code is to extract the "aa" dummy name to a constant.

Beyond that the existing code was extracted and then heavily tested.

There is in addition a bug fix as the stream to find an existing name found the first match which might not be the shortest match. For example if there is the name "dan" and "dan (1)", the code could find "dan (1)" and generate "dan (1) (1)" instead of "dan (2)". The 'sort' line added fixes this.

- The new thread to show the dialog is a bit suspect, but is actually needed. Removing that results in  a case where the dialog message cannot be closed.
