### PR TITLE
Fix ClassCastException on JOptionPanes if Escape is pressed.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1539,7 +1539,7 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
                 if (!dialog.isVisible()) {
                   return;
                 }
-                // Note: No cast to String, as we get JOptionPane.DEFAULT_OPTION on Escape.
+                // Note: getValue() can return either an int (user pressed escape), or a String.
                 final Object option = optionPane.getValue();
                 if (option.equals(optionNone)) {
                   unitPanels.clear();
@@ -1716,6 +1716,7 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
                 if (!dialog.isVisible()) {
                   return;
                 }
+                // Note: getValue() can return either an int (user pressed escape), or a JButton.
                 final Object option = optionPane.getValue();
                 if (option == noneButton) {
                   choosers.clear();
@@ -1811,7 +1812,7 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
                 if (!dialog.isVisible()) {
                   return;
                 }
-                // Note: No cast to String, as we get JOptionPane.DEFAULT_OPTION on Escape.
+                // Note: getValue() can return either an int (user pressed escape), or a String.
                 final Object option = optionPane.getValue();
                 if (option.equals(optionNone)) {
                   selection.clear();

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1539,7 +1539,8 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
                 if (!dialog.isVisible()) {
                   return;
                 }
-                final String option = ((String) optionPane.getValue());
+                // Note: No cast to String, as we get JOptionPane.DEFAULT_OPTION on Escape.
+                final Object option = optionPane.getValue();
                 if (option.equals(optionNone)) {
                   unitPanels.clear();
                   selection.clear();
@@ -1810,7 +1811,8 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
                 if (!dialog.isVisible()) {
                   return;
                 }
-                final String option = ((String) optionPane.getValue());
+                // Note: No cast to String, as we get JOptionPane.DEFAULT_OPTION on Escape.
+                final Object option = optionPane.getValue();
                 if (option.equals(optionNone)) {
                   selection.clear();
                   dialog.setVisible(false);


### PR DESCRIPTION
Fix ClassCastException on JOptionPanes if Escape is pressed.

Repro instructions for the bug:
  1. Play a solo map of Global 40 2nd with all humans.
  2. On Germany combat, send a Bomber to London to Bomb.
  3. On the dialog to intercept, hit Escape.

Without this fix, a ClassCastException happens.
![Screen Shot 2019-10-15 at 11 15 55 PM](https://user-images.githubusercontent.com/17648/66886109-4e5e7900-efa4-11e9-98eb-19d7fd0747c3.png)

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[X] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[] No manual testing done
[X] Manually tested

See above.
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

