### PR TITLE
Refactor Remove lobby login challenge keys from RsaAuthenticator

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import javax.swing.JOptionPane;
 import org.triplea.lobby.common.LobbyConstants;
+import org.triplea.lobby.common.login.LobbyLoginChallengeKeys;
 import org.triplea.lobby.common.login.LobbyLoginResponseKeys;
 import org.triplea.lobby.common.login.RsaAuthenticator;
 
@@ -80,7 +81,10 @@ public class LobbyLogin {
           if (anonymousLogin) {
             response.put(LobbyLoginResponseKeys.ANONYMOUS_LOGIN, Boolean.TRUE.toString());
           } else {
-            response.putAll(RsaAuthenticator.newResponse(challenge, password));
+            response.put(
+                LobbyLoginResponseKeys.RSA_ENCRYPTED_PASSWORD,
+                RsaAuthenticator.encrpytPassword(
+                    challenge.get(LobbyLoginChallengeKeys.RSA_PUBLIC_KEY), password));
           }
           response.put(
               LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString());
@@ -158,7 +162,10 @@ public class LobbyLogin {
           final Map<String, String> response = new HashMap<>();
           response.put(LobbyLoginResponseKeys.REGISTER_NEW_USER, Boolean.TRUE.toString());
           response.put(LobbyLoginResponseKeys.EMAIL, email);
-          response.putAll(RsaAuthenticator.newResponse(challenge, password));
+          response.put(
+              LobbyLoginResponseKeys.RSA_ENCRYPTED_PASSWORD,
+              RsaAuthenticator.encrpytPassword(
+                  challenge.get(LobbyLoginChallengeKeys.RSA_PUBLIC_KEY), password));
           response.put(
               LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString());
           return response;

--- a/game-core/src/main/java/org/triplea/lobby/common/login/RsaAuthenticator.java
+++ b/game-core/src/main/java/org/triplea/lobby/common/login/RsaAuthenticator.java
@@ -97,19 +97,6 @@ public final class RsaAuthenticator {
     }
   }
 
-  private static String encryptPassword(final String publicKeyString, final String password) {
-    try {
-      final PublicKey publicKey =
-          KeyFactory.getInstance(RSA)
-              .generatePublic(new X509EncodedKeySpec(Base64.getDecoder().decode(publicKeyString)));
-      final Cipher cipher = Cipher.getInstance(RSA_ECB_OAEPP);
-      cipher.init(Cipher.ENCRYPT_MODE, publicKey);
-      return Base64.getEncoder().encodeToString(cipher.doFinal(getHashedBytes(password)));
-    } catch (final GeneralSecurityException e) {
-      throw new IllegalStateException(e);
-    }
-  }
-
   /**
    * Returns UTF-8 encoded bytes of a "salted" SHA-512 hash of the given input string. See {@link
    * #hashPasswordWithSalt(String)} for more information.
@@ -149,15 +136,20 @@ public final class RsaAuthenticator {
   /**
    * Creates a response to the specified challenge for the lobby client to send to the lobby server.
    *
-   * @param challenge The challenge as a collection of properties.
+   * @param rsaPublicKey Public key string sent from server.
    * @param password The lobby client's password.
-   * @return The response as a collection of properties to be added to the message the lobby client
-   *     sends back to the lobby server.
+   * @return Encrypted password using provided rsa public key.
    */
-  public static Map<String, String> newResponse(
-      final Map<String, String> challenge, final String password) {
-    return Collections.singletonMap(
-        LobbyLoginResponseKeys.RSA_ENCRYPTED_PASSWORD,
-        encryptPassword(challenge.get(LobbyLoginChallengeKeys.RSA_PUBLIC_KEY), password));
+  public static String encrpytPassword(final String rsaPublicKey, final String password) {
+    try {
+      final PublicKey publicKey =
+          KeyFactory.getInstance(RSA)
+              .generatePublic(new X509EncodedKeySpec(Base64.getDecoder().decode(rsaPublicKey)));
+      final Cipher cipher = Cipher.getInstance(RSA_ECB_OAEPP);
+      cipher.init(Cipher.ENCRYPT_MODE, publicKey);
+      return Base64.getEncoder().encodeToString(cipher.doFinal(getHashedBytes(password)));
+    } catch (final GeneralSecurityException e) {
+      throw new IllegalStateException(e);
+    }
   }
 }

--- a/game-core/src/test/java/org/triplea/lobby/common/login/RsaAuthenticatorTest.java
+++ b/game-core/src/test/java/org/triplea/lobby/common/login/RsaAuthenticatorTest.java
@@ -42,8 +42,11 @@ final class RsaAuthenticatorTest {
       final Function<String, String> action = mock(Function.class);
 
       final Map<String, String> challenge = new HashMap<>(rsaAuthenticator.newChallenge());
-      final Map<String, String> response =
-          new HashMap<>(RsaAuthenticator.newResponse(challenge, password));
+      final Map<String, String> response = new HashMap<>();
+      response.put(
+          LobbyLoginResponseKeys.RSA_ENCRYPTED_PASSWORD,
+          RsaAuthenticator.encrpytPassword(
+              challenge.get(LobbyLoginChallengeKeys.RSA_PUBLIC_KEY), password));
       rsaAuthenticator.decryptPasswordForAction(response, action);
 
       verify(action).apply(RsaAuthenticator.hashPasswordWithSalt(password));

--- a/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorTest.java
@@ -26,6 +26,7 @@ import org.mindrot.jbcrypt.BCrypt;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.lobby.common.LobbyConstants;
+import org.triplea.lobby.common.login.LobbyLoginChallengeKeys;
 import org.triplea.lobby.common.login.LobbyLoginResponseKeys;
 import org.triplea.lobby.common.login.RsaAuthenticator;
 import org.triplea.lobby.server.TestUserUtils;
@@ -301,7 +302,10 @@ final class LobbyLoginValidatorTest {
                   .put(LobbyLoginResponseKeys.HASHED_PASSWORD, md5Crypt(PASSWORD))
                   .put(
                       LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString())
-                  .putAll(RsaAuthenticator.newResponse(challenge, PASSWORD))
+                  .put(
+                      LobbyLoginResponseKeys.RSA_ENCRYPTED_PASSWORD,
+                      RsaAuthenticator.encrpytPassword(
+                          challenge.get(LobbyLoginChallengeKeys.RSA_PUBLIC_KEY), PASSWORD))
                   .build();
         }
       }
@@ -370,7 +374,10 @@ final class LobbyLoginValidatorTest {
         return challenge ->
             ImmutableMap.<String, String>builder()
                 .put(LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString())
-                .putAll(RsaAuthenticator.newResponse(challenge, PASSWORD))
+                .put(
+                    LobbyLoginResponseKeys.RSA_ENCRYPTED_PASSWORD,
+                    RsaAuthenticator.encrpytPassword(
+                        challenge.get(LobbyLoginChallengeKeys.RSA_PUBLIC_KEY), PASSWORD))
                 .build();
       }
     }


### PR DESCRIPTION
## Overview
Simplify RsaAuthenticator slightly by removing challenge map keys and moving them to callers. Adds a bit of redundancy with a trade-off of fixing a SRP violation (RsaAuthenticator should not know about challenge keys necessarily) and makes the logic of which keys are placed where more epxlicit.

