### PR TITLE
Replace key listeners with key bindings

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/KeyBindingSupplier.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/KeyBindingSupplier.java
@@ -23,7 +23,7 @@ import javax.swing.KeyStroke;
  *   KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.CTRL_DOWN_MASK));
  * </pre>
  */
-public interface KeyBindings extends Supplier<Map<KeyStroke, Runnable>> {
+public interface KeyBindingSupplier extends Supplier<Map<KeyStroke, Runnable>> {
 
   /**
    * Convenience method to create a {@code KeyStroke} without modifiers.

--- a/game-core/src/main/java/games/strategy/triplea/ui/KeyBindings.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/KeyBindings.java
@@ -1,0 +1,39 @@
+package games.strategy.triplea.ui;
+
+import com.google.common.base.Preconditions;
+import java.awt.event.KeyEvent;
+import java.util.Map;
+import java.util.function.Supplier;
+import javax.swing.KeyStroke;
+
+/**
+ * Interface for classes that have key listeners. Key bindings are more 'global' than classic swing
+ * key listeners. Key bindings will fire even if the source component does not have focus. Key
+ * bindings need to be registered to the JFrame ContentPane to function.
+ *
+ * <p>To register a {@code KeyStroke} with no modifiers, use:
+ *
+ * <pre>
+ *   KeyStroke.getKeyStroke(KeyEvent.VK_S, 0);
+ * </pre>
+ *
+ * To register a {@code KeyStroke} with modifier, for example "Ctrl+S", use:
+ *
+ * <pre>
+ *   KeyStroke.getKeyStroke(KeyEvent.VK_S, InputEvent.CTRL_DOWN_MASK));
+ * </pre>
+ */
+public interface KeyBindings extends Supplier<Map<KeyStroke, Runnable>> {
+
+  /**
+   * Convenience method to create a {@code KeyStroke} without modifiers.
+   *
+   * @param code A KeyEvent code, should be a constant from the class {@code KeyEvent}
+   */
+  default KeyStroke fromKeyEventCode(int code) {
+    Preconditions.checkArgument(
+        !KeyEvent.getKeyText(code).toUpperCase().contains("UNKNOWN"),
+        "Be sure to use a constant from 'KeyEvent', unknown key constant: " + code);
+    return KeyStroke.getKeyStroke(code, 0);
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/ui/KeyBindings.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/KeyBindings.java
@@ -30,7 +30,7 @@ public interface KeyBindings extends Supplier<Map<KeyStroke, Runnable>> {
    *
    * @param code A KeyEvent code, should be a constant from the class {@code KeyEvent}
    */
-  default KeyStroke fromKeyEventCode(int code) {
+  static KeyStroke fromKeyEventCode(int code) {
     Preconditions.checkArgument(
         !KeyEvent.getKeyText(code).toUpperCase().contains("UNKNOWN"),
         "Be sure to use a constant from 'KeyEvent', unknown key constant: " + code);

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -1598,16 +1598,17 @@ public class MovePanel extends AbstractMovePanel implements KeyBindings {
   @Override
   public Map<KeyStroke, Runnable> get() {
     final Map<KeyStroke, Runnable> bindings = new HashMap<>();
-    bindings.put(fromKeyEventCode(KeyEvent.VK_SPACE), unitScroller::skipCurrentUnits);
-    bindings.put(KeyStroke.getKeyStroke(KeyEvent.VK_S, 0), unitScroller::sleepCurrentUnits);
+    bindings.put(KeyBindings.fromKeyEventCode(KeyEvent.VK_SPACE), unitScroller::skipCurrentUnits);
+    bindings.put(KeyBindings.fromKeyEventCode(KeyEvent.VK_S), unitScroller::sleepCurrentUnits);
     bindings.put(
-        KeyStroke.getKeyStroke(KeyEvent.VK_C, 0), unitScroller::centerOnCurrentMovableUnit);
-    bindings.put(KeyStroke.getKeyStroke(KeyEvent.VK_N, 0), unitScroller::centerOnNextMovableUnit);
+        KeyBindings.fromKeyEventCode(KeyEvent.VK_C), unitScroller::centerOnCurrentMovableUnit);
     bindings.put(
-        KeyStroke.getKeyStroke(KeyEvent.VK_M, 0), unitScroller::centerOnPreviousMovableUnit);
-    bindings.put(KeyStroke.getKeyStroke(KeyEvent.VK_F, 0), this::highlightMovableUnits);
+        KeyBindings.fromKeyEventCode(KeyEvent.VK_N), unitScroller::centerOnNextMovableUnit);
     bindings.put(
-        KeyStroke.getKeyStroke(KeyEvent.VK_U, 0),
+        KeyBindings.fromKeyEventCode(KeyEvent.VK_M), unitScroller::centerOnPreviousMovableUnit);
+    bindings.put(KeyBindings.fromKeyEventCode(KeyEvent.VK_F), this::highlightMovableUnits);
+    bindings.put(
+        KeyBindings.fromKeyEventCode(KeyEvent.VK_U),
         () -> undoableMovesPanel.undoMoves(getMap().getHighlightedUnits()));
     return bindings;
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -30,7 +30,6 @@ import java.awt.Component;
 import java.awt.Image;
 import java.awt.Point;
 import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
 import java.awt.event.MouseEvent;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -48,6 +47,7 @@ import java.util.function.Predicate;
 import java.util.logging.Level;
 import javax.annotation.Nullable;
 import javax.swing.JOptionPane;
+import javax.swing.KeyStroke;
 import lombok.Setter;
 import lombok.extern.java.Log;
 import org.triplea.java.ObjectUtils;
@@ -57,7 +57,7 @@ import org.triplea.java.collections.IntegerMap;
 
 /** The action panel displayed during the combat and non-combat move actions. */
 @Log
-public class MovePanel extends AbstractMovePanel {
+public class MovePanel extends AbstractMovePanel implements KeyBindings {
   private static final long serialVersionUID = 5004515340964828564L;
   private static final int defaultMinTransportCost = 5;
   /**
@@ -1595,46 +1595,21 @@ public class MovePanel extends AbstractMovePanel {
     getMap().addMouseOverUnitListener(mouseOverUnitListener);
   }
 
-  KeyListener getCustomKeyListeners() {
-    return new KeyListener() {
-      @Override
-      public void keyTyped(final KeyEvent e) {}
-
-      @Override
-      public void keyPressed(final KeyEvent e) {
-        switch (e.getKeyCode()) {
-          case KeyEvent.VK_SPACE:
-            unitScroller.skipCurrentUnits();
-            break;
-          case KeyEvent.VK_S:
-            unitScroller.sleepCurrentUnits();
-            break;
-          case KeyEvent.VK_C:
-            unitScroller.centerOnCurrentMovableUnit();
-            break;
-          case KeyEvent.VK_N:
-            unitScroller.centerOnNextMovableUnit();
-            break;
-          case KeyEvent.VK_M:
-            unitScroller.centerOnPreviousMovableUnit();
-            break;
-          case KeyEvent.VK_F:
-            highlightMovableUnits();
-            break;
-          case KeyEvent.VK_U:
-            if (!getMap().getHighlightedUnits().isEmpty()) {
-              undoableMovesPanel.undoMoves(getMap().getHighlightedUnits());
-            }
-            break;
-          default:
-            // ignore key
-            break;
-        }
-      }
-
-      @Override
-      public void keyReleased(final KeyEvent e) {}
-    };
+  @Override
+  public Map<KeyStroke, Runnable> get() {
+    final Map<KeyStroke, Runnable> bindings = new HashMap<>();
+    bindings.put(fromKeyEventCode(KeyEvent.VK_SPACE), unitScroller::skipCurrentUnits);
+    bindings.put(KeyStroke.getKeyStroke(KeyEvent.VK_S, 0), unitScroller::sleepCurrentUnits);
+    bindings.put(
+        KeyStroke.getKeyStroke(KeyEvent.VK_C, 0), unitScroller::centerOnCurrentMovableUnit);
+    bindings.put(KeyStroke.getKeyStroke(KeyEvent.VK_N, 0), unitScroller::centerOnNextMovableUnit);
+    bindings.put(
+        KeyStroke.getKeyStroke(KeyEvent.VK_M, 0), unitScroller::centerOnPreviousMovableUnit);
+    bindings.put(KeyStroke.getKeyStroke(KeyEvent.VK_F, 0), this::highlightMovableUnits);
+    bindings.put(
+        KeyStroke.getKeyStroke(KeyEvent.VK_U, 0),
+        () -> undoableMovesPanel.undoMoves(getMap().getHighlightedUnits()));
+    return bindings;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -1598,14 +1598,18 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
   @Override
   public Map<KeyStroke, Runnable> get() {
     final Map<KeyStroke, Runnable> bindings = new HashMap<>();
-    bindings.put(KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_SPACE), unitScroller::skipCurrentUnits);
-    bindings.put(KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_S), unitScroller::sleepCurrentUnits);
     bindings.put(
-        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_C), unitScroller::centerOnCurrentMovableUnit);
+        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_SPACE), unitScroller::skipCurrentUnits);
+    bindings.put(
+        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_S), unitScroller::sleepCurrentUnits);
+    bindings.put(
+        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_C),
+        unitScroller::centerOnCurrentMovableUnit);
     bindings.put(
         KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_N), unitScroller::centerOnNextMovableUnit);
     bindings.put(
-        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_M), unitScroller::centerOnPreviousMovableUnit);
+        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_M),
+        unitScroller::centerOnPreviousMovableUnit);
     bindings.put(KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_F), this::highlightMovableUnits);
     bindings.put(
         KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_U),

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -57,7 +57,7 @@ import org.triplea.java.collections.IntegerMap;
 
 /** The action panel displayed during the combat and non-combat move actions. */
 @Log
-public class MovePanel extends AbstractMovePanel implements KeyBindings {
+public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
   private static final long serialVersionUID = 5004515340964828564L;
   private static final int defaultMinTransportCost = 5;
   /**
@@ -1598,17 +1598,17 @@ public class MovePanel extends AbstractMovePanel implements KeyBindings {
   @Override
   public Map<KeyStroke, Runnable> get() {
     final Map<KeyStroke, Runnable> bindings = new HashMap<>();
-    bindings.put(KeyBindings.fromKeyEventCode(KeyEvent.VK_SPACE), unitScroller::skipCurrentUnits);
-    bindings.put(KeyBindings.fromKeyEventCode(KeyEvent.VK_S), unitScroller::sleepCurrentUnits);
+    bindings.put(KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_SPACE), unitScroller::skipCurrentUnits);
+    bindings.put(KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_S), unitScroller::sleepCurrentUnits);
     bindings.put(
-        KeyBindings.fromKeyEventCode(KeyEvent.VK_C), unitScroller::centerOnCurrentMovableUnit);
+        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_C), unitScroller::centerOnCurrentMovableUnit);
     bindings.put(
-        KeyBindings.fromKeyEventCode(KeyEvent.VK_N), unitScroller::centerOnNextMovableUnit);
+        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_N), unitScroller::centerOnNextMovableUnit);
     bindings.put(
-        KeyBindings.fromKeyEventCode(KeyEvent.VK_M), unitScroller::centerOnPreviousMovableUnit);
-    bindings.put(KeyBindings.fromKeyEventCode(KeyEvent.VK_F), this::highlightMovableUnits);
+        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_M), unitScroller::centerOnPreviousMovableUnit);
+    bindings.put(KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_F), this::highlightMovableUnits);
     bindings.put(
-        KeyBindings.fromKeyEventCode(KeyEvent.VK_U),
+        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_U),
         () -> undoableMovesPanel.undoMoves(getMap().getHighlightedUnits()));
     return bindings;
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -169,7 +169,7 @@ import org.triplea.util.Tuple;
 
 /** Main frame for the triple a game. */
 @Log
-public final class TripleAFrame extends JFrame implements KeyBindings {
+public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
   private static final long serialVersionUID = 7640069668264418976L;
   private final LocalPlayers localPlayers;
   private final GameData data;
@@ -751,7 +751,7 @@ public final class TripleAFrame extends JFrame implements KeyBindings {
     uiContext.addShutdownWindow(this);
   }
 
-  private void addKeyBindings(final KeyBindings... keyBindings) {
+  private void addKeyBindings(final KeyBindingSupplier... keyBindings) {
     Arrays.stream(keyBindings)
         .map(Supplier::get)
         .map(Map::entrySet)

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -94,7 +94,7 @@ import java.awt.Toolkit;
 import java.awt.event.ActionEvent;
 import java.awt.event.FocusAdapter;
 import java.awt.event.FocusEvent;
-import java.awt.event.KeyAdapter;
+import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
 import java.awt.event.WindowAdapter;
@@ -114,6 +114,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -143,6 +144,7 @@ import javax.swing.JTabbedPane;
 import javax.swing.JTextArea;
 import javax.swing.JToggleButton;
 import javax.swing.JToolTip;
+import javax.swing.KeyStroke;
 import javax.swing.ListCellRenderer;
 import javax.swing.ListSelectionModel;
 import javax.swing.Popup;
@@ -167,7 +169,7 @@ import org.triplea.util.Tuple;
 
 /** Main frame for the triple a game. */
 @Log
-public final class TripleAFrame extends JFrame {
+public final class TripleAFrame extends JFrame implements KeyBindings {
   private static final long serialVersionUID = 7640069668264418976L;
   private final LocalPlayers localPlayers;
   private final GameData data;
@@ -669,9 +671,8 @@ public final class TripleAFrame extends JFrame {
     final MovePanel movePanel = new MovePanel(data, mapPanel, this);
     actionButtons = new ActionButtons(data, mapPanel, movePanel, this);
 
-    SwingUtilities.invokeLater(() -> mapPanel.addKeyListener(getFullScreenListener()));
+    addKeyBindings(movePanel, this);
     SwingUtilities.invokeLater(() -> mapPanel.addKeyListener(getArrowKeyListener()));
-    SwingUtilities.invokeLater(() -> mapPanel.addKeyListener(movePanel.getCustomKeyListeners()));
     SwingUtilities.invokeLater(() -> mapPanel.addKeyListener(getFlagToggleKeyListener(this)));
 
     addTab("Actions", actionButtons, 'C');
@@ -748,6 +749,37 @@ public final class TripleAFrame extends JFrame {
     data.addDataChangeListener(dataChangeListener);
     game.getData().addGameDataEventListener(GameDataEvent.GAME_STEP_CHANGED, this::updateStep);
     uiContext.addShutdownWindow(this);
+  }
+
+  private void addKeyBindings(final KeyBindings... keyBindings) {
+    Arrays.stream(keyBindings)
+        .map(Supplier::get)
+        .map(Map::entrySet)
+        .flatMap(Collection::stream)
+        .forEach(
+            binding -> {
+              final JPanel contentPane = (JPanel) getContentPane();
+              final String keyBindingIdentifier = UUID.randomUUID().toString();
+
+              contentPane
+                  .getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
+                  .put(binding.getKey(), keyBindingIdentifier);
+              contentPane
+                  .getActionMap()
+                  .put(keyBindingIdentifier, SwingAction.of(e -> binding.getValue().run()));
+            });
+  }
+
+  @Override
+  public Map<KeyStroke, Runnable> get() {
+    return Collections.singletonMap(
+        KeyStroke.getKeyStroke(KeyEvent.VK_Z, InputEvent.CTRL_DOWN_MASK),
+        () ->
+            gameCenterPanel.setDividerLocation(
+                (gameCenterPanel.getDividerLocation()
+                        <= gameCenterPanel.getMaximumDividerLocation())
+                    ? 1.0
+                    : gameCenterPanel.getLastDividerLocation()));
   }
 
   /**
@@ -2061,21 +2093,6 @@ public final class TripleAFrame extends JFrame {
                     }
                   }
                 }));
-  }
-
-  private KeyListener getFullScreenListener() {
-    return new KeyAdapter() {
-      @Override
-      public void keyPressed(final KeyEvent e) {
-        if (e.isControlDown() && e.getKeyCode() == KeyEvent.VK_Z) {
-          if (gameCenterPanel.getDividerLocation() <= gameCenterPanel.getMaximumDividerLocation()) {
-            gameCenterPanel.setDividerLocation(1.0);
-          } else {
-            gameCenterPanel.setDividerLocation(gameCenterPanel.getLastDividerLocation());
-          }
-        }
-      }
-    };
   }
 
   private String getUnitInfo() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -172,8 +172,6 @@ public class UnitScroller {
 
     final JButton centerOnUnit = new JButton(UnitScrollerIcon.CENTER_ON_UNIT.get());
     centerOnUnit.setToolTipText(CENTER_UNITS_TOOLTIP);
-    // disallow focus so that key listeners from MovePanel will continue to function
-    centerOnUnit.setFocusable(false);
     centerOnUnit.setAlignmentX(JComponent.CENTER_ALIGNMENT);
     centerOnUnit.addActionListener(e -> centerOnCurrentMovableUnit());
     panel.add(centerOnUnit, BorderLayout.NORTH);
@@ -187,7 +185,6 @@ public class UnitScroller {
 
     final JButton prevUnit = new JButton(UnitScrollerIcon.LEFT_ARROW.get());
     prevUnit.setToolTipText(PREVIOUS_UNITS_TOOLTIP);
-    prevUnit.setFocusable(false);
     prevUnit.setAlignmentX(JComponent.CENTER_ALIGNMENT);
     prevUnit.addActionListener(e -> centerOnPreviousMovableUnit());
     centerPanel.add(prevUnit);
@@ -195,7 +192,6 @@ public class UnitScroller {
 
     final JButton nextUnit = new JButton(UnitScrollerIcon.RIGHT_ARROW.get());
     nextUnit.setToolTipText(NEXT_UNITS_TOOLTIP);
-    nextUnit.setFocusable(false);
     nextUnit.addActionListener(e -> centerOnNextMovableUnit());
     centerPanel.add(nextUnit, BorderLayout.EAST);
     centerPanel.add(Box.createHorizontalStrut(10));
@@ -205,12 +201,10 @@ public class UnitScroller {
 
     final JButton skipButton = new JButton(UnitScrollerIcon.UNIT_SKIP.get());
     skipButton.setToolTipText(SKIP_UNITS_TOOLTIP);
-    skipButton.setFocusable(false);
     skipButton.addActionListener(e -> skipCurrentUnits());
 
     final JButton sleepButton = new JButton(UnitScrollerIcon.UNIT_SLEEP.get());
     sleepButton.setToolTipText(SLEEP_UNITS_TOOLTIP);
-    sleepButton.setFocusable(false);
     sleepButton.addActionListener(e -> sleepCurrentUnits());
 
     final JPanel skipAndSleepPanel =

--- a/game-core/src/test/java/games/strategy/triplea/ui/KeyBindingsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/KeyBindingsTest.java
@@ -9,22 +9,17 @@ import javax.swing.KeyStroke;
 import org.junit.jupiter.api.Test;
 
 class KeyBindingsTest {
-  private static final KeyBindings testObj =
-      () -> {
-        throw new UnsupportedOperationException("test fake, not supported");
-      };
-
   @Test
   void fromKeyEventCode() {
-    assertThrows(IllegalArgumentException.class, () -> testObj.fromKeyEventCode(1110));
+    assertThrows(IllegalArgumentException.class, () -> KeyBindings.fromKeyEventCode(1110));
   }
 
   @Test
   void fromKeyEventCodeSuccessCases() {
-    assertThat(testObj.fromKeyEventCode(KeyEvent.VK_F), is(KeyStroke.getKeyStroke('F', 0)));
-    assertThat(testObj.fromKeyEventCode(KeyEvent.VK_S), is(KeyStroke.getKeyStroke('S', 0)));
-    assertThat(testObj.fromKeyEventCode(KeyEvent.VK_C), is(KeyStroke.getKeyStroke('C', 0)));
-    assertThat(testObj.fromKeyEventCode(KeyEvent.VK_E), is(KeyStroke.getKeyStroke('E', 0)));
-    assertThat(testObj.fromKeyEventCode(KeyEvent.VK_SPACE), is(KeyStroke.getKeyStroke(' ', 0)));
+    assertThat(KeyBindings.fromKeyEventCode(KeyEvent.VK_F), is(KeyStroke.getKeyStroke('F', 0)));
+    assertThat(KeyBindings.fromKeyEventCode(KeyEvent.VK_S), is(KeyStroke.getKeyStroke('S', 0)));
+    assertThat(KeyBindings.fromKeyEventCode(KeyEvent.VK_C), is(KeyStroke.getKeyStroke('C', 0)));
+    assertThat(KeyBindings.fromKeyEventCode(KeyEvent.VK_E), is(KeyStroke.getKeyStroke('E', 0)));
+    assertThat(KeyBindings.fromKeyEventCode(KeyEvent.VK_SPACE), is(KeyStroke.getKeyStroke(' ', 0)));
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/ui/KeyBindingsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/KeyBindingsTest.java
@@ -16,10 +16,15 @@ class KeyBindingsTest {
 
   @Test
   void fromKeyEventCodeSuccessCases() {
-    assertThat(KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_F), is(KeyStroke.getKeyStroke('F', 0)));
-    assertThat(KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_S), is(KeyStroke.getKeyStroke('S', 0)));
-    assertThat(KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_C), is(KeyStroke.getKeyStroke('C', 0)));
-    assertThat(KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_E), is(KeyStroke.getKeyStroke('E', 0)));
-    assertThat(KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_SPACE), is(KeyStroke.getKeyStroke(' ', 0)));
+    assertThat(
+        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_F), is(KeyStroke.getKeyStroke('F', 0)));
+    assertThat(
+        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_S), is(KeyStroke.getKeyStroke('S', 0)));
+    assertThat(
+        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_C), is(KeyStroke.getKeyStroke('C', 0)));
+    assertThat(
+        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_E), is(KeyStroke.getKeyStroke('E', 0)));
+    assertThat(
+        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_SPACE), is(KeyStroke.getKeyStroke(' ', 0)));
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/ui/KeyBindingsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/KeyBindingsTest.java
@@ -1,0 +1,30 @@
+package games.strategy.triplea.ui;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.awt.event.KeyEvent;
+import javax.swing.KeyStroke;
+import org.junit.jupiter.api.Test;
+
+class KeyBindingsTest {
+  private static final KeyBindings testObj =
+      () -> {
+        throw new UnsupportedOperationException("test fake, not supported");
+      };
+
+  @Test
+  void fromKeyEventCode() {
+    assertThrows(IllegalArgumentException.class, () -> testObj.fromKeyEventCode(1110));
+  }
+
+  @Test
+  void fromKeyEventCodeSuccessCases() {
+    assertThat(testObj.fromKeyEventCode(KeyEvent.VK_F), is(KeyStroke.getKeyStroke('F', 0)));
+    assertThat(testObj.fromKeyEventCode(KeyEvent.VK_S), is(KeyStroke.getKeyStroke('S', 0)));
+    assertThat(testObj.fromKeyEventCode(KeyEvent.VK_C), is(KeyStroke.getKeyStroke('C', 0)));
+    assertThat(testObj.fromKeyEventCode(KeyEvent.VK_E), is(KeyStroke.getKeyStroke('E', 0)));
+    assertThat(testObj.fromKeyEventCode(KeyEvent.VK_SPACE), is(KeyStroke.getKeyStroke(' ', 0)));
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/ui/KeyBindingsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/KeyBindingsTest.java
@@ -11,15 +11,15 @@ import org.junit.jupiter.api.Test;
 class KeyBindingsTest {
   @Test
   void fromKeyEventCode() {
-    assertThrows(IllegalArgumentException.class, () -> KeyBindings.fromKeyEventCode(1110));
+    assertThrows(IllegalArgumentException.class, () -> KeyBindingSupplier.fromKeyEventCode(1110));
   }
 
   @Test
   void fromKeyEventCodeSuccessCases() {
-    assertThat(KeyBindings.fromKeyEventCode(KeyEvent.VK_F), is(KeyStroke.getKeyStroke('F', 0)));
-    assertThat(KeyBindings.fromKeyEventCode(KeyEvent.VK_S), is(KeyStroke.getKeyStroke('S', 0)));
-    assertThat(KeyBindings.fromKeyEventCode(KeyEvent.VK_C), is(KeyStroke.getKeyStroke('C', 0)));
-    assertThat(KeyBindings.fromKeyEventCode(KeyEvent.VK_E), is(KeyStroke.getKeyStroke('E', 0)));
-    assertThat(KeyBindings.fromKeyEventCode(KeyEvent.VK_SPACE), is(KeyStroke.getKeyStroke(' ', 0)));
+    assertThat(KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_F), is(KeyStroke.getKeyStroke('F', 0)));
+    assertThat(KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_S), is(KeyStroke.getKeyStroke('S', 0)));
+    assertThat(KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_C), is(KeyStroke.getKeyStroke('C', 0)));
+    assertThat(KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_E), is(KeyStroke.getKeyStroke('E', 0)));
+    assertThat(KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_SPACE), is(KeyStroke.getKeyStroke(' ', 0)));
   }
 }


### PR DESCRIPTION
## Overview
Convert some key listeners to key bindings. Key bindings do not need exact component focus and more reliably fire. Fixes problem where component focus is lost after moving units in multiplayer game making hotkeys no longer work. Because focus is not required, the 'setfocusable(false)' flag on buttons is no longer required.

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Code Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[X] Bug fix

<!-- If fixing a bug, uncomment the below and fill in each section -->
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)
https://github.com/triplea-game/triplea/issues/4959

### Root Cause (What caused the bug?)
Swing focus can be lost relatively easily

### Fix description (How is the bug fixed?)

Use key bindings instead of key listeners

> Key listeners are also difficult if the key binding is to be active when the component doesn't have focus. Some of the advantages of key bindings are they're somewhat self documenting, take the containment hierarchy into account, encourage reusable chunks of code (Action objects), and allow actions to be easily removed, customized, or shared. Also, they make it easy to change the key to which an action is bound. Another advantage of Actions is that they have an enabled state which provides an easy way to disable the action without having to track which component it is attached to.
(https://docs.oracle.com/javase/tutorial/uiswing/misc/keybinding.html)


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[X] Manually tested
[ ] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->

### Manual Testing
- Launched a network game, moved a unit, used hotkeys  'f', 'n', 'm'  


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->
