### PR TITLE
Convert JPanelBuilder to a type-safe builder

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
@@ -52,8 +52,7 @@ public class MainPanel extends JPanel implements Observer, Consumer<SetupPanel> 
   private final JPanel gameSetupPanelHolder = new JPanelBuilder().borderLayout().build();
   private final JPanel mainPanel;
   private final JSplitPane chatSplit;
-  private final JPanel chatPanelHolder =
-      new JPanelBuilder().borderLayout().preferredHeight(62).build();
+  private final JPanel chatPanelHolder = new JPanelBuilder().height(62).borderLayout().build();
   private SetupPanel gameSetupPanel;
 
   /**
@@ -111,12 +110,7 @@ public class MainPanel extends JPanel implements Observer, Consumer<SetupPanel> 
             .actionListener(GameRunner::quitGame)
             .build();
     final JPanel buttonsPanel =
-        new JPanelBuilder()
-            .borderEtched()
-            .flowLayout(JPanelBuilder.FlowLayoutJustification.CENTER)
-            .add(playButton)
-            .add(quitButton)
-            .build();
+        new JPanelBuilder().borderEtched().add(playButton).add(quitButton).build();
     add(buttonsPanel, BorderLayout.SOUTH);
     setPreferredSize(initialSize);
     setWidgetActivation();

--- a/swing-lib/src/main/java/org/triplea/swing/jpanel/BorderLayoutBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/jpanel/BorderLayoutBuilder.java
@@ -1,0 +1,81 @@
+package org.triplea.swing.jpanel;
+
+import com.google.common.base.Preconditions;
+import java.awt.BorderLayout;
+import java.awt.Component;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.JPanel;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+public class BorderLayoutBuilder {
+  private JPanelBuilder panelBuilder;
+
+  private final List<BorderLayoutComponent> components = new ArrayList<>();
+
+  @AllArgsConstructor
+  private static class BorderLayoutComponent {
+    private final Component component;
+    private final BorderLayoutPosition position;
+
+    private void addToPanel(final JPanel panel) {
+      position.place(component, panel);
+    }
+  }
+
+  /** Swing border layout locations. */
+  @AllArgsConstructor
+  private enum BorderLayoutPosition {
+    CENTER(BorderLayout.CENTER),
+    SOUTH(BorderLayout.SOUTH),
+    NORTH(BorderLayout.NORTH),
+    WEST(BorderLayout.WEST),
+    EAST(BorderLayout.EAST);
+
+    private final String swingPlacement;
+
+    private void place(final Component component, final JPanel panel) {
+      panel.add(component, swingPlacement);
+    }
+  }
+
+  public JPanel build() {
+    final JPanel panel = panelBuilder.build();
+    panel.setLayout(new BorderLayout());
+    components.forEach(c -> c.addToPanel(panel));
+    return panel;
+  }
+
+  /** Adds a given component to the southern portion of a border layout. */
+  public BorderLayoutBuilder addSouth(final Component component) {
+    return add(component, BorderLayoutPosition.SOUTH);
+  }
+
+  /** Adds a given component to the 'north' portion of the border layout. */
+  public BorderLayoutBuilder addNorth(final Component component) {
+    return add(component, BorderLayoutPosition.NORTH);
+  }
+
+  /** Adds a given component to the 'east' portion of the border layout. */
+  public BorderLayoutBuilder addEast(final Component component) {
+    return add(component, BorderLayoutPosition.EAST);
+  }
+
+  /** Adds a given component to the 'west' portion of the border layout. */
+  public BorderLayoutBuilder addWest(final Component component) {
+    return add(component, BorderLayoutPosition.WEST);
+  }
+
+  /** Adds a given component to the 'center' portion of the border layout. */
+  public BorderLayoutBuilder addCenter(final Component component) {
+    return add(component, BorderLayoutPosition.CENTER);
+  }
+
+  private BorderLayoutBuilder add(final Component component, final BorderLayoutPosition position) {
+    Preconditions.checkNotNull(component);
+    components.add(new BorderLayoutComponent(component, position));
+    return this;
+  }
+}

