### PR TITLE
Remove parallel stream operation, does not improve performance

### DIFF
--- a/game-core/src/main/java/games/strategy/net/PlayerNameAssigner.java
+++ b/game-core/src/main/java/games/strategy/net/PlayerNameAssigner.java
@@ -52,7 +52,6 @@ public final class PlayerNameAssigner {
     final Collection<String> playerNames = new HashSet<>(
         loggedInNodes.stream()
             .map(INode::getName)
-            .parallel()
             .collect(Collectors.toSet()));
     final String originalName = currentName;
     for (int i = 1; playerNames.contains(currentName); i++) {


### PR DESCRIPTION
Tested out performance of parallel stream operation with 'map', turns out not to be any faster (https://github.com/triplea-game/triplea/pull/4946#discussion_r312175194)