### PR TITLE
Wire IP address to api-key-generator

### DIFF
--- a/game-core/src/main/java/games/strategy/net/IServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/IServerMessenger.java
@@ -2,8 +2,9 @@ package games.strategy.net;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import java.net.InetAddress;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import javax.annotation.Nullable;
 import org.triplea.domain.data.ApiKey;
 import org.triplea.domain.data.PlayerName;
@@ -51,5 +52,5 @@ public interface IServerMessenger extends IMessenger {
     return (spaceIndex != -1) ? name.substring(0, spaceIndex) : name;
   }
 
-  void setApiKeyGenerator(Function<PlayerName, ApiKey> apiKeyGenerator);
+  void setApiKeyGenerator(BiFunction<PlayerName, InetAddress, ApiKey> apiKeyGenerator);
 }

--- a/game-core/src/main/java/games/strategy/net/LocalNoOpMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/LocalNoOpMessenger.java
@@ -1,9 +1,10 @@
 package games.strategy.net;
 
 import java.io.Serializable;
+import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Set;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import javax.annotation.Nullable;
 import org.triplea.domain.data.ApiKey;
 import org.triplea.domain.data.PlayerName;
@@ -89,5 +90,6 @@ public class LocalNoOpMessenger implements IServerMessenger {
   }
 
   @Override
-  public void setApiKeyGenerator(final Function<PlayerName, ApiKey> apiKeyGenerator) {}
+  public void setApiKeyGenerator(
+      final BiFunction<PlayerName, InetAddress, ApiKey> apiKeyGenerator) {}
 }

--- a/game-core/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ServerMessenger.java
@@ -8,6 +8,7 @@ import games.strategy.net.nio.QuarantineConversation;
 import games.strategy.net.nio.ServerQuarantineConversation;
 import java.io.IOException;
 import java.io.Serializable;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SelectionKey;
@@ -23,7 +24,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.logging.Level;
 import javax.annotation.Nullable;
 import lombok.Getter;
@@ -51,7 +52,7 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
   private ILoginValidator loginValidator;
 
   @Setter(onMethod_ = {@Override})
-  private Function<PlayerName, ApiKey> apiKeyGenerator;
+  private BiFunction<PlayerName, InetAddress, ApiKey> apiKeyGenerator;
 
   // all our nodes
   private final Map<INode, SocketChannel> nodeToChannel = new ConcurrentHashMap<>();

