### PR TITLE
Colorize unit images

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -228,9 +228,7 @@ public class ResourceLoader implements Closeable {
    */
   public @Nullable URL getResource(final String inputPath) {
     final String path = resourceLocationTracker.getMapPrefix() + inputPath;
-    return getMatchingResources(path).stream()
-        .findFirst()
-        .orElse(getMatchingResources(inputPath).stream().findFirst().orElse(null));
+    return findResource(path).or(() -> findResource(inputPath)).orElse(null);
   }
 
   /**
@@ -244,16 +242,15 @@ public class ResourceLoader implements Closeable {
   public @Nullable URL getResource(final String inputPath, final String inputPath2) {
     final String path = resourceLocationTracker.getMapPrefix() + inputPath;
     final String path2 = resourceLocationTracker.getMapPrefix() + inputPath2;
-    return getMatchingResources(path).stream()
-        .findFirst()
-        .orElse(
-            getMatchingResources(path2).stream()
-                .findFirst()
-                .orElse(
-                    getMatchingResources(inputPath).stream()
-                        .findFirst()
-                        .orElse(
-                            getMatchingResources(inputPath2).stream().findFirst().orElse(null))));
+    return findResource(path)
+        .or(() -> findResource(path2))
+        .or(() -> findResource(inputPath))
+        .or(() -> findResource(inputPath2))
+        .orElse(null);
+  }
+
+  private Optional<URL> findResource(final String searchPath) {
+    return getMatchingResources(searchPath).stream().findFirst();
   }
 
   private List<URL> getMatchingResources(final String path) {

--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -233,6 +233,28 @@ public class ResourceLoader implements Closeable {
         .orElse(getMatchingResources(inputPath).stream().findFirst().orElse(null));
   }
 
+  /**
+   * Returns the URL of the resource at the specified path or {@code null} if the resource does not
+   * exist.
+   *
+   * @param inputPath (The name of a resource is a '/'-separated path name that identifies the
+   *     resource. Do not use '\' or File.separator)
+   */
+  public @Nullable URL getResource(final String inputPath, final String inputPath2) {
+    final String path = resourceLocationTracker.getMapPrefix() + inputPath;
+    final String path2 = resourceLocationTracker.getMapPrefix() + inputPath2;
+    return getMatchingResources(path).stream()
+        .findFirst()
+        .orElse(
+            getMatchingResources(path2).stream()
+                .findFirst()
+                .orElse(
+                    getMatchingResources(inputPath).stream()
+                        .findFirst()
+                        .orElse(
+                            getMatchingResources(inputPath2).stream().findFirst().orElse(null))));
+  }
+
   private List<URL> getMatchingResources(final String path) {
     try {
       return Collections.list(loader.getResources(path));

--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -235,10 +235,11 @@ public class ResourceLoader implements Closeable {
 
   /**
    * Returns the URL of the resource at the specified path or {@code null} if the resource does not
-   * exist.
+   * exist. Tries the given 2 paths in order first in the map resources then engine resources.
    *
    * @param inputPath (The name of a resource is a '/'-separated path name that identifies the
    *     resource. Do not use '\' or File.separator)
+   * @param inputPath2 Same as inputPath but this takes second priority when loading
    */
   public @Nullable URL getResource(final String inputPath, final String inputPath2) {
     final String path = resourceLocationTracker.getMapPrefix() + inputPath;

--- a/game-core/src/main/java/games/strategy/triplea/image/ImageColorizer.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/ImageColorizer.java
@@ -1,0 +1,91 @@
+package games.strategy.triplea.image;
+
+import java.awt.Color;
+import java.awt.image.BufferedImage;
+
+/**
+ * Class used to colorize images. Based on finding the luminance from the original image then
+ * applying hue, saturation, and brightness to colorize it.
+ */
+public class ImageColorizer {
+
+  private static final int MAX_COLOR = 256;
+  private static final float LUMINANCE_RED = 0.2126f;
+  private static final float LUMINANCE_GREEN = 0.7152f;
+  private static final float LUMINANCE_BLUE = 0.0722f;
+
+  /**
+   * Apply color to the given image. This takes the hue and saturation of the given color and
+   * applies it to the image. It ignores the brightness of the color which can cause images to
+   * become poor quality.
+   */
+  public static void applyColor(final Color color, final BufferedImage image) {
+    final float[] hsb = Color.RGBtoHSB(color.getRed(), color.getGreen(), color.getBlue(), null);
+    applyHsb((int) (hsb[0] * 360), (int) (hsb[1] * 100), 0, image);
+  }
+
+  /**
+   * Apply HSB values to the given image.
+   *
+   * @param hue 0 to 360
+   * @param saturation 0 to 100
+   * @param brightness -100 to 100, which adjusts the given image's brightness
+   * @param image the image to transform
+   */
+  public static void applyHsb(
+      final int hue, final int saturation, final int brightness, final BufferedImage image) {
+
+    // Create color lookup table for luminance values
+    final int[] redLookup = new int[MAX_COLOR];
+    final int[] greenLookup = new int[MAX_COLOR];
+    final int[] blueLookup = new int[MAX_COLOR];
+    final float hueFloat = hue / 360f;
+    final float saturationFloat = saturation / 100f;
+    for (int i = 0; i < MAX_COLOR; i++) {
+      final float brightnessFloat = i / 255f;
+      final Color color = Color.getHSBColor(hueFloat, saturationFloat, brightnessFloat);
+      redLookup[i] = (color.getRed());
+      greenLookup[i] = (color.getGreen());
+      blueLookup[i] = (color.getBlue());
+    }
+
+    // Loop through image to colorize each pixel
+    for (int x = 0; x < image.getWidth(); x++) {
+      for (int y = 0; y < image.getHeight(); y++) {
+        final Color color = new Color(image.getRGB(x, y), true);
+
+        // Don't worry about colorization if pixel is transparent
+        if (color.getAlpha() == 0) {
+          continue;
+        }
+
+        // Avoid colorization if pixel is close to black so image stays sharp
+        final float[] hsb = Color.RGBtoHSB(color.getRed(), color.getGreen(), color.getBlue(), null);
+        if (hsb[2] < 0.1) {
+          continue;
+        }
+
+        // Find luminance and use lookup table to set resulting color
+        final int lum = findLuminance(color, brightness);
+        final Color finalColor =
+            new Color(redLookup[lum], greenLookup[lum], blueLookup[lum], color.getAlpha());
+        image.setRGB(x, y, finalColor.getRGB());
+      }
+    }
+  }
+
+  private static int findLuminance(final Color color, final int brightness) {
+    int lum =
+        (int)
+            (color.getRed() * LUMINANCE_RED
+                + color.getGreen() * LUMINANCE_GREEN
+                + color.getBlue() * LUMINANCE_BLUE);
+    if (brightness > 0) {
+      lum = (int) (lum * (100f - brightness) / 100f);
+      lum += 255f - (100f - brightness) * 255f / 100f;
+    } else if (brightness < 0) {
+      lum = (int) ((lum * (brightness + 100f)) / 100f);
+    }
+    return lum;
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/image/ImageColorizer.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/ImageColorizer.java
@@ -14,6 +14,8 @@ public class ImageColorizer {
   private static final float LUMINANCE_GREEN = 0.7152f;
   private static final float LUMINANCE_BLUE = 0.0722f;
 
+  private ImageColorizer() {}
+
   /**
    * Apply color to the given image. This takes the hue and saturation of the given color and
    * applies it to the image. It ignores the brightness of the color which can cause images to
@@ -44,9 +46,9 @@ public class ImageColorizer {
     for (int i = 0; i < MAX_COLOR; i++) {
       final float brightnessFloat = i / 255f;
       final Color color = Color.getHSBColor(hueFloat, saturationFloat, brightnessFloat);
-      redLookup[i] = (color.getRed());
-      greenLookup[i] = (color.getGreen());
-      blueLookup[i] = (color.getBlue());
+      redLookup[i] = color.getRed();
+      greenLookup[i] = color.getGreen();
+      blueLookup[i] = color.getBlue();
     }
 
     // Loop through image to colorize each pixel
@@ -82,7 +84,7 @@ public class ImageColorizer {
                 + color.getBlue() * LUMINANCE_BLUE);
     if (brightness > 0) {
       lum = (int) (lum * (100f - brightness) / 100f);
-      lum += 255f - (100f - brightness) * 255f / 100f;
+      lum = (int) (lum + (255f - (100f - brightness) * 255f / 100f));
     } else if (brightness < 0) {
       lum = (int) ((lum * (brightness + 100f)) / 100f);
     }

--- a/game-core/src/main/java/games/strategy/triplea/image/ImageTransformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/ImageTransformer.java
@@ -1,29 +1,32 @@
 package games.strategy.triplea.image;
 
 import java.awt.Color;
+import java.awt.geom.AffineTransform;
+import java.awt.image.AffineTransformOp;
 import java.awt.image.BufferedImage;
 
 /**
- * Class used to colorize images. Based on finding the luminance from the original image then
- * applying hue, saturation, and brightness to colorize it.
+ * Class used to transform images including colorizing and flipping. Colorizing is based on finding
+ * the luminance from the original image then applying hue, saturation, and brightness to colorize
+ * it. More information about luminance can be found here:
+ * https://en.wikipedia.org/wiki/Relative_luminance.
  */
-public class ImageColorizer {
+public class ImageTransformer {
 
   private static final int MAX_COLOR = 256;
   private static final float LUMINANCE_RED = 0.2126f;
   private static final float LUMINANCE_GREEN = 0.7152f;
   private static final float LUMINANCE_BLUE = 0.0722f;
 
-  private ImageColorizer() {}
+  private ImageTransformer() {}
 
   /**
-   * Apply color to the given image. This takes the hue and saturation of the given color and
-   * applies it to the image. It ignores the brightness of the color which can cause images to
-   * become poor quality.
+   * Apply color and brightness to the given image. This uses the hue and saturation of the given
+   * color. It ignores the brightness of the color and uses the given brightness value.
    */
-  public static void applyColor(final Color color, final BufferedImage image) {
+  public static void colorize(final Color color, final int brightness, final BufferedImage image) {
     final float[] hsb = Color.RGBtoHSB(color.getRed(), color.getGreen(), color.getBlue(), null);
-    applyHsb((int) (hsb[0] * 360), (int) (hsb[1] * 100), 0, image);
+    colorize((int) (hsb[0] * 360), (int) (hsb[1] * 100), brightness, image);
   }
 
   /**
@@ -34,7 +37,7 @@ public class ImageColorizer {
    * @param brightness -100 to 100, which adjusts the given image's brightness
    * @param image the image to transform
    */
-  public static void applyHsb(
+  private static void colorize(
       final int hue, final int saturation, final int brightness, final BufferedImage image) {
 
     // Create color lookup table for luminance values
@@ -44,7 +47,7 @@ public class ImageColorizer {
     final float hueFloat = hue / 360f;
     final float saturationFloat = saturation / 100f;
     for (int i = 0; i < MAX_COLOR; i++) {
-      final float brightnessFloat = i / 255f;
+      final float brightnessFloat = (float) i / (MAX_COLOR - 1);
       final Color color = Color.getHSBColor(hueFloat, saturationFloat, brightnessFloat);
       redLookup[i] = color.getRed();
       greenLookup[i] = color.getGreen();
@@ -89,5 +92,12 @@ public class ImageColorizer {
       lum = (int) ((lum * (brightness + 100f)) / 100f);
     }
     return lum;
+  }
+
+  public static BufferedImage flipHorizontally(final BufferedImage image) {
+    final AffineTransform tx = AffineTransform.getScaleInstance(-1, 1);
+    tx.translate(-image.getWidth(null), 0);
+    final AffineTransformOp op = new AffineTransformOp(tx, AffineTransformOp.TYPE_NEAREST_NEIGHBOR);
+    return op.filter(image, null);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -175,7 +175,7 @@ public class UnitImageFactory {
 
   private static boolean needToTransformImage(
       final PlayerId id, final UnitType type, final MapData mapData) {
-    return !mapData.ignoreColorizingUnit(type.getName())
+    return !mapData.ignoreTransformingUnit(type.getName())
         && (mapData.getUnitColor(id.getName()).isPresent() || mapData.shouldFlipUnit(id.getName()));
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -119,7 +119,7 @@ public class UnitImageFactory {
     if (images.containsKey(fullName)) {
       return Optional.of(images.get(fullName));
     }
-    final Optional<Image> image = getBaseImage(baseName, player, type);
+    final Optional<Image> image = getTransformedImage(baseName, player, type);
     if (image.isEmpty()) {
       return Optional.empty();
     }
@@ -151,7 +151,7 @@ public class UnitImageFactory {
     return Optional.ofNullable(url);
   }
 
-  private Optional<Image> getBaseImage(
+  private Optional<Image> getTransformedImage(
       final String baseImageName, final PlayerId id, final UnitType type) {
     final Optional<URL> imageLocation = getBaseImageUrl(baseImageName, id);
     Image image = null;
@@ -220,7 +220,7 @@ public class UnitImageFactory {
     if (icons.containsKey(fullName)) {
       return Optional.of(icons.get(fullName));
     }
-    final Optional<Image> image = getBaseImage(baseName, player, type);
+    final Optional<Image> image = getTransformedImage(baseName, player, type);
     if (image.isEmpty()) {
       return Optional.empty();
     }
@@ -303,7 +303,7 @@ public class UnitImageFactory {
   public Dimension getImageDimensions(final UnitType type, final PlayerId player) {
     final String baseName = getBaseImageName(type, player, false, false);
     final Image baseImage =
-        getBaseImage(baseName, player, type)
+        getTransformedImage(baseName, player, type)
             .orElseThrow(
                 () ->
                     new RuntimeException(

--- a/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
@@ -78,7 +78,8 @@ public class HeadedUiContext extends AbstractUiContext {
         mapData.getDefaultUnitWidth(),
         mapData.getDefaultUnitHeight(),
         mapData.getDefaultUnitCounterOffsetWidth(),
-        mapData.getDefaultUnitCounterOffsetHeight());
+        mapData.getDefaultUnitCounterOffsetHeight(),
+        mapData);
     // TODO: separate scale for resources
     resourceImageFactory.setResourceLoader(resourceLoader);
     territoryEffectImageFactory.setResourceLoader(resourceLoader);

--- a/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -367,6 +367,10 @@ public class MapData implements Closeable {
     final int brightness =
         Integer.parseInt(
             mapProperties.getProperty(PROPERTY_UNITS_COLOR_BRIGHTNESS_PREFIX + playerName, "0"));
+    if (brightness < -100 || brightness > 100) {
+      throw new IllegalStateException(
+          "Valid brightness value range is -100 to 100, not: " + brightness);
+    }
     unitBrightnesses.put(playerName, brightness);
     return brightness;
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -51,10 +51,11 @@ public class MapData implements Closeable {
   public static final String PROPERTY_UNITS_COUNTER_OFFSET_WIDTH = "units.counter.offset.width";
   public static final String PROPERTY_UNITS_COUNTER_OFFSET_HEIGHT = "units.counter.offset.height";
   public static final String PROPERTY_UNITS_STACK_SIZE = "units.stack.size";
-  public static final String PROPERTY_UNITS_COLOR_PREFIX = "units.color.";
-  public static final String PROPERTY_UNITS_COLOR_BRIGHTNESS_PREFIX = "units.color.brightness.";
-  public static final String PROPERTY_UNITS_COLOR_FLIP_PREFIX = "units.color.flip.";
-  public static final String PROPERTY_UNITS_COLOR_IGNORE = "units.color.ignore";
+  public static final String PROPERTY_UNITS_TRANSFORM_COLOR_PREFIX = "units.transform.color.";
+  public static final String PROPERTY_UNITS_TRANSFORM_BRIGHTNESS_PREFIX =
+      "units.transform.brightness.";
+  public static final String PROPERTY_UNITS_TRANSFORM_FLIP_PREFIX = "units.transform.flip.";
+  public static final String PROPERTY_UNITS_TRANSFORM_IGNORE = "units.transform.ignore";
   public static final String PROPERTY_SCREENSHOT_TITLE_ENABLED = "screenshot.title.enabled";
   public static final String PROPERTY_SCREENSHOT_TITLE_X = "screenshot.title.x";
   public static final String PROPERTY_SCREENSHOT_TITLE_Y = "screenshot.title.y";
@@ -109,7 +110,7 @@ public class MapData implements Closeable {
   private final Map<String, Color> unitColors = new HashMap<>();
   private final Map<String, Integer> unitBrightnesses = new HashMap<>();
   private final Map<String, Boolean> unitFlips = new HashMap<>();
-  private Set<String> ignoreColorUnits;
+  private Set<String> ignoreTransformingUnits;
   private final Map<String, Tuple<List<Point>, Boolean>> place = new HashMap<>();
   private final Map<String, List<Polygon>> polys = new HashMap<>();
   private final Map<String, Point> centers = new HashMap<>();
@@ -352,7 +353,7 @@ public class MapData implements Closeable {
       return Optional.ofNullable(unitColors.get(playerName));
     }
     // look in map.properties
-    final Color color = getColorProperty(PROPERTY_UNITS_COLOR_PREFIX + playerName);
+    final Color color = getColorProperty(PROPERTY_UNITS_TRANSFORM_COLOR_PREFIX + playerName);
     unitColors.put(playerName, color);
     return Optional.ofNullable(color);
   }
@@ -366,7 +367,8 @@ public class MapData implements Closeable {
     // look in map.properties
     final int brightness =
         Integer.parseInt(
-            mapProperties.getProperty(PROPERTY_UNITS_COLOR_BRIGHTNESS_PREFIX + playerName, "0"));
+            mapProperties.getProperty(
+                PROPERTY_UNITS_TRANSFORM_BRIGHTNESS_PREFIX + playerName, "0"));
     if (brightness < -100 || brightness > 100) {
       throw new IllegalStateException(
           "Valid brightness value range is -100 to 100, not: " + brightness);
@@ -384,17 +386,17 @@ public class MapData implements Closeable {
     // look in map.properties
     final boolean shouldFlipUnit =
         Boolean.parseBoolean(
-            mapProperties.getProperty(PROPERTY_UNITS_COLOR_FLIP_PREFIX + playerName, "false"));
+            mapProperties.getProperty(PROPERTY_UNITS_TRANSFORM_FLIP_PREFIX + playerName, "false"));
     unitFlips.put(playerName, shouldFlipUnit);
     return shouldFlipUnit;
   }
 
-  public boolean ignoreColorizingUnit(final String unitName) {
-    if (ignoreColorUnits == null) {
-      final String property = mapProperties.getProperty(PROPERTY_UNITS_COLOR_IGNORE, "");
-      ignoreColorUnits = new HashSet<>(Arrays.asList(property.split(",")));
+  public boolean ignoreTransformingUnit(final String unitName) {
+    if (ignoreTransformingUnits == null) {
+      final String property = mapProperties.getProperty(PROPERTY_UNITS_TRANSFORM_IGNORE, "");
+      ignoreTransformingUnits = new HashSet<>(Arrays.asList(property.split(",")));
     }
-    return ignoreColorUnits.contains(unitName);
+    return ignoreTransformingUnits.contains(unitName);
   }
 
   public boolean shouldDrawUnit(final String unitName) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -386,7 +386,7 @@ public class MapData implements Closeable {
     return Optional.ofNullable(hsb);
   }
 
-  /** Returns the unit color associated with the player named {@code playerName}. */
+  /** Returns whether to flip unit images associated with the player named {@code playerName}. */
   public boolean shouldFlipUnit(final String playerName) {
     // already loaded, just return
     if (unitFlips.containsKey(playerName)) {


### PR DESCRIPTION
## Overview
- Implement feature request: https://forums.triplea-game.org/topic/1548/dyeing-colorizing-unit-images
- Add ability for engine to colorize images. This will take a color code (only apply its hue and saturation) or take a HSB value (apply all 3 values, increasing brightness is often not ideal so kind of an advanced use at your own risk). It also ignores any pixels that are close to black (brightness < 10%) as especially if increasing brightness these get faded and make images look less sharp.
- Add ability to flip colorized unit images
- Add ability to place unit images in unit folder directly which are then shared across all nations (it will first check for an image in the nation folder and if not found then check the unit folder and then check the images included with TripleA). This will allow flexibility if not all units can be shared or aren't monocolored.
- Add new properties to map.properties:
  - *A color or HSB value* - apply to unit images for each nation (this will be applied to ALL units of that nation unless exempt). This will allow map makers to potentially use a single set of unit images and specify colors for each nation. Also allow users to override the default unit image color just like they can for territory colors.
  - *Flip unit* - flip colorized unit images for each nation (this will be applied to ALL units of that nation unless exempt)
  - *A list of units exempt from colorization* - this could include things like factories that are the same color for all nations or units that were already colorized by hand for each nation like AA radar or damaged battleships

## Functional Changes
<!-- Put an X next to an item -->
[ ] New map or map update
[X] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix

## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[X] Manually tested
[ ] No testing done


### Testing
- Tested being able to load unit image that are placed directly in the units folder and that the priority of unit images is: nations folder in map, units folder in map, nations folder in engine assets, units folder in engine assets
- Tested the colorization and flipping of units images with the following properties and result

**Properties**
```
units.transform.color.Germans=FF0000
units.transform.flip.Germans=true
units.transform.color.Russians=00BBBB
units.transform.brightness.Russians=25
units.transform.color.British=00FF00
units.transform.ignore=factory,fighter
```

**Result**
![311a4a2b-7b46-404b-afad-18804f151b28-image](https://user-images.githubusercontent.com/1427689/64584540-be9d2d80-d35a-11e9-9368-b9b86c177c32.png)



