### PR TITLE
Revert "Faster Builds with Parallel travis VMs "

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,27 +4,9 @@ language: java
 matrix:
   include:
   - jdk: openjdk11
-    env:
-      - TASKS="shadowJar downloadAssets"
-      - TRIPLEA_RELEASE=true
-  - jdk: openjdk11
-    env: 
-      - TASKS="test jacocoTestReport"
-      - PUSH_REPORTS=true
-      - TRIPLEA_RELEASE=false
-  - jdk: openjdk11
-    env: 
-      - TASKS="validateYamls spotlessCheck checkstyleMain checkstyleTest pmdMain"
-      - TRIPLEA_RELEASE=false
-  - jdk: openjdk11
-    env: 
-      - TASKS=integTest
-      - INSTALL=true
-      - TRIPLEA_RELEASE=false
+    env: TRIPLEA_RELEASE=true
   - jdk: openjdk12
-    env: 
-      - TASKS=test
-      - TRIPLEA_RELEASE=false
+    env: TRIPLEA_RELEASE=false
 addons:
   postgresql: "10"
   apt:
@@ -36,25 +18,24 @@ install:
 - echo "================ Build step 'install' =================" > /dev/null
 ## shellcheck all shell scripts
 -  find .travis/ -type f | xargs grep -lE "^#\!/bin/bash$" | xargs shellcheck
-## Update product version to include build number.
-## EG: replace "2.0.0" to be "2.0.15555";
-- sed -i "s/.0$/.$TRAVIS_BUILD_NUMBER/" game-core/src/main/resources/META-INF/triplea/product.properties
-- if [ -n "$INSTALL" ]; then ./.travis/install; fi
+## validate ASAP so syntax, checkstyle or unit tests fail the build early
+- ./gradlew validateYamls checkstyleMain checkstyleTest spotlessCheck test
+- ./.travis/install
 before_script:
 - echo "================ Build step 'before_script' =================" > /dev/null
-- if [ "$TASKS" = release ]; then ./.travis/setup_gpg; fi
+- ./.travis/setup_gpg
 script:
 - echo "================ Build step 'script' =================" > /dev/null
-- ./gradlew --parallel $TASKS
+- ./gradlew check jacocoTestReport
 after_success:
 - echo "================ Build step 'after_success'' =================" > /dev/null
-- if [ -n "$PUSH_REPORTS" ]; then bash <(curl -s https://codecov.io/bash); fi # upload coverage report - https://github.com/codecov/example-gradle
+- bash <(curl -s https://codecov.io/bash)  # upload coverage report - https://github.com/codecov/example-gradle
 after_failure:
 - echo "================ Build step 'after_failure' =================" > /dev/null
 - test "$TRAVIS_BRANCH" = master && ./.travis/report_build_status FAILURE
 before_deploy:
 - echo "================ Build step 'before_deploy' =================" > /dev/null
-- if [ -n "$RELEASE" ]; then ./.travis/do_release; fi
+- ./.travis/do_release
 deploy:
   provider: releases
   api_key:
@@ -66,6 +47,6 @@ deploy:
   prerelease: true
   on:
     tags: false
-    condition: $TRIPLEA_RELEASE = true
+    condition: "$TRIPLEA_RELEASE = true"
     repo: triplea-game/triplea
     branch: master

--- a/.travis/install
+++ b/.travis/install
@@ -6,6 +6,10 @@ echo "create database lobby_db" | psql -h localhost -U postgres -d postgres
 echo "create user lobby_user with password 'postgres'" | psql -h localhost -U postgres -d postgres
 echo "alter database lobby_db owner to lobby_user" | psql -h localhost -U postgres -d postgres
 
+## Update product version to include build number.
+## EG: replace "2.0.0" to be "2.0.15555";
+sed -i "s/.0$/.$TRAVIS_BUILD_NUMBER/" game-core/src/main/resources/META-INF/triplea/product.properties
+
 ./gradlew flywayMigrate
 ./gradlew :http-server:shadowJar
 


### PR DESCRIPTION
Reverts triplea-game/triplea#5146

(1) The build is a lot faster with parallel VMs, but deployment does not wait for all build matrix jobs to complete. (seems we might have that problem where if JDK11 job completes but JDK12 fails, we would deploy).

(2) There is also a bug in the update as a RELEASE variable value was not renamed. RELEASE apparently is a reserved variable value and using that caused JDK install to fail, so it was renamed and one of the variable instances was not renamed. This then went on to cause the 'do_release' task to be skipped which skips the tag push step, hence the untagged release.


Item (1) is a bad problem, looks like we need to back up a bit. Build stages seem to be the way to coordinate parallelism.