### PR TITLE
Use jakarta dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,4 @@ this Program grant you additional permission to convey the resulting work.
 
 Library | Group ID | Artifact ID | SPDX License ID
 :-- | :-- | :-- | :--
-JavaMail | com.sun.mail | javax.mail | GPL-2.0-only
+Jakarta Mail | com.sun.mail | jakarta.mail | GPL-2.0-only

--- a/build.gradle
+++ b/build.gradle
@@ -71,6 +71,7 @@ subprojects {
         mockitoVersion = '2.24.5'
         postgresqlVersion = '42.2.5'
         sonatypeGoodiesPrefsVersion = '2.2.5'
+        jakartaMailVersion = '1.6.4'
     }
 
     repositories {

--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation project(':swing-lib')
     implementation 'org.snakeyaml:snakeyaml-engine:1.0'
     implementation 'com.googlecode.soundlibs:jlayer:1.0.1.4'
-    implementation 'com.sun.mail:javax.mail:1.6.2'
+    implementation 'com.sun.mail:jakarta.mail:1.6.3'
     implementation 'commons-cli:commons-cli:1.4'
     implementation 'commons-codec:commons-codec:1.11'
     implementation 'commons-io:commons-io:2.6'

--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -12,7 +12,7 @@ dependencies {
     implementation project(':swing-lib')
     implementation 'org.snakeyaml:snakeyaml-engine:1.0'
     implementation 'com.googlecode.soundlibs:jlayer:1.0.1.4'
-    implementation 'com.sun.mail:jakarta.mail:1.6.3'
+    implementation "com.sun.mail:jakarta.mail:$jakartaMailVersion"
     implementation 'commons-cli:commons-cli:1.4'
     implementation 'commons-codec:commons-codec:1.11'
     implementation 'commons-io:commons-io:2.6'

--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation project(':http-clients')
     implementation project(':lobby-db-dao')
 
-    implementation 'com.sun.mail:javax.mail:1.6.2'
+    implementation 'com.sun.mail:jakarta.mail:1.6.3'
     implementation 'io.dropwizard:dropwizard-core:1.3.12'
     implementation 'io.dropwizard:dropwizard-jdbi3:1.3.12'
     implementation 'org.jdbi:jdbi3-core:3.8.2'

--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -24,7 +24,7 @@ dependencies {
     implementation project(':http-clients')
     implementation project(':lobby-db-dao')
 
-    implementation 'com.sun.mail:jakarta.mail:1.6.3'
+    implementation "com.sun.mail:jakarta.mail:$jakartaMailVersion"
     implementation 'io.dropwizard:dropwizard-core:1.3.12'
     implementation 'io.dropwizard:dropwizard-jdbi3:1.3.12'
     implementation 'org.jdbi:jdbi3-core:3.8.2'


### PR DESCRIPTION
## Overview
This PR changes the JavaMail dependency to use the maintained "jakarta" artifact, which is the version now maintained by the eclipse foundation.
This change should change absolutely nothing as stated on their website: https://eclipse-ee4j.github.io/mail/#Latest_News
There is a 1.6.4 version that contains some bugfixes, but I wasn't feeling confident enough to use that directly

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[x] Configuration Change
[ ] Bug fix

<!-- If fixing a bug, uncomment the below and fill in each section -->
<!--
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)

### Root Cause (What caused the bug?)

### Fix description (How is the bug fixed?)

-->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[ ] Manually tested
[x] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
<!--
### Manual Testing
 
-->


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

