### PR TITLE
Fix: Handle save game file not found

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -1,6 +1,5 @@
 package games.strategy.engine.framework.startup.mc;
 
-import com.google.common.base.Preconditions;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParseException;
@@ -67,8 +66,9 @@ public class GameSelectorModel extends Observable {
    *     returns false and internal {@code GameData} is null.
    */
   public boolean load(final File file) {
-    Preconditions.checkArgument(
-        file.exists() && file.isFile(), "File should exist at: " + file.getAbsolutePath());
+    if (!file.isFile()) {
+      return false;
+    }
 
     final GameData newData;
     try {


### PR DESCRIPTION
## Overview
User is able to select a missing save game from the save game dialog. When this happens we would assert the file exists. It is not guaranteed and we wind up with 'control-flow-by-exception-handling.' The problem with the exception is we offer the choice for a user to report the bug to TripleA when it is not a bug.

This update checks for missing file rather than asserting, and if so notifies the user through an error dialog that the file does not exist

## Functional Changes
Missing save game file no longer treated as error, instead handled with an error dialog.

## Manual Testing Performed
- verified save game loading before and after. Easiest way to repro is to select a game file and remove the extension (when saving a game, the extension is appended, so it's pretty easy to then try to load the same save game file and hit this situation).

## Before & After Screen Shots
### Before
![Screenshot from 2019-08-17 19-25-28](https://user-images.githubusercontent.com/12397753/63219355-fda5dd80-c124-11e9-8ad5-7ee8cd2eb0da.png)


### After
Note, there is no "report to triplea button":
![Screenshot from 2019-08-17 19-24-41](https://user-images.githubusercontent.com/12397753/63219357-01396480-c125-11e9-9ef7-084bdd0a02e8.png)


## Additional Review Notes
A follow up enhancement that might be good would be to fall back and try appending the save game suffix to the file path that we are loading.
