### PR TITLE
Fix highlight units, correct turn

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -1645,7 +1645,7 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
       getData().releaseReadLock();
     }
     final Predicate<Unit> movableUnitOwnedByMe =
-        PredicateBuilder.of(Matches.unitIsOwnedBy(getCurrentPlayer()))
+        PredicateBuilder.of(Matches.unitIsOwnedBy(getData().getSequence().getStep().getPlayerId()))
             .and(Matches.unitHasMovementLeft())
             // if not non combat, cannot move aa units
             .andIf(!nonCombat, Matches.unitCanNotMoveDuringCombatMove().negate())


### PR DESCRIPTION
## Overview
Action panel current player does not increment correctly on first phase of turn (at least). This fix grabs the actual current player which allows the highlight current units to highlight the right units. Previously on a purchase phase the units of the previous turn would be higlighted.

<!-- What changes did you make? Provide a summary of the updates included in this pull request -->

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Code Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[X] Bug fix

<!-- If fixing a bug, uncomment the below and fill in each section -->
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)
https://github.com/triplea-game/triplea/issues/5060

### Root Cause (What caused the bug?)
Previous 'currentPlayer' value does not update correctly. (Why is unknown)

### Fix description (How is the bug fixed?)
Use gameData getSequence current player which does update to be the latest player



## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[X] Manually tested
[ ] No testing done
