### PR TITLE
Reduce gradle build compiler warning count

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,7 +122,7 @@ subprojects {
     tasks.withType(JavaCompile).configureEach {
         options.compilerArgs += [
             '-Xlint:all,-processing',
-            '-Xmaxwarns', '1000'
+            '-Xmaxwarns', '15'
         ]
         options.encoding = 'UTF-8'
         options.errorprone {


### PR DESCRIPTION
Reduce number of compiler warnings displayed on gradle builds
to reduce noise in build output. Important when we need
to find error messages amongst the output.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[] No manual testing done
[x] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes
Main goal here is so we can have cleaner output and not necessarily ignore compiler warnings altogether. Happy to discuss appropriate thresholds, 15 is chosen so we get a good sample of warnings but the output is still not overwhelming.

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

