### PR TITLE
Properly catch unwrapped exception

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -307,6 +307,10 @@ public class ServerGame extends AbstractGame {
           runStep(false);
         }
       }
+    } catch (final GameOverException e) {
+      if (!isGameOver) {
+        log.log(Level.SEVERE, "GameOverException raised, but game is not over", e);
+      }
     } catch (final RuntimeException e) {
       if (e.getCause() instanceof GameOverException) {
         if (!isGameOver) {

--- a/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -311,14 +311,6 @@ public class ServerGame extends AbstractGame {
       if (!isGameOver) {
         log.log(Level.SEVERE, "GameOverException raised, but game is not over", e);
       }
-    } catch (final RuntimeException e) {
-      if (e.getCause() instanceof GameOverException) {
-        if (!isGameOver) {
-          log.log(Level.SEVERE, "GameOverException raised, but game is not over", e);
-        }
-      } else {
-        throw e;
-      }
     }
   }
 


### PR DESCRIPTION
## Overview
This fixes a bug introduced by #5018 

## Functional Changes
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Code Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[x] Bug fix

## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)
Fixes #5027

### Root Cause (What caused the bug?)
I missed a case where the exception was directly thrown an wasn't wrapped into a RuntimeException.

### Fix description (How is the bug fixed?)
By catching GameOverException explicitly as well.

## Testing
[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[x] Manually tested
[ ] No testing done

### Manual Testing
I verified the error no longer appears after closing a local game, and verified no unintentional bugs were introduced to the networked variants.
Note that I'm not 100% sure if the recent Exception catching changes were done too well: I have the suspicion that since we're now properly catching all the exceptions, users don't get a savegame when an opponent disconnects because previously this caused an exception to be propagated to all connected users, and now the Exception is caught and everything safely terminates.
I'm not 100% sure how exactly this mechanic is supposed to behave, so I'd kindly ask you to double check this.