### PR TITLE
Refactor: LobbyClient use immutable values over cached

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/LobbyClient.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/LobbyClient.java
@@ -13,32 +13,23 @@ import org.triplea.lobby.common.IModeratorController;
 import org.triplea.lobby.common.IUserManager;
 
 /** Provides information about a client connection to a lobby server. */
+@Getter
 public class LobbyClient {
-  @Getter private final Messengers messengers;
-  private final boolean isAnonymousLogin;
-  private Boolean isAdmin;
+  private final Messengers messengers;
+  private final boolean anonymousLogin;
+  private final boolean admin;
 
   public LobbyClient(final IMessenger messenger, final boolean anonymousLogin) {
     messengers = new Messengers(messenger);
-    isAnonymousLogin = anonymousLogin;
+    this.anonymousLogin = anonymousLogin;
+    final var moderatorController =
+        (IModeratorController) messengers.getRemote(IModeratorController.REMOTE_NAME);
+    admin = moderatorController.isAdmin();
   }
 
   @Nullable
   public String updatePassword(final String newPassword) {
     return getUserManager().updateUser(messengers.getLocalNode().getName(), null, newPassword);
-  }
-
-  public boolean isAdmin() {
-    if (isAdmin == null) {
-      final IModeratorController controller =
-          (IModeratorController) messengers.getRemote(IModeratorController.REMOTE_NAME);
-      isAdmin = controller.isAdmin();
-    }
-    return isAdmin;
-  }
-
-  public boolean isAnonymousLogin() {
-    return isAnonymousLogin;
   }
 
   public IUserManager getUserManager() {


### PR DESCRIPTION
- No functionality change
- Simplifies getters to be just lombok annotations
- Instead of caching 'isAdmin' when calling the getter, we'll set the value in constructor


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next to an item, if other, please specify -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[x] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix
[ ] Other:

<!-- If fixing a bug, uncomment the below and fill in each section -->
<!--

### Bug Issue Number or Reproduction Steps 

### Root Cause - What caused the bug?

### Fix description - How was the bug fixed?

-->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[ ] Manually tested
[x] No testing done
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details 
  that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

