### PR TITLE
Add count for support bonus type

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
+++ b/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
@@ -129,7 +129,7 @@ public abstract class DefaultAttachment extends GameDataComponent implements IAt
    */
   @Override
   public String toString() {
-    return getClass().getSimpleName() + " attached to:" + attachedTo + " with name:" + name;
+    return getClass().getSimpleName() + " attached to: " + attachedTo + " with name: " + name;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -3262,7 +3262,7 @@ public class UnitAttachment extends DefaultAttachment {
                     : (support.getOffence() ? "Attack" : "Defense"));
         final String text =
             support.getBonus()
-                + (moreThanOneSupportType ? " " + support.getBonusType().getSecond() : "")
+                + (moreThanOneSupportType ? " " + support.getBonusType().getName() : "")
                 + " "
                 + (support.getDice() == null
                     ? ""

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -3262,7 +3262,7 @@ public class UnitAttachment extends DefaultAttachment {
                     : (support.getOffence() ? "Attack" : "Defense"));
         final String text =
             support.getBonus()
-                + (moreThanOneSupportType ? " " + support.getBonusType() : "")
+                + (moreThanOneSupportType ? " " + support.getBonusType().getSecond() : "")
                 + " "
                 + (support.getDice() == null
                     ? ""

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -37,6 +37,10 @@ public class UnitSupportAttachment extends DefaultAttachment {
     @Nonnull String name;
     @Nonnull Integer count;
 
+    public int getCount() {
+      return count < 0 ? Integer.MAX_VALUE : count;
+    }
+
     boolean isOldArtilleryRule() {
       return name.equals(Constants.OLD_ART_RULE_NAME);
     }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -9,6 +9,7 @@ import games.strategy.engine.data.MutableProperty;
 import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Constants;
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -30,7 +31,9 @@ public class UnitSupportAttachment extends DefaultAttachment {
 
   /** Type to represent name and count */
   @Value
-  public static class BonusType {
+  public static class BonusType implements Serializable {
+    private static final long serialVersionUID = -7445551357956238314L;
+
     @Nonnull String name;
     @Nonnull Integer count;
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -1069,8 +1069,7 @@ public class DiceRoll implements Externalizable {
       final Predicate<UnitSupportAttachment> ruleFilter) {
     int givenSupport = 0;
     for (final List<UnitSupportAttachment> bonusType : supportsAvailable) {
-      final int bonusTypeCount = bonusType.get(0).getBonusType().getCount();
-      int maxPerBonusType = bonusTypeCount >= 1 ? bonusTypeCount : Integer.MAX_VALUE;
+      int maxPerBonusType = bonusType.get(0).getBonusType().getCount();
       for (final UnitSupportAttachment rule : bonusType) {
         if (!ruleFilter.test(rule)) {
           continue;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -1039,10 +1039,10 @@ public class DiceRoll implements Externalizable {
       final Iterator<List<UnitSupportAttachment>> iter2 = supportsAvailable.iterator();
       List<UnitSupportAttachment> ruleType = null;
       boolean found = false;
-      final String bonusType = rule.getBonusType().getSecond();
+      final String bonusType = rule.getBonusType().getName();
       while (iter2.hasNext()) {
         ruleType = iter2.next();
-        if (ruleType.get(0).getBonusType().getSecond().equals(bonusType)) {
+        if (ruleType.get(0).getBonusType().getName().equals(bonusType)) {
           found = true;
           break;
         }
@@ -1069,7 +1069,7 @@ public class DiceRoll implements Externalizable {
       final Predicate<UnitSupportAttachment> ruleFilter) {
     int givenSupport = 0;
     for (final List<UnitSupportAttachment> bonusType : supportsAvailable) {
-      final int bonusTypeCount = bonusType.get(0).getBonusType().getFirst();
+      final int bonusTypeCount = bonusType.get(0).getBonusType().getCount();
       int maxPerBonusType = bonusTypeCount >= 1 ? bonusTypeCount : Integer.MAX_VALUE;
       for (final UnitSupportAttachment rule : bonusType) {
         if (!ruleFilter.test(rule)) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -1039,10 +1039,10 @@ public class DiceRoll implements Externalizable {
       final Iterator<List<UnitSupportAttachment>> iter2 = supportsAvailable.iterator();
       List<UnitSupportAttachment> ruleType = null;
       boolean found = false;
-      final String bonusType = rule.getBonusType();
+      final String bonusType = rule.getBonusType().getSecond();
       while (iter2.hasNext()) {
         ruleType = iter2.next();
-        if (ruleType.get(0).getBonusType().equals(bonusType)) {
+        if (ruleType.get(0).getBonusType().getSecond().equals(bonusType)) {
           found = true;
           break;
         }
@@ -1069,27 +1069,33 @@ public class DiceRoll implements Externalizable {
       final Predicate<UnitSupportAttachment> ruleFilter) {
     int givenSupport = 0;
     for (final List<UnitSupportAttachment> bonusType : supportsAvailable) {
+      final int bonusTypeCount = bonusType.get(0).getBonusType().getFirst();
+      int maxPerBonusType = bonusTypeCount >= 1 ? bonusTypeCount : Integer.MAX_VALUE;
       for (final UnitSupportAttachment rule : bonusType) {
         if (!ruleFilter.test(rule)) {
           continue;
         }
         final Set<UnitType> types = rule.getUnitType();
         if (types != null && types.contains(unit.getType()) && supportLeft.getInt(rule) > 0) {
-          givenSupport += rule.getBonus();
-          supportLeft.add(rule, -1);
-          final IntegerMap<Unit> supportersLeft = supportUnitsLeft.get(rule);
-          if (supportersLeft != null) {
-            final Set<Unit> supporters = supportersLeft.keySet();
-            if (!supporters.isEmpty()) {
-              final Unit u = supporters.iterator().next();
-              supportUnitsLeft.get(rule).add(u, -1);
-              if (supportUnitsLeft.get(rule).getInt(u) <= 0) {
-                supportUnitsLeft.get(rule).removeKey(u);
-              }
-              unitSupportMap.computeIfAbsent(u, i -> new IntegerMap<>()).add(unit, rule.getBonus());
+          final int numSupportToApply =
+              Math.min(
+                  maxPerBonusType,
+                  Math.min(supportLeft.getInt(rule), supportUnitsLeft.get(rule).size()));
+          for (int i = 0; i < numSupportToApply; i++) {
+            givenSupport += rule.getBonus();
+            supportLeft.add(rule, -1);
+            final Set<Unit> supporters = supportUnitsLeft.get(rule).keySet();
+            final Unit u = supporters.iterator().next();
+            supportUnitsLeft.get(rule).add(u, -1);
+            if (supportUnitsLeft.get(rule).getInt(u) <= 0) {
+              supportUnitsLeft.get(rule).removeKey(u);
             }
+            unitSupportMap.computeIfAbsent(u, j -> new IntegerMap<>()).add(unit, rule.getBonus());
           }
-          break;
+          maxPerBonusType -= numSupportToApply;
+          if (maxPerBonusType <= 0) {
+            break;
+          }
         }
       }
     }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -8,6 +8,7 @@ import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
 import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -748,6 +749,68 @@ class DiceRollTest {
     gameData.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, Boolean.TRUE);
     assertThat(StrategicBombingRaidBattle.getSbrRolls(bomber, british), is(2));
     assertThat(StrategicBombingRaidBattle.getSbrRolls(bomber, british), is(2));
+  }
+
+  @Test
+  void testGetTotalPowerForSupportBonusTypeCount() throws Exception {
+    final GameData twwGameData = TestMapGameData.TWW.getGameData();
+
+    // Move regular units
+    final PlayerId germans = GameDataTestUtil.germany(twwGameData);
+    final Territory berlin = territory("Berlin", twwGameData);
+    final List<Unit> attackers = new ArrayList<>();
+
+    attackers.addAll(GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
+    attackers.addAll(GameDataTestUtil.germanArtillery(twwGameData).create(1, germans));
+    int attackPower =
+        DiceRoll.getTotalPower(
+            DiceRoll.getUnitPowerAndRollsForNormalBattles(
+                attackers,
+                new ArrayList<>(),
+                false,
+                twwGameData,
+                berlin,
+                new ArrayList<>(),
+                false,
+                null),
+            twwGameData);
+    assertEquals(attackPower, 6, "1 artillery should provide +1 support to the infantry");
+
+    attackers.addAll(GameDataTestUtil.germanArtillery(twwGameData).create(1, germans));
+    attackPower =
+        DiceRoll.getTotalPower(
+            DiceRoll.getUnitPowerAndRollsForNormalBattles(
+                attackers,
+                new ArrayList<>(),
+                false,
+                twwGameData,
+                berlin,
+                new ArrayList<>(),
+                false,
+                null),
+            twwGameData);
+    assertEquals(
+        attackPower,
+        10,
+        "2 artillery should provide +2 support to the infantry as stack count is 2");
+
+    attackers.addAll(GameDataTestUtil.germanArtillery(twwGameData).create(1, germans));
+    attackPower =
+        DiceRoll.getTotalPower(
+            DiceRoll.getUnitPowerAndRollsForNormalBattles(
+                attackers,
+                new ArrayList<>(),
+                false,
+                twwGameData,
+                berlin,
+                new ArrayList<>(),
+                false,
+                null),
+            twwGameData);
+    assertEquals(
+        attackPower,
+        13,
+        "3 artillery should provide +2 support to the infantry as can't provide more than 2");
   }
 
   @Nested

--- a/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -257,6 +257,11 @@ public final class GameDataTestUtil {
     return unitType("germanMine", data);
   }
 
+  /** Returns a germanArtillery UnitType object for the specified GameData object. */
+  public static UnitType germanArtillery(final GameData data) {
+    return unitType("germanArtillery", data);
+  }
+
   /** Returns a germanAntiTankGun UnitType object for the specified GameData object. */
   public static UnitType germanAntiTankGun(final GameData data) {
     return unitType("germanAntiTankGun", data);

--- a/game-core/src/test/resources/Total_World_War_Dec1941.xml
+++ b/game-core/src/test/resources/Total_World_War_Dec1941.xml
@@ -16755,7 +16755,7 @@
       <option name="dice" value="strength"/>
       <option name="bonus" value="1"/>
       <option name="number" value="1"/>
-      <option name="bonusType" value="ArtilleryBonus"/>
+      <option name="bonusType" value="ArtilleryBonus" count="2"/>
       <option name="impArtTech" value="false"/>
       <option name="players" value="Germany"/>
     </attachment>


### PR DESCRIPTION
Addresses: https://forums.triplea-game.org/topic/1560/stack-unit-support

A count can now be specified for a supportAttachment bonusType which specifies how many units can stack support onto the given support target (previously it was always just 1). The count can be any numerical value with 1 being the default but anything less than 1 will represent infinite stacking (0, -1, etc). Infinite stacking for strength support is not advised because you still have the dice sides limit it but infinite stacking for roll modifiers can make sense.

**New bonusType optional count parameter**
```
<option name="bonusType" value="Cover" count="3"/>
```

**Infantry receives support from up to 2 artillery**
```
        <attachment name="supportAttachmentArtillerygerman" attachTo="germanArtillery" javaClass="UnitSupportAttachment" type="unitType">
            <option name="unitType" value="germanInfantry:germanMarine:germanCombatEngineer:germanAlpineInfantry:germanParatrooper"/>
            <option name="faction" value="allied"/>
            <option name="side" value="offence"/>
            <option name="dice" value="strength"/>
            <option name="bonus" value="1"/>
            <option name="number" value="1"/>
            <option name="bonusType" value="ArtilleryBonus" count="2"/>
            <option name="impArtTech" value="false"/>
            <option name="players" value="Germany"/>
        </attachment>
```

**Infantry receives support from up to 3 static defenses (entrenchment, fortification)**
```
        <attachment name="supportAttachmentEntrenchmentgerman" attachTo="germanEntrenchment" javaClass="UnitSupportAttachment" type="unitType">
            <option name="unitType" value="germanInfantry:germanMarine:germanCombatEngineer:germanAlpineInfantry:germanParatrooper:italianInfantry:italianMarine:italianCombatEngineer:italianAlpineInfantry:italianParatrooper:japaneseInfantry:japaneseMarine:japaneseCombatEngineer:japaneseAlpineInfantry:japaneseParatrooper"/>
            <option name="faction" value="allied"/>
            <option name="side" value="defence"/>
            <option name="dice" value="strength"/>
            <option name="bonus" value="1"/>
            <option name="number" value="2"/>
            <option name="bonusType" value="FortBonus" count="3"/>
            <option name="impArtTech" value="false"/>
            <option name="players" value="Germany"/>
        </attachment>
        <attachment name="supportAttachmentFortificationgerman" attachTo="germanFortification" javaClass="UnitSupportAttachment" type="unitType">
            <option name="unitType" value="germanInfantry:germanMarine:germanCombatEngineer:germanAlpineInfantry:germanParatrooper:italianInfantry:italianMarine:italianCombatEngineer:italianAlpineInfantry:italianParatrooper:japaneseInfantry:japaneseMarine:japaneseCombatEngineer:japaneseAlpineInfantry:japaneseParatrooper"/>
            <option name="faction" value="allied"/>
            <option name="side" value="defence"/>
            <option name="dice" value="strength"/>
            <option name="bonus" value="2"/>
            <option name="number" value="3"/>
            <option name="bonusType" value="FortBonus" count="3"/>
            <option name="impArtTech" value="false"/>
            <option name="players" value="Germany"/>
        </attachment>
```

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[x] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[] No manual testing done
[x] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->

Ran a few maps like revised on all AI to ensure no regressions. Edited TWW XML to test the new parameter and opened the BC to see the calculated power.

