### PR TITLE
Introduce 'DaoTest' utility base class

### DIFF
--- a/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/AccessLogDaoTest.java
+++ b/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/AccessLogDaoTest.java
@@ -5,20 +5,13 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
 
 import com.github.database.rider.core.api.dataset.DataSet;
-import com.github.database.rider.junit5.DBUnitExtension;
 import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.triplea.lobby.server.db.JdbiDatabase;
 import org.triplea.lobby.server.db.data.AccessLogDaoData;
-import org.triplea.test.common.Integration;
 
-@ExtendWith(DBUnitExtension.class)
-@Integration
-class AccessLogDaoTest {
-  private static final AccessLogDao accessLogDao =
-      JdbiDatabase.newConnection().onDemand(AccessLogDao.class);
+class AccessLogDaoTest extends DaoTest {
+  private final AccessLogDao accessLogDao = DaoTest.newDao(AccessLogDao.class);
 
   @Test
   @DataSet(cleanBefore = true, value = "access_log/empty_data.yml")

--- a/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/BadWordsDaoTest.java
+++ b/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/BadWordsDaoTest.java
@@ -5,22 +5,15 @@ import static org.hamcrest.core.Is.is;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
-import com.github.database.rider.junit5.DBUnitExtension;
 import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.triplea.lobby.server.db.JdbiDatabase;
-import org.triplea.test.common.Integration;
 
-@ExtendWith(DBUnitExtension.class)
-@Integration
 @DataSet(cleanBefore = true, value = "bad_words/select.yml")
-class BadWordsDaoTest {
-  private static final BadWordsDao badWordsDao =
-      JdbiDatabase.newConnection().onDemand(BadWordsDao.class);
-
+class BadWordsDaoTest extends DaoTest {
   private static final List<String> expectedBadWords = Arrays.asList("aaa", "one", "two", "zzz");
+
+  private final BadWordsDao badWordsDao = DaoTest.newDao(BadWordsDao.class);
 
   @Test
   void getBadWords() {

--- a/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/BannedUserNamesDaoTest.java
+++ b/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/BannedUserNamesDaoTest.java
@@ -6,21 +6,13 @@ import static org.hamcrest.core.Is.is;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
-import com.github.database.rider.junit5.DBUnitExtension;
 import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.triplea.lobby.server.db.JdbiDatabase;
 import org.triplea.lobby.server.db.data.UsernameBanDaoData;
-import org.triplea.test.common.Integration;
 
-@ExtendWith(DBUnitExtension.class)
-@Integration
-class BannedUserNamesDaoTest {
-
-  private static final UsernameBanDao bannedUserNamesDao =
-      JdbiDatabase.newConnection().onDemand(UsernameBanDao.class);
+class BannedUserNamesDaoTest extends DaoTest {
+  private final UsernameBanDao bannedUserNamesDao = DaoTest.newDao(UsernameBanDao.class);
 
   @DataSet(cleanBefore = true, value = "banned_names/two_rows.yml")
   @Test

--- a/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/DaoTest.java
+++ b/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/DaoTest.java
@@ -1,0 +1,16 @@
+package org.triplea.lobby.server.db.dao;
+
+import com.github.database.rider.junit5.DBUnitExtension;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.triplea.lobby.server.db.JdbiDatabase;
+import org.triplea.test.common.Integration;
+
+@Integration
+@ExtendWith(DBUnitExtension.class)
+@SuppressWarnings("PrivateConstructorForUtilityClass")
+public abstract class DaoTest {
+
+  protected static <T> T newDao(final Class<T> classType) {
+    return JdbiDatabase.newConnection().onDemand(classType);
+  }
+}

--- a/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/ErrorReportingDaoTest.java
+++ b/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/ErrorReportingDaoTest.java
@@ -2,32 +2,25 @@ package org.triplea.lobby.server.db.dao;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
-import com.github.database.rider.junit5.DBUnitExtension;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.triplea.lobby.server.db.JdbiDatabase;
-import org.triplea.test.common.Integration;
 
-@ExtendWith(DBUnitExtension.class)
-@Integration
-final class ErrorReportingDaoTest {
-  private static final ErrorReportingDao REPORTING_DAO =
-      JdbiDatabase.newConnection().onDemand(ErrorReportingDao.class);
+final class ErrorReportingDaoTest extends DaoTest {
+  private final ErrorReportingDao errorReportingDao = DaoTest.newDao(ErrorReportingDao.class);
 
   /** Simple check that if we insert a record we'll get a new record in the expected dataset. */
   @DataSet(cleanBefore = true, value = "error_reporting/pre-insert.yml")
   @ExpectedDataSet(value = "error_reporting/post-insert.yml")
   @Test
   void insertRow() {
-    REPORTING_DAO.insertHistoryRecord("second");
+    errorReportingDao.insertHistoryRecord("second");
   }
 
   @DataSet(cleanBefore = true, value = "error_reporting/pre-purge.yml")
   @ExpectedDataSet(value = "error_reporting/post-purge.yml")
   @Test
   void purgeOld() {
-    REPORTING_DAO.purgeOld(LocalDateTime.of(2016, 1, 3, 23, 0, 0).toInstant(ZoneOffset.UTC));
+    errorReportingDao.purgeOld(LocalDateTime.of(2016, 1, 3, 23, 0, 0).toInstant(ZoneOffset.UTC));
   }
 }

--- a/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/ModeratorsDaoTest.java
+++ b/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/ModeratorsDaoTest.java
@@ -7,27 +7,20 @@ import static org.hamcrest.core.IsNull.nullValue;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
-import com.github.database.rider.junit5.DBUnitExtension;
 import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.triplea.lobby.server.db.JdbiDatabase;
 import org.triplea.lobby.server.db.data.ModeratorUserDaoData;
 import org.triplea.lobby.server.db.data.UserRole;
-import org.triplea.test.common.Integration;
 
-@Integration
-@ExtendWith(DBUnitExtension.class)
 @DataSet(cleanBefore = true, value = "moderators/select.yml")
-class ModeratorsDaoTest {
+class ModeratorsDaoTest extends DaoTest {
 
   private static final int NOT_MODERATOR_ID = 100000;
   private static final int MODERATOR_ID = 900000;
   private static final int SUPER_MODERATOR_ID = 900001;
 
-  private final ModeratorsDao moderatorsDao =
-      JdbiDatabase.newConnection().onDemand(ModeratorsDao.class);
+  private final ModeratorsDao moderatorsDao = DaoTest.newDao(ModeratorsDao.class);
 
   @Test
   void getModerators() {

--- a/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/TempPasswordDaoTest.java
+++ b/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/TempPasswordDaoTest.java
@@ -6,17 +6,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
 import com.github.database.rider.core.api.dataset.DataSet;
-import com.github.database.rider.core.api.dataset.SeedStrategy;
-import com.github.database.rider.junit5.DBUnitExtension;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.triplea.lobby.server.db.JdbiDatabase;
-import org.triplea.test.common.Integration;
 
-@Integration
-@ExtendWith(DBUnitExtension.class)
-@DataSet(cleanBefore = true, value = "temp_password/sample.yml", strategy = SeedStrategy.REFRESH)
-class TempPasswordDaoTest {
+@DataSet(cleanBefore = true, value = "temp_password/sample.yml")
+class TempPasswordDaoTest extends DaoTest {
 
   private static final String USERNAME = "username";
   private static final String EMAIL = "email";
@@ -25,8 +18,7 @@ class TempPasswordDaoTest {
   private static final String PASSWORD = "temp";
   private static final String NEW_PASSWORD = "new-temp";
 
-  private final TempPasswordDao tempPasswordDao =
-      JdbiDatabase.newConnection().onDemand(TempPasswordDao.class);
+  private final TempPasswordDao tempPasswordDao = DaoTest.newDao(TempPasswordDao.class);
 
   @Test
   void fetchTempPassword() {

--- a/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/TempPasswordHistoryDaoTest.java
+++ b/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/TempPasswordHistoryDaoTest.java
@@ -4,38 +4,32 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
 import com.github.database.rider.core.api.dataset.DataSet;
-import com.github.database.rider.junit5.DBUnitExtension;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.triplea.lobby.server.db.JdbiDatabase;
-import org.triplea.test.common.Integration;
 
-@Integration
-@ExtendWith(DBUnitExtension.class)
 @DataSet(cleanBefore = true, value = "temp_password_history/sample.yml")
-class TempPasswordHistoryDaoTest {
+class TempPasswordHistoryDaoTest extends DaoTest {
 
   private static final String USERNAME = "username";
 
-  private final TempPasswordHistoryDao tempPasswordDao =
-      JdbiDatabase.newConnection().onDemand(TempPasswordHistoryDao.class);
+  private final TempPasswordHistoryDao tempPasswordHistoryDao =
+      DaoTest.newDao(TempPasswordHistoryDao.class);
 
   @Test
   void verifyCountAndInsert() {
 
     final String localhost = "127.0.0.1";
-    assertThat(tempPasswordDao.countRequestsFromAddress(localhost), is(0));
+    assertThat(tempPasswordHistoryDao.countRequestsFromAddress(localhost), is(0));
 
-    tempPasswordDao.recordTempPasswordRequest(localhost, USERNAME);
-    assertThat(tempPasswordDao.countRequestsFromAddress(localhost), is(1));
+    tempPasswordHistoryDao.recordTempPasswordRequest(localhost, USERNAME);
+    assertThat(tempPasswordHistoryDao.countRequestsFromAddress(localhost), is(1));
 
-    tempPasswordDao.recordTempPasswordRequest(localhost, USERNAME);
-    assertThat(tempPasswordDao.countRequestsFromAddress(localhost), is(2));
+    tempPasswordHistoryDao.recordTempPasswordRequest(localhost, USERNAME);
+    assertThat(tempPasswordHistoryDao.countRequestsFromAddress(localhost), is(2));
 
-    tempPasswordDao.recordTempPasswordRequest(localhost, "other-user");
-    assertThat(tempPasswordDao.countRequestsFromAddress(localhost), is(3));
+    tempPasswordHistoryDao.recordTempPasswordRequest(localhost, "other-user");
+    assertThat(tempPasswordHistoryDao.countRequestsFromAddress(localhost), is(3));
 
     final String otherAddress = "127.0.0.2";
-    assertThat(tempPasswordDao.countRequestsFromAddress(otherAddress), is(0));
+    assertThat(tempPasswordHistoryDao.countRequestsFromAddress(otherAddress), is(0));
   }
 }

--- a/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/UserJdbiDaoTest.java
+++ b/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/UserJdbiDaoTest.java
@@ -7,16 +7,10 @@ import static org.hamcrest.core.Is.is;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
-import com.github.database.rider.junit5.DBUnitExtension;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.triplea.lobby.server.db.JdbiDatabase;
-import org.triplea.test.common.Integration;
 
-@Integration
-@ExtendWith(DBUnitExtension.class)
 @DataSet(cleanBefore = true, value = "user/select.yml")
-class UserJdbiDaoTest {
+class UserJdbiDaoTest extends DaoTest {
 
   private static final int USER_ID = 900000;
   private static final String USERNAME = "user";
@@ -25,7 +19,7 @@ class UserJdbiDaoTest {
   private static final String NEW_PASSWORD =
       "$2a$abcde_123456789_123456789_123456789_123456789_123456789_";
 
-  private final UserJdbiDao userDao = JdbiDatabase.newConnection().onDemand(UserJdbiDao.class);
+  private final UserJdbiDao userDao = DaoTest.newDao(UserJdbiDao.class);
 
   @Test
   void lookupUserIdByName() {


### PR DESCRIPTION
- Add new base class 'DaoTest' to capture common DaoTest (DbRider)
  test case annotations and provide utility method to construct DAO objects.
- Clean up DAO tests and make test objects names more consistent


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[x] No manual testing done
[] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

