### PR TITLE
Name de-dupe by MAC instead of by IP

### DIFF
--- a/game-core/src/main/java/games/strategy/net/PlayerNameAssigner.java
+++ b/game-core/src/main/java/games/strategy/net/PlayerNameAssigner.java
@@ -1,13 +1,12 @@
 package games.strategy.net;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Multimap;
 import games.strategy.engine.lobby.PlayerNameValidation;
-import java.net.InetAddress;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashSet;
+import java.util.Map;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.triplea.lobby.common.LobbyConstants;
@@ -22,24 +21,29 @@ public final class PlayerNameAssigner {
    * for the second node with the name "foo", this method will return "foo (1)".
    *
    * @param desiredName The name being requested by a new user joining.
-   * @param ipAddress The IP address of the user that is joining. Used to determine if the user is
+   * @param mac The (hashed) mac of the user that is joining. Used to determine if the user is
    *     already connected under a different name.
-   * @param loggedInNodes Collection of nodes that have already joined.
    */
   public static String assignName(
       final String desiredName,
-      final InetAddress ipAddress,
-      final Collection<INode> loggedInNodes) {
-    Preconditions.checkNotNull(ipAddress);
-    Preconditions.checkNotNull(loggedInNodes);
+      final String mac,
+      final Multimap<String, String> loggedInMacsToNames) {
     Preconditions.checkArgument(PlayerNameValidation.serverSideValidate(desiredName) == null);
+    Preconditions.checkNotNull(mac);
+    Preconditions.checkNotNull(loggedInMacsToNames);
 
-    String currentName = findLoggedInName(ipAddress, loggedInNodes).orElse(desiredName);
-    if (currentName.length() > 50) {
-      currentName = currentName.substring(0, 50);
+    String currentName = desiredName;
+
+    if (!isBotName(desiredName)) {
+      if (currentName.length() > 50) {
+        currentName = currentName.substring(0, 50);
+      }
+      currentName =
+          findExistingLoggedInNameFromSameMac(mac, loggedInMacsToNames).orElse(currentName);
     }
-    final Collection<String> playerNames =
-        new HashSet<>(loggedInNodes.stream().map(INode::getName).collect(Collectors.toSet()));
+
+    final Collection<String> playerNames = loggedInMacsToNames.values();
+
     final String originalName = currentName;
     for (int i = 1; playerNames.contains(currentName); i++) {
       currentName = originalName + " (" + i + ")";
@@ -47,12 +51,13 @@ public final class PlayerNameAssigner {
     return currentName;
   }
 
-  private static Optional<String> findLoggedInName(
-      final InetAddress socketAddress, final Collection<INode> nodes) {
-    return nodes.stream()
-        .filter(node -> node.getAddress().equals(socketAddress) && !isBotName(node.getName()))
-        .min(Comparator.naturalOrder())
-        .map(INode::getName);
+  private static Optional<String> findExistingLoggedInNameFromSameMac(
+      final String mac, final Multimap<String, String> loggedInMacsToNames) {
+
+    return loggedInMacsToNames.entries().stream()
+        .filter(entry -> mac.equals(entry.getKey()))
+        .map(Map.Entry::getValue)
+        .min(Comparator.naturalOrder());
   }
 
   private static boolean isBotName(final String desiredName) {

--- a/game-core/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ServerMessenger.java
@@ -9,7 +9,6 @@ import games.strategy.net.nio.QuarantineConversation;
 import games.strategy.net.nio.ServerQuarantineConversation;
 import java.io.IOException;
 import java.io.Serializable;
-import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SelectionKey;
@@ -17,7 +16,6 @@ import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
@@ -134,8 +132,6 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
    * Invoked when the node with the specified unique name has successfully logged in. Note that
    * {@code uniquePlayerName} is the node name and may not be identical to the name of the player
    * associated with the node
-   *
-   * @see PlayerNameAssigner#assignName(String, InetAddress, Collection)
    */
   public void notifyPlayerLogin(final String uniquePlayerName, final String mac) {
     cachedMacAddresses.put(uniquePlayerName, mac);

--- a/game-core/src/test/java/games/strategy/net/PlayerNameAssignerTest.java
+++ b/game-core/src/test/java/games/strategy/net/PlayerNameAssignerTest.java
@@ -1,29 +1,28 @@
 package games.strategy.net;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptyList;
-import static java.util.Collections.singleton;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.net.InetAddress;
-import java.util.Arrays;
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class PlayerNameAssignerTest {
 
-  private static final String name1 = "Never_endure_a_plunder";
-  private static final String name2 = "Cmon_never_vandalize_a_gull";
+  private static final String NAME_1 = "name_one";
+  private static final String NAME_2 = "name_two";
 
-  @Mock private InetAddress address1;
+  private static final String MAC = "mac 1";
+  private static final String MAC_2 = "mac 2";
 
-  @Mock private InetAddress address2;
+  //  @Mock private InetAddress address1;
+
+  //  @Mock private InetAddress address2;
 
   @Nested
   final class ErrorCases {
@@ -35,17 +34,10 @@ class PlayerNameAssignerTest {
     void nullArguments() {
       assertThrows(
           NullPointerException.class,
-          () -> PlayerNameAssigner.assignName(name1, null, emptyList()));
+          () -> PlayerNameAssigner.assignName(NAME_1, null, HashMultimap.create()));
 
       assertThrows(
-          NullPointerException.class, () -> PlayerNameAssigner.assignName(name1, address1, null));
-
-      Arrays.asList(null, "", "a", "_")
-          .forEach(
-              nameTooShort ->
-                  assertThrows(
-                      IllegalArgumentException.class,
-                      () -> PlayerNameAssigner.assignName(nameTooShort, address1, emptyList())));
+          NullPointerException.class, () -> PlayerNameAssigner.assignName(NAME_1, MAC, null));
     }
   }
 
@@ -53,27 +45,27 @@ class PlayerNameAssignerTest {
   void assignNameShouldGetAssignedNameWhenNotTaken() {
     assertThat(
         "no nodes to match against, we should get the desired name",
-        PlayerNameAssigner.assignName(name1, address1, emptyList()),
-        is(name1));
+        PlayerNameAssigner.assignName(NAME_1, MAC, HashMultimap.create()),
+        is(NAME_1));
 
     assertThat(
         "name and address do not match, should get the desired name",
-        PlayerNameAssigner.assignName(name1, address1, singleton(createNode(name2, address2))),
-        is(name1));
+        PlayerNameAssigner.assignName(NAME_1, MAC, createMacToPlayerMap(MAC_2, NAME_2)),
+        is(NAME_1));
   }
 
   @Test
   void assignNameWithMatchingNames() {
     assertThat(
         "name match, should be assigned a numeral name",
-        PlayerNameAssigner.assignName(name1, address1, singleton(createNode(name1, address2))),
-        is(name1 + " (1)"));
+        PlayerNameAssigner.assignName(NAME_1, MAC, createMacToPlayerMap(MAC_2, NAME_1)),
+        is(NAME_1 + " (1)"));
 
     assertThat(
         "name match, matching against multiple nodes",
         PlayerNameAssigner.assignName(
-            name1, address1, asList(createNode(name2, address2), createNode(name1, address2))),
-        is(name1 + " (1)"));
+            NAME_1, MAC, createMacToPlayerMap(MAC_2, NAME_2, "other-mac", NAME_1)),
+        is(NAME_1 + " (1)"));
   }
 
   /**
@@ -85,18 +77,8 @@ class PlayerNameAssignerTest {
     assertThat(
         "name match, should get next sequential numeral appended",
         PlayerNameAssigner.assignName(
-            name1,
-            address1,
-            asList(createNode(name1, address2), createNode(name1 + " (1)", address2))),
-        is(name1 + " (2)"));
-
-    assertThat(
-        "name match, should get next sequential numeral appended, " + "ordering should not matter",
-        PlayerNameAssigner.assignName(
-            name1,
-            address1,
-            asList(createNode(name1 + " (1)", address2), createNode(name1, address2))),
-        is(name1 + " (2)"));
+            NAME_1, MAC, createMacToPlayerMap(MAC_2, NAME_1, MAC_2, NAME_1 + " (1)")),
+        is(NAME_1 + " (2)"));
   }
 
   /**
@@ -107,39 +89,33 @@ class PlayerNameAssignerTest {
   void assignNameShouldFillInMissingNumerals() {
     assertThat(
         "name does not actually match",
-        PlayerNameAssigner.assignName(
-            name1, address1, singleton(createNode(name1 + " (1)", address2))),
-        is(name1));
+        PlayerNameAssigner.assignName(NAME_1, MAC, createMacToPlayerMap(MAC_2, NAME_1 + " (1)")),
+        is(NAME_1));
 
     assertThat(
         "name matches and there is gap in numbering",
         PlayerNameAssigner.assignName(
-            name1,
-            address1,
-            asList(createNode(name1, address2), createNode(name1 + " (2)", address2))),
-        is(name1 + " (1)"));
+            NAME_1, MAC, createMacToPlayerMap(MAC_2, NAME_1, MAC_2, NAME_1 + " (2)")),
+        is(NAME_1 + " (1)"));
 
     assertThat(
         "name matches and there is gap in numbering, ordering should not matter",
         PlayerNameAssigner.assignName(
-            name1,
-            address1,
-            asList(
-                createNode(name1 + " (3)", address2),
-                createNode(name1 + " (1)", address2),
-                createNode(name1, address2))),
-        is(name1 + " (2)"));
+            NAME_1,
+            MAC,
+            createMacToPlayerMap(
+                MAC_2, NAME_1 + " (3)",
+                MAC_2, NAME_1 + " (1)",
+                MAC_2, NAME_1)),
+        is(NAME_1 + " (2)"));
 
     assertThat(
         "should get next ascending numeral",
         PlayerNameAssigner.assignName(
-            name1,
-            address1,
-            asList(
-                createNode(name1 + " (2)", address2),
-                createNode(name1 + " (1)", address2),
-                createNode(name1, address2))),
-        is(name1 + " (3)"));
+            NAME_1,
+            MAC,
+            createMacToPlayerMap(MAC_2, NAME_1 + " (2)", MAC_2, NAME_1 + " (1)", MAC_2, NAME_1)),
+        is(NAME_1 + " (3)"));
   }
 
   /**
@@ -150,27 +126,48 @@ class PlayerNameAssignerTest {
   void matchingAddressWillIncrementOriginalName() {
     assertThat(
         "addresses match",
-        PlayerNameAssigner.assignName(name1, address1, singleton(createNode(name2, address1))),
-        is(name2 + " (1)"));
+        PlayerNameAssigner.assignName(NAME_1, MAC, createMacToPlayerMap(MAC, NAME_2)),
+        is(NAME_2 + " (1)"));
 
     assertThat(
         "addresses match, ordering should not matter",
         PlayerNameAssigner.assignName(
-            name1,
-            address1,
-            asList(createNode(name2 + " (1)", address1), createNode(name2, address1))),
-        is(name2 + " (2)"));
+            NAME_1, MAC, createMacToPlayerMap(MAC, NAME_2 + " (1)", MAC, NAME_2)),
+        is(NAME_2 + " (2)"));
 
     assertThat(
         "addresses match, should fill in gaps in the numerals",
         PlayerNameAssigner.assignName(
-            name1,
-            address1,
-            asList(createNode(name2 + " (2)", address1), createNode(name2, address1))),
-        is(name2 + " (1)"));
+            NAME_1, MAC, createMacToPlayerMap(MAC, NAME_2 + " (2)", MAC, NAME_2)),
+        is(NAME_2 + " (1)"));
   }
 
-  private static INode createNode(final String name, final InetAddress inetAddress) {
-    return new Node(name, inetAddress, 1234);
+  private static Multimap<String, String> createMacToPlayerMap(
+      final String mac1, final String name1) {
+    final Multimap<String, String> map = HashMultimap.create();
+    map.put(mac1, name1);
+    return map;
+  }
+
+  private static Multimap<String, String> createMacToPlayerMap(
+      final String mac1, final String name1, final String mac2, final String name2) {
+    final Multimap<String, String> map = HashMultimap.create();
+    map.put(mac1, name1);
+    map.put(mac2, name2);
+    return map;
+  }
+
+  private static Multimap<String, String> createMacToPlayerMap(
+      final String mac1,
+      final String name1,
+      final String mac2,
+      final String name2,
+      final String mac3,
+      final String name3) {
+    final Multimap<String, String> map = HashMultimap.create();
+    map.put(mac1, name1);
+    map.put(mac2, name2);
+    map.put(mac3, name3);
+    return map;
   }
 }


### PR DESCRIPTION
## Overview
Previous feature to enforce one player name per IP is switched to be one player name per MAC. After this update, logging in with the same device multiple times would always force teh same name. The switch from IP to MAC is to avoid a situation where a 'LAN party' (minus host) are all stuck using the same name.

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[X] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix

<!-- If fixing a bug, uncomment the below and fill in each section -->
<!--
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)

### Root Cause (What caused the bug?)

### Fix description (How is the bug fixed?)

-->


## Testing
<!-- Place an X next to any that apply -->

[X] Covered by existing automated tests
[ ] Covered by newly added automated tests
[ ] Manually tested
[ ] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
<!--
### Manual Testing
 
-->


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