--- a/swing-lib/src/main/java/org/triplea/swing/jpanel/BoxLayoutBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/jpanel/BoxLayoutBuilder.java
@@ -1,0 +1,73 @@
+package org.triplea.swing.jpanel;
+
+import java.awt.Component;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JPanel;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+public class BoxLayoutBuilder {
+  private final JPanelBuilder panelBuilder;
+  private final BoxLayoutOrientation boxLayoutOrientation;
+
+  private List<Component> components = new ArrayList<>();
+
+  @AllArgsConstructor(access = AccessLevel.PRIVATE)
+  enum BoxLayoutOrientation {
+    HORIZONTAL(BoxLayout.X_AXIS),
+    VERTICAL(BoxLayout.Y_AXIS);
+
+    private final int swingLayoutCode;
+  }
+
+  public JPanel build() {
+    final JPanel panel = panelBuilder.build();
+    panel.setLayout(new BoxLayout(panel, boxLayoutOrientation.swingLayoutCode));
+    components.forEach(panel::add);
+    return panel;
+  }
+
+  public BoxLayoutBuilder add(final Component component) {
+    components.add(component);
+    return this;
+  }
+
+  /**
+   * use this when you want an empty space component that will take up extra space. For example,
+   * with a gridbag layout with 2 columns, if you have 2 components, the second will be stretched by
+   * default to fill all available space to the right. This right hand component would then resize
+   * with the window. If on the other hand a 3 column grid bag were used and the last element were a
+   * horizontal glue, then the 2nd component would then have a fixed size.
+   */
+  public BoxLayoutBuilder addHorizontalGlue() {
+    components.add(Box.createHorizontalGlue());
+    return this;
+  }
+
+  public BoxLayoutBuilder addVerticalStrut(final int strutSize) {
+    components.add(Box.createVerticalStrut(strutSize));
+    return this;
+  }
+
+  public BoxLayoutBuilder addHorizontalStrut(final int strutSize) {
+    components.add(Box.createHorizontalStrut(strutSize));
+    return this;
+  }
+
+  /**
+   * Adds {@code component} to the panel and ensures it will be left-justified in the final layout.
+   * Primarily for use with vertical box layouts.
+   */
+  public BoxLayoutBuilder addLeftJustified(final Component component) {
+    final Box box = Box.createHorizontalBox();
+    box.add(component);
+    box.add(Box.createHorizontalGlue());
+    components.add(box);
+    return this;
+  }
+}

--- a/swing-lib/src/main/java/org/triplea/swing/jpanel/FlowLayoutBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/jpanel/FlowLayoutBuilder.java
@@ -1,0 +1,65 @@
+package org.triplea.swing.jpanel;
+
+import com.google.common.base.Preconditions;
+import java.awt.Component;
+import java.awt.FlowLayout;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+public class FlowLayoutBuilder {
+  private final JPanelBuilder panelBuilder;
+
+  private final List<Component> components = new ArrayList<>();
+  private Direction direction = Direction.CENTER;
+
+  private int hgap = 5;
+  private int vgap = 5;
+
+  public JPanel build() {
+    final JPanel panel = panelBuilder.build();
+    panel.setLayout(new FlowLayout(direction.swingCode, hgap, vgap));
+    components.forEach(panel::add);
+    return panel;
+  }
+
+  @AllArgsConstructor
+  public enum Direction {
+    CENTER(FlowLayout.CENTER),
+    RIGHT(FlowLayout.RIGHT);
+
+    private final int swingCode;
+  }
+
+  public FlowLayoutBuilder flowDirection(final Direction direction) {
+    this.direction = direction;
+    return this;
+  }
+
+  public FlowLayoutBuilder add(final Component component) {
+    Preconditions.checkNotNull(component);
+    components.add(component);
+    return this;
+  }
+
+  public FlowLayoutBuilder hgap(final int hgap) {
+    Preconditions.checkArgument(hgap >= 0);
+    this.hgap = hgap;
+    return this;
+  }
+
+  public FlowLayoutBuilder vgap(final int vgap) {
+    Preconditions.checkArgument(vgap >= 0);
+    this.vgap = vgap;
+    return this;
+  }
+
+  public FlowLayoutBuilder addLabel(final String text) {
+    return add(new JLabel(text));
+  }
+}

