### PR TITLE
Fix potential NPE with default values in GridBagConstraintBuilder

### DIFF
--- a/swing-lib/src/main/java/org/triplea/swing/jpanel/GridBagConstraintsBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/jpanel/GridBagConstraintsBuilder.java
@@ -35,8 +35,8 @@ public class GridBagConstraintsBuilder {
   private double weightX;
   private double weightY;
 
-  private GridBagConstraintsAnchor anchor;
-  private GridBagConstraintsFill fill;
+  private GridBagConstraintsAnchor anchor = GridBagConstraintsAnchor.WEST;
+  private GridBagConstraintsFill fill = GridBagConstraintsFill.NONE;
 
   private Insets insets = new Insets(0, 0, 0, 0);
 
@@ -86,11 +86,20 @@ public class GridBagConstraintsBuilder {
     return this;
   }
 
+  /**
+   * Sets grid bag constraint anchor value, this dictates how components are placed in the grid
+   * cell. If not specified, defaults to: GridBagConstraintsAnchor.WEST
+   */
   public GridBagConstraintsBuilder anchor(final GridBagConstraintsAnchor anchor) {
     this.anchor = anchor;
     return this;
   }
 
+  /**
+   * Sets grid bag constraint fill value, this dictates how components are adjusted when placed in
+   * grid cell, whether they are expanded to fill space. If not specified, defaults to:
+   * GridBagConstraintsFill.NONE
+   */
   public GridBagConstraintsBuilder fill(final GridBagConstraintsFill fill) {
     this.fill = fill;
     return this;


### PR DESCRIPTION
- Adds default values for anchor and fill, otherwise if these properties are not specified there would be a NPE in 'build()'
- Add some javadocs


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[x] Bug fix:  <!-- Link to bug issue or forum post here -->
[ ] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[ ] Manually tested
[x] No testing done
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

