### PR TITLE
Remove legacy login handling

### DIFF
--- a/lobby/src/main/java/org/triplea/lobby/server/db/UserController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/UserController.java
@@ -97,17 +97,14 @@ final class UserController implements UserDao {
   @Override
   public void createUser(
       final String name, final String email, final HashedPassword hashedPassword) {
-    Preconditions.checkState(hashedPassword.isHashedWithSalt());
-
     try (Connection con = connection.get();
         PreparedStatement ps =
             con.prepareStatement(
-                "insert into lobby_user (username, password, bcrypt_password, email) "
-                    + "values (?, ?, ?, ?)")) {
+                "insert into lobby_user (username, bcrypt_password, email) "
+                    + "values (?, ?, ?)")) {
       ps.setString(1, name);
-      ps.setString(2, hashedPassword.isBcrypted() ? null : hashedPassword.value);
-      ps.setString(3, hashedPassword.isBcrypted() ? hashedPassword.value : null);
-      ps.setString(4, email);
+      ps.setString(2, hashedPassword.value);
+      ps.setString(3, email);
       ps.execute();
       con.commit();
     } catch (final SQLException e) {
@@ -122,27 +119,13 @@ final class UserController implements UserDao {
   @Override
   public boolean login(final String username, final HashedPassword hashedPassword) {
     try (Connection con = connection.get()) {
-      if (hashedPassword.isHashedWithSalt()) {
-        try (PreparedStatement ps =
-            con.prepareStatement(
-                "select username from  lobby_user where username = ? and password = ?")) {
-          ps.setString(1, username);
-          ps.setString(2, hashedPassword.value);
-          try (ResultSet rs = ps.executeQuery()) {
-            if (!rs.next()) {
-              return false;
-            }
-          }
-        }
-      } else {
-        final HashedPassword actualPassword = getPassword(username);
-        if (actualPassword == null) {
-          return false;
-        }
-        Preconditions.checkState(actualPassword.isBcrypted());
-        if (!BCrypt.checkpw(hashedPassword.value, actualPassword.value)) {
-          return false;
-        }
+      final HashedPassword actualPassword = getPassword(username);
+      if (actualPassword == null) {
+        return false;
+      }
+      Preconditions.checkState(actualPassword.isBcrypted());
+      if (!BCrypt.checkpw(hashedPassword.value, actualPassword.value)) {
+        return false;
       }
       // update last login time
       try (PreparedStatement ps =

--- a/lobby/src/main/java/org/triplea/lobby/server/db/UserController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/UserController.java
@@ -17,26 +17,17 @@ final class UserController implements UserDao {
   private final Supplier<Connection> connection;
 
   @Override
-  public HashedPassword getLegacyPassword(final String username) {
-    return getPassword(username, true);
-  }
-
-  @Override
   public HashedPassword getPassword(final String username) {
-    return getPassword(username, false);
-  }
-
-  private HashedPassword getPassword(final String username, final boolean legacy) {
     try (Connection con = connection.get();
         PreparedStatement ps =
             con.prepareStatement(
-                "select password, coalesce(bcrypt_password, password) "
+                "select coalesce(bcrypt_password, password) "
                     + "from lobby_user "
                     + "where username = ?")) {
       ps.setString(1, username);
       try (ResultSet rs = ps.executeQuery()) {
         if (rs.next()) {
-          return new HashedPassword(rs.getString(legacy ? 1 : 2));
+          return new HashedPassword(rs.getString(1));
         }
         return null;
       }

--- a/lobby/src/main/java/org/triplea/lobby/server/db/UserDao.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/UserDao.java
@@ -6,9 +6,6 @@ public interface UserDao {
   /** Returns null if the user does not exist. */
   HashedPassword getPassword(String username);
 
-  /** Returns null if the user does not exist or the user has no legacy password stored. */
-  HashedPassword getLegacyPassword(String username);
-
   boolean doesUserExist(String username);
 
   void updateUser(String name, String email, HashedPassword password);

--- a/lobby/src/main/java/org/triplea/lobby/server/login/LobbyLoginValidator.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/login/LobbyLoginValidator.java
@@ -1,7 +1,6 @@
 package org.triplea.lobby.server.login;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Strings;
 import games.strategy.engine.lobby.PlayerEmailValidation;
 import games.strategy.engine.lobby.PlayerNameValidation;
 import games.strategy.net.ILoginValidator;
@@ -20,13 +19,11 @@ import lombok.AllArgsConstructor;
 import lombok.extern.java.Log;
 import org.mindrot.jbcrypt.BCrypt;
 import org.triplea.lobby.common.LobbyConstants;
-import org.triplea.lobby.common.login.LobbyLoginChallengeKeys;
 import org.triplea.lobby.common.login.LobbyLoginResponseKeys;
 import org.triplea.lobby.common.login.RsaAuthenticator;
 import org.triplea.lobby.server.User;
 import org.triplea.lobby.server.db.DatabaseDao;
 import org.triplea.lobby.server.db.HashedPassword;
-import org.triplea.util.Md5Crypt;
 import org.triplea.util.Version;
 
 /**
@@ -58,19 +55,7 @@ public final class LobbyLoginValidator implements ILoginValidator {
 
   @Override
   public Map<String, String> getChallengeProperties(final String userName) {
-    final Map<String, String> challenge = new HashMap<>();
-    challenge.putAll(newMd5CryptAuthenticatorChallenge(userName));
-    challenge.putAll(rsaAuthenticator.newChallenge());
-    return challenge;
-  }
-
-  private Map<String, String> newMd5CryptAuthenticatorChallenge(final String userName) {
-    final Map<String, String> challenge = new HashMap<>();
-    final HashedPassword password = database.getUserDao().getLegacyPassword(userName);
-    if (password != null && Strings.emptyToNull(password.value) != null) {
-      challenge.put(LobbyLoginChallengeKeys.SALT, Md5Crypt.getSalt(password.value));
-    }
-    return challenge;
+    return new HashMap<>(rsaAuthenticator.newChallenge());
   }
 
   @Nullable

--- a/lobby/src/test/java/org/triplea/lobby/server/db/AbstractModeratorServiceControllerTestCase.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/db/AbstractModeratorServiceControllerTestCase.java
@@ -9,12 +9,12 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import org.mindrot.jbcrypt.BCrypt;
 import org.triplea.java.function.ThrowingConsumer;
 import org.triplea.lobby.server.TestUserUtils;
 import org.triplea.lobby.server.User;
 import org.triplea.lobby.server.config.TestLobbyConfigurations;
 import org.triplea.test.common.Integration;
-import org.triplea.util.Md5Crypt;
 
 /** Superclass for fixtures that test a moderator service controller. */
 @Integration
@@ -31,7 +31,7 @@ public abstract class AbstractModeratorServiceControllerTestCase {
         .createUser(
             user.getUsername(),
             "email@email.com",
-            new HashedPassword(Md5Crypt.hash("pass", "salt")));
+            new HashedPassword(BCrypt.hashpw("pass", BCrypt.gensalt())));
     return user;
   }
 

--- a/lobby/src/test/java/org/triplea/lobby/server/db/UserControllerIntegrationTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/db/UserControllerIntegrationTest.java
@@ -27,7 +27,7 @@ final class UserControllerIntegrationTest {
   void testCreate() throws Exception {
     final int startCount = getUserCount();
 
-    newUserWithMd5CryptHash();
+    newUserWithBCryptHash();
     assertEquals(getUserCount(), startCount + 1);
 
     newUserWithBCryptHash();
@@ -36,19 +36,19 @@ final class UserControllerIntegrationTest {
 
   @Test
   void testGet() {
-    final String user = newUserWithMd5CryptHash();
+    final String user = newUserWithBCryptHash();
     assertEquals(generateEmailAddress(user), controller.getUserEmailByName(user));
   }
 
   @Test
   void testDoesUserExist() {
-    assertTrue(controller.doesUserExist(newUserWithMd5CryptHash()));
+    assertTrue(controller.doesUserExist(newUserWithBCryptHash()));
     assertTrue(controller.doesUserExist(newUserWithBCryptHash()));
   }
 
   @Test
   void testCreateDupe() {
-    final String user = newUserWithMd5CryptHash();
+    final String user = newUserWithBCryptHash();
     assertThrows(
         Exception.class,
         () ->
@@ -61,17 +61,16 @@ final class UserControllerIntegrationTest {
 
   @Test
   void testLogin() {
-    final String password = md5Crypt(TestUserUtils.newUniqueTimestamp());
+    final String password = bcrypt(TestUserUtils.newUniqueTimestamp());
     final String user = newUserWithHash(password, Function.identity());
     controller.updateUser(
         user, generateEmailAddress(user), new HashedPassword(bcrypt(obfuscate(password))));
-    assertTrue(controller.login(user, new HashedPassword(password)));
     assertTrue(controller.login(user, new HashedPassword(obfuscate(password))));
   }
 
   @Test
   void testUpdate() throws Exception {
-    final String user = newUserWithMd5CryptHash();
+    final String user = newUserWithBCryptHash();
     assertTrue(controller.doesUserExist(user));
     final String password2 = md5Crypt("foo");
     final String email2 = "foo@foo.foo";
@@ -86,11 +85,6 @@ final class UserControllerIntegrationTest {
       assertEquals(password2, rs.getString("password"));
       assertNull(rs.getString("bcrypt_password"));
     }
-  }
-
-  private String newUserWithMd5CryptHash() {
-    return newUserWithHash(
-        TestUserUtils.newUniqueTimestamp(), UserControllerIntegrationTest::md5Crypt);
   }
 
   private String newUserWithBCryptHash() {

--- a/lobby/src/test/java/org/triplea/lobby/server/db/UserControllerIntegrationTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/db/UserControllerIntegrationTest.java
@@ -43,7 +43,6 @@ final class UserControllerIntegrationTest {
   @Test
   void testDoesUserExist() {
     assertTrue(controller.doesUserExist(newUserWithBCryptHash()));
-    assertTrue(controller.doesUserExist(newUserWithBCryptHash()));
   }
 
   @Test

--- a/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorTest.java
@@ -280,115 +280,9 @@ final class LobbyLoginValidatorTest {
     }
 
     @Nested
-    final class WhenUserDoesNotExistTest {
-      @ExtendWith(MockitoExtension.class)
-      @Nested
-      final class WhenUsingLegacyClientTest extends AbstractNoBansTestCase {
-        @Test
-        void shouldCreateNewUserWithOnlyMd5CryptedPassword() {
-          givenUserDoesNotExist();
-          when(databaseDao.getAccessLogDao()).thenReturn(accessLog);
-
-          whenAuthenticating(givenAuthenticationResponse());
-
-          thenAuthenticationShouldSucceed();
-          thenUserShouldBeCreatedWithMd5CryptedPassword();
-          thenUserShouldNotBeUpdatedWithBcryptedPassword();
-        }
-
-        private ResponseGenerator givenAuthenticationResponse() {
-          return challenge ->
-              ImmutableMap.of(
-                  LobbyLoginResponseKeys.EMAIL, EMAIL,
-                  LobbyLoginResponseKeys.HASHED_PASSWORD, md5Crypt(PASSWORD),
-                  LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString(),
-                  LobbyLoginResponseKeys.REGISTER_NEW_USER, Boolean.TRUE.toString());
-        }
-      }
-
-      @ExtendWith(MockitoExtension.class)
-      @Nested
-      final class WhenUsingCurrentClientTest extends AbstractNoBansTestCase {
-        @Test
-        void shouldCreateNewUserWithBothPasswords() {
-          givenUserDoesNotExist();
-          when(databaseDao.getAccessLogDao()).thenReturn(accessLog);
-
-          whenAuthenticating(givenAuthenticationResponse());
-
-          thenAuthenticationShouldSucceed();
-          thenUserShouldBeCreatedWithMd5CryptedPassword();
-          thenUserShouldBeUpdatedWithBcryptedPassword();
-        }
-
-        private ResponseGenerator givenAuthenticationResponse() {
-          return challenge ->
-              ImmutableMap.<String, String>builder()
-                  .put(LobbyLoginResponseKeys.EMAIL, EMAIL)
-                  .put(LobbyLoginResponseKeys.HASHED_PASSWORD, md5Crypt(PASSWORD))
-                  .put(
-                      LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString())
-                  .put(LobbyLoginResponseKeys.REGISTER_NEW_USER, Boolean.TRUE.toString())
-                  .putAll(RsaAuthenticator.newResponse(challenge, PASSWORD))
-                  .build();
-        }
-      }
-    }
-
-    @Nested
     final class WhenUserExistsTest {
       @ExtendWith(MockitoExtension.class)
       @Nested
-      final class WhenUsingLegacyClientTest extends AbstractNoBansTestCase {
-        @Test
-        void shouldNotUpdatePasswordsWhenUserHasOnlyMd5CryptedPassword() {
-          givenUserDoesNotHaveBcryptedPassword();
-          givenAuthenticationWillUseMd5CryptedPasswordAndSucceed();
-          when(databaseDao.getAccessLogDao()).thenReturn(accessLog);
-
-          whenAuthenticating(givenAuthenticationResponse());
-
-          thenAuthenticationShouldSucceed();
-          thenUserShouldNotBeCreated();
-          thenUserShouldNotBeUpdated();
-        }
-
-        @Test
-        void shouldNotUpdatePasswordsWhenUserHasBothPasswords() {
-          givenUserHasBcryptedPassword();
-          givenAuthenticationWillUseMd5CryptedPasswordAndSucceed();
-          when(databaseDao.getAccessLogDao()).thenReturn(accessLog);
-
-          whenAuthenticating(givenAuthenticationResponse());
-
-          thenAuthenticationShouldSucceed();
-          thenUserShouldNotBeCreated();
-          thenUserShouldNotBeUpdated();
-        }
-
-        @Test
-        void shouldNotUpdatePasswordsWhenUserHasOnlyBcryptedPassword() {
-          givenUserHasBcryptedPassword();
-          givenAuthenticationWillUseMd5CryptedPasswordAndFail();
-
-          whenAuthenticating(givenAuthenticationResponse());
-
-          thenAuthenticationShouldFailWithMessage(
-              LobbyLoginValidator.ErrorMessages.AUTHENTICATION_FAILED);
-          thenUserShouldNotBeCreated();
-          thenUserShouldNotBeUpdated();
-        }
-
-        private ResponseGenerator givenAuthenticationResponse() {
-          return challenge ->
-              ImmutableMap.of(
-                  LobbyLoginResponseKeys.HASHED_PASSWORD, md5Crypt(PASSWORD),
-                  LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString());
-        }
-      }
-
-      @ExtendWith(MockitoExtension.class)
-      @Nested
       final class WhenUsingCurrentClientTest extends AbstractNoBansTestCase {
         @Test
         void shouldNotUpdatePasswordsWhenUserHasBothPasswords() {
@@ -402,38 +296,6 @@ final class LobbyLoginValidatorTest {
           thenAuthenticationShouldSucceed();
           thenUserShouldNotBeCreated();
           thenUserShouldNotBeUpdated();
-        }
-
-        @Test
-        void shouldUpdateBcryptedPasswordWhenUserHasOnlyMd5CryptedPassword() {
-          givenUserExists();
-          givenUserHasMd5CryptedPassword();
-          givenUserDoesNotHaveBcryptedPassword();
-          givenAuthenticationWillUseMd5CryptedPasswordAndSucceed();
-          when(databaseDao.getAccessLogDao()).thenReturn(accessLog);
-
-          whenAuthenticating(givenAuthenticationResponse());
-
-          thenAuthenticationShouldSucceed();
-          thenUserShouldNotBeCreated();
-          thenUserShouldNotBeUpdatedWithMd5CryptedPassword();
-          thenUserShouldBeUpdatedWithBcryptedPassword();
-        }
-
-        @Test
-        void shouldUpdateBothPasswordsWhenUserHasOnlyBcryptedPassword() {
-          givenUserExists();
-          givenUserDoesNotHaveMd5CryptedPassword();
-          givenUserHasBcryptedPassword();
-          givenAuthenticationWillUseObfuscatedPasswordAndSucceed();
-          when(databaseDao.getAccessLogDao()).thenReturn(accessLog);
-
-          whenAuthenticating(givenAuthenticationResponse());
-
-          thenAuthenticationShouldSucceed();
-          thenUserShouldNotBeCreated();
-          thenUserShouldBeUpdatedWithMd5CryptedPassword();
-          thenUserShouldBeUpdatedWithBcryptedPassword();
         }
 
         private ResponseGenerator givenAuthenticationResponse() {
@@ -455,7 +317,7 @@ final class LobbyLoginValidatorTest {
     @Nested
     final class WhenUserIsAnonymous extends AbstractNoBansTestCase {
       @Test
-      void shouldLogSuccessfulAuthenticationWhenAuthenticationSucceeds() throws Exception {
+      void shouldLogSuccessfulAuthenticationWhenAuthenticationSucceeds() {
         givenAnonymousAuthenticationWillSucceed();
         when(databaseDao.getAccessLogDao()).thenReturn(accessLog);
 
@@ -486,7 +348,7 @@ final class LobbyLoginValidatorTest {
     @Nested
     final class WhenUserIsRegistered extends AbstractNoBansTestCase {
       @Test
-      void shouldLogSuccessfulAuthenticationWhenAuthenticationSucceeds() throws Exception {
+      void shouldLogSuccessfulAuthenticationWhenAuthenticationSucceeds() {
         givenUserHasBcryptedPassword();
         givenAuthenticationWillUseObfuscatedPasswordAndSucceed();
         when(databaseDao.getAccessLogDao()).thenReturn(accessLog);

--- a/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorTest.java
@@ -143,7 +143,6 @@ final class LobbyLoginValidatorTest {
 
     final void givenUserDoesNotHaveMd5CryptedPassword() {
       when(databaseDao.getUserDao()).thenReturn(userDao);
-      when(userDao.getLegacyPassword(user.getUsername())).thenReturn(new HashedPassword(""));
     }
 
     final void givenUserExists() {
@@ -159,8 +158,6 @@ final class LobbyLoginValidatorTest {
 
     final void givenUserHasMd5CryptedPassword() {
       when(databaseDao.getUserDao()).thenReturn(userDao);
-      when(userDao.getLegacyPassword(user.getUsername()))
-          .thenReturn(new HashedPassword(md5Crypt(PASSWORD)));
     }
 
     final void whenAuthenticating(final ResponseGenerator responseGenerator) {


### PR DESCRIPTION
## Overview
Remove code in login that handled previous clients. Latest lobby will only be available to latest client. Sending login requests from latest client, this update removes server side paths that are now impossible. With those code paths removed, failing tests were removed.

## Functional Changes
None, legacy clients will not be able to connect to latest lobby; 

## Manual Testing Performed
- Ran lobby code through a debugger while logging in with a latest client and was able to login.

