### PR TITLE
Refactor: run refresh code on EDT

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -231,7 +231,7 @@ abstract class AbstractMovePanel extends ActionPanel {
           removeAll();
           add(movedUnitsPanel(id, actionLabel));
           add(getUnitScrollerPanel());
-          SwingUtilities.invokeLater(refresh);
+          refresh.run();
         });
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/ActionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ActionPanel.java
@@ -6,6 +6,7 @@ import games.strategy.triplea.Properties;
 import java.util.concurrent.CountDownLatch;
 import javax.swing.BoxLayout;
 import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -17,12 +18,14 @@ public abstract class ActionPanel extends JPanel {
 
   @Getter(AccessLevel.PROTECTED)
   protected final MapPanel map;
-  /** Refreshes the action panel. Should be run within the swing event queue. */
+  /** Refreshes the action panel. */
   protected final Runnable refresh =
-      () -> {
-        revalidate();
-        repaint();
-      };
+      () ->
+          SwingUtilities.invokeLater(
+              () -> {
+                revalidate();
+                repaint();
+              });
 
   @Getter(AccessLevel.PROTECTED)
   private final GameData data;

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -91,7 +91,7 @@ public final class BattlePanel extends ActionPanel {
             }
           }
           add(panel, BorderLayout.NORTH);
-          SwingUtilities.invokeLater(refresh);
+          refresh.run();
         });
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
@@ -203,7 +203,7 @@ public class PurchasePanel extends ActionPanel {
             getData().releaseReadLock();
           }
           add(Box.createVerticalGlue());
-          SwingUtilities.invokeLater(refresh);
+          refresh.run();
         });
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/RepairPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/RepairPanel.java
@@ -105,7 +105,7 @@ class RepairPanel extends ActionPanel {
           unitsPanel.setUnitsFromRepairRuleMap(new HashMap<>(), id, getData());
           add(unitsPanel);
           add(Box.createVerticalGlue());
-          SwingUtilities.invokeLater(refresh);
+          refresh.run();
         });
   }
 


### PR DESCRIPTION
## Overview
Rather than warning users to run code on EDT, just run refresh code on EDT. Turns out this update is not necessary as the refresh code is run on EDT anyways, regardless we can remove the warning and go ahead and run on EDT code to begin with. A future update could reduce the scope of the code run on EDT.
## Manual Testing Performed
- none
