### PR TITLE
Don't use fixed width tabs on mac look and feel.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -312,7 +312,7 @@ public class DownloadMapsWindow extends JFrame {
   private Component newTabbedPanelForMaps(
       final List<DownloadFileDescription> downloads,
       final Set<DownloadFileDescription> pendingDownloads) {
-    final JTabbedPane mapTabs = SwingComponents.newJTabbedPane();
+    final JTabbedPane mapTabs = SwingComponents.newJTabbedPaneWithFixedWidthTabs(900, 600);
     for (final DownloadFileDescription.MapCategory mapCategory :
         DownloadFileDescription.MapCategory.values()) {
       final List<DownloadFileDescription> categorizedDownloads =

--- a/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
+++ b/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
@@ -140,7 +140,7 @@ public final class SwingComponents {
   }
 
   public static JTabbedPane newJTabbedPane(final int width, final int height) {
-    final JTabbedPane tabbedPane = new JTabbedPaneWithFixedWidthTabs();
+    final JTabbedPane tabbedPane = new JTabbedPane();
     tabbedPane.setPreferredSize(new Dimension(width, height));
     return tabbedPane;
   }

--- a/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
+++ b/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
@@ -139,11 +139,13 @@ public final class SwingComponents {
             });
   }
 
-  public static JTabbedPane newJTabbedPane() {
-    return newJTabbedPane(900, 600);
+  public static JTabbedPane newJTabbedPane(final int width, final int height) {
+    final JTabbedPane tabbedPane = new JTabbedPaneWithFixedWidthTabs();
+    tabbedPane.setPreferredSize(new Dimension(width, height));
+    return tabbedPane;
   }
 
-  public static JTabbedPane newJTabbedPane(final int width, final int height) {
+  public static JTabbedPane newJTabbedPaneWithFixedWidthTabs(final int width, final int height) {
     final JTabbedPane tabbedPane = new JTabbedPaneWithFixedWidthTabs();
     tabbedPane.setPreferredSize(new Dimension(width, height));
     return tabbedPane;

--- a/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
+++ b/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
@@ -3,7 +3,6 @@ package org.triplea.swing;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
-import games.strategy.engine.framework.system.SystemProperties;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Frame;
@@ -42,7 +41,6 @@ import javax.swing.ListModel;
 import javax.swing.RootPaneContainer;
 import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
-import javax.swing.UIManager;
 import javax.swing.filechooser.FileFilter;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import org.triplea.awt.OpenFileUtility;
@@ -146,12 +144,7 @@ public final class SwingComponents {
   }
 
   public static JTabbedPane newJTabbedPane(final int width, final int height) {
-    // On Mac with the native L&F, JTabbedPane does not show multiple rows of tabs, so having
-    // them fixed width causes more to overflow. Don't use fixed width tabs in that case.
-    final boolean useFixedWidthTabs =
-        !SystemProperties.isMac() || !UIManager.getLookAndFeel().isNativeLookAndFeel();
-    final JTabbedPane tabbedPane =
-        useFixedWidthTabs ? new JTabbedPaneWithFixedWidthTabs() : new JTabbedPane();
+    final JTabbedPane tabbedPane = new JTabbedPaneWithFixedWidthTabs();
     tabbedPane.setPreferredSize(new Dimension(width, height));
     return tabbedPane;
   }

--- a/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
+++ b/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
@@ -3,6 +3,7 @@ package org.triplea.swing;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
+import games.strategy.engine.framework.system.SystemProperties;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Frame;
@@ -41,6 +42,7 @@ import javax.swing.ListModel;
 import javax.swing.RootPaneContainer;
 import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
+import javax.swing.UIManager;
 import javax.swing.filechooser.FileFilter;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import org.triplea.awt.OpenFileUtility;
@@ -144,7 +146,12 @@ public final class SwingComponents {
   }
 
   public static JTabbedPane newJTabbedPane(final int width, final int height) {
-    final JTabbedPane tabbedPane = new JTabbedPaneWithFixedWidthTabs();
+    // On Mac with the native L&F, JTabbedPane does not show multiple rows of tabs, so having
+    // them fixed width causes more to overflow. Don't use fixed width tabs in that case.
+    final boolean useFixedWidthTabs =
+        !SystemProperties.isMac() || !UIManager.getLookAndFeel().isNativeLookAndFeel();
+    final JTabbedPane tabbedPane =
+        useFixedWidthTabs ? new JTabbedPaneWithFixedWidthTabs() : new JTabbedPane();
     tabbedPane.setPreferredSize(new Dimension(width, height));
     return tabbedPane;
   }


### PR DESCRIPTION
It especially looks bad with the Mac native look and feel, but even on other look and feels, the tabs weren't fixed width anyway since some of them were wider.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[X] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing

[] No manual testing done
[X] Manually tested

## Screens Shots

### Before
<img width="1132" alt="Screen Shot 2019-10-21 at 8 32 11 PM" src="https://user-images.githubusercontent.com/17648/67253697-17c2ab80-f447-11e9-95c4-d59af3309994.png">

### After
<img width="1132" alt="Screen Shot 2019-10-21 at 8 32 36 PM" src="https://user-images.githubusercontent.com/17648/67253703-21e4aa00-f447-11e9-8ead-0737c690da7a.png">


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

