### PR TITLE
Consolidate icon image download

### DIFF
--- a/game-headed/build.gradle
+++ b/game-headed/build.gradle
@@ -44,11 +44,17 @@ jar {
 task downloadImages {
     doLast {
         [
-                'unit_scroller/left_arrow.png',
-                'unit_scroller/right_arrow.png',
-                'unit_scroller/unit_center.png',
-                'unit_scroller/unit_skip.png',
-                'unit_scroller/unit_sleep.png',
+            'icons/triplea_icon_16_16.png',
+            'icons/triplea_icon_32_32.png',
+            'icons/triplea_icon_48_48.png',
+            'icons/triplea_icon_64_64.png',
+            'icons/triplea_icon_128_128.png',
+            'icons/triplea_icon_256_256.png',
+            'unit_scroller/left_arrow.png',
+            'unit_scroller/right_arrow.png',
+            'unit_scroller/unit_center.png',
+            'unit_scroller/unit_skip.png',
+            'unit_scroller/unit_sleep.png',
         ].each { path ->
             download {
                 src "https://raw.githubusercontent.com/triplea-game/assets/master/images/$path"
@@ -66,12 +72,6 @@ run {
 task downloadPlatformInstallerAssets(group: 'release', dependsOn: downloadImages) {
     doLast {
         [
-            'icons/triplea_icon_16_16.png',
-            'icons/triplea_icon_32_32.png',
-            'icons/triplea_icon_48_48.png',
-            'icons/triplea_icon_64_64.png',
-            'icons/triplea_icon_128_128.png',
-            'icons/triplea_icon_256_256.png',
             'install4j/macosx-amd64-11.0.3.tar.gz',
             'install4j/windows-amd64-11.0.3.tar.gz',
             'install4j/OpenJDK11U-jre_x86-32_windows_hotspot_11.0.3_7.tar.gz',


### PR DESCRIPTION

## Overview
Related to icon images moved in assets repo: https://github.com/triplea-game/assets/pull/33

This update consolidates the download image task so that, in the same task, we download all images defined in the gradle build.

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Code Removal
[ ] Code Cleanup or refactor
[X] Configuration Change
[ ] Bug fix
<!-- Uncomment the below and list any changes that users would notice --> 
<!--
### User facing changes
-->

<!-- If fixing a bug, uncomment the below and fill in each section -->
<!--
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)

### Root Cause (What caused the bug?)

### Fix description (How is the bug fixed?)

-->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[ ] Manually tested
[X ] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
<!--
### Manual Testing
 
-->


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

