### PR TITLE
Add: Lobby Login Throttle

### DIFF
--- a/lobby/src/main/java/org/triplea/lobby/server/LobbyServer.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/LobbyServer.java
@@ -13,6 +13,7 @@ import org.triplea.lobby.common.ILobbyGameBroadcaster;
 import org.triplea.lobby.common.LobbyConstants;
 import org.triplea.lobby.common.login.RsaAuthenticator;
 import org.triplea.lobby.server.config.LobbyConfiguration;
+import org.triplea.lobby.server.login.FailedLoginThrottle;
 import org.triplea.lobby.server.login.LobbyLoginValidator;
 
 /**
@@ -45,7 +46,10 @@ final class LobbyServer {
     final Messengers messengers = new Messengers(server);
     server.setLoginValidator(
         new LobbyLoginValidator(
-            lobbyConfiguration.getDatabaseDao(), new RsaAuthenticator(), BCrypt::gensalt));
+            lobbyConfiguration.getDatabaseDao(),
+            new RsaAuthenticator(),
+            BCrypt::gensalt,
+            new FailedLoginThrottle()));
 
     new UserManager(lobbyConfiguration.getDatabaseDao()).register(messengers);
 

--- a/lobby/src/main/java/org/triplea/lobby/server/login/FailedLoginThrottle.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/login/FailedLoginThrottle.java
@@ -1,0 +1,45 @@
+package org.triplea.lobby.server.login;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import java.net.InetAddress;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Class to enforce login throttling if there are too many failed login attempts. This is to prevent
+ * brute-force attacks attempting to crack a users password.
+ */
+public class FailedLoginThrottle {
+  /**
+   * How many failed login attempts per time period that can be attempted before we outright reject
+   * any further login attempts.
+   */
+  @VisibleForTesting static final int MAX_FAILED_LOGIN_ATTEMPTS = 7;
+
+  /**
+   * How much time (in minutes) must be waited before user can attempt a login after having too many
+   * failed login attempts.
+   */
+  private static final int FAILED_LOGIN_COOLOFF = 3;
+
+  /**
+   * Cache that maps inet address to failed login attempts. This is to keep track of failed login
+   * attempts and eventaully lock a user out (and prevent a brute-force password cracking attempt).
+   */
+  private final Cache<InetAddress, Integer> failedLoginCache =
+      CacheBuilder.newBuilder().expireAfterWrite(FAILED_LOGIN_COOLOFF, TimeUnit.MINUTES).build();
+
+  boolean tooManyFailedLoginAttempts(final InetAddress address) {
+    final int failedAttempts =
+        Optional.ofNullable(failedLoginCache.getIfPresent(address)).orElse(0) + 1;
+    return failedAttempts >= MAX_FAILED_LOGIN_ATTEMPTS;
+  }
+
+  void increment(final InetAddress address) {
+    final int failedAttempts =
+        Optional.ofNullable(failedLoginCache.getIfPresent(address)).orElse(0) + 1;
+    failedLoginCache.put(address, failedAttempts);
+  }
+}

--- a/lobby/src/test/java/org/triplea/lobby/server/login/FailedLoginThrottleTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/login/FailedLoginThrottleTest.java
@@ -1,0 +1,27 @@
+package org.triplea.lobby.server.login;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import java.net.InetAddress;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class FailedLoginThrottleTest {
+
+  @Mock private InetAddress address;
+
+  @Test
+  void verifyThrottle() {
+    final var throttle = new FailedLoginThrottle();
+
+    for (int i = 0; i < FailedLoginThrottle.MAX_FAILED_LOGIN_ATTEMPTS - 1; i++) {
+      assertThat(throttle.tooManyFailedLoginAttempts(address), is(false));
+      throttle.increment(address);
+    }
+    assertThat(throttle.tooManyFailedLoginAttempts(address), is(true));
+  }
+}

--- a/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
@@ -34,7 +34,8 @@ class LobbyLoginValidatorIntegrationTest {
       new LobbyLoginValidator(
           TestLobbyConfigurations.INTEGRATION_TEST.getDatabaseDao(),
           new RsaAuthenticator(),
-          BCrypt::gensalt);
+          BCrypt::gensalt,
+          new FailedLoginThrottle());
 
   @Test
   void testLegacyCreateNewUser() {

--- a/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorTest.java
@@ -14,6 +14,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import java.net.InetSocketAddress;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.Function;
@@ -59,13 +60,15 @@ final class LobbyLoginValidatorTest {
 
     @Mock DatabaseDao databaseDao;
 
-    private LobbyLoginValidator lobbyLoginValidator;
+    @Mock FailedLoginThrottle failedLoginThrottle;
+
+    LobbyLoginValidator lobbyLoginValidator;
 
     private String authenticationErrorMessage;
 
     private final String bcryptSalt = BCrypt.gensalt();
 
-    private final User user = TestUserUtils.newUser();
+    final User user = TestUserUtils.newUser();
 
     private final String md5CryptSalt = Md5Crypt.newSalt();
 
@@ -75,7 +78,8 @@ final class LobbyLoginValidatorTest {
           new LobbyLoginValidator(
               databaseDao,
               new RsaAuthenticator(TestSecurityUtils.loadRsaKeyPair()),
-              () -> bcryptSalt);
+              () -> bcryptSalt,
+              failedLoginThrottle);
     }
 
     final String bcrypt(final String password) {
@@ -509,6 +513,25 @@ final class LobbyLoginValidatorTest {
                 .put(LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString())
                 .putAll(RsaAuthenticator.newResponse(challenge, PASSWORD))
                 .build();
+      }
+    }
+
+    @ExtendWith(MockitoExtension.class)
+    @Nested
+    final class LoginThrottleTest extends AbstractTestCase {
+      @Test
+      void loginThrottleDeniesLogin() {
+        when(failedLoginThrottle.tooManyFailedLoginAttempts(any())).thenReturn(true);
+
+        final String result =
+            lobbyLoginValidator.verifyConnection(
+                new HashMap<>(),
+                new HashMap<>(),
+                "",
+                "",
+                new InetSocketAddress(user.getInetAddress(), 9999));
+
+        assertThat(result, is(LobbyLoginValidator.ErrorMessages.TOO_MANY_FAILED_LOGIN_ATTEMPTS));
       }
     }
   }

--- a/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorTest.java
@@ -64,11 +64,11 @@ final class LobbyLoginValidatorTest {
 
     LobbyLoginValidator lobbyLoginValidator;
 
+    final User user = TestUserUtils.newUser();
+
     private String authenticationErrorMessage;
 
     private final String bcryptSalt = BCrypt.gensalt();
-
-    final User user = TestUserUtils.newUser();
 
     private final String md5CryptSalt = Md5Crypt.newSalt();
 


### PR DESCRIPTION
## Overview

Adds a throttle for too many failed login attempts to lobby. If a user fails too many times due to invalid password (or other), then they will be locked out for three minutes. This is to prevent brute-force password-cracking attacks.

## Functional Changes
- Adds new lobby login failure if user attempts to login too many times and fails repeatedly.
- 3 minute cache is the cooldown period, any renewed attempts will extend the cooldown by 3 minutes
- Lockout can happen for any login failure reason, bad version, bad name, or bad password.

## Manual Testing Performed
- Before update, verified bad passwords can be repeatedly tried
- After update, verified that after 'n' failed password attempts there is a lockout message.

## Screen Shots

After failing to login too many times:
![Screenshot from 2019-08-11 20-34-18](https://user-images.githubusercontent.com/12397753/62845254-63a0e980-bc7b-11e9-8a37-4c9581796f4d.png)
