### PR TITLE
Expected build fix, add update-index to fix diff-index

### DIFF
--- a/.travis/do_release
+++ b/.travis/do_release
@@ -141,6 +141,8 @@ function pushMaps() {
   (
     set -x
     cd website
+
+    git update-index --refresh
     if ! git diff-index --quiet HEAD --; then
       git add --all _maps/
       git commit -m "Bot: update map files after game engine build ${TRAVIS_BUILD_NUMBER}"


### PR DESCRIPTION
## Overview

diff-index appears to do a very "quick look" of files and this means if it can look at only last modified time stamp, it will not do a deep-dive for file differences until git has actually inspected content. This update adds a command 'git update-index --refresh' that will then have git diff-index detect if there are content differences beyond the last modified timestamp being altered.

The solution and problem are discussed in this stack overflow:
https://stackoverflow.com/questions/34807971/why-does-git-diff-index-head-result-change-for-touched-files-after-git-diff-or-g

It was possible to reproduce the build failure by running:
(1) map yaml splitter
(2) git diff-index --shortstat HEAD --

(2) would show 120 modified files with no lines changed or removed. Comparing SHA256 values the files truly were not altered.
Though, after running git status, git diff, or the update-index refresh command, running (2) again would show no changes. This indicates git has behavior of diff-index to do a shallow comparison when it can even if perhaps the file contents are not altered.

<!-- What changes did you make? Provide a summary of the updates included in this pull request -->

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[X] Configuration Change
[X] Bug fix

<!-- If fixing a bug, uncomment the below and fill in each section -->
<!--
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)

### Root Cause (What caused the bug?)

### Fix description (How is the bug fixed?)

-->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[ ] Manually tested
[ ] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
<!--
### Manual Testing
 
-->


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->


## Additional Review Notes

This behavior of git diff-index is not new, it was seemingly always broken. We did not notice as 'git commit' failed after committing zero files, and git push then did nothing, and the script happily then continued executing. We noticed this build failure after adding the 'set -e' flag that instructs bash to halt on failure, in which case the script then started to halt on the failing 'git commit' command.

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

