### PR TITLE
Add failed build issue creation to Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ script:
 - ./gradlew check jacocoTestReport
 after_success:
 - bash <(curl -s https://codecov.io/bash)  # upload coverage report - https://github.com/codecov/example-gradle
+after_failure:
+- test "$TRAVIS_BRANCH" = master && ./.travis/report_build_status FAILURE
 before_deploy:
 - ./.travis/do_release
 deploy:

--- a/.travis/do_release
+++ b/.travis/do_release
@@ -1,11 +1,13 @@
 #!/bin/bash
 
-set -eu
+set -eEu
 
 
 readonly INSTALL4J_HOME=~/install4j
 readonly ARTIFACTS_DIR=./build/artifacts
 
+
+trapErr "./.travis/report_build_status FAILURE" ERR
 
 function main() {
   installInstall4j
@@ -14,6 +16,7 @@ function main() {
   generateArtifactChecksums
   triggerGithubReleaseWithTagPush
   pushMaps
+  ./.travis/report_build_status SUCCESS
 }
 
 

--- a/.travis/report_build_status
+++ b/.travis/report_build_status
@@ -1,0 +1,102 @@
+#!/bin/bash
+
+# This script is used to automatically create a "build broken" tracking issue.
+# On success, this script will check for an open "build broken" issue and will close it.
+# On failure, this script will check for an open "build broken" issue and will create one
+# if there is not one already open.
+
+set -eu
+
+# Should be one of {SUCCESS|FAILURE}
+RESULT=${1-}
+
+readonly BROKEN_BUILD_ISSUE_TITLE="Travis Master Branch Build Failed";
+readonly LATEST_BUILD_LINK="[#$TRAVIS_JOB_ID]($TRAVIS_BUILD_WEB_URL)"
+readonly BROKEN_BUILD_ISSUE_BODY="Latest master branch travis build $LATEST_BUILD_LINK failed.\n\
+No release artifacts will be generated until this is fixed."
+
+readonly API_URL="https://api.github.com/repos/triplea-game/triplea"
+readonly API_AUTH="Authorization: token $GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS"
+
+if [ -z "$RESULT" ]; then
+  echo "Error, expected one parameter, but got no parameters."
+  exit 1
+fi
+
+function main() {
+case "$RESULT" in
+  SUCCESS)
+    reportBuildSuccess
+    ;;
+  FAILURE)
+    reportBuildFailure
+    ;;
+  *)
+     echo "Error, unknown parameter value, expected {SUCCESS|FAILURE}, got: $RESULT"
+     exit 1
+esac
+}
+
+
+# Finds any open issues with failure title and returns that issue number
+function findOpenFailedBuildIssue() {
+         # list all issues
+         # parse values 'state, number and title'
+         # find target title
+         # filter for open status
+         # grab just the issue number line
+         # filter issue number line for just the issue number
+   curl -s -H "$API_AUTH" "$API_URL/issues" \
+         | grep -E "^\s+\"state\": |^\s+\"number\": |^\s+\"title\": " \
+         | grep -EC1 "^\s+\"title\": \"$BROKEN_BUILD_ISSUE_TITLE" \
+         | grep -EB2 "^\s+\"state\": \"open\",$" \
+         | grep -E "^\s+\"number\":" \
+         | sed 's/.*number": \(.*\),/\1/'
+}
+
+# On success, if there is an open failed build issue:
+# - comment that the latest succeeded
+# - close the issue
+function reportBuildSuccess() {
+  local -r failedBuildIssue=$(findOpenFailedBuildIssue)
+  if [ -n "$failedBuildIssue" ]; then
+    commentOnIssue "$failedBuildIssue" "Build $LATEST_BUILD_LINK succeeded."
+    closeIssue "$failedBuildIssue"
+  fi
+}
+
+function commentOnIssue() {
+  local -r issueNumber="$1"
+  local -r comment="$2"
+
+  curl -s -d "{\"body\": \"$comment\"}" -X POST -H "$API_AUTH" \
+     "$API_URL/issues/$issueNumber/comments"
+}
+
+function closeIssue() {
+  local -r issueNumber="$1"
+
+  curl -H "$API_AUTH" -X PATCH -d "{\"state\": \"closed\"}" \
+    "$API_URL/issues/$issueNumber"
+}
+
+
+# Open a new failed build issue if one is not open. Otherwise add
+# a comment to the existing issue.
+function reportBuildFailure() {
+  local -r failedBuildIssue=$(findOpenFailedBuildIssue)
+  if [ -z "$failedBuildIssue" ]; then
+     openNewFailedBuildIssue
+  else
+     commentOnIssue "$failedBuildIssue" "Build $LATEST_BUILD_LINK failed"
+  fi
+}
+
+function openNewFailedBuildIssue() {
+  curl -X POST -d "{\"title\": \"$BROKEN_BUILD_ISSUE_TITLE\", \"body\": \
+\"$BROKEN_BUILD_ISSUE_BODY\", \"labels\": [\"Release Blocker\"]}" \
+        -H "$API_AUTH" "$API_URL/issues"
+}
+
+main
+


### PR DESCRIPTION
## Overview
Adds a script to travis that will create a new github issue when there is a failed build. If the build fails again, a comment is added to that issue. If the build is fixed, the issue is closed and a comment is added noting the build succeeded.


## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix
[X] Travis build update
<!-- If fixing a bug, uncomment the below and fill in each section -->
<!--
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)

### Root Cause (What caused the bug?)

### Fix description (How is the bug fixed?)

-->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[X] Manually tested
[ ] No testing done

Create a test repo and invoked the script with 'FAILURE' and 'SUCCESS' flags: https://github.com/DanVanAtta/test/issues

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
<!--
### Manual Testing
 
-->


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

