### PR TITLE
Update label name in Build monitoring script

### DIFF
--- a/.travis/report_build_status
+++ b/.travis/report_build_status
@@ -94,7 +94,7 @@ function reportBuildFailure() {
 
 function openNewFailedBuildIssue() {
   curl -X POST -d "{\"title\": \"$BROKEN_BUILD_ISSUE_TITLE\", \"body\": \
-\"$BROKEN_BUILD_ISSUE_BODY\", \"labels\": [\"Release Blocker\"]}" \
+\"$BROKEN_BUILD_ISSUE_BODY\", \"labels\": [\"Pre-Release Problem\"]}" \
         -H "$API_AUTH" "$API_URL/issues"
 }
 


### PR DESCRIPTION
Release Blocker was renaemd to 'Pre-Release Problem', this update changes the build monitor script to have the updated label name.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[x] Configuration Change
[ ] Bug fix:  <!-- Link to bug issue or forum post here -->
[ ] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[ ] Manually tested
[x] No testing done
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

