### PR TITLE
Improve "units to place" panel.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameStep.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameStep.java
@@ -168,4 +168,8 @@ public class GameStep extends GameDataComponent {
   public static boolean isPurchaseOrBidStep(final String stepName) {
     return stepName.endsWith("Bid") || stepName.endsWith("Purchase");
   }
+
+  public static boolean isPlaceStep(final String stepName) {
+    return stepName.endsWith("Place");
+  }
 }

--- a/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -146,7 +146,7 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer {
       }
     } else if (name.endsWith("Battle")) {
       battle();
-    } else if (name.endsWith("Place")) {
+    } else if (GameStep.isPlaceStep(name)) {
       place();
     } else if (name.endsWith("Politics")) {
       politics(true);

--- a/game-core/src/main/java/games/strategy/triplea/ui/ActionButtons.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ActionButtons.java
@@ -16,6 +16,7 @@ import games.strategy.triplea.delegate.data.MoveDescription;
 import games.strategy.triplea.delegate.data.TechRoll;
 import games.strategy.triplea.delegate.remote.IPoliticsDelegate;
 import games.strategy.triplea.delegate.remote.IUserActionDelegate;
+import games.strategy.triplea.settings.ClientSetting;
 import java.awt.CardLayout;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
@@ -30,6 +31,8 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
+import lombok.AccessLevel;
+import lombok.Getter;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.util.Tuple;
 
@@ -39,11 +42,18 @@ public class ActionButtons extends JPanel implements KeyBindingSupplier {
       "Press shift+D or click this button to end the current turn phase";
   private static final long serialVersionUID = 2175685892863042399L;
   private final CardLayout layout = new CardLayout();
+
+  @Getter(AccessLevel.PUBLIC)
   private BattlePanel battlePanel;
+
   private MovePanel movePanel;
+
   private PurchasePanel purchasePanel;
   private RepairPanel repairPanel;
+
+  @Getter(AccessLevel.PUBLIC)
   private PlacePanel placePanel;
+
   private TechPanel techPanel;
   private EndTurnPanel endTurnPanel;
   private MoveForumPosterPanel moveForumPosterPanel;
@@ -61,7 +71,11 @@ public class ActionButtons extends JPanel implements KeyBindingSupplier {
     this.movePanel = movePanel;
     purchasePanel = new PurchasePanel(data, map);
     repairPanel = new RepairPanel(data, map);
-    placePanel = new PlacePanel(data, map, parent);
+    if (ClientSetting.showBetaFeatures.getValueOrThrow()) {
+      placePanel = new PlacePanel(data, map, PlacePanel.Mode.UNITS_TO_PLACE_VIEW_DETACHED, parent);
+    } else {
+      placePanel = new PlacePanel(data, map, PlacePanel.Mode.UNITS_TO_PLACE_VIEW_ATTACHED, parent);
+    }
     techPanel = new TechPanel(data, map);
     endTurnPanel = new EndTurnPanel(data, map);
     moveForumPosterPanel = new MoveForumPosterPanel(data, map);
@@ -270,10 +284,6 @@ public class ActionButtons extends JPanel implements KeyBindingSupplier {
 
   public Optional<ActionPanel> getCurrent() {
     return Optional.ofNullable(actionPanel);
-  }
-
-  public BattlePanel getBattlePanel() {
-    return battlePanel;
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/ui/ActionButtons.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ActionButtons.java
@@ -31,7 +31,6 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.KeyStroke;
 import javax.swing.SwingUtilities;
-import lombok.AccessLevel;
 import lombok.Getter;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.util.Tuple;
@@ -43,16 +42,14 @@ public class ActionButtons extends JPanel implements KeyBindingSupplier {
   private static final long serialVersionUID = 2175685892863042399L;
   private final CardLayout layout = new CardLayout();
 
-  @Getter(AccessLevel.PUBLIC)
-  private BattlePanel battlePanel;
+  @Getter private BattlePanel battlePanel;
 
   private MovePanel movePanel;
 
   private PurchasePanel purchasePanel;
   private RepairPanel repairPanel;
 
-  @Getter(AccessLevel.PUBLIC)
-  private PlacePanel placePanel;
+  @Getter private PlacePanel placePanel;
 
   private TechPanel techPanel;
   private EndTurnPanel endTurnPanel;
@@ -71,11 +68,11 @@ public class ActionButtons extends JPanel implements KeyBindingSupplier {
     this.movePanel = movePanel;
     purchasePanel = new PurchasePanel(data, map);
     repairPanel = new RepairPanel(data, map);
-    if (ClientSetting.showBetaFeatures.getValueOrThrow()) {
-      placePanel = new PlacePanel(data, map, PlacePanel.Mode.UNITS_TO_PLACE_VIEW_DETACHED, parent);
-    } else {
-      placePanel = new PlacePanel(data, map, PlacePanel.Mode.UNITS_TO_PLACE_VIEW_ATTACHED, parent);
-    }
+    final var placeMode =
+        ClientSetting.showBetaFeatures.getValueOrThrow()
+            ? PlacePanel.Mode.UNITS_TO_PLACE_VIEW_DETACHED
+            : PlacePanel.Mode.UNITS_TO_PLACE_VIEW_ATTACHED;
+    placePanel = new PlacePanel(data, map, placeMode, parent);
     techPanel = new TechPanel(data, map);
     endTurnPanel = new EndTurnPanel(data, map);
     moveForumPosterPanel = new MoveForumPosterPanel(data, map);

--- a/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -149,7 +149,7 @@ class PlacePanel extends AbstractMovePanel {
     SwingUtilities.invokeLater(
         () -> {
           JSplitPane splitPane = null;
-          Component parent = unitsToPlacePanel.getParent();
+          final Component parent = unitsToPlacePanel.getParent();
           if (parent instanceof JSplitPane) {
             splitPane = ((JSplitPane) parent);
           }

--- a/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -287,10 +287,14 @@ class PlacePanel extends AbstractMovePanel {
   }
 
   private void updateUnits() {
-    final Collection<UnitCategory> unitCategories =
-        UnitSeparator.categorize(getCurrentPlayer().getUnits());
-    unitsToPlacePanel.setUnitsFromCategories(unitCategories);
-    unitsToPlacePanel.revalidate();
+    SwingUtilities.invokeLater(
+        () -> {
+          final Collection<UnitCategory> unitCategories =
+              UnitSeparator.categorize(getCurrentPlayer().getUnits());
+          unitsToPlacePanel.setUnitsFromCategories(unitCategories);
+          unitsToPlacePanel.revalidate();
+          unitsToPlacePanel.repaint();
+        });
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -166,11 +166,9 @@ class PlacePanel extends AbstractMovePanel implements GameDataChangeListener {
       lastPlayer = player;
       // During the place step, listen for changes to update the panel.
       if (GameStep.isPlaceStep(step.getName())) {
-        if (showUnitsToPlace) {
-          data.addDataChangeListener(this);
-        } else {
-          data.removeDataChangeListener(this);
-        }
+        data.addDataChangeListener(this);
+      } else {
+        data.removeDataChangeListener(this);
       }
     } finally {
       data.releaseReadLock();

--- a/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -149,7 +149,7 @@ class PlacePanel extends AbstractMovePanel {
     SwingUtilities.invokeLater(
         () -> {
           JSplitPane splitPane = null;
-          Component parent = (JSplitPane) unitsToPlacePanel.getParent();
+          Component parent = unitsToPlacePanel.getParent();
           if (parent instanceof JSplitPane) {
             splitPane = ((JSplitPane) parent);
           }
@@ -170,9 +170,8 @@ class PlacePanel extends AbstractMovePanel {
           } else {
             // Hide the panel.
             if (splitPane != null) {
-              // If the panel was visible before, remember whether the split pane
-              // was minimized so that we don't open it up again the next time
-              // we show it.
+              // If the panel was visible before, remember whether the split pane was
+              // minimized so that we don't open it up again the next time we show it.
               if (unitsToPlacePanel.isVisible()) {
                 // Note: We don't use getMaximumDividerLocation() because that takes into account
                 // the preferred size of the unit panel and therefore when not minimized, it may

--- a/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -189,7 +189,7 @@ class PlacePanel extends AbstractMovePanel implements GameDataChangeListener {
   }
 
   @Override
-  public void gameDataChanged(Change change) {
+  public void gameDataChanged(final Change change) {
     final Collection<UnitCategory> unitsToPlace;
     final GameData data = getData();
     data.acquireReadLock();

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -187,7 +187,7 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
   private final JLabel player = new JLabel("xxxxxx");
   private final ActionButtons actionButtons;
   private final JPanel gameMainPanel = new JPanel();
-  private JPanel rightHandSidePanel;
+  private final JPanel rightHandSidePanel = new JPanel();
   private final JTabbedPane tabsPanel = new JTabbedPane();
   private final StatPanel statsPanel;
   private final EconomyPanel economyPanel;
@@ -592,7 +592,6 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
     step.setHorizontalTextPosition(SwingConstants.LEADING);
     gameSouthPanel.add(stepPanel, BorderLayout.EAST);
     gameMainPanel.add(gameSouthPanel, BorderLayout.SOUTH);
-    rightHandSidePanel = new JPanel();
     rightHandSidePanel.setLayout(new BorderLayout());
     final FocusAdapter focusToMapPanelFocusListener =
         new FocusAdapter() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -187,7 +187,7 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
   private final JLabel player = new JLabel("xxxxxx");
   private final ActionButtons actionButtons;
   private final JPanel gameMainPanel = new JPanel();
-  private JSplitPane rightHandSideSplit;
+  private JPanel rightHandSidePanel;
   private final JTabbedPane tabsPanel = new JTabbedPane();
   private final StatPanel statsPanel;
   private final EconomyPanel economyPanel;
@@ -592,7 +592,7 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
     step.setHorizontalTextPosition(SwingConstants.LEADING);
     gameSouthPanel.add(stepPanel, BorderLayout.EAST);
     gameMainPanel.add(gameSouthPanel, BorderLayout.SOUTH);
-    final JPanel rightHandSidePanel = new JPanel();
+    rightHandSidePanel = new JPanel();
     rightHandSidePanel.setLayout(new BorderLayout());
     final FocusAdapter focusToMapPanelFocusListener =
         new FocusAdapter() {
@@ -611,17 +611,10 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
 
     final MovePanel movePanel = new MovePanel(data, mapPanel, this);
     actionButtons = new ActionButtons(data, mapPanel, movePanel, this);
-
-    rightHandSideSplit =
-        new JSplitPane(
-            JSplitPane.VERTICAL_SPLIT,
-            rightHandSidePanel,
-            actionButtons.getPlacePanel().getUnitsToPlacePanel());
-    rightHandSideSplit.setOneTouchExpandable(true);
-    rightHandSideSplit.setResizeWeight(1.0);
-    // Initial divider size is 0 so that the split pane is basically invisible.
-    // This will be adjusted when the units to place panel gets shown.
-    rightHandSideSplit.setDividerSize(0);
+    final PlacePanel placePanel = actionButtons.getPlacePanel();
+    if (placePanel.getMode() == PlacePanel.Mode.UNITS_TO_PLACE_VIEW_DETACHED) {
+      rightHandSidePanel.add(placePanel.getDetachedUnitsToPlacePanel(), BorderLayout.SOUTH);
+    }
 
     addKeyBindings(movePanel, actionButtons, this);
     SwingUtilities.invokeLater(() -> mapPanel.addKeyListener(getArrowKeyListener()));
@@ -668,12 +661,12 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
             editPanel.setActive(false);
           }
         });
-    rightHandSideSplit.setPreferredSize(
+    rightHandSidePanel.setPreferredSize(
         new Dimension(
             (int) smallView.getPreferredSize().getWidth(),
             (int) mapPanel.getPreferredSize().getHeight()));
     gameCenterPanel =
-        new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, mapAndChatPanel, rightHandSideSplit);
+        new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, mapAndChatPanel, rightHandSidePanel);
     gameCenterPanel.setOneTouchExpandable(true);
     gameCenterPanel.setDividerSize(8);
     gameCenterPanel.setResizeWeight(1.0);
@@ -2106,11 +2099,11 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
   }
 
   public void showRightHandSidePanel() {
-    rightHandSideSplit.setVisible(true);
+    rightHandSidePanel.setVisible(true);
   }
 
   public void hideRightHandSidePanel() {
-    rightHandSideSplit.setVisible(false);
+    rightHandSidePanel.setVisible(false);
   }
 
   public HistoryPanel getHistoryPanel() {
@@ -2371,7 +2364,7 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
       gameMainPanel.removeAll();
       gameMainPanel.setLayout(new BorderLayout());
       gameMainPanel.add(mapAndChatPanel, BorderLayout.CENTER);
-      gameMainPanel.add(rightHandSideSplit, BorderLayout.EAST);
+      gameMainPanel.add(rightHandSidePanel, BorderLayout.EAST);
       gameMainPanel.add(gameSouthPanel, BorderLayout.SOUTH);
       getContentPane().removeAll();
       getContentPane().add(gameMainPanel, BorderLayout.CENTER);

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -214,7 +214,6 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
   private List<Unit> unitsBeingMousedOver;
   private PlayerId lastStepPlayer;
   private PlayerId currentStepPlayer;
-  private boolean postProductionStep;
   private final Map<PlayerId, Boolean> requiredTurnSeries = new HashMap<>();
   private final ThreadPool messageAndDialogThreadPool = new ThreadPool(1);
   private final MapUnitTooltipManager tooltipManager;

--- a/swing-lib/src/main/java/org/triplea/swing/CollapsiblePanel.java
+++ b/swing-lib/src/main/java/org/triplea/swing/CollapsiblePanel.java
@@ -1,0 +1,59 @@
+package org.triplea.swing;
+
+import games.strategy.engine.framework.system.SystemProperties;
+import java.awt.BorderLayout;
+import javax.swing.JButton;
+import javax.swing.JPanel;
+
+/**
+ * A panel that can be collapsed and expanded via a button at the top of it.
+ *
+ * <p>The panel supports a main content component that will either be shown or hidden, depending on
+ * whether the panel is expanded or collapsed and a a title that will be shown on the toggle button.
+ */
+public class CollapsiblePanel extends JPanel {
+  private static final long serialVersionUID = 1L;
+
+  private final String title;
+  private final JPanel content;
+  private final JButton toggleButton;
+
+  public CollapsiblePanel(final JPanel content, final String title) {
+    super();
+    this.title = title;
+    this.content = content;
+    this.toggleButton = new JButton();
+    // We want the button to have square edges. On Mac, there's a special property for that.
+    if (SystemProperties.isMac()) {
+      toggleButton.putClientProperty("JButton.buttonType", "gradient");
+    }
+    toggleButton.addActionListener(
+        e -> {
+          if (content.isVisible()) {
+            collapse();
+          } else {
+            expand();
+          }
+        });
+    setLayout(new BorderLayout());
+    add(toggleButton, BorderLayout.NORTH);
+    add(content, BorderLayout.CENTER);
+    expand();
+  }
+
+  public boolean isExpanded() {
+    return content.isVisible();
+  }
+
+  public void collapse() {
+    toggleButton.setText(title + " ►");
+    content.setVisible(false);
+    revalidate();
+  }
+
+  public void expand() {
+    toggleButton.setText(title + " ▼");
+    content.setVisible(true);
+    revalidate();
+  }
+}


### PR DESCRIPTION
- As units are placed, they are removed from the panel.
- The place units tab no longer shows units to be placed
  since this information is shown in the new panel.
- Implements a collapsible panel component and uses it,
  allowing the panel to be minimized.
- Minimized state is remembered, once minimized - it stays
  that way between phases and turns.
- Moves logic for managing this panel from TripleAFrame to
  PlacePanel.
- This new behavior is still behind "use beta features". When
  that is off, the game behaves as before.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[X] Feature update or enhancement
[] Feature Removal
[X] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[] No manual testing done
[X] Manually tested

- Tested to make sure things look unchanged if "beta features" are off.
- Tested to make sure that if panel was minimized, it stays that way across
   phases and turns and vice versa.

<!-- If manually tested, summarize the testing done below this line. -->



## Screens Shots

### After

Panel not minimized:

![Screen Shot 2019-10-20 at 12 08 37 PM](https://user-images.githubusercontent.com/17648/67162490-6fbbbe00-f332-11e9-9eaa-f5dd52fa380c.png)

Panel minimized:
![Screen Shot 2019-10-20 at 12 08 47 PM](https://user-images.githubusercontent.com/17648/67162495-75190880-f332-11e9-9b90-a2441fb0338e.png)

<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

