### PR TITLE
JMenuItem Checkbox Persistence

### DIFF
--- a/game-core/src/main/java/games/strategy/sound/SoundOptionCheckBox.java
+++ b/game-core/src/main/java/games/strategy/sound/SoundOptionCheckBox.java
@@ -15,7 +15,7 @@ class SoundOptionCheckBox extends BooleanProperty {
    */
   SoundOptionCheckBox(final String clipName, final String title) {
     super(title, null, true);
-    if (ClipPlayer.getInstance().isMuted(clipName)) {
+    if (ClipPlayer.getInstance().isSoundClipMuted(clipName)) {
       setValue(false);
     }
     this.clipName = clipName;

--- a/game-core/src/main/java/games/strategy/sound/SoundOptions.java
+++ b/game-core/src/main/java/games/strategy/sound/SoundOptions.java
@@ -1,13 +1,14 @@
 package games.strategy.sound;
 
 import games.strategy.engine.data.properties.PropertiesUi;
+import games.strategy.triplea.settings.ClientSetting;
 import java.awt.event.KeyEvent;
 import java.util.List;
-import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JComponent;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JScrollPane;
+import org.triplea.swing.JMenuItemCheckBoxBuilder;
 
 /** Sound option window framework. */
 public final class SoundOptions {
@@ -54,17 +55,15 @@ public final class SoundOptions {
       }
     }
     for (final SoundOptionCheckBox property : properties) {
-      clipPlayer.setMute(property.getClipName(), !property.getValue());
+      clipPlayer.setSoundClipMute(property.getClipName(), !property.getValue());
     }
     clipPlayer.saveSoundPreferences();
   }
 
   /** Builds a checkbox menu item to turn sounds on or off. */
   public static JMenuItem buildGlobalSoundSwitchMenuItem() {
-    final JCheckBoxMenuItem soundCheckBox = new JCheckBoxMenuItem("Enable Sound");
-    soundCheckBox.setMnemonic(KeyEvent.VK_N);
-    soundCheckBox.setSelected(!ClipPlayer.getBeSilent());
-    soundCheckBox.addActionListener(e -> ClipPlayer.setBeSilent(!soundCheckBox.isSelected()));
-    return soundCheckBox;
+    return new JMenuItemCheckBoxBuilder("Enable Sound", 'N')
+        .bindSetting(ClientSetting.soundEnabled)
+        .build();
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/settings/BooleanClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/BooleanClientSetting.java
@@ -1,6 +1,14 @@
 package games.strategy.triplea.settings;
 
-final class BooleanClientSetting extends ClientSetting<Boolean> {
+import org.triplea.swing.JMenuItemCheckBoxBuilder;
+
+public final class BooleanClientSetting extends ClientSetting<Boolean>
+    implements JMenuItemCheckBoxBuilder.SettingPersistence {
+
+  BooleanClientSetting(final String name) {
+    this(name, false);
+  }
+
   BooleanClientSetting(final String name, final boolean defaultValue) {
     super(Boolean.class, name, defaultValue);
   }
@@ -13,5 +21,15 @@ final class BooleanClientSetting extends ClientSetting<Boolean> {
   @Override
   protected Boolean decodeValue(final String encodedValue) {
     return Boolean.valueOf(encodedValue);
+  }
+
+  @Override
+  public void saveSetting(final boolean value) {
+    setValueAndFlush(value);
+  }
+
+  @Override
+  public boolean getSetting() {
+    return getDefaultValue().orElse(false);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -41,6 +41,7 @@ import lombok.extern.java.Log;
  *
  * @param <T> The type of the setting value.
  */
+@SuppressWarnings("StaticInitializerReferencesSubClass")
 @Log
 public abstract class ClientSetting<T> implements GameSetting<T> {
   public static final ClientSetting<Integer> aiPauseDuration =
@@ -52,9 +53,9 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
   public static final ClientSetting<Integer> battleCalcSimulationCountLowLuck =
       new IntegerClientSetting("BATTLE_CALC_SIMULATION_COUNT_LOW_LUCK", 500);
   public static final ClientSetting<Boolean> confirmDefensiveRolls =
-      new BooleanClientSetting("CONFIRM_DEFENSIVE_ROLLS", false);
+      new BooleanClientSetting("CONFIRM_DEFENSIVE_ROLLS");
   public static final ClientSetting<Boolean> confirmEnemyCasualties =
-      new BooleanClientSetting("CONFIRM_ENEMY_CASUALTIES", false);
+      new BooleanClientSetting("CONFIRM_ENEMY_CASUALTIES");
   public static final ClientSetting<String> defaultGameName =
       new StringClientSetting("DEFAULT_GAME_NAME_PREF", "Big World : 1942");
   public static final ClientSetting<String> defaultGameUri =
@@ -69,6 +70,7 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
       new IntegerClientSetting("LOBBY_LAST_USED_PORT");
   public static final ClientSetting<Integer> lobbyLastUsedHttpsPort =
       new IntegerClientSetting("LOBBY_LAST_USED_HTTPS_PORT");
+  public static final BooleanClientSetting lockMap = new BooleanClientSetting("LOCK_MAP");
   public static final ClientSetting<String> lookAndFeel =
       new StringClientSetting("LOOK_AND_FEEL_PREF", LookAndFeel.getDefaultLookAndFeelClassName());
   public static final ClientSetting<Integer> mapEdgeScrollSpeed =
@@ -101,9 +103,14 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
   public static final ClientSetting<Boolean> showBattlesWhenObserving =
       new BooleanClientSetting("SHOW_BATTLES_WHEN_OBSERVING", true);
   public static final ClientSetting<Boolean> showBetaFeatures =
-      new BooleanClientSetting("SHOW_BETA_FEATURES", false);
-  public static final ClientSetting<Boolean> showConsole =
-      new BooleanClientSetting("SHOW_CONSOLE", false);
+      new BooleanClientSetting("SHOW_BETA_FEATURES");
+  public static final BooleanClientSetting showChatTimeSettings =
+      new BooleanClientSetting("SHOW_CHAT_TIME");
+  public static final BooleanClientSetting showCommentLog =
+      new BooleanClientSetting("SHOW_COMMENT_LOG");
+  public static final ClientSetting<Boolean> showConsole = new BooleanClientSetting("SHOW_CONSOLE");
+  public static final BooleanClientSetting soundEnabled =
+      new BooleanClientSetting("SOUND_ENABLED", true);
   public static final ClientSetting<String> testLobbyHost =
       new StringClientSetting("TEST_LOBBY_HOST");
   public static final ClientSetting<Integer> testLobbyPort =
@@ -127,7 +134,7 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
   public static final ClientSetting<String> playerName =
       new StringClientSetting("PLAYER_NAME", SystemProperties.getUserName());
   public static final ClientSetting<Boolean> useExperimentalJavaFxUi =
-      new BooleanClientSetting("USE_EXPERIMENTAL_JAVAFX_UI", false);
+      new BooleanClientSetting("USE_EXPERIMENTAL_JAVAFX_UI");
   public static final ClientSetting<String> loggingVerbosity =
       new StringClientSetting("LOGGING_VERBOSITY", Level.WARNING.getName());
   public static final ClientSetting<String> emailServerHost =

--- a/game-core/src/main/java/games/strategy/triplea/ui/AbstractUiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/AbstractUiContext.java
@@ -37,7 +37,6 @@ public abstract class AbstractUiContext implements UiContext {
   static final String MAP_SCALE_PREF = "MapScale";
 
   private static final String MAP_SKIN_PREF = "MapSkin";
-  private static final String LOCK_MAP = "LockMap";
   private static final String SHOW_END_OF_TURN_REPORT = "ShowEndOfTurnReport";
   private static final String SHOW_TRIGGERED_NOTIFICATIONS = "ShowTriggeredNotifications";
   private static final String SHOW_TRIGGERED_CHANCE_SUCCESSFUL = "ShowTriggeredChanceSuccessful";
@@ -253,23 +252,6 @@ public abstract class AbstractUiContext implements UiContext {
       actor.deactivate();
     } catch (final RuntimeException e) {
       log.log(Level.SEVERE, "Failed to deactivate actor", e);
-    }
-  }
-
-  @Override
-  public boolean getLockMap() {
-    final Preferences prefs = Preferences.userNodeForPackage(AbstractUiContext.class);
-    return prefs.getBoolean(LOCK_MAP, false);
-  }
-
-  @Override
-  public void setLockMap(final boolean lockMap) {
-    final Preferences prefs = Preferences.userNodeForPackage(AbstractUiContext.class);
-    prefs.putBoolean(LOCK_MAP, lockMap);
-    try {
-      prefs.flush();
-    } catch (final BackingStoreException ex) {
-      log.log(Level.SEVERE, "Failed to flush preferences: " + prefs.absolutePath(), ex);
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -17,6 +17,7 @@ import games.strategy.engine.data.events.TerritoryListener;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.delegate.Matches;
+import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.screen.SmallMapImageManager;
 import games.strategy.triplea.ui.screen.Tile;
 import games.strategy.triplea.ui.screen.TileManager;
@@ -376,7 +377,7 @@ public class MapPanel extends ImageScrollerLargeView {
   }
 
   public void centerOn(final @Nullable Territory territory) {
-    if (territory == null || uiContext.getLockMap()) {
+    if (territory == null || ClientSetting.lockMap.getSetting()) {
       return;
     }
     centerOnTerritoryIgnoringMapLock(territory);
@@ -398,26 +399,9 @@ public class MapPanel extends ImageScrollerLargeView {
 
   public void highlightTerritory(
       final Territory territory, final int totalFrames, final int delay) {
-    withMapUnlocked(
-        () -> {
-          centerOn(territory);
-          highlightedTerritory = territory;
-          territoryHighlighter.highlight(territory, totalFrames, delay);
-        });
-  }
-
-  private void withMapUnlocked(final Runnable runnable) {
-    final boolean lockMap = uiContext.getLockMap();
-    if (lockMap) {
-      uiContext.setLockMap(false);
-    }
-    try {
-      runnable.run();
-    } finally {
-      if (lockMap) {
-        uiContext.setLockMap(true);
-      }
-    }
+    centerOn(territory);
+    highlightedTerritory = territory;
+    territoryHighlighter.highlight(territory, totalFrames, delay);
   }
 
   void clearHighlightedTerritory() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
@@ -31,7 +31,6 @@ public class PurchasePanel extends ActionPanel {
   private static final long serialVersionUID = -6121756876868623355L;
   // if this is set Purchase will use the tabbedProductionPanel - this is modifiable through the
   // View Menu
-  private static boolean tabbedProduction = true;
   private static final String BUY = "Buy...";
   private static final String CHANGE = "Change...";
 
@@ -52,25 +51,14 @@ public class PurchasePanel extends ActionPanel {
         public void actionPerformed(final ActionEvent e) {
           final PlayerId player = getCurrentPlayer();
           final GameData data = getData();
-          if (isTabbedProduction()) {
-            purchase =
-                TabbedProductionPanel.getProduction(
-                    player,
-                    (JFrame) getTopLevelAncestor(),
-                    data,
-                    bid,
-                    purchase,
-                    getMap().getUiContext());
-          } else {
-            purchase =
-                ProductionPanel.getProduction(
-                    player,
-                    (JFrame) getTopLevelAncestor(),
-                    data,
-                    bid,
-                    purchase,
-                    getMap().getUiContext());
-          }
+          purchase =
+              TabbedProductionPanel.getProduction(
+                  player,
+                  (JFrame) getTopLevelAncestor(),
+                  data,
+                  bid,
+                  purchase,
+                  getMap().getUiContext());
           purchasedUnits.setUnitsFromProductionRuleMap(purchase, player);
           if (purchase.totalValues() == 0) {
             purchasedLabel.setText("");
@@ -243,13 +231,5 @@ public class PurchasePanel extends ActionPanel {
   @Override
   public String toString() {
     return "PurchasePanel";
-  }
-
-  public static void setTabbedProduction(final boolean tabbedProduction) {
-    PurchasePanel.tabbedProduction = tabbedProduction;
-  }
-
-  public static boolean isTabbedProduction() {
-    return tabbedProduction;
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -153,6 +153,7 @@ import javax.swing.WindowConstants;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.EtchedBorder;
 import javax.swing.tree.DefaultMutableTreeNode;
+import lombok.Getter;
 import lombok.extern.java.Log;
 import org.triplea.java.Interruptibles;
 import org.triplea.java.collections.IntegerMap;
@@ -204,9 +205,8 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
   private final JSplitPane chatSplit;
   private JSplitPane commentSplit;
   private final EditPanel editPanel;
-  private final ButtonModel editModeButtonModel;
-  private final ButtonModel showCommentLogButtonModel;
-  private IEditDelegate editDelegate;
+  @Getter private final ButtonModel editModeButtonModel;
+  @Getter private IEditDelegate editDelegate;
   private final JSplitPane gameCenterPanel;
   private Territory territoryLastEntered;
   private List<Unit> unitsBeingMousedOver;
@@ -462,16 +462,7 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
     this.setCursor(uiContext.getCursor());
     editModeButtonModel = new JToggleButton.ToggleButtonModel();
     editModeButtonModel.setEnabled(false);
-    showCommentLogButtonModel = new JToggleButton.ToggleButtonModel();
-    showCommentLogButtonModel.setSelected(false);
-    showCommentLogButtonModel.addActionListener(
-        e -> {
-          if (showCommentLogButtonModel.isSelected()) {
-            showCommentLog();
-          } else {
-            hideCommentLog();
-          }
-        });
+
     SwingUtilities.invokeLater(() -> this.setJMenuBar(new TripleAMenuBar(this)));
     final ImageScrollModel model = new ImageScrollModel();
     model.setMaxBounds(
@@ -762,7 +753,7 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
     return frame;
   }
 
-  private void hideCommentLog() {
+  public void hideCommentLog() {
     if (chatPanel != null) {
       commentSplit.setBottomComponent(null);
       chatSplit.setBottomComponent(chatPanel);
@@ -776,7 +767,7 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
     }
   }
 
-  private void showCommentLog() {
+  public void showCommentLog() {
     if (chatPanel != null) {
       commentSplit.setBottomComponent(chatPanel);
       chatSplit.setBottomComponent(commentSplit);
@@ -2413,18 +2404,6 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
     // force a data change event to update the UI for edit mode
     dataChangeListener.gameDataChanged(ChangeFactory.EMPTY_CHANGE);
     setWidgetActivation();
-  }
-
-  public IEditDelegate getEditDelegate() {
-    return editDelegate;
-  }
-
-  public ButtonModel getEditModeButtonModel() {
-    return editModeButtonModel;
-  }
-
-  public ButtonModel getShowCommentLogButtonModel() {
-    return showCommentLogButtonModel;
   }
 
   private boolean getEditMode() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -111,10 +111,6 @@ public interface UiContext {
 
   void setShowMapOnly(boolean showMapOnly);
 
-  boolean getLockMap();
-
-  void setLockMap(boolean lockMap);
-
   boolean getShowEndOfTurnReport();
 
   void setShowEndOfTurnReport(boolean value);

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -7,14 +7,15 @@ import games.strategy.engine.lobby.client.ui.LobbyFrame;
 import games.strategy.engine.lobby.moderator.toolbox.ShowToolboxController;
 import games.strategy.sound.SoundOptions;
 import games.strategy.triplea.UrlConstants;
+import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.MacOsIntegration;
-import javax.swing.JCheckBoxMenuItem;
 import javax.swing.JMenu;
 import javax.swing.JMenuBar;
 import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import org.triplea.lobby.common.IUserManager;
 import org.triplea.lobby.common.login.RsaAuthenticator;
+import org.triplea.swing.JMenuItemCheckBoxBuilder;
 import org.triplea.swing.SwingAction;
 import org.triplea.swing.SwingComponents;
 
@@ -93,10 +94,11 @@ public final class LobbyMenu extends JMenuBar {
   }
 
   private void addChatTimeMenu(final JMenu parentMenu) {
-    final JCheckBoxMenuItem chatTimeBox = new JCheckBoxMenuItem("Show Chat Times");
-    chatTimeBox.addActionListener(e -> lobbyFrame.setShowChatTime(chatTimeBox.isSelected()));
-    chatTimeBox.setSelected(true);
-    parentMenu.add(chatTimeBox);
+    parentMenu.add(
+        new JMenuItemCheckBoxBuilder("Show Chat Times", 'C')
+            .bindSetting(ClientSetting.showChatTimeSettings)
+            .actionListener(lobbyFrame::setShowChatTime)
+            .build());
   }
 
   private void addUpdateAccountMenu(final JMenu account) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -7,9 +7,9 @@ import games.strategy.engine.data.properties.NumberProperty;
 import games.strategy.engine.data.properties.PropertiesUi;
 import games.strategy.triplea.image.MapImage;
 import games.strategy.triplea.image.TileImageFactory;
+import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.AbstractUiContext;
 import games.strategy.triplea.ui.FindTerritoryAction;
-import games.strategy.triplea.ui.PurchasePanel;
 import games.strategy.triplea.ui.TripleAFrame;
 import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.screen.UnitsDrawer;
@@ -43,6 +43,7 @@ import javax.swing.JSpinner;
 import javax.swing.KeyStroke;
 import javax.swing.SpinnerNumberModel;
 import lombok.extern.java.Log;
+import org.triplea.swing.JMenuItemCheckBoxBuilder;
 import org.triplea.swing.SwingAction;
 
 @Log
@@ -79,7 +80,6 @@ final class ViewMenu extends JMenu {
     addMapFontAndColorEditorMenu();
     addChatTimeMenu();
     addShowCommentLog();
-    addTabbedProduction();
     addSeparator();
     addFindTerritory();
 
@@ -87,18 +87,17 @@ final class ViewMenu extends JMenu {
   }
 
   private void addShowCommentLog() {
-    final JCheckBoxMenuItem showCommentLog = new JCheckBoxMenuItem("Show Comment Log");
-    showCommentLog.setModel(frame.getShowCommentLogButtonModel());
-    add(showCommentLog).setMnemonic(KeyEvent.VK_L);
-  }
-
-  private void addTabbedProduction() {
-    final JCheckBoxMenuItem tabbedProduction = new JCheckBoxMenuItem("Show Production Tabs");
-    tabbedProduction.setMnemonic(KeyEvent.VK_P);
-    tabbedProduction.setSelected(PurchasePanel.isTabbedProduction());
-    tabbedProduction.addActionListener(
-        e -> PurchasePanel.setTabbedProduction(tabbedProduction.isSelected()));
-    add(tabbedProduction);
+    new JMenuItemCheckBoxBuilder("Show Comment Log", 'L')
+        .bindSetting(ClientSetting.showCommentLog)
+        .actionListener(
+            value -> {
+              if (value) {
+                frame.showCommentLog();
+              } else {
+                frame.hideCommentLog();
+              }
+            })
+        .build();
   }
 
   private void addZoomMenu() {
@@ -428,11 +427,7 @@ final class ViewMenu extends JMenu {
   }
 
   private void addLockMap() {
-    final JCheckBoxMenuItem lockMapBox = new JCheckBoxMenuItem("Lock Map");
-    lockMapBox.setMnemonic(KeyEvent.VK_M);
-    lockMapBox.setSelected(uiContext.getLockMap());
-    lockMapBox.addActionListener(e -> uiContext.setLockMap(lockMapBox.isSelected()));
-    add(lockMapBox);
+    add(new JMenuItemCheckBoxBuilder("Lock Map", 'M').bindSetting(ClientSetting.lockMap).build());
   }
 
   private void addUnitNationDrawMenu() {

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -22,7 +22,6 @@ import games.strategy.engine.framework.startup.mc.GameSelectorModel;
 import games.strategy.engine.framework.startup.mc.ServerModel;
 import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
-import games.strategy.sound.ClipPlayer;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.settings.ClientSetting;
 import java.io.File;
@@ -540,7 +539,6 @@ public class HeadlessGameServer {
 
     ArgParser.handleCommandLineArgs(args);
     handleHeadlessGameServerArgs();
-    ClipPlayer.setBeSilentInPreferencesWithoutAffectingCurrent(true);
     try {
       new HeadlessGameServer();
     } catch (final Exception e) {

--- a/lobby/src/main/java/org/triplea/lobby/server/LobbyServer.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/LobbyServer.java
@@ -6,7 +6,6 @@ import games.strategy.net.DefaultObjectStreamFactory;
 import games.strategy.net.IServerMessenger;
 import games.strategy.net.Messengers;
 import games.strategy.net.ServerMessenger;
-import games.strategy.sound.ClipPlayer;
 import java.io.IOException;
 import org.mindrot.jbcrypt.BCrypt;
 import org.triplea.lobby.common.ILobbyGameBroadcaster;
@@ -39,8 +38,6 @@ final class LobbyServer {
    * the lobby server is running.
    */
   static void start(final LobbyConfiguration lobbyConfiguration) throws IOException {
-    ClipPlayer.setBeSilentInPreferencesWithoutAffectingCurrent(true);
-
     final IServerMessenger server =
         new ServerMessenger(
             LobbyConstants.ADMIN_USERNAME,


### PR DESCRIPTION
## Overview
- Remove setting "show tabbed production"
- Refactor multiple JMenuItem checkboxes to use swing build API.
- Set the following checkboxes up to remember their setting:
  - Show comment log
  - Show chat times
- Simplify boolean client setting, default to false

To support the persistence we add a new interface to ClientSetting boolean values that can be injected into a JMenuItemCheckBoxMenuItemBuilder

<!-- What changes did you make? Provide a summary of the updates included in this pull request -->

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[x] Feature update or enhancement
[x] Feature Removal
[x] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix

<!-- If fixing a bug, uncomment the below and fill in each section -->
<!--
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)

### Root Cause (What caused the bug?)

### Fix description (How is the bug fixed?)

-->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[x] Manually tested
[ ] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
<!--
### Manual Testing
 
-->


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

