### PR TITLE
Fix refactor bug that disabled sound on headed clients

### DIFF
--- a/game-core/src/main/java/games/strategy/sound/ClipPlayer.java
+++ b/game-core/src/main/java/games/strategy/sound/ClipPlayer.java
@@ -251,7 +251,7 @@ public class ClipPlayer {
   }
 
   private boolean isSoundEnabled() {
-    return Boolean.parseBoolean(System.getProperty(GameRunner.TRIPLEA_HEADLESS, "false"))
+    return !Boolean.parseBoolean(System.getProperty(GameRunner.TRIPLEA_HEADLESS, "false"))
         && !"true".equals(System.getenv("java.awt.headless"))
         && ClientSetting.soundEnabled.getSetting();
   }


### PR DESCRIPTION
## Overview
A refactoring bug flipped a boolean condition, net effect is sound would not play on headed clients.

<!-- What changes did you make? Provide a summary of the updates included in this pull request -->

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[X] Bug fix

<!-- If fixing a bug, uncomment the below and fill in each section -->
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)
https://github.com/triplea-game/triplea/issues/5156
### Root Cause (What caused the bug?)
Refactoring bug
### Fix description (How is the bug fixed?)


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[X] Manually tested
[ ] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
<!--
### Manual Testing
 
-->


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

