### PR TITLE
Update givesMovement to allow multiple units

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -1817,20 +1817,22 @@ public class UnitAttachment extends DefaultAttachment {
 
   private void setGivesMovement(final String value) throws GameParseException {
     final String[] s = splitOnColon(value);
-    if (s.length <= 0 || s.length > 2) {
+    if (s.length < 2) {
       throw new GameParseException(
-          "givesMovement cannot be empty or have more than two fields" + thisErrorMsg());
+          "givesMovement must have an integer followed by 1 or more unit types" + thisErrorMsg());
     }
-    final String unitTypeToProduce = s[1];
-    // validate that this unit exists in the xml
-    final UnitType ut = getData().getUnitTypeList().getUnitType(unitTypeToProduce);
-    if (ut == null) {
-      throw new GameParseException("No unit called:" + unitTypeToProduce + thisErrorMsg());
+    final int movement = getInt(s[0]);
+    for (int i = 1; i < s.length; i++) {
+      final String unitTypeName = s[i];
+      // validate that this unit exists in the xml
+      final UnitType type = getData().getUnitTypeList().getUnitType(unitTypeName);
+      if (type == null) {
+        throw new GameParseException("No unit called: " + unitTypeName + thisErrorMsg());
+      }
+      // we should allow positive and negative numbers, since you can give bonuses to units or take
+      // away a unit's movement
+      givesMovement.put(type, movement);
     }
-    // we should allow positive and negative numbers, since you can give bonuses to units or take
-    // away a unit's movement
-    final int n = getInt(s[0]);
-    givesMovement.put(ut, n);
   }
 
   private void setGivesMovement(final IntegerMap<UnitType> value) {


### PR DESCRIPTION
Addresses feature request: https://forums.triplea-game.org/topic/1586/allow-unit-property-givesmovement-to-use-variable-lists

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[] No manual testing done
[x] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->

Updated TWW XML to have the following and made sure it parsed and provided bonus movement to german fighters and naval fighters as well as still worked properly for existing airbases with just 1 unit specified in the givesMovement list:
```
        <attachment name="unitAttachment" attachTo="germanAirfield" javaClass="UnitAttachment" type="unitType">
            <option name="isInfrastructure" value="true"/>
            <option name="movement" value="0"/>
            <option name="attack" value="0"/>
            <option name="defense" value="0"/>
            <option name="canBeDamaged" value="true"/>
            <option name="maxDamage" value="8"/>
            <option name="maxOperationalDamage" value="5"/>
            <option name="canDieFromReachingMaxDamage" value="true"/>
            <option name="isAirBase" value="true"/>
            <option name="isConstruction" value="true"/>
            <option name="constructionType" value="Airfield"/>
            <option name="constructionsPerTerrPerTypePerTurn" value="3"/>
            <option name="maxScrambleCount" value="2"/>
            <option name="maxConstructionsPerTypePerTerr" value="3"/>
            <option name="givesMovement" value="2:germanFighter:germanNavalFighter"/>
         </attachment>  
```
