### PR TITLE
Fix Travis shell script and resolve shellchecks

### DIFF
--- a/.travis/do_release
+++ b/.travis/do_release
@@ -3,7 +3,8 @@
 set -eu
 
 
-INSTALL4J_HOME=~/install4j
+readonly INSTALL4J_HOME=~/install4j
+readonly ARTIFACTS_DIR=./build/artifacts
 
 
 function main() {
@@ -22,7 +23,7 @@ function installInstall4j() {
           https://raw.githubusercontent.com/triplea-game/assets/master/install4j/install4j_unix_7_0_9.sh
   chmod +x install4j_unix.sh
   ./install4j_unix.sh -q -dir "$INSTALL4J_HOME"
-  "$INSTALL4J_HOME/bin/install4jc" -L $INSTALL4J_7_LICENSE
+  "$INSTALL4J_HOME/bin/install4jc" -L "$INSTALL4J_7_LICENSE"
 }
 
 function buildReleaseArtifacts() {
@@ -38,7 +39,6 @@ function buildReleaseArtifacts() {
 # preparation for release.
 #
 function collectArtifacts() {
-  readonly ARTIFACTS_DIR=./build/artifacts
   mkdir -p ${ARTIFACTS_DIR}
   cp -v ./**/build/artifacts/* ${ARTIFACTS_DIR}
 }
@@ -48,7 +48,6 @@ function collectArtifacts() {
 # This function generates checksums for all release artifacts.
 #
 function generateArtifactChecksums() {
-  readonly ARTIFACTS_DIR=./build/artifacts
   readonly -a ENGINES=(md5sum sha1sum sha256sum)
 
   # Change to artifacts directory so file names in checksum files are bare
@@ -57,15 +56,14 @@ function generateArtifactChecksums() {
   # Write checksum files outside the artifacts directory so they are not
   # considered by subsequent engines 
   declare -A checksum_files=()
-  for engine in ${ENGINES[@]}; do
+  for engine in "${ENGINES[@]}"; do
     echo "Generating artifact checksums using '$engine'..."
     checksum_files[$engine]=$(mktemp)
     eval "$engine * > ${checksum_files[$engine]}"
   done
   
-  # Move checksum files to artifacts directory after all engines have run
-  for engine in ${ENGINES[@]}; do
-    mv ${checksum_files[$engine]} ./${engine}.txt
+  for engine in "${ENGINES[@]}"; do
+    mv "${checksum_files[$engine]}" "./${engine}.txt"
   done
  
   ## Enable pinentry loopback mode: https://www.fluidkeys.com/tweak-gpg-2.1.11/
@@ -81,12 +79,12 @@ function generateArtifactChecksums() {
   # b) signing the checksum file itself is susceptible to spoofing because the
   #    *sum commands will process checksums outside the signature block (see
   #    https://github.com/nodejs/node/issues/6821#issuecomment-220033176)
-  for engine in ${ENGINES[@]}; do
+  for engine in "${ENGINES[@]}"; do
     echo "Signing artifact checksums for '$engine'..."
     gpg2 --batch --no-tty --yes --armor --detach-sign \
         --pinentry-mode loopback \
         --passphrase-file <(echo "$GPG_PRIVATE_KEY_PASSPHRASE") \
-        ./${engine}.txt
+        "./${engine}.txt"
   done
 }
 
@@ -98,19 +96,19 @@ function generateArtifactChecksums() {
 # Note, the tag itself is also considered a branch and trigger an extraneous branch build in travis.
 #
 function triggerGithubReleaseWithTagPush() {
-  TAG_VALUE=$(./gradlew --console=plain :game-core:properties | grep -Po '(?<=^version: )\S+$')
+  local -r TAG_VALUE=$(./gradlew --console=plain :game-core:properties | grep -Po '(?<=^version: )\S+$')
   
   git config --global user.email "tripleabuilderbot@gmail.com"
   git config --global user.name "tripleabuilderbot"
 
   echo "Attempting to delete tag $TAG_VALUE, this is so we will recreate the release if this build is being re-run. Ignore any errors from this"
-  git push -q https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea --delete "refs/tags/$TAG_VALUE"
+  git push -q "https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea" --delete "refs/tags/$TAG_VALUE"
   echo "Done deleting existing tag if it existed."
 
   git tag "$TAG_VALUE" -a -f -m "$TAG_VALUE"
 
   echo "Pushing tag: $TAG_VALUE to github to trigger releases deployment"
-  git push -q https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea --tags
+  git push -q "https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea" --tags
 }
 
 
@@ -118,13 +116,9 @@ function triggerGithubReleaseWithTagPush() {
 ## Live update maps list on website, read the maps in 'triplea_maps.yaml' and 
 ## commit updated data files to website json data directory.
 function pushMaps() { 
-  ## TODO: this is a bug, no parameter is passed here..
-  VERSION_NUMBER=$1
-
-  git config --global user.email "tripleabuilderbot@gmail.com"
   git config --global user.name "tripleabuilderbot"
 
-  git clone --quiet https://${PUSH_TO_WEBSITE_TOKEN}@github.com/triplea-game/triplea-game.github.io.git website
+  git clone --quiet "https://${PUSH_TO_WEBSITE_TOKEN}@github.com/triplea-game/triplea-game.github.io.git" website
 
   #Clear directory
   rm ./website/_maps/*
@@ -134,8 +128,8 @@ function pushMaps() {
   ## do git stuff, check if there is a diff, if so, commit and push it
   cd website
   if ! git diff-index --quiet HEAD --; then
-    git add  --all _maps/
-    git commit -m "Bot: update map files after game engine build $VERSION_NUMBER"
+    git add --all _maps/
+    git commit -m "Bot: update map files after game engine build ${TRAVIS_BUILD_NUMBER:-}"
     git push -fq origin master
   fi
   cd ..

--- a/.travis/install
+++ b/.travis/install
@@ -8,6 +8,6 @@ RELEASE_VERSION=$(sed 's/version\s*=\s*//' game-core/src/main/resources/META-INF
 ./gradlew flywayMigrate
 ./gradlew shadowJar
  # Http server needs to be launched to supprt integ testing. Launching it here allows output from the server to go to the travis log.
-java -jar http-server/build/libs/triplea-http-server-${RELEASE_VERSION}.jar server ./http-server/configuration-prerelease.yml &
+java -jar "http-server/build/libs/triplea-http-server-${RELEASE_VERSION}.jar server" ./http-server/configuration-prerelease.yml &
 
 


### PR DESCRIPTION
## Overview

(1) Fix readonly variable defined twice (buildfix)

(2) Fix missing version number bug in 'pushmaps'

(3) Fix shellcheck violations in scripts
- This is mostly adding double quotes

<!-- What changes did you make? Provide a summary of the updates included in this pull request -->

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[X] Code Cleanup or refactor
[ ] Configuration Change
[X] Bug fix


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[X] Manually tested
[ ] No testing done

Build looks good from branch build. The 'do_release' script is not executed on branch builds for forks, that is not tested..
