### PR TITLE
Fix sample_data.sql script to remove table with FKs to lobby_user

### DIFF
--- a/lobby-db/sample_data.sql
+++ b/lobby-db/sample_data.sql
@@ -1,6 +1,8 @@
 delete
 from moderator_action_history;
 delete
+from api_key;
+delete
 from lobby_user;
 delete
 from access_log;


### PR DESCRIPTION
 Fix sample_data.sql script to remove table with FKs to lobby_user before we drop lobby_user


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[x] Bug fix:  <!-- Link to bug issue or forum post here -->
[ ] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[x] Manually tested
[ ] No testing done
<!-- If manually tested, summarize the testing done below this line. -->
Repro, apply script twice, on second run the delete data of lobby_user fails

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

