### PR TITLE
Add: Forgot Password Feature

### DIFF
--- a/.idea/runConfigurations/LobbyRunner.xml
+++ b/.idea/runConfigurations/LobbyRunner.xml
@@ -1,5 +1,8 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="LobbyRunner" type="Application" factoryName="Application" nameIsGenerated="true">
+    <envs>
+      <env name="LOCAL_DEV" value="true" />
+    </envs>
     <option name="MAIN_CLASS_NAME" value="org.triplea.lobby.server.LobbyRunner" />
     <module name="triplea.lobby" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/lobby" />

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -30,12 +30,11 @@ import games.strategy.engine.framework.ui.background.WaitWindow;
 import games.strategy.engine.message.RemoteName;
 import games.strategy.engine.player.IGamePlayer;
 import games.strategy.io.IoUtils;
-import games.strategy.net.ClientMessenger;
+import games.strategy.net.ClientMessengerFactory;
 import games.strategy.net.CouldNotLogInException;
 import games.strategy.net.IClientMessenger;
 import games.strategy.net.IMessengerErrorListener;
 import games.strategy.net.INode;
-import games.strategy.net.MacFinder;
 import games.strategy.net.Messengers;
 import games.strategy.triplea.settings.ClientSetting;
 import java.awt.Component;
@@ -218,12 +217,10 @@ public class ClientModel implements IMessengerErrorListener {
           this.ui, "Invalid Port: " + port, "Error", JOptionPane.ERROR_MESSAGE);
       return false;
     }
