### PR TITLE
JMenuItem Checkbox Persistence

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/settings/BooleanClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/BooleanClientSetting.java
@@ -1,6 +1,14 @@
 package games.strategy.triplea.settings;
 
-final class BooleanClientSetting extends ClientSetting<Boolean> {
+import org.triplea.swing.JMenuItemCheckBoxBuilder;
+
+final class BooleanClientSetting extends ClientSetting<Boolean>
+    implements JMenuItemCheckBoxBuilder.SettingPersistence {
+
+  BooleanClientSetting(final String name) {
+    this(name, false);
+  }
+
   BooleanClientSetting(final String name, final boolean defaultValue) {
     super(Boolean.class, name, defaultValue);
   }
@@ -13,5 +21,15 @@ final class BooleanClientSetting extends ClientSetting<Boolean> {
   @Override
   protected Boolean decodeValue(final String encodedValue) {
     return Boolean.valueOf(encodedValue);
+  }
+
+  @Override
+  public void saveSetting(final boolean value) {
+    setValueAndFlush(value);
+  }
+
+  @Override
+  public boolean getSetting() {
+    return getDefaultValue().orElse(false);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/settings/BooleanClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/BooleanClientSetting.java
@@ -2,7 +2,7 @@ package games.strategy.triplea.settings;
 
 import org.triplea.swing.JMenuItemCheckBoxBuilder;
 
-final class BooleanClientSetting extends ClientSetting<Boolean>
+public final class BooleanClientSetting extends ClientSetting<Boolean>
     implements JMenuItemCheckBoxBuilder.SettingPersistence {
 
   BooleanClientSetting(final String name) {

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -41,6 +41,7 @@ import lombok.extern.java.Log;
  *
  * @param <T> The type of the setting value.
  */
+@SuppressWarnings("StaticInitializerReferencesSubClass")
 @Log
 public abstract class ClientSetting<T> implements GameSetting<T> {
   public static final ClientSetting<Integer> aiPauseDuration =
@@ -104,6 +105,8 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
       new BooleanClientSetting("SHOW_BETA_FEATURES");
   public static final BooleanClientSetting showChatSettings =
       new BooleanClientSetting("SHOW_CHAT_SETTINGS");
+  public static final BooleanClientSetting showCommentLog =
+      new BooleanClientSetting("SHOW_COMMENT_LOG");
   public static final ClientSetting<Boolean> showConsole = new BooleanClientSetting("SHOW_CONSOLE");
   public static final ClientSetting<String> testLobbyHost =
       new StringClientSetting("TEST_LOBBY_HOST");

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -111,8 +111,7 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
   public static final ClientSetting<Boolean> showConsole = new BooleanClientSetting("SHOW_CONSOLE");
   public static final BooleanClientSetting showTerritoryEffects =
       new BooleanClientSetting("SHOW_TERRITORY_EFFECTS", true);
-  public static final BooleanClientSetting showUnits =
-      new BooleanClientSetting("SHOW_UNITS", true);
+  public static final BooleanClientSetting showUnits = new BooleanClientSetting("SHOW_UNITS", true);
   public static final ClientSetting<String> testLobbyHost =
       new StringClientSetting("TEST_LOBBY_HOST");
   public static final ClientSetting<Integer> testLobbyPort =

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -52,9 +52,9 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
   public static final ClientSetting<Integer> battleCalcSimulationCountLowLuck =
       new IntegerClientSetting("BATTLE_CALC_SIMULATION_COUNT_LOW_LUCK", 500);
   public static final ClientSetting<Boolean> confirmDefensiveRolls =
-      new BooleanClientSetting("CONFIRM_DEFENSIVE_ROLLS", false);
+      new BooleanClientSetting("CONFIRM_DEFENSIVE_ROLLS");
   public static final ClientSetting<Boolean> confirmEnemyCasualties =
-      new BooleanClientSetting("CONFIRM_ENEMY_CASUALTIES", false);
+      new BooleanClientSetting("CONFIRM_ENEMY_CASUALTIES");
   public static final ClientSetting<String> defaultGameName =
       new StringClientSetting("DEFAULT_GAME_NAME_PREF", "Big World : 1942");
   public static final ClientSetting<String> defaultGameUri =
@@ -101,9 +101,10 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
   public static final ClientSetting<Boolean> showBattlesWhenObserving =
       new BooleanClientSetting("SHOW_BATTLES_WHEN_OBSERVING", true);
   public static final ClientSetting<Boolean> showBetaFeatures =
-      new BooleanClientSetting("SHOW_BETA_FEATURES", false);
-  public static final ClientSetting<Boolean> showConsole =
-      new BooleanClientSetting("SHOW_CONSOLE", false);
+      new BooleanClientSetting("SHOW_BETA_FEATURES");
+  public static final BooleanClientSetting showChatSettings =
+      new BooleanClientSetting("SHOW_CHAT_SETTINGS");
+  public static final ClientSetting<Boolean> showConsole = new BooleanClientSetting("SHOW_CONSOLE");
   public static final ClientSetting<String> testLobbyHost =
       new StringClientSetting("TEST_LOBBY_HOST");
   public static final ClientSetting<Integer> testLobbyPort =
@@ -127,7 +128,7 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
   public static final ClientSetting<String> playerName =
       new StringClientSetting("PLAYER_NAME", SystemProperties.getUserName());
   public static final ClientSetting<Boolean> useExperimentalJavaFxUi =
-      new BooleanClientSetting("USE_EXPERIMENTAL_JAVAFX_UI", false);
+      new BooleanClientSetting("USE_EXPERIMENTAL_JAVAFX_UI");
   public static final ClientSetting<String> loggingVerbosity =
       new StringClientSetting("LOGGING_VERBOSITY", Level.WARNING.getName());
   public static final ClientSetting<String> emailServerHost =

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -70,6 +70,7 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
       new IntegerClientSetting("LOBBY_LAST_USED_PORT");
   public static final ClientSetting<Integer> lobbyLastUsedHttpsPort =
       new IntegerClientSetting("LOBBY_LAST_USED_HTTPS_PORT");
+  public static final BooleanClientSetting lockMap = new BooleanClientSetting("LOCK_MAP");
   public static final ClientSetting<String> lookAndFeel =
       new StringClientSetting("LOOK_AND_FEEL_PREF", LookAndFeel.getDefaultLookAndFeelClassName());
   public static final ClientSetting<Integer> mapEdgeScrollSpeed =
@@ -108,6 +109,10 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
   public static final BooleanClientSetting showCommentLog =
       new BooleanClientSetting("SHOW_COMMENT_LOG");
   public static final ClientSetting<Boolean> showConsole = new BooleanClientSetting("SHOW_CONSOLE");
+  public static final BooleanClientSetting showTerritoryEffects =
+      new BooleanClientSetting("SHOW_TERRITORY_EFFECTS", true);
+  public static final BooleanClientSetting showUnits =
+      new BooleanClientSetting("SHOW_UNITS", true);
   public static final ClientSetting<String> testLobbyHost =
       new StringClientSetting("TEST_LOBBY_HOST");
   public static final ClientSetting<Integer> testLobbyPort =

--- a/game-core/src/main/java/games/strategy/triplea/ui/AbstractUiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/AbstractUiContext.java
@@ -257,23 +257,6 @@ public abstract class AbstractUiContext implements UiContext {
   }
 
   @Override
-  public boolean getLockMap() {
-    final Preferences prefs = Preferences.userNodeForPackage(AbstractUiContext.class);
-    return prefs.getBoolean(LOCK_MAP, false);
-  }
-
-  @Override
-  public void setLockMap(final boolean lockMap) {
-    final Preferences prefs = Preferences.userNodeForPackage(AbstractUiContext.class);
-    prefs.putBoolean(LOCK_MAP, lockMap);
-    try {
-      prefs.flush();
-    } catch (final BackingStoreException ex) {
-      log.log(Level.SEVERE, "Failed to flush preferences: " + prefs.absolutePath(), ex);
-    }
-  }
-
-  @Override
   public boolean getShowEndOfTurnReport() {
     final Preferences prefs = Preferences.userNodeForPackage(AbstractUiContext.class);
     return prefs.getBoolean(SHOW_END_OF_TURN_REPORT, true);

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -399,9 +399,9 @@ public class MapPanel extends ImageScrollerLargeView {
 
   public void highlightTerritory(
       final Territory territory, final int totalFrames, final int delay) {
-      centerOn(territory);
-      highlightedTerritory = territory;
-      territoryHighlighter.highlight(territory, totalFrames, delay);
+    centerOn(territory);
+    highlightedTerritory = territory;
+    territoryHighlighter.highlight(territory, totalFrames, delay);
   }
 
   void clearHighlightedTerritory() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -17,6 +17,7 @@ import games.strategy.engine.data.events.TerritoryListener;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.delegate.Matches;
+import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.screen.SmallMapImageManager;
 import games.strategy.triplea.ui.screen.Tile;
 import games.strategy.triplea.ui.screen.TileManager;
@@ -376,7 +377,7 @@ public class MapPanel extends ImageScrollerLargeView {
   }
 
   public void centerOn(final @Nullable Territory territory) {
-    if (territory == null || uiContext.getLockMap()) {
+    if (territory == null || ClientSetting.lockMap.getSetting()) {
       return;
     }
     centerOnTerritoryIgnoringMapLock(territory);
@@ -398,26 +399,9 @@ public class MapPanel extends ImageScrollerLargeView {
 
   public void highlightTerritory(
       final Territory territory, final int totalFrames, final int delay) {
-    withMapUnlocked(
-        () -> {
-          centerOn(territory);
-          highlightedTerritory = territory;
-          territoryHighlighter.highlight(territory, totalFrames, delay);
-        });
-  }
-
-  private void withMapUnlocked(final Runnable runnable) {
-    final boolean lockMap = uiContext.getLockMap();
-    if (lockMap) {
-      uiContext.setLockMap(false);
-    }
-    try {
-      runnable.run();
-    } finally {
-      if (lockMap) {
-        uiContext.setLockMap(true);
-      }
-    }
+      centerOn(territory);
+      highlightedTerritory = territory;
+      territoryHighlighter.highlight(territory, totalFrames, delay);
   }
 
   void clearHighlightedTerritory() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
@@ -31,7 +31,6 @@ public class PurchasePanel extends ActionPanel {
   private static final long serialVersionUID = -6121756876868623355L;
   // if this is set Purchase will use the tabbedProductionPanel - this is modifiable through the
   // View Menu
-  private static boolean tabbedProduction = true;
   private static final String BUY = "Buy...";
   private static final String CHANGE = "Change...";
 
@@ -52,25 +51,14 @@ public class PurchasePanel extends ActionPanel {
         public void actionPerformed(final ActionEvent e) {
           final PlayerId player = getCurrentPlayer();
           final GameData data = getData();
-          if (isTabbedProduction()) {
-            purchase =
-                TabbedProductionPanel.getProduction(
-                    player,
-                    (JFrame) getTopLevelAncestor(),
-                    data,
-                    bid,
-                    purchase,
-                    getMap().getUiContext());
-          } else {
-            purchase =
-                ProductionPanel.getProduction(
-                    player,
-                    (JFrame) getTopLevelAncestor(),
-                    data,
-                    bid,
-                    purchase,
-                    getMap().getUiContext());
-          }
+          purchase =
+              TabbedProductionPanel.getProduction(
+                  player,
+                  (JFrame) getTopLevelAncestor(),
+                  data,
+                  bid,
+                  purchase,
+                  getMap().getUiContext());
           purchasedUnits.setUnitsFromProductionRuleMap(purchase, player);
           if (purchase.totalValues() == 0) {
             purchasedLabel.setText("");
@@ -243,13 +231,5 @@ public class PurchasePanel extends ActionPanel {
   @Override
   public String toString() {
     return "PurchasePanel";
-  }
-
-  public static void setTabbedProduction(final boolean tabbedProduction) {
-    PurchasePanel.tabbedProduction = tabbedProduction;
-  }
-
-  public static boolean isTabbedProduction() {
-    return tabbedProduction;
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -205,10 +205,8 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
   private final JSplitPane chatSplit;
   private JSplitPane commentSplit;
   private final EditPanel editPanel;
-  @Getter
-  private final ButtonModel editModeButtonModel;
-  @Getter
-  private IEditDelegate editDelegate;
+  @Getter private final ButtonModel editModeButtonModel;
+  @Getter private IEditDelegate editDelegate;
   private final JSplitPane gameCenterPanel;
   private Territory territoryLastEntered;
   private List<Unit> unitsBeingMousedOver;

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -153,6 +153,7 @@ import javax.swing.WindowConstants;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.EtchedBorder;
 import javax.swing.tree.DefaultMutableTreeNode;
+import lombok.Getter;
 import lombok.extern.java.Log;
 import org.triplea.java.Interruptibles;
 import org.triplea.java.collections.IntegerMap;
@@ -204,8 +205,9 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
   private final JSplitPane chatSplit;
   private JSplitPane commentSplit;
   private final EditPanel editPanel;
+  @Getter
   private final ButtonModel editModeButtonModel;
-  private final ButtonModel showCommentLogButtonModel;
+  @Getter
   private IEditDelegate editDelegate;
   private final JSplitPane gameCenterPanel;
   private Territory territoryLastEntered;
@@ -462,16 +464,7 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
     this.setCursor(uiContext.getCursor());
     editModeButtonModel = new JToggleButton.ToggleButtonModel();
     editModeButtonModel.setEnabled(false);
-    showCommentLogButtonModel = new JToggleButton.ToggleButtonModel();
-    showCommentLogButtonModel.setSelected(false);
-    showCommentLogButtonModel.addActionListener(
-        e -> {
-          if (showCommentLogButtonModel.isSelected()) {
-            showCommentLog();
-          } else {
-            hideCommentLog();
-          }
-        });
+
     SwingUtilities.invokeLater(() -> this.setJMenuBar(new TripleAMenuBar(this)));
     final ImageScrollModel model = new ImageScrollModel();
     model.setMaxBounds(
@@ -762,7 +755,7 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
     return frame;
   }
 
-  private void hideCommentLog() {
+  public void hideCommentLog() {
     if (chatPanel != null) {
       commentSplit.setBottomComponent(null);
       chatSplit.setBottomComponent(chatPanel);
@@ -776,7 +769,7 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
     }
   }
 
-  private void showCommentLog() {
+  public void showCommentLog() {
     if (chatPanel != null) {
       commentSplit.setBottomComponent(chatPanel);
       chatSplit.setBottomComponent(commentSplit);
@@ -2413,18 +2406,6 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
     // force a data change event to update the UI for edit mode
     dataChangeListener.gameDataChanged(ChangeFactory.EMPTY_CHANGE);
     setWidgetActivation();
-  }
-
-  public IEditDelegate getEditDelegate() {
-    return editDelegate;
-  }
-
-  public ButtonModel getEditModeButtonModel() {
-    return editModeButtonModel;
-  }
-
-  public ButtonModel getShowCommentLogButtonModel() {
-    return showCommentLogButtonModel;
   }
 
   private boolean getEditMode() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -111,10 +111,6 @@ public interface UiContext {
 
   void setShowMapOnly(boolean showMapOnly);
 
-  boolean getLockMap();
-
-  void setLockMap(boolean lockMap);
-
   boolean getShowEndOfTurnReport();
 
   void setShowEndOfTurnReport(boolean value);

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -7,14 +7,15 @@ import games.strategy.engine.lobby.client.ui.LobbyFrame;
 import games.strategy.engine.lobby.moderator.toolbox.ShowToolboxController;
 import games.strategy.sound.SoundOptions;
 import games.strategy.triplea.UrlConstants;
+import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.MacOsIntegration;
-import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JMenu;
 import javax.swing.JMenuBar;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import org.triplea.lobby.common.IUserManager;
 import org.triplea.lobby.common.login.RsaAuthenticator;
+import org.triplea.swing.JMenuItemCheckBoxBuilder;
 import org.triplea.swing.SwingAction;
 import org.triplea.swing.SwingComponents;
 
@@ -89,10 +90,11 @@ public final class LobbyMenu extends JMenuBar {
   }
 
   private void addChatTimeMenu(final JMenu parentMenu) {
-    final JCheckBoxMenuItem chatTimeBox = new JCheckBoxMenuItem("Show Chat Times");
-    chatTimeBox.addActionListener(e -> lobbyFrame.setShowChatTime(chatTimeBox.isSelected()));
-    chatTimeBox.setSelected(true);
-    parentMenu.add(chatTimeBox);
+    parentMenu.add(
+        new JMenuItemCheckBoxBuilder("Show Chat Times", 'C')
+            .bindSetting(ClientSetting.showChatSettings)
+            .actionListener(lobbyFrame::setShowChatTime)
+            .build());
   }
 
   private void addUpdateAccountMenu(final JMenu account) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -81,7 +81,6 @@ final class ViewMenu extends JMenu {
     addMapFontAndColorEditorMenu();
     addChatTimeMenu();
     addShowCommentLog();
-    addTabbedProduction();
     addSeparator();
     addFindTerritory();
 
@@ -100,15 +99,6 @@ final class ViewMenu extends JMenu {
               }
             })
         .build();
-  }
-
-  private void addTabbedProduction() {
-    final JCheckBoxMenuItem tabbedProduction = new JCheckBoxMenuItem("Show Production Tabs");
-    tabbedProduction.setMnemonic(KeyEvent.VK_P);
-    tabbedProduction.setSelected(PurchasePanel.isTabbedProduction());
-    tabbedProduction.addActionListener(
-        e -> PurchasePanel.setTabbedProduction(tabbedProduction.isSelected()));
-    add(tabbedProduction);
   }
 
   private void addZoomMenu() {
@@ -438,11 +428,9 @@ final class ViewMenu extends JMenu {
   }
 
   private void addLockMap() {
-    final JCheckBoxMenuItem lockMapBox = new JCheckBoxMenuItem("Lock Map");
-    lockMapBox.setMnemonic(KeyEvent.VK_M);
-    lockMapBox.setSelected(uiContext.getLockMap());
-    lockMapBox.addActionListener(e -> uiContext.setLockMap(lockMapBox.isSelected()));
-    add(lockMapBox);
+    add(new JMenuItemCheckBoxBuilder("Lock Map", 'M')
+        .bindSetting(ClientSetting.lockMap)
+        .build());
   }
 
   private void addUnitNationDrawMenu() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -7,6 +7,7 @@ import games.strategy.engine.data.properties.NumberProperty;
 import games.strategy.engine.data.properties.PropertiesUi;
 import games.strategy.triplea.image.MapImage;
 import games.strategy.triplea.image.TileImageFactory;
+import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.AbstractUiContext;
 import games.strategy.triplea.ui.FindTerritoryAction;
 import games.strategy.triplea.ui.PurchasePanel;
@@ -43,6 +44,7 @@ import javax.swing.JSpinner;
 import javax.swing.KeyStroke;
 import javax.swing.SpinnerNumberModel;
 import lombok.extern.java.Log;
+import org.triplea.swing.JMenuItemCheckBoxBuilder;
 import org.triplea.swing.SwingAction;
 
 @Log
@@ -87,9 +89,17 @@ final class ViewMenu extends JMenu {
   }
 
   private void addShowCommentLog() {
-    final JCheckBoxMenuItem showCommentLog = new JCheckBoxMenuItem("Show Comment Log");
-    showCommentLog.setModel(frame.getShowCommentLogButtonModel());
-    add(showCommentLog).setMnemonic(KeyEvent.VK_L);
+    new JMenuItemCheckBoxBuilder("Show Comment Log", 'L')
+        .bindSetting(ClientSetting.showCommentLog)
+        .actionListener(
+            value -> {
+              if (value) {
+                frame.showCommentLog();
+              } else {
+                frame.hideCommentLog();
+              }
+            })
+        .build();
   }
 
   private void addTabbedProduction() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -10,7 +10,6 @@ import games.strategy.triplea.image.TileImageFactory;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.AbstractUiContext;
 import games.strategy.triplea.ui.FindTerritoryAction;
-import games.strategy.triplea.ui.PurchasePanel;
 import games.strategy.triplea.ui.TripleAFrame;
 import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.screen.UnitsDrawer;
@@ -428,9 +427,7 @@ final class ViewMenu extends JMenu {
   }
 
   private void addLockMap() {
-    add(new JMenuItemCheckBoxBuilder("Lock Map", 'M')
-        .bindSetting(ClientSetting.lockMap)
-        .build());
+    add(new JMenuItemCheckBoxBuilder("Lock Map", 'M').bindSetting(ClientSetting.lockMap).build());
   }
 
   private void addUnitNationDrawMenu() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -8,6 +8,7 @@ import games.strategy.engine.data.Unit;
 import games.strategy.thread.LockUtil;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
+import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.triplea.ui.screen.TerritoryOverLayDrawable.Operation;
@@ -281,7 +282,7 @@ public class TileManager {
     if (territoryOverlays.get(territory.getName()) != null) {
       drawing.add(territoryOverlays.get(territory.getName()));
     }
-    if (uiContext.getShowTerritoryEffects()) {
+    if (ClientSetting.showTerritoryEffects.getSetting()) {
       drawTerritoryEffects(territory, mapData, drawing);
     }
     if (uiContext.getShowUnits()) {

--- a/swing-lib/src/main/java/org/triplea/swing/JMenuItemCheckBoxBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/JMenuItemCheckBoxBuilder.java
@@ -1,6 +1,7 @@
 package org.triplea.swing;
 
 import com.google.common.base.Preconditions;
+import java.util.Optional;
 import java.util.function.Consumer;
 import javax.swing.JCheckBoxMenuItem;
 import org.triplea.java.ArgChecker;
@@ -23,6 +24,7 @@ public class JMenuItemCheckBoxBuilder {
   private Character mnemonic;
   private Consumer<Boolean> action;
   private boolean selected;
+  private SettingPersistence settingPersistence;
 
   /** Sets the title that appears next to the checkbox. */
   public JMenuItemCheckBoxBuilder(final String title, final char mnemonic) {
@@ -39,8 +41,18 @@ public class JMenuItemCheckBoxBuilder {
 
     final var checkBox = new JCheckBoxMenuItem(title);
     checkBox.setMnemonic(mnemonic);
-    checkBox.setSelected(selected);
-    checkBox.addActionListener(e -> action.accept(checkBox.isSelected()));
+
+    checkBox.setSelected(
+        Optional.ofNullable(settingPersistence)
+            .map(SettingPersistence::getSetting)
+            .orElse(selected));
+
+    checkBox.addActionListener(
+        e -> {
+          Optional.ofNullable(settingPersistence)
+              .ifPresent(s -> s.saveSetting(checkBox.isSelected()));
+          Optional.ofNullable(action).ifPresent(a -> a.accept(checkBox.isSelected()));
+        });
     return checkBox;
   }
 
@@ -52,5 +64,20 @@ public class JMenuItemCheckBoxBuilder {
   public JMenuItemCheckBoxBuilder actionListener(final Consumer<Boolean> actionListener) {
     this.action = actionListener;
     return this;
+  }
+
+  /**
+   * Binds setting to a persistence object. The persistence object will be used to load the selected
+   * value and when selected will be used to save the selected value.
+   */
+  public JMenuItemCheckBoxBuilder bindSetting(final SettingPersistence settingPersistence) {
+    this.settingPersistence = settingPersistence;
+    return this;
+  }
+
+  public interface SettingPersistence {
+    void saveSetting(boolean value);
+
+    boolean getSetting();
   }
 }


### PR DESCRIPTION
## Overview
- Remove setting "show tabbed production"
- Refactor multiple JMenuItem checkboxes to use swing build API.
- Set the following checkboxes up to remember their setting:
  - Show comment log
  - Show chat times
- Simplify boolean client setting, default to false

To support the persistence we add a new interface to ClientSetting boolean values that can be injected into a JMenuItemCheckBoxMenuItemBuilder

<!-- What changes did you make? Provide a summary of the updates included in this pull request -->

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[X] Feature update or enhancement
[X] Feature Removal
[X] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix

<!-- If fixing a bug, uncomment the below and fill in each section -->
<!--
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)

### Root Cause (What caused the bug?)

### Fix description (How is the bug fixed?)

-->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[X] Manually tested
[ ] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
<!--
### Manual Testing
 
-->


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

