### PR TITLE
Update: Allow user password update without updating email

### DIFF
--- a/lobby/src/main/java/org/triplea/lobby/server/db/UserController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/db/UserController.java
@@ -60,12 +60,10 @@ final class UserController implements UserDao {
                     "update lobby_user set %s=?%s where username=?",
                     getPasswordColumn(hashedPassword), email == null ? "" : ", email=?"))) {
       ps.setString(1, hashedPassword.value);
-      int index = 2;
       if (email != null) {
-        ps.setString(index, email);
-        index++;
+        ps.setString(2, email);
       }
-      ps.setString(index, name);
+      ps.setString(email != null ? 3 : 2, name);
       ps.execute();
       if (!hashedPassword.isBcrypted()) {
         try (PreparedStatement ps2 =


### PR DESCRIPTION
## Overview
- (1) Future looking update to allow for email to be passed as 'null' when updating user password. In this case the email is not updated. In this way we do not require user email when updating user password. This will be useful for future 'forget password' feature so we do not need to lookup user email nor ask user for email so we can call this method with a non-null email.

- (2) Small refactor to combine try-with resources lines. The open connection line can be moved lower and combined into a single try-with-resources line.

