### PR TITLE
Remove preference key instead of nulling it out.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -468,7 +468,7 @@ final class ViewMenu extends JMenu {
           // null out previous value. This is not necessary, but if anyone is using a previous
           // release then they will get an error when an unknown enum value is mapped.
           if (!toggleFlags.isSelected()) {
-            prefs.put(UnitsDrawer.PreferenceKeys.DRAW_MODE.name(), null);
+            prefs.remove(UnitsDrawer.PreferenceKeys.DRAW_MODE.name());
           }
           frame.getMapPanel().resetMap();
         });


### PR DESCRIPTION
## Overview
Fix for: https://forums.triplea-game.org/topic/1531/menu-absent-new-bug-in-old-version/7
With enum flags different, reading a latest pre-release setting on the release version causes an enum not found failure. Nulling the value out causes a NPE. This update removes the preference key instead of nulling it out.

<!-- What changes did you make? Provide a summary of the updates included in this pull request -->

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix

<!-- If fixing a bug, uncomment the below and fill in each section -->
<!--
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)

### Root Cause (What caused the bug?)

### Fix description (How is the bug fixed?)

-->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[ ] Manually tested
[ ] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
<!--
### Manual Testing
 
-->


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

