### PR TITLE
Fix mouse offset on smaller maps

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -640,8 +640,8 @@ public class MapPanel extends ImageScrollerLargeView {
     g2d.clip(new Rectangle2D.Double(0, 0, getImageWidth(), getImageHeight()));
     final boolean fittingWidth = mapWidthFitsOnScreen();
     final boolean fittingHeight = mapHeightFitsOnScreen();
-    int x = fittingWidth ? 0 : model.getX();
-    int y = fittingHeight ? 0 : model.getY();
+    int x = getXOffset();
+    int y = getYOffset();
     final List<Tile> images = new ArrayList<>();
     final List<Tile> undrawnTiles = new ArrayList<>();
     // make sure we use the same data for the entire paint
@@ -739,6 +739,16 @@ public class MapPanel extends ImageScrollerLargeView {
                   }
                   SwingUtilities.invokeLater(MapPanel.this::repaint);
                 }));
+  }
+
+  @Override
+  public int getXOffset() {
+    return mapWidthFitsOnScreen() ? 0 : model.getX();
+  }
+
+  @Override
+  public int getYOffset() {
+    return mapHeightFitsOnScreen() ? 0 : model.getY();
   }
 
   private void clearPendingDrawOperations() {


### PR DESCRIPTION
<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 
This should hopefully fix https://forums.triplea-game.org/topic/1558/more-problem-with-small-maps

I hope I there aren't any unintended consequences, but it seems to work correctly.

I'd appreciate if the reviewer could check one or 2 uncommon maps, I checked Hexglobe FFA, Minimap and Classic WW 3rd, they all looked fine

## Functional Changes
<!-- Put an X next any that apply -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[x] Bug fix:  <!-- Link to bug issue or forum post here -->
[ ] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[x] Manually tested
[ ] No testing done
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

