### PR TITLE
Support showing purchased units for all players.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameStep.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameStep.java
@@ -45,6 +45,10 @@ public class GameStep extends GameDataComponent {
     String ONLY_REPAIR_IF_DISABLED = "onlyRepairIfDisabled";
   }
 
+  public static boolean isPurchaseOrBidStep(String stepName) {
+    return stepName.endsWith("Bid") || stepName.endsWith("Purchase");
+  }
+
   /**
    * Creates new GameStep.
    *

--- a/game-core/src/main/java/games/strategy/engine/data/GameStep.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameStep.java
@@ -45,10 +45,6 @@ public class GameStep extends GameDataComponent {
     String ONLY_REPAIR_IF_DISABLED = "onlyRepairIfDisabled";
   }
 
-  public static boolean isPurchaseOrBidStep(String stepName) {
-    return stepName.endsWith("Bid") || stepName.endsWith("Purchase");
-  }
-
   /**
    * Creates new GameStep.
    *
@@ -167,5 +163,9 @@ public class GameStep extends GameDataComponent {
             .map(Boolean::parseBoolean)
             .orElse(false)
         || name.endsWith("NonCombatMove");
+  }
+
+  public static boolean isPurchaseOrBidStep(final String stepName) {
+    return stepName.endsWith("Bid") || stepName.endsWith("Purchase");
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -1,6 +1,7 @@
 package games.strategy.triplea;
 
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GameStep;
 import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.data.ProductionRule;
 import games.strategy.engine.data.RepairRule;
@@ -130,7 +131,7 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer {
     boolean badStep = false;
     if (name.endsWith("Tech")) {
       tech();
-    } else if (name.endsWith("Bid") || name.endsWith("Purchase")) {
+    } else if (GameStep.isPurchaseOrBidStep(name)) {
       purchase(GameStepPropertiesHelper.isBid(getGameData()));
       if (!GameStepPropertiesHelper.isBid(getGameData())) {
         ui.waitForMoveForumPoster(getPlayerId(), getPlayerBridge());


### PR DESCRIPTION
- Changes the new purchased units panel to also show purchased units from non-local players.
- Renames the panel to "Units to Place", since it can now show units that are available to place that were not purchased, such as China on WWII V3 1942.
- New logic for showing the panel:
  - Either we're past the purchase phase for the current player (even if they didn't buy anything).
  - Or there are units available to place regardless (e.g. the player may not have a purchase phase like China on WWII V3 1942, or unplaced units from last turn).

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[X] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing

[] No manual testing done
[X] Manually tested

Played on WWII V3 1942 and tested the following cases:
  - That Chinese reinforcements show up.
  - Units for AI controlled players show up.
  - Units for networked players show up.
  - Units bought a previous turn, but not placed, show up in the next turn.
