### PR TITLE
Add: Forgot Password DB Table and DAO

### DIFF
--- a/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/dao/TempPasswordDao.java
+++ b/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/dao/TempPasswordDao.java
@@ -1,0 +1,49 @@
+package org.triplea.lobby.server.db.dao;
+
+import java.util.Optional;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+
+/**
+ * DAO for CRUD operations on temp password table. A table that stores temporary passwords issued to
+ * them with the 'forgot password' feature.
+ */
+public interface TempPasswordDao {
+  @SqlQuery(
+      "select temp_password"
+          + " from user_temp_password t"
+          + " join lobby_user lu on lu.id = t.lobby_user_id"
+          + " where lu.username = :username"
+          + "   and t.date_invalidated is null")
+  Optional<String> fetchTempPassword(@Bind("username") String username);
+
+  @SqlQuery("select id from lobby_user where username = :username")
+  Optional<Integer> lookupUserIdByUsername(@Bind("username") String username);
+
+  @SqlUpdate(
+      "insert into user_temp_password"
+          + " (lobby_user_id, temp_password)"
+          + " values (:userId, :password)")
+  void insertPassword(@Bind("userId") int userId, @Bind("password") String password);
+
+  @SqlUpdate(
+      "update user_temp_password"
+          + " set date_invalidated = now()"
+          + " where lobby_user_id = (select id from lobby_user where username = :username)"
+          + "   and date_invalidated is null")
+  void invalidateTempPasswords(@Bind("username") String username);
+
+  default boolean insertTempPassword(final String username, final String password) {
+    invalidateTempPasswords(username);
+    final Optional<Integer> userId = lookupUserIdByUsername(username);
+    if (userId.isEmpty()) {
+      return false;
+    }
+    insertPassword(userId.get(), password);
+    return true;
+  }
+
+  @SqlQuery("select email from lobby_user where username = :username")
+  Optional<String> lookupUserEmail(@Bind("username") String username);
+}

--- a/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/TempPasswordDaoTest.java
+++ b/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/TempPasswordDaoTest.java
@@ -1,0 +1,71 @@
+package org.triplea.lobby.server.db.dao;
+
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.junit5.DBUnitExtension;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.triplea.lobby.server.db.JdbiDatabase;
+import org.triplea.test.common.Integration;
+
+@Integration
+@ExtendWith(DBUnitExtension.class)
+@DataSet("temp_password/sample.yml")
+class TempPasswordDaoTest {
+
+  private static final String USERNAME = "username";
+  private static final String EMAIL = "email";
+  private static final int USER_ID = 500000;
+
+  private static final String PASSWORD = "temp";
+  private static final String NEW_PASSWORD = "new-temp";
+
+  private final TempPasswordDao tempPasswordDao =
+      JdbiDatabase.newConnection().onDemand(TempPasswordDao.class);
+
+  @Test
+  void fetchTempPassword() {
+    assertThat(tempPasswordDao.fetchTempPassword(USERNAME), isPresentAndIs(PASSWORD));
+    assertThat(tempPasswordDao.fetchTempPassword("DNE"), isEmpty());
+  }
+
+  @Test
+  void lookupUserIdByUsername() {
+    assertThat(tempPasswordDao.lookupUserIdByUsername(USERNAME), isPresentAndIs(USER_ID));
+    assertThat(tempPasswordDao.lookupUserIdByUsername("DNE"), isEmpty());
+  }
+
+  @Test
+  void insertPasswordReturnsFalseIfUserNotFound() {
+    assertThat(tempPasswordDao.insertTempPassword("DNE", PASSWORD), is(false));
+  }
+
+  @Test
+  void insertTempPassword() {
+    assertThat(tempPasswordDao.insertTempPassword(USERNAME, NEW_PASSWORD), is(true));
+    assertThat(tempPasswordDao.fetchTempPassword(USERNAME), isPresentAndIs(NEW_PASSWORD));
+  }
+
+  @Test
+  void invalidateTempPasswordsForMissingNameDoesNothing() {
+    assertThat(tempPasswordDao.fetchTempPassword(USERNAME), isPresentAndIs(PASSWORD));
+    tempPasswordDao.invalidateTempPasswords("DNE");
+    assertThat(tempPasswordDao.fetchTempPassword(USERNAME), isPresentAndIs(PASSWORD));
+  }
+
+  @Test
+  void invalidatePassword() {
+    tempPasswordDao.invalidateTempPasswords(USERNAME);
+    assertThat(tempPasswordDao.fetchTempPassword(USERNAME), isEmpty());
+  }
+
+  @Test
+  void lookupUserEmail() {
+    assertThat(tempPasswordDao.lookupUserEmail(USERNAME), isPresentAndIs(EMAIL));
+    assertThat(tempPasswordDao.lookupUserEmail("DNE"), isEmpty());
+  }
+}

