### PR TITLE
Add Chat 'Connected' API and use 'set' for chatters

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/ChatClient.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatClient.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.chat;
 
+import java.util.Collection;
 import org.triplea.domain.data.PlayerName;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
 import org.triplea.http.client.lobby.chat.events.server.ChatMessage;
@@ -14,6 +15,11 @@ import org.triplea.http.client.lobby.chat.events.server.StatusUpdate;
  * local client of chat events.
  */
 public interface ChatClient {
+  /**
+   * Initial (async) connection to server is established. Not invoked for synchronous connections.
+   */
+  void connected(Collection<ChatParticipant> chatters);
+
   /** A chat message has been received. */
   void messageReceived(ChatMessage chatMessage);
 


### PR DESCRIPTION
- Connected API is to provide a callback for chat transmitter
  to update with the current list of players. Previously the
  current list of players was a synchronous-only operation done
  at the time of connection. With websockets that will become
  an async operation necessitating a callback.

- Use 'set' for chatters on Client. Chatters joining chat receive
  a connected message and will receive a join message for their
  own connection. The 'set' prevents the duplicate add between
  the initial player list and the join message.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[x] Other:  Add forward looking API  <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[x] No manual testing done
[] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

