### PR TITLE
Refactor: fix law of demeter violation in LobbyMenu

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/LobbyClient.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/LobbyClient.java
@@ -4,6 +4,7 @@ import games.strategy.net.IMessenger;
 import games.strategy.net.Messengers;
 import lombok.Getter;
 import org.triplea.lobby.common.IModeratorController;
+import org.triplea.lobby.common.IUserManager;
 
 /** Provides information about a client connection to a lobby server. */
 public class LobbyClient {
@@ -27,5 +28,9 @@ public class LobbyClient {
 
   public boolean isAnonymousLogin() {
     return isAnonymousLogin;
+  }
+
+  public IUserManager getUserManager() {
+    return (IUserManager) messengers.getRemote(IUserManager.REMOTE_NAME);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -300,9 +300,7 @@ public final class LobbyMenu extends JMenuBar {
   }
 
   private void updateAccountDetails() {
-    final IUserManager manager =
-        (IUserManager)
-            lobbyFrame.getLobbyClient().getMessengers().getRemote(IUserManager.REMOTE_NAME);
+    final IUserManager manager = lobbyFrame.getLobbyClient().getUserManager();
     final String username = lobbyFrame.getLobbyClient().getMessengers().getLocalNode().getName();
     final String email = manager.getUserEmail(username);
     if (email == null) {


### PR DESCRIPTION
## Overview
Move cast and get of IUserManager to LobbyClient from LobbyMenu. Helps encapsulate the casting and fixes a law of demeter violation.

