### PR TITLE
Send bot messages line by line, restore message cap to hosts

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/Chat.java
@@ -43,7 +43,6 @@ public class Chat implements ChatClient {
   private final ChatIgnoreList ignoreList = new ChatIgnoreList();
   private final ChatSoundProfile chatSoundProfile;
   @Getter private final PlayerName localPlayerName;
-  @Getter private final PlayerName serverPlayerName;
   private final Collection<BiConsumer<PlayerName, String>> statusUpdateListeners =
       new ArrayList<>();
 
@@ -57,7 +56,6 @@ public class Chat implements ChatClient {
   public Chat(
       final Messengers messengers, final String chatName, final ChatSoundProfile chatSoundProfile) {
     this.localPlayerName = messengers.getLocalNode().getPlayerName();
-    this.serverPlayerName = messengers.getServerNode().getPlayerName();
     chatTransmitter = new JavaSocketChatTransmitter(this, chatName, messengers);
     this.chatSoundProfile = chatSoundProfile;
     sentMessagesHistory = new SentMessagesHistory();

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
@@ -252,12 +252,7 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
   }
 
   private void addChatMessage(final String originalMessage, final PlayerName from) {
-    // we don't want to truncate messages from the server as those may be logs with accompanying
-    // stack traces
-    final String message =
-        from.equals(chat.getServerPlayerName())
-            ? originalMessage
-            : Ascii.truncate(originalMessage, 200, "...");
+    final String message = Ascii.truncate(originalMessage, 200, "...");
     final String time = "(" + TimeManager.getLocalizedTime() + ")";
     final Document doc = text.getDocument();
     try {

--- a/game-headless/src/main/java/org/triplea/game/server/debug/ChatHandler.java
+++ b/game-headless/src/main/java/org/triplea/game/server/debug/ChatHandler.java
@@ -72,6 +72,6 @@ public final class ChatHandler extends Handler {
   }
 
   private List<String> formatChatMessage(final LogRecord record) {
-    return Arrays.asList(getFormatter().format(record).trim().split("\n"));
+    return Arrays.asList(getFormatter().format(record).trim().split("\\n"));
   }
 }

--- a/game-headless/src/main/java/org/triplea/game/server/debug/ChatHandler.java
+++ b/game-headless/src/main/java/org/triplea/game/server/debug/ChatHandler.java
@@ -1,6 +1,8 @@
 package org.triplea.game.server.debug;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.logging.Handler;
@@ -56,7 +58,7 @@ public final class ChatHandler extends Handler {
     if (isLoggable(record) && enabled) {
       enabled = false;
       try {
-        sendChatMessage.accept(formatChatMessage(record));
+        formatChatMessage(record).forEach(sendChatMessage);
       } finally {
         enabled = true;
       }
@@ -69,7 +71,7 @@ public final class ChatHandler extends Handler {
         .ifPresent(chat -> chat.sendMessage(message));
   }
 
-  private String formatChatMessage(final LogRecord record) {
-    return getFormatter().format(record).trim();
+  private List<String> formatChatMessage(final LogRecord record) {
+    return Arrays.asList(getFormatter().format(record).trim().split("\n"));
   }
 }

--- a/game-headless/src/test/java/org/triplea/game/server/debug/ChatHandlerTest.java
+++ b/game-headless/src/test/java/org/triplea/game/server/debug/ChatHandlerTest.java
@@ -28,6 +28,10 @@ final class ChatHandlerTest {
       return new LogRecord(Level.WARNING, "message");
     }
 
+    private LogRecord newLoggableLogRecordWithMultipleLines() {
+      return new LogRecord(Level.WARNING, "message\nmessage2\n");
+    }
+
     private LogRecord newUnloggableLogRecord() {
       return new LogRecord(Level.FINEST, "message");
     }
@@ -45,6 +49,14 @@ final class ChatHandlerTest {
       // first line is logged date, second line is the message
       verify(sendChatMessage, times(2)).accept(anyString());
     }
+
+    @Test
+    void shouldSplitMessagesOnNewLines() {
+      publish(newLoggableLogRecordWithMultipleLines());
+
+      verify(sendChatMessage, times(3)).accept(anyString());
+    }
+
 
     @Test
     void shouldNotSendChatMessageWhenRecordIsNotLoggable() {

--- a/game-headless/src/test/java/org/triplea/game/server/debug/ChatHandlerTest.java
+++ b/game-headless/src/test/java/org/triplea/game/server/debug/ChatHandlerTest.java
@@ -42,7 +42,8 @@ final class ChatHandlerTest {
     void shouldSendChatMessageWhenRecordIsLoggable() {
       publish(newLoggableLogRecord());
 
-      verify(sendChatMessage).accept(anyString());
+      // first line is logged date, second line is the message
+      verify(sendChatMessage, times(2)).accept(anyString());
     }
 
     @Test
@@ -56,7 +57,8 @@ final class ChatHandlerTest {
     void shouldNotIncludeTrailingNewlineInChatMessage() {
       publish(newLoggableLogRecord());
 
-      verify(sendChatMessage).accept(not(endsWith("\n")));
+      // first line is logged date, second line is the message
+      verify(sendChatMessage, times(2)).accept(not(endsWith("\n")));
     }
 
     @Test
@@ -71,7 +73,8 @@ final class ChatHandlerTest {
 
       publish(newLoggableLogRecord());
 
-      verify(sendChatMessage, times(1)).accept(anyString());
+      // first line is logged date, second line is the message
+      verify(sendChatMessage, times(2)).accept(anyString());
     }
   }
 }

--- a/game-headless/src/test/java/org/triplea/game/server/debug/ChatHandlerTest.java
+++ b/game-headless/src/test/java/org/triplea/game/server/debug/ChatHandlerTest.java
@@ -57,7 +57,6 @@ final class ChatHandlerTest {
       verify(sendChatMessage, times(3)).accept(anyString());
     }
 
-
     @Test
     void shouldNotSendChatMessageWhenRecordIsNotLoggable() {
       publish(newUnloggableLogRecord());


### PR DESCRIPTION
Main goal is to remove the 'serverPlayer' property from Chat.java
which is only used in ChatMessagePanel to determine if messages
are coming from the server player in order to not truncate them.

This is done as bots send stack traces to chat and to avoid
truncating those chat messages. It can be the case though
that a server player is a human, not bot, in which case they
are the one human player without a chat limit.

This update restores the message cap to all players and to fix
the bot stack trace situation, stack traces are sent line-by-line.
This is a possible solution now because flood control has been
removed from bots. Flood control is done client-side, which did
not make sense for bots and previously would have prevented
this situation. Client-side flood control does not make sense
for bots and was removed, which enables this solution.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[x] Bug fix:  Human hosts had no message cap <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[] No manual testing done
[x] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->

Joined a headless server, opened a save game that was incompatible, verified stack trace message.

<!-- If there are UI updates, uncomment and include screenshots below -->
## Screens Shots

### Before
![Screenshot from 2019-10-02 21-55-59](https://user-images.githubusercontent.com/12397753/66101266-07fc2980-e563-11e9-8d3e-10bfe8e472d0.png)

### After
![Screenshot from 2019-10-02 22-01-41](https://user-images.githubusercontent.com/12397753/66101270-0c284700-e563-11e9-9f67-8d1073fedefb.png)


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

