### PR TITLE
Fix pre-release to release bad enum value problem for flag settings

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -465,6 +465,11 @@ final class ViewMenu extends JMenu {
           UnitsDrawer.enabledFlags = toggleFlags.isSelected();
           prefs.putBoolean(
               UnitsDrawer.PreferenceKeys.DRAWING_ENABLED.name(), toggleFlags.isSelected());
+          // null out previous value. This is not necessary, but if anyone is using a previous
+          // release then they will get an error when an unknown enum value is mapped.
+          if (!toggleFlags.isSelected()) {
+            prefs.put(UnitsDrawer.PreferenceKeys.DRAW_MODE.name(), null);
+          }
           frame.getMapPanel().resetMap();
         });
     unitSizeMenu.add(toggleFlags);


### PR DESCRIPTION
## Overview
Null out flag value when flag values are turned off.



## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[X] Bug fix

<!-- If fixing a bug, uncomment the below and fill in each section -->
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)
Reported in: https://forums.triplea-game.org/topic/1531/menu-absent-new-bug-in-old-version/5

### Root Cause (What caused the bug?)
Newest release sets an enum value that is not present in previous release. When the previous release reads that value, it errors out with 'enum value not found'. To fix this, update latest to null out the enum flag value (even though it is not necessary). This way when flags are turned off and a null value is present, the latest release will read a null value and would not error out.




## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[ ] Manually tested
[X] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
<!--
### Manual Testing
 
-->


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

