### PR TITLE
Refactor: Fix variable shadowing in test

### DIFF
--- a/game-core/src/test/java/games/strategy/triplea/delegate/TerritoryEffectHelperTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/TerritoryEffectHelperTest.java
@@ -33,7 +33,8 @@ class TerritoryEffectHelperTest extends AbstractDelegateTestCase {
   void testGetMaxMovementCostZero() throws Exception {
     final BigDecimal result =
         TerritoryEffectHelper.getMaxMovementCost(
-            sicily, GameDataTestUtil.unitType("germanInfantry", twwGameData).create(1, germanPlayer));
+            sicily,
+            GameDataTestUtil.unitType("germanInfantry", twwGameData).create(1, germanPlayer));
     assertThat(
         "Expect German infantry to have 0 movement cost for Sicily island territory effect",
         result.compareTo(BigDecimal.ZERO),
@@ -79,8 +80,10 @@ class TerritoryEffectHelperTest extends AbstractDelegateTestCase {
   void testGetMaxMovementCostMultipleUnits() throws Exception {
     final List<Unit> units = new ArrayList<>();
     units.addAll(GameDataTestUtil.unitType("germanInfantry", twwGameData).create(1, germanPlayer));
-    units.addAll(GameDataTestUtil.unitType("germanAlpineInfantry", twwGameData).create(1, germanPlayer));
-    units.addAll(GameDataTestUtil.unitType("germanCombatEngineer", twwGameData).create(1, germanPlayer));
+    units.addAll(
+        GameDataTestUtil.unitType("germanAlpineInfantry", twwGameData).create(1, germanPlayer));
+    units.addAll(
+        GameDataTestUtil.unitType("germanCombatEngineer", twwGameData).create(1, germanPlayer));
     units.addAll(GameDataTestUtil.unitType("germanMarine", twwGameData).create(1, germanPlayer));
     final BigDecimal result = TerritoryEffectHelper.getMaxMovementCost(sicily, units);
     assertThat(

--- a/game-core/src/test/java/games/strategy/triplea/delegate/TerritoryEffectHelperTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/TerritoryEffectHelperTest.java
@@ -19,13 +19,13 @@ import org.junit.jupiter.api.Test;
 class TerritoryEffectHelperTest extends AbstractDelegateTestCase {
 
   private GameData twwGameData;
-  private PlayerId germans;
+  private PlayerId germanPlayer;
   private Territory sicily;
 
   @BeforeEach
   void setup() throws Exception {
     twwGameData = TestMapGameData.TWW.getGameData();
-    germans = GameDataTestUtil.germany(twwGameData);
+    germanPlayer = GameDataTestUtil.germany(twwGameData);
     sicily = territory("Sicily", twwGameData);
   }
 
@@ -33,7 +33,7 @@ class TerritoryEffectHelperTest extends AbstractDelegateTestCase {
   void testGetMaxMovementCostZero() throws Exception {
     final BigDecimal result =
         TerritoryEffectHelper.getMaxMovementCost(
-            sicily, GameDataTestUtil.unitType("germanInfantry", twwGameData).create(1, germans));
+            sicily, GameDataTestUtil.unitType("germanInfantry", twwGameData).create(1, germanPlayer));
     assertThat(
         "Expect German infantry to have 0 movement cost for Sicily island territory effect",
         result.compareTo(BigDecimal.ZERO),
@@ -45,7 +45,7 @@ class TerritoryEffectHelperTest extends AbstractDelegateTestCase {
     final BigDecimal result =
         TerritoryEffectHelper.getMaxMovementCost(
             sicily,
-            GameDataTestUtil.unitType("germanAlpineInfantry", twwGameData).create(1, germans));
+            GameDataTestUtil.unitType("germanAlpineInfantry", twwGameData).create(1, germanPlayer));
     assertThat(
         "Expect German alpine to have 0.5 movement cost for Sicily island territory effect",
         result.compareTo(new BigDecimal("0.5")),
@@ -57,7 +57,7 @@ class TerritoryEffectHelperTest extends AbstractDelegateTestCase {
     final BigDecimal result =
         TerritoryEffectHelper.getMaxMovementCost(
             sicily,
-            GameDataTestUtil.unitType("germanCombatEngineer", twwGameData).create(1, germans));
+            GameDataTestUtil.unitType("germanCombatEngineer", twwGameData).create(1, germanPlayer));
     assertThat(
         "Expect German combat engineer to have 2 movement cost for Sicily island territory effect",
         result.compareTo(new BigDecimal("2")),
@@ -68,7 +68,7 @@ class TerritoryEffectHelperTest extends AbstractDelegateTestCase {
   void testGetMaxMovementCostNoEffect() throws Exception {
     final BigDecimal result =
         TerritoryEffectHelper.getMaxMovementCost(
-            sicily, GameDataTestUtil.unitType("germanMarine", twwGameData).create(1, germans));
+            sicily, GameDataTestUtil.unitType("germanMarine", twwGameData).create(1, germanPlayer));
     assertThat(
         "Expect German marine to have 1 movement cost for no territory effects",
         result.compareTo(BigDecimal.ONE),
@@ -78,10 +78,10 @@ class TerritoryEffectHelperTest extends AbstractDelegateTestCase {
   @Test
   void testGetMaxMovementCostMultipleUnits() throws Exception {
     final List<Unit> units = new ArrayList<>();
-    units.addAll(GameDataTestUtil.unitType("germanInfantry", twwGameData).create(1, germans));
-    units.addAll(GameDataTestUtil.unitType("germanAlpineInfantry", twwGameData).create(1, germans));
-    units.addAll(GameDataTestUtil.unitType("germanCombatEngineer", twwGameData).create(1, germans));
-    units.addAll(GameDataTestUtil.unitType("germanMarine", twwGameData).create(1, germans));
+    units.addAll(GameDataTestUtil.unitType("germanInfantry", twwGameData).create(1, germanPlayer));
+    units.addAll(GameDataTestUtil.unitType("germanAlpineInfantry", twwGameData).create(1, germanPlayer));
+    units.addAll(GameDataTestUtil.unitType("germanCombatEngineer", twwGameData).create(1, germanPlayer));
+    units.addAll(GameDataTestUtil.unitType("germanMarine", twwGameData).create(1, germanPlayer));
     final BigDecimal result = TerritoryEffectHelper.getMaxMovementCost(sicily, units);
     assertThat(
         "Expect German units to have 2 movement cost as that is max across all units",


### PR DESCRIPTION
Fixes an error prone warning, renames a variable that shadows
a variable from parent class.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[x] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix:  <!-- Link to bug issue or forum post here -->
[ ] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[x] No manual testing done
[ ] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

