### PR TITLE
Require playernames to start with a character

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/PlayerNameValidation.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/PlayerNameValidation.java
@@ -39,7 +39,7 @@ public final class PlayerNameValidation {
       return "Name is too short (minimum " + MIN_LENGTH + " characters)";
     } else if (username.length() > MAX_LENGTH) {
       return "Name is too long (maximum " + MAX_LENGTH + " characters)";
-    } else if (!username.matches("[0-9a-zA-Z_-]+")) {
+    } else if (!username.matches("[a-zA-Z][0-9a-zA-Z_-]+")) {
       return "Name can only contain alphanumeric characters, hyphens (-), and underscores (_)";
     } else if (username.toLowerCase().contains(LobbyConstants.ADMIN_USERNAME.toLowerCase())) {
       return "Name can't contain the word " + LobbyConstants.ADMIN_USERNAME;

--- a/game-core/src/test/java/games/strategy/engine/lobby/PlayerNameValidationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/PlayerNameValidationTest.java
@@ -26,6 +26,12 @@ class PlayerNameValidationTest {
             "a,b",
             "ab?",
             "   ", // no spaces
+            "---", // must start with a character
+            "___",
+            "_ab",
+            "01a",
+            "123",
+            "-ab",
             "a b")
         .forEach(
             invalidName -> {
@@ -65,7 +71,7 @@ class PlayerNameValidationTest {
 
   @Test
   void usernameValidationWithValidNames() {
-    Arrays.asList("abc", Strings.repeat("a", PlayerNameValidation.MAX_LENGTH), "123", "---")
+    Arrays.asList("abc", Strings.repeat("a", PlayerNameValidation.MAX_LENGTH), "a12", "a--")
         .forEach(
             validName -> {
               assertThat(

--- a/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/login/LobbyLoginValidatorIntegrationTest.java
@@ -44,7 +44,7 @@ class LobbyLoginValidatorIntegrationTest {
           JdbiDatabase.newConnection().onDemand(TempPasswordDao.class));
 
   private ChallengeResultFunction generateChallenge(final HashedPassword password) {
-    return generateChallenge(TestUserUtils.newUniqueTimestamp(), password);
+    return generateChallenge("a" + TestUserUtils.newUniqueTimestamp(), password);
   }
 
   private ChallengeResultFunction generateChallenge(
@@ -73,7 +73,7 @@ class LobbyLoginValidatorIntegrationTest {
 
   @Test
   void testCreateNewUser() {
-    final String name = TestUserUtils.newUniqueTimestamp();
+    final String name = "a" + TestUserUtils.newUniqueTimestamp();
     final String password = "password";
     final Map<String, String> response = new HashMap<>();
     response.put(LobbyLoginResponseKeys.REGISTER_NEW_USER, Boolean.TRUE.toString());


### PR DESCRIPTION
## Overview
This update disallows names such as "---" and required player names to begin with a character.

Addresses requested naming requirement (4) in: https://github.com/triplea-game/triplea/issues/3783#issuecomment-465382253

> 4. Must start with a letter (not with numbers or dash or underscore) (which implies they will have at least a letter in them).


## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[X] Feature update or enhancement
[ ] Code Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix

<!-- If fixing a bug, uncomment the below and fill in each section -->
<!--
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)

### Root Cause (What caused the bug?)

### Fix description (How is the bug fixed?)

-->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[X] Manually tested
[ ] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
<!--
### Manual Testing
 
-->


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

