### PR TITLE
Wire Https Port to Server Games

### DIFF
--- a/.travis/run_smoke_tests
+++ b/.travis/run_smoke_tests
@@ -74,6 +74,7 @@ function startBot() {
     -Dtriplea.name=Bot01Testing \
     -Dtriplea.lobby.host=localhost \
     -Dtriplea.lobby.port=3304 \
+    -Dtriplea.lobby.https.port=8080 \
     -Dtriplea.lobby.game.supportPassword= \
     -Dtriplea.map.folder=~/triplea/downloadedMaps/ \
     -jar "$BOT_JAR_PATH" > "$BOT_OUTPUT" 2>&1 &

--- a/game-core/src/main/java/games/strategy/engine/framework/CliProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/CliProperties.java
@@ -11,6 +11,7 @@ public class CliProperties {
   public static final String SERVER_PASSWORD = "triplea.server.password";
   public static final String LOBBY_HOST = "triplea.lobby.host";
   public static final String LOBBY_PORT = "triplea.lobby.port";
+  public static final String LOBBY_HTTPS_PORT = "triplea.lobby.https.port";
   public static final String LOBBY_GAME_COMMENTS = "triplea.lobby.game.comments";
   public static final String LOBBY_GAME_SUPPORT_PASSWORD = "triplea.lobby.game.supportPassword";
   public static final String MAP_FOLDER = "triplea.map.folder";

--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static games.strategy.engine.framework.CliProperties.LOBBY_GAME_COMMENTS;
 import static games.strategy.engine.framework.CliProperties.LOBBY_HOST;
+import static games.strategy.engine.framework.CliProperties.LOBBY_HTTPS_PORT;
 import static games.strategy.engine.framework.CliProperties.LOBBY_PORT;
 import static games.strategy.engine.framework.CliProperties.SERVER_PASSWORD;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_CLIENT;
@@ -22,6 +23,7 @@ import games.strategy.engine.framework.startup.mc.SetupPanelModel;
 import games.strategy.engine.framework.startup.ui.panels.main.MainPanelBuilder;
 import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.engine.framework.ui.background.BackgroundTaskRunner;
+import games.strategy.engine.lobby.client.login.LobbyServerProperties;
 import games.strategy.triplea.ai.pro.ProAi;
 import java.awt.Component;
 import java.awt.FileDialog;
@@ -227,15 +229,15 @@ public final class GameRunner {
       final String playerName,
       final String comments,
       final String password,
-      final String lobbyHostAddress,
-      final int lobbyPort) {
+      final LobbyServerProperties lobbyServerProperties) {
     final List<String> commands = new ArrayList<>();
     ProcessRunnerUtil.populateBasicJavaArgs(commands);
     commands.add("-D" + TRIPLEA_SERVER + "=true");
     commands.add("-D" + TRIPLEA_PORT + "=" + port);
     commands.add("-D" + TRIPLEA_NAME + "=" + playerName);
-    commands.add("-D" + LOBBY_HOST + "=" + lobbyHostAddress);
-    commands.add("-D" + LOBBY_PORT + "=" + lobbyPort);
+    commands.add("-D" + LOBBY_HOST + "=" + lobbyServerProperties.getHost());
+    commands.add("-D" + LOBBY_PORT + "=" + lobbyServerProperties.getPort());
+    commands.add("-D" + LOBBY_HTTPS_PORT + "=" + lobbyServerProperties.getHttpsPort());
     commands.add("-D" + LOBBY_GAME_COMMENTS + "=" + comments);
     if (password != null && password.length() > 0) {
       commands.add("-D" + SERVER_PASSWORD + "=" + password);

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -2,6 +2,7 @@ package games.strategy.engine.framework.startup.ui;
 
 import static games.strategy.engine.framework.CliProperties.LOBBY_GAME_COMMENTS;
 import static games.strategy.engine.framework.CliProperties.LOBBY_HOST;
+import static games.strategy.engine.framework.CliProperties.LOBBY_HTTPS_PORT;
 import static games.strategy.engine.framework.CliProperties.LOBBY_PORT;
 import static games.strategy.engine.framework.CliProperties.SERVER_PASSWORD;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_NAME;
@@ -189,8 +190,10 @@ public class InGameLobbyWatcher {
     Preconditions.checkNotNull(handler);
     final @Nullable String host = getLobbySystemProperty(LOBBY_HOST);
     final @Nullable String port = getLobbySystemProperty(LOBBY_PORT);
+    final @Nullable String httpsPort = getLobbySystemProperty(LOBBY_HTTPS_PORT);
+    // TODO: Project#12 use https port
     final @Nullable String hostedBy = getLobbySystemProperty(TRIPLEA_NAME);
-    if (host == null || port == null) {
+    if (host == null || port == null || httpsPort == null) {
       return null;
     }
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/LobbyClient.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/LobbyClient.java
@@ -64,14 +64,6 @@ public class LobbyClient {
     return messengers.getLocalNode().getName();
   }
 
-  public String getLobbyHostAddress() {
-    return messengers.getRemoteServerSocketAddress().getAddress().getHostAddress();
-  }
-
-  public int getLobbyPort() {
-    return messengers.getRemoteServerSocketAddress().getPort();
-  }
-
   public IModeratorController getModeratorController() {
     return (IModeratorController) messengers.getRemote(IModeratorController.REMOTE_NAME);
   }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -55,7 +55,7 @@ public class LobbyFrame extends JFrame {
 
     final LobbyGameTableModel tableModel =
         new LobbyGameTableModel(client.isAdmin(), client.getMessengers());
-    final LobbyGamePanel gamePanel = new LobbyGamePanel(client, tableModel);
+    final LobbyGamePanel gamePanel = new LobbyGamePanel(client, lobbyServerProperties, tableModel);
 
     final JSplitPane leftSplit = new JSplitPane();
     leftSplit.setOrientation(JSplitPane.VERTICAL_SPLIT);

--- a/game-core/src/main/java/games/strategy/net/ClientMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ClientMessenger.java
@@ -269,11 +269,6 @@ public class ClientMessenger implements IClientMessenger, NioSocketListener {
   }
 
   @Override
-  public InetSocketAddress getRemoteServerSocketAddress() {
-    return (InetSocketAddress) socketChannel.socket().getRemoteSocketAddress();
-  }
-
-  @Override
   public void addConnectionChangeListener(final IConnectionChangeListener listener) {}
 
   @Override

--- a/game-core/src/main/java/games/strategy/net/IMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/IMessenger.java
@@ -1,7 +1,6 @@
 package games.strategy.net;
 
 import java.io.Serializable;
-import java.net.InetSocketAddress;
 
 /**
  * A simple way to connect multiple socket end points. An IMessenger listens for incoming messages,
@@ -36,14 +35,6 @@ public interface IMessenger {
 
   /** Returns the local node if we are a server node. */
   INode getServerNode();
-
-  /**
-   * Get the socket address to which we talk to the server. This may be different than
-   * getServerNode().getSocketAddress() since the server will report the socket that he thinks the
-   * server is running on, if the server is behind a firewall, or a NAT, then this socket will be
-   * different than the actual port we use.
-   */
-  InetSocketAddress getRemoteServerSocketAddress();
 
   /** Add a listener for change in connection status. */
   void addConnectionChangeListener(IConnectionChangeListener listener);

--- a/game-core/src/main/java/games/strategy/net/LocalNoOpMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/LocalNoOpMessenger.java
@@ -3,7 +3,6 @@ package games.strategy.net;
 import games.strategy.engine.lobby.ApiKey;
 import games.strategy.engine.lobby.PlayerName;
 import java.io.Serializable;
-import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
 import java.util.Set;
 import java.util.function.Function;
@@ -49,11 +48,6 @@ public class LocalNoOpMessenger implements IServerMessenger {
   @Override
   public INode getServerNode() {
     return node;
-  }
-
-  @Override
-  public InetSocketAddress getRemoteServerSocketAddress() {
-    return null;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/net/Messengers.java
+++ b/game-core/src/main/java/games/strategy/net/Messengers.java
@@ -13,7 +13,6 @@ import games.strategy.engine.message.RemoteMessenger;
 import games.strategy.engine.message.RemoteName;
 import games.strategy.engine.message.unifiedmessenger.UnifiedMessenger;
 import java.io.Serializable;
-import java.net.InetSocketAddress;
 import lombok.ToString;
 
 /** Convenience grouping of a messenger, remote messenger and channel messenger. */
@@ -152,11 +151,6 @@ public class Messengers implements IMessenger, IRemoteMessenger, IChannelMesseng
   @Override
   public INode getServerNode() {
     return messenger.getServerNode();
-  }
-
-  @Override
-  public InetSocketAddress getRemoteServerSocketAddress() {
-    return messenger.getRemoteServerSocketAddress();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ServerMessenger.java
@@ -357,11 +357,6 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
   }
 
   @Override
-  public InetSocketAddress getRemoteServerSocketAddress() {
-    return node.getSocketAddress();
-  }
-
-  @Override
   public String toString() {
     return getClass().getSimpleName()
         + " LocalNode:"

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -3,6 +3,7 @@ package org.triplea.game.server;
 import static games.strategy.engine.framework.CliProperties.LOBBY_GAME_COMMENTS;
 import static games.strategy.engine.framework.CliProperties.LOBBY_GAME_SUPPORT_PASSWORD;
 import static games.strategy.engine.framework.CliProperties.LOBBY_HOST;
+import static games.strategy.engine.framework.CliProperties.LOBBY_HTTPS_PORT;
 import static games.strategy.engine.framework.CliProperties.LOBBY_PORT;
 import static games.strategy.engine.framework.CliProperties.MAP_FOLDER;
 import static games.strategy.engine.framework.CliProperties.TRIPLEA_GAME;
@@ -565,6 +566,9 @@ public class HeadlessGameServer {
             + "   "
             + LOBBY_PORT
             + "=<LOBBY_PORT>\n"
+            + "   "
+            + LOBBY_HTTPS_PORT
+            + "=<LOBBY_HTTPS_PORT>\n"
             + "   "
             + LOBBY_GAME_SUPPORT_PASSWORD
             + "=<password for remote actions, such as remote stop game>\n"


### PR DESCRIPTION
- Use LobbyServerProperties object to pass lobby properties, this results in simplifications
where we no longer need to get lobby properties from LobbyClient

- Pass HTTPs port to bot via args.

Net result is HTTPS port should become available to hosted games.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[ ] New map or map update
[ ] New Feature
[x] Feature update or enhancement
[ ] Feature Removal
[x] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix:  <!-- Link to bug issue or forum post here -->
[ ] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to any that apply -->

[x] Covered by existing automated tests
[ ] Covered by newly added automated tests
[ ] Manually tested
[ ] No testing done
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