--- a/game-core/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
+++ b/game-core/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
@@ -8,12 +8,13 @@ import games.strategy.net.Node;
 import games.strategy.net.PlayerNameAssigner;
 import games.strategy.net.ServerMessenger;
 import java.io.Serializable;
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.channels.SocketChannel;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Optional;
-import java.util.function.Function;
+import java.util.function.BiFunction;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 import lombok.extern.java.Log;
@@ -54,14 +55,14 @@ public class ServerQuarantineConversation extends QuarantineConversation {
   private String remoteMac;
   private Map<String, String> challenge;
   private final ServerMessenger serverMessenger;
-  private final Function<PlayerName, ApiKey> apiKeyGenerator;
+  private final BiFunction<PlayerName, InetAddress, ApiKey> apiKeyGenerator;
 
   public ServerQuarantineConversation(
       final ILoginValidator validator,
       final SocketChannel channel,
       final NioSocket socket,
       final ServerMessenger serverMessenger,
-      final Function<PlayerName, ApiKey> apiKeyGenerator) {
+      final BiFunction<PlayerName, InetAddress, ApiKey> apiKeyGenerator) {
     this.validator = validator;
     this.socket = socket;
     this.channel = channel;
@@ -114,7 +115,10 @@ public class ServerQuarantineConversation extends QuarantineConversation {
             }
             apiKey =
                 Optional.ofNullable(apiKeyGenerator)
-                    .map(keyGenerator -> keyGenerator.apply(PlayerName.of(remoteName)))
+                    .map(
+                        keyGenerator ->
+                            keyGenerator.apply(
+                                PlayerName.of(remoteName), channel.socket().getInetAddress()))
                     .map(ApiKey::getValue)
                     .orElse(null);
           } else {

--- a/http-server/src/main/java/org/triplea/server/access/ApiKeyGenerator.java
+++ b/http-server/src/main/java/org/triplea/server/access/ApiKeyGenerator.java
@@ -1,8 +1,10 @@
 package org.triplea.server.access;
 
 import com.google.common.hash.Hashing;
+import java.net.InetAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import lombok.Builder;
@@ -12,7 +14,7 @@ import org.triplea.lobby.server.db.dao.UserJdbiDao;
 
 // TODO: Project#12 This is copy/pasted from lobby sub-project
 @Builder
-public class ApiKeyGenerator implements Supplier<ApiKey> {
+public class ApiKeyGenerator implements Function<InetAddress, ApiKey> {
 
   @Nonnull private final ApiKeyDao apiKeyDao;
   @Nonnull private final UserJdbiDao userDao;
@@ -39,7 +41,7 @@ public class ApiKeyGenerator implements Supplier<ApiKey> {
   }
 
   @Override
-  public ApiKey get() {
+  public ApiKey apply(final InetAddress inetAddress) {
     final ApiKey key = keyMaker.get();
     apiKeyDao.storeKey(null, key.getValue());
     apiKeyDao.deleteOldKeys();

--- a/lobby/src/main/java/org/triplea/lobby/server/api/key/ApiKeyGeneratorFactory.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/api/key/ApiKeyGeneratorFactory.java
@@ -21,6 +21,7 @@ public final class ApiKeyGeneratorFactory {
             .apiKeyDao(jdbi.onDemand(ApiKeyDao.class))
             .userDao(jdbi.onDemand(UserJdbiDao.class))
             .build();
+    // TODO: Project#12 replace ApiKeyGeneartor with ApiKeyDaoWrapper
     return (name, ip) -> keyGenerator.apply(name);
   }
 }

--- a/lobby/src/main/java/org/triplea/lobby/server/api/key/ApiKeyGeneratorFactory.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/api/key/ApiKeyGeneratorFactory.java
@@ -1,6 +1,7 @@
 package org.triplea.lobby.server.api.key;
 
-import java.util.function.Function;
+import java.net.InetAddress;
+import java.util.function.BiFunction;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.jdbi.v3.core.Jdbi;
@@ -13,11 +14,13 @@ import org.triplea.lobby.server.db.dao.UserJdbiDao;
 public final class ApiKeyGeneratorFactory {
 
   /** Creates a new key generator instance that can generate a new API key for a given player. */
-  public static Function<PlayerName, ApiKey> newApiKeyGenerator(final Jdbi jdbi) {
-    return ApiKeyGenerator.builder()
-        .keyMaker(ApiKeyGenerator.createKeyMaker())
-        .apiKeyDao(jdbi.onDemand(ApiKeyDao.class))
-        .userDao(jdbi.onDemand(UserJdbiDao.class))
-        .build();
+  public static BiFunction<PlayerName, InetAddress, ApiKey> newApiKeyGenerator(final Jdbi jdbi) {
+    final ApiKeyGenerator keyGenerator =
+        ApiKeyGenerator.builder()
+            .keyMaker(ApiKeyGenerator.createKeyMaker())
+            .apiKeyDao(jdbi.onDemand(ApiKeyDao.class))
+            .userDao(jdbi.onDemand(UserJdbiDao.class))
+            .build();
+    return (name, ip) -> keyGenerator.apply(name);
   }
 }


### PR DESCRIPTION
Future looking update to send IP data to Api key generation. Future
updates will store IP address with API-keys. This way when we ban
an IP, we can reference the corresponding API keys and mark them
as invalid.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[x] No manual testing done
[] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

