### PR TITLE
Refactor: Remove Observable from SetupModel

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
@@ -9,7 +9,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Observer;
+import java.util.function.Consumer;
+import javax.annotation.Nullable;
 import javax.swing.Action;
 import javax.swing.JButton;
 import javax.swing.JComboBox;
@@ -27,20 +28,17 @@ public abstract class SetupPanel extends JPanel implements SetupModel {
   private static final long serialVersionUID = 4001323470187210773L;
   private static final String SET_ALL_DEFAULT_LABEL = "Default";
 
-  private final List<Observer> listeners = new ArrayList<>();
+  private final List<Consumer<SetupPanel>> listeners = new ArrayList<>();
 
-  @Override
-  public void addObserver(final Observer observer) {
+  public void addObserver(final Consumer<SetupPanel> observer) {
     listeners.add(observer);
   }
 
-  @Override
-  public void notifyObservers() {
-    for (final Observer observer : listeners) {
-      observer.update(null, null);
-    }
+  void notifyObservers() {
+    listeners.forEach(consumer -> consumer.accept(this));
   }
 
+  @Nullable
   @Override
   public ChatModel getChatModel() {
     return null;

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessServerSetup.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessServerSetup.java
@@ -10,11 +10,8 @@ import games.strategy.engine.framework.startup.mc.ServerModel;
 import games.strategy.engine.framework.startup.ui.InGameLobbyWatcher;
 import games.strategy.engine.framework.startup.ui.InGameLobbyWatcherWrapper;
 import games.strategy.engine.framework.startup.ui.LocalServerAvailabilityCheck;
-import java.util.List;
 import java.util.Map;
-import java.util.Observer;
 import java.util.Optional;
-import java.util.concurrent.CopyOnWriteArrayList;
 import lombok.extern.java.Log;
 import org.triplea.game.chat.ChatModel;
 import org.triplea.game.startup.SetupModel;
@@ -23,7 +20,6 @@ import org.triplea.java.Interruptibles;
 /** Server setup model. */
 @Log
 class HeadlessServerSetup implements IRemoteModelListener, SetupModel {
-  private final List<Observer> listeners = new CopyOnWriteArrayList<>();
   private final ServerModel model;
   private final GameSelectorModel gameSelectorModel;
   private final InGameLobbyWatcherWrapper lobbyWatcher = new InGameLobbyWatcherWrapper();
@@ -33,7 +29,6 @@ class HeadlessServerSetup implements IRemoteModelListener, SetupModel {
     this.gameSelectorModel = gameSelectorModel;
     this.model.setRemoteModelListener(this);
     createLobbyWatcher();
-    internalPlayerListChanged();
   }
 
   private void createLobbyWatcher() {
@@ -90,22 +85,10 @@ class HeadlessServerSetup implements IRemoteModelListener, SetupModel {
   }
 
   @Override
-  public void playerListChanged() {
-    internalPlayerListChanged();
-  }
+  public void playerListChanged() {}
 
   @Override
-  public void playersTakenChanged() {
-    internalPlayersTakenChanged();
-  }
-
-  private void internalPlayersTakenChanged() {
-    notifyObservers();
-  }
-
-  private void internalPlayerListChanged() {
-    internalPlayersTakenChanged();
-  }
+  public void playersTakenChanged() {}
 
   @Override
   public ChatModel getChatModel() {
@@ -125,18 +108,6 @@ class HeadlessServerSetup implements IRemoteModelListener, SetupModel {
               launcher.setInGameLobbyWatcher(lobbyWatcher);
               return launcher;
             });
-  }
-
-  @Override
-  public void addObserver(final Observer observer) {
-    listeners.add(observer);
-  }
-
-  @Override
-  public void notifyObservers() {
-    for (final Observer observer : listeners) {
-      observer.update(null, null);
-    }
   }
 
   @Override

--- a/game-core/src/main/java/org/triplea/game/startup/SetupModel.java
+++ b/game-core/src/main/java/org/triplea/game/startup/SetupModel.java
@@ -5,7 +5,6 @@ import games.strategy.engine.framework.startup.launcher.ILauncher;
 import games.strategy.engine.pbem.IEmailSender;
 import games.strategy.engine.pbem.IForumPoster;
 import games.strategy.engine.random.IRemoteDiceServer;
-import java.util.Observer;
 import java.util.Optional;
 import org.triplea.game.chat.ChatModel;
 
@@ -14,10 +13,6 @@ import org.triplea.game.chat.ChatModel;
  * mechanisms.
  */
 public interface SetupModel {
-
-  void addObserver(Observer observer);
-
-  void notifyObservers();
 
   ChatModel getChatModel();
 


### PR DESCRIPTION
(1) Remove observer methods from SetupModel, this cascades
to HeadlessServerSetup and turns out we add no observers
to HeadlessServerSetup. Looking at the headed version, the
observe methods are used to update UI, it makes sense then
that headless is a no-op.

(2) Convert SetupPanel Observer interface to a listener with
a Java8 API.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[x] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix:  <!-- Link to bug issue or forum post here -->
[ ] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[ ] No manual testing done
[x] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->
- launched a bot on local server
- connected to the bot server twice, changed map and selected/deselected players and started a game

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