--- a/swing-lib/src/main/java/org/triplea/swing/jpanel/GridBagLayoutBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/jpanel/GridBagLayoutBuilder.java
@@ -1,0 +1,40 @@
+package org.triplea.swing.jpanel;
+
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+public class GridBagLayoutBuilder {
+  private JPanelBuilder panelBuilder;
+
+  private final List<GridBagComponent> components = new ArrayList<>();
+
+  @AllArgsConstructor
+  private static class GridBagComponent {
+    private final JComponent component;
+    private final GridBagConstraints constraints;
+  }
+
+  /**
+   * Constructs a Swing JPanel using current builder values. Values that must be set: (requires no
+   * values to be set)
+   */
+  public JPanel build() {
+    final JPanel panel = panelBuilder.build();
+    panel.setLayout(new GridBagLayout());
+    components.forEach(c -> panel.add(c.component, c.constraints));
+    return panel;
+  }
+
+  public GridBagLayoutBuilder add(
+      final JComponent component, final GridBagConstraints constraints) {
+    components.add(new GridBagComponent(component, constraints));
+    return this;
+  }
+}

--- a/swing-lib/src/main/java/org/triplea/swing/jpanel/GridLayoutBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/jpanel/GridLayoutBuilder.java
@@ -1,0 +1,31 @@
+package org.triplea.swing.jpanel;
+
+import java.awt.Component;
+import java.awt.GridLayout;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.JPanel;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+public class GridLayoutBuilder {
+
+  private final JPanelBuilder panelBuilder;
+  private final int rows;
+  private final int columns;
+
+  private final List<Component> components = new ArrayList<>();
+
+  public JPanel build() {
+    final JPanel panel = panelBuilder.build();
+    panel.setLayout(new GridLayout(rows, columns));
+    components.forEach(panel::add);
+    return panel;
+  }
+
+  public GridLayoutBuilder add(final Component component) {
+    components.add(component);
+    return this;
+  }
+}

--- a/swing-lib/src/main/java/org/triplea/swing/jpanel/JPanelBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/jpanel/JPanelBuilder.java
@@ -1,103 +1,47 @@
 package org.triplea.swing.jpanel;
 
-import com.google.common.base.Preconditions;
-import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
-import java.awt.FlowLayout;
-import java.awt.GridBagLayout;
-import java.awt.GridLayout;
-import java.awt.LayoutManager;
-import java.util.ArrayList;
-import java.util.Collection;
-import javax.annotation.Nonnull;
 import javax.swing.BorderFactory;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
 import javax.swing.JComponent;
-import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.border.Border;
 import javax.swing.border.EtchedBorder;
-import lombok.AllArgsConstructor;
-import lombok.ToString;
-import lombok.Value;
 
 /**
- * Example usage:. <code><pre>
+ * Example usage:<br>
+ * <br>
+ * Default layout is a flow layout: <code><pre>
  *   final JPanel panel = new JPanelBuilder()
- *       .gridLayout(2, 1)
- *       .add(new JLabel("")
- *       .add(new JLabel("")
+ *       .addLabel("label")
+ *       .add(new JButton("button"))
  *       .build();
- * </pre></code>
+ *  </pre></code><br>
+ * <br>
+ * Using a grid layout: <code><pre>
+ *   final JPanel panel = new JPanelBuilder()
+ *       .gridLayout()
+ *       .rows(2)
+ *       .columns(1)
+ *       .add(new JLabel(""))
+ *       .add(new JLabel(""))
+ *       .build();
+ * </pre></code><br>
  */
 public class JPanelBuilder {
-
-  @Value
-  private static class PanelComponent {
-    @Nonnull private final Component component;
-    @Nonnull private final PanelProperties panelProperties;
-  }
-
-  private final Collection<PanelComponent> panelComponents = new ArrayList<>();
   private Float horizontalAlignment;
   private Border border;
-  private LayoutManager layout;
-  private BoxLayoutType boxLayoutType = null;
   private Integer preferredHeight;
 
   /**
-   * Constructs a Swing JPanel using current builder values. Values that must be set: (requires no
-   * values to be set)
+   * Constructs JPanel with all properties from JPanelBuilder, in effect this should be everything
+   * minus components placed in their layout.
    */
-  public JPanel build() {
+  JPanel build() {
     final JPanel panel = new JPanel();
-
     panel.setOpaque(false);
-
     if (border != null) {
       panel.setBorder(border);
-    }
-
-    if (layout == null && boxLayoutType != null) {
-      final int boxDirection =
-          boxLayoutType == BoxLayoutType.HORIZONTAL ? BoxLayout.X_AXIS : BoxLayout.Y_AXIS;
-      layout = new BoxLayout(panel, boxDirection);
-    } else if (layout == null) {
-      layout = new FlowLayout();
-    }
-
-    panel.setLayout(layout);
-
-    for (final PanelComponent panelComponent : panelComponents) {
-      final PanelProperties panelProperties = panelComponent.getPanelProperties();
-
-      if (panelProperties.borderLayoutPosition == BorderLayoutPosition.DEFAULT) {
-        panel.add(panelComponent.getComponent());
-      } else {
-        switch (panelProperties.borderLayoutPosition) {
-          case CENTER:
-            panel.add(panelComponent.getComponent(), BorderLayout.CENTER);
-            break;
-          case SOUTH:
-            panel.add(panelComponent.getComponent(), BorderLayout.SOUTH);
-            break;
-          case NORTH:
-            panel.add(panelComponent.getComponent(), BorderLayout.NORTH);
-            break;
-          case WEST:
-            panel.add(panelComponent.getComponent(), BorderLayout.WEST);
-            break;
-          case EAST:
-            panel.add(panelComponent.getComponent(), BorderLayout.EAST);
-            break;
-          default:
-            Preconditions.checkState(layout != null);
-            panel.add(panelComponent.getComponent());
-            break;
-        }
-      }
     }
     if (horizontalAlignment != null) {
       panel.setAlignmentX(horizontalAlignment);
@@ -107,69 +51,6 @@ public class JPanelBuilder {
       panel.setPreferredSize(new Dimension(panel.getWidth(), preferredHeight));
     }
     return panel;
-  }
-
-  /** Sets the layout to {@code GridBagLayout}. */
-  public JPanelBuilder gridBagLayout() {
-    layout = new GridBagLayout();
-    return this;
-  }
-
-  public JPanelBuilder boxLayoutHorizontal() {
-    boxLayoutType = BoxLayoutType.HORIZONTAL;
-    return this;
-  }
-
-  public JPanelBuilder boxLayoutVertical() {
-    boxLayoutType = BoxLayoutType.VERTICAL;
-    return this;
-  }
-
-  /**
-   * Toggles a border layout, adds a given component to the 'north' portion of the border layout.
-   */
-  public JPanelBuilder addNorth(final Component child) {
-    layout = new BorderLayout();
-    Preconditions.checkNotNull(child);
-    panelComponents.add(new PanelComponent(child, new PanelProperties(BorderLayoutPosition.NORTH)));
-    return this;
-  }
-
-  /** Toggles a border layout, adds a given component to the 'east' portion of the border layout. */
-  public JPanelBuilder addEast(final Component child) {
-    layout = new BorderLayout();
-    Preconditions.checkNotNull(child);
-    panelComponents.add(new PanelComponent(child, new PanelProperties(BorderLayoutPosition.EAST)));
-    return this;
-  }
-
-  /** Toggles a border layout, adds a given component to the 'west' portion of the border layout. */
-  public JPanelBuilder addWest(final Component child) {
-    layout = new BorderLayout();
-    Preconditions.checkNotNull(child);
-    panelComponents.add(new PanelComponent(child, new PanelProperties(BorderLayoutPosition.WEST)));
-    return this;
-  }
-
-  /**
-   * Toggles a border layout, adds a given component to the 'center' portion of the border layout.
-   */
-  public JPanelBuilder addCenter(final Component child) {
-    layout = new BorderLayout();
-    panelComponents.add(
-        new PanelComponent(child, new PanelProperties(BorderLayoutPosition.CENTER)));
-    return this;
-  }
-
-  /**
-   * Specify a grid layout with a given number of rows and columns.
-   *
-   * @param rows First parameter for 'new GridLayout'
-   * @param columns Second parameter for 'new GridLayout'
-   */
-  public JPanelBuilder gridLayout(final int rows, final int columns) {
-    layout = new GridLayout(rows, columns);
-    return this;
   }
 
   public JPanelBuilder border(final Border border) {
@@ -197,125 +78,40 @@ public class JPanelBuilder {
     return this;
   }
 
-  public JPanelBuilder flowLayout() {
-    return flowLayout(FlowLayoutJustification.DEFAULT);
-  }
-
-  public JPanelBuilder flowLayout(final FlowLayoutJustification flowLayoutDirection) {
-    layout = flowLayoutDirection.newFlowLayout();
-    return this;
-  }
-
-  /**
-   * Adds {@code component} to the panel and ensures it will be left-justified in the final layout.
-   * Primarily for use with vertical box layouts.
-   */
-  public JPanelBuilder addLeftJustified(final Component component) {
-    final Box box = Box.createHorizontalBox();
-    box.add(component);
-    box.add(Box.createHorizontalGlue());
-    return add(box);
-  }
-
-  public JPanelBuilder add(final Component component) {
-    Preconditions.checkNotNull(component);
-    panelComponents.add(
-        new PanelComponent(component, new PanelProperties(BorderLayoutPosition.DEFAULT)));
-    return this;
-  }
-
-  /** Adds a given component to the southern portion of a border layout. */
-  public JPanelBuilder addSouth(final JComponent child) {
-    layout = new BorderLayout();
-    Preconditions.checkNotNull(child);
-    panelComponents.add(new PanelComponent(child, new PanelProperties(BorderLayoutPosition.SOUTH)));
-    return this;
-  }
-
-  public JPanelBuilder addLabel(final String text) {
-    add(new JLabel(text));
-    return this;
-  }
-
-  /**
-   * use this when you want an empty space component that will take up extra space. For example,
-   * with a gridbag layout with 2 columns, if you have 2 components, the second will be stretched by
-   * default to fill all available space to the right. This right hand component would then resize
-   * with the window. If on the other hand a 3 column grid bag were used and the last element were a
-   * horizontal glue, then the 2nd component would then have a fixed size.
-   */
-  public JPanelBuilder addHorizontalGlue() {
-    add(Box.createHorizontalGlue());
-    return this;
-  }
-
-  public JPanelBuilder addVerticalStrut(final int strutSize) {
-    add(Box.createVerticalStrut(strutSize));
-    return this;
-  }
-
-  public JPanelBuilder addHorizontalStrut(final int strutSize) {
-    add(Box.createHorizontalStrut(strutSize));
-    return this;
-  }
-
-  public JPanelBuilder borderLayout() {
-    layout = new BorderLayout();
-    return this;
-  }
-
-  public JPanelBuilder preferredHeight(final int height) {
+  public JPanelBuilder height(final int height) {
     preferredHeight = height;
     return this;
   }
 
-  /**
-   * BoxLayout needs a reference to the panel component that is using the layout, so we cannot
-   * create the layout until after we create the component. Thus we use a flag to create it, rather
-   * than creating and storing the layout manager directly as we do for the other layouts such as
-   * gridLayout.
-   */
-  private enum BoxLayoutType {
-    NONE,
-    HORIZONTAL,
-    VERTICAL
+  public FlowLayoutBuilder add(final Component component) {
+    return flowLayout().add(component);
   }
 
-  /** Swing border layout locations. */
-  public enum BorderLayoutPosition {
-    DEFAULT,
-    CENTER,
-    SOUTH,
-    NORTH,
-    WEST,
-    EAST
+  public FlowLayoutBuilder flowLayout() {
+    return new FlowLayoutBuilder(this);
   }
 
-  /** Type-safe alias for magic values in {@code FlowLayout}. */
-  @AllArgsConstructor
-  public enum FlowLayoutJustification {
-    DEFAULT(FlowLayout.CENTER),
-
-    CENTER(FlowLayout.CENTER),
-
-    LEFT(FlowLayout.LEFT),
-
-    RIGHT(FlowLayout.RIGHT);
-
-    private final int align;
-
-    FlowLayout newFlowLayout() {
-      return new FlowLayout(align);
-    }
+  public BorderLayoutBuilder borderLayout() {
+    return new BorderLayoutBuilder(this);
   }
 
-  /** Struct-like class for the various properties and styles that can be applied to a panel. */
-  @ToString
-  private static final class PanelProperties {
-    private final BorderLayoutPosition borderLayoutPosition;
+  public GridLayoutBuilder gridLayout(final int rows, final int columns) {
+    return new GridLayoutBuilder(this, rows, columns);
+  }
 
-    PanelProperties(final BorderLayoutPosition borderLayoutPosition) {
-      this.borderLayoutPosition = borderLayoutPosition;
-    }
+  public BoxLayoutBuilder boxLayoutHorizontal() {
+    return new BoxLayoutBuilder(this, BoxLayoutBuilder.BoxLayoutOrientation.HORIZONTAL);
+  }
+
+  public BoxLayoutBuilder boxLayoutVertical() {
+    return new BoxLayoutBuilder(this, BoxLayoutBuilder.BoxLayoutOrientation.VERTICAL);
+  }
+
+  public GridBagLayoutBuilder gridBagLayout() {
+    return new GridBagLayoutBuilder(this);
+  }
+
+  public SimpleGridBagLayoutBuilder gridBagLayout(final int columnCount) {
+    return new SimpleGridBagLayoutBuilder(this, columnCount);
   }
 }

--- a/swing-lib/src/main/java/org/triplea/swing/jpanel/SimpleGridBagLayoutBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/jpanel/SimpleGridBagLayoutBuilder.java
@@ -1,0 +1,105 @@
+package org.triplea.swing.jpanel;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.util.ArrayList;
+import java.util.List;
+import javax.swing.JComponent;
+import javax.swing.JPanel;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.triplea.java.PostConditions;
+
+/**
+ * Convenience builder for Gridbag layout where row/column numbers are auto-incremented. Example:
+ * <code><pre>
+ *   final int columnCount = 2;
+ *   final JPanel panel = new JPanelBuilder()
+ *       .gridLayout(columnCount)
+ *       .add(new JLabel("placed in: row 0, column 0"))
+ *       .add(new JLabel("placed in: row 0, column 1"))
+ *       .add(new JLabel("placed in: row 1, column 0"))
+ *       .add(new JLabel("placed in: row 1, column 1"))
+ *       .build();
+ * </pre></code>
+ */
+@RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+public class SimpleGridBagLayoutBuilder {
+  private final JPanelBuilder panelBuilder;
+  private final int columnCount;
+
+  private final List<GridBagComponent> components = new ArrayList<>();
+  private int element = 0;
+
+  @AllArgsConstructor
+  private static class GridBagComponent {
+    private final JComponent component;
+    private final GridBagConstraints constraints;
+  }
+
+  /**
+   * Constructs a Swing JPanel using current builder values. Values that must be set: (requires no
+   * values to be set)
+   */
+  public JPanel build() {
+    final JPanel panel = panelBuilder.build();
+    panel.setLayout(new GridBagLayout());
+    components.forEach(c -> panel.add(c.component, c.constraints));
+    return panel;
+  }
+
+  public SimpleGridBagLayoutBuilder add(final JComponent component) {
+    final CoordinateCalculator coordinateCalculator = new CoordinateCalculator(columnCount);
+    components.add(
+        new GridBagComponent(
+            component,
+            new GridBagConstraintsBuilder(
+                    coordinateCalculator.calculateColumn(element),
+                    coordinateCalculator.calculateRow(element))
+                .build()));
+    element++;
+    return this;
+  }
+
+  public SimpleGridBagLayoutBuilder add(
+      final JComponent component,
+      final GridBagConstraintsAnchor anchor,
+      final GridBagConstraintsFill fill) {
+    final CoordinateCalculator coordinateCalculator = new CoordinateCalculator(columnCount);
+    components.add(
+        new GridBagComponent(
+            component,
+            new GridBagConstraintsBuilder(
+                    coordinateCalculator.calculateColumn(element),
+                    coordinateCalculator.calculateRow(element))
+                .anchor(anchor)
+                .fill(fill)
+                .build()));
+    element++;
+    return this;
+  }
+
+  @VisibleForTesting
+  static class CoordinateCalculator {
+    private final int columnCount;
+
+    CoordinateCalculator(final int columnCount) {
+      Preconditions.checkArgument(columnCount > 0);
+      this.columnCount = columnCount;
+    }
+
+    int calculateRow(final int elementCount) {
+      return elementCount / columnCount;
+    }
+
+    int calculateColumn(final int elementCount) {
+      final int column = elementCount % columnCount;
+      PostConditions.assertState(
+          column < columnCount, "Column out of bounds: " + column + ", max: " + columnCount);
+      return column;
+    }
+  }
+}

--- a/swing-lib/src/test/java/org/triplea/swing/jpanel/JPanelBuilderTest.java
+++ b/swing-lib/src/test/java/org/triplea/swing/jpanel/JPanelBuilderTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.core.Is.is;
-import static org.hamcrest.core.IsNull.notNullValue;
 
 import java.awt.BorderLayout;
 import java.awt.FlowLayout;
@@ -21,13 +20,9 @@ import org.junit.jupiter.api.Test;
 class JPanelBuilderTest {
 
   @Test
-  void minBuildCase() {
-    assertThat(new JPanelBuilder().build(), notNullValue());
-  }
-
-  @Test
   void horizontalAlignmentCenter() {
-    final JPanel panel = new JPanelBuilder().horizontalAlignmentCenter().build();
+    final JPanel panel =
+        new JPanelBuilder().horizontalAlignmentCenter().add(new JLabel("")).build();
     assertThat(panel.getAlignmentX(), is(JComponent.CENTER_ALIGNMENT));
   }
 
@@ -45,7 +40,8 @@ class JPanelBuilderTest {
 
   @Test
   void defaultLayoutIsFlowLayout() {
-    assertThat(new JPanelBuilder().build().getLayout(), instanceOf(FlowLayout.class));
+    assertThat(
+        new JPanelBuilder().add(new JLabel()).build().getLayout(), instanceOf(FlowLayout.class));
   }
 
   @Test
@@ -66,7 +62,7 @@ class JPanelBuilderTest {
   @Test
   void emptyBorderWithSingleWidth() {
     final int borderWidth = 100;
-    final JPanel panel = new JPanelBuilder().border(borderWidth).build();
+    final JPanel panel = new JPanelBuilder().border(borderWidth).add(new JLabel()).build();
     assertThat(panel.getBorder(), instanceOf(EmptyBorder.class));
     final Insets insets = panel.getBorder().getBorderInsets(panel);
     assertThat(insets.top, is(borderWidth));
@@ -77,7 +73,7 @@ class JPanelBuilderTest {
 
   @Test
   void emptyBorderWithIndependentWidths() {
-    final JPanel panel = new JPanelBuilder().border(1, 2, 3, 4).build();
+    final JPanel panel = new JPanelBuilder().border(1, 2, 3, 4).add(new JLabel()).build();
 
     assertThat(panel.getBorder(), instanceOf(EmptyBorder.class));
 
@@ -92,7 +88,7 @@ class JPanelBuilderTest {
   void addLabel() {
     final String labelText = "abc";
 
-    final JPanel panel = new JPanelBuilder().addLabel(labelText).build();
+    final JPanel panel = new JPanelBuilder().add(new JLabel(labelText)).build();
 
     assertThat(panel.getComponents().length, is(1));
     assertThat(panel.getComponents()[0], instanceOf(JLabel.class));

--- a/swing-lib/src/test/java/org/triplea/swing/jpanel/SimpleGridBagLayoutBuilderTest.java
+++ b/swing-lib/src/test/java/org/triplea/swing/jpanel/SimpleGridBagLayoutBuilderTest.java
@@ -1,0 +1,107 @@
+package org.triplea.swing.jpanel;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import org.junit.jupiter.api.Test;
+
+class SimpleGridBagLayoutBuilderTest {
+
+  /** Single column case means every element will land in first column and a new row. */
+  @Test
+  void coordinateCalculatorSingleColumn() {
+    final SimpleGridBagLayoutBuilder.CoordinateCalculator coordinateCalculator =
+        new SimpleGridBagLayoutBuilder.CoordinateCalculator(1);
+
+    for (int i = 0; i < 10; i++) {
+      assertThat(
+          "With one column, every element will be in the same column.",
+          coordinateCalculator.calculateColumn(i),
+          is(0));
+      assertThat(
+          "With only one column, each element should land on its own row.",
+          coordinateCalculator.calculateRow(i),
+          is(i));
+    }
+  }
+
+  /**
+   * Sets up a grid that is 'length' columns across, we'll add the same number of elements and
+   * expect each element to be in the first row and in subsequent columns.
+   */
+  @Test
+  void coordinateCalculatorSingleRow() {
+    final int length = 10;
+    final SimpleGridBagLayoutBuilder.CoordinateCalculator coordinateCalculator =
+        new SimpleGridBagLayoutBuilder.CoordinateCalculator(length);
+
+    for (int i = 0; i < length; i++) {
+      assertThat(
+          "With 'n' columns and adding 'n' elements,"
+              + " each element should land in the subsequent column.",
+          coordinateCalculator.calculateColumn(i),
+          is(i));
+      assertThat(
+          "Each element should be in the same row.", coordinateCalculator.calculateRow(i), is(0));
+    }
+  }
+
+  /**
+   * Another special case with 2 columns, column number should alternate between 0 and 1 (modulus of
+   * the element count), and the row number should be the flow of the element count divided by two.
+   */
+  @Test
+  void twoColumns() {
+    final int length = 10;
+    final SimpleGridBagLayoutBuilder.CoordinateCalculator coordinateCalculator =
+        new SimpleGridBagLayoutBuilder.CoordinateCalculator(2);
+
+    for (int i = 0; i < length; i++) {
+      assertThat(
+          "With 2 columns, each element should land in the zero or one column, alternating",
+          coordinateCalculator.calculateColumn(i),
+          is(i % 2));
+      assertThat(
+          "With 2 columns, row count should be the flow of the element count divided by 2",
+          coordinateCalculator.calculateRow(i),
+          is(i / 2));
+    }
+  }
+
+  /** Verify some brute force calculations. */
+  @Test
+  void threeColumns() {
+    final SimpleGridBagLayoutBuilder.CoordinateCalculator coordinateCalculator =
+        new SimpleGridBagLayoutBuilder.CoordinateCalculator(3);
+
+    // first row
+    assertThat(coordinateCalculator.calculateColumn(0), is(0));
+    assertThat(coordinateCalculator.calculateRow(0), is(0));
+
+    assertThat(coordinateCalculator.calculateColumn(1), is(1));
+    assertThat(coordinateCalculator.calculateRow(1), is(0));
+
+    assertThat(coordinateCalculator.calculateColumn(2), is(2));
+    assertThat(coordinateCalculator.calculateRow(2), is(0));
+
+    // second row
+    assertThat(coordinateCalculator.calculateColumn(3), is(0));
+    assertThat(coordinateCalculator.calculateRow(3), is(1));
+
+    assertThat(coordinateCalculator.calculateColumn(4), is(1));
+    assertThat(coordinateCalculator.calculateRow(4), is(1));
+
+    assertThat(coordinateCalculator.calculateColumn(5), is(2));
+    assertThat(coordinateCalculator.calculateRow(5), is(1));
+
+    // third row
+    assertThat(coordinateCalculator.calculateColumn(6), is(0));
+    assertThat(coordinateCalculator.calculateRow(6), is(2));
+
+    assertThat(coordinateCalculator.calculateColumn(7), is(1));
+    assertThat(coordinateCalculator.calculateRow(7), is(2));
+
+    assertThat(coordinateCalculator.calculateColumn(8), is(2));
+    assertThat(coordinateCalculator.calculateRow(8), is(2));
+  }
+}


### PR DESCRIPTION
Calling a layout method on JPanelBuilder now returns a specific layout builder.
This allows for layout specific methods to be available only after invoking
that layout. For example, before a flowlayout could be used with a 'addNorth'
method, specific to border layout.

In addition, as a new feature, We add a new method to GridBagLayout to have an
'add(Component, GridbagConstraint)' method.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[x] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix:  <!-- Link to bug issue or forum post here -->
[ ] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[x] Manually tested
[ ] No testing done
<!-- If manually tested, summarize the testing done below this line. -->

Checked various UI windows to look for rendering problems

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes

SimpleGridBagLayout is not yet used. Most of the test code added revolves around it.


<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

