### PR TITLE
Update test xml to include givesMovement to multiple unit types

### DIFF
--- a/game-core/src/test/resources/Total_World_War_Dec1941.xml
+++ b/game-core/src/test/resources/Total_World_War_Dec1941.xml
@@ -6068,16 +6068,14 @@
       <option name="maxConstructionsPerTypePerTerr" value="3"/>
       <option name="requiresUnits" value="spanishCombatEngineer"/>
       <option name="consumesUnits" value="1:Material"/>
-      <option name="givesMovement" value="2:germanFighter"/>
+      <option name="givesMovement" value="2:germanFighter:germanNavalFighter:germanRocket"/>
       <option name="givesMovement" value="4:germanAdvancedFighter"/>
-      <option name="givesMovement" value="2:germanNavalFighter"/>
       <option name="givesMovement" value="4:germanAdvancedNavalFighter"/>
       <option name="givesMovement" value="3:germanTacticalBomber"/>
       <option name="givesMovement" value="5:germanAdvancedTacticalBomber"/>
       <option name="givesMovement" value="4:germanStrategicBomber"/>
       <option name="givesMovement" value="6:germanHeavyStrategicBomber"/>
       <option name="givesMovement" value="3:germanAirTransport"/>
-      <option name="givesMovement" value="2:germanRocket"/>
       <option name="givesMovement" value="4:germanAdvancedRocket"/>
       <option name="givesMovement" value="2:italianFighter"/>
       <option name="givesMovement" value="4:italianAdvancedFighter"/>


### PR DESCRIPTION
Add new format for givesMovement XML to tests as a follow up to https://github.com/triplea-game/triplea/pull/5316. This tests that the new format at least parses without errors.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[x] Other:   Add Test XML<!-- Please specify -->

