### PR TITLE
Chat Refactors: IChatListener breakup, chat history fix, constructor injection

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/Chat.java
@@ -29,7 +29,8 @@ public class Chat implements ChatClient {
 
   private final ChatTransmitter chatTransmitter;
 
-  private final List<IChatListener> listeners = new CopyOnWriteArrayList<>();
+  private final List<ChatMessageListener> chatMessageListeners = new CopyOnWriteArrayList<>();
+  private final List<ChatPlayerListener> chatPlayerListeners = new CopyOnWriteArrayList<>();
 
   @Getter(AccessLevel.PACKAGE)
   private final SentMessagesHistory sentMessagesHistory;
@@ -71,9 +72,7 @@ public class Chat implements ChatClient {
             .sorted(Comparator.comparing(c -> c.getPlayerName().getValue()))
             .collect(Collectors.toList());
 
-    for (final IChatListener listener : listeners) {
-      listener.updatePlayerList(playerNames);
-    }
+    chatPlayerListeners.forEach(listener -> listener.updatePlayerList(playerNames));
   }
 
   @Override
@@ -83,9 +82,7 @@ public class Chat implements ChatClient {
       return;
     }
     chatHistory.add(new ChatMessage(message, from));
-    for (final IChatListener listener : listeners) {
-      listener.addMessage(message, from);
-    }
+    chatMessageListeners.forEach(listener -> listener.addMessage(message, from));
   }
 
   @Override
@@ -95,12 +92,13 @@ public class Chat implements ChatClient {
     }
     chatters.put(chatParticipant, "");
     updateConnections();
-    for (final IChatListener listener : listeners) {
-      listener.addStatusMessage(chatParticipant.getPlayerName() + " has joined");
-      if (chatSoundProfile == ChatSoundProfile.GAME_CHATROOM) {
-        ClipPlayer.play(SoundPath.CLIP_CHAT_JOIN_GAME);
-      }
-    }
+    chatMessageListeners.forEach(
+        listener -> {
+          listener.addStatusMessage(chatParticipant.getPlayerName() + " has joined");
+          if (chatSoundProfile == ChatSoundProfile.GAME_CHATROOM) {
+            ClipPlayer.play(SoundPath.CLIP_CHAT_JOIN_GAME);
+          }
+        });
   }
 
   @Override
@@ -112,26 +110,22 @@ public class Chat implements ChatClient {
             node -> {
               chatters.remove(node);
               updateConnections();
-              for (final IChatListener listener : listeners) {
-                listener.addStatusMessage(node.getPlayerName() + " has left");
-              }
+              chatMessageListeners.forEach(
+                  listener -> listener.addStatusMessage(node.getPlayerName() + " has left"));
             });
   }
 
   @Override
   public void slappedBy(final PlayerName from) {
     final String message = "You were slapped by " + from;
-    for (final IChatListener listener : listeners) {
-      chatHistory.add(new ChatMessage(message, from));
-      listener.addMessageWithSound(message, from, SoundPath.CLIP_CHAT_SLAP);
-    }
+    chatHistory.add(new ChatMessage(message, from));
+    chatMessageListeners.forEach(
+        listener -> listener.addMessageWithSound(message, from, SoundPath.CLIP_CHAT_SLAP));
   }
 
   @Override
   public void eventMessage(final String eventMessage) {
-    for (final IChatListener listener : listeners) {
-      listener.addStatusMessage(eventMessage);
-    }
+    chatMessageListeners.forEach(listener -> listener.addStatusMessage(eventMessage));
   }
 
   @Override
@@ -158,17 +152,25 @@ public class Chat implements ChatClient {
         .orElse("");
   }
 
