### PR TITLE
Isolate Chat Messengers Dependencies and Chat Refactor Improvements

### DIFF
--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -16,6 +16,7 @@ dependencies {
     implementation 'commons-cli:commons-cli:1.4'
     implementation 'commons-codec:commons-codec:1.11'
     implementation 'commons-io:commons-io:2.6'
+    implementation 'io.github.openfeign:feign-gson:10.2.0'
     implementation 'org.apache.commons:commons-math3:3.6.1'
     implementation "org.apache.httpcomponents:httpclient:$apacheHttpComponentsVersion"
     implementation "org.apache.httpcomponents:httpmime:$apacheHttpComponentsVersion"

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatClient.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatClient.java
@@ -12,7 +12,7 @@ import games.strategy.engine.lobby.PlayerName;
  */
 public interface ChatClient {
   /** A chat message has been received. */
-  void messageReceived(String message);
+  void messageReceived(PlayerName from, String message);
 
   /**
    * A new chatter has joined.

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatController.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatController.java
@@ -7,6 +7,7 @@ import games.strategy.engine.message.RemoteName;
 import games.strategy.net.IConnectionChangeListener;
 import games.strategy.net.INode;
 import games.strategy.net.Messengers;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.Executors;
@@ -101,7 +102,7 @@ public class ChatController implements IChatController {
 
   // a player has joined
   @Override
-  public Map<ChatParticipant, String> joinChat() {
+  public Collection<ChatParticipant> joinChat() {
     final INode node = MessageContext.getSender();
     log.info("Chatter:" + node + " is joining chat:" + chatName);
     final Tag tag = isModerator.test(node) ? Tag.MODERATOR : Tag.NONE;
@@ -120,10 +121,9 @@ public class ChatController implements IChatController {
                   ChatParticipant.builder()
                       .isModerator(entry.getValue() == Tag.MODERATOR)
                       .playerName(entry.getKey().getPlayerName())
+                      .status(chatterStatus.get(entry.getKey().getPlayerName()))
                       .build())
-          .collect(
-              Collectors.toMap(
-                  p -> p, p -> Strings.nullToEmpty(chatterStatus.get(p.getPlayerName()))));
+          .collect(Collectors.toSet());
     }
   }
 

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatPanel.java
@@ -46,7 +46,7 @@ public class ChatPanel extends JPanel implements ChatModel {
    */
   public static ChatPanel newChatPanel(
       final Messengers messengers, final String chatName, final ChatSoundProfile chatSoundProfile) {
-    final Chat chat = new Chat(messengers, chatName);
+    final Chat chat = new Chat(new MessengersChatTransmitter(chatName, messengers));
     return Interruptibles.awaitResult(
             () -> SwingAction.invokeAndWaitResult(() -> new ChatPanel(chat, chatSoundProfile)))
         .result

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatParticipant.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatParticipant.java
@@ -1,19 +1,27 @@
 package games.strategy.engine.chat;
 
+import com.google.common.base.Strings;
 import games.strategy.engine.lobby.PlayerName;
 import java.io.Serializable;
+import javax.annotation.Nullable;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NonNull;
+import lombok.Setter;
 import lombok.ToString;
 
 @Builder
 @Getter
-@EqualsAndHashCode
+@EqualsAndHashCode(of = "playerName")
 @ToString
 public class ChatParticipant implements Serializable {
   private static final long serialVersionUID = 7103177780407531008L;
   @NonNull private final PlayerName playerName;
   private final boolean isModerator;
+  @Setter @Nullable private String status;
+
+  public String getStatus() {
+    return Strings.nullToEmpty(status);
+  }
 }

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatTransmitter.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatTransmitter.java
@@ -1,18 +1,17 @@
 package games.strategy.engine.chat;
 
 import games.strategy.engine.lobby.PlayerName;
-import java.util.Map;
+import java.util.Collection;
 
 /**
  * Interface to represent 'send' actions from a chat client to server. This interface can be used to
  * push messages to the server.
  */
 public interface ChatTransmitter {
-  /**
-   * Connects to chat, adds current player and returns the set of players that are in chat mapped to
-   * their status.
-   */
-  Map<ChatParticipant, String> connect();
+  void setChatClient(ChatClient chatClient);
+
+  /** Connects to chat, adds current player and returns the set of players that are in chat. */
+  Collection<ChatParticipant> connect();
 
   /** Disconnects current player from chat. */
   void disconnect();
@@ -25,4 +24,6 @@ public interface ChatTransmitter {
 
   /** Updates the status of current player. */
   void updateStatus(String status);
+
+  PlayerName getLocalPlayerName();
 }

--- a/game-core/src/main/java/games/strategy/engine/chat/IChatController.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/IChatController.java
@@ -1,7 +1,7 @@
 package games.strategy.engine.chat;
 
 import games.strategy.engine.message.IRemote;
-import java.util.Map;
+import java.util.Collection;
 
 /**
  * A central controller of who is in the chat.
@@ -9,8 +9,8 @@ import java.util.Map;
  * <p>When joining you get a list of all the players currently in the chat and their statuses.
  */
 public interface IChatController extends IRemote {
-  /** Join the chat, returns the chatters currently in the chat mapped to their status. */
-  Map<ChatParticipant, String> joinChat();
+  /** Join the chat, returns the chatters currently in the chat. */
+  Collection<ChatParticipant> joinChat();
 
   /** Leave the chat, and ask that everyone stops bothering me. */
   void leaveChat();

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -13,6 +13,7 @@ import games.strategy.engine.chat.ChatController;
 import games.strategy.engine.chat.ChatMessagePanel.ChatSoundProfile;
 import games.strategy.engine.chat.ChatPanel;
 import games.strategy.engine.chat.HeadlessChat;
+import games.strategy.engine.chat.MessengersChatTransmitter;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.data.properties.GameProperties;
@@ -396,7 +397,8 @@ public class ServerModel extends Observable implements IConnectionChangeListener
       chatController = new ChatController(CHAT_NAME, messengers, node -> false);
 
       if (ui == null) {
-        chatModel = new HeadlessChat(new Chat(messengers, CHAT_NAME));
+        chatModel =
+            new HeadlessChat(new Chat(new MessengersChatTransmitter(CHAT_NAME, messengers)));
         chatModelCancel = Runnables.doNothing();
       } else {
         final var chatPanel = ChatPanel.newChatPanel(messengers, CHAT_NAME, ChatSoundProfile.GAME);

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -6,6 +6,7 @@ import games.strategy.engine.chat.ChatMessagePanel;
 import games.strategy.engine.chat.ChatMessagePanel.ChatSoundProfile;
 import games.strategy.engine.chat.ChatParticipant;
 import games.strategy.engine.chat.ChatPlayerPanel;
+import games.strategy.engine.chat.MessengersChatTransmitter;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.lobby.client.LobbyClient;
 import games.strategy.engine.lobby.client.login.LobbyServerProperties;
@@ -40,7 +41,8 @@ public class LobbyFrame extends JFrame {
     setIconImage(JFrameBuilder.getGameIcon());
     this.client = client;
     setJMenuBar(new LobbyMenu(this));
-    final Chat chat = new Chat(client.getMessengers(), LobbyConstants.LOBBY_CHAT);
+    final Chat chat =
+        new Chat(new MessengersChatTransmitter(LobbyConstants.LOBBY_CHAT, client.getMessengers()));
     final ChatMessagePanel chatMessagePanel = new ChatMessagePanel(chat, ChatSoundProfile.LOBBY);
     lobbyServerProperties.getServerMessage().ifPresent(chatMessagePanel::addServerMessage);
     final ChatPlayerPanel chatPlayers = new ChatPlayerPanel(chat);

--- a/game-core/src/test/java/games/strategy/engine/chat/ChatIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/chat/ChatIntegrationTest.java
@@ -132,7 +132,7 @@ final class ChatIntegrationTest {
   }
 
   private static Chat newChat(final Messengers messengers) {
-    return new Chat(messengers, CHAT_NAME);
+    return new Chat(new MessengersChatTransmitter(CHAT_NAME, messengers));
   }
 
   private static void waitFor(final Runnable assertion) throws InterruptedException {


### PR DESCRIPTION
Messengers isolating changes:
(1) Inject ChatTransmitter dependency into Chat
(2) Update ChatClient#messageReceived API to take in playerName,
    this way we can pass in the player name from MessengersChatTransmitter
    and not rely on messengers specific code
(3) Break circular dependency in ChatTransmitter constructor on ChatClient,
    use new setter: ChatTransmitter#setChatClient instead

Chat cleanups/refactors:
(4) Move 'status' to ChatParticipant, avoids map of
    'chatParticipant -> status' and converts to set of 'chatParticipant'
(5) Rename 'JavaSocketChatTransmitter' -> 'MessengersChatTransmitter'


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[] No manual testing done
[x] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->
Did a quick smoke-test, connected to a local lobby and confirmed chat and setting player status worked.

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

