### PR TITLE
Remove Checkstyle summary javadoc rule

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -208,9 +208,6 @@
         </module>
         <module name="NonEmptyAtclauseDescription"/>
         <module name="JavadocTagContinuationIndentation"/>
-        <module name="SummaryJavadoc">
-            <property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
-        </module>
         <module name="AtclauseOrder">
             <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
             <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>


### PR DESCRIPTION
The rule requires a first sentence to end in a period.

This has resulted in 'hack' situations where the first sentence ends naturally in a colon,
in which case an extraneous period is introduced ".:"

More fundamentally it's useful/important to be required to add meaningful javadocs, otherwise
we likely won't add them. With that, this syntax requirement is not that helpful and
gets into a nitpicking territory that we do not enforce at review, ie: it's not
important for a single sentence javadoc to end in a period or not.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[x] Configuration Change
[ ] Bug fix:  <!-- Link to bug issue or forum post here -->
[ ] Other:   <!-- Please specify -->

