### PR TITLE
Allow air units to move when unloading

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -533,7 +533,7 @@ public class MovePanel extends AbstractMovePanel {
 
         private void selectEndPoint(final Territory territory) {
           final Route route = getRoute(getFirstSelectedTerritory(), territory, selectedUnits);
-          final List<Unit> units = unitsThatCanMoveOnRoute;
+          final List<Unit> units = new ArrayList<>(unitsThatCanMoveOnRoute);
           setSelectedEndpointTerritory(territory);
           if (units.isEmpty() || route == null) {
             cancelMove();
@@ -1076,6 +1076,9 @@ public class MovePanel extends AbstractMovePanel {
         && route.getEnd().isWater()
         && !route.isLoad()) {
       best = CollectionUtils.getMatches(best, Matches.unitIsLand().negate());
+    }
+    if (route.isUnload()) {
+      best = CollectionUtils.getMatches(best, Matches.unitIsNotSea());
     }
     sortUnitsToMove(best, route);
     Collections.reverse(best);


### PR DESCRIPTION
## Overview
- Improve unloading moves so that if air units are selected they are moved as well
- Follow up to discussion in #5049

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[x] Feature update or enhancement
[ ] Code Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix

![image](https://user-images.githubusercontent.com/1427689/63566746-e35c6d00-c533-11e9-85b3-11cde753e4a9.png)

![image](https://user-images.githubusercontent.com/1427689/63566758-ec4d3e80-c533-11e9-8fbc-931a77849b18.png)
