### PR TITLE
Add: Update unit_scroller to have a unit_sleep button

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -191,7 +191,7 @@ public final class Matches {
     return unitIsStrategicBomber().negate();
   }
 
-  static Predicate<Unit> unitHasMoved() {
+  public static Predicate<Unit> unitHasMoved() {
     return unit -> TripleAUnit.get(unit).getAlreadyMoved() > 0;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -1600,6 +1600,9 @@ public class MovePanel extends AbstractMovePanel {
           case KeyEvent.VK_SPACE:
             unitScroller.skipCurrentUnits();
             break;
+          case KeyEvent.VK_S:
+            unitScroller.sleepCurrentUnits();
+            break;
           case KeyEvent.VK_C:
             unitScroller.centerOnCurrentMovableUnit();
             break;
@@ -1664,7 +1667,7 @@ public class MovePanel extends AbstractMovePanel {
     final Collection<Collection<Unit>> highlight = new ArrayList<>();
     for (final Territory t : allTerritories) {
       final List<Unit> movableUnits = t.getUnitCollection().getMatches(movableUnitOwnedByMe);
-      movableUnits.removeAll(unitScroller.getSkippedUnits());
+      movableUnits.removeAll(unitScroller.getAllSkippedUnits());
       if (!movableUnits.isEmpty()) {
         highlight.add(movableUnits);
       }

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScrollerIcon.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScrollerIcon.java
@@ -17,6 +17,7 @@ class UnitScrollerIcon implements Supplier<Icon> {
   static final UnitScrollerIcon RIGHT_ARROW = new UnitScrollerIcon("right_arrow.png");
   static final UnitScrollerIcon CENTER_ON_UNIT = new UnitScrollerIcon("unit_center.png");
   static final UnitScrollerIcon UNIT_SKIP = new UnitScrollerIcon("unit_skip.png");
+  static final UnitScrollerIcon UNIT_SLEEP = new UnitScrollerIcon("unit_sleep.png");
 
   private static final File IMAGE_PATH = new File(ResourceLoader.RESOURCE_FOLDER, "unit_scroller");
 

--- a/game-headed/build.gradle
+++ b/game-headed/build.gradle
@@ -48,6 +48,7 @@ task downloadImages {
                 'unit_scroller/right_arrow.png',
                 'unit_scroller/unit_center.png',
                 'unit_scroller/unit_skip.png',
+                'unit_scroller/unit_sleep.png',
         ].each { path ->
             download {
                 src "https://raw.githubusercontent.com/triplea-game/assets/master/images/$path"


### PR DESCRIPTION
## Overview

Unit sleep will auto-skip a unit until it has been moved. Useful for example for units that are on islands or AA guns.

In this update the old unit-skip image, a moon, is renamed and re-used to be the unit sleep icon. A new 'checkmark' icon image is used for skip. Otherwise this feature update adds a second button next to the unit skip button for the unit sleep action.
<!-- What changes did you make? Provide a summary of the updates included in this pull request -->

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[X] Feature update or enhancement
[ ] Code Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix
<!-- Uncomment the below and list any changes that users would notice --> 
### User facing changes
-  Added new button with hotkey 's' for unit sleep


<!-- If fixing a bug, uncomment the below and fill in each section -->
<!--
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)

### Root Cause (What caused the bug?)

### Fix description (How is the bug fixed?)

-->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[X] Manually tested
[ ] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
### Manual Testing
Started a revised game, slept all Russian units. Then moved a couple units and verified they showed as movable during non-combat. Also verified they were not highlighted with F key. Then cycled turns back to Russia and verified sleeping units were still sleeping.

<!-- If there any user facing changes, uncomment the section below and include screenshots -->
## Screens Shots

### Before
![Screenshot from 2019-08-21 19-25-54](https://user-images.githubusercontent.com/12397753/63481309-f09d2d00-c449-11e9-9907-681fb6983386.png)

### After
![Screenshot from 2019-08-21 19-15-44](https://user-images.githubusercontent.com/12397753/63481098-41f8ec80-c449-11e9-8e9e-0055516d8681.png)

## Additional Review Notes
- Feature is discussed in this thread: https://forums.triplea-game.org/topic/1433/screen-centering-cycling-around-map-ui-idea/
- Original nabble forum thread discussion on this feature: https://forums.triplea-game.org/search?term=unit%20scroller&in=titlesposts