### PR TITLE
Add always on top flag for battle window

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -254,6 +254,7 @@ public final class BattlePanel extends ActionPanel {
                     }
                     if (ClientSetting.showBattlesWhenObserving.getValueOrThrow()
                         || foundHumanInBattle) {
+                      battleFrame.setAlwaysOnTop(true);
                       battleFrame.setVisible(true);
                       battleFrame.validate();
                       battleFrame.invalidate();


### PR DESCRIPTION
## Overview
This prevents the battle window from going to background (behind map window) when the casualty selection window is shown. Addresses: #4954

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Code Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[X] Bug fix
<!-- Uncomment the below and list any changes that users would notice --> 
<!--
### User facing changes
-->

<!-- If fixing a bug, uncomment the below and fill in each section -->
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)
#4954
### Root Cause (What caused the bug?)
- Unknown
### Fix description (How is the bug fixed?)
Add swing 'always on top' flag to battle window 


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[X] Manually tested
[ ] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
### Manual Testing
Fight a battle where casualty selection window is shown. 


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


## Additional Review Notes
<!-- Add here any extra notes that would be helpful to reviewers or leave blank -->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

