### PR TITLE
Blank email is not allowed in client or server.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/CreateUpdateAccountPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/CreateUpdateAccountPanel.java
@@ -277,7 +277,7 @@ public final class CreateUpdateAccountPanel extends JPanel {
           "Invalid name",
           JOptionPane.ERROR_MESSAGE);
       return;
-    } else if (emailField.getText().length() == 0) {
+    } else if (emailField.getText().isEmpty()) {
       JOptionPane.showMessageDialog(
           this, "You must enter an email", "No Email", JOptionPane.ERROR_MESSAGE);
       return;

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/CreateUpdateAccountPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/CreateUpdateAccountPanel.java
@@ -277,9 +277,10 @@ public final class CreateUpdateAccountPanel extends JPanel {
           "Invalid name",
           JOptionPane.ERROR_MESSAGE);
       return;
-    } else if (usernameField.getText().length() == 0) {
+    } else if (emailField.getText().length() == 0) {
       JOptionPane.showMessageDialog(
           this, "You must enter an email", "No Email", JOptionPane.ERROR_MESSAGE);
+      return;
     } else if (passwordField.getPassword().length == 0) {
       JOptionPane.showMessageDialog(
           this, "You must enter a password", "No Password", JOptionPane.ERROR_MESSAGE);

--- a/lobby/src/main/java/org/triplea/lobby/server/login/LobbyLoginValidator.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/login/LobbyLoginValidator.java
@@ -237,12 +237,12 @@ public final class LobbyLoginValidator implements ILoginValidator {
       return validationMessage;
     }
 
-    if (email.trim().equals("")) {
-      return "Empty email address";
+    if (email.trim().isEmpty()) {
+      return "Must provide an email address";
     }
 
     if (email.trim().contains(" ")) {
-      return "Email address contains spaces";
+      return "Email address may not contain spaces";
     }
 
     if (database.getUserDao().doesUserExist(username)) {

--- a/lobby/src/main/java/org/triplea/lobby/server/login/LobbyLoginValidator.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/login/LobbyLoginValidator.java
@@ -229,20 +229,19 @@ public final class LobbyLoginValidator implements ILoginValidator {
   private @Nullable String createUser(final Map<String, String> response, final User user) {
     final String username = user.getUsername();
     final String email = response.get(LobbyLoginResponseKeys.EMAIL);
+    if (email == null || email.trim().isEmpty()) {
+      return "Must provide an email address";
+    }
+
+    if (email.trim().contains(" ")) {
+      return "Email address may not contain spaces";
+    }
 
     final String validationMessage =
         Optional.ofNullable(PlayerNameValidation.validate(username))
             .orElseGet(() -> PlayerEmailValidation.validate(email));
     if (validationMessage != null) {
       return validationMessage;
-    }
-
-    if (email.trim().isEmpty()) {
-      return "Must provide an email address";
-    }
-
-    if (email.trim().contains(" ")) {
-      return "Email address may not contain spaces";
     }
 
     if (database.getUserDao().doesUserExist(username)) {

--- a/lobby/src/main/java/org/triplea/lobby/server/login/LobbyLoginValidator.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/login/LobbyLoginValidator.java
@@ -237,6 +237,14 @@ public final class LobbyLoginValidator implements ILoginValidator {
       return validationMessage;
     }
 
+    if (email.trim().equals("")) {
+      return "Empty email address";
+    }
+
+    if (email.trim().contains(" ")) {
+      return "Email address contains spaces";
+    }
+
     if (database.getUserDao().doesUserExist(username)) {
       return "That user name has already been taken";
     }


### PR DESCRIPTION
## Overview
<!-- What changes did you make? Provide a summary of the updates included in this pull request -->
Now, the client shows an error if you attempt to sign up with an empty email address, and the server shows an error if the client allows the email address through. The server also doesn't allow multiple email addresses to be used.

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Code Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[X] Bug fix

<!-- If fixing a bug, uncomment the below and fill in each section -->
## Bug Fix
It was possible to sign up for the lobby with an empty email address.

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)
Fixes #4990

### Root Cause (What caused the bug?)
There was just some validation that needed to happen.

### Fix description (How is the bug fixed?)
Added needed validation.


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[X] Manually tested
[ ] No testing done

### Manual Testing
Tried to log in with an empty email address, first with the unmodified client to test the server, then with the modified client to test the client.


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

### Notes
I had to fix a small bug with my last pull request where I was actually testing the username field in the client.