-    final String address = props.getHost();
     try {
-      final String mac = MacFinder.getHashedMacAddress();
       messenger =
-          new ClientMessenger(
-              address, port, props.getName(), mac, objectStreamFactory, new ClientLogin(this.ui));
+          ClientMessengerFactory.newClientMessenger(
+              props, objectStreamFactory, new ClientLogin(this.ui));
     } catch (final CouldNotLogInException e) {
       EventThreadJOptionPane.showMessageDialog(this.ui, e.getMessage());
       return false;
@@ -472,7 +469,7 @@ public class ClientModel implements IMessengerErrorListener {
   /** Simple data object for which host we are connecting to and with which name. */
   @Getter
   @Builder
-  private static class ClientProps {
+  public static class ClientProps {
     @Nonnull private Integer port;
     @Nonnull private String name;
     @Nonnull private String host;

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/LobbyClient.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/LobbyClient.java
@@ -2,6 +2,7 @@ package games.strategy.engine.lobby.client;
 
 import games.strategy.net.IMessenger;
 import games.strategy.net.Messengers;
+import javax.annotation.Nullable;
 import lombok.Getter;
 import org.triplea.lobby.common.IModeratorController;
 import org.triplea.lobby.common.IUserManager;
@@ -15,6 +16,11 @@ public class LobbyClient {
   public LobbyClient(final IMessenger messenger, final boolean anonymousLogin) {
     messengers = new Messengers(messenger);
     isAnonymousLogin = anonymousLogin;
+  }
+
+  @Nullable
+  public String updatePassword(final String newPassword) {
+    return getUserManager().updateUser(messengers.getLocalNode().getName(), null, newPassword);
   }
 
   public boolean isAdmin() {
@@ -32,5 +38,9 @@ public class LobbyClient {
 
   public IUserManager getUserManager() {
     return (IUserManager) messengers.getRemote(IUserManager.REMOTE_NAME);
+  }
+
+  public boolean isPasswordChangeRequired() {
+    return messengers.isPasswordChangeRequired();
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/ChangePasswordPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/ChangePasswordPanel.java
@@ -130,8 +130,8 @@ public final class ChangePasswordPanel extends JPanel {
   }
 
   private void close() {
-    if (validatePasswords() && dialog != null) {
-      dialog.dispose();
+    if (dialog != null) {
+      dialog.setVisible(false);
     }
   }
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/ChangePasswordPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/ChangePasswordPanel.java
@@ -1,0 +1,161 @@
+package games.strategy.engine.lobby.client.login;
+
+import games.strategy.ui.Util;
+import java.awt.BorderLayout;
+import java.awt.FlowLayout;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.Window;
+import java.util.Arrays;
+import javax.annotation.Nullable;
+import javax.swing.BorderFactory;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JPasswordField;
+import org.triplea.swing.DocumentListenerBuilder;
+import org.triplea.swing.SwingComponents;
+
+/** Panel dedicated to changing password after user has logged in with a temporary password. */
+public final class ChangePasswordPanel extends JPanel {
+
+  private final String title = "Change Password";
+  private @Nullable JDialog dialog;
+  private final JPasswordField passwordField = new JPasswordField();
+  private final JPasswordField passwordConfirmField = new JPasswordField();
+  private final JButton okButton = new JButton("OK");
+
+  private ChangePasswordPanel() {
+    layoutComponents();
+    setupListeners();
+  }
+
+  /**
+   * Creates a new instance of the {@code CreateUpdateAccountPanel} class that is used to update the
+   * specified lobby account.
+   *
+   * @return A new {@code CreateUpdateAccountPanel}.
+   */
+  public static ChangePasswordPanel newChangePasswordPanel() {
+    return new ChangePasswordPanel();
+  }
+
+  private void layoutComponents() {
+    setLayout(new BorderLayout());
+    final JLabel label = new JLabel(new ImageIcon(Util.getBanner(title)));
+    add(label, BorderLayout.NORTH);
+
+    final JPanel main = new JPanel();
+    add(main, BorderLayout.CENTER);
+    main.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+    main.setLayout(new GridBagLayout());
+    main.add(
+        new JLabel("Password:"),
+        new GridBagConstraints(
+            0,
+            0,
+            1,
+            1,
+            0.0,
+            0.0,
+            GridBagConstraints.WEST,
+            GridBagConstraints.NONE,
+            new Insets(5, 0, 0, 0),
+            0,
+            0));
+    main.add(
+        passwordField,
+        new GridBagConstraints(
+            1,
+            0,
+            1,
+            1,
+            1.0,
+            0.0,
+            GridBagConstraints.WEST,
+            GridBagConstraints.HORIZONTAL,
+            new Insets(5, 5, 0, 0),
+            0,
+            0));
+    main.add(
+        new JLabel("Confirm Password:"),
+        new GridBagConstraints(
+            0,
+            1,
+            1,
+            1,
+            0.0,
+            0.0,
+            GridBagConstraints.WEST,
+            GridBagConstraints.NONE,
+            new Insets(5, 0, 0, 0),
+            0,
+            0));
+    main.add(
+        passwordConfirmField,
+        new GridBagConstraints(
+            1,
+            1,
+            1,
+            1,
+            1.0,
+            0.0,
+            GridBagConstraints.WEST,
+            GridBagConstraints.HORIZONTAL,
+            new Insets(5, 5, 0, 0),
+            0,
+            0));
+
+    final JPanel buttons = new JPanel();
+    add(buttons, BorderLayout.SOUTH);
+    buttons.setBorder(BorderFactory.createEmptyBorder(10, 5, 10, 5));
+    buttons.setLayout(new FlowLayout(FlowLayout.RIGHT, 5, 0));
+    buttons.add(okButton);
+    okButton.setEnabled(false);
+  }
+
+  private void setupListeners() {
+    okButton.addActionListener(e -> close());
+
+    SwingComponents.addEnterKeyListener(this, this::close);
+
+    DocumentListenerBuilder.attachDocumentListener(
+        passwordField, () -> okButton.setEnabled(validatePasswords()));
+    DocumentListenerBuilder.attachDocumentListener(
+        passwordConfirmField, () -> okButton.setEnabled(validatePasswords()));
+  }
+
+  private void close() {
+    if (validatePasswords() && dialog != null) {
+      dialog.dispose();
+    }
+  }
+
+  private boolean validatePasswords() {
+    return Arrays.equals(passwordField.getPassword(), passwordConfirmField.getPassword())
+        && passwordField.getPassword().length > 2;
+  }
+
+  /**
+   * Shows this panel in a modal dialog.
+   *
+   * @param parent The dialog parent window.
+   * @return New password entered by user, otherwise null if the window is closed.
+   */
+  @Nullable
+  public String show(final Window parent) {
+    dialog = new JDialog(JOptionPane.getFrameForComponent(parent), title, true);
+    dialog.getContentPane().add(this);
+    SwingComponents.addEscapeKeyListener(dialog, this::close);
+    dialog.pack();
+    dialog.setLocationRelativeTo(parent);
+    dialog.setVisible(true);
+    dialog.dispose();
+    dialog = null;
+    return validatePasswords() ? String.valueOf(passwordField.getPassword()) : null;
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/ForgotPasswordPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/ForgotPasswordPanel.java
@@ -1,0 +1,151 @@
+package games.strategy.engine.lobby.client.login;
+
+import games.strategy.engine.lobby.PlayerNameValidation;
+import games.strategy.ui.Util;
+import java.awt.BorderLayout;
+import java.awt.FlowLayout;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+import java.awt.Window;
+import javax.annotation.Nullable;
+import javax.swing.BorderFactory;
+import javax.swing.ImageIcon;
+import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JLabel;
+import javax.swing.JOptionPane;
+import javax.swing.JPanel;
+import javax.swing.JTextField;
+import org.triplea.swing.SwingComponents;
+
+/**
+ * Panel used to request a new temporary password. The panel displays a single text field for
+ * username.
+ */
+final class ForgotPasswordPanel extends JPanel {
+
+  /** Indicates how the user dismissed the dialog displaying the panel. */
+  public enum ReturnValue {
+    CANCEL,
+    OK
+  }
+
+  private final String title = "Forgot Password";
+  private @Nullable JDialog dialog;
+  private final JTextField userNameField = new JTextField();
+  private final JButton okButton = new JButton("OK");
+  private final JButton cancelButton = new JButton("Cancel");
+  private ReturnValue returnValue = ReturnValue.CANCEL;
+
+  private ForgotPasswordPanel() {
+    layoutComponents();
+    setupListeners();
+  }
+
+  /**
+   * Creates a new instance of the {@code CreateUpdateAccountPanel} class used to request a
+   * temporary password.
+   *
+   * @return A new {@code CreateUpdateAccountPanel}.
+   */
+  static ForgotPasswordPanel newForgotPasswordPanel() {
+    return new ForgotPasswordPanel();
+  }
+
+  private void layoutComponents() {
+    setLayout(new BorderLayout());
+    final JLabel label = new JLabel(new ImageIcon(Util.getBanner(title)));
+    add(label, BorderLayout.NORTH);
+
+    final JPanel main = new JPanel();
+    add(main, BorderLayout.CENTER);
+    main.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+    main.setLayout(new GridBagLayout());
+    main.add(
+        new JLabel("Username:"),
+        new GridBagConstraints(
+            0,
+            0,
+            1,
+            1,
+            0.0,
+            0.0,
+            GridBagConstraints.WEST,
+            GridBagConstraints.NONE,
+            new Insets(0, 0, 0, 0),
+            0,
+            0));
+    main.add(
+        userNameField,
+        new GridBagConstraints(
+            1,
+            0,
+            1,
+            1,
+            1.0,
+            0.0,
+            GridBagConstraints.WEST,
+            GridBagConstraints.HORIZONTAL,
+            new Insets(0, 5, 0, 0),
+            0,
+            0));
+
+    final JPanel buttons = new JPanel();
+    add(buttons, BorderLayout.SOUTH);
+    buttons.setBorder(BorderFactory.createEmptyBorder(10, 5, 10, 5));
+    buttons.setLayout(new FlowLayout(FlowLayout.RIGHT, 5, 0));
+    buttons.add(okButton);
+    buttons.add(cancelButton);
+  }
+
+  private void setupListeners() {
+    cancelButton.addActionListener(e -> close());
+    okButton.addActionListener(e -> okPressed());
+
+    SwingComponents.addEnterKeyListener(this, this::okPressed);
+  }
+
+  private void close() {
+    if (dialog != null) {
+      dialog.setVisible(false);
+    }
+  }
+
+  private void okPressed() {
+    if (!PlayerNameValidation.isValid(userNameField.getText())) {
+      JOptionPane.showMessageDialog(
+          this,
+          PlayerNameValidation.validate(userNameField.getText()),
+          "Invalid name",
+          JOptionPane.ERROR_MESSAGE);
+      return;
+    }
+
+    returnValue = ReturnValue.OK;
+    close();
+  }
+
+  /**
+   * Shows this panel in a modal dialog.
+   *
+   * @param parent The dialog parent window.
+   * @return {@link ReturnValue#OK} if the user clicks 'okay' button, otherwise {@link
+   *     ReturnValue#CANCEL}.
+   */
+  ReturnValue show(final Window parent) {
+    dialog = new JDialog(JOptionPane.getFrameForComponent(parent), title, true);
+    dialog.getContentPane().add(this);
+    SwingComponents.addEscapeKeyListener(dialog, this::close);
+    dialog.pack();
+    dialog.setLocationRelativeTo(parent);
+    dialog.setVisible(true);
+    dialog.dispose();
+    dialog = null;
+    return returnValue;
+  }
+
+  String getUserName() {
+    return userNameField.getText();
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LoginPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LoginPanel.java
@@ -27,7 +27,8 @@ final class LoginPanel extends JPanel {
   enum ReturnValue {
     CANCEL,
     LOGON,
-    CREATE_ACCOUNT
+    CREATE_ACCOUNT,
+    FORGOT_PASSWORD
   }
 
   private @Nullable JDialog dialog;
@@ -35,7 +36,8 @@ final class LoginPanel extends JPanel {
   private final JTextField username = new JTextField();
   private final JCheckBox credentialsSaved = new JCheckBox("Remember me");
   private final JCheckBox anonymousLogin = new JCheckBox("Login anonymously");
-  private final JButton createAccount = new JButton("Create Account...");
+  private final JButton createAccount = new JButton("Create Account");
+  private final JButton forgotPassword = new JButton("Forgot Password");
   private ReturnValue returnValue = ReturnValue.CANCEL;
   private final JButton logon = new JButton("Login");
   private final JButton cancel = new JButton("Cancel");
@@ -183,6 +185,7 @@ final class LoginPanel extends JPanel {
     buttons.setLayout(new FlowLayout(FlowLayout.RIGHT, 5, 0));
     buttons.add(logon);
     buttons.add(createAccount);
+    buttons.add(forgotPassword);
     buttons.add(cancel);
   }
 
@@ -195,7 +198,11 @@ final class LoginPanel extends JPanel {
         });
     cancel.addActionListener(e -> close());
     anonymousLogin.addActionListener(e -> updateComponents());
-
+    forgotPassword.addActionListener(
+        e -> {
+          returnValue = ReturnValue.FORGOT_PASSWORD;
+          close();
+        });
     SwingComponents.addEnterKeyListener(this, this::logonPressed);
   }
 

--- a/game-core/src/main/java/games/strategy/net/ClientMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ClientMessenger.java
@@ -227,7 +227,7 @@ public class ClientMessenger implements IClientMessenger, NioSocketListener {
   }
 
   @Override
-  public void socketUnqaurantined(
+  public void socketUnquarantined(
       final SocketChannel channel, final QuarantineConversation quarantineConversation) {
     final ClientQuarantineConversation conversation =
         (ClientQuarantineConversation) quarantineConversation;

--- a/game-core/src/main/java/games/strategy/net/ClientMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ClientMessenger.java
@@ -229,8 +229,7 @@ public class ClientMessenger implements IClientMessenger, NioSocketListener {
   @Override
   public void socketUnquarantined(
       final SocketChannel channel, final QuarantineConversation quarantineConversation) {
-    final ClientQuarantineConversation conversation =
-        (ClientQuarantineConversation) quarantineConversation;
+    final var conversation = (ClientQuarantineConversation) quarantineConversation;
     // all ids are based on the socket address of nodes in the network
     // but the address of a node changes depending on who is looking at it
     // ie, sometimes it is the loopback address if connecting locally,

--- a/game-core/src/main/java/games/strategy/net/ClientMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ClientMessenger.java
@@ -8,6 +8,7 @@ import games.strategy.engine.message.HubInvoke;
 import games.strategy.engine.message.RemoteMethodCall;
 import games.strategy.engine.message.RemoteName;
 import games.strategy.net.nio.ClientQuarantineConversation;
+import games.strategy.net.nio.ForgotPasswordConversation;
 import games.strategy.net.nio.NioSocket;
 import games.strategy.net.nio.NioSocketListener;
 import games.strategy.net.nio.QuarantineConversation;
@@ -25,6 +26,7 @@ import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.logging.Level;
+import lombok.Getter;
 import lombok.extern.java.Log;
 import org.triplea.java.Interruptibles;
 
@@ -41,11 +43,14 @@ public class ClientMessenger implements IClientMessenger, NioSocketListener {
   private INode serverNode;
   private volatile boolean shutDown = false;
 
+  @Getter(onMethod_ = {@Override})
+  private boolean passwordChangeRequired;
+
   /**
    * Note, the name parameter passed in here may not match the name of the ClientMessenger after it
    * has been constructed.
    */
-  public ClientMessenger(
+  ClientMessenger(
       final String host,
       final int port,
       final String name,
@@ -69,6 +74,7 @@ public class ClientMessenger implements IClientMessenger, NioSocketListener {
    * Note, the name parameter passed in here may not match the name of the ClientMessenger after it
    * has been constructed.
    */
+  @VisibleForTesting
   public ClientMessenger(
       final String host,
       final int port,
@@ -113,6 +119,7 @@ public class ClientMessenger implements IClientMessenger, NioSocketListener {
     nioSocket = new NioSocket(streamFact, this);
     final ClientQuarantineConversation conversation =
         new ClientQuarantineConversation(login, socketChannel, nioSocket, name, mac);
+
     nioSocket.add(socketChannel, conversation);
     // allow the credentials to be shown in this thread
     conversation.showCredentials();
@@ -128,6 +135,15 @@ public class ClientMessenger implements IClientMessenger, NioSocketListener {
         // ignore
       }
     }
+    passwordChangeRequired = conversation.isPasswordChangeRequired();
+
+    if (conversation.getErrorMessage() != null
+        && conversation
+            .getErrorMessage()
+            .equals(ForgotPasswordConversation.TEMP_PASSWORD_GENERATED_RESPONSE)) {
+      return;
+    }
+
     if (conversation.getErrorMessage() != null || connectionRefusedError != null) {
       // our socket channel should already be closed
       nioSocket.shutDown();
@@ -212,8 +228,9 @@ public class ClientMessenger implements IClientMessenger, NioSocketListener {
 
   @Override
   public void socketUnqaurantined(
-      final SocketChannel channel, final QuarantineConversation converstaion2) {
-    final ClientQuarantineConversation conversation = (ClientQuarantineConversation) converstaion2;
+      final SocketChannel channel, final QuarantineConversation quarantineConversation) {
+    final ClientQuarantineConversation conversation =
+        (ClientQuarantineConversation) quarantineConversation;
     // all ids are based on the socket address of nodes in the network
     // but the address of a node changes depending on who is looking at it
     // ie, sometimes it is the loopback address if connecting locally,

--- a/game-core/src/main/java/games/strategy/net/ClientMessengerFactory.java
+++ b/game-core/src/main/java/games/strategy/net/ClientMessengerFactory.java
@@ -13,7 +13,7 @@ import org.triplea.lobby.common.login.LobbyLoginChallengeKeys;
 import org.triplea.lobby.common.login.LobbyLoginResponseKeys;
 import org.triplea.lobby.common.login.RsaAuthenticator;
 
-/** Default implementation of {@link IClientMessenger}. */
+/** Factory class for implementations of {@link IClientMessenger}. */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class ClientMessengerFactory {
 

--- a/game-core/src/main/java/games/strategy/net/ClientMessengerFactory.java
+++ b/game-core/src/main/java/games/strategy/net/ClientMessengerFactory.java
@@ -1,0 +1,158 @@
+package games.strategy.net;
+
+import games.strategy.engine.framework.startup.login.ClientLogin;
+import games.strategy.engine.framework.startup.mc.ClientModel;
+import games.strategy.engine.lobby.client.login.LobbyServerProperties;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.triplea.lobby.common.LobbyConstants;
+import org.triplea.lobby.common.login.LobbyLoginChallengeKeys;
+import org.triplea.lobby.common.login.LobbyLoginResponseKeys;
+import org.triplea.lobby.common.login.RsaAuthenticator;
+
+/** Default implementation of {@link IClientMessenger}. */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ClientMessengerFactory {
+
+  /** Creates a client messenger suitable for connecting to a hosted game server. */
+  public static IClientMessenger newClientMessenger(
+      final ClientModel.ClientProps props,
+      final IObjectStreamFactory objectStreamFactory,
+      final ClientLogin clientLogin)
+      throws IOException {
+    final String mac = MacFinder.getHashedMacAddress();
+    return new ClientMessenger(
+        props.getHost(), props.getPort(), props.getName(), mac, objectStreamFactory, clientLogin);
+  }
+
+  /**
+   * Creates a client messenger that will connect to lobby, creating a new account.
+   *
+   * @param lobbyServerProperties Properties used to connect to the lobby.
+   * @param username Desired new username to connect with.
+   * @param email Email associated with the new user account.
+   * @param password Plain-text (new) password read from UI.
+   * @throws IOException Thrown if there are any errors establishing a socket connection to lobby.
+   */
+  public static IClientMessenger newCreateAccountMessenger(
+      final LobbyServerProperties lobbyServerProperties,
+      final String username,
+      final String email,
+      final String password)
+      throws IOException {
+    return new ClientMessenger(
+        lobbyServerProperties.getHost(),
+        lobbyServerProperties.getPort(),
+        username,
+        MacFinder.getHashedMacAddress(),
+        challenge -> {
+          final Map<String, String> response = new HashMap<>();
+          response.put(LobbyLoginResponseKeys.REGISTER_NEW_USER, Boolean.TRUE.toString());
+          response.put(LobbyLoginResponseKeys.EMAIL, email);
+          response.put(
+              LobbyLoginResponseKeys.RSA_ENCRYPTED_PASSWORD, encryptPassword(challenge, password));
+          response.put(
+              LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString());
+          return response;
+        });
+  }
+
+  private static String encryptPassword(
+      final Map<String, String> challenge, final String password) {
+    final String rsaKeyFromServer = challenge.get(LobbyLoginChallengeKeys.RSA_PUBLIC_KEY);
+    return RsaAuthenticator.encrpytPassword(rsaKeyFromServer, password);
+  }
+
+  /**
+   * Creates a messenger that will connect to lobby and do a name-only login. This is called
+   * anonymous login, a registered account is not required.
+   */
+  public static IClientMessenger newAnonymousUserMessenger(
+      final LobbyServerProperties lobbyServerProperties, final String username) throws IOException {
+    return login(lobbyServerProperties, username, null);
+  }
+
+  /**
+   * Creates a client messenger that will connect to a lobby using username and password (registered
+   * users).
+   */
+  public static IClientMessenger newRegisteredUserMessenger(
+      final LobbyServerProperties lobbyServerProperties,
+      final String username,
+      final String password)
+      throws IOException {
+    return login(lobbyServerProperties, username, password);
+  }
+
+  private static IClientMessenger login(
+      final LobbyServerProperties lobbyServerProperties,
+      final String userName,
+      final String password)
+      throws IOException {
+
+    return new ClientMessenger(
+        lobbyServerProperties.getHost(),
+        lobbyServerProperties.getPort(),
+        userName,
+        MacFinder.getHashedMacAddress(),
+        challenge -> {
+          final Map<String, String> response = new HashMap<>();
+          if (password == null) {
+            response.put(LobbyLoginResponseKeys.ANONYMOUS_LOGIN, Boolean.TRUE.toString());
+          } else {
+            response.put(
+                LobbyLoginResponseKeys.RSA_ENCRYPTED_PASSWORD,
+                encryptPassword(challenge, password));
+          }
+          response.put(
+              LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString());
+          return response;
+        });
+  }
+
+  /** Creates a messenger suitable for lobby watchers (bots). */
+  public static IClientMessenger newLobbyWatcherMessenger(
+      final String host, final int port, final String hostedByName) throws IOException {
+
+    final IConnectionLogin login =
+        challenge -> {
+          final Map<String, String> response = new HashMap<>();
+          response.put(LobbyLoginResponseKeys.ANONYMOUS_LOGIN, Boolean.TRUE.toString());
+          response.put(
+              LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString());
+          response.put(LobbyLoginResponseKeys.LOBBY_WATCHER_LOGIN, Boolean.TRUE.toString());
+          return response;
+        };
+
+    return new ClientMessenger(
+        host,
+        port,
+        IServerMessenger.getRealName(hostedByName) + "_" + LobbyConstants.LOBBY_WATCHER_NAME,
+        MacFinder.getHashedMacAddress(),
+        login);
+  }
+
+  /**
+   * Creates a messenger that will connect to lobby and request a temporary password to be sent to
+   * the users email.
+   */
+  public static IClientMessenger newForgotPasswordMessenger(
+      final LobbyServerProperties lobbyServerProperties, final String userName) throws IOException {
+
+    return new ClientMessenger(
+        lobbyServerProperties.getHost(),
+        lobbyServerProperties.getPort(),
+        userName,
+        MacFinder.getHashedMacAddress(),
+        challenge -> {
+          final Map<String, String> response = new HashMap<>();
+          response.put(LobbyLoginResponseKeys.FORGOT_PASSWORD, Boolean.TRUE.toString());
+          response.put(
+              LobbyLoginResponseKeys.LOBBY_VERSION, LobbyConstants.LOBBY_VERSION.toString());
+          return response;
+        });
+  }
+}

--- a/game-core/src/main/java/games/strategy/net/IClientMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/IClientMessenger.java
@@ -18,4 +18,6 @@ public interface IClientMessenger extends IMessenger {
 
   /** Stop listening for errors. */
   void removeErrorListener(IMessengerErrorListener listener);
+
+  boolean isPasswordChangeRequired();
 }

--- a/game-core/src/main/java/games/strategy/net/IServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/IServerMessenger.java
@@ -2,6 +2,7 @@ package games.strategy.net;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import games.strategy.net.nio.ForgotPasswordConversation;
 import java.util.Set;
 import javax.annotation.Nullable;
 
@@ -12,6 +13,8 @@ public interface IServerMessenger extends IMessenger {
   void setLoginValidator(ILoginValidator loginValidator);
 
   ILoginValidator getLoginValidator();
+
+  void setForgotPasswordConversation(ForgotPasswordConversation forgotPasswordConversation);
 
   /** Remove the node from the network. */
   void removeConnection(INode node);

--- a/game-core/src/main/java/games/strategy/net/LocalNoOpMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/LocalNoOpMessenger.java
@@ -1,5 +1,6 @@
 package games.strategy.net;
 
+import games.strategy.net.nio.ForgotPasswordConversation;
 import java.io.Serializable;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
@@ -62,6 +63,12 @@ public class LocalNoOpMessenger implements IServerMessenger {
   @Override
   public ILoginValidator getLoginValidator() {
     return null;
+  }
+
+  @Override
+  public void setForgotPasswordConversation(
+      final ForgotPasswordConversation forgotPasswordConversation) {
+    throw new UnsupportedOperationException("Password reset not supported by local servers.");
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/net/Messengers.java
+++ b/game-core/src/main/java/games/strategy/net/Messengers.java
@@ -40,6 +40,11 @@ public class Messengers implements IMessenger, IRemoteMessenger, IChannelMesseng
     this.channelMessenger = channelMessenger;
   }
 
+  public boolean isPasswordChangeRequired() {
+    return messenger instanceof IClientMessenger
+        && ((IClientMessenger) messenger).isPasswordChangeRequired();
+  }
+
   // TODO: API could be improved, perhaps return an optional, and/or store exact instance types from
   // constructor.
   public IServerMessenger getServerMessenger() {

--- a/game-core/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ServerMessenger.java
@@ -348,7 +348,7 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
   }
 
   @Override
-  public void socketUnqaurantined(
+  public void socketUnquarantined(
       final SocketChannel channel, final QuarantineConversation conversation) {
     final ServerQuarantineConversation con = (ServerQuarantineConversation) conversation;
     final INode remote =

--- a/game-core/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ServerMessenger.java
@@ -2,6 +2,7 @@ package games.strategy.net;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import games.strategy.net.nio.ForgotPasswordConversation;
 import games.strategy.net.nio.NioSocket;
 import games.strategy.net.nio.NioSocketListener;
 import games.strategy.net.nio.QuarantineConversation;
@@ -49,6 +50,10 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
   @Getter(onMethod_ = {@Override})
   @Setter(onMethod_ = {@Override})
   private ILoginValidator loginValidator;
+
+  @Setter(onMethod_ = {@Override})
+  private ForgotPasswordConversation forgotPasswordConversation;
+
   // all our nodes
   private final Map<INode, SocketChannel> nodeToChannel = new ConcurrentHashMap<>();
   private final Map<SocketChannel, INode> channelToNode = new ConcurrentHashMap<>();
@@ -290,7 +295,11 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
             }
             final ServerQuarantineConversation conversation =
                 new ServerQuarantineConversation(
-                    loginValidator, socketChannel, nioSocket, ServerMessenger.this);
+                    loginValidator,
+                    socketChannel,
+                    nioSocket,
+                    ServerMessenger.this,
+                    forgotPasswordConversation);
             nioSocket.add(socketChannel, conversation);
           } else if (!key.isValid()) {
             key.cancel();

--- a/game-core/src/main/java/games/strategy/net/TempPasswordHistory.java
+++ b/game-core/src/main/java/games/strategy/net/TempPasswordHistory.java
@@ -1,0 +1,13 @@
+package games.strategy.net;
+
+import java.net.InetAddress;
+
+/**
+ * Interface for accessing temp password history. The history is used for audit and rate limiting so
+ * a user cannot create unlimited temp passwords requests.
+ */
+public interface TempPasswordHistory {
+  int countRequestsFromAddress(InetAddress address);
+
+  void recordTempPasswordRequest(InetAddress address, String username);
+}

--- a/game-core/src/main/java/games/strategy/net/nio/ClientQuarantineConversation.java
+++ b/game-core/src/main/java/games/strategy/net/nio/ClientQuarantineConversation.java
@@ -39,6 +39,8 @@ public class ClientQuarantineConversation extends QuarantineConversation {
   private volatile boolean isClosed = false;
   @Getter private volatile String errorMessage;
 
+  @Getter private boolean passwordChangeRequired = false;
+
   public ClientQuarantineConversation(
       final IConnectionLogin login,
       final SocketChannel channel,
@@ -130,6 +132,12 @@ public class ClientQuarantineConversation extends QuarantineConversation {
           }
           localName = strings[0];
           serverName = strings[1];
+          if (strings.length > 2) {
+            passwordChangeRequired =
+                strings[2] != null
+                    && strings[2].equals(ServerQuarantineConversation.CHANGE_PASSWORD);
+          }
+
           step = Step.READ_ADDRESS;
           return Action.NONE;
         case READ_ADDRESS:

--- a/game-core/src/main/java/games/strategy/net/nio/ForgotPasswordConversation.java
+++ b/game-core/src/main/java/games/strategy/net/nio/ForgotPasswordConversation.java
@@ -1,0 +1,38 @@
+package games.strategy.net.nio;
+
+import com.google.common.annotations.VisibleForTesting;
+import games.strategy.net.TempPasswordHistory;
+import java.net.InetAddress;
+import java.util.function.Predicate;
+import javax.annotation.Nonnull;
+import lombok.Builder;
+
+/**
+ * A subsequence of server conversation to handle requests for password reset. Returns a magic
+ * string to indicate success or an error message.
+ */
+@Builder
+public class ForgotPasswordConversation {
+
+  public static final String TEMP_PASSWORD_GENERATED_RESPONSE = "password_reset";
+  @VisibleForTesting static final int MAX_TEMP_PASSWORD_REQUESTS_PER_DAY = 3;
+
+  @Nonnull private final Predicate<String> forgotPasswordModule;
+  @Nonnull private final TempPasswordHistory tempPasswordHistory;
+
+  String handle(final InetAddress requestingAddress, final String username) {
+    if (tempPasswordHistory.countRequestsFromAddress(requestingAddress)
+        >= MAX_TEMP_PASSWORD_REQUESTS_PER_DAY) {
+      return "Too many password reset attempts";
+    }
+
+    final String result =
+        forgotPasswordModule.test(username)
+            ? TEMP_PASSWORD_GENERATED_RESPONSE
+            : "Error, temp password not generated - check username";
+    if (result.equals(TEMP_PASSWORD_GENERATED_RESPONSE)) {
+      tempPasswordHistory.recordTempPasswordRequest(requestingAddress, username);
+    }
+    return result;
+  }
+}

--- a/game-core/src/main/java/games/strategy/net/nio/NioSocket.java
+++ b/game-core/src/main/java/games/strategy/net/nio/NioSocket.java
@@ -73,7 +73,7 @@ public class NioSocket implements ErrorReporter {
   }
 
   void unquarantine(final SocketChannel channel, final QuarantineConversation conversation) {
-    listener.socketUnqaurantined(channel, conversation);
+    listener.socketUnquarantined(channel, conversation);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/net/nio/NioSocketListener.java
+++ b/game-core/src/main/java/games/strategy/net/nio/NioSocketListener.java
@@ -10,7 +10,7 @@ public interface NioSocketListener {
    * This connection will leave quarantine. Messages on this channel will not be read until after
    * this method returns, allowing for setup of the channel.
    */
-  void socketUnqaurantined(SocketChannel channel, QuarantineConversation conversation);
+  void socketUnquarantined(SocketChannel channel, QuarantineConversation conversation);
 
   /** An error occurred on the channel and it was shut down. */
   void socketError(SocketChannel channel, Exception error);

--- a/game-core/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
+++ b/game-core/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
@@ -89,7 +89,8 @@ public class ServerQuarantineConversation extends QuarantineConversation {
           final Map<String, String> response = (Map<String, String>) serializable;
           String error = null;
           if (validator != null) {
-            if (response.containsKey(LobbyLoginResponseKeys.FORGOT_PASSWORD)) {
+            if (forgotPasswordConversation != null
+                && response.containsKey(LobbyLoginResponseKeys.FORGOT_PASSWORD)) {
               send(
                   forgotPasswordConversation.handle(channel.socket().getInetAddress(), remoteName));
               step = Step.ACK_ERROR;

--- a/game-core/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
+++ b/game-core/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
@@ -13,10 +13,17 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.logging.Level;
 import lombok.extern.java.Log;
+import org.triplea.lobby.common.login.LobbyLoginResponseKeys;
 
 /** Server-side implementation of {@link QuarantineConversation}. */
 @Log
 public class ServerQuarantineConversation extends QuarantineConversation {
+  /**
+   * Magic authentication error string to indicate temporary password was used to authenticate and
+   * password should be reset.
+   */
+  public static final String CHANGE_PASSWORD = "change_password";
+
   /*
    * Communication sequence
    * 1) server reads client name
@@ -42,16 +49,19 @@ public class ServerQuarantineConversation extends QuarantineConversation {
   private String remoteMac;
   private Map<String, String> challenge;
   private final ServerMessenger serverMessenger;
+  private final ForgotPasswordConversation forgotPasswordConversation;
 
   public ServerQuarantineConversation(
       final ILoginValidator validator,
       final SocketChannel channel,
       final NioSocket socket,
-      final ServerMessenger serverMessenger) {
+      final ServerMessenger serverMessenger,
+      final ForgotPasswordConversation forgotPasswordConversation) {
     this.validator = validator;
     this.socket = socket;
     this.channel = channel;
     this.serverMessenger = serverMessenger;
+    this.forgotPasswordConversation = forgotPasswordConversation;
   }
 
   public String getRemoteName() {
@@ -77,20 +87,30 @@ public class ServerQuarantineConversation extends QuarantineConversation {
         case CHALLENGE:
           @SuppressWarnings("unchecked")
           final Map<String, String> response = (Map<String, String>) serializable;
+          String error = null;
           if (validator != null) {
-            final String error =
-                Optional.ofNullable(
-                        validator.verifyConnection(
-                            challenge,
-                            response,
-                            remoteName,
-                            remoteMac,
-                            channel.socket().getRemoteSocketAddress()))
-                    .orElseGet(() -> PlayerNameValidation.serverSideValidate(remoteName));
-            send(error);
-            if (error != null) {
+            if (response.containsKey(LobbyLoginResponseKeys.FORGOT_PASSWORD)) {
+              send(
+                  forgotPasswordConversation.handle(channel.socket().getInetAddress(), remoteName));
               step = Step.ACK_ERROR;
               return Action.NONE;
+            } else {
+              error =
+                  Optional.ofNullable(
+                          validator.verifyConnection(
+                              challenge,
+                              response,
+                              remoteName,
+                              remoteMac,
+                              channel.socket().getRemoteSocketAddress()))
+                      .orElseGet(() -> PlayerNameValidation.serverSideValidate(remoteName));
+              if (error != null && !error.equals(CHANGE_PASSWORD)) {
+                step = Step.ACK_ERROR;
+                send(error);
+                return Action.NONE;
+              } else {
+                send(null);
+              }
             }
           } else {
             send(null);
@@ -101,7 +121,7 @@ public class ServerQuarantineConversation extends QuarantineConversation {
                     remoteName, channel.socket().getInetAddress(), serverMessenger.getNodes());
           }
           // send the node its assigned name and our name
-          send(new String[] {remoteName, serverMessenger.getLocalNode().getName()});
+          send(new String[] {remoteName, serverMessenger.getLocalNode().getName(), error});
           // send the node its and our address as we see it
           send(
               new InetSocketAddress[] {

--- a/game-core/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
+++ b/game-core/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
@@ -1,5 +1,6 @@
 package games.strategy.net.nio;
 
+import com.google.common.base.Preconditions;
 import games.strategy.engine.lobby.PlayerNameValidation;
 import games.strategy.net.ILoginValidator;
 import games.strategy.net.MessageHeader;
@@ -89,8 +90,11 @@ public class ServerQuarantineConversation extends QuarantineConversation {
           final Map<String, String> response = (Map<String, String>) serializable;
           String error = null;
           if (validator != null) {
-            if (forgotPasswordConversation != null
-                && response.containsKey(LobbyLoginResponseKeys.FORGOT_PASSWORD)) {
+            if (response.containsKey(LobbyLoginResponseKeys.FORGOT_PASSWORD)) {
+              Preconditions.checkState(
+                  forgotPasswordConversation != null,
+                  "Coding error, forgot password module must be set to support "
+                      + "the 'forgot password' feature.");
               send(
                   forgotPasswordConversation.handle(channel.socket().getInetAddress(), remoteName));
               step = Step.ACK_ERROR;

--- a/game-core/src/main/java/org/triplea/lobby/common/login/LobbyLoginResponseKeys.java
+++ b/game-core/src/main/java/org/triplea/lobby/common/login/LobbyLoginResponseKeys.java
@@ -9,6 +9,7 @@ public final class LobbyLoginResponseKeys {
   public static final String LOBBY_WATCHER_LOGIN = "LOBBY_WATCHER_LOGIN";
   public static final String REGISTER_NEW_USER = "REGISTER_USER";
   public static final String RSA_ENCRYPTED_PASSWORD = "RSAPWD";
+  public static final String FORGOT_PASSWORD = "FORGOT_PASSWORD";
 
   private LobbyLoginResponseKeys() {}
 }

--- a/game-core/src/main/java/org/triplea/lobby/common/login/RsaAuthenticator.java
+++ b/game-core/src/main/java/org/triplea/lobby/common/login/RsaAuthenticator.java
@@ -97,19 +97,6 @@ public final class RsaAuthenticator {
     }
   }
 
-  private static String encryptPassword(final String publicKeyString, final String password) {
-    try {
-      final PublicKey publicKey =
-          KeyFactory.getInstance(RSA)
-              .generatePublic(new X509EncodedKeySpec(Base64.getDecoder().decode(publicKeyString)));
-      final Cipher cipher = Cipher.getInstance(RSA_ECB_OAEPP);
-      cipher.init(Cipher.ENCRYPT_MODE, publicKey);
-      return Base64.getEncoder().encodeToString(cipher.doFinal(getHashedBytes(password)));
-    } catch (final GeneralSecurityException e) {
-      throw new IllegalStateException(e);
-    }
-  }
-
   /**
    * Returns UTF-8 encoded bytes of a "salted" SHA-512 hash of the given input string. See {@link
    * #hashPasswordWithSalt(String)} for more information.
@@ -149,15 +136,20 @@ public final class RsaAuthenticator {
   /**
    * Creates a response to the specified challenge for the lobby client to send to the lobby server.
    *
-   * @param challenge The challenge as a collection of properties.
+   * @param rsaPublicKey Public key string sent from server.
    * @param password The lobby client's password.
-   * @return The response as a collection of properties to be added to the message the lobby client
-   *     sends back to the lobby server.
+   * @return Encrypted password using provided rsa public key.
    */
-  public static Map<String, String> newResponse(
-      final Map<String, String> challenge, final String password) {
-    return Collections.singletonMap(
-        LobbyLoginResponseKeys.RSA_ENCRYPTED_PASSWORD,
-        encryptPassword(challenge.get(LobbyLoginChallengeKeys.RSA_PUBLIC_KEY), password));
+  public static String encrpytPassword(final String rsaPublicKey, final String password) {
+    try {
+      final PublicKey publicKey =
+          KeyFactory.getInstance(RSA)
+              .generatePublic(new X509EncodedKeySpec(Base64.getDecoder().decode(rsaPublicKey)));
+      final Cipher cipher = Cipher.getInstance(RSA_ECB_OAEPP);
+      cipher.init(Cipher.ENCRYPT_MODE, publicKey);
+      return Base64.getEncoder().encodeToString(cipher.doFinal(getHashedBytes(password)));
+    } catch (final GeneralSecurityException e) {
+      throw new IllegalStateException(e);
+    }
   }
 }

--- a/game-core/src/test/java/games/strategy/net/nio/ForgotPasswordConversationTest.java
+++ b/game-core/src/test/java/games/strategy/net/nio/ForgotPasswordConversationTest.java
@@ -1,0 +1,65 @@
+package games.strategy.net.nio;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import games.strategy.net.TempPasswordHistory;
+import java.net.InetAddress;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ForgotPasswordConversationTest {
+  private static final String USERNAME = "username";
+
+  @Mock private Predicate<String> forgotPasswordModule;
+  @Mock private TempPasswordHistory tempPasswordHistory;
+
+  @InjectMocks private ForgotPasswordConversation forgotPasswordConversation;
+
+  @Mock private InetAddress address;
+
+  @Test
+  void rejectIfLimitIsReached() {
+    when(tempPasswordHistory.countRequestsFromAddress(address))
+        .thenReturn(ForgotPasswordConversation.MAX_TEMP_PASSWORD_REQUESTS_PER_DAY);
+
+    final String result = forgotPasswordConversation.handle(address, USERNAME);
+
+    assertThat(result, is(not(ForgotPasswordConversation.TEMP_PASSWORD_GENERATED_RESPONSE)));
+
+    verify(forgotPasswordModule, never()).test(any());
+    verify(tempPasswordHistory, never()).recordTempPasswordRequest(any(), any());
+  }
+
+  @Test
+  void doNotRecordHistoryIfFailToGenerate() {
+    when(tempPasswordHistory.countRequestsFromAddress(address)).thenReturn(0);
+    when(forgotPasswordModule.test(USERNAME)).thenReturn(false);
+
+    final String result = forgotPasswordConversation.handle(address, USERNAME);
+
+    assertThat(result, is(not(ForgotPasswordConversation.TEMP_PASSWORD_GENERATED_RESPONSE)));
+    verify(tempPasswordHistory, never()).recordTempPasswordRequest(any(), any());
+  }
+
+  @Test
+  void verifySuccessCase() {
+    when(tempPasswordHistory.countRequestsFromAddress(address)).thenReturn(0);
+    when(forgotPasswordModule.test(USERNAME)).thenReturn(true);
+
+    final String result = forgotPasswordConversation.handle(address, USERNAME);
+
+    assertThat(result, is(ForgotPasswordConversation.TEMP_PASSWORD_GENERATED_RESPONSE));
+    verify(tempPasswordHistory).recordTempPasswordRequest(address, USERNAME);
+  }
+}

--- a/game-core/src/test/java/org/triplea/lobby/common/login/RsaAuthenticatorTest.java
+++ b/game-core/src/test/java/org/triplea/lobby/common/login/RsaAuthenticatorTest.java
@@ -42,8 +42,11 @@ final class RsaAuthenticatorTest {
       final Function<String, String> action = mock(Function.class);
 
       final Map<String, String> challenge = new HashMap<>(rsaAuthenticator.newChallenge());
-      final Map<String, String> response =
-          new HashMap<>(RsaAuthenticator.newResponse(challenge, password));
+      final Map<String, String> response = new HashMap<>();
+      response.put(
+          LobbyLoginResponseKeys.RSA_ENCRYPTED_PASSWORD,
+          RsaAuthenticator.encrpytPassword(
+              challenge.get(LobbyLoginChallengeKeys.RSA_PUBLIC_KEY), password));
       rsaAuthenticator.decryptPasswordForAction(response, action);
 
       verify(action).apply(RsaAuthenticator.hashPasswordWithSalt(password));

--- a/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/dao/TempPasswordDao.java
+++ b/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/dao/TempPasswordDao.java
@@ -12,7 +12,7 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 public interface TempPasswordDao {
   @SqlQuery(
       "select temp_password"
-          + " from user_temp_password t"
+          + " from temp_password_request t"
           + " join lobby_user lu on lu.id = t.lobby_user_id"
           + " where lu.username = :username"
           + "   and t.date_invalidated is null")
@@ -22,13 +22,13 @@ public interface TempPasswordDao {
   Optional<Integer> lookupUserIdByUsername(@Bind("username") String username);
 
   @SqlUpdate(
-      "insert into user_temp_password"
+      "insert into temp_password_request"
           + " (lobby_user_id, temp_password)"
           + " values (:userId, :password)")
   void insertPassword(@Bind("userId") int userId, @Bind("password") String password);
 
   @SqlUpdate(
-      "update user_temp_password"
+      "update temp_password_request"
           + " set date_invalidated = now()"
           + " where lobby_user_id = (select id from lobby_user where username = :username)"
           + "   and date_invalidated is null")

--- a/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/dao/TempPasswordDao.java
+++ b/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/dao/TempPasswordDao.java
@@ -10,11 +10,16 @@ import org.jdbi.v3.sqlobject.statement.SqlUpdate;
  * them with the 'forgot password' feature.
  */
 public interface TempPasswordDao {
+  String TEMP_PASSWORD_EXPIRATION = "1 day";
+
   @SqlQuery(
       "select temp_password"
           + " from temp_password_request t"
           + " join lobby_user lu on lu.id = t.lobby_user_id"
           + " where lu.username = :username"
+          + "   and t.date_created >  (now() - '"
+          + TEMP_PASSWORD_EXPIRATION
+          + "'::interval)"
           + "   and t.date_invalidated is null")
   Optional<String> fetchTempPassword(@Bind("username") String username);
 

--- a/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/dao/TempPasswordHistoryDao.java
+++ b/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/dao/TempPasswordHistoryDao.java
@@ -1,0 +1,40 @@
+package org.triplea.lobby.server.db.dao;
+
+import java.net.InetAddress;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+
+/**
+ * DAO for CRUD operations on temp password history table. A table that stores a history of requests
+ * for temporary passwords.
+ */
+public interface TempPasswordHistoryDao {
+
+  /**
+   * Returns the number of temp password requests made in the last day from a particular IP address.
+   */
+  @SqlQuery(
+      "select count(*)"
+          + " from temp_password_request_history"
+          + " where inetaddress = :inetAddress::inet"
+          + "   and date_created >  (now() - '1 day'::interval)")
+  int countRequestsFromAddress(@Bind("inetAddress") String address);
+
+  default int countRequestsFromAddress(InetAddress address) {
+    return countRequestsFromAddress(address.getHostAddress());
+  }
+
+  /**
+   * Records a temp password request being made from a given IP address and for a given username.
+   */
+  @SqlUpdate(
+      "insert into temp_password_request_history(inetaddress,  username)"
+          + " values(:inetaddress::inet, :username)")
+  void recordTempPasswordRequest(
+      @Bind("inetaddress") String address, @Bind("username") String username);
+
+  default void recordTempPasswordRequest(InetAddress address, String username) {
+    recordTempPasswordRequest(address.getHostAddress(), username);
+  }
+}

--- a/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/TempPasswordDaoTest.java
+++ b/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/TempPasswordDaoTest.java
@@ -29,8 +29,10 @@ class TempPasswordDaoTest {
 
   @Test
   void fetchTempPassword() {
-    assertThat(tempPasswordDao.fetchTempPassword(USERNAME), isPresentAndIs(PASSWORD));
+    assertThat(tempPasswordDao.fetchTempPassword(USERNAME), isEmpty());
     assertThat(tempPasswordDao.fetchTempPassword("DNE"), isEmpty());
+    tempPasswordDao.insertTempPassword(USERNAME, PASSWORD);
+    assertThat(tempPasswordDao.fetchTempPassword(USERNAME), isPresentAndIs(PASSWORD));
   }
 
   @Test
@@ -52,6 +54,7 @@ class TempPasswordDaoTest {
 
   @Test
   void invalidateTempPasswordsForMissingNameDoesNothing() {
+    tempPasswordDao.insertTempPassword(USERNAME, PASSWORD);
     assertThat(tempPasswordDao.fetchTempPassword(USERNAME), isPresentAndIs(PASSWORD));
     tempPasswordDao.invalidateTempPasswords("DNE");
     assertThat(tempPasswordDao.fetchTempPassword(USERNAME), isPresentAndIs(PASSWORD));

--- a/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/TempPasswordHistoryDaoTest.java
+++ b/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/TempPasswordHistoryDaoTest.java
@@ -1,0 +1,42 @@
+package org.triplea.lobby.server.db.dao;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.junit5.DBUnitExtension;
+import java.net.InetAddress;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.triplea.lobby.server.db.JdbiDatabase;
+import org.triplea.test.common.Integration;
+
+@Integration
+@ExtendWith(DBUnitExtension.class)
+@DataSet("temp_password_history/sample.yml")
+class TempPasswordHistoryDaoTest {
+
+  private static final String USERNAME = "username";
+
+  private final TempPasswordHistoryDao tempPasswordDao =
+      JdbiDatabase.newConnection().onDemand(TempPasswordHistoryDao.class);
+
+  @Test
+  void verifyCountAndInsert() throws Exception {
+
+    final InetAddress localhost = InetAddress.getLocalHost();
+    assertThat(tempPasswordDao.countRequestsFromAddress(localhost), is(0));
+
+    tempPasswordDao.recordTempPasswordRequest(localhost, USERNAME);
+    assertThat(tempPasswordDao.countRequestsFromAddress(localhost), is(1));
+
+    tempPasswordDao.recordTempPasswordRequest(localhost, USERNAME);
+    assertThat(tempPasswordDao.countRequestsFromAddress(localhost), is(2));
+
+    tempPasswordDao.recordTempPasswordRequest(localhost, "other-user");
+    assertThat(tempPasswordDao.countRequestsFromAddress(localhost), is(3));
+
+    final InetAddress otherAddress = InetAddress.getByName("127.0.0.2");
+    assertThat(tempPasswordDao.countRequestsFromAddress(otherAddress), is(0));
+  }
+}

--- a/lobby-db-dao/src/test/resources/datasets/moderator_api_key/select.yml
+++ b/lobby-db-dao/src/test/resources/datasets/moderator_api_key/select.yml
@@ -37,4 +37,4 @@ moderator_api_key:
 
 moderator_action_history:
 moderator_single_use_key:
-user_temp_password:
+temp_password_request:

--- a/lobby-db-dao/src/test/resources/datasets/moderator_audit/history-select.yml
+++ b/lobby-db-dao/src/test/resources/datasets/moderator_audit/history-select.yml
@@ -1,6 +1,6 @@
 moderator_api_key:
 moderator_single_use_key:
-user_temp_password:
+temp_password_request:
 
 lobby_user:
   - id: 800000

--- a/lobby-db-dao/src/test/resources/datasets/moderator_audit/pre-insert.yml
+++ b/lobby-db-dao/src/test/resources/datasets/moderator_audit/pre-insert.yml
@@ -1,7 +1,7 @@
 moderator_api_key:
 moderator_single_use_key:
 moderator_action_history:
-user_temp_password:
+temp_password_request:
 
 lobby_user:
   - id: 900000

--- a/lobby-db-dao/src/test/resources/datasets/moderator_single_use_key/empty.yml
+++ b/lobby-db-dao/src/test/resources/datasets/moderator_single_use_key/empty.yml
@@ -8,4 +8,4 @@ lobby_user:
 moderator_single_use_key:
 moderator_action_history:
 moderator_api_key:
-user_temp_password:
+temp_password_request:

--- a/lobby-db-dao/src/test/resources/datasets/moderator_single_use_key/select.yml
+++ b/lobby-db-dao/src/test/resources/datasets/moderator_single_use_key/select.yml
@@ -23,4 +23,4 @@ moderator_single_use_key:
 
 moderator_action_history:
 moderator_api_key:
-user_temp_password:
+temp_password_request:

--- a/lobby-db-dao/src/test/resources/datasets/moderators/select.yml
+++ b/lobby-db-dao/src/test/resources/datasets/moderators/select.yml
@@ -34,4 +34,4 @@ moderator_single_use_key:
     api_key: b109f3bbbc244eb82441917ed06d618b9008dd09b3befd1b5e07394c706a8bb980b1d7785e5976ec049b46df5f1326af5a2ea6d103fd07c95385ffab0cacbc86
 
 moderator_action_history:
-user_temp_password:
+temp_password_request:

--- a/lobby-db-dao/src/test/resources/datasets/temp_password/sample.yml
+++ b/lobby-db-dao/src/test/resources/datasets/temp_password/sample.yml
@@ -6,7 +6,7 @@ lobby_user:
     admin: false
     super_mod: false
 
-user_temp_password:
+temp_password_request:
   - lobby_user_id: 500000
     temp_password: invalid
     date_created: 2016-01-01 23:59:20.0
@@ -15,6 +15,6 @@ user_temp_password:
     temp_password: temp
     date_created: 2016-01-01 23:59:20.0
 
-
+moderator_api_key:
 moderator_action_history:
 moderator_single_use_key:

--- a/lobby-db-dao/src/test/resources/datasets/temp_password_history/sample.yml
+++ b/lobby-db-dao/src/test/resources/datasets/temp_password_history/sample.yml
@@ -1,0 +1,5 @@
+temp_password_request_history:
+  - id: 4000
+    inetaddress: 127.0.0.1
+    username: user
+    date_created: 2016-01-01 23:59:20.0

--- a/lobby-db-dao/src/test/resources/datasets/user_lookup/select.yml
+++ b/lobby-db-dao/src/test/resources/datasets/user_lookup/select.yml
@@ -9,4 +9,4 @@ lobby_user:
 moderator_api_key:
 moderator_action_history:
 moderator_single_use_key:
-user_temp_password:
+temp_password_request:

--- a/lobby-db/src/main/resources/db/migration/V1.10.00.20190812__temp_password.sql
+++ b/lobby-db/src/main/resources/db/migration/V1.10.00.20190812__temp_password.sql
@@ -1,4 +1,4 @@
-create table user_temp_password
+create table temp_password_request
 (
     id               serial primary key,
     lobby_user_id    int         not null references lobby_user (id),
@@ -7,15 +7,15 @@ create table user_temp_password
     date_invalidated timestamptz
 );
 
-alter table user_temp_password
+alter table temp_password_request
     owner to lobby_user;
 
-comment on table user_temp_password is
+comment on table temp_password_request is
     $$Table that stores temporary passwords issued to players. They are intended to be single use.$$;
-comment on column user_temp_password.id is 'synthetic PK column';
-comment on column user_temp_password.lobby_user_id is 'FK to lobby_user table.';
-comment on column user_temp_password.temp_password is 'Temp password value created for user.';
-comment on column user_temp_password.date_created is 'Timestamp of when the ban temporary password was created.';
-comment on column user_temp_password.date_invalidated is
+comment on column temp_password_request.id is 'synthetic PK column';
+comment on column temp_password_request.lobby_user_id is 'FK to lobby_user table.';
+comment on column temp_password_request.temp_password is 'Temp password value created for user.';
+comment on column temp_password_request.date_created is 'Timestamp of when the ban temporary password was created.';
+comment on column temp_password_request.date_invalidated is
     $$Timestamp of when the temporary password is either used or marked invalid.
     A temp password can be marked as invalid if multiple are issued.$$

--- a/lobby-db/src/main/resources/db/migration/V1.10.00.20190815__temp_password_audit.sql
+++ b/lobby-db/src/main/resources/db/migration/V1.10.00.20190815__temp_password_audit.sql
@@ -1,0 +1,20 @@
+create table temp_password_request_history
+(
+    id           serial primary key,
+    inetaddress  inet        not null,
+    username     varchar(40) not null,
+    date_created timestamptz not null default now()
+);
+
+alter table temp_password_request_history
+    owner to lobby_user;
+
+comment on table temp_password_request_history is
+    $$Table that stores requests for temporary passwords for audit purposes. This will let us rate limit requests and
+    prevent a single player from spamming email to many userse.$$;
+comment on column temp_password_request_history.id is 'synthetic PK column';
+comment on column temp_password_request_history.inetaddress is 'IP of the address making the temp password request.';
+comment on column temp_password_request_history.username is 'The requested username for a temp password.';
+comment on column temp_password_request_history.date_created is 'Timestamp of when the temp password request is made';
+
+create index temp_password_request_history_inet on temp_password_request_history (inetaddress);

--- a/lobby/.eclipse/LobbyRunner.launch
+++ b/lobby/.eclipse/LobbyRunner.launch
@@ -6,6 +6,9 @@
 <listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
 <listEntry value="1"/>
 </listAttribute>
+<mapAttribute key="org.eclipse.debug.core.environmentVariables">
+<mapEntry key="LOCAL_DEV" value="true"/>
+</mapAttribute>
 <stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.buildship.core.classpathprovider"/>
 <stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value="org.triplea.lobby.server.LobbyRunner"/>
 <stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="lobby"/>

--- a/lobby/build.gradle
+++ b/lobby/build.gradle
@@ -12,6 +12,8 @@ dependencies {
     implementation project(':java-extras')
     implementation project(':game-core')
     implementation project(':lobby-db-dao')
+
+    implementation 'javax.mail:mail:1.5.0-b01'
     implementation "org.mindrot:jbcrypt:$jbcryptVersion"
     implementation 'org.jdbi:jdbi3-core:3.8.2'
     implementation 'org.jdbi:jdbi3-sqlobject:3.8.2'

--- a/lobby/build.gradle
+++ b/lobby/build.gradle
@@ -13,7 +13,7 @@ dependencies {
     implementation project(':game-core')
     implementation project(':lobby-db-dao')
 
-    implementation 'javax.mail:mail:1.5.0-b01'
+    implementation 'com.sun.mail:javax.mail:1.6.2'
     implementation "org.mindrot:jbcrypt:$jbcryptVersion"
     implementation 'org.jdbi:jdbi3-core:3.8.2'
     implementation 'org.jdbi:jdbi3-sqlobject:3.8.2'

--- a/lobby/src/main/java/org/triplea/lobby/server/EnvironmentVariable.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/EnvironmentVariable.java
@@ -6,11 +6,18 @@ import lombok.AllArgsConstructor;
 /** Class that represent OS environment variable keys with default values. */
 @AllArgsConstructor
 public enum EnvironmentVariable {
-  PORT("3304");
+  PORT("3304"),
+
+  /** Flag to indicate the lobby is running locally on a developer machine. */
+  LOCAL_DEV("false");
 
   private final String defaultValue;
 
   public String getValue() {
     return Optional.ofNullable(System.getenv(name())).orElse(defaultValue);
+  }
+
+  public boolean getBoolean() {
+    return Boolean.parseBoolean(getValue());
   }
 }

--- a/lobby/src/main/java/org/triplea/lobby/server/LobbyServer.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/LobbyServer.java
@@ -6,15 +6,23 @@ import games.strategy.net.DefaultObjectStreamFactory;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.Messengers;
 import games.strategy.net.ServerMessenger;
+import games.strategy.net.TempPasswordHistory;
+import games.strategy.net.nio.ForgotPasswordConversation;
 import games.strategy.sound.ClipPlayer;
 import java.io.IOException;
+import java.net.InetAddress;
 import org.mindrot.jbcrypt.BCrypt;
 import org.triplea.lobby.common.ILobbyGameBroadcaster;
 import org.triplea.lobby.common.LobbyConstants;
 import org.triplea.lobby.common.login.RsaAuthenticator;
 import org.triplea.lobby.server.config.LobbyConfiguration;
+import org.triplea.lobby.server.db.JdbiDatabase;
+import org.triplea.lobby.server.db.dao.TempPasswordDao;
+import org.triplea.lobby.server.db.dao.TempPasswordHistoryDao;
 import org.triplea.lobby.server.login.FailedLoginThrottle;
 import org.triplea.lobby.server.login.LobbyLoginValidator;
+import org.triplea.lobby.server.login.forgot.password.create.ForgotPasswordModuleFactory;
+import org.triplea.lobby.server.login.forgot.password.verify.TempPasswordVerification;
 
 /**
  * A lobby server.
@@ -44,12 +52,38 @@ final class LobbyServer {
             lobbyConfiguration.getPort(),
             new DefaultObjectStreamFactory());
     final Messengers messengers = new Messengers(server);
+
+    final var tempPasswordDao = JdbiDatabase.newConnection().onDemand(TempPasswordDao.class);
+
     server.setLoginValidator(
         new LobbyLoginValidator(
             lobbyConfiguration.getDatabaseDao(),
             new RsaAuthenticator(),
             BCrypt::gensalt,
-            new FailedLoginThrottle()));
+            new FailedLoginThrottle(),
+            new TempPasswordVerification(tempPasswordDao),
+            tempPasswordDao));
+
+    final TempPasswordHistoryDao tempPasswordHistoryDao =
+        JdbiDatabase.newConnection().onDemand(TempPasswordHistoryDao.class);
+
+    server.setForgotPasswordConversation(
+        ForgotPasswordConversation.builder()
+            .forgotPasswordModule(ForgotPasswordModuleFactory.buildForgotPasswordModule())
+            .tempPasswordHistory(
+                new TempPasswordHistory() {
+                  @Override
+                  public int countRequestsFromAddress(final InetAddress address) {
+                    return tempPasswordHistoryDao.countRequestsFromAddress(address);
+                  }
+
+                  @Override
+                  public void recordTempPasswordRequest(
+                      final InetAddress address, final String username) {
+                    tempPasswordHistoryDao.recordTempPasswordRequest(address, username);
+                  }
+                })
+            .build());
 
     new UserManager(lobbyConfiguration.getDatabaseDao()).register(messengers);
 

--- a/lobby/src/main/java/org/triplea/lobby/server/UserManager.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/UserManager.java
@@ -37,7 +37,8 @@ final class UserManager implements IUserManager {
 
     final String validationError =
         Optional.ofNullable(PlayerNameValidation.validate(username))
-            .orElseGet(() -> PlayerEmailValidation.validate(emailAddress));
+            .orElseGet(
+                () -> emailAddress == null ? null : PlayerEmailValidation.validate(emailAddress));
 
     if (validationError != null) {
       return validationError;

--- a/lobby/src/main/java/org/triplea/lobby/server/login/forgot/password/create/ForgotPasswordModule.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/login/forgot/password/create/ForgotPasswordModule.java
@@ -1,0 +1,36 @@
+package org.triplea.lobby.server.login.forgot.password.create;
+
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import javax.annotation.Nonnull;
+import lombok.Builder;
+
+/**
+ * Module to orchestrate generating a temporary password for a user, storing that password in the
+ * temp password table and sending that password in an email to the user.
+ */
+@Builder
+public final class ForgotPasswordModule implements Predicate<String> {
+  @Nonnull private final Function<String, Optional<String>> emailLookup;
+  @Nonnull private final BiConsumer<String, String> passwordEmailSender;
+  @Nonnull private final PasswordGenerator passwordGenerator;
+  @Nonnull private final TempPasswordPersistence tempPasswordPersistence;
+
+  @Override
+  public boolean test(final String username) {
+    final Optional<String> email = emailLookup.apply(username);
+    if (email.isEmpty()) {
+      return false;
+    }
+
+    final String generatedPassword = passwordGenerator.generatePassword();
+
+    if (!tempPasswordPersistence.storeTempPassword(username, generatedPassword)) {
+      return false;
+    }
+    passwordEmailSender.accept(email.get(), generatedPassword);
+    return true;
+  }
+}

--- a/lobby/src/main/java/org/triplea/lobby/server/login/forgot/password/create/ForgotPasswordModuleFactory.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/login/forgot/password/create/ForgotPasswordModuleFactory.java
@@ -1,0 +1,29 @@
+package org.triplea.lobby.server.login.forgot.password.create;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.function.BiConsumer;
+import java.util.function.Predicate;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.triplea.lobby.server.db.JdbiDatabase;
+import org.triplea.lobby.server.db.dao.TempPasswordDao;
+
+/** Constructs a {@code ForgotPasswordModule} with dependencies. */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ForgotPasswordModuleFactory {
+
+  public static Predicate<String> buildForgotPasswordModule() {
+    return buildForgotPasswordModule(new PasswordEmailSender());
+  }
+
+  @VisibleForTesting
+  static Predicate<String> buildForgotPasswordModule(
+      final BiConsumer<String, String> passwordEmailSender) {
+    return ForgotPasswordModule.builder()
+        .emailLookup(JdbiDatabase.newConnection().onDemand(TempPasswordDao.class)::lookupUserEmail)
+        .passwordEmailSender(passwordEmailSender)
+        .passwordGenerator(new PasswordGenerator())
+        .tempPasswordPersistence(TempPasswordPersistence.newInstance())
+        .build();
+  }
+}

--- a/lobby/src/main/java/org/triplea/lobby/server/login/forgot/password/create/PasswordEmailSender.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/login/forgot/password/create/PasswordEmailSender.java
@@ -10,6 +10,7 @@ import javax.mail.Transport;
 import javax.mail.internet.InternetAddress;
 import javax.mail.internet.MimeMessage;
 import org.triplea.lobby.server.EnvironmentVariable;
+import org.triplea.lobby.server.db.dao.TempPasswordDao;
 
 /** Sends a temporary password to a target user. */
 class PasswordEmailSender implements BiConsumer<String, String> {
@@ -43,7 +44,8 @@ class PasswordEmailSender implements BiConsumer<String, String> {
     return "Your TripleA temporary password is: "
         + generatedPassword
         + "\nUse this password to login to the TripleA lobby."
-        + "\nThis password may only be used once."
+        + "\nThis password may only be used once and will expire in "
+        + TempPasswordDao.TEMP_PASSWORD_EXPIRATION
         + "\nAfter login you will be prompted to create a new password";
   }
 

--- a/lobby/src/main/java/org/triplea/lobby/server/login/forgot/password/create/PasswordEmailSender.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/login/forgot/password/create/PasswordEmailSender.java
@@ -1,0 +1,57 @@
+package org.triplea.lobby.server.login.forgot.password.create;
+
+import java.io.UnsupportedEncodingException;
+import java.util.Properties;
+import java.util.function.BiConsumer;
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.Session;
+import javax.mail.Transport;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+import org.triplea.lobby.server.EnvironmentVariable;
+
+/** Sends a temporary password to a target user. */
+class PasswordEmailSender implements BiConsumer<String, String> {
+  private static final String FROM = "no-reply@triplea-game.org";
+
+  @Override
+  public void accept(final String email, final String generatedPassword) {
+    if (EnvironmentVariable.LOCAL_DEV.getBoolean()) {
+      // do not send emails from local dev.
+      return;
+    }
+
+    final Properties props = new Properties();
+    final Session session = Session.getDefaultInstance(props, null);
+
+    try {
+      final Message message = new MimeMessage(session);
+      message.setFrom(new InternetAddress(FROM, "no-reply"));
+      message.addRecipient(Message.RecipientType.TO, new InternetAddress(email, email));
+      message.setSubject("Temporary Password");
+      message.setText(createMailBody(generatedPassword));
+      Transport.send(message);
+    } catch (final MessagingException e) {
+      throw new EmailSendFailure(e);
+    } catch (final UnsupportedEncodingException e) {
+      throw new AssertionError(e);
+    }
+  }
+
+  private static String createMailBody(final String generatedPassword) {
+    return "Your TripleA temporary password is: "
+        + generatedPassword
+        + "\nUse this password to login to the TripleA lobby."
+        + "\nThis password may only be used once."
+        + "\nAfter login you will be prompted to create a new password";
+  }
+
+  private static class EmailSendFailure extends RuntimeException {
+    private static final long serialVersionUID = -7190784731567635418L;
+
+    EmailSendFailure(final Exception e) {
+      super("Failed to send email", e);
+    }
+  }
+}

--- a/lobby/src/main/java/org/triplea/lobby/server/login/forgot/password/create/PasswordGenerator.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/login/forgot/password/create/PasswordGenerator.java
@@ -1,0 +1,13 @@
+package org.triplea.lobby.server.login.forgot.password.create;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.UUID;
+
+/** Generates a plaintext password to be stored as a temporary password. */
+class PasswordGenerator {
+  @VisibleForTesting static final int PASSWORD_LENGTH = 18;
+
+  String generatePassword() {
+    return UUID.randomUUID().toString().substring(0, PASSWORD_LENGTH);
+  }
+}

--- a/lobby/src/main/java/org/triplea/lobby/server/login/forgot/password/create/TempPasswordPersistence.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/login/forgot/password/create/TempPasswordPersistence.java
@@ -1,0 +1,40 @@
+package org.triplea.lobby.server.login.forgot.password.create;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import org.mindrot.jbcrypt.BCrypt;
+import org.triplea.lobby.common.login.RsaAuthenticator;
+import org.triplea.lobby.server.db.HashedPassword;
+import org.triplea.lobby.server.db.JdbiDatabase;
+import org.triplea.lobby.server.db.dao.TempPasswordDao;
+
+/**
+ * Stores a user temporary password in database. When we generate a new temporary password, all
+ * existing temporary passwords are invalidated so that a user only has one temp password at a time.
+ */
+@AllArgsConstructor(
+    access = AccessLevel.PACKAGE,
+    onConstructor_ = {@VisibleForTesting})
+class TempPasswordPersistence {
+  @Nonnull private final TempPasswordDao tempPasswordDao;
+  @Nonnull private final Function<String, HashedPassword> passwordHasher;
+  @Nonnull private final Function<HashedPassword, String> hashedPasswordBcrypter;
+
+  static TempPasswordPersistence newInstance() {
+    return new TempPasswordPersistence(
+        JdbiDatabase.newConnection().onDemand(TempPasswordDao.class),
+        pass -> new HashedPassword(RsaAuthenticator.hashPasswordWithSalt(pass)),
+        hashedPass -> BCrypt.hashpw(hashedPass.value, BCrypt.gensalt()));
+  }
+
+  boolean storeTempPassword(final String username, final String generatedPassword) {
+    tempPasswordDao.invalidateTempPasswords(username);
+
+    final HashedPassword hashedPass = passwordHasher.apply(generatedPassword);
+    final String tempPass = hashedPasswordBcrypter.apply(hashedPass);
+    return tempPasswordDao.insertTempPassword(username, tempPass);
+  }
+}

--- a/lobby/src/main/java/org/triplea/lobby/server/login/forgot/password/verify/TempPasswordVerification.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/login/forgot/password/verify/TempPasswordVerification.java
@@ -1,0 +1,36 @@
+package org.triplea.lobby.server.login.forgot.password.verify;
+
+import lombok.AllArgsConstructor;
+import org.mindrot.jbcrypt.BCrypt;
+import org.triplea.lobby.server.db.dao.TempPasswordDao;
+
+/**
+ * Module to verify if a users temporary password is valid, if so then invalidates the temporary
+ * password so that it cannot be used again.
+ */
+@AllArgsConstructor
+public class TempPasswordVerification {
+
+  private final TempPasswordDao tempPasswordDao;
+
+  /**
+   * Validates if a given password matches a temp password for a given user. If the password is
+   * matched, it is invalidated (single-use).
+   *
+   * @param username Username whose password will be checked.
+   * @param hashedPassword Candidate temporary password.
+   * @return True if the hashedPassword matches a temp password for the given user.
+   */
+  public boolean checkTempPassword(final String username, final String hashedPassword) {
+    final String tempPassword = tempPasswordDao.fetchTempPassword(username).orElse(null);
+    if (tempPassword == null) {
+      return false;
+    }
+
+    if (!BCrypt.checkpw(hashedPassword, tempPassword)) {
+      return false;
+    }
+    tempPasswordDao.invalidateTempPasswords(username);
+    return true;
+  }
+}

--- a/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
@@ -11,6 +11,7 @@ import games.strategy.net.MacFinder;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -157,14 +158,11 @@ class LobbyLoginValidatorIntegrationTest {
     assertError(
         generateChallenge(user, null)
             .apply(
-                challenge -> {
-                  final Map<String, String> map = new HashMap<>();
-                  map.put(
-                      LobbyLoginResponseKeys.RSA_ENCRYPTED_PASSWORD,
-                      RsaAuthenticator.encrpytPassword(
-                          challenge.get(LobbyLoginChallengeKeys.RSA_PUBLIC_KEY), "wrong"));
-                  return map;
-                }),
+                challenge ->
+                    Collections.singletonMap(
+                        LobbyLoginResponseKeys.RSA_ENCRYPTED_PASSWORD,
+                        RsaAuthenticator.encrpytPassword(
+                            challenge.get(LobbyLoginChallengeKeys.RSA_PUBLIC_KEY), "wrong"))),
         "password");
     // with a non existent user
     assertError(generateChallenge(null).apply(challenge -> response), "user");

--- a/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
@@ -11,7 +11,6 @@ import games.strategy.net.MacFinder;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.function.Function;
@@ -158,11 +157,14 @@ class LobbyLoginValidatorIntegrationTest {
     assertError(
         generateChallenge(user, null)
             .apply(
-                challenge ->
-                    Collections.singletonMap(
-                        LobbyLoginResponseKeys.RSA_ENCRYPTED_PASSWORD,
-                        RsaAuthenticator.encrpytPassword(
-                            challenge.get(LobbyLoginChallengeKeys.RSA_PUBLIC_KEY), "wrong"))),
+                challenge -> {
+                  final Map<String, String> map = new HashMap<>();
+                  map.put(
+                      LobbyLoginResponseKeys.RSA_ENCRYPTED_PASSWORD,
+                      RsaAuthenticator.encrpytPassword(
+                          challenge.get(LobbyLoginChallengeKeys.RSA_PUBLIC_KEY), "wrong"));
+                  return map;
+                }),
         "password");
     // with a non existent user
     assertError(generateChallenge(null).apply(challenge -> response), "user");

--- a/lobby/src/test/java/org/triplea/lobby/server/login/forgot/password/create/ForgotPasswordModuleIntegrationTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/login/forgot/password/create/ForgotPasswordModuleIntegrationTest.java
@@ -1,0 +1,29 @@
+package org.triplea.lobby.server.login.forgot.password.create;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.junit5.DBUnitExtension;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.triplea.test.common.Integration;
+
+@ExtendWith(DBUnitExtension.class)
+@Integration
+@DataSet("forgot_password/user_data.yml")
+class ForgotPasswordModuleIntegrationTest {
+  private final Predicate<String> module =
+      ForgotPasswordModuleFactory.buildForgotPasswordModule((name, password) -> {});
+
+  @Test
+  void userDoesNotExist() {
+    assertThat(module.test("user_DNE"), is(false));
+  }
+
+  @Test
+  void userExists() {
+    assertThat(module.test("user"), is(true));
+  }
+}

--- a/lobby/src/test/java/org/triplea/lobby/server/login/forgot/password/create/ForgotPasswordModuleTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/login/forgot/password/create/ForgotPasswordModuleTest.java
@@ -1,0 +1,63 @@
+package org.triplea.lobby.server.login.forgot.password.create;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import java.util.function.Function;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ForgotPasswordModuleTest {
+  private static final String PASSWORD = "temp";
+  private static final String USERNAME = "user";
+  private static final String EMAIL = "email";
+
+  @Mock private Function<String, Optional<String>> emailLookup;
+  @Mock private PasswordEmailSender passwordEmailSender;
+  @Mock private PasswordGenerator passwordGenerator;
+  @Mock private TempPasswordPersistence tempPasswordPersistence;
+
+  @InjectMocks private ForgotPasswordModule forgotPasswordModule;
+
+  @Test
+  void changePasswordUsernameNotFound() {
+    when(emailLookup.apply(USERNAME)).thenReturn(Optional.of(EMAIL));
+    when(passwordGenerator.generatePassword()).thenReturn(PASSWORD);
+    when(tempPasswordPersistence.storeTempPassword(USERNAME, PASSWORD)).thenReturn(false);
+
+    assertThat(forgotPasswordModule.test(USERNAME), is(false));
+
+    verify(passwordEmailSender, never()).accept(any(), any());
+  }
+
+  @Test
+  void userWithNoEmail() {
+    when(emailLookup.apply(USERNAME)).thenReturn(Optional.empty());
+
+    assertThat(forgotPasswordModule.test(USERNAME), is(false));
+
+    verify(passwordGenerator, never()).generatePassword();
+    verify(tempPasswordPersistence, never()).storeTempPassword(any(), any());
+    verify(passwordEmailSender, never()).accept(any(), any());
+  }
+
+  @Test
+  void changePasswordSuccess() {
+    when(emailLookup.apply(USERNAME)).thenReturn(Optional.of(EMAIL));
+    when(passwordGenerator.generatePassword()).thenReturn(PASSWORD);
+    when(tempPasswordPersistence.storeTempPassword(USERNAME, PASSWORD)).thenReturn(true);
+
+    assertThat(forgotPasswordModule.test(USERNAME), is(true));
+
+    verify(passwordEmailSender).accept(EMAIL, PASSWORD);
+  }
+}

--- a/lobby/src/test/java/org/triplea/lobby/server/login/forgot/password/create/PasswordGeneratorTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/login/forgot/password/create/PasswordGeneratorTest.java
@@ -1,0 +1,33 @@
+package org.triplea.lobby.server.login.forgot.password.create;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class PasswordGeneratorTest {
+
+  @Test
+  void verifyPasswordLength() {
+    assertThat(
+        new PasswordGenerator().generatePassword().length(), is(PasswordGenerator.PASSWORD_LENGTH));
+  }
+
+  /**
+   * Generate a password, check we do not have it in a set, add the password to the set and repeat
+   * many times.
+   */
+  @Test
+  void verifyPasswordChanges() {
+    final var passwordGenerator = new PasswordGenerator();
+
+    final Set<String> strings = new HashSet<>();
+    for (int i = 0; i < 1000; i++) {
+      final String generated = passwordGenerator.generatePassword();
+      assertThat(strings.contains(generated), is(false));
+      strings.add(generated);
+    }
+  }
+}

--- a/lobby/src/test/java/org/triplea/lobby/server/login/forgot/password/create/PasswordGeneratorTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/login/forgot/password/create/PasswordGeneratorTest.java
@@ -26,7 +26,11 @@ class PasswordGeneratorTest {
     final Set<String> strings = new HashSet<>();
     for (int i = 0; i < 1000; i++) {
       final String generated = passwordGenerator.generatePassword();
-      assertThat(strings.contains(generated), is(false));
+      assertThat(
+          "If this test fails, DO NOT IGNORE IT! Instead increase the length of the generated "
+              + "temporary password",
+          strings.contains(generated),
+          is(false));
       strings.add(generated);
     }
   }

--- a/lobby/src/test/java/org/triplea/lobby/server/login/forgot/password/create/TempPasswordPersistenceTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/login/forgot/password/create/TempPasswordPersistenceTest.java
@@ -1,0 +1,59 @@
+package org.triplea.lobby.server.login.forgot.password.create;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.lobby.server.db.HashedPassword;
+import org.triplea.lobby.server.db.dao.TempPasswordDao;
+
+@ExtendWith(MockitoExtension.class)
+class TempPasswordPersistenceTest {
+  private static final String USERNAME = "user";
+  private static final String PASSWORD = "pass";
+  private static final HashedPassword HASHED_PASS = new HashedPassword("hashed");
+  private static final String BCRYPTED_PASS = "bcrypted";
+
+  @Mock private TempPasswordDao tempPasswordDao;
+  @Mock private Function<String, HashedPassword> passwordHasher;
+  @Mock private Function<HashedPassword, String> hashedPasswordBcrypter;
+
+  private TempPasswordPersistence tempPasswordPersistence;
+
+  @BeforeEach
+  void setup() {
+    tempPasswordPersistence =
+        new TempPasswordPersistence(tempPasswordDao, passwordHasher, hashedPasswordBcrypter);
+  }
+
+  @Test
+  void storeTempPasswordUsernameNotFound() {
+    givenInsertResult(false);
+
+    assertThat(tempPasswordPersistence.storeTempPassword(USERNAME, PASSWORD), is(false));
+
+    verify(tempPasswordDao).invalidateTempPasswords(USERNAME);
+  }
+
+  private void givenInsertResult(final boolean result) {
+    when(passwordHasher.apply(PASSWORD)).thenReturn(HASHED_PASS);
+    when(hashedPasswordBcrypter.apply(HASHED_PASS)).thenReturn(BCRYPTED_PASS);
+    when(tempPasswordDao.insertTempPassword(USERNAME, BCRYPTED_PASS)).thenReturn(result);
+  }
+
+  @Test
+  void storeTempPassword() {
+    givenInsertResult(true);
+
+    assertThat(tempPasswordPersistence.storeTempPassword(USERNAME, PASSWORD), is(true));
+
+    verify(tempPasswordDao).invalidateTempPasswords(USERNAME);
+  }
+}

--- a/lobby/src/test/resources/datasets/forgot_password/user_data.yml
+++ b/lobby/src/test/resources/datasets/forgot_password/user_data.yml
@@ -1,0 +1,12 @@
+lobby_user:
+  - id: 1234000
+    username: user
+    password: 12345678901234567890123456
+    email: email
+    admin: false
+    super_mod: false
+
+moderator_api_key:
+moderator_action_history:
+moderator_single_use_key:
+temp_password_request:


### PR DESCRIPTION
## Overview:
Update lobby login prompt to have a 'forgot password' button. Clicking that a user can enter a username (subject to rate limit of three times a day) to then request a temporary password be sent to them (by username) via email. The email contains a temporary password that can then be used to login. After logging in with a temporary password, user is prompted to change password.

## Changes:
- Add a 'Forgot Password' button to the lobby login pop-up
- Add table 'temp_password_request_history' to keep track of temporary passwords requested. If user reaches a limit then no new temporary passwords will be issued.
- Add lobby logic to generate a temporary password and store it in temp password table
- Add lobby logic to check password supplied against temporary password table
- Add magic return value to indicate a temorary password was used for login, this triggers a new 'change password' dialog on login.
- Add environment flag for lobby "local_dev" to skip sending email when running lobby locally.
- Refactor: extract creation of ClientMessenger to a factory class. This is to help consolidate the challenge/response and simplify creation of the client messenger through convenience methods.
- Add new ClientMessenger for forgot password. Server responds with a magic string if a temporary password is sent via email, otherwise returns an error message to client.
- Refactor: RSA authenticator code, extract challenge keys from the class and move creation of challenge keys to client classes of the authenticator.
- Update: rename table 'user_temp_password' to 'temp_password_request'

## Functional Changes
Adds 'forgot password' feature

## Manual Testing Performed
- Verifies main use-cases locally.
- Small bug note: after hitting the rate limit case, server socket can be closed out of sync from client and this displays a pop-up. It is not consistent, does not happen all the time, and overall is a relatively minor (skipping a fix for it, for now.)
- Deployed a test-app to prod server to send email and verified email sender code.

## Screen Shots

### Before
![Screenshot from 2019-08-15 21-46-08](https://user-images.githubusercontent.com/12397753/63144080-1dfb5e00-bfa6-11e9-8773-e60c4c5f8997.png)

### After

Clicking "Play Online" button, notice the new "Forgot Password Button" (and the dots are removed from "Create Account.."):
![Screenshot from 2019-08-15 21-44-38](https://user-images.githubusercontent.com/12397753/63144040-f0aeb000-bfa5-11e9-8772-483b8bd970ab.png)

Clicking forgot password, the following dialog is displayed:
![Screenshot from 2019-08-15 21-20-00](https://user-images.githubusercontent.com/12397753/63144010-d70d6880-bfa5-11e9-92bb-d5974406928e.png)

Enter in a username in forgot password that exists, this dialog is displayed:
![Screenshot from 2019-08-15 21-20-10](https://user-images.githubusercontent.com/12397753/63144011-d70d6880-bfa5-11e9-9364-ee890767f85f.png)

If entering in an invalid username, one that does not exist in DB, this error message is shown:
![Screenshot from 2019-08-15 21-49-09](https://user-images.githubusercontent.com/12397753/63144183-92ce9800-bfa6-11e9-88b9-16ae001790b7.png)

If user has requested too many temporary passwords, this error message is displayed:
![Screenshot from 2019-08-15 21-24-23](https://user-images.githubusercontent.com/12397753/63144014-d7a5ff00-bfa5-11e9-8595-2ec5b78ba881.png)

If successfully requested new temporary password, the email sent looks like this:
![Screenshot from 2019-08-15 21-43-55](https://user-images.githubusercontent.com/12397753/63144015-d7a5ff00-bfa5-11e9-8606-7a6e6747fcd2.png)

The body of the email looks like this:
![Screenshot from 2019-08-15 21-44-03](https://user-images.githubusercontent.com/12397753/63144016-d7a5ff00-bfa5-11e9-85ca-bca06e28f7d7.png)

After logging in to the server with temporary password, this change password dialog is shown (okay button is enabled when password matches verification and is of min length):
![Screenshot from 2019-08-15 21-20-32](https://user-images.githubusercontent.com/12397753/63144012-d7a5ff00-bfa5-11e9-9e0f-414b2ee93d99.png)

After setting a new password, this dialog is displayed:
![Screenshot from 2019-08-15 21-20-46](https://user-images.githubusercontent.com/12397753/63144013-d7a5ff00-bfa5-11e9-88dc-e1835d1dcd02.png)
