### PR TITLE
Fix name assignment de-duper matching against bot names

### DIFF
--- a/game-core/src/main/java/games/strategy/net/PlayerNameAssigner.java
+++ b/game-core/src/main/java/games/strategy/net/PlayerNameAssigner.java
@@ -56,6 +56,7 @@ public final class PlayerNameAssigner {
 
     return loggedInMacsToNames.entries().stream()
         .filter(entry -> mac.equals(entry.getKey()))
+        .filter(entry -> !isBotName(entry.getValue()))
         .map(Map.Entry::getValue)
         .min(Comparator.naturalOrder());
   }


### PR DESCRIPTION
## Overview
Problem, connect a bot, then log in to lobby. In this case the name de-duper will see the bot name and override the requested name to be "bot01 (1)". This update adds a check to the name assigner to ignore logged in bot names.

<!-- What changes did you make? Provide a summary of the updates included in this pull request -->

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[x] Bug fix

<!-- If fixing a bug, uncomment the below and fill in each section -->
<!--
## Bug Fix

### Issue number or Reproduction Steps  (if no existing issue, how can the bug be reproduced?)

### Root Cause (What caused the bug?)

### Fix description (How is the bug fixed?)

-->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[x] Covered by newly added automated tests
[ ] Manually tested
[ ] No testing done

<!-- 
  If manually tested, uncomment the section below and list the test-case scenarios manually tested.
-->
<!--
### Manual Testing
 
-->


<!-- If there any user facing changes, uncomment the section below and include screenshots -->
<!--
## Screens Shots

### Before

### After
-->


<!-- Uncomment the next section and add here any extra notes that would be helpful to reviewers -->

<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
https://github.com/triplea-game/triplea/tree/master/docs/dev
-->

