### PR TITLE
Remove "me" messages & unused method 'speakerTagUpdated'

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/Chat.java
@@ -67,27 +67,13 @@ public class Chat {
             return;
           }
           synchronized (mutexNodes) {
-            chatHistory.add(new ChatMessage(message, from.getName(), false));
+            chatHistory.add(new ChatMessage(message, from.getName()));
             for (final IChatListener listener : listeners) {
-              listener.addMessage(message, from.getName(), false);
+              listener.addMessage(message, from.getName());
             }
             // limit the number of messages in our history.
             while (chatHistory.size() > 1000) {
               chatHistory.remove(0);
-            }
-          }
-        }
-
-        @Override
-        public void meMessageOccurred(final String message) {
-          final INode from = MessageContext.getSender();
-          if (isIgnored(from)) {
-            return;
-          }
-          synchronized (mutexNodes) {
-            chatHistory.add(new ChatMessage(message, from.getName(), true));
-            for (final IChatListener listener : listeners) {
-              listener.addMessage(message, from.getName(), true);
             }
           }
         }
@@ -132,15 +118,6 @@ public class Chat {
         }
 
         @Override
-        public void speakerTagUpdated(final INode node, final Tag tag) {
-          synchronized (mutexNodes) {
-            notesMap.remove(node);
-            addToNotesMap(node, tag);
-            updateConnections();
-          }
-        }
-
-        @Override
         public void slapOccurred(final String to) {
           final INode from = MessageContext.getSender();
           if (isIgnored(from)) {
@@ -157,8 +134,8 @@ public class Chat {
 
         private void handleSlap(final String message, final INode from) {
           for (final IChatListener listener : listeners) {
-            chatHistory.add(new ChatMessage(message, from.getName(), false));
-            listener.addMessageWithSound(message, from.getName(), false, SoundPath.CLIP_CHAT_SLAP);
+            chatHistory.add(new ChatMessage(message, from.getName()));
+            listener.addMessageWithSound(message, from.getName(), SoundPath.CLIP_CHAT_SLAP);
           }
         }
 
@@ -303,15 +280,11 @@ public class Chat {
     remote.slapOccurred(playerName);
   }
 
-  public void sendMessage(final String message, final boolean meMessage) {
+  public void sendMessage(final String message) {
     final IChatChannel remote =
         (IChatChannel)
             messengers.getChannelBroadcaster(new RemoteName(chatChannelName, IChatChannel.class));
-    if (meMessage) {
-      remote.meMessageOccurred(message);
-    } else {
-      remote.chatOccurred(message);
-    }
+    remote.chatOccurred(message);
     sentMessages.append(message);
   }
 

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatMessage.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatMessage.java
@@ -1,25 +1,11 @@
 package games.strategy.engine.chat;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
 class ChatMessage {
   private final String message;
   private final String from;
-  private final boolean isMyMessage;
-
-  ChatMessage(final String message, final String from, final boolean isMyMessage) {
-    this.message = message;
-    this.from = from;
-    this.isMyMessage = isMyMessage;
-  }
-
-  String getFrom() {
-    return from;
-  }
-
-  boolean isMyMessage() {
-    return isMyMessage;
-  }
-
-  String getMessage() {
-    return message;
-  }
 }

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
@@ -226,11 +226,10 @@ public class ChatPlayerPanel extends JPanel implements IChatListener {
   }
 
   @Override
-  public void addMessageWithSound(
-      final String message, final String from, final boolean thirdPerson, final String sound) {}
+  public void addMessageWithSound(final String message, final String from, final String sound) {}
 
   @Override
-  public void addMessage(final String message, final String from, final boolean thirdPerson) {}
+  public void addMessage(final String message, final String from) {}
 
   private String getDisplayString(final INode node) {
     if (chat == null) {

--- a/game-core/src/main/java/games/strategy/engine/chat/IChatChannel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/IChatChannel.java
@@ -14,15 +14,11 @@ public interface IChatChannel extends IChannelSubscriber {
   // we get the sender from MessageContext
   void chatOccurred(String message);
 
-  void meMessageOccurred(String message);
-
   void slapOccurred(String playerName);
 
   void speakerAdded(INode node, Tag tag, long version);
 
   void speakerRemoved(INode node, long version);
-
-  void speakerTagUpdated(INode node, Tag tag);
 
   // purely here to keep connections open and stop NATs and crap from thinking that our connection
   // is closed when it is

--- a/game-core/src/main/java/games/strategy/engine/chat/IChatListener.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/IChatListener.java
@@ -7,9 +7,9 @@ import java.util.Collection;
 public interface IChatListener {
   void updatePlayerList(Collection<INode> players);
 
-  void addMessage(String message, String from, boolean thirdPerson);
+  void addMessage(String message, String from);
 
-  void addMessageWithSound(String message, String from, boolean thirdPerson, String sound);
+  void addMessageWithSound(String message, String from, String sound);
 
   void addStatusMessage(String message);
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -422,7 +422,7 @@ public class ClientModel implements IMessengerErrorListener {
     // disconnected.
     if (chatPanel != null) {
       Optional.ofNullable(chatPanel.getChat())
-          .ifPresent(chat -> chat.sendMessage("*** Was Disconnected ***", false));
+          .ifPresent(chat -> chat.sendMessage("*** Was Disconnected ***"));
     }
     EventThreadJOptionPane.showMessageDialog(
         ui,

--- a/game-core/src/test/java/games/strategy/engine/chat/ChatIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/chat/ChatIntegrationTest.java
@@ -162,8 +162,7 @@ final class ChatIntegrationTest {
   }
 
   private static void sendMessagesFrom(final Chat node) {
-    new Thread(
-            () -> IntStream.range(0, MESSAGE_COUNT).forEach(i -> node.sendMessage("Test", false)))
+    new Thread(() -> IntStream.range(0, MESSAGE_COUNT).forEach(i -> node.sendMessage("Test")))
         .start();
   }
 
@@ -183,15 +182,14 @@ final class ChatIntegrationTest {
     }
 
     @Override
-    public void addMessageWithSound(
-        final String message, final String from, final boolean thirdPerson, final String sound) {
+    public void addMessageWithSound(final String message, final String from, final String sound) {
       lastMessageReceived.set(message);
       messageCount.incrementAndGet();
     }
 
     @Override
-    public void addMessage(final String message, final String from, final boolean thirdPerson) {
-      addMessageWithSound(message, from, thirdPerson, SoundPath.CLIP_CHAT_MESSAGE);
+    public void addMessage(final String message, final String from) {
+      addMessageWithSound(message, from, SoundPath.CLIP_CHAT_MESSAGE);
     }
 
     @Override

--- a/game-headless/src/main/java/org/triplea/game/server/debug/ChatHandler.java
+++ b/game-headless/src/main/java/org/triplea/game/server/debug/ChatHandler.java
@@ -66,7 +66,7 @@ public final class ChatHandler extends Handler {
   private static void sendChatMessage(final String message) {
     Optional.ofNullable(HeadlessGameServer.getInstance())
         .map(HeadlessGameServer::getChat)
-        .ifPresent(chat -> chat.sendMessage(message, false));
+        .ifPresent(chat -> chat.sendMessage(message));
   }
 
   private String formatChatMessage(final LogRecord record) {


### PR DESCRIPTION
(1) Unadvertised feature, pretty obviously implemented with copy/paste, not necessary as '3rd person' 
messages are often simulated with other means, such as square bracketted messages.

Discussed in: https://forums.triplea-game.org/topic/1571/undocumented-chat-features

(2) speakerTagUpdated is simply unused, intended to allow for moderator tag to be updated dynamically.
Given how often moderators change, It is just as well to rejoin chat to view the moderator tag.

<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[x] Feature Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix:  <!-- Link to bug issue or forum post here -->
[ ] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[ ] Manually tested
[x] No testing done
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

