### PR TITLE
Revert "Fix default run configurations for Intellij Idea."

### DIFF
--- a/.idea/runConfigurations/HeadedGameRunner.xml
+++ b/.idea/runConfigurations/HeadedGameRunner.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="HeadedGameRunner" type="Application" factoryName="Application" singleton="false" nameIsGenerated="true">
     <option name="MAIN_CLASS_NAME" value="org.triplea.game.client.HeadedGameRunner" />
-    <module name="triplea.game-headed.main" />
+    <module name="triplea.game-headed" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/game-headed" />
     <extension name="coverage">
       <pattern>

--- a/.idea/runConfigurations/HeadlessGameRunner.xml
+++ b/.idea/runConfigurations/HeadlessGameRunner.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="HeadlessGameRunner" type="Application" factoryName="Application" nameIsGenerated="true">
     <option name="MAIN_CLASS_NAME" value="org.triplea.game.server.HeadlessGameRunner" />
-    <module name="triplea.game-headless.main" />
+    <module name="triplea.game-headless" />
     <option name="PROGRAM_PARAMETERS" value="-Ptriplea.name=Bot01-testbot -Ptriplea.port=4000 -Ptriplea.lobby.port=3304 -Ptriplea.lobby.host=localhost" />
     <extension name="coverage">
       <pattern>

--- a/.idea/runConfigurations/LobbyRunner.xml
+++ b/.idea/runConfigurations/LobbyRunner.xml
@@ -4,7 +4,7 @@
       <env name="LOCAL_DEV" value="true" />
     </envs>
     <option name="MAIN_CLASS_NAME" value="org.triplea.lobby.server.LobbyRunner" />
-    <module name="triplea.lobby.main" />
+    <module name="triplea.lobby" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/lobby" />
     <extension name="coverage">
       <pattern>

--- a/.idea/runConfigurations/ServerApplication.xml
+++ b/.idea/runConfigurations/ServerApplication.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="ServerApplication" type="Application" factoryName="Application" nameIsGenerated="true">
     <option name="MAIN_CLASS_NAME" value="org.triplea.server.http.ServerApplication" />
-    <module name="triplea.http-server.main" />
+    <module name="triplea.http-server" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/http-server" />
     <extension name="coverage">
       <pattern>


### PR DESCRIPTION
Reverts triplea-game/triplea#4999

Ping-pong back to previous configuration. To have the latest work I need to rename project modules to have a ".main" suffix and then re-importing from gradle can often break this. 

@OrdoFlammae , @RoiEXLab, if either of you can find the "trick" to get IDEA to the right configuration, we desperately could use documentation for it.