### PR TITLE
Move add/remove error listener from IMessenger to IClientMessenger

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -29,7 +29,6 @@ import games.strategy.engine.framework.startup.ui.ServerOptions;
 import games.strategy.engine.message.RemoteName;
 import games.strategy.io.IoUtils;
 import games.strategy.net.IConnectionChangeListener;
-import games.strategy.net.IMessengerErrorListener;
 import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.Messengers;
@@ -68,8 +67,7 @@ import org.triplea.util.Version;
 
 /** Represents a network-aware game server to which multiple clients may connect. */
 @Log
-public class ServerModel extends Observable
-    implements IMessengerErrorListener, IConnectionChangeListener {
+public class ServerModel extends Observable implements IConnectionChangeListener {
   public static final RemoteName SERVER_REMOTE_NAME =
       new RemoteName(
           "games.strategy.engine.framework.ui.ServerStartup.SERVER_REMOTE",
@@ -273,7 +271,6 @@ public class ServerModel extends Observable
     if (messengers != null) {
       chatController.deactivate();
       messengers.shutDown();
-      messengers.removeErrorListener(this);
       chatModel.setChat(null);
     }
   }
@@ -389,7 +386,6 @@ public class ServerModel extends Observable
       final ClientLoginValidator clientLoginValidator = new ClientLoginValidator(serverMessenger);
       clientLoginValidator.setGamePassword(props.getPassword());
       serverMessenger.setLoginValidator(clientLoginValidator);
-      serverMessenger.addErrorListener(this);
       serverMessenger.addConnectionChangeListener(this);
 
       messengers = new Messengers(serverMessenger);
@@ -521,14 +517,6 @@ public class ServerModel extends Observable
 
   public synchronized Map<String, Collection<String>> getPlayerNamesAndAlliancesInTurnOrder() {
     return new LinkedHashMap<>(playerNamesAndAlliancesInTurnOrder);
-  }
-
-  @Override
-  public void messengerInvalid(final Throwable reason) {
-    if (ui != null) {
-      JOptionPane.showMessageDialog(ui, "Connection lost", "Error", JOptionPane.ERROR_MESSAGE);
-    }
-    serverSetupModel.showSelectType();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -17,6 +17,7 @@ import games.strategy.engine.message.RemoteMessenger;
 import games.strategy.engine.message.unifiedmessenger.UnifiedMessenger;
 import games.strategy.net.ClientMessenger;
 import games.strategy.net.GUID;
+import games.strategy.net.IClientMessenger;
 import games.strategy.net.IConnectionChangeListener;
 import games.strategy.net.IConnectionLogin;
 import games.strategy.net.IMessenger;
@@ -116,7 +117,9 @@ public class InGameLobbyWatcher {
     synchronized (postMutex) {
       controller.postGame(gameId, gameDescription);
     }
-    this.messenger.addErrorListener(messengerErrorListener);
+    if (this.messenger instanceof IClientMessenger) {
+      ((IClientMessenger) this.messenger).addErrorListener(messengerErrorListener);
+    }
     connectionChangeListener =
         new IConnectionChangeListener() {
           @Override
@@ -299,7 +302,9 @@ public class InGameLobbyWatcher {
 
   void shutDown() {
     isShutdown = true;
-    messenger.removeErrorListener(messengerErrorListener);
+    if (messenger instanceof IClientMessenger) {
+      ((IClientMessenger) this.messenger).removeErrorListener(messengerErrorListener);
+    }
     messenger.shutDown();
     serverMessenger.removeConnectionChangeListener(connectionChangeListener);
     cleanUpGameModelListener();

--- a/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
+++ b/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
@@ -14,6 +14,7 @@ import games.strategy.engine.message.SpokeInvocationResults;
 import games.strategy.engine.message.SpokeInvoke;
 import games.strategy.engine.message.UnifiedMessengerHub;
 import games.strategy.net.GUID;
+import games.strategy.net.IClientMessenger;
 import games.strategy.net.IMessenger;
 import games.strategy.net.INode;
 import java.io.Serializable;
@@ -53,7 +54,9 @@ public class UnifiedMessenger {
   public UnifiedMessenger(final IMessenger messenger) {
     this.messenger = messenger;
     this.messenger.addMessageListener(this::messageReceived);
-    this.messenger.addErrorListener(this::messengerInvalid);
+    if (messenger instanceof IClientMessenger) {
+      ((IClientMessenger) this.messenger).addErrorListener(this::messengerInvalid);
+    }
     if (this.messenger.isServer()) {
       hub = new UnifiedMessengerHub(this.messenger, this);
     }

--- a/game-core/src/main/java/games/strategy/net/IClientMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/IClientMessenger.java
@@ -12,4 +12,10 @@ public interface IClientMessenger extends IMessenger {
   void changeToGameSave(byte[] bytes, String fileName);
 
   void changeToGameSave(File saveGame, String fileName);
+
+  /** Listen for errors. */
+  void addErrorListener(IMessengerErrorListener listener);
+
+  /** Stop listening for errors. */
+  void removeErrorListener(IMessengerErrorListener listener);
 }

--- a/game-core/src/main/java/games/strategy/net/IMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/IMessenger.java
@@ -19,12 +19,6 @@ public interface IMessenger {
   /** Listen for messages. */
   void addMessageListener(IMessageListener listener);
 
-  /** Listen for errors. */
-  void addErrorListener(IMessengerErrorListener listener);
-
-  /** Stop listening for errors. */
-  void removeErrorListener(IMessengerErrorListener listener);
-
   /** Get the local node. */
   INode getLocalNode();
 

--- a/game-core/src/main/java/games/strategy/net/LocalNoOpMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/LocalNoOpMessenger.java
@@ -26,12 +26,6 @@ public class LocalNoOpMessenger implements IServerMessenger {
   public void addMessageListener(final IMessageListener listener) {}
 
   @Override
-  public void addErrorListener(final IMessengerErrorListener listener) {}
-
-  @Override
-  public void removeErrorListener(final IMessengerErrorListener listener) {}
-
-  @Override
   public INode getLocalNode() {
     return node;
   }

--- a/game-core/src/main/java/games/strategy/net/Messengers.java
+++ b/game-core/src/main/java/games/strategy/net/Messengers.java
@@ -1,5 +1,6 @@
 package games.strategy.net;
 
+import com.google.common.annotations.VisibleForTesting;
 import games.strategy.engine.chat.ChatController;
 import games.strategy.engine.chat.IChatChannel;
 import games.strategy.engine.chat.IChatController;
@@ -29,6 +30,7 @@ public class Messengers implements IMessenger, IRemoteMessenger, IChannelMesseng
     remoteMessenger = new RemoteMessenger(unifiedMessenger);
   }
 
+  @VisibleForTesting
   public Messengers(
       final IMessenger messenger,
       final IRemoteMessenger remoteMessenger,
@@ -110,15 +112,16 @@ public class Messengers implements IMessenger, IRemoteMessenger, IChannelMesseng
     messenger.addMessageListener(listener);
   }
 
-  @Override
   public void addErrorListener(final IMessengerErrorListener listener) {
-    messenger.addErrorListener(listener);
+    if (messenger instanceof ClientMessenger) {
+      ((ClientMessenger) messenger).addErrorListener(listener);
+    }
   }
 
-  @Override
   public void removeErrorListener(final IMessengerErrorListener listener) {
-
-    messenger.removeErrorListener(listener);
+    if (messenger instanceof ClientMessenger) {
+      ((ClientMessenger) messenger).removeErrorListener(listener);
+    }
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ServerMessenger.java
@@ -209,12 +209,6 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
   }
 
   @Override
-  public void addErrorListener(final IMessengerErrorListener listener) {}
-
-  @Override
-  public void removeErrorListener(final IMessengerErrorListener listener) {}
-
-  @Override
   public void addConnectionChangeListener(final IConnectionChangeListener listener) {
     connectionListeners.add(listener);
   }

--- a/game-core/src/test/java/games/strategy/net/MessengerIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/net/MessengerIntegrationTest.java
@@ -21,7 +21,7 @@ import org.triplea.test.common.Integration;
 @Integration
 class MessengerIntegrationTest {
   private IServerMessenger serverMessenger;
-  private IMessenger client1Messenger;
+  private IClientMessenger client1Messenger;
   private IMessenger client2Messenger;
   private final MessageListener serverMessageListener = new MessageListener();
   private final MessageListener client1MessageListener = new MessageListener();


### PR DESCRIPTION
## Overview
Goal is to remove calls that result in no-op. ServerMessenger and LocalNoOpMessenger are no-ops for add/remove error listener. The methods are moved to related interfacer IClientMessenger where is always an effect. Cases where those methods are called on IMessenger, and sometimes when we have an IClientMessenger, an 'instanceof' check is added to cast the IMessenger to an IClientMessenger. In cases when the IMessenger is always a ServerMessenger (and a no-op), those calls are removed.

## Functional Changes
None

## Manual Testing Performed
None
