### PR TITLE
Update unit scroller, highlight current territory

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -151,6 +151,9 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
   public static final ClientSetting<char[]> aaForumPassword =
       new ProtectedStringClientSetting("A&A_FORUM_PASSWORD");
 
+  public static final ClientSetting<Boolean> unitScrollerHighlightTerritory =
+      new BooleanClientSetting("UNIT_SCROLLER_HIGHLIGHT_TERRITORY", true);
+
   private static final AtomicReference<Preferences> preferencesRef = new AtomicReference<>();
 
   @Getter(value = AccessLevel.PROTECTED)

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -357,6 +357,17 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
       return SelectionComponentFactory.forumPosterSettings(
           ClientSetting.aaForumUsername, ClientSetting.aaForumPassword);
     }
+  },
+
+  UNIT_SCROLLER_HIGHLIGHT_TERRITORY(
+      "Highlight Territory on Unit Scroll",
+      SettingType.GAME,
+      "When scrolling through units, whether to also highlight territory") {
+    @Override
+    public SelectionComponent<JComponent> newSelectionComponent() {
+      return SelectionComponentFactory.booleanRadioButtons(
+          ClientSetting.unitScrollerHighlightTerritory);
+    }
   };
 
   @Getter(onMethod_ = {@Override})

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -386,12 +386,23 @@ public class MapPanel extends ImageScrollerLargeView {
     highlightTerritory(territory, Integer.MAX_VALUE);
   }
 
-  void highlightTerritory(final Territory territory, final int totalFrames) {
+  /**
+   * Adds a highlight to a territory. The highlight is a white outline that will flash.
+   *
+   * @param territory The territory to highlight
+   * @param totalFrames The number of times to flash on and off the territory highlight.
+   */
+  public void highlightTerritory(final Territory territory, final int totalFrames) {
+    highlightTerritory(territory, totalFrames, 500);
+  }
+
+  public void highlightTerritory(
+      final Territory territory, final int totalFrames, final int delay) {
     withMapUnlocked(
         () -> {
           centerOn(territory);
           highlightedTerritory = territory;
-          territoryHighlighter.highlight(territory, totalFrames);
+          territoryHighlighter.highlight(territory, totalFrames, delay);
         });
   }
 
@@ -938,9 +949,9 @@ public class MapPanel extends ImageScrollerLargeView {
     private @Nullable Territory territory;
     private final Timer timer = new Timer(500, e -> animateNextFrame());
 
-    void highlight(final Territory territory, final int totalFrames) {
+    void highlight(final Territory territory, final int totalFrames, final int delay) {
       stopAnimation();
-      startAnimation(territory, totalFrames);
+      startAnimation(territory, totalFrames, delay);
     }
 
     private void stopAnimation() {
@@ -953,11 +964,12 @@ public class MapPanel extends ImageScrollerLargeView {
       territory = null;
     }
 
-    private void startAnimation(final Territory territory, final int totalFrames) {
+    private void startAnimation(final Territory territory, final int totalFrames, final int delay) {
       this.territory = territory;
       this.totalFrames = totalFrames;
       frame = 0;
 
+      timer.setDelay(delay);
       timer.start();
     }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -266,8 +266,15 @@ public class UnitScroller {
                   currentPlayerSupplier.get(),
                   getAllSkippedUnits())));
       mapPanel.centerOnTerritoryIgnoringMapLock(lastFocusedTerritory);
+      highlightTerritory(lastFocusedTerritory);
     } else {
       centerOnNextMovableUnit();
+    }
+  }
+
+  private void highlightTerritory(final Territory territory) {
+    if (ClientSetting.unitScrollerHighlightTerritory.getValueOrThrow()) {
+      mapPanel.highlightTerritory(territory, 4, 200);
     }
   }
 
@@ -378,6 +385,7 @@ public class UnitScroller {
       lastFocusedTerritory = newFocusedTerritory;
       territoryNameLabel.setText(lastFocusedTerritory.getName());
       mapPanel.centerOn(newFocusedTerritory);
+      highlightTerritory(newFocusedTerritory);
     }
   }
 }


### PR DESCRIPTION
## Overview
Update unit scroller, highlight current territory
    
- When using the unit scroller to select next, previous or current territory, not only will the units be highlighted, so will the territory. This is to help really draw the eye to the location.
- Adds a client setting to turn this behavior off if desired.

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[X] Feature update or enhancement
[ ] Code Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix

<!-- If fixing a bug, uncomment the below and fill in each section -->
<!--
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)

### Root Cause (What caused the bug?)

### Fix description (How is the bug fixed?)

-->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[X] Manually tested
[ ] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
<!--
### Manual Testing
 
-->


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
## Screens Shots
![Screenshot from 2019-08-24 21-01-12](https://user-images.githubusercontent.com/12397753/63645430-05302e00-c6b3-11e9-8b81-acaeb32c992c.png)

Notice the territory highlight:
![Screenshot from 2019-08-24 21-02-36](https://user-images.githubusercontent.com/12397753/63645431-05302e00-c6b3-11e9-9225-c023873ecb9e.png)


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

