### PR TITLE
Game Listing Server Backend

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -60,7 +60,7 @@ public class LobbyLogin {
       panel.getLobbyLoginPreferences().save();
       return new LobbyClient(
           messenger,
-          new HttpLobbyClient(
+          HttpLobbyClient.newClient(
               lobbyServerProperties.getHttpsServerUri(), messenger.getApiKey().getValue()),
           panel.isAnonymousLogin());
     } catch (final CouldNotLogInException e) {
@@ -131,7 +131,7 @@ public class LobbyLogin {
       panel.getLobbyLoginPreferences().save();
       return new LobbyClient(
           messenger,
-          new HttpLobbyClient(
+          HttpLobbyClient.newClient(
               lobbyServerProperties.getHttpsServerUri(), messenger.getApiKey().getValue()));
     } catch (final CouldNotLogInException e) {
       showError("Account Creation Failed", e.getMessage());

--- a/http-clients/src/main/java/org/triplea/http/client/AuthenticationHeaders.java
+++ b/http-clients/src/main/java/org/triplea/http/client/AuthenticationHeaders.java
@@ -1,0 +1,20 @@
+package org.triplea.http.client;
+
+import java.util.HashMap;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+
+/** Small class to encapsulate api key and create http Authorization header. */
+@AllArgsConstructor
+public class AuthenticationHeaders {
+  public static final String API_KEY_HEADER = "Authorization";
+  public static final String KEY_BEARER_PREFIX = "Bearer";
+
+  private final String apiKey;
+
+  public Map<String, Object> createHeaders() {
+    final Map<String, Object> headerMap = new HashMap<>();
+    headerMap.put(API_KEY_HEADER, KEY_BEARER_PREFIX + " " + apiKey);
+    return headerMap;
+  }
+}

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/HttpLobbyClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/HttpLobbyClient.java
@@ -2,15 +2,21 @@ package org.triplea.http.client.lobby;
 
 import java.net.URI;
 import lombok.Getter;
+import org.triplea.http.client.lobby.game.listing.GameListingClient;
 import org.triplea.http.client.lobby.moderator.toolbox.HttpModeratorToolboxClient;
 
 /** Holder class for the various http clients that access lobby resources. */
 @Getter
 public class HttpLobbyClient {
   private final HttpModeratorToolboxClient httpModeratorToolboxClient;
-  // TODO: Project#12 Add additional http clients
+  private final GameListingClient gameListingClient;
 
-  public HttpLobbyClient(final URI lobbyUri, final String apiKey) {
+  private HttpLobbyClient(final URI lobbyUri, final String apiKey) {
     httpModeratorToolboxClient = new HttpModeratorToolboxClient(lobbyUri, apiKey);
+    gameListingClient = GameListingClient.newClient(lobbyUri, apiKey);
+  }
+
+  public static HttpLobbyClient newClient(final URI lobbyUri, final String apiKey) {
+    return new HttpLobbyClient(lobbyUri, apiKey);
   }
 }

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/game/listing/GameListingClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/game/listing/GameListingClient.java
@@ -1,0 +1,57 @@
+package org.triplea.http.client.lobby.game.listing;
+
+import java.net.URI;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.triplea.http.client.AuthenticationHeaders;
+import org.triplea.http.client.HttpClient;
+
+/**
+ * Http client for interacting with lobby game listing. Can be used to post, remove, boot, fetch and
+ * update games.
+ */
+@AllArgsConstructor
+public class GameListingClient {
+
+  public static final String BOOT_GAME_PATH = "/lobby/games/boot-game";
+  public static final String FETCH_GAMES_PATH = "/lobby/games/fetch-games";
+  public static final String KEEP_ALIVE_PATH = "/lobby/games/keep-alive";
+  public static final String POST_GAME_PATH = "/lobby/games/post-game";
+  public static final String UPDATE_GAME_PATH = "/lobby/games/update-game";
+  public static final String REMOVE_GAME_PATH = "/lobby/games/remove-game";
+
+  private final AuthenticationHeaders authenticationHeaders;
+  private final GameListingFeignClient gameListingFeignClient;
+
+  public static GameListingClient newClient(final URI serverUri, final String apiKey) {
+    return new GameListingClient(
+        new AuthenticationHeaders(apiKey),
+        new HttpClient<>(GameListingFeignClient.class, serverUri).get());
+  }
+
+  public List<LobbyGameListing> fetchGameListing() {
+    return gameListingFeignClient.fetchGameListing(authenticationHeaders.createHeaders());
+  }
+
+  public String postGame(final LobbyGame lobbyGame) {
+    return gameListingFeignClient.postGame(authenticationHeaders.createHeaders(), lobbyGame);
+  }
+
+  public void updateGame(final String gameId, final LobbyGame lobbyGame) {
+    gameListingFeignClient.updateGame(
+        authenticationHeaders.createHeaders(),
+        UpdateGameRequest.builder().gameId(gameId).gameData(lobbyGame).build());
+  }
+
+  public boolean sendKeepAlive(final String gameId) {
+    return gameListingFeignClient.sendKeepAlive(authenticationHeaders.createHeaders(), gameId);
+  }
+
+  public void removeGame(final String gameId) {
+    gameListingFeignClient.removeGame(authenticationHeaders.createHeaders(), gameId);
+  }
+
+  public void bootGame(final String gameId) {
+    gameListingFeignClient.bootGame(authenticationHeaders.createHeaders(), gameId);
+  }
+}

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/game/listing/GameListingFeignClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/game/listing/GameListingFeignClient.java
@@ -1,0 +1,29 @@
+package org.triplea.http.client.lobby.game.listing;
+
+import feign.HeaderMap;
+import feign.Headers;
+import feign.RequestLine;
+import java.util.List;
+import java.util.Map;
+import org.triplea.http.client.HttpConstants;
+
+@Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
+interface GameListingFeignClient {
+  @RequestLine("GET " + GameListingClient.FETCH_GAMES_PATH)
+  List<LobbyGameListing> fetchGameListing(@HeaderMap Map<String, Object> headers);
+
+  @RequestLine("POST " + GameListingClient.POST_GAME_PATH)
+  String postGame(@HeaderMap Map<String, Object> headers, LobbyGame lobbyGame);
+
+  @RequestLine("POST " + GameListingClient.UPDATE_GAME_PATH)
+  void updateGame(@HeaderMap Map<String, Object> headers, UpdateGameRequest updateGameRequest);
+
+  @RequestLine("POST " + GameListingClient.REMOVE_GAME_PATH)
+  void removeGame(@HeaderMap Map<String, Object> headers, String gameId);
+
+  @RequestLine("POST " + GameListingClient.KEEP_ALIVE_PATH)
+  boolean sendKeepAlive(@HeaderMap Map<String, Object> headers, String gameId);
+
+  @RequestLine("POST " + GameListingClient.BOOT_GAME_PATH)
+  void bootGame(@HeaderMap Map<String, Object> headers, String gameId);
+}

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/game/listing/LobbyGame.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/game/listing/LobbyGame.java
@@ -1,0 +1,29 @@
+package org.triplea.http.client.lobby.game.listing;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+/** Data structure representing a game in the lobby. */
+@Builder
+@ToString
+@EqualsAndHashCode
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class LobbyGame {
+  private String hostIpAddress;
+  private Integer hostPort;
+  private String hostName;
+  private String mapName;
+  private Integer playerCount;
+  private Integer gameRound;
+  private Long epochMilliTimeStarted;
+  private String mapVersion;
+  private Boolean passworded;
+  private String status;
+  private String comments;
+}

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/game/listing/LobbyGameListing.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/game/listing/LobbyGameListing.java
@@ -1,0 +1,18 @@
+package org.triplea.http.client.lobby.game.listing;
+
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+
+/**
+ * Data structure representing a game that is registered in the lobby. Lobby tracks games by a
+ * 'gameId'.
+ */
+@Getter
+@Builder
+@EqualsAndHashCode
+public class LobbyGameListing {
+  @NonNull private final String gameId;
+  @NonNull private final LobbyGame lobbyGame;
+}

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/game/listing/UpdateGameRequest.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/game/listing/UpdateGameRequest.java
@@ -1,0 +1,15 @@
+package org.triplea.http.client.lobby.game.listing;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class UpdateGameRequest {
+  private String gameId;
+  private LobbyGame gameData;
+}

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/game/listing/GameListingClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/game/listing/GameListingClientTest.java
@@ -1,0 +1,132 @@
+package org.triplea.http.client.lobby.game.listing;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.get;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.core.Is.is;
+import static org.triplea.http.client.HttpClientTesting.API_KEY;
+import static org.triplea.http.client.HttpClientTesting.EXPECTED_API_KEY;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import java.net.URI;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.triplea.http.client.AuthenticationHeaders;
+import org.triplea.http.client.HttpClientTesting;
+import ru.lanwen.wiremock.ext.WiremockResolver;
+import ru.lanwen.wiremock.ext.WiremockUriResolver;
+
+@ExtendWith({WiremockResolver.class, WiremockUriResolver.class})
+class GameListingClientTest {
+
+  private static final String GAME_ID = "gameId";
+
+  private static final LobbyGame LOBBY_GAME =
+      LobbyGame.builder()
+          .hostIpAddress("127.0.0.1")
+          .hostPort(12)
+          .hostName("name")
+          .mapName("map")
+          .playerCount(3)
+          .gameRound(1)
+          .epochMilliTimeStarted(Instant.now().toEpochMilli())
+          .mapVersion("1")
+          .passworded(false)
+          .status("WAITING_FOR_PLAYERS")
+          .comments("comments")
+          .build();
+
+  private static final LobbyGameListing LOBBY_GAME_LISTING =
+      LobbyGameListing.builder().gameId(GAME_ID).lobbyGame(LOBBY_GAME).build();
+
+  private static GameListingClient newClient(final WireMockServer wireMockServer) {
+    final URI hostUri = URI.create(wireMockServer.url(""));
+    return GameListingClient.newClient(hostUri, API_KEY);
+  }
+
+  @Test
+  void fetchGameListing(@WiremockResolver.Wiremock final WireMockServer server) {
+    server.stubFor(
+        get(GameListingClient.FETCH_GAMES_PATH)
+            .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
+            .willReturn(
+                WireMock.aResponse()
+                    .withStatus(200)
+                    .withBody(
+                        HttpClientTesting.toJson(Collections.singletonList(LOBBY_GAME_LISTING)))));
+
+    final List<LobbyGameListing> results = newClient(server).fetchGameListing();
+
+    assertThat(results, hasSize(1));
+    assertThat(results.get(0), is(LOBBY_GAME_LISTING));
+  }
+
+  @Test
+  void postGame(@WiremockResolver.Wiremock final WireMockServer server) {
+    server.stubFor(
+        post(GameListingClient.POST_GAME_PATH)
+            .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
+            .withRequestBody(equalToJson(HttpClientTesting.toJson(LOBBY_GAME)))
+            .willReturn(WireMock.aResponse().withStatus(200).withBody(GAME_ID)));
+
+    final String gameId = newClient(server).postGame(LOBBY_GAME);
+
+    assertThat(gameId, is(GAME_ID));
+  }
+
+  @Test
+  void updateGame(@WiremockResolver.Wiremock final WireMockServer server) {
+    server.stubFor(
+        post(GameListingClient.UPDATE_GAME_PATH)
+            .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
+            .withRequestBody(
+                equalToJson(
+                    HttpClientTesting.toJson(
+                        UpdateGameRequest.builder().gameId(GAME_ID).gameData(LOBBY_GAME).build())))
+            .willReturn(WireMock.aResponse().withStatus(200)));
+
+    newClient(server).updateGame(GAME_ID, LOBBY_GAME);
+  }
+
+  @Test
+  void sendKeepAlive(@WiremockResolver.Wiremock final WireMockServer server) {
+    server.stubFor(
+        post(GameListingClient.KEEP_ALIVE_PATH)
+            .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
+            .withRequestBody(equalTo(GAME_ID))
+            .willReturn(WireMock.aResponse().withStatus(200).withBody("true")));
+
+    final boolean result = newClient(server).sendKeepAlive(GAME_ID);
+
+    assertThat(result, is(true));
+  }
+
+  @Test
+  void removeGame(@WiremockResolver.Wiremock final WireMockServer server) {
+    server.stubFor(
+        post(GameListingClient.REMOVE_GAME_PATH)
+            .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
+            .withRequestBody(equalTo(GAME_ID))
+            .willReturn(WireMock.aResponse().withStatus(200)));
+
+    newClient(server).removeGame(GAME_ID);
+  }
+
+  @Test
+  void bootGame(@WiremockResolver.Wiremock final WireMockServer server) {
+    server.stubFor(
+        post(GameListingClient.BOOT_GAME_PATH)
+            .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
+            .withRequestBody(equalTo(GAME_ID))
+            .willReturn(WireMock.aResponse().withStatus(200)));
+
+    newClient(server).bootGame(GAME_ID);
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/access/ApiKeyAuthenticator.java
+++ b/http-server/src/main/java/org/triplea/server/access/ApiKeyAuthenticator.java
@@ -24,6 +24,7 @@ public class ApiKeyAuthenticator implements Authenticator<String, AuthenticatedU
                 AuthenticatedUser.builder()
                     .userId(userData.getUserId())
                     .userRole(userData.getRole())
+                    .apiKey(apiKey)
                     .build());
   }
 }

--- a/http-server/src/main/java/org/triplea/server/access/AuthenticatedUser.java
+++ b/http-server/src/main/java/org/triplea/server/access/AuthenticatedUser.java
@@ -16,6 +16,7 @@ import org.triplea.lobby.server.db.data.UserRole;
 public class AuthenticatedUser implements Principal {
   @Getter @Nullable private final Integer userId;
   @Getter @Nonnull private final String userRole;
+  @Getter @Nullable private final String apiKey;
 
   @Override
   public String getName() {

--- a/http-server/src/main/java/org/triplea/server/http/ServerApplication.java
+++ b/http-server/src/main/java/org/triplea/server/http/ServerApplication.java
@@ -30,6 +30,7 @@ import org.triplea.server.access.AuthenticatedUser;
 import org.triplea.server.access.RoleAuthorizer;
 import org.triplea.server.error.reporting.ErrorReportControllerFactory;
 import org.triplea.server.forgot.password.ForgotPasswordControllerFactory;
+import org.triplea.server.lobby.game.listing.GameListingControllerFactory;
 import org.triplea.server.moderator.toolbox.access.log.AccessLogControllerFactory;
 import org.triplea.server.moderator.toolbox.audit.history.ModeratorAuditHistoryControllerFactory;
 import org.triplea.server.moderator.toolbox.bad.words.BadWordControllerFactory;
@@ -134,6 +135,7 @@ public class ServerApplication extends Application<AppConfig> {
         AccessLogControllerFactory.buildController(appConfig, jdbi),
         BadWordControllerFactory.buildController(jdbi),
         ForgotPasswordControllerFactory.buildController(appConfig, jdbi),
+        GameListingControllerFactory.buildController(jdbi),
         UsernameBanControllerFactory.buildController(appConfig, jdbi),
         UserBanControllerFactory.buildController(appConfig, jdbi),
         ErrorReportControllerFactory.buildController(appConfig, jdbi),

--- a/http-server/src/main/java/org/triplea/server/lobby/game/listing/GameListing.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/game/listing/GameListing.java
@@ -1,0 +1,204 @@
+package org.triplea.server.lobby.game.listing;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Consumer;
+import java.util.stream.Collectors;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+import org.triplea.http.client.lobby.game.listing.LobbyGame;
+import org.triplea.http.client.lobby.game.listing.LobbyGameListing;
+import org.triplea.lobby.server.db.dao.ModeratorAuditHistoryDao;
+
+/**
+ * Class that stores the set of games in the lobby. Games are identified by a combination of two
+ * values, the api-key of the user that created the game and a UUID assigned when the game is
+ * posted. Keep in mind that the 'gameId' is a publicly known value. Therefore we use API key, for
+ * example, to ensure that other users can't invoke endpoints directly to remove the games of other
+ * players.<br>
+ *
+ * <h2>Keep-Alive</h2>
+ *
+ * The game listing has a concept of 'keep-alive' where games, after posting, need to send
+ * 'keep-alive' messages periodically or they will be de-listed. If a game has been de-listed, and
+ * we get a 'keep-alive' message, the client will get a 'false' value back indicating they would
+ * need to (automatically) re-post their game. This way for example if the lobby were to be
+ * restarted, clients sending keep-alives would notice that their game is no longer listed and would
+ * automatically send a game post message to re-post their game.
+ *
+ * <h2>Moderator Boot Game</h2>
+ *
+ * The moderator boot is similar to remove game but there is no check for an API key, any moderator
+ * can boot any game.
+ *
+ * <h2>Event Updates</h2>
+ *
+ * A listener for game created or updated events and another listener game removed are injected into
+ * this class. Those listeners are invoked for the respective events. The listener is then intended
+ * to be a websocket to notify players of the change event.
+ */
+@Builder
+@Slf4j
+// TODO: Project#12 Create a thread that will invoke game reaper periodically to prune dead games
+class GameListing {
+  @NonNull private final Consumer<LobbyGameListing> gameUpdateListener;
+  @NonNull private final Consumer<String> gameRemoveListener;
+  @NonNull private final GameReaper gameReaper;
+  @NonNull private final ModeratorAuditHistoryDao auditHistoryDao;
+
+  private final Map<GameId, LobbyGame> games = new HashMap<>();
+
+  @Builder
+  @EqualsAndHashCode
+  @Getter
+  static class GameId {
+    @NonNull private final String apiKey;
+    @NonNull private final String id;
+  }
+
+  @VisibleForTesting
+  class GameNotFound extends RuntimeException {
+    private static final long serialVersionUID = 2161752095040334977L;
+
+    private GameNotFound(final String gameId) {
+      super("Error: Game not found, report this error to TripleA Development");
+      log.error(
+          "Game ID not found: {}, available game IDs: {}",
+          gameId,
+          games.keySet().stream().map(GameId::getId).collect(Collectors.toList()));
+    }
+  }
+
+  @VisibleForTesting
+  static class IncorrectApiKey extends RuntimeException {
+    private static final long serialVersionUID = -131279328512375629L;
+
+    IncorrectApiKey() {
+      super("Illegal game modification attempt, access key is incorrect.");
+    }
+  }
+
+  /** Adds a game. Duplicate postings return the same gameId. */
+  String postGame(final String apiKey, final LobbyGame lobbyGame) {
+    final Optional<String> existingGameId =
+        games.entrySet().stream()
+            .filter(entry -> entry.getKey().apiKey.equals(apiKey))
+            .filter(entry -> entry.getValue().equals(lobbyGame))
+            .map(entry -> entry.getKey().id)
+            .findAny();
+    if (existingGameId.isPresent()) {
+      log.warn("Received duplicate game post request for game: {}", existingGameId.get());
+      return existingGameId.get();
+    }
+
+    final String gameId = UUID.randomUUID().toString();
+    gameReaper.registerKeepAlive(gameId);
+    games.put(GameId.builder().id(gameId).apiKey(apiKey).build(), lobbyGame);
+    gameUpdateListener.accept(
+        LobbyGameListing.builder().gameId(gameId).lobbyGame(lobbyGame).build());
+    log.info("Posted game: {}", gameId);
+    return gameId;
+  }
+
+  /** Adds or updates a game. If game is updated, emits a game update event. */
+  void updateGame(final String apiKey, final String gameId, final LobbyGame lobbyGame) {
+    final Map.Entry<GameId, LobbyGame> game =
+        // find game by gameId
+        games.entrySet().stream()
+            .filter(entry -> entry.getKey().id.equals(gameId))
+            .findAny()
+            .orElseThrow(() -> new GameNotFound(gameId));
+    if (!game.getKey().apiKey.equals(apiKey)) {
+      throw new IncorrectApiKey();
+    }
+
+    games.put(game.getKey(), lobbyGame);
+    gameUpdateListener.accept(
+        LobbyGameListing.builder().gameId(game.getKey().id).lobbyGame(lobbyGame).build());
+  }
+
+  void removeGame(final String apiKey, final String gameId) {
+    final var game =
+        games.entrySet().stream().filter(entry -> entry.getKey().id.equals(gameId)).findAny();
+    game.ifPresent(
+        gameEntryToRemove -> {
+          final GameId gameIdToRemove = gameEntryToRemove.getKey();
+          if (!gameIdToRemove.apiKey.equals(apiKey)) {
+            throw new IncorrectApiKey();
+          }
+          removeGame(gameIdToRemove);
+        });
+  }
+
+  private void removeGame(final GameId gameId) {
+    log.info("Removing game: {}", gameId);
+    games.remove(gameId);
+    gameRemoveListener.accept(gameId.id);
+  }
+
+  List<LobbyGameListing> getGames() {
+    gameReaper.findDeadGames(games.keySet()).forEach(this::removeGame);
+
+    return games.entrySet().stream()
+        .map(
+            entry ->
+                LobbyGameListing.builder()
+                    .gameId(entry.getKey().id)
+                    .lobbyGame(entry.getValue())
+                    .build())
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * If a game does not receive a 'keepAlive' in a timely manner, it is removed from the list.
+   *
+   * @return Return false to inform client game is not present. Client can respond by re-posting
+   *     their game. Otherwise true indicates the game is present and the keep-alive period has been
+   *     extended.
+   */
+  boolean keepAlive(final String apiKey, final String gameId) {
+    final var gameEntry =
+        games.entrySet().stream().filter(entry -> entry.getKey().id.equals(gameId)).findAny();
+    if (gameEntry.isEmpty()) {
+      log.warn("Keep alive received for DEAD game: {}", gameId);
+      return false;
+    }
+
+    final var id = gameEntry.get().getKey();
+
+    if (!id.apiKey.equals(apiKey)) {
+      throw new IncorrectApiKey();
+    }
+    gameReaper.registerKeepAlive(gameId);
+    log.info("Keep alive received for game: {}", gameId);
+    return true;
+  }
+
+  /** Moderator action to remove a game. */
+  void bootGame(final int moderatorId, final String gameId) {
+    final GameId gameToRemove =
+        games.entrySet().stream()
+            .filter(entry -> entry.getKey().id.equals(gameId))
+            .findAny()
+            .map(Map.Entry::getKey)
+            .orElseThrow(() -> new GameNotFound(gameId));
+
+    final String hostName = games.get(gameToRemove).getHostName();
+
+    removeGame(gameToRemove);
+    log.info("Moderator {} booted game: {}, hosted by: {}", moderatorId, gameId, hostName);
+    auditHistoryDao.addAuditRecord(
+        ModeratorAuditHistoryDao.AuditArgs.builder()
+            .moderatorUserId(moderatorId)
+            .actionName(ModeratorAuditHistoryDao.AuditAction.BOOT_GAME)
+            .actionTarget(hostName)
+            .build());
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/lobby/game/listing/GameListingController.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/game/listing/GameListingController.java
@@ -1,0 +1,115 @@
+package org.triplea.server.lobby.game.listing;
+
+import com.google.common.annotations.VisibleForTesting;
+import es.moki.ratelimij.dropwizard.annotation.Rate;
+import es.moki.ratelimij.dropwizard.annotation.RateLimited;
+import es.moki.ratelimij.dropwizard.filter.KeyPart;
+import io.dropwizard.auth.Auth;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import org.triplea.http.client.lobby.game.listing.GameListingClient;
+import org.triplea.http.client.lobby.game.listing.LobbyGame;
+import org.triplea.http.client.lobby.game.listing.LobbyGameListing;
+import org.triplea.http.client.lobby.game.listing.UpdateGameRequest;
+import org.triplea.lobby.server.db.data.UserRole;
+import org.triplea.server.access.AuthenticatedUser;
+
+/** Controller with endpoints for posting, getting and removing games. */
+@Builder
+@Produces(MediaType.APPLICATION_JSON)
+@Path("/")
+@AllArgsConstructor(
+    access = AccessLevel.PACKAGE,
+    onConstructor_ = {@VisibleForTesting})
+@RolesAllowed(UserRole.ANONYMOUS)
+public class GameListingController {
+
+  private final GameListing gameListing;
+
+  /**
+   * Adds a game to the lobby listing. Responds with the gameId assigned to the new game. If we see
+   * duplicate posts, the same gameId will be returned.
+   */
+  @RateLimited(
+      keys = {KeyPart.IP},
+      rates = {@Rate(limit = 10, duration = 1, timeUnit = TimeUnit.MINUTES)})
+  @POST
+  @Path(GameListingClient.POST_GAME_PATH)
+  public String postGame(
+      @Auth final AuthenticatedUser authenticatedUser, final LobbyGame lobbyGame) {
+    return gameListing.postGame(authenticatedUser.getApiKey(), lobbyGame);
+  }
+
+  /** Explicit remove of a game from the lobby. */
+  @RateLimited(
+      keys = {KeyPart.IP},
+      rates = {@Rate(limit = 5, duration = 1, timeUnit = TimeUnit.SECONDS)})
+  @POST
+  @Path(GameListingClient.REMOVE_GAME_PATH)
+  public Response removeGame(@Auth final AuthenticatedUser authenticatedUser, final String gameId) {
+    gameListing.removeGame(authenticatedUser.getApiKey(), gameId);
+    return Response.ok().build();
+  }
+
+  /**
+   * "Alive" endpoint to periodically invoked after a game has been posted to indicate the client is
+   * still hosting and is alive. If the endpoint is not invoked within a cutoff time then the game
+   * with the corresponding gameId will be unlisted. The return value indicates if the game has been
+   * kept alive, or false indicates the game was already removed and the client should re-post.
+   */
+  @RateLimited(
+      keys = {KeyPart.IP},
+      rates = {@Rate(limit = 5, duration = 1, timeUnit = TimeUnit.SECONDS)})
+  @POST
+  @Path(GameListingClient.KEEP_ALIVE_PATH)
+  public boolean keepAlive(@Auth final AuthenticatedUser authenticatedUser, final String gameId) {
+    return gameListing.keepAlive(authenticatedUser.getApiKey(), gameId);
+  }
+
+  /** Returns a listing of the current games. */
+  @RateLimited(
+      keys = {KeyPart.IP},
+      rates = {@Rate(limit = 5, duration = 1, timeUnit = TimeUnit.SECONDS)})
+  @GET
+  @Path(GameListingClient.FETCH_GAMES_PATH)
+  public Collection<LobbyGameListing> fetchGames() {
+    return gameListing.getGames();
+  }
+
+  /** Replaces an existing game with new game data details. */
+  @RateLimited(
+      keys = {KeyPart.IP},
+      rates = {@Rate(limit = 10, duration = 1, timeUnit = TimeUnit.SECONDS)})
+  @POST
+  @Path(GameListingClient.UPDATE_GAME_PATH)
+  public Response updateGame(
+      @Auth final AuthenticatedUser authenticatedUser, final UpdateGameRequest updateGameRequest) {
+    gameListing.updateGame(
+        authenticatedUser.getApiKey(),
+        updateGameRequest.getGameId(),
+        updateGameRequest.getGameData());
+    return Response.ok().build();
+  }
+
+  /** Moderator action to remove a game. */
+  @RateLimited(
+      keys = {KeyPart.IP},
+      rates = {@Rate(limit = 10, duration = 1, timeUnit = TimeUnit.SECONDS)})
+  @POST
+  @Path(GameListingClient.BOOT_GAME_PATH)
+  @RolesAllowed(UserRole.MODERATOR)
+  public Response bootGame(@Auth final AuthenticatedUser authenticatedUser, final String gameId) {
+    gameListing.bootGame(authenticatedUser.getUserId(), gameId);
+    return Response.ok().build();
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/lobby/game/listing/GameListingControllerFactory.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/game/listing/GameListingControllerFactory.java
@@ -1,0 +1,24 @@
+package org.triplea.server.lobby.game.listing;
+
+import java.util.concurrent.TimeUnit;
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import org.jdbi.v3.core.Jdbi;
+import org.triplea.lobby.server.db.dao.ModeratorAuditHistoryDao;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class GameListingControllerFactory {
+
+  public static GameListingController buildController(final Jdbi jdbi) {
+    return GameListingController.builder()
+        .gameListing(
+            GameListing.builder()
+                .auditHistoryDao(jdbi.onDemand(ModeratorAuditHistoryDao.class))
+                .gameReaper(new GameReaper(10, TimeUnit.SECONDS))
+                // TODO: Project#12 Wire game remove/update listeners
+                .gameRemoveListener(game -> {})
+                .gameUpdateListener(game -> {})
+                .build())
+        .build();
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/lobby/game/listing/GameReaper.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/game/listing/GameReaper.java
@@ -32,7 +32,7 @@ class GameReaper {
     if (!deadGames.isEmpty()) {
       log.info(
           "Game reaper killing games: "
-              + deadGames.stream().map(GameListing.GameId::getId).collect(Collectors.toList()));
+              + deadGames.stream().map(GameId::getId).collect(Collectors.toList()));
     }
     return deadGames;
   }

--- a/http-server/src/main/java/org/triplea/server/lobby/game/listing/GameReaper.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/game/listing/GameReaper.java
@@ -7,6 +7,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.triplea.server.lobby.game.listing.GameListing.GameId;
 
 /** Removes games that have not had a keep alive. */
 @AllArgsConstructor
@@ -22,8 +23,8 @@ class GameReaper {
    * Returns set of game ids to be reaped. These are games that have not received a keep alive
    * within the cut-off time.
    */
-  Collection<GameListing.GameId> findDeadGames(final Collection<GameListing.GameId> gameIds) {
-    final Collection<GameListing.GameId> deadGames =
+  Collection<GameId> findDeadGames(final Collection<GameId> gameIds) {
+    final Collection<GameId> deadGames =
         gameIds.stream()
             .filter(id -> keepAliveCache.getIfPresent(id.getId()) == null)
             .collect(Collectors.toSet());

--- a/http-server/src/main/java/org/triplea/server/lobby/game/listing/GameReaper.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/game/listing/GameReaper.java
@@ -1,0 +1,43 @@
+package org.triplea.server.lobby.game.listing;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import java.util.Collection;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/** Removes games that have not had a keep alive. */
+@AllArgsConstructor
+@Slf4j
+class GameReaper {
+  private final Cache<String, Boolean> keepAliveCache;
+
+  GameReaper(final int duration, final TimeUnit timeUnit) {
+    this(CacheBuilder.newBuilder().expireAfterWrite(duration, timeUnit).build());
+  }
+
+  /**
+   * Returns set of game ids to be reaped. These are games that have not received a keep alive
+   * within the cut-off time.
+   */
+  Collection<GameListing.GameId> findDeadGames(final Collection<GameListing.GameId> gameIds) {
+    final Collection<GameListing.GameId> deadGames =
+        gameIds.stream()
+            .filter(id -> keepAliveCache.getIfPresent(id.getId()) == null)
+            .collect(Collectors.toSet());
+
+    if (!deadGames.isEmpty()) {
+      log.info(
+          "Game reaper killing games: "
+              + deadGames.stream().map(GameListing.GameId::getId).collect(Collectors.toList()));
+    }
+    return deadGames;
+  }
+
+  /** Re-news the keep-alive period . */
+  void registerKeepAlive(final String gameId) {
+    keepAliveCache.put(gameId, true);
+  }
+}

--- a/http-server/src/test/java/org/triplea/server/http/ProtectedEndpointTest.java
+++ b/http-server/src/test/java/org/triplea/server/http/ProtectedEndpointTest.java
@@ -38,11 +38,13 @@ public abstract class ProtectedEndpointTest<T> extends DropwizardTest {
   }
 
   /** Use this to verify an endpoint that returns data. */
-  protected void verifyEndpointReturningObject(final Function<T, ?> methodRunner) {
-    assertThat(methodRunner.apply(clientBuilder.apply(localhost, VALID_API_TOKEN)), notNullValue());
+  protected <X> X verifyEndpointReturningObject(final Function<T, X> methodRunner) {
     assertThrows(
         HttpInteractionException.class,
         () -> methodRunner.apply(clientBuilder.apply(localhost, INVALID_API_TOKEN)));
+    final X value = methodRunner.apply(clientBuilder.apply(localhost, VALID_API_TOKEN));
+    assertThat(value, notNullValue());
+    return value;
   }
 
   /**

--- a/http-server/src/test/java/org/triplea/server/lobby/game/listing/GameListingControllerTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/game/listing/GameListingControllerTest.java
@@ -1,0 +1,68 @@
+package org.triplea.server.lobby.game.listing;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.triplea.http.client.lobby.game.listing.GameListingClient;
+import org.triplea.http.client.lobby.game.listing.LobbyGame;
+import org.triplea.server.http.ProtectedEndpointTest;
+
+class GameListingControllerTest extends ProtectedEndpointTest<GameListingClient> {
+
+  private static final LobbyGame LOBBY_GAME =
+      LobbyGame.builder()
+          .hostIpAddress("127.0.0.1")
+          .hostPort(12)
+          .hostName("name")
+          .mapName("map")
+          .playerCount(3)
+          .gameRound(1)
+          .epochMilliTimeStarted(Instant.now().toEpochMilli())
+          .mapVersion("1")
+          .passworded(false)
+          .status("WAITING_FOR_PLAYERS")
+          .comments("comments")
+          .build();
+
+  GameListingControllerTest() {
+    super(GameListingClient::newClient);
+  }
+
+  @Test
+  void postGame() {
+    verifyEndpointReturningObject(client -> client.postGame(LOBBY_GAME));
+  }
+
+  @Test
+  void removeGame() {
+    final String gameId = verifyEndpointReturningObject(client -> client.postGame(LOBBY_GAME));
+    verifyEndpointReturningVoid(client -> client.removeGame(gameId));
+  }
+
+  @Test
+  void keepAlive() {
+    final String gameId = verifyEndpointReturningObject(client -> client.postGame(LOBBY_GAME));
+    final boolean result = verifyEndpointReturningObject(client -> client.sendKeepAlive(gameId));
+    assertThat(result, is(true));
+  }
+
+  @Test
+  void fetchGames() {
+    verifyEndpointReturningObject(client -> client.postGame(LOBBY_GAME));
+    verifyEndpointReturningCollection(GameListingClient::fetchGameListing);
+  }
+
+  @Test
+  void updateGame() {
+    final String gameId = verifyEndpointReturningObject(client -> client.postGame(LOBBY_GAME));
+    verifyEndpointReturningVoid(client -> client.updateGame(gameId, LOBBY_GAME));
+  }
+
+  @Test
+  void bootGame() {
+    final String gameId = verifyEndpointReturningObject(client -> client.postGame(LOBBY_GAME));
+    verifyEndpointReturningVoid(client -> client.bootGame(gameId));
+  }
+}

--- a/http-server/src/test/java/org/triplea/server/lobby/game/listing/GameListingTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/game/listing/GameListingTest.java
@@ -1,0 +1,343 @@
+package org.triplea.server.lobby.game.listing;
+
+import static java.util.Collections.emptyList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.IsSame.sameInstance;
+import static org.hamcrest.text.IsEmptyString.emptyString;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.http.client.lobby.game.listing.LobbyGame;
+import org.triplea.http.client.lobby.game.listing.LobbyGameListing;
+import org.triplea.lobby.server.db.dao.ModeratorAuditHistoryDao;
+
+/**
+ * Items to test.: <br>
+ * - core functionality of get, add, remove, and keep-alive<br>
+ * - games are added with an API key, keep-alive and remove should not do anything if API key is
+ * incorrect<br>
+ * - 'dead-games' should be reaped on 'get'<br>
+ * - boot-game, the authentication should be already done on controller level, so we just need to be
+ * sure there is bookkeeping.
+ */
+@ExtendWith(MockitoExtension.class)
+class GameListingTest {
+  private static final String GAME_ID = "id0";
+
+  private static final String API_KEY_0 = "apiKey0";
+  private static final String API_KEY_1 = "apiKey1";
+
+  private static final String HOST_NAME = "host-player";
+  private static final int MODERATOR_ID = 33;
+
+  @Mock private Consumer<LobbyGameListing> gameUpdateListener;
+  @Mock private Consumer<String> gameRemoveListener;
+  @Mock private GameReaper gameReaper;
+  @Mock private ModeratorAuditHistoryDao moderatorAuditHistoryDao;
+
+  private GameListing gameListing;
+
+  @Mock private LobbyGame lobbyGame0;
+  @Mock private LobbyGame lobbyGame1;
+  @Mock private LobbyGame lobbyGame2;
+
+  @BeforeEach
+  void setup() {
+    gameListing =
+        GameListing.builder()
+            .gameReaper(gameReaper)
+            .gameUpdateListener(gameUpdateListener)
+            .gameRemoveListener(gameRemoveListener)
+            .auditHistoryDao(moderatorAuditHistoryDao)
+            .build();
+  }
+
+  @Nested
+  final class GetGames {
+    /** Basic case, no games added, expect none to be returned. */
+    @Test
+    void getGamesEmptyCase() {
+      when(gameReaper.findDeadGames(any())).thenReturn(emptyList());
+
+      final var games = gameListing.getGames();
+
+      assertThat("Without adding any games, getGames() should return empty", games, empty());
+      verify(gameReaper).findDeadGames(any());
+    }
+
+    /** Add one game, reap none, expect one game to be returned. */
+    @Test
+    void getGamesSingletonGame() {
+      when(gameReaper.findDeadGames(any())).thenReturn(emptyList());
+      gameListing.postGame(API_KEY_0, lobbyGame0);
+
+      final var games = gameListing.getGames();
+
+      assertThat("We added one game, expect there to be one game returned", games, hasSize(1));
+      assertThat(
+          "We expect the one game to be the same one we added",
+          games.get(0).getLobbyGame(),
+          sameInstance(lobbyGame0));
+    }
+
+    /**
+     * Add 3 games, set the reaper to remove 2 of those games, we expected one game to come back.
+     */
+    @Test
+    void getGamesWithReaper() {
+      final String id0 = gameListing.postGame(API_KEY_0, lobbyGame0);
+      final String id1 = gameListing.postGame(API_KEY_0, lobbyGame1);
+      final String id2 = gameListing.postGame(API_KEY_0, lobbyGame2);
+      when(gameReaper.findDeadGames(any()))
+          .thenReturn(
+              Arrays.asList(
+                  GameListing.GameId.builder().apiKey(API_KEY_0).id(id0).build(),
+                  GameListing.GameId.builder().apiKey(API_KEY_0).id(id1).build()));
+
+      final var games = gameListing.getGames();
+
+      assertThat(
+          "Reaper returned two out of three games to be reaped, we expect "
+              + "only one game to remain.",
+          games,
+          hasSize(1));
+      assertThat(games.get(0).getGameId(), is(id2));
+      assertThat(games.get(0).getLobbyGame(), sameInstance(lobbyGame2));
+
+      verify(gameRemoveListener).accept(id0);
+      verify(gameRemoveListener).accept(id1);
+    }
+  }
+
+  @Nested
+  final class KeepAlive {
+    @Test
+    void noGamesPresent() {
+      final boolean result = gameListing.keepAlive(API_KEY_0, GAME_ID);
+
+      assertThat("no games added, keep alive should not match anything", result, is(false));
+      // game is not there, do not call reaper as the game was not found (already dead)
+      verify(gameReaper, never()).registerKeepAlive(any());
+    }
+
+    @Test
+    void mismatchingGameId() {
+      final String id0 = gameListing.postGame(API_KEY_0, lobbyGame0);
+
+      final boolean result = gameListing.keepAlive(API_KEY_0, GAME_ID);
+
+      assertThat("game id does not match, expecting false", result, is(false));
+      verify(gameReaper).registerKeepAlive(id0);
+    }
+
+    @Test
+    void mismatchingApiKey() {
+      final String id0 = gameListing.postGame(API_KEY_0, lobbyGame0);
+
+      assertThrows(GameListing.IncorrectApiKey.class, () -> gameListing.keepAlive(API_KEY_1, id0));
+
+      verify(gameReaper).registerKeepAlive(id0);
+    }
+
+    @Test
+    void correctApiKeyAndGameId() {
+      final String id0 = gameListing.postGame(API_KEY_0, lobbyGame0);
+
+      final boolean result = gameListing.keepAlive(API_KEY_0, id0);
+
+      assertThat(result, is(true));
+
+      // keep alive called on insert (post) and then again on the explicit keep alive call
+      verify(gameReaper, times(2)).registerKeepAlive(id0);
+    }
+  }
+
+  @Nested
+  final class RemoveGame {
+    @Test
+    void removeGameWithNoGames() {
+      gameListing.removeGame(API_KEY_0, GAME_ID);
+
+      verify(gameUpdateListener, never()).accept(any());
+      verify(gameRemoveListener, never()).accept(any());
+    }
+
+    @Test
+    void withMatchingApiKeyRemoveGame() {
+      final String id0 = gameListing.postGame(API_KEY_0, lobbyGame0);
+
+      gameListing.removeGame(API_KEY_0, id0);
+
+      assertThat(
+          "The one game added should be removed leaving no games", gameListing.getGames(), empty());
+      verify(gameRemoveListener).accept(id0);
+    }
+
+    @Test
+    void mismatchingApiKeyDoesNothingOnRemove() {
+      final String id0 = gameListing.postGame(API_KEY_0, lobbyGame0);
+
+      assertThrows(GameListing.IncorrectApiKey.class, () -> gameListing.removeGame(API_KEY_1, id0));
+
+      assertThat("The one game added should remain", gameListing.getGames(), hasSize(1));
+      verify(gameRemoveListener, never()).accept(any());
+    }
+  }
+
+  @Nested
+  final class PostGame {
+    @Test
+    void postGameAddsGame() {
+      assertThat(gameListing.getGames(), empty());
+
+      final String id0 = gameListing.postGame(API_KEY_0, lobbyGame0);
+
+      assertThat(id0, not(emptyString()));
+      assertThat(gameListing.getGames(), hasSize(1));
+      assertThat(gameListing.getGames().get(0).getLobbyGame(), sameInstance(lobbyGame0));
+      assertThat(gameListing.getGames().get(0).getGameId(), is(id0));
+      verify(gameUpdateListener)
+          .accept(LobbyGameListing.builder().gameId(id0).lobbyGame(lobbyGame0).build());
+      verify(gameReaper).registerKeepAlive(id0);
+    }
+
+    @Test
+    void dupeGamePostIsNoOp() {
+      final String id0 = gameListing.postGame(API_KEY_0, lobbyGame0);
+      final String id1 = gameListing.postGame(API_KEY_0, lobbyGame0);
+
+      assertThat(
+          "Second posting should be idempotent returning same gameId already posted", id0, is(id1));
+      assertThat(gameListing.getGames(), hasSize(1));
+      // expecting just the one call to updateListener and not two
+      verify(gameUpdateListener)
+          .accept(LobbyGameListing.builder().gameId(id0).lobbyGame(lobbyGame0).build());
+    }
+
+    @Test
+    void newApiKeyCreatesNewGame() {
+      final String id0 = gameListing.postGame(API_KEY_0, lobbyGame0);
+      final String id1 = gameListing.postGame(API_KEY_1, lobbyGame0);
+
+      assertThat(
+          "Even though posting the same game data, differing API keys will cause new game posts",
+          id0,
+          not(is(id1)));
+      assertThat(gameListing.getGames(), hasSize(2));
+      verify(gameUpdateListener)
+          .accept(LobbyGameListing.builder().gameId(id0).lobbyGame(lobbyGame0).build());
+      verify(gameUpdateListener)
+          .accept(LobbyGameListing.builder().gameId(id1).lobbyGame(lobbyGame0).build());
+      verify(gameReaper).registerKeepAlive(id0);
+      verify(gameReaper).registerKeepAlive(id1);
+    }
+  }
+
+  @Nested
+  final class UpdateGame {
+    @Test
+    void updateGameThatDoesNotExist() {
+      assertThrows(
+          GameListing.GameNotFound.class,
+          () -> gameListing.updateGame(API_KEY_0, GAME_ID, lobbyGame0));
+      verify(gameUpdateListener, never()).accept(any());
+      verify(gameRemoveListener, never()).accept(any());
+    }
+
+    @Test
+    void updateGameWithIncorrectGameId() {
+      final String id0 = gameListing.postGame(API_KEY_0, lobbyGame0);
+
+      assertThrows(
+          GameListing.GameNotFound.class,
+          () -> gameListing.updateGame(API_KEY_0, GAME_ID, lobbyGame1));
+      verify(gameUpdateListener)
+          .accept(LobbyGameListing.builder().gameId(id0).lobbyGame(lobbyGame0).build());
+      verify(gameRemoveListener, never()).accept(any());
+    }
+
+    @Test
+    void updateGameWithIncorrectApiKey() {
+      final String id0 = gameListing.postGame(API_KEY_0, lobbyGame0);
+
+      assertThrows(
+          GameListing.IncorrectApiKey.class,
+          () -> gameListing.updateGame(API_KEY_1, id0, lobbyGame1));
+      // first update listener we expect to be called by the first game posting.
+      verify(gameUpdateListener)
+          .accept(LobbyGameListing.builder().gameId(id0).lobbyGame(lobbyGame0).build());
+      verify(gameRemoveListener, never()).accept(any());
+    }
+
+    @Test
+    void updateGameThatExists() {
+      final String id0 = gameListing.postGame(API_KEY_0, lobbyGame0);
+
+      gameListing.updateGame(API_KEY_0, id0, lobbyGame1);
+
+      verify(gameUpdateListener)
+          .accept(LobbyGameListing.builder().gameId(id0).lobbyGame(lobbyGame1).build());
+    }
+  }
+
+  @Nested
+  final class BootGame {
+    @Test
+    void bootGameNoGames() {
+      assertThrows(
+          GameListing.GameNotFound.class, () -> gameListing.bootGame(MODERATOR_ID, GAME_ID));
+
+      verify(moderatorAuditHistoryDao, never()).addAuditRecord(any());
+      verify(gameUpdateListener, never()).accept(any());
+      verify(gameRemoveListener, never()).accept(any());
+    }
+
+    @Test
+    void bootGameNotFound() {
+      gameListing.postGame(API_KEY_0, lobbyGame0);
+
+      assertThrows(
+          GameListing.GameNotFound.class, () -> gameListing.bootGame(MODERATOR_ID, GAME_ID));
+
+      verify(moderatorAuditHistoryDao, never()).addAuditRecord(any());
+      verify(gameRemoveListener, never()).accept(any());
+    }
+
+    @Test
+    void bootGameFound() {
+      when(lobbyGame0.getHostName()).thenReturn(HOST_NAME);
+      final String id0 = gameListing.postGame(API_KEY_0, lobbyGame0);
+
+      gameListing.bootGame(MODERATOR_ID, id0);
+
+      assertThat(
+          "We had one game added, one booted, no games should remain",
+          gameListing.getGames(),
+          empty());
+      verify(moderatorAuditHistoryDao)
+          .addAuditRecord(
+              ModeratorAuditHistoryDao.AuditArgs.builder()
+                  .actionName(ModeratorAuditHistoryDao.AuditAction.BOOT_GAME)
+                  .actionTarget(HOST_NAME)
+                  .moderatorUserId(MODERATOR_ID)
+                  .build());
+      verify(gameRemoveListener).accept(id0);
+    }
+  }
+}

--- a/http-server/src/test/java/org/triplea/server/lobby/game/listing/GameReaperTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/game/listing/GameReaperTest.java
@@ -1,0 +1,86 @@
+package org.triplea.server.lobby.game.listing;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.cache.Cache;
+import java.util.Arrays;
+import java.util.Collection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class GameReaperTest {
+
+  private static final String ID0 = "id0";
+  private static final String ID1 = "id1";
+  private static final String ID2 = "id2";
+
+  private static final Collection<GameListing.GameId> ids =
+      Arrays.asList(newGameId(ID0), newGameId(ID1), newGameId(ID2));
+
+  @Mock private Cache<String, Boolean> cache;
+
+  private GameReaper gameReaper;
+
+  private static GameListing.GameId newGameId(final String id) {
+    return GameListing.GameId.builder().id(id).apiKey("key").build();
+  }
+
+  @BeforeEach
+  void setup() {
+    gameReaper = new GameReaper(cache);
+  }
+
+  @Nested
+  class FindDeadGames {
+    @Test
+    void nothingInCache() {
+      when(cache.getIfPresent(ID0)).thenReturn(null);
+      when(cache.getIfPresent(ID1)).thenReturn(null);
+      when(cache.getIfPresent(ID2)).thenReturn(null);
+
+      final Collection<GameListing.GameId> results = gameReaper.findDeadGames(ids);
+
+      assertThat(results, hasSize(3));
+    }
+
+    @Test
+    void oneElementInCache() {
+      when(cache.getIfPresent(ID0)).thenReturn(null);
+      when(cache.getIfPresent(ID1)).thenReturn(true);
+      when(cache.getIfPresent(ID2)).thenReturn(null);
+
+      final Collection<GameListing.GameId> results = gameReaper.findDeadGames(ids);
+
+      assertThat(results, hasSize(2));
+      assertThat(results, hasItem(newGameId(ID0)));
+      assertThat(results, hasItem(newGameId(ID2)));
+    }
+
+    @Test
+    void allElementsInCache() {
+      when(cache.getIfPresent(ID0)).thenReturn(true);
+      when(cache.getIfPresent(ID1)).thenReturn(true);
+      when(cache.getIfPresent(ID2)).thenReturn(true);
+
+      final Collection<GameListing.GameId> results = gameReaper.findDeadGames(ids);
+
+      assertThat(results, hasSize(0));
+    }
+  }
+
+  @Test
+  void registerKeepAlive() {
+    gameReaper.registerKeepAlive(ID0);
+
+    verify(cache).put(ID0, true);
+  }
+}

--- a/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/dao/ModeratorAuditHistoryDao.java
+++ b/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/dao/ModeratorAuditHistoryDao.java
@@ -30,6 +30,8 @@ public interface ModeratorAuditHistoryDao {
 
     REMOVE_USERNAME_BAN,
 
+    BOOT_GAME,
+
     BOOT_USER_FROM_BOT,
 
     BOOT_USER_FROM_LOBBY,


### PR DESCRIPTION
Adds HTTP endpoints for 'game listing' functionality: {post, remove, update, boot, keep-alive, fetch}

There are two unimplemented listeners for notifying existing, connected,
clients for game updates, those are marked with TODOs and will land in future updates.

'GameReaper', a utility to enforce keep-alive and prune 'dead' games implements
the keep-alive feature. See the javadoc of that class for further details.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix:  <!-- Link to bug issue or forum post here -->
[ ] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[ ] Manually tested
[ ] No testing done
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

