### PR TITLE
Update IDE setup documentation with notes for google-java-format

### DIFF
--- a/docs/dev/ide-setup/eclipse.md
+++ b/docs/dev/ide-setup/eclipse.md
@@ -1,0 +1,49 @@
+# *Eclipse* Setup
+
+##  Plugins:
+  - ***Buildship Gradle Integration***
+     1. [Install Plugin](https://marketplace.eclipse.org/content/buildship-gradle-integration)
+  - ***Checkstyle***
+     1. [Install Plugin](http://eclipse-cs.sourceforge.net)
+     1. Follow: https://checkstyle.org/eclipse-cs/#!/project-setup
+     1. After step 3 "Activate Checkstyle for your project", select the TripleA configuration file
+      instead of "Sun Checks". Checkstyle file: [triplea/config/checkstyle/checkstyle.xml
+     ](https://github.com/triplea-game/triplea/blob/master/config/checkstyle/checkstyle.xml)
+  - ***Lombok*** 
+    1. Download [jar file](https://projectlombok.org/downloads/lombok.jar) and execute it: `java -jar lombok.jar`
+       - [manual install](https://groups.google.com/forum/#!topic/project-lombok/3rVS0eXVl5U)
+         if that does not work
+       - Version to use: Same version as Gradle (see `lombok` configuration in the top-level [Gradle buildscript](https://github.com/triplea-game/triplea/blob/master/build.gradle))
+    2. Enable annotation processing: [how-to-configure-java-annotation-processors-in-eclipse
+      ](https://stackoverflow.com/questions/43404891/how-to-configure-java-annotation-processors-in-eclipse)
+
+## Formatter
+1. [Install Google Java Format Plugin](https://github.com/google/google-java-format#eclipse)
+1. *Project > Java Code Style > Formatter*
+   1. Import profile, select the Triplea formatter file: [triplea/.ide-eclipse/format/triplea-eclipse-java-google-style.xml
+     ](https://github.com/triplea-game/triplea/blob/master/.ide-eclipse/format/triplea-eclipse-java-google-style.xml)
+   1. Change Formatter implementation to 'google-java-format'
+![Screenshot from 2019-08-08 16-46-41
+](https://user-images.githubusercontent.com/12397753/62744601-224ed680-b9fc-11e9-8922-df3564c4207f.png)
+
+## Cleanup
+1. *Project > Java Code Style > Cleanup*
+1. Select the Triplea cleanup file: [triplea/.ide-eclipse/format/triplea_java_eclipse_format_style.xml
+   ](https://github.com/triplea-game/triplea/blob/master/.eclipse/format/triplea_java_eclipse_format_style.xml)
+
+![screenshot from 2019-01-10 15-07-46
+  ](https://user-images.githubusercontent.com/12397753/51002909-acc46b80-14e9-11e9-8a49-80281769f81a.png)
+
+## Import Order
+1. *Project > Java Code Style > Organize Imports*
+1. Click 'Import' and select the import file: [triplea/.ide-eclipse/format/triplea.importorder
+](https://github.com/triplea-game/triplea/blob/master/.eclipse/format/triplea.importorder)
+
+Should look like this when configured: <br />
+![Screenshot from 2019-08-08 16-45-04
+](https://user-images.githubusercontent.com/12397753/62744560-e7e53980-b9fb-11e9-815c-2a6432d77e42.png)
+
+## Useful:
+  - [EGit in Eclipse](http://www.eclipse.org/egit/) - with [tutorial
+      ](http://www.vogella.com/tutorials/EclipseGit/article.html)
+  - Run Configurations are checked in

--- a/docs/dev/ide-setup/intellij.md
+++ b/docs/dev/ide-setup/intellij.md
@@ -1,0 +1,22 @@
+## *IntelliJ* Setup
+
+### Plugins:
+  - *Google Java Format* 
+    - *settings > Other settings > google-java-format*
+    - Check 'enable'
+      ![Screenshot from 2019-08-08 17-35-52
+      ](https://user-images.githubusercontent.com/12397753/62746114-07cc2b80-ba03-11e9-9ac0-0b1e6e1e8788.png)
+  - *checkstyle-IDEA* [plugin](https://github.com/jshiell/checkstyle-idea) 
+    - after install finish configuration in: **Other Settings > Checkstyle**
+    - select checkstyle file:  
+  - *Save Actions*
+    - configure in settings to add 'final' to local variables and class variables.
+  - *Lombok*
+
+### Settings
+  - *File > Import Settings*
+  - Select file: [.ide-intellij/intellij-settings.zip
+   ](https://github.com/triplea-game/triplea/blob/master/.ide-intellij/intellij-settings.zip)
+   
+### Lombok:
+ - requires annotation processing to be turned on (settings > 'annotation processing')


### PR DESCRIPTION
## Overview
- An isolated commit with instructions just for IDE setup with new google-java-format
- Additional commits will remove now-legacy instructions and otherwise update the documentation.

## Functional Changes
None

## Additional Review Notes
Contains just the instructions for setting up google java format.
