### PR TITLE
ChatModel simplification

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/ChatPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatPanel.java
@@ -60,7 +60,6 @@ public class ChatPanel extends JPanel implements ChatModel {
     return chatMessagePanel.getAllText();
   }
 
-  @Override
   public void setChat(final Chat chat) {
     chatMessagePanel.setChat(chat);
     chatPlayerPanel.setChat(chat);

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatPanel.java
@@ -3,9 +3,7 @@ package games.strategy.engine.chat;
 import games.strategy.engine.chat.Chat.ChatSoundProfile;
 import games.strategy.net.Messengers;
 import java.awt.BorderLayout;
-import java.awt.Component;
 import java.awt.Dimension;
-import java.util.Optional;
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.JPanel;
 import javax.swing.JSplitPane;
@@ -79,10 +77,5 @@ public class ChatPanel extends JPanel implements ChatModel {
 
   public ChatMessagePanel getChatMessagePanel() {
     return chatMessagePanel;
-  }
-
-  @Override
-  public Optional<Component> getViewComponent() {
-    return Optional.of(this);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/chat/HeadlessChat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/HeadlessChat.java
@@ -41,11 +41,6 @@ public class HeadlessChat implements IChatListener, ChatModel {
   @Override
   public void updatePlayerList(final Collection<ChatParticipant> players) {}
 
-  @Override
-  public void setChat(final Chat chat) {
-    throw new UnsupportedOperationException("Headless bots do not support resetting of chat");
-  }
-
   /** thread safe. */
   @Override
   public void addMessage(final String originalMessage, final PlayerName from) {

--- a/game-core/src/main/java/games/strategy/engine/chat/HeadlessChat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/HeadlessChat.java
@@ -4,9 +4,7 @@ import com.google.common.base.Ascii;
 import games.strategy.engine.chat.Chat.ChatSoundProfile;
 import games.strategy.engine.lobby.PlayerName;
 import games.strategy.net.Messengers;
-import java.awt.Component;
 import java.util.Collection;
-import java.util.Optional;
 import org.triplea.game.chat.ChatModel;
 import org.triplea.java.TimeManager;
 
@@ -68,10 +66,5 @@ public class HeadlessChat implements IChatListener, ChatModel {
     if (allText.length() > MAX_LENGTH) {
       allText.delete(0, MAX_LENGTH / 2);
     }
-  }
-
-  @Override
-  public Optional<Component> getViewComponent() {
-    return Optional.empty();
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -272,7 +272,9 @@ public class ServerModel extends Observable implements IConnectionChangeListener
     if (messengers != null) {
       chatController.deactivate();
       messengers.shutDown();
-      chatModel.setChat(null);
+      if (ui != null) {
+        ((ChatPanel) chatModel).setChat(null);
+      }
     }
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -7,6 +7,7 @@ import static games.strategy.engine.framework.CliProperties.TRIPLEA_SERVER;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.Runnables;
 import games.strategy.engine.chat.Chat;
 import games.strategy.engine.chat.ChatController;
 import games.strategy.engine.chat.ChatPanel;
@@ -91,6 +92,7 @@ public class ServerModel extends Observable implements IConnectionChangeListener
   @Nullable private final JFrame ui;
   private final LaunchAction launchAction;
   private ChatModel chatModel;
+  private Runnable chatModelCancel = Runnables.doNothing();
   private ChatController chatController;
   private final Map<String, PlayerType> localPlayerTypes = new HashMap<>();
   // while our server launcher is not null, delegate new/lost connections to it
@@ -272,9 +274,7 @@ public class ServerModel extends Observable implements IConnectionChangeListener
     if (messengers != null) {
       chatController.deactivate();
       messengers.shutDown();
-      if (ui != null) {
-        ((ChatPanel) chatModel).setChat(null);
-      }
+      chatModelCancel.run();
     }
   }
 
@@ -397,9 +397,12 @@ public class ServerModel extends Observable implements IConnectionChangeListener
 
       if (ui == null) {
         chatModel = new HeadlessChat(messengers, CHAT_NAME, Chat.ChatSoundProfile.GAME_CHATROOM);
+        chatModelCancel = Runnables.doNothing();
       } else {
-        chatModel =
+        final var chatPanel =
             ChatPanel.newChatPanel(messengers, CHAT_NAME, Chat.ChatSoundProfile.GAME_CHATROOM);
+        chatModelCancel = () -> chatPanel.setChat(null);
+        chatModel = chatPanel;
       }
 
       serverMessenger.setAcceptNewConnections(true);

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.framework.startup.ui.panels.main;
 
+import games.strategy.engine.chat.ChatPanel;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.startup.ui.SetupPanel;
 import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorPanel;
@@ -94,11 +95,8 @@ public class MainPanel extends JPanel implements Observer, Consumer<SetupPanel> 
             .build());
     setLayout(new BorderLayout());
 
-    final Optional<Component> chatComponent =
-        Optional.ofNullable(chatModel).flatMap(ChatModel::getViewComponent);
-
-    if (chatComponent.isPresent()) {
-      addChat(chatComponent.get());
+    if (chatModel instanceof ChatPanel) {
+      addChat((ChatPanel) chatModel);
     } else {
       add(mainPanel, BorderLayout.CENTER);
     }
@@ -148,7 +146,8 @@ public class MainPanel extends JPanel implements Observer, Consumer<SetupPanel> 
     }
 
     Optional.ofNullable(panel.getChatModel())
-        .flatMap(ChatModel::getViewComponent)
+        .filter(ChatPanel.class::isInstance)
+        .map(ChatPanel.class::cast)
         .ifPresentOrElse(
             this::addChat,
             () -> {

--- a/game-core/src/main/java/org/triplea/game/chat/ChatModel.java
+++ b/game-core/src/main/java/org/triplea/game/chat/ChatModel.java
@@ -1,8 +1,6 @@
 package org.triplea.game.chat;
 
 import games.strategy.engine.chat.Chat;
-import java.awt.Component;
-import java.util.Optional;
 
 /**
  * Interface to abstract common functionality to configure a chat that is shared between headed and
@@ -13,6 +11,4 @@ public interface ChatModel {
   Chat getChat();
 
   String getAllText();
-
-  Optional<Component> getViewComponent();
 }

--- a/game-core/src/main/java/org/triplea/game/chat/ChatModel.java
+++ b/game-core/src/main/java/org/triplea/game/chat/ChatModel.java
@@ -10,8 +10,6 @@ import java.util.Optional;
  */
 public interface ChatModel {
 
-  void setChat(Chat chat);
-
   Chat getChat();
 
   String getAllText();


### PR DESCRIPTION
<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 
Follow-up to #5289

This PR moves methods out of the `ChatModel` interface that clearly don't belong there.
I must admit that the "workaround" for the `ChatModel#getViewComponent` method is not really clean, but `HeadlessChat` really shouldn't depend on swing either.

## Functional Changes
<!-- Put an X next any that apply -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[x] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix:  <!-- Link to bug issue or forum post here -->
[ ] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[ ] No manual testing done
[x] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->
I verified I could open the usual screens where a chat is displayed.

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

