### PR TITLE
Ensure non-unloading units can move along route

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -262,7 +262,8 @@ public class MovePanel extends AbstractMovePanel {
             // Load Bombers with paratroops
             if ((!nonCombat || isParatroopersCanMoveDuringNonCombat(getData()))
                 && TechAttachment.isAirTransportable(getCurrentPlayer())
-                && selectedUnits.stream()
+                && selectedUnits
+                    .stream()
                     .anyMatch(Matches.unitIsAirTransport().and(Matches.unitHasNotMoved()))) {
               final PlayerId player = getCurrentPlayer();
               // TODO Transporting allied units
@@ -555,7 +556,8 @@ public class MovePanel extends AbstractMovePanel {
             units.addAll(
                 getUnitsToUnload(
                     route, CollectionUtils.getMatches(selectedUnits, getUnloadableMatch())));
-            units.addAll(CollectionUtils.getMatches(selectedUnits, getUnloadableMatch().negate()));
+            units.addAll(
+                CollectionUtils.getMatches(unitsThatCanMoveOnRoute, getUnloadableMatch().negate()));
             if (units.isEmpty()) {
               cancelMove();
               return;
@@ -984,7 +986,8 @@ public class MovePanel extends AbstractMovePanel {
   private static Predicate<Unit> areOwnedUnitsOfType(
       final Collection<Unit> units, final PlayerId owner) {
     return mainUnit ->
-        units.stream()
+        units
+            .stream()
             .filter(unit -> unit.getOwner().equals(owner))
             .anyMatch(Matches.unitIsOfType(mainUnit.getType()));
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -262,8 +262,7 @@ public class MovePanel extends AbstractMovePanel {
             // Load Bombers with paratroops
             if ((!nonCombat || isParatroopersCanMoveDuringNonCombat(getData()))
                 && TechAttachment.isAirTransportable(getCurrentPlayer())
-                && selectedUnits
-                    .stream()
+                && selectedUnits.stream()
                     .anyMatch(Matches.unitIsAirTransport().and(Matches.unitHasNotMoved()))) {
               final PlayerId player = getCurrentPlayer();
               // TODO Transporting allied units
@@ -986,8 +985,7 @@ public class MovePanel extends AbstractMovePanel {
   private static Predicate<Unit> areOwnedUnitsOfType(
       final Collection<Unit> units, final PlayerId owner) {
     return mainUnit ->
-        units
-            .stream()
+        units.stream()
             .filter(unit -> unit.getOwner().equals(owner))
             .anyMatch(Matches.unitIsOfType(mainUnit.getType()));
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -552,9 +552,11 @@ public class MovePanel extends AbstractMovePanel {
           } else if ((route.isUnload() && units.stream().anyMatch(Matches.unitIsLand()))
               || paratroopsLanding) {
             units.clear();
+            // Have user select which transports and land units to unload
             units.addAll(
                 getUnitsToUnload(
                     route, CollectionUtils.getMatches(selectedUnits, getUnloadableMatch())));
+            // Add in non-unloadable units (air) which can move along unloading route
             units.addAll(
                 CollectionUtils.getMatches(unitsThatCanMoveOnRoute, getUnloadableMatch().negate()));
             if (units.isEmpty()) {


### PR DESCRIPTION
## Overview
Fixes shift click movement offloading units from transports. Fixed by removing a 'negation' line that adds the sea units to the current selected units (#5035).

This bug was introduced when fixing #4835. Before that fix, the engine was honoring the specific transports that the user selected to unload and was just randomly picking which units to unload. That fix corrected that issue but also then tried to move all other non-unloadable selected units to the territory even if they couldn't legally move there (ex. sea units onto land).

This now only adds in non-unloadable units which can actually legally move along the route + the units from the transports that the user selected.

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Code Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[x] Bug fix
