### PR TITLE
Move purchasedUnitsPanel update to Swing thread.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -913,9 +913,12 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
     actionButtons.changeToProduce(player);
     final IntegerMap<ProductionRule> production = actionButtons.waitForPurchase(bid);
     if (ClientSetting.showBetaFeatures.getValueOrThrow()) {
-      // TODO: Topic#1602 Support updating the purchasedUnitsPanel on opponents' moves.
-      purchasedUnitsPanel.setUnitsFromProductionRuleMap(production, player);
-      rightHandSidePanel.add(purchasedUnitsPanel, BorderLayout.SOUTH);
+      SwingUtilities.invokeLater(
+          () -> {
+            // TODO: Topic#1602 Support updating the purchasedUnitsPanel on opponents' moves.
+            purchasedUnitsPanel.setUnitsFromProductionRuleMap(production, player);
+            rightHandSidePanel.add(purchasedUnitsPanel, BorderLayout.SOUTH);
+          });
     }
     return production;
   }


### PR DESCRIPTION
Move purchasedUnitsPanel update to Swing thread. The previous code was not running the UI code on the right thread. This caused the panel to not work with Subspace L&F which was catching this issue.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[X] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing

[] No manual testing done
[X] Manually tested

Enabled beta features and tried out the new purchase units panel with subspace look and feel. It should work as expected.
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

