### PR TITLE
Show account menu only when logged in via registered account

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -32,7 +32,11 @@ public final class LobbyMenu extends JMenuBar {
     } else {
       MacOsIntegration.addQuitHandler(lobbyFrame::shutdown);
     }
-    createAccountMenu(this);
+
+    if (!lobbyFrame.getLobbyClient().isAnonymousLogin()) {
+      createAccountMenu(this);
+    }
+
     if (lobbyFrame.getLobbyClient().isAdmin()) {
       createAdminMenu(this);
     }
@@ -97,8 +101,6 @@ public final class LobbyMenu extends JMenuBar {
 
   private void addUpdateAccountMenu(final JMenu account) {
     final JMenuItem update = new JMenuItem("Update Account...");
-    // only if we are not anonymous login
-    update.setEnabled(!lobbyFrame.getLobbyClient().isAnonymousLogin());
     update.addActionListener(e -> updateAccountDetails());
     account.add(update);
   }


### PR DESCRIPTION
## Overview
Instead of disabling the account menu, do not show it when logged in anonymously

<!-- What changes did you make? Provide a summary of the updates included in this pull request -->

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[x] Feature update or enhancement
[ ] Feature Removal
[x] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix

<!-- If fixing a bug, uncomment the below and fill in each section -->
<!--
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)

### Root Cause (What caused the bug?)

### Fix description (How is the bug fixed?)

-->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[ ] Manually tested
[X] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
<!--
### Manual Testing
 
-->


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

