### PR TITLE
Minor fix: add explicit equalsAndHashCode callSuper = false

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/Unit.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Unit.java
@@ -19,7 +19,7 @@ import lombok.extern.java.Log;
  */
 @Log
 @Getter
-@EqualsAndHashCode(of = "id")
+@EqualsAndHashCode(of = "id", callSuper = false)
 public class Unit extends GameDataComponent implements DynamicallyModifiable {
   private static final long serialVersionUID = -7906193079642776282L;
 


### PR DESCRIPTION
## Overview
Resolves a compiler warning from lombok to make this parameter explicit to signal its ommission is not a mistake.
