### PR TITLE
Fix find territory respecting territory lock; Improve APIs

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -116,7 +116,13 @@ public final class BattlePanel extends ActionPanel {
             .addEast(
                 JButtonBuilder.builder()
                     .title("Center")
-                    .actionListener(() -> getMap().highlightTerritory(territory, 4))
+                    .actionListener(
+                        () ->
+                            getMap()
+                                .highlightTerritory(
+                                    territory,
+                                    MapPanel.AnimationDuration.STANDARD,
+                                    MapPanel.HighlightDelay.STANDARD_DELAY))
                     .build())
             .build());
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -66,6 +66,7 @@ import javax.annotation.Nullable;
 import javax.swing.SwingUtilities;
 import javax.swing.Timer;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.triplea.java.Interruptibles;
 import org.triplea.java.ObjectUtils;
@@ -383,25 +384,46 @@ public class MapPanel extends ImageScrollerLargeView {
     centerOnTerritoryIgnoringMapLock(territory);
   }
 
+  /**
+   * Centers on a territory and highlights it, the territory highlight animation does not turn off
+   * until #clearHighlight is called.
+   */
   void highlightTerritory(final Territory territory) {
-    highlightTerritory(territory, Integer.MAX_VALUE);
+    highlightTerritory(territory, AnimationDuration.INFINITE, HighlightDelay.STANDARD_DELAY);
   }
 
   /**
-   * Adds a highlight to a territory. The highlight is a white outline that will flash.
+   * Centers on and highlights a territory. The highlight is a white outline that will flash.
    *
    * @param territory The territory to highlight
-   * @param totalFrames The number of times to flash on and off the territory highlight.
+   * @param animationDuration Duration for how long the flashing territory animation would be
+   *     active.
+   * @param highlightDelay Time duration for how long before starting the flashing territory
+   *     animation.
    */
-  public void highlightTerritory(final Territory territory, final int totalFrames) {
-    highlightTerritory(territory, totalFrames, 500);
+  public void highlightTerritory(
+      final Territory territory,
+      final AnimationDuration animationDuration,
+      final HighlightDelay highlightDelay) {
+    centerOnTerritoryIgnoringMapLock(territory);
+    highlightedTerritory = territory;
+    territoryHighlighter.highlight(territory, animationDuration.frameCount, highlightDelay.delayMs);
   }
 
-  public void highlightTerritory(
-      final Territory territory, final int totalFrames, final int delay) {
-    centerOn(territory);
-    highlightedTerritory = territory;
-    territoryHighlighter.highlight(territory, totalFrames, delay);
+  @AllArgsConstructor(access = AccessLevel.PRIVATE)
+  public enum AnimationDuration {
+    STANDARD(4),
+    INFINITE(Integer.MAX_VALUE);
+
+    private final int frameCount;
+  }
+
+  @AllArgsConstructor(access = AccessLevel.PRIVATE)
+  public enum HighlightDelay {
+    SHORT_DELAY(200),
+    STANDARD_DELAY(500);
+
+    private final int delayMs;
   }
 
   void clearHighlightedTerritory() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -274,7 +274,8 @@ public class UnitScroller {
 
   private void highlightTerritory(final Territory territory) {
     if (ClientSetting.unitScrollerHighlightTerritory.getValueOrThrow()) {
-      mapPanel.highlightTerritory(territory, 4, 200);
+      mapPanel.highlightTerritory(
+          territory, MapPanel.AnimationDuration.STANDARD, MapPanel.HighlightDelay.SHORT_DELAY);
     }
   }
 


### PR DESCRIPTION
## Overview
(1) BugFix: Convert 'centerOnTerritory' call to be 'centerOnIgnoringTerritory'
(2) Update javadocs for highlight territory, and note the centerOnTerritory side-effect
(3) Update API of highlight territory to take enum 'flag' values so we are not passing integers
(4) Simplify highlightTerritory APIs, remove a 3rd variant so we have just the two variants: one with just a territory arg, a second variant with territory arg and animation control flags.

<!-- What changes did you make? Provide a summary of the updates included in this pull request -->

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[X] Code Cleanup or refactor
[ ] Configuration Change
[X] Bug fix

<!-- If fixing a bug, uncomment the below and fill in each section -->
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)
https://github.com/triplea-game/triplea/issues/5162

### Root Cause (What caused the bug?)
Refactor bug

### Fix description (How is the bug fixed?)
Convert a 'centerOn' call to be 'centerOnIgnoringTerritoryLock'


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[X] Manually tested
[ ] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
<!--
### Manual Testing
 
-->


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

## Additional Review Notes
I chose not to restore the original "withMapUnlocked" code for a few reasons:
1) All that is needed is to convert a 'centerOn' call to 'centerOnIgnoringMapUnlock'. The root cause of the refactor bug is code complexity, lack of tests, missing documentation, and just a mistake.
2) WithMapUnlocked has performance implications and is perhaps overly clever. Updating a system setting is a very slow operation, specifically the 'flush' of the system preference. On the other hand, if there is no 'flush', then future reads of the setting will not read the updated value. Hence, it's better to not update and flush a setting unless it is really needed.

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

