### PR TITLE
Unit scroller improvements

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -83,6 +83,8 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
       new PathClientSetting("MAP_LIST_OVERRIDE");
   public static final ClientSetting<String> moderatorApiKey =
       new StringClientSetting("MODERATOR_API_KEY");
+  public static final ClientSetting<Boolean> notifyAllUnitsMoved =
+      new BooleanClientSetting("NOTIFY_ALL_UNITS_MOVED", true);
   public static final ClientSetting<HttpProxy.ProxyChoice> proxyChoice =
       new EnumClientSetting<>(
           HttpProxy.ProxyChoice.class, "PROXY_CHOICE", HttpProxy.ProxyChoice.NONE);

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -152,6 +152,16 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
     }
   },
 
+  NOTIFY_ALL_UNITS_MOVED(
+      "Notify When All Units Moved",
+      SettingType.GAME,
+      "Game will show a pop-up notification message when all units have been moved") {
+    @Override
+    public SelectionComponent<JComponent> newSelectionComponent() {
+      return booleanRadioButtons(ClientSetting.notifyAllUnitsMoved);
+    }
+  },
+
   SERVER_START_GAME_SYNC_WAIT_TIME_BINDING(
       "Start game timeout",
       SettingType.NETWORK_TIMEOUTS,

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -300,7 +300,8 @@ public class UnitScroller {
             null,
             new String[] {"OK", "Do not show again"},
             "OK");
-    if (result == 1) {
+    final boolean doNotShowAgainClicked = (result == 1);
+    if (doNotShowAgainClicked) {
       ClientSetting.notifyAllUnitsMoved.setValueAndFlush(false);
       DialogBuilder.builder()
           .parent(mapPanel)


### PR DESCRIPTION
## Overview

(1) Notify when all units moved via popup. If this is annoying to users, it can be turned off with a 'do not show again' button or turned off/on via game settings.
(2) If all units in current territory are moved, 'c' will focus on next territory instead of focusing on the current (and empty) territory
(3) Sleep only movable units in a territory. For example landing bombers with an AA gun, it's common to only want the AA gun to be slept.

<!-- What changes did you make? Provide a summary of the updates included in this pull request -->

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[X] Feature update or enhancement
[ ] Code Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[X] Bug fix
<!-- Uncomment the below and list any changes that users would notice --> 
### User facing changes
See overview

<!-- If fixing a bug, uncomment the below and fill in each section -->
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)
Hit the 'm' key for previous unit, should see an exception.

### Root Cause (What caused the bug?)

Terrritory list is returned as an immutable list, reversing that in-place throws UnSupportedOperation.

### Fix description (How is the bug fixed?)
Copy the immutable territory list to a mutable list and reverse that list instead.


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[X] Manually tested
[ ] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->

### Manual Testing
- Use 'n' to select next territory, move all units out of that territory. Press 'c' and notice that the next territory is selected 
- Press 'm' to select previous territory, notice no errors.
- Press 's' to sleep all units, notice pop-up, click 'turn-off' and repeat again in next move phase and notice pop-up is not shown
- For example with a territory with AA gun, move a unit to that territory and ensure it has no movement left. During non-combat, when AA gun is up, click sleep, then during next move phase verify the unit that had exhausted movement does not come up in the scroller


## Screens Shots

![Screenshot from 2019-08-21 23-49-41](https://user-images.githubusercontent.com/12397753/63495137-1dfed080-c474-11e9-86e3-a1b8e12cd081.png)
![Screenshot from 2019-08-21 23-50-40](https://user-images.githubusercontent.com/12397753/63495138-1dfed080-c474-11e9-9863-a068c3325dbf.png)
![Screenshot from 2019-08-21 23-50-56](https://user-images.githubusercontent.com/12397753/63495139-1dfed080-c474-11e9-9563-e259552b6f46.png)

