### PR TITLE
Refactor: Convert 'String' to value object 'PlayerName'

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/ChatFloodControl.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatFloodControl.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.chat;
 
+import games.strategy.engine.lobby.PlayerName;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -14,7 +15,7 @@ class ChatFloodControl {
   static final int WINDOW = ONE_MINUTE;
 
   private final Object lock = new Object();
-  private final Map<String, Integer> messageCount = new HashMap<>();
+  private final Map<PlayerName, Integer> messageCount = new HashMap<>();
   private long clearTime;
 
   ChatFloodControl() {
@@ -25,7 +26,7 @@ class ChatFloodControl {
     clearTime = initialClearTime;
   }
 
-  boolean allow(final String from, final long now) {
+  boolean allow(final PlayerName from, final long now) {
     synchronized (lock) {
       // reset the window
       if (now > clearTime) {

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatIgnoreList.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatIgnoreList.java
@@ -1,32 +1,34 @@
 package games.strategy.engine.chat;
 
-import java.util.Collections;
+import games.strategy.engine.lobby.PlayerName;
+import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.logging.Level;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
+import java.util.stream.Collectors;
 import lombok.extern.java.Log;
 
 @Log
 class ChatIgnoreList {
   private final Object lock = new Object();
-  private final Set<String> ignore = new HashSet<>();
+  private final Set<PlayerName> ignore = new HashSet<>();
 
   ChatIgnoreList() {
     final Preferences prefs = getPrefNode();
     try {
-      Collections.addAll(ignore, prefs.keys());
+      ignore.addAll(Arrays.stream(prefs.keys()).map(PlayerName::of).collect(Collectors.toSet()));
     } catch (final BackingStoreException e) {
       log.log(Level.FINE, e.getMessage(), e);
     }
   }
 
-  void add(final String name) {
+  void add(final PlayerName name) {
     synchronized (lock) {
       ignore.add(name);
       final Preferences prefs = getPrefNode();
-      prefs.put(name, "true");
+      prefs.put(name.getValue(), "true");
       try {
         prefs.flush();
       } catch (final BackingStoreException e) {
@@ -39,11 +41,11 @@ class ChatIgnoreList {
     return Preferences.userNodeForPackage(ChatIgnoreList.class);
   }
 
-  void remove(final String name) {
+  void remove(final PlayerName name) {
     synchronized (lock) {
       ignore.remove(name);
       final Preferences prefs = getPrefNode();
-      prefs.remove(name);
+      prefs.remove(name.getValue());
       try {
         prefs.flush();
       } catch (final BackingStoreException e) {
@@ -52,7 +54,7 @@ class ChatIgnoreList {
     }
   }
 
-  boolean shouldIgnore(final String name) {
+  boolean shouldIgnore(final PlayerName name) {
     synchronized (lock) {
       return ignore.contains(name);
     }

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatMessage.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatMessage.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.chat;
 
+import games.strategy.engine.lobby.PlayerName;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
@@ -7,5 +8,5 @@ import lombok.Getter;
 @Getter
 class ChatMessage {
   private final String message;
-  private final String from;
+  private final PlayerName from;
 }

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
@@ -1,6 +1,7 @@
 package games.strategy.engine.chat;
 
 import com.google.common.base.Ascii;
+import games.strategy.engine.lobby.PlayerName;
 import games.strategy.net.INode;
 import games.strategy.sound.ClipPlayer;
 import games.strategy.sound.SoundPath;
@@ -230,13 +231,13 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
 
   /** thread safe. */
   @Override
-  public void addMessage(final String message, final String from) {
+  public void addMessage(final String message, final PlayerName from) {
     addMessageWithSound(message, from, SoundPath.CLIP_CHAT_MESSAGE);
   }
 
   /** thread safe. */
   @Override
-  public void addMessageWithSound(final String message, final String from, final String sound) {
+  public void addMessageWithSound(final String message, final PlayerName from, final String sound) {
     SwingAction.invokeNowOrLater(
         () -> {
           if (from == null
@@ -247,8 +248,9 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
             return;
           }
           if (!floodControl.allow(from, System.currentTimeMillis())) {
-            if (from.equals(chat.getLocalNode().getName())) {
-              addChatMessage("MESSAGE LIMIT EXCEEDED, TRY AGAIN LATER", "ADMIN_FLOOD_CONTROL");
+            if (from.equals(chat.getLocalNode().getPlayerName())) {
+              addChatMessage(
+                  "MESSAGE LIMIT EXCEEDED, TRY AGAIN LATER", PlayerName.of("ADMIN_FLOOD_CONTROL"));
             }
             return;
           }
@@ -262,11 +264,11 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
         });
   }
 
-  private void addChatMessage(final String originalMessage, final String from) {
+  private void addChatMessage(final String originalMessage, final PlayerName from) {
     // we don't want to truncate messages from the server as those may be logs with accompanying
     // stack traces
     final String message =
-        from.equals(chat.getServerNode().getName())
+        from.equals(chat.getServerNode().getPlayerName())
             ? originalMessage
             : Ascii.truncate(originalMessage, 200, "...");
     final String time = "(" + TimeManager.getLocalizedTime() + ")";

--- a/game-core/src/main/java/games/strategy/engine/chat/HeadlessChat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/HeadlessChat.java
@@ -2,6 +2,7 @@ package games.strategy.engine.chat;
 
 import com.google.common.base.Ascii;
 import games.strategy.engine.chat.Chat.ChatSoundProfile;
+import games.strategy.engine.lobby.PlayerName;
 import games.strategy.net.INode;
 import games.strategy.net.Messengers;
 import games.strategy.sound.ClipPlayer;
@@ -62,7 +63,7 @@ public class HeadlessChat implements IChatListener, ChatModel {
       synchronized (this.chat.getMutex()) {
         allText = new StringBuilder();
         for (final ChatMessage message : this.chat.getChatHistory()) {
-          addChatMessage(message.getMessage(), message.getFrom());
+          addChatMessage(message.getMessage(), message.getFrom().getValue());
         }
       }
     } else {
@@ -72,23 +73,23 @@ public class HeadlessChat implements IChatListener, ChatModel {
 
   /** thread safe. */
   @Override
-  public void addMessage(final String message, final String from) {
+  public void addMessage(final String message, final PlayerName from) {
     addMessageWithSound(message, from, SoundPath.CLIP_CHAT_MESSAGE);
   }
 
   /** thread safe. */
   @Override
-  public void addMessageWithSound(final String message, final String from, final String sound) {
+  public void addMessageWithSound(final String message, final PlayerName from, final String sound) {
     // TODO: I don't really think we need a new thread for this...
     new Thread(
             () -> {
               if (!floodControl.allow(from, System.currentTimeMillis())) {
-                if (from.equals(chat.getLocalNode().getName())) {
+                if (from.equals(chat.getLocalNode().getPlayerName())) {
                   addChatMessage("MESSAGE LIMIT EXCEEDED, TRY AGAIN LATER", "ADMIN_FLOOD_CONTROL");
                 }
                 return;
               }
-              addChatMessage(message, from);
+              addChatMessage(message, from.getValue());
               ClipPlayer.play(sound);
             })
         .start();

--- a/game-core/src/main/java/games/strategy/engine/chat/IChatChannel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/IChatChannel.java
@@ -1,6 +1,7 @@
 package games.strategy.engine.chat;
 
 import games.strategy.engine.chat.IChatController.Tag;
+import games.strategy.engine.lobby.PlayerName;
 import games.strategy.engine.message.IChannelSubscriber;
 import games.strategy.net.INode;
 
@@ -14,7 +15,7 @@ public interface IChatChannel extends IChannelSubscriber {
   // we get the sender from MessageContext
   void chatOccurred(String message);
 
-  void slapOccurred(String playerName);
+  void slapOccurred(PlayerName playerName);
 
   void speakerAdded(INode node, Tag tag, long version);
 

--- a/game-core/src/main/java/games/strategy/engine/chat/IChatListener.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/IChatListener.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.chat;
 
+import games.strategy.engine.lobby.PlayerName;
 import games.strategy.net.INode;
 import java.util.Collection;
 
@@ -7,9 +8,9 @@ import java.util.Collection;
 public interface IChatListener {
   void updatePlayerList(Collection<INode> players);
 
-  void addMessage(String message, String from);
+  void addMessage(String message, PlayerName from);
 
-  void addMessageWithSound(String message, String from, String sound);
+  void addMessageWithSound(String message, PlayerName from, String sound);
 
   void addStatusMessage(String message);
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/ClientGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ClientGame.java
@@ -184,7 +184,7 @@ public class ClientGame extends AbstractGame {
 
   public static RemoteName getRemoteStepAdvancerName(final INode node) {
     return new RemoteName(
-        ClientGame.class.getName() + ".REMOTE_STEP_ADVANCER:" + node.getName(),
+        ClientGame.class.getName() + ".REMOTE_STEP_ADVANCER:" + node.getPlayerName(),
         IGameStepAdvancer.class);
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/network/ui/BanPlayerAction.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/network/ui/BanPlayerAction.java
@@ -47,7 +47,7 @@ public class BanPlayerAction extends AbstractAction {
     for (final INode node : messenger.getNodes()) {
       if (node.getName().equals(name)) {
         final String ip = node.getAddress().getHostAddress();
-        final String mac = messenger.getPlayerMac(node.getName());
+        final String mac = messenger.getPlayerMac(node.getPlayerName());
         messenger.banPlayer(ip, mac);
         messenger.removeConnection(node);
         return;

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
@@ -5,6 +5,7 @@ import games.strategy.engine.framework.HeadlessAutoSaveType;
 import games.strategy.engine.framework.startup.launcher.ILauncher;
 import games.strategy.engine.framework.startup.mc.ClientModel;
 import games.strategy.engine.framework.startup.mc.IRemoteModelListener;
+import games.strategy.engine.lobby.PlayerName;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.GridBagConstraints;
@@ -67,7 +68,7 @@ public class ClientSetupPanel extends SetupPanel {
               name, playerNamesAndAlliancesInTurnOrder.get(name), enabledPlayers.get(name));
       playerRows.add(playerRow);
       SwingUtilities.invokeLater(
-          () -> playerRow.update(players.get(name), disableable.contains(name)));
+          () -> playerRow.update(PlayerName.of(players.get(name)), disableable.contains(name)));
     }
     SwingUtilities.invokeLater(this::layoutComponents);
   }
@@ -203,15 +204,15 @@ public class ClientSetupPanel extends SetupPanel {
       return enabledCheckBox;
     }
 
-    public void update(final String playerName, final boolean disableable) {
+    public void update(final PlayerName playerName, final boolean disableable) {
       if (playerName == null) {
         playerLabel.setText("-");
         final JButton button = new JButton(takeAction);
         button.setMargin(buttonInsets);
         playerComponent = button;
       } else {
-        playerLabel.setText(playerName);
-        if (playerName.equals(clientModel.getClientMessenger().getLocalNode().getName())) {
+        playerLabel.setText(playerName.getValue());
+        if (playerName.equals(clientModel.getClientMessenger().getLocalNode().getPlayerName())) {
           final JButton button = new JButton(dontTakeAction);
           button.setMargin(buttonInsets);
           playerComponent = button;

--- a/game-core/src/main/java/games/strategy/engine/lobby/PlayerName.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/PlayerName.java
@@ -1,13 +1,17 @@
 package games.strategy.engine.lobby;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
 
 /** Simple value object to encapsulate a player name and provide strong typing. */
 @AllArgsConstructor(staticName = "of")
+@EqualsAndHashCode
 public class PlayerName {
-  private final String name;
+  @Getter private final String value;
 
-  public String getValue() {
-    return name;
+  @Override
+  public String toString() {
+    return getValue();
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/LobbyClient.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/LobbyClient.java
@@ -39,7 +39,8 @@ public class LobbyClient {
 
   @Nullable
   public String updatePassword(final String newPassword) {
-    return getUserManager().updateUser(messengers.getLocalNode().getName(), null, newPassword);
+    return getUserManager()
+        .updateUser(messengers.getLocalNode().getPlayerName(), null, newPassword);
   }
 
   public IUserManager getUserManager() {

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -99,9 +99,9 @@ public class LobbyFrame extends JFrame {
     final List<Action> actions = new ArrayList<>();
     actions.add(
         SwingAction.of(
-            "Boot " + clickedOn.getName(),
+            "Boot " + clickedOn.getPlayerName(),
             e -> {
-              if (!confirm("Boot " + clickedOn.getName())) {
+              if (!confirm("Boot " + clickedOn.getPlayerName())) {
                 return;
               }
               controller.boot(clickedOn);

--- a/game-core/src/main/java/games/strategy/net/INode.java
+++ b/game-core/src/main/java/games/strategy/net/INode.java
@@ -1,5 +1,6 @@
 package games.strategy.net;
 
+import games.strategy.engine.lobby.PlayerName;
 import java.io.Serializable;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
@@ -16,6 +17,10 @@ import java.net.InetSocketAddress;
 public interface INode extends Serializable, Comparable<INode> {
   /** Returns the display/user name for the node. */
   String getName();
+
+  default PlayerName getPlayerName() {
+    return PlayerName.of(getName());
+  }
 
   /** Returns the address for the node as seen by the server. */
   InetAddress getAddress();

--- a/game-core/src/main/java/games/strategy/net/IServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/IServerMessenger.java
@@ -34,7 +34,7 @@ public interface IServerMessenger extends IMessenger {
    * Returns the hashed MAC address for the user with the specified name or {@code null} if unknown.
    */
   @Nullable
-  String getPlayerMac(String name);
+  String getPlayerMac(PlayerName name);
 
   boolean isPlayerBanned(String ip, String mac);
 

--- a/game-core/src/main/java/games/strategy/net/LocalNoOpMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/LocalNoOpMessenger.java
@@ -79,7 +79,7 @@ public class LocalNoOpMessenger implements IServerMessenger {
   public void banPlayer(final String ip, final String mac) {}
 
   @Override
-  public @Nullable String getPlayerMac(final String name) {
+  public @Nullable String getPlayerMac(final PlayerName name) {
     return null;
   }
 

--- a/game-core/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ServerMessenger.java
@@ -56,7 +56,7 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
   // all our nodes
   private final Map<INode, SocketChannel> nodeToChannel = new ConcurrentHashMap<>();
   private final Map<SocketChannel, INode> channelToNode = new ConcurrentHashMap<>();
-  private final Map<String, String> cachedMacAddresses = new ConcurrentHashMap<>();
+  private final Map<PlayerName, String> cachedMacAddresses = new ConcurrentHashMap<>();
   private final Set<String> miniBannedIpAddresses = new ConcurrentSkipListSet<>();
   private final Set<String> miniBannedMacAddresses = new ConcurrentSkipListSet<>();
 
@@ -122,7 +122,7 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
   }
 
   @Override
-  public @Nullable String getPlayerMac(final String name) {
+  public @Nullable String getPlayerMac(final PlayerName name) {
     return cachedMacAddresses.get(name);
   }
 
@@ -131,12 +131,12 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
    * {@code uniquePlayerName} is the node name and may not be identical to the name of the player
    * associated with the node
    */
-  public void notifyPlayerLogin(final String uniquePlayerName, final String mac) {
+  public void notifyPlayerLogin(final PlayerName uniquePlayerName, final String mac) {
     cachedMacAddresses.put(uniquePlayerName, mac);
   }
 
   private void notifyPlayerRemoval(final INode node) {
-    cachedMacAddresses.remove(node.getName());
+    cachedMacAddresses.remove(node.getPlayerName());
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
+++ b/game-core/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
@@ -140,9 +140,11 @@ public class ServerQuarantineConversation extends QuarantineConversation {
             // aggregate all player names by mac address (there can be multiple names per mac
             // address)
             serverMessenger.getNodes().stream()
-                .filter(n -> serverMessenger.getPlayerMac(n.getName()) != null)
+                .filter(n -> serverMessenger.getPlayerMac(n.getPlayerName()) != null)
                 .forEach(
-                    n -> macToName.put(serverMessenger.getPlayerMac(n.getName()), n.getName()));
+                    n ->
+                        macToName.put(
+                            serverMessenger.getPlayerMac(n.getPlayerName()), n.getName()));
             remoteName = PlayerNameAssigner.assignName(remoteName, remoteMac, macToName);
           }
 
@@ -159,7 +161,7 @@ public class ServerQuarantineConversation extends QuarantineConversation {
               });
 
           // Login succeeded, so notify the ServerMessenger about the login with the name, mac, etc.
-          serverMessenger.notifyPlayerLogin(remoteName, remoteMac);
+          serverMessenger.notifyPlayerLogin(PlayerName.of(remoteName), remoteMac);
           // We are good
           return Action.UNQUARANTINE;
         case ACK_ERROR:

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -1,6 +1,7 @@
 package games.strategy.triplea.ui.menubar;
 
 import games.strategy.engine.framework.system.SystemProperties;
+import games.strategy.engine.lobby.PlayerName;
 import games.strategy.engine.lobby.client.login.CreateUpdateAccountPanel;
 import games.strategy.engine.lobby.client.ui.LobbyFrame;
 import games.strategy.engine.lobby.moderator.toolbox.ToolBoxWindow;
@@ -80,14 +81,16 @@ public final class LobbyMenu extends JMenuBar {
 
   private void updateAccountDetails() {
     final IUserManager manager = lobbyFrame.getLobbyClient().getUserManager();
-    final String username = lobbyFrame.getLobbyClient().getMessengers().getLocalNode().getName();
+    final PlayerName username =
+        lobbyFrame.getLobbyClient().getMessengers().getLocalNode().getPlayerName();
     final String email = manager.getUserEmail(username);
     if (email == null) {
       showErrorDialog("No user info found");
       return;
     }
 
-    final CreateUpdateAccountPanel panel = CreateUpdateAccountPanel.newUpdatePanel(username, email);
+    final CreateUpdateAccountPanel panel =
+        CreateUpdateAccountPanel.newUpdatePanel(username.getValue(), email);
     final CreateUpdateAccountPanel.ReturnValue returnValue = panel.show(lobbyFrame);
     if (returnValue == CreateUpdateAccountPanel.ReturnValue.CANCEL) {
       return;

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -404,7 +404,7 @@ public class HeadlessGameServer {
                   for (final INode node : nodes) {
                     final String realName = IServerMessenger.getRealName(node.getName());
                     final String ip = node.getAddress().getHostAddress();
-                    final String mac = messenger.getPlayerMac(node.getName());
+                    final String mac = messenger.getPlayerMac(node.getPlayerName());
                     if (realName.equals(playerName)) {
                       log.info("Remote Ban of Player: " + playerName);
                       try {

--- a/game-core/src/main/java/org/triplea/lobby/common/IUserManager.java
+++ b/game-core/src/main/java/org/triplea/lobby/common/IUserManager.java
@@ -1,5 +1,6 @@
 package org.triplea.lobby.common;
 
+import games.strategy.engine.lobby.PlayerName;
 import games.strategy.engine.message.IRemote;
 import games.strategy.engine.message.RemoteName;
 
@@ -12,7 +13,7 @@ public interface IUserManager extends IRemote {
       new RemoteName("games.strategy.engine.lobby.server.USER_MANAGER", IUserManager.class);
 
   /** Update the user info, returning an error string if an error occurs. */
-  String updateUser(String username, String emailAddress, String hashedPassword);
+  String updateUser(PlayerName username, String emailAddress, String hashedPassword);
 
-  String getUserEmail(String username);
+  String getUserEmail(PlayerName username);
 }

--- a/game-core/src/test/java/games/strategy/engine/chat/ChatFloodControlTest.java
+++ b/game-core/src/test/java/games/strategy/engine/chat/ChatFloodControlTest.java
@@ -3,6 +3,7 @@ package games.strategy.engine.chat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import games.strategy.engine.lobby.PlayerName;
 import org.junit.jupiter.api.Test;
 
 class ChatFloodControlTest {
@@ -11,24 +12,24 @@ class ChatFloodControlTest {
 
   @Test
   void testSimple() {
-    assertTrue(testObj.allow("", System.currentTimeMillis()));
+    assertTrue(testObj.allow(PlayerName.of("a"), System.currentTimeMillis()));
   }
 
   @Test
   void testDeny() {
     final long now = 123;
     for (int i = 0; i < ChatFloodControl.EVENTS_PER_WINDOW; i++) {
-      assertTrue(testObj.allow("", now));
+      assertTrue(testObj.allow(PlayerName.of("a"), now));
     }
-    assertFalse(testObj.allow("", now));
+    assertFalse(testObj.allow(PlayerName.of("a"), now));
   }
 
   @Test
   void throttlingReleasedAfterTimePeriod() {
     final long now = 100;
     for (int i = 0; i < 100; i++) {
-      testObj.allow("", now);
+      testObj.allow(PlayerName.of("a"), now);
     }
-    assertTrue(testObj.allow("", INITIAL_CLEAR_TIME + ChatFloodControl.WINDOW + 1));
+    assertTrue(testObj.allow(PlayerName.of("a"), INITIAL_CLEAR_TIME + ChatFloodControl.WINDOW + 1));
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/chat/ChatIgnoreListTest.java
+++ b/game-core/src/test/java/games/strategy/engine/chat/ChatIgnoreListTest.java
@@ -3,6 +3,7 @@ package games.strategy.engine.chat;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import games.strategy.engine.lobby.PlayerName;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 import org.junit.jupiter.api.AfterEach;
@@ -10,6 +11,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class ChatIgnoreListTest {
+  private static final PlayerName PLAYER_NAME = PlayerName.of("test");
+
   @BeforeEach
   void setUp() throws BackingStoreException {
     // clear this
@@ -30,10 +33,10 @@ class ChatIgnoreListTest {
   @Test
   void testLoadStore() {
     ChatIgnoreList list = new ChatIgnoreList();
-    assertFalse(list.shouldIgnore("test"));
-    list.add("test");
-    assertTrue(list.shouldIgnore("test"));
+    assertFalse(list.shouldIgnore(PLAYER_NAME));
+    list.add(PLAYER_NAME);
+    assertTrue(list.shouldIgnore(PLAYER_NAME));
     list = new ChatIgnoreList();
-    assertTrue(list.shouldIgnore("test"));
+    assertTrue(list.shouldIgnore(PLAYER_NAME));
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/chat/ChatIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/chat/ChatIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
+import games.strategy.engine.lobby.PlayerName;
 import games.strategy.engine.message.ChannelMessenger;
 import games.strategy.engine.message.RemoteMessenger;
 import games.strategy.engine.message.unifiedmessenger.UnifiedMessenger;
@@ -182,13 +183,14 @@ final class ChatIntegrationTest {
     }
 
     @Override
-    public void addMessageWithSound(final String message, final String from, final String sound) {
+    public void addMessageWithSound(
+        final String message, final PlayerName from, final String sound) {
       lastMessageReceived.set(message);
       messageCount.incrementAndGet();
     }
 
     @Override
-    public void addMessage(final String message, final String from) {
+    public void addMessage(final String message, final PlayerName from) {
       addMessageWithSound(message, from, SoundPath.CLIP_CHAT_MESSAGE);
     }
 

--- a/lobby/src/main/java/org/triplea/lobby/server/UserManager.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/UserManager.java
@@ -1,6 +1,7 @@
 package org.triplea.lobby.server;
 
 import games.strategy.engine.lobby.PlayerEmailValidation;
+import games.strategy.engine.lobby.PlayerName;
 import games.strategy.engine.lobby.PlayerNameValidation;
 import games.strategy.engine.message.IRemoteMessenger;
 import games.strategy.engine.message.MessageContext;
@@ -24,9 +25,9 @@ final class UserManager implements IUserManager {
 
   @Override
   public String updateUser(
-      final String username, final String emailAddress, final String hashedPassword) {
+      final PlayerName username, final String emailAddress, final String hashedPassword) {
     final INode remote = MessageContext.getSender();
-    if (!username.equals(remote.getName())) {
+    if (!username.equals(remote.getPlayerName())) {
       log.severe(
           "Tried to update user permission, but not correct user, username:"
               + username
@@ -36,7 +37,7 @@ final class UserManager implements IUserManager {
     }
 
     final String validationError =
-        Optional.ofNullable(PlayerNameValidation.validate(username))
+        Optional.ofNullable(PlayerNameValidation.validate(username.getValue()))
             .orElseGet(
                 () -> emailAddress == null ? null : PlayerEmailValidation.validate(emailAddress));
 
@@ -49,7 +50,7 @@ final class UserManager implements IUserManager {
       database
           .getUserDao()
           .updateUser(
-              username,
+              username.getValue(),
               emailAddress,
               password.isHashedWithSalt()
                   ? password
@@ -61,13 +62,13 @@ final class UserManager implements IUserManager {
   }
 
   @Override
-  public String getUserEmail(final String username) {
+  public String getUserEmail(final PlayerName username) {
     final INode remote = MessageContext.getSender();
-    if (!username.equals(remote.getName())) {
+    if (!username.equals(remote.getPlayerName())) {
       log.severe(
           "Tried to get user info, but not correct user, username:" + username + " node:" + remote);
       throw new IllegalStateException("Sorry, but I can't let you do that");
     }
-    return database.getUserDao().getUserEmailByName(username);
+    return database.getUserDao().getUserEmailByName(username.getValue());
   }
 }

--- a/lobby/src/test/java/org/triplea/lobby/server/ModeratorControllerIntegrationTest.java
+++ b/lobby/src/test/java/org/triplea/lobby/server/ModeratorControllerIntegrationTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import games.strategy.engine.lobby.PlayerName;
 import games.strategy.engine.message.MessageContext;
 import games.strategy.net.IConnectionChangeListener;
 import games.strategy.net.INode;
@@ -52,7 +53,7 @@ class ModeratorControllerIntegrationTest {
     UserDaoTestSupport.makeAdmin(adminName);
 
     adminNode = new Node(adminName, InetAddress.getLocalHost(), 0);
-    when(serverMessenger.getPlayerMac(adminName)).thenReturn(newHashedMacAddress());
+    when(serverMessenger.getPlayerMac(PlayerName.of(adminName))).thenReturn(newHashedMacAddress());
   }
 
   @Test


### PR DESCRIPTION
First iteration to mass convert unbounded strings to domain object 'PlayerName'.
Refactor begins with updating the API of of 'Node' to have a 'getPlayerName'
method with objective to eventually to convert the internal data type of
'Node.name' to be 'PlayerName' and be strongly typed whenever accessed.

Another goal behind this conversion is to avoid passing 'Node' data where
typically only one property of the Node, name, is used.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[x] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix:  <!-- Link to bug issue or forum post here -->
[ ] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to any that apply -->

[ ] Covered by existing automated tests
[ ] Covered by newly added automated tests
[ ] Manually tested
[x] No testing done
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes

Notable benefits:
- domain objects! Good step, if we add validation/constraints then we'll be approaching  'domain driven security' (eg: https://www.youtube.com/watch?v=9mGsLcruhwQ "Domain Driven Security")
- type-safe, can't accidentally use incompatible types as parameters or variables, get a warning when comparing incompatible types

The big driver here is to start isolating node data from player name data. We currently pass a list of nodes to chat, we do not need IP addresses, but because it is attached to node, we pass it anyways and thereby leak player IP addresses.

This update is not complete, to avoid a completely overwhelming review it will be done in iterations. We also need to strike up a domain terminology conversation, notably because there is room for error and further updates start to run up against other Strings that represent other domain entities. It's notable for example that 'player' has multiple meanings (in the code, and even within the same sub-domain).


<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

