### PR TITLE
Cleanup: use 'getUserIdOrThrow' api

### DIFF
--- a/http-server/src/main/java/org/triplea/server/user/account/UserAccountController.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/UserAccountController.java
@@ -33,10 +33,9 @@ public class UserAccountController {
   public Response changePassword(
       @Auth final AuthenticatedUser authenticatedUser, final String newPassword) {
     ArgChecker.checkNotEmpty(newPassword);
-    // TODO: Project#12 use 'getUserIdOrThrow'
-    Preconditions.checkArgument(authenticatedUser.getUserId() > 0);
+    Preconditions.checkArgument(authenticatedUser.getUserIdOrThrow() > 0);
 
-    userAccountService.changePassword(authenticatedUser.getUserId(), newPassword);
+    userAccountService.changePassword(authenticatedUser.getUserIdOrThrow(), newPassword);
     return Response.ok().build();
   }
 
@@ -44,10 +43,10 @@ public class UserAccountController {
   @Path(UserAccountClient.FETCH_EMAIL_PATH)
   @RolesAllowed(UserRole.PLAYER)
   public FetchEmailResponse fetchEmail(@Auth final AuthenticatedUser authenticatedUser) {
-    Preconditions.checkArgument(authenticatedUser.getUserId() > 0);
+    Preconditions.checkArgument(authenticatedUser.getUserIdOrThrow() > 0);
 
-    final String email = userAccountService.fetchEmail(authenticatedUser.getUserId());
-    return new FetchEmailResponse(email);
+    return new FetchEmailResponse(
+        userAccountService.fetchEmail(authenticatedUser.getUserIdOrThrow()));
   }
 
   @POST
@@ -56,9 +55,9 @@ public class UserAccountController {
   public Response changeEmail(
       @Auth final AuthenticatedUser authenticatedUser, final String newEmail) {
     ArgChecker.checkNotEmpty(newEmail);
-    Preconditions.checkArgument(authenticatedUser.getUserId() > 0);
+    Preconditions.checkArgument(authenticatedUser.getUserIdOrThrow() > 0);
 
-    userAccountService.changeEmail(authenticatedUser.getUserId(), newEmail);
+    userAccountService.changeEmail(authenticatedUser.getUserIdOrThrow(), newEmail);
     return Response.ok().build();
   }
 }

--- a/http-server/src/test/java/org/triplea/server/user/account/UserAccountControllerTest.java
+++ b/http-server/src/test/java/org/triplea/server/user/account/UserAccountControllerTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.sun.mail.imap.protocol.FetchResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/http-server/src/test/java/org/triplea/server/user/account/UserAccountControllerTest.java
+++ b/http-server/src/test/java/org/triplea/server/user/account/UserAccountControllerTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.sun.mail.imap.protocol.FetchResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -37,22 +38,22 @@ class UserAccountControllerTest {
   void changePassword() {
     userAccountController.changePassword(AUTHENTICATED_USER, NEW_PASSWORD);
 
-    verify(userAccountService).changePassword(AUTHENTICATED_USER.getUserId(), NEW_PASSWORD);
+    verify(userAccountService).changePassword(AUTHENTICATED_USER.getUserIdOrThrow(), NEW_PASSWORD);
   }
 
   @Test
   void fetchEmail() {
-    when(userAccountService.fetchEmail(AUTHENTICATED_USER.getUserId())).thenReturn(EMAIL);
+    when(userAccountService.fetchEmail(AUTHENTICATED_USER.getUserIdOrThrow())).thenReturn(EMAIL);
 
     final FetchEmailResponse response = userAccountController.fetchEmail(AUTHENTICATED_USER);
 
-    assertThat(response.getUserEmail(), is(EMAIL));
+    assertThat(response, is(new FetchEmailResponse(EMAIL)));
   }
 
   @Test
   void changeEmail() {
     userAccountController.changeEmail(AUTHENTICATED_USER, EMAIL);
 
-    verify(userAccountService).changeEmail(AUTHENTICATED_USER.getUserId(), EMAIL);
+    verify(userAccountService).changeEmail(AUTHENTICATED_USER.getUserIdOrThrow(), EMAIL);
   }
 }


### PR DESCRIPTION
Simple use 'getUserIdOrThrow' api instead of 'getUserid'
- Removes IDE warnings over potential NPE
- Updated method provides additional validation


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[x] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix:  <!-- Link to bug issue or forum post here -->
[ ] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to any that apply -->

[x] Covered by existing automated tests
[ ] Covered by newly added automated tests
[ ] Manually tested
[ ] No testing done
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

