### PR TITLE
Update travis to delete existing tag if it exists

### DIFF
--- a/.travis/do_release
+++ b/.travis/do_release
@@ -102,14 +102,21 @@ function triggerGithubReleaseWithTagPush() {
   git config --global user.email "tripleabuilderbot@gmail.com"
   git config --global user.name "tripleabuilderbot"
 
-  echo "Attempting to delete tag $TAG_VALUE, this is so we will recreate the release if this build is being re-run. Ignore any errors from this"
-  git push -q "https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea" --delete "refs/tags/$TAG_VALUE"
-  echo "Done deleting existing tag if it existed."
+  local -r gitRepo="https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea"
 
+  # Sometimes assets will fail to upload but we'll still have a tag created
+  # Check if the current tag exists, if so, delete it. 
+  git ls-remote --tags origin | grep -q "2.0.15585$" && \
+    (  
+    echo "Deleting tag $TAG_VALUE to recreate the release." && \
+    git push -q "$gitRepo" --delete "refs/tags/$TAG_VALUE"
+    )
+
+  ## create tag locally
   git tag "$TAG_VALUE" -a -f -m "$TAG_VALUE"
 
-  echo "Pushing tag: $TAG_VALUE to github to trigger releases deployment"
-  git push -q "https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea" --tags
+  echo "Triggering github release by pushing tag: $TAG_VALUE"
+  git push -q "$gitRepo" --tags
 }
 
 

--- a/.travis/do_release
+++ b/.travis/do_release
@@ -104,10 +104,10 @@ function triggerGithubReleaseWithTagPush() {
 
   local -r gitRepo="https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea"
 
-  # Sometimes assets will fail to upload but we'll still have a tag created
-  # Check if the current tag exists, if so, delete it. 
+  # Sometimes a tag will be created from a previous build and assets will fail to upload.
+  # Check if the current tag exists, if so, delete it.
   git ls-remote --tags origin | grep -q "2.0.15585$" && \
-    (  
+    (
     echo "Deleting tag $TAG_VALUE to recreate the release." && \
     git push -q "$gitRepo" --delete "refs/tags/$TAG_VALUE"
     )

--- a/.travis/do_release
+++ b/.travis/do_release
@@ -106,7 +106,7 @@ function triggerGithubReleaseWithTagPush() {
 
   # Sometimes a tag will be created from a previous build and assets will fail to upload.
   # Check if the current tag exists, if so, delete it.
-  git ls-remote --tags origin | grep -q "2.0.15585$" && \
+  git ls-remote --tags origin | grep -q "2.0.${TRAVIS_BUILD_NUMBER}$" && \
     (
     echo "Deleting tag $TAG_VALUE to recreate the release." && \
     git push -q "$gitRepo" --delete "refs/tags/$TAG_VALUE"
@@ -138,7 +138,7 @@ function pushMaps() {
     cd website
     if ! git diff-index --quiet HEAD --; then
       git add --all _maps/
-      git commit -m "Bot: update map files after game engine build ${TRAVIS_BUILD_NUMBER:-}"
+      git commit -m "Bot: update map files after game engine build ${TRAVIS_BUILD_NUMBER}"
       git push -fq origin master
     fi
   )


### PR DESCRIPTION
## Overview
Potentially a build fix, it looks like introducing 'set -eu' is failing the build. Previously the build would blindly try to delete tags and we ignored any failures there. With 'set -eu', this potentially causes a failure.

The update here adds a 'git ls-remote --tags' to look for tags and then conditionally executes the delete tag if the target tag is found.

<!-- What changes did you make? Provide a summary of the updates included in this pull request -->

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[X] Configuration Change
[X] Bug fix

<!-- If fixing a bug, uncomment the below and fill in each section -->
<!--
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)

### Root Cause (What caused the bug?)

### Fix description (How is the bug fixed?)

-->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[ ] Manually tested
[ ] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
### Manual Testing
Verified script still passes shellcheck 
Verified grep -q command executes the second part of the command on tag found case and not when tag is not found.

<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

