### PR TITLE
Suppress Travis pack200 errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,6 @@ before_deploy:
 - INSTALL4J_HOME=~/install4j
 - ./.travis/install_install4j "$INSTALL4J_HOME"
 - (./gradlew -Pinstall4jHomeDir="$INSTALL4J_HOME" release  2> errors && echo "INSTALL4J finished with $(wc -l errors)") || (echo "INSTALL4J FAILED" && tail -500 errors)
-- ./gradlew -Pinstall4jHomeDir="$INSTALL4J_HOME" release | egrep -v "^WARNING: Passing class file uncompressed due to unrecognized attribute|Pack200Logger warning$"
 - ./.travis/collect_artifacts
 - ./.travis/generate_artifact_checksums
 - ./.travis/push_tag

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ after_success:
 before_deploy:
 - INSTALL4J_HOME=~/install4j
 - ./.travis/install_install4j "$INSTALL4J_HOME"
-- ./gradlew -Pinstall4jHomeDir="$INSTALL4J_HOME" release
+- ./gradlew -Pinstall4jHomeDir="$INSTALL4J_HOME" release | egrep -v "^WARNING: Passing class file uncompressed due to unrecognized attribute|Pack200Logger warning$"
 - ./.travis/collect_artifacts
 - ./.travis/generate_artifact_checksums
 - ./.travis/push_tag

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,6 +35,7 @@ after_success:
 before_deploy:
 - INSTALL4J_HOME=~/install4j
 - ./.travis/install_install4j "$INSTALL4J_HOME"
+- (./gradlew -Pinstall4jHomeDir="$INSTALL4J_HOME" release  2> errors && echo "INSTALL4J finished with $(wc -l errors)") || (echo "INSTALL4J FAILED" && tail -500 errors)
 - ./gradlew -Pinstall4jHomeDir="$INSTALL4J_HOME" release | egrep -v "^WARNING: Passing class file uncompressed due to unrecognized attribute|Pack200Logger warning$"
 - ./.travis/collect_artifacts
 - ./.travis/generate_artifact_checksums


### PR DESCRIPTION
Logs becoming truncated obscuring actual error messages making debug excessively difficult.

Example (https://api.travis-ci.org/v3/job/575694759/log.txt)
```
Aug 23, 2019 7:18:36 AM com.sun.java.util.jar.pack.Utils$Pack200Logger warning
WARNING: Passing class file uncompressed due to unrecognized attribute: javafx/beans/property/IntegerPropertyBase$2.class
Aug 23, 2019 7:18:36 AM com.sun.java.util.jar.pack.Utils$Pack200Logger warning
WARNING: Passing class file uncompressed due to unrecognized attribu
```