### PR TITLE
MapData improvements

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -82,7 +82,8 @@ public class MapData implements Closeable {
   private static final String PROPERTY_MAP_SMALLMAPTERRITORYSATURATION =
       "smallMap.territory.saturation";
   private static final String PROPERTY_MAP_SMALLMAPUNITSIZE = "smallMap.unit.size";
-  private static final String PROPERTY_MAP_SMALLMAPVIEWERBORDERCOLOR = "smallMap.viewer.borderColor";
+  private static final String PROPERTY_MAP_SMALLMAPVIEWERBORDERCOLOR =
+      "smallMap.viewer.borderColor";
   private static final String PROPERTY_MAP_SMALLMAPVIEWERFILLCOLOR = "smallMap.viewer.fillColor";
   private static final String PROPERTY_MAP_SMALLMAPVIEWERFILLALPHA = "smallMap.viewer.fillAlpha";
   private static final String PROPERTY_UNITS_TRANSFORM_COLOR_PREFIX = "units.transform.color.";
@@ -90,7 +91,6 @@ public class MapData implements Closeable {
       "units.transform.brightness.";
   private static final String PROPERTY_UNITS_TRANSFORM_FLIP_PREFIX = "units.transform.flip.";
   private static final String PROPERTY_UNITS_TRANSFORM_IGNORE = "units.transform.ignore";
-
 
   private static final String CENTERS_FILE = "centers.txt";
   private static final String POLYGON_FILE = "polygons.txt";
@@ -129,7 +129,6 @@ public class MapData implements Closeable {
   private final Map<String, Image> territoryNameImages = new HashMap<>();
   private final Map<String, Image> effectImages = new HashMap<>();
   private final ResourceLoader resourceLoader;
-
 
   public MapData(final String mapNameDir) {
     this(ResourceLoader.getMapResourceLoader(mapNameDir));
@@ -366,8 +365,8 @@ public class MapData implements Closeable {
 
   /** Returns whether to flip unit images associated with the player named {@code playerName}. */
   public boolean shouldFlipUnit(final String playerName) {
-    return    Boolean.parseBoolean(
-            mapProperties.getProperty(PROPERTY_UNITS_TRANSFORM_FLIP_PREFIX + playerName, "false"));
+    return Boolean.parseBoolean(
+        mapProperties.getProperty(PROPERTY_UNITS_TRANSFORM_FLIP_PREFIX + playerName, "false"));
   }
 
   public boolean ignoreTransformingUnit(final String unitName) {


### PR DESCRIPTION
Measured perf difference of caching values that are already found in a 'Properties', there was a very small benefit to the caching. Numbers below are in NS:

```
BEFORE:
should-draw: 1681.42
should-flip: 4861.17
get-unit-color: 5076.25 

After:  
should-draw: 2576.44
should-flip: 7462
get-unit-color: 12239
```

The original caching did cache a 'Color' object, very possible back in Java 1.3 when this code was new, there was a performance gain (object creation used to be horribly expensive pre Java1.4, post Java8 it is now incredibly cheap).

This update removes the caching and cleans up some warnings to downgrade public scoped items to private. 

The original comments "load from map.properties" were incorrect. They implied a file system read when instead the read was from in-memory.

<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next to an item, if other, please specify -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[x] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix
[ ] Other:

<!-- If fixing a bug, uncomment the below and fill in each section -->
<!--

### Bug Issue Number or Reproduction Steps 

### Root Cause - What caused the bug?

### Fix description - How was the bug fixed?

-->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[x] Manually tested
[ ] No testing done
<!-- If manually tested, summarize the testing done below this line. -->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details 
  that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

