### PR TITLE
Enhance debugging for RemoteNotFoundException

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/message/UnifiedMessengerHub.java
+++ b/game-core/src/main/java/games/strategy/engine/message/UnifiedMessengerHub.java
@@ -14,8 +14,10 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import lombok.extern.java.Log;
 
 /** The hub node in a spoke-hub messaging architecture. */
+@Log
 public class UnifiedMessengerHub implements IMessageListener, IConnectionChangeListener {
   private final UnifiedMessenger localUnified;
   // the messenger we are based on
@@ -47,6 +49,7 @@ public class UnifiedMessengerHub implements IMessageListener, IConnectionChangeL
     if (msg instanceof HasEndPointImplementor) {
       synchronized (endPointMutex) {
         final HasEndPointImplementor hasEndPoint = (HasEndPointImplementor) msg;
+        log.info("Adding endpoint: " + hasEndPoint + ", from: " + from);
         final Collection<INode> nodes =
             endPoints.computeIfAbsent(hasEndPoint.endPointName, k -> new ArrayList<>());
         if (nodes.contains(from)) {
@@ -87,7 +90,11 @@ public class UnifiedMessengerHub implements IMessageListener, IConnectionChangeL
         if (invoke.needReturnValues) {
           final RemoteMethodCallResults results =
               new RemoteMethodCallResults(
-                  new RemoteNotFoundException("Not found:" + invoke.call.getRemoteName()));
+                  new RemoteNotFoundException(
+                      "Not found:"
+                          + invoke.call.getRemoteName()
+                          + ", endpoints available: "
+                          + endPoints.keySet()));
           send(new SpokeInvocationResults(results, invoke.methodCallId), from);
         }
         // no end points, this is ok, we are a channel with no implementors

--- a/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
+++ b/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
@@ -93,7 +93,13 @@ public class UnifiedMessenger {
     final List<RemoteMethodCallResults> results =
         local.invokeLocal(remoteCall, number, getLocalNode());
     if (results.size() == 0) {
-      throw new RemoteNotFoundException("Not found:" + endPointName);
+      throw new RemoteNotFoundException(
+          "Not found:"
+              + endPointName
+              + ", method name: "
+              + remoteCall.getMethodName()
+              + ", remote name: "
+              + remoteCall.getRemoteName());
     }
     if (results.size() > 1) {
       throw new IllegalStateException("Too many implementors, got back:" + results);


### PR DESCRIPTION
- Print out endpoints that are available when endpoint is not found
- Add more information to RemoteNotFoundException


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[ ] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix:  <!-- Link to bug issue or forum post here -->
[x] Other:  Debug/Logging Enhancement <!-- Please specify -->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[x] Manually tested
[ ] No testing done
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

Example:

Caused by: games.strategy.engine.message.RemoteNotFoundException: Not found:games.strategy.engine.lobby.server.RemoteHostUtils:Bot01-testbot_lobby_watcher port:4000 ip:127.0.0.1, endpoints available: [games.strategy.engine.lobby.server.RemoteHostUtils:Admin port:3304 ip:2601:601:f00:ed0:0:0:0:1%enp0s10, games.strategy.engine.chat.IStatusChannel.STATUS, games.strategy.engine.chat.IStatusController.STATUS_CONTROLLER, _ChatRmt_LOBBY_CHAT, games.strategy.engine.lobby.server.ModeratorController:Global, games.strategy.engine.lobby.server.IGameController.GAME_CONTROLLER_REMOTE, games.strategy.engine.lobby.server.RemoteHostUtils:Bot01-testbot_lobby_watcher port:59660 ip:127.0.0.1, games.strategy.engine.lobby.server.RemoteHostUtils:Bot01-testbot_lobby_watcher port:59758 ip:127.0.0.1, games.strategy.engine.lobby.server.IGameBroadcaster.CHANNEL, games.strategy.engine.lobby.server.RemoteHostUtils:Bot01-testbot_lobby_watcher port:60050 ip:127.0.0.1, _ChatCtrl_LOBBY_CHAT, games.strategy.engine.lobby.server.RemoteHostUtils:Bot01-testbot_lobby_watcher port:59712 ip:127.0.0.1, games.strategy.engine.lobby.server.USER_MANAGER]
