### PR TITLE
Simple refactor: convert a couple messaging objects to '@Value'

### DIFF
--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/events/server/ChatMessage.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/events/server/ChatMessage.java
@@ -1,12 +1,10 @@
 package org.triplea.http.client.lobby.chat.events.server;
 
 import javax.annotation.Nonnull;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.Value;
 import org.triplea.domain.data.PlayerName;
 
-@AllArgsConstructor
-@Getter
+@Value
 public class ChatMessage {
   @Nonnull private final PlayerName from;
   @Nonnull private final String message;

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/events/server/StatusUpdate.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/events/server/StatusUpdate.java
@@ -1,11 +1,9 @@
 package org.triplea.http.client.lobby.chat.events.server;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.Value;
 import org.triplea.domain.data.PlayerName;
 
-@AllArgsConstructor
-@Getter
+@Value
 public class StatusUpdate {
   private final PlayerName playerName;
   private final String status;


### PR DESCRIPTION
Convert a couple DTO objects to be @Value so that we have an equals method
to allow them to be used in (future) tests and 'toString' for debug


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[] No manual testing done
[] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

