### PR TITLE
Divide by float rather than int

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -809,7 +809,7 @@ class ProPurchaseAi {
           ProBattleUtils.territoryHasLocalLandSuperiority(
               t, ProBattleUtils.SHORT_RANGE, player, purchaseTerritories);
       if (!finalResult.isHasLandUnitRemaining()
-          || (finalResult.getTuvSwing() - resourceTracker.getTempPUs(data) / 2)
+          || (finalResult.getTuvSwing() - resourceTracker.getTempPUs(data) / 2f)
               < placeTerritory.getMinBattleResult().getTuvSwing()
           || t.equals(ProData.myCapital)
           || (!t.isWater() && hasLocalSuperiority)) {


### PR DESCRIPTION
## Overview
Float-division rather than int division.
@ron-murhammer It would be nice if you could check if this will continue to work fine.
The alternative would be to explicitly round the result afterwards to make it explicit, or to assign the intermediate result to an int first.

## Functional Changes
Unknown

## Manual Testing Performed
None