### PR TITLE
Add travis deploy on condition

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,6 +53,10 @@ jobs:
         file: build/artifacts/*
         skip_cleanup: true        
         prerelease: true
+        on:
+          tags: false
+          repo: triplea-game/triplea
+          branch: master
 after_failure:
   - echo "================ Build step 'after_failure' =================" > /dev/null
   - test "$TRAVIS_BRANCH" = master && ./.travis/report_build_status FAILURE


### PR DESCRIPTION
## Overview
Looks like there is a white list requirement for travis deploy.

On previous build got:
"Skipping a deployment with the releases provider because this branch is not permitted: master"

<!-- What changes did you make? Provide a summary of the updates included in this pull request -->

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[x] Configuration Change
[x] Bug fix