--- a/lobby-db-dao/src/test/resources/datasets/moderator_api_key/select.yml
+++ b/lobby-db-dao/src/test/resources/datasets/moderator_api_key/select.yml
@@ -37,3 +37,4 @@ moderator_api_key:
 
 moderator_action_history:
 moderator_single_use_key:
+user_temp_password:

--- a/lobby-db-dao/src/test/resources/datasets/moderator_audit/history-select.yml
+++ b/lobby-db-dao/src/test/resources/datasets/moderator_audit/history-select.yml
@@ -1,5 +1,6 @@
 moderator_api_key:
 moderator_single_use_key:
+user_temp_password:
 
 lobby_user:
   - id: 800000

--- a/lobby-db-dao/src/test/resources/datasets/moderator_audit/pre-insert.yml
+++ b/lobby-db-dao/src/test/resources/datasets/moderator_audit/pre-insert.yml
@@ -1,6 +1,7 @@
 moderator_api_key:
 moderator_single_use_key:
 moderator_action_history:
+user_temp_password:
 
 lobby_user:
   - id: 900000

--- a/lobby-db-dao/src/test/resources/datasets/moderator_single_use_key/empty.yml
+++ b/lobby-db-dao/src/test/resources/datasets/moderator_single_use_key/empty.yml
@@ -8,3 +8,4 @@ lobby_user:
 moderator_single_use_key:
 moderator_action_history:
 moderator_api_key:
+user_temp_password:

--- a/lobby-db-dao/src/test/resources/datasets/moderator_single_use_key/select.yml
+++ b/lobby-db-dao/src/test/resources/datasets/moderator_single_use_key/select.yml
@@ -23,3 +23,4 @@ moderator_single_use_key:
 
 moderator_action_history:
 moderator_api_key:
+user_temp_password:

--- a/lobby-db-dao/src/test/resources/datasets/moderators/select.yml
+++ b/lobby-db-dao/src/test/resources/datasets/moderators/select.yml
@@ -34,3 +34,4 @@ moderator_single_use_key:
     api_key: b109f3bbbc244eb82441917ed06d618b9008dd09b3befd1b5e07394c706a8bb980b1d7785e5976ec049b46df5f1326af5a2ea6d103fd07c95385ffab0cacbc86
 
 moderator_action_history:
+user_temp_password:

--- a/lobby-db-dao/src/test/resources/datasets/temp_password/sample.yml
+++ b/lobby-db-dao/src/test/resources/datasets/temp_password/sample.yml
@@ -1,0 +1,20 @@
+lobby_user:
+  - id: 500000
+    username: username
+    password: 12345678901234567890123456
+    email: email
+    admin: false
+    super_mod: false
+
+user_temp_password:
+  - lobby_user_id: 500000
+    temp_password: invalid
+    date_created: 2016-01-01 23:59:20.0
+    date_invalidated: 2016-01-02 23:59:20.0
+  - lobby_user_id: 500000
+    temp_password: temp
+    date_created: 2016-01-01 23:59:20.0
+
+
+moderator_action_history:
+moderator_single_use_key:

--- a/lobby-db-dao/src/test/resources/datasets/user_lookup/select.yml
+++ b/lobby-db-dao/src/test/resources/datasets/user_lookup/select.yml
@@ -9,3 +9,4 @@ lobby_user:
 moderator_api_key:
 moderator_action_history:
 moderator_single_use_key:
+user_temp_password:

--- a/lobby-db/src/main/resources/db/migration/V1.10.00.20190812__temp_password.sql
+++ b/lobby-db/src/main/resources/db/migration/V1.10.00.20190812__temp_password.sql
@@ -1,0 +1,21 @@
+create table user_temp_password
+(
+    id               serial primary key,
+    lobby_user_id    int         not null references lobby_user (id),
+    temp_password    varchar(60) not null,
+    date_created     timestamptz not null default now(),
+    date_invalidated timestamptz
+);
+
+alter table user_temp_password
+    owner to lobby_user;
+
+comment on table user_temp_password is
+    $$Table that stores temporary passwords issued to players. They are intended to be single use.$$;
+comment on column user_temp_password.id is 'synthetic PK column';
+comment on column user_temp_password.lobby_user_id is 'FK to lobby_user table.';
+comment on column user_temp_password.temp_password is 'Temp password value created for user.';
+comment on column user_temp_password.date_created is 'Timestamp of when the ban temporary password was created.';
+comment on column user_temp_password.date_invalidated is
+    $$Timestamp of when the temporary password is either used or marked invalid.
+    A temp password can be marked as invalid if multiple are issued.$$


### PR DESCRIPTION
## Overview
Adds table and DAO for storing temp passwords generated by upcoming 'forget password' feature. Code to use the DAO will be added in future commits.
