### PR TITLE
Add HttpServer UserAccount service

### DIFF
--- a/http-clients/src/main/java/org/triplea/http/client/AuthenticationHeaders.java
+++ b/http-clients/src/main/java/org/triplea/http/client/AuthenticationHeaders.java
@@ -1,0 +1,20 @@
+package org.triplea.http.client;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+
+/** Small class to encapsulate api key and create http Authorization header. */
+@AllArgsConstructor
+public class AuthenticationHeaders {
+  public static final String API_KEY_HEADER = "Authorization";
+  public static final String KEY_BEARER_PREFIX = "Bearer";
+
+  private final String apiKey;
+
+  public Map<String, Object> createHeaders() {
+    final Map<String, Object> headerMap = new HashMap<>();
+    headerMap.put(API_KEY_HEADER, KEY_BEARER_PREFIX + " " + apiKey);
+    return headerMap;
+  }
+}

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/user/account/FetchEmailResponse.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/user/account/FetchEmailResponse.java
@@ -1,0 +1,16 @@
+package org.triplea.http.client.lobby.user.account;
+
+import javax.annotation.Nonnull;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@AllArgsConstructor
+@Getter
+@EqualsAndHashCode
+public class FetchEmailResponse {
+  /** User's email as found in database. */
+  @Nonnull private final String userEmail;
+}

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/user/account/UserAccountClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/user/account/UserAccountClient.java
@@ -1,0 +1,36 @@
+package org.triplea.http.client.lobby.user.account;
+
+import java.net.URI;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import org.triplea.http.client.AuthenticationHeaders;
+import org.triplea.http.client.HttpClient;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserAccountClient {
+
+  public static final String CHANGE_PASSWORD_PATH = "/user-account/change-password";
+  public static final String FETCH_EMAIL_PATH = "/user-account/fetch-email";
+  public static final String CHANGE_EMAIL_PATH = "/user-account/change-email";
+
+  private final AuthenticationHeaders authenticationHeaders;
+  private final UserAccountFeignClient userAccountFeignClient;
+
+  public static UserAccountClient newClient(final URI serverUri, final String apiKey) {
+    return new UserAccountClient(
+        new AuthenticationHeaders(apiKey),
+        new HttpClient<>(UserAccountFeignClient.class, serverUri).get());
+  }
+
+  public void changePassword(final String newPassword) {
+    userAccountFeignClient.changePassword(authenticationHeaders.createHeaders(), newPassword);
+  }
+
+  public String fetchEmail() {
+    return userAccountFeignClient.fetchEmail(authenticationHeaders.createHeaders()).getUserEmail();
+  }
+
+  public void changeEmail(final String newEmail) {
+    userAccountFeignClient.changeEmail(authenticationHeaders.createHeaders(), newEmail);
+  }
+}

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/user/account/UserAccountFeignClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/user/account/UserAccountFeignClient.java
@@ -1,0 +1,21 @@
+package org.triplea.http.client.lobby.user.account;
+
+import feign.HeaderMap;
+import feign.Headers;
+import feign.RequestLine;
+import java.util.Map;
+import org.triplea.http.client.HttpConstants;
+
+interface UserAccountFeignClient {
+  @RequestLine("POST " + UserAccountClient.CHANGE_PASSWORD_PATH)
+  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
+  void changePassword(@HeaderMap Map<String, Object> headers, String newPassword);
+
+  @RequestLine("GET " + UserAccountClient.FETCH_EMAIL_PATH)
+  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
+  FetchEmailResponse fetchEmail(@HeaderMap Map<String, Object> headers);
+
+  @RequestLine("POST " + UserAccountClient.CHANGE_EMAIL_PATH)
+  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
+  void changeEmail(@HeaderMap Map<String, Object> headers, String newEmail);
+}

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/user/account/UserAccountClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/user/account/UserAccountClientTest.java
@@ -1,0 +1,66 @@
+package org.triplea.http.client.lobby.user.account;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.triplea.http.client.HttpClientTesting.API_KEY;
+import static org.triplea.http.client.HttpClientTesting.EXPECTED_API_KEY;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.triplea.http.client.AuthenticationHeaders;
+import org.triplea.http.client.HttpClientTesting;
+import ru.lanwen.wiremock.ext.WiremockResolver;
+import ru.lanwen.wiremock.ext.WiremockUriResolver;
+
+@ExtendWith({WiremockResolver.class, WiremockUriResolver.class})
+class UserAccountClientTest {
+
+  private static final String NEW_PASSWORD = "updated-password";
+  private static final String EMAIL = "email";
+
+  private static UserAccountClient newClient(final WireMockServer wireMockServer) {
+    final URI hostUri = URI.create(wireMockServer.url(""));
+    return UserAccountClient.newClient(hostUri, API_KEY);
+  }
+
+  @Test
+  void updatePassword(@WiremockResolver.Wiremock final WireMockServer server) {
+    server.stubFor(
+        WireMock.post(UserAccountClient.CHANGE_PASSWORD_PATH)
+            .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
+            .withRequestBody(equalTo(NEW_PASSWORD))
+            .willReturn(WireMock.aResponse().withStatus(200)));
+
+    newClient(server).changePassword(NEW_PASSWORD);
+  }
+
+  @Test
+  void fetchPassword(@WiremockResolver.Wiremock final WireMockServer server) {
+    server.stubFor(
+        WireMock.get(UserAccountClient.FETCH_EMAIL_PATH)
+            .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
+            .willReturn(
+                WireMock.aResponse()
+                    .withStatus(200)
+                    .withBody(HttpClientTesting.toJson(new FetchEmailResponse(EMAIL)))));
+
+    final String result = newClient(server).fetchEmail();
+
+    assertThat(result, is(EMAIL));
+  }
+
+  @Test
+  void changeEmail(@WiremockResolver.Wiremock final WireMockServer server) {
+    server.stubFor(
+        WireMock.post(UserAccountClient.CHANGE_EMAIL_PATH)
+            .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
+            .withRequestBody(equalTo(EMAIL))
+            .willReturn(WireMock.aResponse().withStatus(200)));
+
+    newClient(server).changeEmail(EMAIL);
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/http/ServerApplication.java
+++ b/http-server/src/main/java/org/triplea/server/http/ServerApplication.java
@@ -34,6 +34,7 @@ import org.triplea.server.moderator.toolbox.bad.words.BadWordControllerFactory;
 import org.triplea.server.moderator.toolbox.banned.names.UsernameBanControllerFactory;
 import org.triplea.server.moderator.toolbox.banned.users.UserBanControllerFactory;
 import org.triplea.server.moderator.toolbox.moderators.ModeratorsControllerFactory;
+import org.triplea.server.user.account.UserAccountControllerFactory;
 
 /**
  * Main entry-point for launching drop wizard HTTP server. This class is responsible for configuring
@@ -135,7 +136,8 @@ public class ServerApplication extends Application<AppConfig> {
         UserBanControllerFactory.buildController(appConfig, jdbi),
         ErrorReportControllerFactory.buildController(appConfig, jdbi),
         ModeratorAuditHistoryControllerFactory.buildController(appConfig, jdbi),
-        ModeratorsControllerFactory.buildController(appConfig, jdbi));
+        ModeratorsControllerFactory.buildController(appConfig, jdbi),
+        UserAccountControllerFactory.buildController(jdbi));
   }
 
   private Jdbi createJdbi(final AppConfig configuration, final Environment environment) {

--- a/http-server/src/main/java/org/triplea/server/user/account/PasswordBCrypter.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/PasswordBCrypter.java
@@ -1,0 +1,11 @@
+package org.triplea.server.user.account;
+
+import java.util.function.Function;
+import org.mindrot.jbcrypt.BCrypt;
+
+public class PasswordBCrypter implements Function<String, String> {
+  @Override
+  public String apply(final String password) {
+    return BCrypt.hashpw(password, BCrypt.gensalt());
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/user/account/UserAccountController.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/UserAccountController.java
@@ -1,0 +1,64 @@
+package org.triplea.server.user.account;
+
+import com.google.common.base.Preconditions;
+import io.dropwizard.auth.Auth;
+import javax.annotation.Nonnull;
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import lombok.Builder;
+import org.triplea.http.client.lobby.user.account.FetchEmailResponse;
+import org.triplea.http.client.lobby.user.account.UserAccountClient;
+import org.triplea.java.ArgChecker;
+import org.triplea.lobby.server.db.data.UserRole;
+import org.triplea.server.access.AuthenticatedUser;
+
+/** Controller providing endpoints for user account management. */
+@Path("")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Builder
+public class UserAccountController {
+
+  @Nonnull private final UserAccountService userAccountService;
+
+  @POST
+  @Path(UserAccountClient.CHANGE_PASSWORD_PATH)
+  @RolesAllowed(UserRole.PLAYER)
+  public Response changePassword(
+      @Auth final AuthenticatedUser authenticatedUser, final String newPassword) {
+    ArgChecker.checkNotEmpty(newPassword);
+    // TODO: Project#12 use 'getUserIdOrThrow'
+    Preconditions.checkArgument(authenticatedUser.getUserId() > 0);
+
+    userAccountService.changePassword(authenticatedUser.getUserId(), newPassword);
+    return Response.ok().build();
+  }
+
+  @GET
+  @Path(UserAccountClient.FETCH_EMAIL_PATH)
+  @RolesAllowed(UserRole.PLAYER)
+  public FetchEmailResponse fetchEmail(@Auth final AuthenticatedUser authenticatedUser) {
+    Preconditions.checkArgument(authenticatedUser.getUserId() > 0);
+
+    final String email = userAccountService.fetchEmail(authenticatedUser.getUserId());
+    return new FetchEmailResponse(email);
+  }
+
+  @POST
+  @Path(UserAccountClient.CHANGE_EMAIL_PATH)
+  @RolesAllowed(UserRole.PLAYER)
+  public Response changeEmail(
+      @Auth final AuthenticatedUser authenticatedUser, final String newEmail) {
+    ArgChecker.checkNotEmpty(newEmail);
+    Preconditions.checkArgument(authenticatedUser.getUserId() > 0);
+
+    userAccountService.changeEmail(authenticatedUser.getUserId(), newEmail);
+    return Response.ok().build();
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/user/account/UserAccountControllerFactory.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/UserAccountControllerFactory.java
@@ -1,0 +1,22 @@
+package org.triplea.server.user.account;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.jdbi.v3.core.Jdbi;
+import org.triplea.lobby.server.db.dao.UserJdbiDao;
+
+/** Creates instances of UserAccountController. */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class UserAccountControllerFactory {
+
+  /** Instantiates controller with dependencies. */
+  public static UserAccountController buildController(final Jdbi jdbi) {
+    return UserAccountController.builder()
+        .userAccountService(
+            UserAccountService.builder()
+                .userJdbiDao(jdbi.onDemand(UserJdbiDao.class))
+                .passwordEncrpter(new PasswordBCrypter())
+                .build())
+        .build();
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/user/account/UserAccountService.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/UserAccountService.java
@@ -1,0 +1,30 @@
+package org.triplea.server.user.account;
+
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+import lombok.Builder;
+import org.triplea.lobby.server.db.dao.UserJdbiDao;
+
+@Builder
+class UserAccountService {
+
+  @Nonnull private final UserJdbiDao userJdbiDao;
+
+  @Nonnull private final Function<String, String> passwordEncrpter;
+
+  void changePassword(final int userId, final String newPassword) {
+    final int updateCount = userJdbiDao.updatePassword(userId, passwordEncrpter.apply(newPassword));
+    assert updateCount == 1;
+  }
+
+  String fetchEmail(final int userId) {
+    final String email = userJdbiDao.fetchEmail(userId);
+    assert email != null;
+    return email;
+  }
+
+  void changeEmail(final int userId, final String newEmail) {
+    final int updateCount = userJdbiDao.updateEmail(userId, newEmail);
+    assert updateCount == 1;
+  }
+}

--- a/http-server/src/test/java/org/triplea/server/user/account/PasswordBcrypterTest.java
+++ b/http-server/src/test/java/org/triplea/server/user/account/PasswordBcrypterTest.java
@@ -1,0 +1,34 @@
+package org.triplea.server.user.account;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.StringStartsWith.startsWith;
+
+import org.junit.jupiter.api.Test;
+import org.mindrot.jbcrypt.BCrypt;
+
+class PasswordBcrypterTest {
+
+  @Test
+  void bcrypt() {
+    final String cryptedResult = new PasswordBCrypter().apply("password");
+
+    assertThat("Simple check to ensure we can invoke the library", cryptedResult, notNullValue());
+
+    assertThat(
+        " Bcrypt hashes have a specific starting sequence", cryptedResult, startsWith("$2a$"));
+
+    assertThat(" Bcrypt hashes have a specific length", cryptedResult.length(), is(60));
+  }
+
+  @Test
+  void bcryptHashAndPasswordVerification() {
+    final String crypted = new PasswordBCrypter().apply("password");
+
+    final boolean result = BCrypt.checkpw("password", crypted);
+
+    assertThat(
+        "Verify BCrypt to match a plaintext password against a crypted password", result, is(true));
+  }
+}

--- a/http-server/src/test/java/org/triplea/server/user/account/UserAccountControllerIntegrationTest.java
+++ b/http-server/src/test/java/org/triplea/server/user/account/UserAccountControllerIntegrationTest.java
@@ -1,0 +1,27 @@
+package org.triplea.server.user.account;
+
+import org.junit.jupiter.api.Test;
+import org.triplea.http.client.lobby.user.account.UserAccountClient;
+import org.triplea.server.http.ProtectedEndpointTest;
+
+class UserAccountControllerIntegrationTest extends ProtectedEndpointTest<UserAccountClient> {
+
+  UserAccountControllerIntegrationTest() {
+    super(UserAccountClient::newClient);
+  }
+
+  @Test
+  void changePassword() {
+    verifyEndpointReturningVoid(client -> client.changePassword("password"));
+  }
+
+  @Test
+  void fetchEmail() {
+    verifyEndpointReturningObject(UserAccountClient::fetchEmail);
+  }
+
+  @Test
+  void changeEmail() {
+    verifyEndpointReturningVoid(client -> client.changeEmail("email"));
+  }
+}

--- a/http-server/src/test/java/org/triplea/server/user/account/UserAccountControllerTest.java
+++ b/http-server/src/test/java/org/triplea/server/user/account/UserAccountControllerTest.java
@@ -1,0 +1,58 @@
+package org.triplea.server.user.account;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.http.client.lobby.user.account.FetchEmailResponse;
+import org.triplea.lobby.server.db.data.UserRole;
+import org.triplea.server.access.AuthenticatedUser;
+
+@ExtendWith(MockitoExtension.class)
+class UserAccountControllerTest {
+
+  private static final AuthenticatedUser AUTHENTICATED_USER =
+      AuthenticatedUser.builder().userId(10).userRole(UserRole.PLAYER).build();
+  private static final String NEW_PASSWORD = "new-password-value";
+
+  private static final String EMAIL = "email-value";
+
+  @Mock private UserAccountService userAccountService;
+
+  private UserAccountController userAccountController;
+
+  @BeforeEach
+  void setup() {
+    userAccountController =
+        UserAccountController.builder().userAccountService(userAccountService).build();
+  }
+
+  @Test
+  void changePassword() {
+    userAccountController.changePassword(AUTHENTICATED_USER, NEW_PASSWORD);
+
+    verify(userAccountService).changePassword(AUTHENTICATED_USER.getUserId(), NEW_PASSWORD);
+  }
+
+  @Test
+  void fetchEmail() {
+    when(userAccountService.fetchEmail(AUTHENTICATED_USER.getUserId())).thenReturn(EMAIL);
+
+    final FetchEmailResponse response = userAccountController.fetchEmail(AUTHENTICATED_USER);
+
+    assertThat(response.getUserEmail(), is(EMAIL));
+  }
+
+  @Test
+  void changeEmail() {
+    userAccountController.changeEmail(AUTHENTICATED_USER, EMAIL);
+
+    verify(userAccountService).changeEmail(AUTHENTICATED_USER.getUserId(), EMAIL);
+  }
+}

--- a/http-server/src/test/java/org/triplea/server/user/account/UserAccountServiceTest.java
+++ b/http-server/src/test/java/org/triplea/server/user/account/UserAccountServiceTest.java
@@ -1,0 +1,65 @@
+package org.triplea.server.user.account;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.lobby.server.db.dao.UserJdbiDao;
+
+@ExtendWith(MockitoExtension.class)
+class UserAccountServiceTest {
+
+  private static final int USER_ID = 100;
+  private static final String PASSWORD = "password-value";
+  private static final String HASHED_PASSWORD = "hashed-password-value";
+  private static final String EMAIL = "email";
+
+  @Mock private UserJdbiDao userJdbiDao;
+  @Mock private Function<String, String> passwordEncrypter;
+
+  private UserAccountService userAccountService;
+
+  @BeforeEach
+  void setup() {
+    userAccountService =
+        UserAccountService.builder()
+            .userJdbiDao(userJdbiDao)
+            .passwordEncrpter(passwordEncrypter)
+            .build();
+  }
+
+  @Test
+  void changePassword() {
+    when(passwordEncrypter.apply(PASSWORD)).thenReturn(HASHED_PASSWORD);
+    when(userJdbiDao.updatePassword(USER_ID, HASHED_PASSWORD)).thenReturn(1);
+
+    userAccountService.changePassword(USER_ID, PASSWORD);
+
+    verify(userJdbiDao).updatePassword(USER_ID, HASHED_PASSWORD);
+  }
+
+  @Test
+  void fetchEmail() {
+    when(userJdbiDao.fetchEmail(USER_ID)).thenReturn(EMAIL);
+
+    final String result = userAccountService.fetchEmail(USER_ID);
+
+    assertThat(result, is(EMAIL));
+  }
+
+  @Test
+  void changeEmail() {
+    when(userJdbiDao.updateEmail(USER_ID, EMAIL)).thenReturn(1);
+
+    userAccountService.changeEmail(USER_ID, EMAIL);
+
+    verify(userJdbiDao).updateEmail(USER_ID, EMAIL);
+  }
+}

--- a/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/dao/UserJdbiDao.java
+++ b/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/dao/UserJdbiDao.java
@@ -15,4 +15,13 @@ public interface UserJdbiDao {
 
   @SqlUpdate("update lobby_user set last_login = now() where username = :username")
   int updateLastLoginTime(@Bind("username") String username);
+
+  @SqlUpdate("update lobby_user set bcrypt_password = :newPassword where id = :userId")
+  int updatePassword(@Bind("userId") int userId, @Bind("newPassword") String newPassword);
+
+  @SqlQuery("select email from lobby_user where id = :userId")
+  String fetchEmail(@Bind("userId") int userId);
+
+  @SqlUpdate("update lobby_user set email = :newEmail where id = :userId")
+  int updateEmail(@Bind("userId") int userId, @Bind("newEmail") String newEmail);
 }

--- a/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/UserJdbiDaoTest.java
+++ b/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/UserJdbiDaoTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.junit5.DBUnitExtension;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -17,9 +18,12 @@ import org.triplea.test.common.Integration;
 @DataSet(cleanBefore = true, value = "user/select.yml")
 class UserJdbiDaoTest {
 
+  private static final int USER_ID = 900000;
   private static final String USERNAME = "user";
   private static final String PASSWORD =
       "$2a$56789_123456789_123456789_123456789_123456789_123456789_";
+  private static final String NEW_PASSWORD =
+      "$2a$abcde_123456789_123456789_123456789_123456789_123456789_";
 
   private final UserJdbiDao userDao = JdbiDatabase.newConnection().onDemand(UserJdbiDao.class);
 
@@ -39,5 +43,22 @@ class UserJdbiDaoTest {
   void updateLastLogin() {
     assertThat(userDao.updateLastLoginTime(USERNAME), is(1));
     assertThat(userDao.updateLastLoginTime("DNE"), is(0));
+  }
+
+  @ExpectedDataSet("user/post_change_password.yml")
+  @Test
+  void updatePassword() {
+    assertThat(userDao.updatePassword(USER_ID, NEW_PASSWORD), is(1));
+  }
+
+  @Test
+  void fetchEmail() {
+    assertThat(userDao.fetchEmail(USER_ID), is("email"));
+  }
+
+  @ExpectedDataSet("user/post_change_email.yml")
+  @Test
+  void updateEmail() {
+    userDao.updateEmail(USER_ID, "new-email");
   }
 }

--- a/lobby-db-dao/src/test/resources/datasets/user/post_change_email.yml
+++ b/lobby-db-dao/src/test/resources/datasets/user/post_change_email.yml
@@ -1,0 +1,6 @@
+lobby_user:
+  - id: 900000
+    username: user
+    bcrypt_password: $2a$56789_123456789_123456789_123456789_123456789_123456789_
+    email: new-email
+    role: PLAYER

--- a/lobby-db-dao/src/test/resources/datasets/user/post_change_password.yml
+++ b/lobby-db-dao/src/test/resources/datasets/user/post_change_password.yml
@@ -1,0 +1,6 @@
+lobby_user:
+  - id: 900000
+    username: user
+    bcrypt_password: $2a$abcde_123456789_123456789_123456789_123456789_123456789_
+    email: email
+    role: PLAYER


### PR DESCRIPTION
Adds HTTP server backend and client for user account management operations to:
- fetch user email
- change user email
- change user password

Will later be wired into the front-end and replace the java-socket operations in IUserManager.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[ ] New map or map update
[ ] New Feature
[x] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix:  <!-- Link to bug issue or forum post here -->
[ ] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[x] Covered by newly added automated tests
[ ] Manually tested
[ ] No testing done
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

