### PR TITLE
Refactor: Move connectivity check to http

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -1,6 +1,9 @@
 package games.strategy.engine.framework.startup.ui;
 
 import static games.strategy.engine.framework.CliProperties.LOBBY_HOST;
+import static games.strategy.engine.framework.CliProperties.LOBBY_HTTPS_PORT;
+import static games.strategy.engine.framework.CliProperties.LOBBY_PORT;
+import static games.strategy.engine.framework.CliProperties.TRIPLEA_NAME;
 
 import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.framework.network.ui.BanPlayerAction;
@@ -23,6 +26,7 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -43,6 +47,7 @@ import javax.swing.SwingUtilities;
 import org.triplea.awt.OpenFileUtility;
 import org.triplea.game.chat.ChatModel;
 import org.triplea.game.startup.SetupModel;
+import org.triplea.http.client.lobby.HttpLobbyClient;
 
 /**
  * Setup panel displayed for hosting a non-lobby network game (using host option from main panel).
@@ -100,11 +105,24 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
                           });
 
               LocalServerAvailabilityCheck.builder()
-                  .controller(watcher.getRemoteMessenger().getLobbyGameController())
+                  .connectivityCheckClient(
+                      HttpLobbyClient.newClient(
+                              URI.create(
+                                  HttpLobbyClient.PROTOCOL
+                                      + System.getProperty(LOBBY_HOST)
+                                      + ":"
+                                      + System.getProperty(LOBBY_HTTPS_PORT)),
+                              watcher.getLobbyMessenger().getApiKey())
+                          .getConnectivityCheckClient())
+                  .localPort(model.getMessenger().getLocalNode().getPort())
                   .errorHandler(errorHandler)
-                  .localNode(model.getMessenger().getLocalNode())
                   .build()
                   .run();
+
+              System.clearProperty(LOBBY_HOST);
+              System.clearProperty(LOBBY_PORT);
+              System.clearProperty(LOBBY_HTTPS_PORT);
+              System.clearProperty(TRIPLEA_NAME);
             });
   }
 

--- a/game-core/src/main/java/games/strategy/net/INode.java
+++ b/game-core/src/main/java/games/strategy/net/INode.java
@@ -22,7 +22,11 @@ public interface INode extends Serializable, Comparable<INode> {
     return PlayerName.of(getName());
   }
 
-  /** Returns the address for the node as seen by the server. */
+  /**
+   * Returns the address for the node as seen by the server. <br>
+   * WARNING! 'getAddress().getHostAddress(); can return IP address *and* network interface, eg:
+   * 2603:603:f00:ed0:5d12:e3b4:a4d3:c2ea%enp0s10, notice the trailing "enp0s10"
+   */
   InetAddress getAddress();
 
   /** Returns the port for the node as seen by the server. */

--- a/game-core/src/main/java/org/triplea/lobby/common/ILobbyGameController.java
+++ b/game-core/src/main/java/org/triplea/lobby/common/ILobbyGameController.java
@@ -2,7 +2,6 @@ package org.triplea.lobby.common;
 
 import games.strategy.engine.message.IRemote;
 import games.strategy.engine.message.RemoteName;
-import games.strategy.net.INode;
 import java.util.Map;
 import java.util.UUID;
 
@@ -18,13 +17,4 @@ public interface ILobbyGameController extends IRemote {
   void updateGame(UUID gameId, GameDescription description);
 
   Map<UUID, GameDescription> listGames();
-
-  /**
-   * Test if the server can connect to the game at this address. This is used to see if the client
-   * address is network accessible (this will not be true if the client is behind a nat or firewall
-   * that is not properly configured).
-   *
-   * <p>This method may only be called by the node that is hosting this game.
-   */
-  boolean testGame(INode node);
 }

--- a/game-core/src/test/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcherTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcherTest.java
@@ -47,15 +47,6 @@ final class InGameLobbyWatcherTest {
     }
 
     @Test
