### PR TITLE
Add commentary to DB helper scripts

### DIFF
--- a/lobby-db/build_docker
+++ b/lobby-db/build_docker
@@ -1,3 +1,7 @@
 #!/bin/bash
 
+# This is a one-time script that needs to be run to set up a docker container.
+# If there are changes to the docker containers configuration, the container should
+# be destroyed and then re-run this script.
+
 docker build --tag triplea/lobby-db:latest .

--- a/lobby-db/connect_to_db
+++ b/lobby-db/connect_to_db
@@ -1,4 +1,6 @@
 #!/bin/bash
 
+# Simple helper script to connect to open a PSQL prompt
+# connected to the DB running locally on docker.
 psql -h localhost -U lobby_user -w -d lobby_db
 

--- a/lobby-db/drop_db
+++ b/lobby-db/drop_db
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Deletes database and creates a fresh database with no tables.
+# Use this script to clear out DB data and start from fresh.
+# Typically flyway migration will be run after this script.
+
 DB=lobby_db
 PSQL="psql -h localhost -U lobby_user -w -d postgres"
 echo "drop database $DB" | $PSQL

--- a/lobby-db/launch_db
+++ b/lobby-db/launch_db
@@ -1,15 +1,14 @@
 #!/bin/bash
 
-# This script is mostly in part documentation and convenience. Here
-# we tie together the full flow of building a docker image, launching
-# it, and then executing flyway to have a DB schema installed.
-
+# Convenience script to get a local DB up and running on docker
+# with some sample data.
 
 set -eu
 
 path=$(dirname $0)
 
-$path/build_docker
 $path/run_docker
+sleep 5
 $path/run_flyway
+$path/load_sample_data
 

--- a/lobby-db/load_sample_data
+++ b/lobby-db/load_sample_data
@@ -1,3 +1,6 @@
 #!/bin/bash
 
+# Inserts a sample data set to the local docker database.
+# Of note, a moderator user named "test" with password "test" will be created.
+
 cat sample_data.sql | psql -h localhost -U lobby_user lobby_db

--- a/lobby-db/run_docker
+++ b/lobby-db/run_docker
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Launches a local docker container that will have a PSQL DB on it.
+# Note, it takes a few seconds for database to initialize after running
+# this script. Once initializated then 'run_flyway' can be run to install
+# schema and tables.
+
 set -eux
 function stop_container() {
   local runningContainerId=$(docker container ls | grep triplea-lobby-db | cut -f 1 -d ' ')

--- a/lobby-db/run_flyway
+++ b/lobby-db/run_flyway
@@ -1,3 +1,11 @@
 #!/bin/bash
 
+# Runs 'flyway' which will execute the SQL statements used to set up database and schema.
+# Note, a flyway migration file can only be run once. If it is altered and run again
+# by flyway, flyway will abort. There is a table set up by flyway to record migration files
+# and a SHA is recorded. Either delete that SHA value or recreated the database with
+# the 'drop_db' script if altering an existing migration file.
+
+# If a migration file has been run on production, it SHOULD NOT be altered.
+
 ../gradlew flywayMigrate


### PR DESCRIPTION
## Overview
Documentation update to describe the scripts. 'launch_db' is updated
to be a bit more useful as it's rare to need to run 'build_docker'.
Instead 'launch_db' now captures the common commands run after any
system restart.

<!-- What changes did you make? Provide a summary of the updates included in this pull request -->

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix
[X] Documentation Change

<!-- If fixing a bug, uncomment the below and fill in each section -->
<!--
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)

### Root Cause (What caused the bug?)

### Fix description (How is the bug fixed?)

-->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[ ] Manually tested
[x] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
<!--
### Manual Testing
 
-->


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

