### PR TITLE
Faster Builds with Parallel travis VMs 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,17 +9,17 @@ matrix:
       - TRIPLEA_RELEASE=true
   - jdk: openjdk11
     env: 
-      - TASKS="test jacocoTestReport integTest"
-      - INSTALL=true
+      - TASKS="test jacocoTestReport"
       - PUSH_REPORTS=true
       - TRIPLEA_RELEASE=false
   - jdk: openjdk11
     env: 
-      - TASKS="validateYamls spotlessCheck checkstyleMain checkstyleTest"
+      - TASKS="validateYamls spotlessCheck checkstyleMain checkstyleTest pmdMain"
       - TRIPLEA_RELEASE=false
   - jdk: openjdk11
     env: 
-      - TASKS=pmdMain
+      - TASKS=integTest
+      - INSTALL=true
       - TRIPLEA_RELEASE=false
   - jdk: openjdk12
     env: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,27 @@ language: java
 matrix:
   include:
   - jdk: openjdk11
-    env: TRIPLEA_RELEASE=true
+    env:
+      - TASKS="shadowJar downloadAssets"
+      - TRIPLEA_RELEASE=true
+  - jdk: openjdk11
+    env: 
+      - TASKS="test jacocoTestReport integTest"
+      - INSTALL=true
+      - PUSH_REPORTS=true
+      - TRIPLEA_RELEASE=false
+  - jdk: openjdk11
+    env: 
+      - TASKS="validateYamls spotlessCheck checkstyleMain checkstyleTest"
+      - TRIPLEA_RELEASE=false
+  - jdk: openjdk11
+    env: 
+      - TASKS=pmdMain
+      - TRIPLEA_RELEASE=false
   - jdk: openjdk12
-    env: TRIPLEA_RELEASE=false
+    env: 
+      - TASKS=test
+      - TRIPLEA_RELEASE=false
 addons:
   postgresql: "10"
   apt:
@@ -18,24 +36,25 @@ install:
 - echo "================ Build step 'install' =================" > /dev/null
 ## shellcheck all shell scripts
 -  find .travis/ -type f | xargs grep -lE "^#\!/bin/bash$" | xargs shellcheck
-## validate ASAP so syntax, checkstyle or unit tests fail the build early
-- ./gradlew validateYamls checkstyleMain checkstyleTest spotlessCheck test
-- ./.travis/install
+## Update product version to include build number.
+## EG: replace "2.0.0" to be "2.0.15555";
+- sed -i "s/.0$/.$TRAVIS_BUILD_NUMBER/" game-core/src/main/resources/META-INF/triplea/product.properties
+- if [ -n "$INSTALL" ]; then ./.travis/install; fi
 before_script:
 - echo "================ Build step 'before_script' =================" > /dev/null
-- ./.travis/setup_gpg
+- if [ "$TASKS" = release ]; then ./.travis/setup_gpg; fi
 script:
 - echo "================ Build step 'script' =================" > /dev/null
-- ./gradlew check jacocoTestReport
+- ./gradlew --parallel $TASKS
 after_success:
 - echo "================ Build step 'after_success'' =================" > /dev/null
-- bash <(curl -s https://codecov.io/bash)  # upload coverage report - https://github.com/codecov/example-gradle
+- if [ -n "$PUSH_REPORTS" ]; then bash <(curl -s https://codecov.io/bash); fi # upload coverage report - https://github.com/codecov/example-gradle
 after_failure:
 - echo "================ Build step 'after_failure' =================" > /dev/null
 - test "$TRAVIS_BRANCH" = master && ./.travis/report_build_status FAILURE
 before_deploy:
 - echo "================ Build step 'before_deploy' =================" > /dev/null
-- ./.travis/do_release
+- if [ -n "$RELEASE" ]; then ./.travis/do_release; fi
 deploy:
   provider: releases
   api_key:
@@ -47,6 +66,6 @@ deploy:
   prerelease: true
   on:
     tags: false
-    condition: "$TRIPLEA_RELEASE = true"
+    condition: $TRIPLEA_RELEASE = true
     repo: triplea-game/triplea
     branch: master

--- a/.travis/install
+++ b/.travis/install
@@ -6,10 +6,6 @@ echo "create database lobby_db" | psql -h localhost -U postgres -d postgres
 echo "create user lobby_user with password 'postgres'" | psql -h localhost -U postgres -d postgres
 echo "alter database lobby_db owner to lobby_user" | psql -h localhost -U postgres -d postgres
 
-## Update product version to include build number.
-## EG: replace "2.0.0" to be "2.0.15555";
-sed -i "s/.0$/.$TRAVIS_BUILD_NUMBER/" game-core/src/main/resources/META-INF/triplea/product.properties
-
 ./gradlew flywayMigrate
 ./gradlew :http-server:shadowJar
 


### PR DESCRIPTION
## Overview
Break up build tasks across a couple more Travis VMs by using build matrix. Should help parallelize build tasks and allow for a faster overall runtime of the build.

Release task is broken out and pre-emptively downloads images while we expect other tasks to still be running. This way if we get to the deploy step (merge builds), then the images will already be downloaded and we can proceed with artifact creation.

Five parallel jobs is chosen specifically as that seems to be the max number of VMs that Travis will spin up for a project fork. Beyond that and we have jobs waiting for previous jobs to terminate to free up VMs. Hence, five seems to be the maximum parallelization available from travis.

Tasks load balanced in an attempt that each of the 5 VMs will take the same amount of time.

<!-- What changes did you make? Provide a summary of the updates included in this pull request -->

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[x] Configuration Change
[ ] Bug fix
