### PR TITLE
Fix jar creation ordering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ install:
  - echo "create database lobby_db" | psql -h localhost -U postgres -d postgres
  - echo "create user lobby_user with password 'postgres'" | psql -h localhost -U postgres -d postgres
  - echo "alter database lobby_db owner to lobby_user" | psql -h localhost -U postgres -d postgres
- - ./gradlew flywayMigrate
- - ./gradlew shadowJar
  - sed -i "s/.0$/.$TRAVIS_BUILD_NUMBER/" game-core/src/main/resources/META-INF/triplea/product.properties
  - RELEASE_VERSION=$(sed 's/version\s*=\s*//' game-core/src/main/resources/META-INF/triplea/product.properties)
+ - ./gradlew flywayMigrate
+ - ./gradlew shadowJar
  # Http server needs to be launched to supprt integ testing. Launching it here allows output from the server to go to the travis log.
  - "java -jar http-server/build/libs/triplea-http-server-${RELEASE_VERSION}.jar server ./http-server/configuration-prerelease.yml &"
 before_script:


### PR DESCRIPTION
## Overview
Create shadow jar *after* setting version number rather than before.
Should fix newly introduced problem of two jar's being created.

<!-- What changes did you make? Provide a summary of the updates included in this pull request -->

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[x] Bug fix

<!-- If fixing a bug, uncomment the below and fill in each section -->
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)
https://github.com/triplea-game/triplea/issues/5095

### Root Cause (What caused the bug?)
ShadowJar task first time around creates a '-2.0.0' artifact.
The release task executed later detects there will be a new artifact created, eg: '-2.0.15111'
The result is two jar files.

### Fix description (How is the bug fixed?)
Change ordering of when we set version. This way the first artifact name will match the second.

## Testing

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[ ] Manually tested
[x] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
<!--
### Manual Testing
 
-->


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

