### PR TITLE
Update git ignore to ignore image and sound asset file types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,8 @@
 *.backup
 *.swp
 *.png
+*.gif
+*.mp3
 
 bin/
 build/

--- a/game-headed/.gitignore
+++ b/game-headed/.gitignore
@@ -1,1 +1,1 @@
-assets
+assets/**/*txt


### PR DESCRIPTION
## Overview

Update git ignore to ignore image and sound asset file types

Update game-headed gitignore to (for now) ignore txt placeholder files. Those likely can be deleted. Such placeholder files exist such that git will not remove an empty folder, that was likely needed as part of the release process to ensure we had all necessary folders present so that they could land in the release artifact.

<!-- What changes did you make? Provide a summary of the updates included in this pull request -->

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[x] Configuration Change
[ ] Bug fix

<!-- If fixing a bug, uncomment the below and fill in each section -->
<!--
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)

### Root Cause (What caused the bug?)

### Fix description (How is the bug fixed?)

-->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[X] Manually tested
[ ] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
<!--
### Manual Testing
 
-->


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

