### PR TITLE
Add shift+d hotkey to close purchase panel

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/KeyBindingSupplier.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/KeyBindingSupplier.java
@@ -1,10 +1,13 @@
 package games.strategy.triplea.ui;
 
 import com.google.common.base.Preconditions;
+import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.util.Map;
 import java.util.function.Supplier;
 import javax.swing.KeyStroke;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 
 /**
  * Interface for classes that have key listeners. Key bindings are more 'global' than classic swing
@@ -25,15 +28,28 @@ import javax.swing.KeyStroke;
  */
 public interface KeyBindingSupplier extends Supplier<Map<KeyStroke, Runnable>> {
 
+  @AllArgsConstructor(access = AccessLevel.PRIVATE)
+  enum ModifierKey {
+    NONE(0),
+    SHIFT(InputEvent.SHIFT_DOWN_MASK),
+    CONTROL(InputEvent.CTRL_DOWN_MASK);
+
+    private final int modifierMask;
+  }
+
   /**
    * Convenience method to create a {@code KeyStroke} without modifiers.
    *
    * @param code A KeyEvent code, should be a constant from the class {@code KeyEvent}
    */
-  static KeyStroke fromKeyEventCode(int code) {
+  static KeyStroke fromKeyEventCode(final int code) {
+    return fromKeyEventCode(code, ModifierKey.NONE);
+  }
+
+  static KeyStroke fromKeyEventCode(final int code, final ModifierKey modifierKey) {
     Preconditions.checkArgument(
         !KeyEvent.getKeyText(code).toUpperCase().contains("UNKNOWN"),
         "Be sure to use a constant from 'KeyEvent', unknown key constant: " + code);
-    return KeyStroke.getKeyStroke(code, 0);
+    return KeyStroke.getKeyStroke(code, modifierKey.modifierMask);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
@@ -31,18 +31,17 @@ import javax.swing.Action;
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
-import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
-import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.EtchedBorder;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.swing.SwingAction;
+import org.triplea.swing.SwingComponents;
 
 class ProductionPanel extends JPanel {
   private static final long serialVersionUID = -1539053979479586609L;
@@ -57,7 +56,7 @@ class ProductionPanel extends JPanel {
 
   private JDialog dialog;
   private boolean bid;
-  final Action doneAction = SwingAction.of("Done", e -> dialog.setVisible(false));
+  final Action doneAction = SwingAction.of("Done", () -> dialog.setVisible(false));
 
   ProductionPanel(final UiContext uiContext) {
     this.uiContext = uiContext;
@@ -93,12 +92,15 @@ class ProductionPanel extends JPanel {
       final IntegerMap<ProductionRule> initialPurchase) {
     dialog = new JDialog(parent, "Produce", true);
     dialog.getContentPane().add(this);
-    final String key = "dialog.close";
-    dialog.getRootPane().getActionMap().put(key, SwingAction.of("", e -> dialog.setVisible(false)));
-    dialog
-        .getRootPane()
-        .getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
-        .put(KeyStroke.getKeyStroke(KeyEvent.VK_ESCAPE, 0), key);
+
+    SwingComponents.addKeyBinding(
+        dialog,
+        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_D, KeyBindingSupplier.ModifierKey.SHIFT),
+        () -> dialog.setVisible(false));
+    SwingComponents.addKeyBinding(
+        dialog,
+        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_ESCAPE),
+        () -> dialog.setVisible(false));
 
     this.bid = bid;
     this.data = data;
@@ -234,6 +236,8 @@ class ProductionPanel extends JPanel {
             0,
             0));
     done = new JButton(doneAction);
+    done.setToolTipText(
+        "Click this button or press 'shift+d' to confirm purchase and close this window");
     this.add(
         done,
         new GridBagConstraints(

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -113,7 +113,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -719,17 +718,7 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
         .map(Map::entrySet)
         .flatMap(Collection::stream)
         .forEach(
-            binding -> {
-              final JPanel contentPane = (JPanel) getContentPane();
-              final String keyBindingIdentifier = UUID.randomUUID().toString();
-
-              contentPane
-                  .getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW)
-                  .put(binding.getKey(), keyBindingIdentifier);
-              contentPane
-                  .getActionMap()
-                  .put(keyBindingIdentifier, SwingAction.of(e -> binding.getValue().run()));
-            });
+            binding -> SwingComponents.addKeyBinding(this, binding.getKey(), binding.getValue()));
   }
 
   @Override

--- a/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
+++ b/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -27,6 +28,7 @@ import javax.swing.ComboBoxModel;
 import javax.swing.DefaultComboBoxModel;
 import javax.swing.DefaultListModel;
 import javax.swing.JComponent;
+import javax.swing.JDialog;
 import javax.swing.JEditorPane;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
@@ -437,5 +439,23 @@ public final class SwingComponents {
     b.add(c);
     b.add(Box.createHorizontalGlue());
     return b;
+  }
+
+  public static void addKeyBinding(
+      final JFrame frame, final KeyStroke keyStroke, final Runnable action) {
+    final JComponent component = (JComponent) frame.getContentPane();
+    addKeyBinding(component, keyStroke, action);
+  }
+
+  public static void addKeyBinding(
+      final JDialog component, final KeyStroke keyStroke, final Runnable action) {
+    addKeyBinding(component.getRootPane(), keyStroke, action);
+  }
+
+  private static void addKeyBinding(
+      final JComponent component, final KeyStroke keyStroke, final Runnable action) {
+    final String keyBindingIdentifier = UUID.randomUUID().toString();
+    component.getInputMap(JComponent.WHEN_IN_FOCUSED_WINDOW).put(keyStroke, keyBindingIdentifier);
+    component.getActionMap().put(keyBindingIdentifier, SwingAction.of(e -> action.run()));
   }
 }


### PR DESCRIPTION
## Overview
This update adds shift+d hotkey to close purchase panel (clicks done button).

While purchase panel has multiple ways to close, the 'done' button is not bound to a hotkey.
On the action paneles, the 'done' buttons are bound to 'shift+d' on each panel, but not 
so for the purchase panel. Ending tech research for example with 'shift-d' to then see 
purchase panel and a 'done' button on purchase that cannot be activated with 'shift+d' 
seems inconsistent. After this update the purchase panel can be closed with shift+d


## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[X] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix

<!-- If fixing a bug, uncomment the below and fill in each section -->
<!--
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)

### Root Cause (What caused the bug?)

### Fix description (How is the bug fixed?)

-->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[X] Manually tested
[ ] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
<!--
### Manual Testing
 
-->


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

