### PR TITLE
Fix UnsupportedOperationException when selecting previous units

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -10,6 +10,7 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.ui.MapPanel;
 import java.awt.BorderLayout;
 import java.awt.Component;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -270,10 +271,12 @@ public class UnitScroller {
   }
 
   private void centerOnMovableUnit(final boolean selectNext) {
-    final List<Territory> allTerritories = gameData.getMap().getTerritories();
+    List<Territory> allTerritories = gameData.getMap().getTerritories();
 
     if (!selectNext) {
-      Collections.reverse(allTerritories);
+      final List<Territory> territories = new ArrayList<>(allTerritories);
+      Collections.reverse(territories);
+      allTerritories = territories;
     }
     // new focused index is 1 greater
     int newFocusedIndex =


### PR DESCRIPTION
## Overview
Bug fix when selecting previous units. Avoid reversing immutable territory list which causes UnsupportedOperationException

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Code Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[X] Bug fix
<!-- Uncomment the below and list any changes that users would notice --> 
<!--
### User facing changes
-->

<!-- If fixing a bug, uncomment the below and fill in each section -->

## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)
- In a move phase with at least one movable unit, press "m" or click previous units button.
- Notice exception message

### Root Cause (What caused the bug?)
Immutable list is returned from game data get territories. Select previous unit reverses this list with `Collections.reverse`

### Fix description (How is the bug fixed?)
Instead of reversing immutable list, create a copy and reverse that.


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[X] Manually tested
[ ] No testing done

<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Add here any extra notes that would be helpful to reviewers or leave blank -->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

