### PR TITLE
Update Travis on-failure script to not fire for PR builds for branches hosted from the main repo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -76,4 +76,4 @@ jobs:
           branch: master
 after_failure:
   - echo "================ Build step 'after_failure' =================" > /dev/null
-  - test "$TRAVIS_BRANCH" = master && ./.travis/report_build_status FAILURE
+  -  test "$TRAVIS_EVENT_TYPE" != "pull_request" && test "$TRAVIS_BRANCH" = master && ./.travis/report_build_status FAILURE


### PR DESCRIPTION
- PR builds from forked branches were already excluded
- Branches on the main repo did not pass the same set of exclusion flags and triggered a build failed ticket.

This update adds config to verify that the branch is not a PR, this should exclude failed PR builds for branches hosted on main repo.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next to an item, if other, please specify -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[x] Configuration Change
[ ] Bug fix
[ ] Other:

<!-- If fixing a bug, uncomment the below and fill in each section -->
<!--

### Bug Issue Number or Reproduction Steps 

### Root Cause - What caused the bug?

### Fix description - How was the bug fixed?

-->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[x] Manually tested
[ ] No testing done
<!-- If manually tested, summarize the testing done below this line. -->

Pushed a series of branches, verified that PR builds for branches hosted on repo triggered build failed notification.

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details 
  that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

