### PR TITLE
Disallow adding an empty email to the lobby DB.

### DIFF
--- a/lobby-db/src/main/resources/db/migration/V1.10.00.20190330__lobby_user_table.sql
+++ b/lobby-db/src/main/resources/db/migration/V1.10.00.20190330__lobby_user_table.sql
@@ -3,7 +3,7 @@ create table lobby_user
     id              serial primary key,
     username        character varying(40) not null unique,
     password        character varying(60),
-    email           character varying(40) not null,
+    email           character varying(40) not null, check (email <> ''),
     date_created    timestamptz           not null default current_timestamp,
     last_login      timestamptz,
     admin           boolean               not null default false,


### PR DESCRIPTION
## Overview
<!-- What changes did you make? Provide a summary of the updates included in this pull request -->

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[X] Bug fix

<!-- If fixing a bug, uncomment the below and fill in each section -->
## Bug Fix
Lobby DB doesn't allow adding a user account with an empty email.

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)
Finally! fixes #4990 

### Root Cause (What caused the bug?)
DB didn't have a constraint on the length of the email.

### Fix description (How is the bug fixed?)
Added necessary constraint


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[X] Manually tested
[ ] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
### Manual Testing
Tested adding a user with empty email.


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

