### PR TITLE
Add "Impact: Incorrect UI Behavior" label to stalebot exclusion label

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -7,6 +7,7 @@ exemptLabels:
   - "Release Blocker"
   - "Impact: Bad Game Rules"
   - "Impact: Game Crashing"
+  - "Impact: Incorrect UI Behavior"
 # Label to use when marking an issue as stale
 staleLabel: 'Stale'
 


### PR DESCRIPTION
- This update will have stalebot exclude issues labeled with 'Bug'

Looking at problems that have been marked as stale, it does not quite seem appropriate
to stop tracking those problems altogether. For example, a set of Mac OS only problems
I was tempted to salvage by putting into a wiki list, but then why not just keep
tracking them as bugs?

We will incur the problem where some bugs will actually become stale, and we'll have
to check that they are still up-to-date. It seems better to still allow a long tail
of a bug queue than to try and track those problems in another manner.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next to an item, if other, please specify -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[x] Configuration Change
[ ] Bug fix
[ ] Other:
