### PR TITLE
Cleanup: HTTP Client consolidate header annotation

### DIFF
--- a/http-clients/src/main/java/org/triplea/http/client/error/report/ErrorUploadClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/error/report/ErrorUploadClient.java
@@ -9,6 +9,7 @@ import org.triplea.http.client.HttpConstants;
 
 /** Http client to upload error reports to the http lobby server. */
 @SuppressWarnings("InterfaceNeverImplemented")
+@Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
 public interface ErrorUploadClient {
 
   String ERROR_REPORT_PATH = "/error-report";
@@ -21,7 +22,6 @@ public interface ErrorUploadClient {
    * @throws FeignException Thrown on non-2xx responses.
    */
   @RequestLine("POST " + ERROR_REPORT_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   ErrorUploadResponse uploadErrorReport(ErrorUploadRequest request);
 
   /** Creates an error report uploader clients, sends error reports and gets a response back. */

--- a/http-clients/src/main/java/org/triplea/http/client/forgot/password/ForgotPasswordClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/forgot/password/ForgotPasswordClient.java
@@ -12,6 +12,7 @@ import org.triplea.http.client.HttpConstants;
  * user.
  */
 @SuppressWarnings("InterfaceNeverImplemented")
+@Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
 public interface ForgotPasswordClient {
 
   String FORGOT_PASSWORD_PATH = "/forgot-password";
@@ -22,7 +23,6 @@ public interface ForgotPasswordClient {
    * @throws FeignException Thrown on non-2xx responses.
    */
   @RequestLine("POST " + FORGOT_PASSWORD_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   ForgotPasswordResponse sendForgotPasswordRequest(ForgotPasswordRequest request);
 
   /** Creates an error report uploader clients, sends error reports and gets a response back. */

--- a/http-clients/src/main/java/org/triplea/http/client/github/issues/GithubClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/github/issues/GithubClient.java
@@ -14,6 +14,7 @@ import org.triplea.http.client.error.report.ErrorUploadRequest;
 import org.triplea.http.client.github.issues.create.CreateIssueResponse;
 
 @SuppressWarnings("InterfaceNeverImplemented")
+@Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
 interface GithubClient {
 
   @VisibleForTesting String CREATE_ISSUE_PATH = "/repos/{org}/{repo}/issues";
@@ -24,7 +25,6 @@ interface GithubClient {
    * @throws FeignException Thrown on non-2xx responses.
    */
   @RequestLine("POST " + CREATE_ISSUE_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   CreateIssueResponse newIssue(
       @HeaderMap Map<String, Object> headerMap,
       @Param("org") String org,

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/login/LobbyLoginClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/login/LobbyLoginClient.java
@@ -11,7 +11,7 @@ import org.triplea.http.client.HttpConstants;
  * use this to gain a single-use token that can be used to establish a non-https socket connection.
  */
 @SuppressWarnings("InterfaceNeverImplemented")
-// TODO: Project#12 - move to package org.triplea.http.client.account.login
+@Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
 public interface LobbyLoginClient {
 
   String LOGIN_PATH = "/login";
@@ -37,7 +37,6 @@ public interface LobbyLoginClient {
    * </pre>
    */
   @RequestLine("POST " + LOGIN_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   LobbyLoginResponse login(RegisteredUserLoginRequest loginRequest);
 
   /**
@@ -57,6 +56,5 @@ public interface LobbyLoginClient {
    * </pre>
    */
   @RequestLine("POST " + ANONYMOUS_LOGIN_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   LobbyLoginResponse anonymousLogin(String name);
 }

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/user/account/UserAccountFeignClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/user/account/UserAccountFeignClient.java
@@ -6,16 +6,14 @@ import feign.RequestLine;
 import java.util.Map;
 import org.triplea.http.client.HttpConstants;
 
+@Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
 interface UserAccountFeignClient {
   @RequestLine("POST " + UserAccountClient.CHANGE_PASSWORD_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   void changePassword(@HeaderMap Map<String, Object> headers, String newPassword);
 
   @RequestLine("GET " + UserAccountClient.FETCH_EMAIL_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   FetchEmailResponse fetchEmail(@HeaderMap Map<String, Object> headers);
 
   @RequestLine("POST " + UserAccountClient.CHANGE_EMAIL_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   void changeEmail(@HeaderMap Map<String, Object> headers, String newEmail);
 }

--- a/http-clients/src/main/java/org/triplea/http/client/moderator/toolbox/access/log/ToolboxAccessLogFeignClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/moderator/toolbox/access/log/ToolboxAccessLogFeignClient.java
@@ -8,9 +8,9 @@ import java.util.Map;
 import org.triplea.http.client.HttpConstants;
 import org.triplea.http.client.moderator.toolbox.PagingParams;
 
+@Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
 interface ToolboxAccessLogFeignClient {
   @RequestLine("POST " + ToolboxAccessLogClient.FETCH_ACCESS_LOG_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   List<AccessLogData> getAccessLog(
       @HeaderMap Map<String, Object> headers, PagingParams pagingParams);
 }

--- a/http-clients/src/main/java/org/triplea/http/client/moderator/toolbox/bad/words/ToolboxBadWordsFeignClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/moderator/toolbox/bad/words/ToolboxBadWordsFeignClient.java
@@ -7,16 +7,14 @@ import java.util.List;
 import java.util.Map;
 import org.triplea.http.client.HttpConstants;
 
+@Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
 interface ToolboxBadWordsFeignClient {
   @RequestLine("POST " + ToolboxBadWordsClient.BAD_WORD_REMOVE_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   void removeBadWord(@HeaderMap Map<String, Object> headerMap, String word);
 
   @RequestLine("POST " + ToolboxBadWordsClient.BAD_WORD_ADD_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   void addBadWord(@HeaderMap Map<String, Object> headerMap, String word);
 
   @RequestLine("GET " + ToolboxBadWordsClient.BAD_WORD_GET_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   List<String> getBadWords(@HeaderMap Map<String, Object> headerMap);
 }

--- a/http-clients/src/main/java/org/triplea/http/client/moderator/toolbox/banned/name/ToolboxUsernameBanFeignClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/moderator/toolbox/banned/name/ToolboxUsernameBanFeignClient.java
@@ -7,17 +7,15 @@ import java.util.List;
 import java.util.Map;
 import org.triplea.http.client.HttpConstants;
 
+@Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
 interface ToolboxUsernameBanFeignClient {
 
   @RequestLine("POST " + ToolboxUsernameBanClient.REMOVE_BANNED_USER_NAME_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   void removeUsernameBan(@HeaderMap Map<String, Object> headers, String username);
 
   @RequestLine("POST " + ToolboxUsernameBanClient.ADD_BANNED_USER_NAME_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   void addUsernameBan(@HeaderMap Map<String, Object> headers, String username);
 
   @RequestLine("GET " + ToolboxUsernameBanClient.GET_BANNED_USER_NAMES_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   List<UsernameBanData> getUsernameBans(@HeaderMap Map<String, Object> headers);
 }

--- a/http-clients/src/main/java/org/triplea/http/client/moderator/toolbox/banned/user/ToolboxUserBanFeignClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/moderator/toolbox/banned/user/ToolboxUserBanFeignClient.java
@@ -7,17 +7,15 @@ import java.util.List;
 import java.util.Map;
 import org.triplea.http.client.HttpConstants;
 
+@Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
 interface ToolboxUserBanFeignClient {
 
   @RequestLine("GET " + ToolboxUserBanClient.GET_USER_BANS_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   List<UserBanData> getUserBans(@HeaderMap Map<String, Object> headers);
 
   @RequestLine("POST " + ToolboxUserBanClient.REMOVE_USER_BAN_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   void removeUserBan(@HeaderMap Map<String, Object> headers, String banId);
 
   @RequestLine("POST " + ToolboxUserBanClient.BAN_USER_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   void banUser(@HeaderMap Map<String, Object> headers, UserBanParams banUserParams);
 }

--- a/http-clients/src/main/java/org/triplea/http/client/moderator/toolbox/event/log/ToolboxEventLogFeignClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/moderator/toolbox/event/log/ToolboxEventLogFeignClient.java
@@ -8,9 +8,9 @@ import java.util.Map;
 import org.triplea.http.client.HttpConstants;
 import org.triplea.http.client.moderator.toolbox.PagingParams;
 
+@Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
 interface ToolboxEventLogFeignClient {
   @RequestLine("POST " + ToolboxEventLogClient.AUDIT_HISTORY_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   List<ModeratorEvent> lookupModeratorEvents(
       @HeaderMap Map<String, Object> headerMap, PagingParams params);
 }

--- a/http-clients/src/main/java/org/triplea/http/client/moderator/toolbox/moderator/management/ToolboxModeratorManagementFeignClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/moderator/toolbox/moderator/management/ToolboxModeratorManagementFeignClient.java
@@ -7,28 +7,23 @@ import java.util.List;
 import java.util.Map;
 import org.triplea.http.client.HttpConstants;
 
+@Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
 interface ToolboxModeratorManagementFeignClient {
   @RequestLine("GET " + ToolboxModeratorManagementClient.FETCH_MODERATORS_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   List<ModeratorInfo> fetchModerators(@HeaderMap Map<String, Object> headerMap);
 
   @RequestLine("GET " + ToolboxModeratorManagementClient.IS_SUPER_MOD_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   boolean isSuperMod(@HeaderMap Map<String, Object> headerMap);
 
   @RequestLine("POST " + ToolboxModeratorManagementClient.ADD_SUPER_MOD_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   void addSuperMod(@HeaderMap Map<String, Object> headers, String moderatorName);
 
   @RequestLine("POST " + ToolboxModeratorManagementClient.REMOVE_MOD_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   void removeMod(@HeaderMap Map<String, Object> headers, String moderatorName);
 
   @RequestLine("POST " + ToolboxModeratorManagementClient.CHECK_USER_EXISTS_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   boolean checkUserExists(@HeaderMap Map<String, Object> headers, String username);
 
   @RequestLine("POST " + ToolboxModeratorManagementClient.ADD_MODERATOR_PATH)
-  @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
   void addModerator(@HeaderMap Map<String, Object> headers, String username);
 }


### PR DESCRIPTION
Http header annotation can be defined either at the method level, or class level
where it applies to all methods. Http clients tend to all use the same header,
to reduce redunancy, this update moves such header annotation tags to class level.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[x] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix:  <!-- Link to bug issue or forum post here -->
[ ] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to any that apply -->

[x] Covered by existing automated tests
[ ] Covered by newly added automated tests
[ ] Manually tested
[ ] No testing done
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

