### PR TITLE
Fix lock map not working bug

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/settings/BooleanClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/BooleanClientSetting.java
@@ -30,6 +30,6 @@ public final class BooleanClientSetting extends ClientSetting<Boolean>
 
   @Override
   public boolean getSetting() {
-    return getDefaultValue().orElse(false);
+    return getValue().or(this::getDefaultValue).orElse(false);
   }
 }


### PR DESCRIPTION
## Overview
'getDefaultValue()' for a boolean condition will typically return false. 'getDefaultValue().orElse(false)' is always false. This update fixes this and uses the intended 'getValue()' option.


## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[X] Bug fix

<!-- If fixing a bug, uncomment the below and fill in each section -->
<!--
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)
https://github.com/triplea-game/triplea/issues/5156

### Root Cause (What caused the bug?)
Refactor bug



## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[X ] Manually tested
[ ] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
<!--
### Manual Testing
 
-->


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

