### PR TITLE
launch_db: Busy wait loop and cleanup output

### DIFF
--- a/lobby-db/launch_db
+++ b/lobby-db/launch_db
@@ -34,7 +34,7 @@ function waitForDatabaseToStart() {
     tryAttempt=$((tryAttempt+1))
     # timeout after 10s
     if [ "$tryAttempt" -gt 50 ]; then
-      echo "Aborting DB startup timed out"
+      echo "Aborting DB startup (timed out)"
       exit 1
     fi
   done

--- a/lobby-db/launch_db
+++ b/lobby-db/launch_db
@@ -3,8 +3,7 @@
 # Convenience script to get a local DB up and running on docker
 # with some sample data.
 
-set -u
-set -e
+set -uu
 
 path=$(dirname "$0")
 "$path/run_docker"

--- a/lobby-db/launch_db
+++ b/lobby-db/launch_db
@@ -3,12 +3,40 @@
 # Convenience script to get a local DB up and running on docker
 # with some sample data.
 
-set -eu
+set -u
+set -e
 
-path=$(dirname $0)
+path=$(dirname "$0")
+"$path/run_docker"
 
-$path/run_docker
-sleep 5
-$path/run_flyway
-$path/load_sample_data
+set +e
+echo -n "Waiting for Database start"
+status=1
+tryAttempt=0
+while [ "$status" != 0 ]; do
+  echo 'select 1' \
+     | psql -h localhost -U lobby_user lobby_db 2> /dev/null \
+     | grep -q '1 row'
+  status=$?
+  sleep 0.2
+  echo -n .
+  tryAttempt=$((tryAttempt+1))
+
+  # timeout after 10s
+  if [ "$tryAttempt" -gt 100 ]; then
+    echo "Aborting DB startup timed out"
+    exit 1
+  fi
+done
+set -e
+
+echo "Database started!"
+echo "Running flyway migrations..."
+
+
+"$path/run_flyway"
+
+echo ""
+echo "Loading Sample data..."
+"$path/load_sample_data"
 

--- a/lobby-db/launch_db
+++ b/lobby-db/launch_db
@@ -3,39 +3,42 @@
 # Convenience script to get a local DB up and running on docker
 # with some sample data.
 
-set -uu
+set -eu
 
 path=$(dirname "$0")
-"$path/run_docker"
 
-set +e
-echo -n "Waiting for Database start"
-status=1
-tryAttempt=0
-while [ "$status" != 0 ]; do
-  echo 'select 1' \
-     | psql -h localhost -U lobby_user lobby_db 2> /dev/null \
-     | grep -q '1 row'
-  status=$?
-  sleep 0.2
-  echo -n .
-  tryAttempt=$((tryAttempt+1))
+function main() {
+  "$path/run_docker"
 
-  # timeout after 10s
-  if [ "$tryAttempt" -gt 100 ]; then
-    echo "Aborting DB startup timed out"
-    exit 1
-  fi
-done
-set -e
+  waitForDatabaseToStart
 
-echo "Database started!"
-echo "Running flyway migrations..."
+  echo "Running flyway migrations..."
+  "$path/run_flyway"
+  echo ""
+  
+  echo "Loading Sample data..."
+  "$path/load_sample_data"
+}
 
+function waitForDatabaseToStart() {
+  echo -n "Waiting for Database start"
+  tryAttempt=0
+  while ! (
+    echo 'select 1' \
+       | psql -h localhost -U lobby_user lobby_db 2> /dev/null \
+       | grep -q '1 row'); do
 
-"$path/run_flyway"
+    sleep 0.2
+    echo -n .
 
-echo ""
-echo "Loading Sample data..."
-"$path/load_sample_data"
+    tryAttempt=$((tryAttempt+1))
+    # timeout after 10s
+    if [ "$tryAttempt" -gt 50 ]; then
+      echo "Aborting DB startup timed out"
+      exit 1
+    fi
+  done
+  echo "Database started!"
+}
 
+main

--- a/lobby-db/run_docker
+++ b/lobby-db/run_docker
@@ -5,12 +5,13 @@
 # this script. Once initializated then 'run_flyway' can be run to install
 # schema and tables.
 
-set -eux
+set -eu
 function stop_container() {
+  echo "Stopping docker..."
   local runningContainerId=$(docker container ls | grep triplea-lobby-db | cut -f 1 -d ' ')
   if [ ! -z "$runningContainerId" ]; then
-     docker container stop $runningContainerId
-     docker container rm $runningContainerId
+     docker container stop $runningContainerId > /dev/null
+     docker container rm $runningContainerId > /dev/null
   fi
 }
 
@@ -21,7 +22,8 @@ function remove_dead_containers() {
 }
 
 function start_container() {
-  docker run -d --name=triplea-lobby-db -p 5432:5432 triplea/lobby-db
+  echo "Starting docker..."
+  docker run -d --name=triplea-lobby-db -p 5432:5432 triplea/lobby-db > /dev/null
 }
 
 stop_container


### PR DESCRIPTION
(1) Current db launch script simply waits 5 seconds for DB to startup.
    This update changes that to add a wait loop that checks for DB
    startup every 0.2s and continues if it has started.
(2) Cleanup launch_db output, remove 'set -x' and add echo output to
    log the current action being taken.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[x] Other:  dev utility script enhancement <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[] No manual testing done
[x] Manually tested

- Also ran shellcheck and fixed up shellcheck issues in 'launch_db'

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
## Screens Shots

### Before
![Screenshot from 2019-10-13 10-52-38](https://user-images.githubusercontent.com/12397753/66719646-9b293080-eda7-11e9-880b-bab48425f659.png)


### After
![Screenshot from 2019-10-13 10-52-05](https://user-images.githubusercontent.com/12397753/66719641-8e0c4180-eda7-11e9-9fab-75cbb5cf2d8a.png)



<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes

The stop of DB docker container is there to kill any dead containers. We may want to enhance this script in the future to detect if docker is running, if so then execute 'drop_db' to clear database and then re-run flyway and sample data. That should be faster. On the other hand, ensuring that we are going to successfully relaunch DB is of value (drop-db will fail if there are active connections, stopping container should likely kill those connections). 

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

