### PR TITLE
Add utility 'CacheUtils' for working with expireAfterWriteCaches

### DIFF
--- a/http-server/src/main/java/org/triplea/server/lobby/CacheUtils.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/CacheUtils.java
@@ -1,0 +1,32 @@
+package org.triplea.server.lobby;
+
+import com.google.common.cache.Cache;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Predicate;
+import lombok.experimental.UtilityClass;
+
+/**
+ * Utility class to provide common operations around a guava cache, notably provides a 'refresh'
+ * method used for keep-alive caches.
+ */
+@UtilityClass
+public class CacheUtils {
+
+  public <X, Y> Optional<Map.Entry<X, Y>> findEntryByKey(
+      final Cache<X, Y> cache, final Predicate<X> keyCheck) {
+    return cache.asMap().entrySet().stream()
+        .filter(entry -> keyCheck.test(entry.getKey()))
+        .findAny();
+  }
+
+  public <X, Y> boolean refresh(final Cache<X, Y> cache, final X key) {
+    return Optional.ofNullable(cache.getIfPresent(key))
+        .map(
+            value -> {
+              cache.put(key, value);
+              return true;
+            })
+        .orElse(false);
+  }
+}

--- a/http-server/src/test/java/org/triplea/server/lobby/CacheUtilsTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/CacheUtilsTest.java
@@ -1,0 +1,94 @@
+package org.triplea.server.lobby;
+
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@SuppressWarnings({"InnerClassMayBeStatic", "OptionalGetWithoutIsPresent"})
+class CacheUtilsTest {
+
+  private static final String KEY = "key-value";
+  private static final int VALUE = 100;
+  private Cache<String, Integer> realCache = CacheBuilder.newBuilder().maximumSize(1).build();
+
+  @Nested
+  class FindEntryByKey {
+
+    @Test
+    void emptyCase() {
+      assertThat(CacheUtils.findEntryByKey(realCache, key -> key.equals(KEY)), isEmpty());
+    }
+
+    @Test
+    void notFoundCase() {
+      realCache.put(KEY, VALUE);
+      assertThat(
+          CacheUtils.findEntryByKey(realCache, key -> key.equals("some-other-key")), isEmpty());
+    }
+
+    @Test
+    void foundCase() {
+      realCache.put(KEY, VALUE);
+
+      final Optional<Map.Entry<String, Integer>> result =
+          CacheUtils.findEntryByKey(realCache, key -> key.equals(KEY));
+
+      assertThat(result.isPresent(), is(true));
+      assertThat(result.get().getKey(), is(KEY));
+      assertThat(result.get().getValue(), is(VALUE));
+    }
+  }
+
+  @ExtendWith(MockitoExtension.class)
+  @Nested
+  class Refresh {
+    @Mock private Cache<String, Integer> mockCache;
+
+    @Test
+    void refreshFalseIfNotInCacheEmptyCase() {
+      final boolean result = CacheUtils.refresh(realCache, KEY);
+
+      assertThat(result, is(false));
+    }
+
+    @Test
+    void refreshFalseIfNotInCacheNotFoundCase() {
+      realCache.put(KEY, VALUE);
+
+      final boolean result = CacheUtils.refresh(realCache, "wrong-key-value");
+
+      assertThat(result, is(false));
+    }
+
+    @Test
+    void refreshTrueWhenFoundInCache() {
+      realCache.put(KEY, VALUE);
+
+      final boolean result = CacheUtils.refresh(realCache, KEY);
+
+      assertThat(result, is(true));
+    }
+
+    @Test
+    void refreshedItemsAreWrittenBackIntoTheCache() {
+      when(mockCache.getIfPresent(KEY)).thenReturn(VALUE);
+
+      final boolean result = CacheUtils.refresh(mockCache, KEY);
+
+      assertThat(result, is(true));
+      verify(mockCache).put(KEY, VALUE);
+    }
+  }
+}

--- a/http-server/src/test/java/org/triplea/server/lobby/game/listing/GameListingTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/game/listing/GameListingTest.java
@@ -112,12 +112,11 @@ class GameListingTest {
     @Test
     void gameExists() {
       when(cache.getIfPresent(ID_0)).thenReturn(lobbyGame0);
-      final Map<GameListing.GameId, LobbyGame> map = new HashMap<>();
-      map.put(ID_0, lobbyGame0);
-      when(cache.asMap()).thenReturn(new ConcurrentHashMap<>(map));
 
       final boolean result = gameListing.keepAlive(API_KEY_0, GAME_ID_0);
+
       assertThat("Game found, keep alive should return true", result, is(true));
+      verify(cache).put(ID_0, lobbyGame0);
     }
   }
 


### PR DESCRIPTION
CacheUtils to provide a 'refresh' method and a convenience findValuebyKey method.
With additional 'keep-alive' caches coming online in the future, the utility methods
become common.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[x] No manual testing done
[] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

