### PR TITLE
Remove opengl flag on headed game runner (intellij) launcher

### DIFF
--- a/.idea/runConfigurations/HeadedGameRunner.xml
+++ b/.idea/runConfigurations/HeadedGameRunner.xml
@@ -2,7 +2,6 @@
   <configuration default="false" name="HeadedGameRunner" type="Application" factoryName="Application" singleton="false" nameIsGenerated="true">
     <option name="MAIN_CLASS_NAME" value="org.triplea.game.client.HeadedGameRunner" />
     <module name="triplea.game-headed" />
-    <option name="VM_PARAMETERS" value="-Dsun.java2d.opengl=true" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/game-headed" />
     <extension name="coverage">
       <pattern>


### PR DESCRIPTION
## Overview
The flag causes buggy rendering on some OS/configurations

Related to: #4941