### PR TITLE
Refactor: fail early in NioSocket

### DIFF
--- a/game-core/src/main/java/games/strategy/net/nio/NioSocket.java
+++ b/game-core/src/main/java/games/strategy/net/nio/NioSocket.java
@@ -57,6 +57,7 @@ public class NioSocket implements ErrorReporter {
   public void send(final SocketChannel to, final MessageHeader header) {
     checkNotNull(to);
     checkNotNull(header);
+    checkNotNull(header.getFrom());
 
     encoder.write(to, header);
   }


### PR DESCRIPTION
## Overview
Add null check for 'from' field of header. If the field is null there will be a NPE in subsequent code flow.
