### PR TITLE
Update README links now that docs are on wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![Code Quality: Java](https://img.shields.io/lgtm/grade/java/g/triplea-game/triplea.svg?logo=lgtm&logoWidth=18&style=flat-square)](https://lgtm.com/projects/g/triplea-game/triplea/context:java)
 [![Total Alerts](https://img.shields.io/lgtm/alerts/g/triplea-game/triplea.svg?logo=lgtm&logoWidth=18&style=flat-square)](https://lgtm.com/projects/g/triplea-game/triplea/alerts)
 [![codecov](https://img.shields.io/codecov/c/github/triplea-game/triplea/master.svg?style=flat-square)](https://codecov.io/gh/triplea-game/triplea)
-[![TripleA license](https://img.shields.io/github/license/triplea-game/triplea.svg?style=flat-square)](https://github.com/triplea-game/triplea/blob/master/LICENSE)
+[![TripleA license](https://img.shields.io/github/license/triplea-game/triplea.svg?style=flat-square)](https://github.com/triplea-game/triplea/blob/master/LICENSE.md)
 
 
 ##  [TripleA Home Page](http://triplea-game.org/)
@@ -12,15 +12,9 @@ TripleA is an open source gaming community, free to play, 100% open source and v
 - ***Contact-us***: 
   - [Forums: Questions & Help](https://forums.triplea-game.org/category/10/help-questions)
   - [Bug Tracker](https://github.com/triplea-game/triplea/issues/new)
-  - [Gitter](https://gitter.im/triplea-game/social)
 - ***Technical Documentation***: 
-  - [Developer Setup](https://github.com/triplea-game/triplea/tree/master/docs/dev)
-  - [Project Documentation](https://github.com/triplea-game/triplea/tree/master/docs/)
+  - Map Making, Admin, and Developer Docs are on the [wiki](https://github.com/triplea-game/triplea/wiki)
 
-
-
-- ***Dashboards***
-  - [Is the lobby running?](https://stats.uptimerobot.com/14RYqsN5m)
 
  
 ## [Download and install TripleA](http://triplea-game.org/download/)
@@ -29,4 +23,4 @@ TripleA is an open source gaming community, free to play, 100% open source and v
 ## License
 
 This project is licensed under the terms of the 
-[GNU General Public License v3.0 with additional permissions](/docs/license.md).
+[GNU General Public License v3.0 with additional permissions](/LICENSE.md).


### PR DESCRIPTION
## Overview

Updates README considering we now have documentation in wiki and no longer in the `/docs` folder.

(1) license file is moving to LICENSE.md
(2) Uptime robot link can live on wiki only, does not need to be on readme
(3) Remove gitter link, our response to gitter is slow and we do not need to advertise that to the public.
(4) Update documentation link to be to the wiki.

<!-- What changes did you make? Provide a summary of the updates included in this pull request -->

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Code Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix
[X] Other / Documentation
<!-- Uncomment the below and list any changes that users would notice --> 
<!--
### User facing changes
-->

<!-- If fixing a bug, uncomment the below and fill in each section -->
<!--
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)

### Root Cause (What caused the bug?)

### Fix description (How is the bug fixed?)

-->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[ ] Manually tested
[X] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
<!--
### Manual Testing
 
-->


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


## Additional Review Notes
- Should be merged after: https://github.com/triplea-game/triplea/pull/5044; #5044 updates the license page location
