### PR TITLE
Add hotkey (shift+d) for 'Done' Button

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/pbem/ForumPosterComponent.java
+++ b/game-core/src/main/java/games/strategy/engine/pbem/ForumPosterComponent.java
@@ -5,15 +5,16 @@ import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.random.IRandomStats;
 import games.strategy.triplea.delegate.GameStepPropertiesHelper;
 import games.strategy.triplea.delegate.remote.IAbstractForumPosterDelegate;
+import games.strategy.triplea.ui.ActionButtons;
 import games.strategy.triplea.ui.TripleAFrame;
 import games.strategy.triplea.ui.history.HistoryLog;
 import java.util.Collection;
-import javax.swing.Action;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JPanel;
 import javax.swing.border.EmptyBorder;
+import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.SwingAction;
 
 /** A panel used to configure and post a PBEM/PBF game. */
@@ -31,11 +32,11 @@ public final class ForumPosterComponent extends JPanel {
   private final JCheckBox showDiceStatisticsCheckBox;
   private final JCheckBox includeSavegameCheckBox;
   private final JCheckBox repostTurnSummaryCheckBox;
-  private final Action doneAction;
+  private final Runnable doneAction;
   private final String title;
   private IAbstractForumPosterDelegate forumPosterDelegate;
 
-  public ForumPosterComponent(final GameData data, final Action doneAction, final String title) {
+  public ForumPosterComponent(final GameData data, final Runnable doneAction, final String title) {
     setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
     setBorder(new EmptyBorder(5, 5, 0, 0));
 
@@ -122,7 +123,12 @@ public final class ForumPosterComponent extends JPanel {
     add(new JButton(SwingAction.of("View " + title, e -> viewHistoryLog())));
     postButton.setEnabled(!hasPosted);
     add(postButton);
-    add(new JButton(doneAction));
+    add(
+        JButtonBuilder.builder()
+            .title("Done")
+            .actionListener(doneAction::run)
+            .toolTip(ActionButtons.DONE_BUTTON_TOOLTIP)
+            .build());
     validate();
     return this;
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -24,7 +24,6 @@ import javax.swing.SwingUtilities;
 import lombok.AccessLevel;
 import lombok.Getter;
 import org.triplea.swing.JButtonBuilder;
-import org.triplea.swing.SwingAction;
 import org.triplea.swing.SwingComponents;
 
 abstract class AbstractMovePanel extends ActionPanel {
@@ -49,6 +48,14 @@ abstract class AbstractMovePanel extends ActionPanel {
     this.frame = frame;
     disableCancelButton();
     undoableMoves = Collections.emptyList();
+  }
+
+  @Override
+  public void performDone() {
+    if (doneMoveAction()) {
+      moveMessage = null;
+      release();
+    }
   }
 
   abstract Component getUnitScrollerPanel(LocalPlayers localPlayers, Runnable toggleFlagsAction);
@@ -256,15 +263,11 @@ abstract class AbstractMovePanel extends ActionPanel {
     }
     movedUnitsPanel.add(
         SwingComponents.leftBox(
-            new JButton(
-                SwingAction.of(
-                    "Done",
-                    e -> {
-                      if (doneMoveAction()) {
-                        moveMessage = null;
-                        release();
-                      }
-                    }))));
+            JButtonBuilder.builder()
+                .title("Done")
+                .toolTip(ActionButtons.DONE_BUTTON_TOOLTIP)
+                .actionListener(this::performDone)
+                .build()));
     getAdditionalButtons().forEach(movedUnitsPanel::add);
     movedUnitsPanel.add(Box.createVerticalStrut(entryPadding));
     movedUnitsPanel.add(undoableMovesPanel);

--- a/game-core/src/main/java/games/strategy/triplea/ui/ActionButtons.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ActionButtons.java
@@ -17,7 +17,10 @@ import games.strategy.triplea.delegate.data.TechRoll;
 import games.strategy.triplea.delegate.remote.IPoliticsDelegate;
 import games.strategy.triplea.delegate.remote.IUserActionDelegate;
 import java.awt.CardLayout;
+import java.awt.event.InputEvent;
+import java.awt.event.KeyEvent;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -25,12 +28,15 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.util.Tuple;
 
 /** Root panel for all action buttons in a triplea game. */
-public class ActionButtons extends JPanel {
+public class ActionButtons extends JPanel implements KeyBindingSupplier {
+  public static final String DONE_BUTTON_TOOLTIP =
+      "Press shift+D or click this button to end the current turn phase";
   private static final long serialVersionUID = 2175685892863042399L;
   private final CardLayout layout = new CardLayout();
   private BattlePanel battlePanel;
@@ -268,5 +274,16 @@ public class ActionButtons extends JPanel {
 
   public BattlePanel getBattlePanel() {
     return battlePanel;
+  }
+
+  /**
+   * Adds a hotkey listener to 'click the done button'. If the current phase has no done button (eg:
+   * combat phase), then the hotkey will be a no-op.
+   */
+  @Override
+  public Map<KeyStroke, Runnable> get() {
+    return Collections.singletonMap(
+        KeyStroke.getKeyStroke(KeyEvent.VK_D, InputEvent.SHIFT_DOWN_MASK),
+        () -> Optional.ofNullable(actionPanel).ifPresent(ActionPanel::performDone));
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/ActionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ActionPanel.java
@@ -115,4 +115,12 @@ public abstract class ActionPanel extends JPanel {
     currentPlayer = player;
     setActive(true);
   }
+
+  /**
+   * Executes the appropriate action when a user clicks the 'done' button. Typically this will be to
+   * end the current turn phase. If the turn phase ends in some other way than a button click, then
+   * this should be a no-op. For example battle phase ends when all battles have been fought and not
+   * when when the user clicks done (there is no done button during the battle phase).
+   */
+  abstract void performDone();
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/ActionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ActionPanel.java
@@ -119,8 +119,8 @@ public abstract class ActionPanel extends JPanel {
   /**
    * Executes the appropriate action when a user clicks the 'done' button. Typically this will be to
    * end the current turn phase. If the turn phase ends in some other way than a button click, then
-   * this should be a no-op. For example battle phase ends when all battles have been fought and not
-   * when when the user clicks done (there is no done button during the battle phase).
+   * this should be a no-op. For example, battle phase ends when all battles have been fought and not
+   * when the user clicks done (there is no done button during the battle phase).
    */
   abstract void performDone();
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/ActionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ActionPanel.java
@@ -119,8 +119,8 @@ public abstract class ActionPanel extends JPanel {
   /**
    * Executes the appropriate action when a user clicks the 'done' button. Typically this will be to
    * end the current turn phase. If the turn phase ends in some other way than a button click, then
-   * this should be a no-op. For example, battle phase ends when all battles have been fought and not
-   * when the user clicks done (there is no done button during the battle phase).
+   * this should be a no-op. For example, battle phase ends when all battles have been fought and
+   * not when the user clicks done (there is no done button during the battle phase).
    */
   abstract void performDone();
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -95,6 +95,11 @@ public final class BattlePanel extends ActionPanel {
         });
   }
 
+  @Override
+  void performDone() {
+    // no-op; battles are done when they all have been fought, there is no done button.
+  }
+
   private void addBattleActions(
       final JPanel panel,
       final Territory territory,

--- a/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -1041,4 +1041,9 @@ class EditPanel extends ActionPanel {
     }
     return false;
   }
+
+  @Override
+  void performDone() {
+    // no-op, no done button to be clicked, instead user should turn edit mode off.
+  }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/EndTurnPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EndTurnPanel.java
@@ -4,30 +4,27 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.pbem.ForumPosterComponent;
 import games.strategy.engine.player.IPlayerBridge;
 import games.strategy.triplea.delegate.remote.IAbstractForumPosterDelegate;
-import javax.swing.Action;
 import javax.swing.JOptionPane;
-import org.triplea.swing.SwingAction;
 
 class EndTurnPanel extends AbstractForumPosterPanel {
   private static final long serialVersionUID = -6282316384529504341L;
-  protected final Action doneAction =
-      SwingAction.of(
-          "Done",
-          e -> {
-            if (forumPosterComponent.getHasPostedTurnSummary()
-                || JOptionPane.YES_OPTION
-                    == JOptionPane.showConfirmDialog(
-                        JOptionPane.getFrameForComponent(EndTurnPanel.this),
-                        "Are you sure you don't want to post?",
-                        "Bypass post",
-                        JOptionPane.YES_NO_OPTION)) {
-              release();
-            }
-          });
 
   EndTurnPanel(final GameData data, final MapPanel map) {
     super(data, map);
-    forumPosterComponent = new ForumPosterComponent(getData(), doneAction, getTitle());
+    forumPosterComponent = new ForumPosterComponent(getData(), this::performDone, getTitle());
+  }
+
+  @Override
+  void performDone() {
+    if (forumPosterComponent.getHasPostedTurnSummary()
+        || JOptionPane.YES_OPTION
+            == JOptionPane.showConfirmDialog(
+                JOptionPane.getFrameForComponent(EndTurnPanel.this),
+                "Are you sure you don't want to post?",
+                "Bypass post",
+                JOptionPane.YES_NO_OPTION)) {
+      release();
+    }
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/ui/MoveForumPosterPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MoveForumPosterPanel.java
@@ -4,16 +4,18 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.pbem.ForumPosterComponent;
 import games.strategy.engine.player.IPlayerBridge;
 import games.strategy.triplea.delegate.remote.IAbstractForumPosterDelegate;
-import javax.swing.Action;
-import org.triplea.swing.SwingAction;
 
 class MoveForumPosterPanel extends AbstractForumPosterPanel {
   private static final long serialVersionUID = -533962696697230277L;
 
   MoveForumPosterPanel(final GameData data, final MapPanel map) {
     super(data, map);
-    final Action doneAction = SwingAction.of("Done", e -> release());
-    forumPosterComponent = new ForumPosterComponent(getData(), doneAction, getTitle());
+    forumPosterComponent = new ForumPosterComponent(getData(), this::performDone, getTitle());
+  }
+
+  @Override
+  void performDone() {
+    release();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
@@ -29,6 +29,7 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
 import javax.swing.SwingUtilities;
+import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.SwingAction;
 
 /**
@@ -49,17 +50,6 @@ public class PoliticsPanel extends ActionPanel {
    * release this model and trigger waitForRelease().
    */
   private final Action selectPoliticalActionAction;
-
-  /** This will stop the politicsPhase. */
-  private final Action dontBotherAction =
-      SwingAction.of(
-          "Done",
-          e -> {
-            if (!firstRun || youSureDoNothing()) {
-              choice = null;
-              release();
-            }
-          });
 
   PoliticsPanel(final GameData data, final MapPanel map, final TripleAFrame parent) {
     super(data, map);
@@ -178,11 +168,24 @@ public class PoliticsPanel extends ActionPanel {
           selectPoliticalActionButton = new JButton(selectPoliticalActionAction);
           selectPoliticalActionButton.setEnabled(false);
           add(selectPoliticalActionButton);
-          doneButton = new JButton(dontBotherAction);
-          doneButton.setEnabled(false);
+          doneButton =
+              JButtonBuilder.builder()
+                  .title("Done")
+                  .actionListener(this::performDone)
+                  .toolTip(ActionButtons.DONE_BUTTON_TOOLTIP)
+                  .enabled(false)
+                  .build();
           SwingUtilities.invokeLater(() -> doneButton.requestFocusInWindow());
           add(doneButton);
         });
+  }
+
+  @Override
+  void performDone() {
+    if (!firstRun || youSureDoNothing()) {
+      choice = null;
+      release();
+    }
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/ui/RepairPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/RepairPanel.java
@@ -10,7 +10,6 @@ import java.awt.event.ActionListener;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import javax.swing.Action;
 import javax.swing.Box;
 import javax.swing.JButton;
 import javax.swing.JFrame;
@@ -18,7 +17,7 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 import org.triplea.java.collections.IntegerMap;
-import org.triplea.swing.SwingAction;
+import org.triplea.swing.JButtonBuilder;
 
 class RepairPanel extends ActionPanel {
   private static final long serialVersionUID = 3045997038627313714L;
@@ -60,25 +59,6 @@ class RepairPanel extends ActionPanel {
         }
       };
 
-  private final Action doneAction =
-      SwingAction.of(
-          "Done",
-          e -> {
-            final boolean hasPurchased = getTotalValues(repair) != 0;
-            if (!hasPurchased) {
-              final int selectedOption =
-                  JOptionPane.showConfirmDialog(
-                      JOptionPane.getFrameForComponent(RepairPanel.this),
-                      "Are you sure you dont want to repair anything?",
-                      "End Purchase",
-                      JOptionPane.YES_NO_OPTION);
-              if (selectedOption != JOptionPane.YES_OPTION) {
-                return;
-              }
-            }
-            release();
-          });
-
   RepairPanel(final GameData data, final MapPanel map) {
     super(data, map);
     unitsPanel = new SimpleUnitPanel(map.getUiContext());
@@ -97,7 +77,12 @@ class RepairPanel extends ActionPanel {
           buyButton.setText(BUY);
           add(actionLabel);
           add(buyButton);
-          add(new JButton(doneAction));
+          add(
+              JButtonBuilder.builder()
+                  .toolTip("Done")
+                  .actionListener(this::performDone)
+                  .toolTip(ActionButtons.DONE_BUTTON_TOOLTIP)
+                  .build());
           repairedSoFar.setText("");
           add(Box.createVerticalStrut(9));
           add(repairedSoFar);
@@ -107,6 +92,23 @@ class RepairPanel extends ActionPanel {
           add(Box.createVerticalGlue());
           refresh.run();
         });
+  }
+
+  @Override
+  void performDone() {
+    final boolean hasPurchased = getTotalValues(repair) != 0;
+    if (!hasPurchased) {
+      final int selectedOption =
+          JOptionPane.showConfirmDialog(
+              JOptionPane.getFrameForComponent(RepairPanel.this),
+              "Are you sure you dont want to repair anything?",
+              "End Purchase",
+              JOptionPane.YES_NO_OPTION);
+      if (selectedOption != JOptionPane.YES_OPTION) {
+        return;
+      }
+    }
+    release();
   }
 
   private void refreshActionLabelText() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/TechPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TechPanel.java
@@ -33,6 +33,7 @@ import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
+import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.SwingAction;
 import org.triplea.swing.SwingComponents;
 
@@ -99,14 +100,6 @@ class TechPanel extends ActionPanel {
                 getData().releaseReadLock();
               }
             }
-            release();
-          });
-
-  private final Action dontBother =
-      SwingAction.of(
-          "Done",
-          e -> {
-            techRoll = null;
             release();
           });
 
@@ -238,9 +231,20 @@ class TechPanel extends ActionPanel {
             add(new JButton(justRollTech));
           } else {
             add(new JButton(getTechRollsAction));
-            add(new JButton(dontBother));
+            add(
+                JButtonBuilder.builder()
+                    .title("Done")
+                    .actionListener(this::performDone)
+                    .toolTip(ActionButtons.DONE_BUTTON_TOOLTIP)
+                    .build());
           }
         });
+  }
+
+  @Override
+  void performDone() {
+    techRoll = null;
+    release();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -619,7 +619,7 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
     final MovePanel movePanel = new MovePanel(data, mapPanel, this);
     actionButtons = new ActionButtons(data, mapPanel, movePanel, this);
 
-    addKeyBindings(movePanel, this);
+    addKeyBindings(movePanel, actionButtons, this);
     SwingUtilities.invokeLater(() -> mapPanel.addKeyListener(getArrowKeyListener()));
 
     addTab("Actions", actionButtons, 'C');

--- a/game-core/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
@@ -29,6 +29,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
+import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.SwingAction;
 
 /** Similar to PoliticsPanel, but for UserActionAttachment/Delegate. */
@@ -103,23 +104,6 @@ public class UserActionPanel extends ActionPanel {
         }
       };
 
-  /** This will stop the user action Phase. */
-  private final Action dontBotherAction =
-      SwingAction.of(
-          "Done",
-          e -> {
-            if (!firstRun
-                || JOptionPane.showConfirmDialog(
-                        JOptionPane.getFrameForComponent(UserActionPanel.this),
-                        "Are you sure you dont want to do anything?",
-                        "End Actions",
-                        JOptionPane.YES_NO_OPTION)
-                    == JOptionPane.YES_OPTION) {
-              choice = null;
-              release();
-            }
-          });
-
   UserActionPanel(final GameData data, final MapPanel map, final TripleAFrame parent) {
     super(data, map);
     this.parent = parent;
@@ -142,11 +126,31 @@ public class UserActionPanel extends ActionPanel {
           selectUserActionButton = new JButton(selectUserActionAction);
           selectUserActionButton.setEnabled(false);
           add(selectUserActionButton);
-          doneButton = new JButton(dontBotherAction);
+          doneButton =
+              JButtonBuilder.builder()
+                  .title("Done")
+                  .actionListener(this::performDone)
+                  .toolTip(ActionButtons.DONE_BUTTON_TOOLTIP)
+                  .enabled(false)
+                  .build();
           doneButton.setEnabled(false);
           SwingUtilities.invokeLater(() -> doneButton.requestFocusInWindow());
           add(doneButton);
         });
+  }
+
+  @Override
+  void performDone() {
+    if (!firstRun
+        || JOptionPane.showConfirmDialog(
+                JOptionPane.getFrameForComponent(UserActionPanel.this),
+                "Are you sure you dont want to do anything?",
+                "End Actions",
+                JOptionPane.YES_NO_OPTION)
+            == JOptionPane.YES_OPTION) {
+      choice = null;
+      release();
+    }
   }
 
   /**


### PR DESCRIPTION
## Overview
Adds a key binding (shift+d) to execute the done action. Some minor refactoring is done to enable this. A tooltip is added to each done button to tell the user of the hotkey. Initially (ctrl+d) was chosen, but it had an OS conflict and did not work, hence 'shift' was chosen.

<!-- What changes did you make? Provide a summary of the updates included in this pull request -->

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[x] New Feature
[ ] Feature update or enhancement
[ ] Code Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix

<!-- If fixing a bug, uncomment the below and fill in each section -->
<!--
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)

### Root Cause (What caused the bug?)

### Fix description (How is the bug fixed?)

-->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[x] Manually tested
[ ] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
<!--
### Manual Testing
 
-->


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

