### PR TITLE
Refactor: Postconditions rename and better failure message

### DIFF
--- a/java-extras/src/main/java/org/triplea/java/Postconditions.java
+++ b/java-extras/src/main/java/org/triplea/java/Postconditions.java
@@ -13,13 +13,13 @@ import lombok.NoArgsConstructor;
  * <pre><code>
  * int methodCall() {
  *    int returnValue = doCalculation();
- *    PostConditions.assertState(returnValue > 0);
+ *    Postconditions.assertState(returnValue > 0);
  *    return returnValue;
  * }
  * </code></pre>
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public final class PostConditions {
+public final class Postconditions {
 
   /**
    * Checks value of a boolean state value to be true, if not throws an exception with message.
@@ -28,7 +28,7 @@ public final class PostConditions {
    */
   public static void assertState(final boolean state) {
     if (!state) {
-      throw new AssertionError("Post condition failed, was: " + state);
+      throw new AssertionError("Post condition failed!");
     }
   }
 
@@ -40,7 +40,7 @@ public final class PostConditions {
    */
   public static void assertState(final boolean state, final String message) {
     if (!state) {
-      throw new AssertionError("Post condition failed, was: " + state + ", details: " + message);
+      throw new AssertionError("Post condition failed! Details: " + message);
     }
   }
 

--- a/java-extras/src/test/java/org/triplea/java/PostconditionsTest.java
+++ b/java-extras/src/test/java/org/triplea/java/PostconditionsTest.java
@@ -7,7 +7,8 @@ import org.hamcrest.core.StringContains;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-class PostConditionsTest {
+@SuppressWarnings("InnerClassMayBeStatic")
+class PostconditionsTest {
 
   private static final String MESSAGE = "additional context and informational message";
 
@@ -15,18 +16,18 @@ class PostConditionsTest {
   final class AssertState {
     @Test
     void positiveCase() {
-      PostConditions.assertState(true);
+      Postconditions.assertState(true);
     }
 
     @Test
     void assertionFails() {
-      assertThrows(AssertionError.class, () -> PostConditions.assertState(false));
+      assertThrows(AssertionError.class, () -> Postconditions.assertState(false));
     }
 
     @Test
     void assertionFailsWithMessage() {
       final Throwable thrown =
-          assertThrows(AssertionError.class, () -> PostConditions.assertState(false, MESSAGE));
+          assertThrows(AssertionError.class, () -> Postconditions.assertState(false, MESSAGE));
       assertThat(thrown.getMessage(), StringContains.containsString(MESSAGE));
     }
   }
@@ -35,13 +36,13 @@ class PostConditionsTest {
   final class AssertNotNull {
     @Test
     void positiveCase() {
-      PostConditions.assertNotNull(new Object(), "no exception expected");
+      Postconditions.assertNotNull(new Object(), "no exception expected");
     }
 
     @Test
     void assertFailsWithMessage() {
       final Throwable thrown =
-          assertThrows(AssertionError.class, () -> PostConditions.assertNotNull(null, MESSAGE));
+          assertThrows(AssertionError.class, () -> Postconditions.assertNotNull(null, MESSAGE));
 
       assertThat(thrown.getMessage(), StringContains.containsString(MESSAGE));
     }

--- a/swing-lib/src/main/java/org/triplea/swing/jpanel/SimpleGridBagLayoutBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/jpanel/SimpleGridBagLayoutBuilder.java
@@ -11,7 +11,7 @@ import javax.swing.JPanel;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
-import org.triplea.java.PostConditions;
+import org.triplea.java.Postconditions;
 
 /**
  * Convenience builder for Gridbag layout where row/column numbers are auto-incremented. Example:
@@ -97,7 +97,7 @@ public class SimpleGridBagLayoutBuilder {
 
     int calculateColumn(final int elementCount) {
       final int column = elementCount % columnCount;
-      PostConditions.assertState(
+      Postconditions.assertState(
           column < columnCount, "Column out of bounds: " + column + ", max: " + columnCount);
       return column;
     }


### PR DESCRIPTION
- Rename 'PostConditions' -> 'Postconditions' so it matches the name of guava 'Preconditions'
- Clean up postconditions assertion failed message, notably do not print the value of the failed
  boolean assertion, it is always 'false'.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[x] No manual testing done
[] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