-  void addChatListener(final IChatListener listener) {
-    listeners.add(listener);
+  void addChatListener(final ChatPlayerListener listener) {
+    chatPlayerListeners.add(listener);
     updateConnections();
+  }
+
+  void addChatListener(final ChatMessageListener listener) {
+    chatMessageListeners.add(listener);
   }
 
   void addStatusUpdateListener(final BiConsumer<PlayerName, String> statusUpdateListener) {
     statusUpdateListeners.add(statusUpdateListener);
   }
 
-  void removeChatListener(final IChatListener listener) {
-    listeners.remove(listener);
+  void removeChatListener(final ChatMessageListener listener) {
+    chatMessageListeners.remove(listener);
+  }
+
+  void removeChatListener(final ChatPlayerListener listener) {
+    chatPlayerListeners.remove(listener);
   }
 
   void removeStatusUpdateListener(final BiConsumer<PlayerName, String> statusUpdateListener) {

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatMessageListener.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatMessageListener.java
@@ -1,12 +1,9 @@
 package games.strategy.engine.chat;
 
 import games.strategy.engine.lobby.PlayerName;
-import java.util.Collection;
 
-/** An interface to allow for testing. */
-public interface IChatListener {
-  void updatePlayerList(Collection<ChatParticipant> players);
-
+/** Callback interface for a component that is interested in chat messages. */
+public interface ChatMessageListener {
   void addMessage(String message, PlayerName from);
 
   void addMessageWithSound(String message, PlayerName from, String sound);

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
@@ -11,8 +11,6 @@ import java.awt.Insets;
 import java.awt.event.KeyEvent;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.logging.Level;
 import javax.swing.Action;
 import javax.swing.BoundedRangeModel;
@@ -43,7 +41,7 @@ import org.triplea.swing.SwingAction;
  * <p>We can change the chat we are connected to using the setChat(...) method.
  */
 @Log
-public class ChatMessagePanel extends JPanel implements IChatListener {
+public class ChatMessagePanel extends JPanel implements ChatMessageListener {
   private static final long serialVersionUID = 118727200083595226L;
   private static final int MAX_LINES = 5000;
 
@@ -110,7 +108,6 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
                   } else {
                     send.setEnabled(false);
                     text.setEnabled(false);
-                    updatePlayerList(Collections.emptyList());
                   }
                 }));
   }
@@ -340,7 +337,4 @@ public class ChatMessagePanel extends JPanel implements IChatListener {
     chat.sendMessage(nextMessage.getText());
     nextMessage.setText("");
   }
-
-  @Override
-  public void updatePlayerList(final Collection<ChatParticipant> players) {}
 }

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerListener.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerListener.java
@@ -1,0 +1,8 @@
+package games.strategy.engine.chat;
+
+import java.util.Collection;
+
+/** Callback interface for a components interested in displaying a list of chat participants. */
+public interface ChatPlayerListener {
+  void updatePlayerList(Collection<ChatParticipant> players);
+}

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
@@ -34,7 +34,7 @@ import javax.swing.UIManager;
 import org.triplea.swing.SwingAction;
 
 /** A UI component that displays the players participating in a chat. */
-public class ChatPlayerPanel extends JPanel implements IChatListener {
+public class ChatPlayerPanel extends JPanel implements ChatPlayerListener {
   private static final String TAG_MODERATOR = "[Mod]";
   private static final long serialVersionUID = -3153022965393962945L;
   private static final Icon ignoreIcon;
@@ -227,13 +227,6 @@ public class ChatPlayerPanel extends JPanel implements IChatListener {
         });
   }
 
-  @Override
-  public void addMessageWithSound(
-      final String message, final PlayerName from, final String sound) {}
-
-  @Override
-  public void addMessage(final String message, final PlayerName from) {}
-
   private String getDisplayString(final ChatParticipant chatParticipant) {
     if (chat == null) {
       return "";
@@ -245,9 +238,6 @@ public class ChatPlayerPanel extends JPanel implements IChatListener {
 
     return chatParticipant.getPlayerName() + extra + suffix;
   }
-
-  @Override
-  public void addStatusMessage(final String message) {}
 
   /**
    * Add an action factory that will be used to populate the pop up many when right clicking on a

--- a/game-core/src/main/java/games/strategy/engine/chat/HeadlessChat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/HeadlessChat.java
@@ -1,23 +1,19 @@
 package games.strategy.engine.chat;
 
 import com.google.common.base.Ascii;
-import games.strategy.engine.chat.Chat.ChatSoundProfile;
 import games.strategy.engine.lobby.PlayerName;
-import games.strategy.net.Messengers;
-import java.util.Collection;
 import org.triplea.game.chat.ChatModel;
 import org.triplea.java.TimeManager;
 
 /** Headless version of ChatPanel. */
-public class HeadlessChat implements IChatListener, ChatModel {
+public class HeadlessChat implements ChatMessageListener, ChatModel {
   // roughly 1000 chat messages
   private static final int MAX_LENGTH = 1000 * 200;
-  private Chat chat;
+  private final Chat chat;
   private final StringBuilder allText = new StringBuilder();
 
-  public HeadlessChat(
-      final Messengers messengers, final String chatName, final ChatSoundProfile chatSoundProfile) {
-    this.chat = new Chat(messengers, chatName, chatSoundProfile);
+  public HeadlessChat(final Chat chat) {
+    this.chat = chat;
     chat.addChatListener(this);
   }
 
@@ -35,9 +31,6 @@ public class HeadlessChat implements IChatListener, ChatModel {
   public Chat getChat() {
     return chat;
   }
-
-  @Override
-  public void updatePlayerList(final Collection<ChatParticipant> players) {}
 
   /** thread safe. */
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -396,7 +396,8 @@ public class ServerModel extends Observable implements IConnectionChangeListener
       chatController = new ChatController(CHAT_NAME, messengers, node -> false);
 
       if (ui == null) {
-        chatModel = new HeadlessChat(messengers, CHAT_NAME, Chat.ChatSoundProfile.GAME_CHATROOM);
+        chatModel =
+            new HeadlessChat(new Chat(messengers, CHAT_NAME, Chat.ChatSoundProfile.NO_SOUND));
         chatModelCancel = Runnables.doNothing();
       } else {
         final var chatPanel =

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -45,9 +45,8 @@ public class LobbyFrame extends JFrame {
             Chat.ChatSoundProfile.LOBBY_CHATROOM);
     final ChatMessagePanel chatMessagePanel = new ChatMessagePanel(chat);
     lobbyServerProperties.getServerMessage().ifPresent(chatMessagePanel::addServerMessage);
-    final ChatPlayerPanel chatPlayers = new ChatPlayerPanel(null);
+    final ChatPlayerPanel chatPlayers = new ChatPlayerPanel(chat);
     chatPlayers.addHiddenPlayerName(LobbyConstants.ADMIN_USERNAME);
-    chatPlayers.setChat(chat);
     chatPlayers.setPreferredSize(new Dimension(200, 600));
     chatPlayers.addActionFactory(this::newAdminActions);
 


### PR DESCRIPTION
(1) Break up IChatListener interface into two, interface segragation principle. Part of
interface was used for message box, the other part was used for the player listing.

(2) Fix bug where 'slap messages' are recorded into chat history 'n' times instead
of just once.

(3) Update HeadlessChat constructor, dependency injection principle. Instead of the
constructor new'ing up a 'Chat' object, we inject it.

(4) Change sound profile of HeadlessChat to 'no sound'. The sounds played on a headless
server are no-ops, we may as well use the 'no sound' profile.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[] No manual testing done
[] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

