### PR TITLE
Travis fix, change directories in a subshell

### DIFF
--- a/.travis/do_release
+++ b/.travis/do_release
@@ -49,43 +49,44 @@ function collectArtifacts() {
 #
 function generateArtifactChecksums() {
   readonly -a ENGINES=(md5sum sha1sum sha256sum)
-
-  # Change to artifacts directory so file names in checksum files are bare
-  cd $ARTIFACTS_DIR
-  
-  # Write checksum files outside the artifacts directory so they are not
-  # considered by subsequent engines 
-  declare -A checksum_files=()
-  for engine in "${ENGINES[@]}"; do
-    echo "Generating artifact checksums using '$engine'..."
-    checksum_files[$engine]=$(mktemp)
-    eval "$engine * > ${checksum_files[$engine]}"
-  done
-  
-  for engine in "${ENGINES[@]}"; do
-    mv "${checksum_files[$engine]}" "./${engine}.txt"
-  done
- 
-  ## Enable pinentry loopback mode: https://www.fluidkeys.com/tweak-gpg-2.1.11/
-  echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
-  gpgconf --reload gpg-agent
-  
-  # Sign checksum files
-  #
-  # We use detached signatures so that
-  #
-  # a) users can verify the checksum files using *sum without any warnings about
-  #    incorrectly-formatted lines, and
-  # b) signing the checksum file itself is susceptible to spoofing because the
-  #    *sum commands will process checksums outside the signature block (see
-  #    https://github.com/nodejs/node/issues/6821#issuecomment-220033176)
-  for engine in "${ENGINES[@]}"; do
-    echo "Signing artifact checksums for '$engine'..."
-    gpg2 --batch --no-tty --yes --armor --detach-sign \
-        --pinentry-mode loopback \
-        --passphrase-file <(echo "$GPG_PRIVATE_KEY_PASSPHRASE") \
-        "./${engine}.txt"
-  done
+  (
+    # Change to artifacts directory so file names in checksum files are bare
+    cd $ARTIFACTS_DIR
+    
+    # Write checksum files outside the artifacts directory so they are not
+    # considered by subsequent engines 
+    declare -A checksum_files=()
+    for engine in "${ENGINES[@]}"; do
+      echo "Generating artifact checksums using '$engine'..."
+      checksum_files[$engine]=$(mktemp)
+      eval "$engine * > ${checksum_files[$engine]}"
+    done
+    
+    for engine in "${ENGINES[@]}"; do
+      mv "${checksum_files[$engine]}" "./${engine}.txt"
+    done
+   
+    ## Enable pinentry loopback mode: https://www.fluidkeys.com/tweak-gpg-2.1.11/
+    echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
+    gpgconf --reload gpg-agent
+    
+    # Sign checksum files
+    #
+    # We use detached signatures so that
+    #
+    # a) users can verify the checksum files using *sum without any warnings about
+    #    incorrectly-formatted lines, and
+    # b) signing the checksum file itself is susceptible to spoofing because the
+    #    *sum commands will process checksums outside the signature block (see
+    #    https://github.com/nodejs/node/issues/6821#issuecomment-220033176)
+    for engine in "${ENGINES[@]}"; do
+      echo "Signing artifact checksums for '$engine'..."
+      gpg2 --batch --no-tty --yes --armor --detach-sign \
+          --pinentry-mode loopback \
+          --passphrase-file <(echo "$GPG_PRIVATE_KEY_PASSPHRASE") \
+          "./${engine}.txt"
+    done
+  )
 }
 
 
@@ -126,14 +127,14 @@ function pushMaps() {
   ./.travis/yaml_splitter ./triplea_maps.yaml ./website/_maps/
 
   ## do git stuff, check if there is a diff, if so, commit and push it
-  cd website
-  if ! git diff-index --quiet HEAD --; then
-    git add --all _maps/
-    git commit -m "Bot: update map files after game engine build ${TRAVIS_BUILD_NUMBER:-}"
-    git push -fq origin master
-  fi
-  cd ..
-  rm -rf website
+  (
+    cd website
+    if ! git diff-index --quiet HEAD --; then
+      git add --all _maps/
+      git commit -m "Bot: update map files after game engine build ${TRAVIS_BUILD_NUMBER:-}"
+      git push -fq origin master
+    fi
+  )
 }
 
 main


### PR DESCRIPTION
## Overview
To avoid incorrect directory after scripts have been combined, update travis script to 'dc' in subshells. When the subshell exits, current directory will revert back to before the subshell was entered. Previously as different scripts, travis executed each one as a subshell. Now that the scripts are combined, 'cd' commands are more significant.

<!-- What changes did you make? Provide a summary of the updates included in this pull request -->

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[X] Bug fix

<!-- If fixing a bug, uncomment the below and fill in each section -->
<!--
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)

### Root Cause (What caused the bug?)

### Fix description (How is the bug fixed?)

-->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[ ] Manually tested
[X] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
<!--
### Manual Testing
 
-->


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