-    void shouldClearPrimaryValueWhenPrimaryValueSet() {
-      givenPrimaryValueSet();
-
-      getLobbySystemProperty(KEY);
-
-      assertThat(System.getProperty(KEY), is(nullValue()));
-    }
-
-    @Test
     void shouldCopyPrimaryValueToBackupValueWhenPrimaryValueSet() {
       givenPrimaryValueSet();
 

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/HttpLobbyClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/HttpLobbyClient.java
@@ -3,6 +3,7 @@ package org.triplea.http.client.lobby;
 import java.net.URI;
 import lombok.Getter;
 import org.triplea.http.client.ApiKey;
+import org.triplea.http.client.lobby.game.ConnectivityCheckClient;
 import org.triplea.http.client.lobby.game.listing.GameListingClient;
 import org.triplea.http.client.lobby.moderator.toolbox.HttpModeratorToolboxClient;
 import org.triplea.http.client.lobby.user.account.UserAccountClient;
@@ -10,13 +11,17 @@ import org.triplea.http.client.lobby.user.account.UserAccountClient;
 /** Holder class for the various http clients that access lobby resources. */
 @Getter
 public class HttpLobbyClient {
-  private final HttpModeratorToolboxClient httpModeratorToolboxClient;
+  public static final String PROTOCOL = "http://";
+
+  private final ConnectivityCheckClient connectivityCheckClient;
   private final GameListingClient gameListingClient;
+  private final HttpModeratorToolboxClient httpModeratorToolboxClient;
   private final UserAccountClient userAccountClient;
 
   private HttpLobbyClient(final URI lobbyUri, final ApiKey apiKey) {
-    httpModeratorToolboxClient = HttpModeratorToolboxClient.newClient(lobbyUri, apiKey);
+    connectivityCheckClient = ConnectivityCheckClient.newClient(lobbyUri, apiKey);
     gameListingClient = GameListingClient.newClient(lobbyUri, apiKey);
+    httpModeratorToolboxClient = HttpModeratorToolboxClient.newClient(lobbyUri, apiKey);
     userAccountClient = UserAccountClient.newClient(lobbyUri, apiKey);
   }
 

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/game/ConnectivityCheckClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/game/ConnectivityCheckClient.java
@@ -1,0 +1,37 @@
+package org.triplea.http.client.lobby.game;
+
+import com.google.common.base.Preconditions;
+import java.net.URI;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import org.triplea.http.client.ApiKey;
+import org.triplea.http.client.AuthenticationHeaders;
+import org.triplea.http.client.HttpClient;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ConnectivityCheckClient {
+  public static final String CONNECTIVITY_CHECK_PATH = "/lobby/check-connectivity";
+
+  private final AuthenticationHeaders authenticationHeaders;
+  private final ConnectivityCheckFeignClient connectivityCheckFeignClient;
+
+  public static ConnectivityCheckClient newClient(final URI serverUri, final ApiKey apiKey) {
+    return new ConnectivityCheckClient(
+        new AuthenticationHeaders(apiKey),
+        new HttpClient<>(ConnectivityCheckFeignClient.class, serverUri).get());
+  }
+
+  /**
+   * Sends a request to the server to attempt a 'reverse' connection back to the local host. This
+   * simulates other clients connecting to the local server. If the connection is successful, true
+   * is returned. This can return false when a host's IP address is not public, in those cases the
+   * reverse connection would fail.
+   */
+  public boolean checkConnectivity(final int port) {
+    Preconditions.checkArgument(port > 0, "Port must be a positive number, was: " + port);
+    Preconditions.checkArgument(
+        port < Math.pow(2, 16), "Port must be less than max value (2^16), was: " + port);
+    return connectivityCheckFeignClient.checkConnectivity(
+        authenticationHeaders.createHeaders(), port);
+  }
+}

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/game/ConnectivityCheckFeignClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/game/ConnectivityCheckFeignClient.java
@@ -1,0 +1,13 @@
+package org.triplea.http.client.lobby.game;
+
+import feign.HeaderMap;
+import feign.Headers;
+import feign.RequestLine;
+import java.util.Map;
+import org.triplea.http.client.HttpConstants;
+
+@Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
+interface ConnectivityCheckFeignClient {
+  @RequestLine("POST " + ConnectivityCheckClient.CONNECTIVITY_CHECK_PATH)
+  boolean checkConnectivity(@HeaderMap Map<String, Object> headers, int port);
+}

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/game/ConnectivityCheckClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/game/ConnectivityCheckClientTest.java
@@ -1,0 +1,35 @@
+package org.triplea.http.client.lobby.game;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.triplea.http.client.HttpClientTesting.EXPECTED_API_KEY;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import org.junit.jupiter.api.Test;
+import org.triplea.http.client.AuthenticationHeaders;
+import org.triplea.http.client.WireMockTest;
+import ru.lanwen.wiremock.ext.WiremockResolver;
+
+class ConnectivityCheckClientTest extends WireMockTest {
+  private static final int PORT = 5000;
+
+  private static ConnectivityCheckClient newClient(final WireMockServer wireMockServer) {
+    return newClient(wireMockServer, ConnectivityCheckClient::newClient);
+  }
+
+  @Test
+  void verifyConnectivityCheck(@WiremockResolver.Wiremock final WireMockServer server) {
+    server.stubFor(
+        post(ConnectivityCheckClient.CONNECTIVITY_CHECK_PATH)
+            .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
+            .withRequestBody(equalTo(String.valueOf(PORT)))
+            .willReturn(WireMock.aResponse().withStatus(200).withBody("true")));
+
+    final boolean result = newClient(server).checkConnectivity(PORT);
+
+    assertThat(result, is(true));
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/http/ServerApplication.java
+++ b/http-server/src/main/java/org/triplea/server/http/ServerApplication.java
@@ -30,6 +30,7 @@ import org.triplea.server.access.AuthenticatedUser;
 import org.triplea.server.access.RoleAuthorizer;
 import org.triplea.server.error.reporting.ErrorReportControllerFactory;
 import org.triplea.server.forgot.password.ForgotPasswordControllerFactory;
+import org.triplea.server.lobby.game.ConnectivityControllerFactory;
 import org.triplea.server.lobby.game.listing.GameListingControllerFactory;
 import org.triplea.server.moderator.toolbox.access.log.AccessLogControllerFactory;
 import org.triplea.server.moderator.toolbox.audit.history.ModeratorAuditHistoryControllerFactory;
@@ -135,6 +136,7 @@ public class ServerApplication extends Application<AppConfig> {
     return ImmutableList.of(
         AccessLogControllerFactory.buildController(appConfig, jdbi),
         BadWordControllerFactory.buildController(jdbi),
+        ConnectivityControllerFactory.buildController(),
         ForgotPasswordControllerFactory.buildController(appConfig, jdbi),
         GameListingControllerFactory.buildController(jdbi),
         UsernameBanControllerFactory.buildController(appConfig, jdbi),

--- a/http-server/src/main/java/org/triplea/server/lobby/game/ConnectivityCheck.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/game/ConnectivityCheck.java
@@ -1,0 +1,29 @@
+package org.triplea.server.lobby.game;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import java.util.function.Supplier;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PACKAGE)
+class ConnectivityCheck implements Predicate<InetSocketAddress> {
+  private final Supplier<Socket> socketSupplier;
+
+  ConnectivityCheck() {
+    this(Socket::new);
+  }
+
+  @Override
+  public boolean test(final InetSocketAddress address) {
+    try (Socket s = socketSupplier.get()) {
+      s.connect(address, (int) TimeUnit.SECONDS.toMillis(10));
+      return true;
+    } catch (final IOException e) {
+      return false;
+    }
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/lobby/game/ConnectivityController.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/game/ConnectivityController.java
@@ -1,0 +1,42 @@
+package org.triplea.server.lobby.game;
+
+import com.google.common.base.Preconditions;
+import es.moki.ratelimij.dropwizard.annotation.Rate;
+import es.moki.ratelimij.dropwizard.annotation.RateLimited;
+import es.moki.ratelimij.dropwizard.filter.KeyPart;
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import javax.annotation.Nonnull;
+import javax.annotation.security.RolesAllowed;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Context;
+import lombok.Builder;
+import org.triplea.http.client.lobby.game.ConnectivityCheckClient;
+import org.triplea.lobby.server.db.data.UserRole;
+import org.triplea.server.http.HttpController;
+
+/**
+ * Provides an endpoint that will attempt a 'reverse' connection back to a potential game host. This
+ * is to verify that the potential host has a publicly available network address.
+ */
+@Builder
+public class ConnectivityController extends HttpController {
+  @Nonnull private final Predicate<InetSocketAddress> connectivityCheck;
+
+  @POST
+  @Path(ConnectivityCheckClient.CONNECTIVITY_CHECK_PATH)
+  @RateLimited(
+      keys = {KeyPart.IP},
+      rates = {@Rate(limit = 10, duration = 1, timeUnit = TimeUnit.MINUTES)})
+  @RolesAllowed(UserRole.ANONYMOUS)
+  public boolean checkConnectivity(@Context final HttpServletRequest request, final Integer port) {
+    Preconditions.checkArgument(port > 0, "Port must be a positive number, was: " + port);
+    Preconditions.checkArgument(
+        port < Math.pow(2, 16), "Port must be less than max value (2^16), was: " + port);
+
+    return connectivityCheck.test(new InetSocketAddress(request.getRemoteAddr(), port));
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/lobby/game/ConnectivityControllerFactory.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/game/ConnectivityControllerFactory.java
@@ -1,0 +1,12 @@
+package org.triplea.server.lobby.game;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+/** Instantiates controller with dependencies. */
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ConnectivityControllerFactory {
+  public static ConnectivityController buildController() {
+    return ConnectivityController.builder().connectivityCheck(new ConnectivityCheck()).build();
+  }
+}

--- a/http-server/src/test/java/org/triplea/server/lobby/game/ConnectivityCheckTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/game/ConnectivityCheckTest.java
@@ -1,0 +1,51 @@
+package org.triplea.server.lobby.game;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ConnectivityCheckTest {
+  @Mock private InetSocketAddress inetSocketAddress;
+
+  @Mock private Socket socket;
+
+  private ConnectivityCheck connectivityCheck;
+
+  @BeforeEach
+  void setup() {
+    connectivityCheck = new ConnectivityCheck(() -> socket);
+  }
+
+  @Test
+  void connectionSuccess() throws IOException {
+    final boolean result = connectivityCheck.test(inetSocketAddress);
+
+    assertThat(result, is(true));
+    verify(socket).close();
+  }
+
+  @Test
+  void connectionFailure() throws IOException {
+    doThrow(new IOException("simulated exception"))
+        .when(socket)
+        .connect(eq(inetSocketAddress), anyInt());
+
+    final boolean result = connectivityCheck.test(inetSocketAddress);
+
+    assertThat(result, is(false));
+    verify(socket).close();
+  }
+}

--- a/http-server/src/test/java/org/triplea/server/lobby/game/ConnectivityControllerTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/game/ConnectivityControllerTest.java
@@ -1,0 +1,54 @@
+package org.triplea.server.lobby.game;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.net.Socket;
+import org.junit.jupiter.api.Test;
+import org.triplea.http.client.lobby.game.ConnectivityCheckClient;
+import org.triplea.server.http.ProtectedEndpointTest;
+
+class ConnectivityControllerTest extends ProtectedEndpointTest<ConnectivityCheckClient> {
+  private static final int PORT = 20000;
+
+  ConnectivityControllerTest() {
+    super(ConnectivityCheckClient::newClient);
+  }
+
+  /** Negative case, check connectivity for a port that is not listening. */
+  @Test
+  void checkConnectivityNegativeCase() {
+    final boolean result =
+        super.verifyEndpointReturningObject(client -> client.checkConnectivity(PORT));
+    assertThat(result, is(false));
+  }
+
+  /**
+   * Positive case, open a local listening port and verify we can connect to it. This test is to
+   * ensure we do not have just a negative case that is trivially true.
+   */
+  @Test
+  void checkConnectivityPositiveCase() throws IOException {
+    openSocket();
+    final boolean result =
+        super.verifyEndpointReturningObject(client -> client.checkConnectivity(PORT));
+    assertThat(result, is(true));
+  }
+
+  private void openSocket() throws IOException {
+    final ServerSocket serverSocket = new ServerSocket(PORT);
+    new Thread(
+            () -> {
+              try {
+                final Socket connectedSocket = serverSocket.accept();
+                connectedSocket.close();
+                serverSocket.close();
+              } catch (final IOException e) {
+                throw new RuntimeException(e);
+              }
+            })
+        .start();
+  }
+}

--- a/lobby/src/main/java/org/triplea/lobby/server/LobbyGameController.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/LobbyGameController.java
@@ -6,9 +6,6 @@ import games.strategy.engine.message.MessageContext;
 import games.strategy.net.IConnectionChangeListener;
 import games.strategy.net.INode;
 import games.strategy.net.IServerMessenger;
-import java.io.IOException;
-import java.net.InetSocketAddress;
-import java.net.Socket;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -84,18 +81,6 @@ final class LobbyGameController implements ILobbyGameController {
 
   void register(final IRemoteMessenger remote) {
     remote.registerRemote(this, REMOTE_NAME);
-  }
-
-  @Override
-  public boolean testGame(final INode node) {
-    // make sure we are being tested from the right node
-    final InetSocketAddress address = node.getSocketAddress();
-    try (Socket s = new Socket()) {
-      s.connect(address, 10 * 1000);
-      return true;
-    } catch (final IOException e) {
-      return false;
-    }
   }
 
   private void assertCorrectGameOwner(final UUID gameId) {


### PR DESCRIPTION
Migrate connectivity test to http server from java socket server.
The connectivity check is the verification that kicks in after hosting
a game where the server tries to establish a 'reverse' connection
to the host to make sure the host is accessible from the internet.

This update moves that check to HTTP server.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[ ] New map or map update
[ ] New Feature
[ ] Feature update or enhancement
[ ] Feature Removal
[x] Code Cleanup or refactor
[ ] Configuration Change
[ ] Bug fix:  <!-- Link to bug issue or forum post here -->
[ ] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[ ] No manual testing done
[x] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->
- launched a local lobby with bot
- joined local lobby, hosted a game

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

