### PR TITLE
Update Drop-DB script to always work, kill connections

### DIFF
--- a/lobby-db/drop_db
+++ b/lobby-db/drop_db
@@ -6,6 +6,8 @@
 
 DB=lobby_db
 PSQL="psql -h localhost -U lobby_user -w -d postgres"
+
+echo "select pg_terminate_backend(pid) from pg_stat_activity where datname='$DB';" | $PSQL
 echo "drop database $DB" | $PSQL
 echo "create database $DB" | $PSQL
 


### PR DESCRIPTION
Update the drop_db script to kill active connections. This allows it
to always run, 'drop_db' fails if there are active connections.

This is particularly useful if background daemon threads are lingering
and have active DB connections.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[] No manual testing done
[x] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

