### PR TITLE
Validate Account Creation on Key-Type

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/CreateAccountPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/CreateAccountPanel.java
@@ -275,7 +275,6 @@ public final class CreateAccountPanel extends JPanel {
     }
   }
 
-  // TODO: Project#12 show validation message as a label (?)
   private Optional<String> validationMessage() {
     if (!Arrays.equals(passwordField.getPassword(), passwordConfirmField.getPassword())) {
       return Optional.of("Passwords must match");
@@ -313,7 +312,7 @@ public final class CreateAccountPanel extends JPanel {
   }
 
   public String getPassword() {
-    // TODO: Md5-Deprecation SHA512 hash password on client side here
+    // TODO: Project#12 SHA512 hash password on client side here
     return new String(passwordField.getPassword());
   }
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/CreateAccountPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/CreateAccountPanel.java
@@ -227,12 +227,7 @@ public final class CreateAccountPanel extends JPanel {
     buttons.add(cancelButton);
 
     cancelButton.addActionListener(e -> close());
-    okButton.addActionListener(
-        e -> {
-          if (okButton.isEnabled()) {
-            okPressed();
-          }
-        });
+    okButton.addActionListener(e -> okPressed());
 
     SwingComponents.addEnterKeyListener(
         this,

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/CreateAccountPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/CreateAccountPanel.java
@@ -5,12 +5,14 @@ import games.strategy.engine.lobby.PlayerNameValidation;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.ui.Util;
 import java.awt.BorderLayout;
+import java.awt.Color;
 import java.awt.FlowLayout;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.Window;
 import java.util.Arrays;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
@@ -23,6 +25,7 @@ import javax.swing.JPanel;
 import javax.swing.JPasswordField;
 import javax.swing.JTextField;
 import org.triplea.swing.JCheckBoxBuilder;
+import org.triplea.swing.KeyTypeValidator;
 import org.triplea.swing.SwingComponents;
 
 /** The panel used to create a new lobby account or update an existing lobby account. */
@@ -195,19 +198,75 @@ public final class CreateAccountPanel extends JPanel {
             0,
             0));
 
+    final JLabel validationLabel = new JLabel(" ");
+    validationLabel.setForeground(Color.RED);
+
+    main.add(
+        validationLabel,
+        new GridBagConstraints(
+            0,
+            5,
+            2,
+            1,
+            0.0,
+            0.0,
+            GridBagConstraints.WEST,
+            GridBagConstraints.NONE,
+            new Insets(5, 5, 0, 0),
+            0,
+            0));
+
     final JPanel buttons = new JPanel();
     add(buttons, BorderLayout.SOUTH);
     buttons.setBorder(BorderFactory.createEmptyBorder(10, 5, 10, 5));
     buttons.setLayout(new FlowLayout(FlowLayout.RIGHT, 5, 0));
     final JButton okButton = new JButton("OK");
+    okButton.setEnabled(false);
     buttons.add(okButton);
     final JButton cancelButton = new JButton("Cancel");
     buttons.add(cancelButton);
 
     cancelButton.addActionListener(e -> close());
-    okButton.addActionListener(e -> okPressed());
+    okButton.addActionListener(
+        e -> {
+          if (okButton.isEnabled()) {
+            okPressed();
+          }
+        });
 
-    SwingComponents.addEnterKeyListener(this, this::okPressed);
+    SwingComponents.addEnterKeyListener(
+        this,
+        () -> {
+          if (okButton.isEnabled()) {
+            okPressed();
+          }
+        });
+
+    Arrays.asList(passwordField, passwordConfirmField, emailField)
+        .forEach(
+            inputField ->
+                new KeyTypeValidator()
+                    .attachKeyTypeValidator(
+                        inputField,
+                        textInput -> validationMessage().isEmpty(),
+                        valid -> {
+                          if (valid) {
+                            validationLabel.setText(" ");
+                            okButton.setEnabled(true);
+                            okButton.setToolTipText("Click to create an account and login");
+                          } else {
+                            okButton.setEnabled(false);
+
+                            final String message = validationMessage().orElse("");
+                            validationLabel.setText(message);
+                            okButton.setToolTipText(message);
+                          }
+                        }));
+  }
+
+  private void okPressed() {
+    returnValue = ReturnValue.OK;
+    Optional.ofNullable(dialog).ifPresent(d -> d.setVisible(false));
   }
 
   private void close() {
@@ -216,43 +275,22 @@ public final class CreateAccountPanel extends JPanel {
     }
   }
 
-  private void okPressed() {
+  // TODO: Project#12 show validation message as a label (?)
+  private Optional<String> validationMessage() {
     if (!Arrays.equals(passwordField.getPassword(), passwordConfirmField.getPassword())) {
-      JOptionPane.showMessageDialog(
-          this, "The passwords do not match", "Passwords Do Not Match", JOptionPane.ERROR_MESSAGE);
-      passwordField.setText("");
-      passwordConfirmField.setText("");
-      return;
+      return Optional.of("Passwords must match");
     } else if (!PlayerEmailValidation.isValid(emailField.getText())) {
-      JOptionPane.showMessageDialog(
-          this, "You must enter a valid email", "No Email", JOptionPane.ERROR_MESSAGE);
-      return;
+      return Optional.of("Email must be valid");
     } else if (!PlayerNameValidation.isValid(usernameField.getText())) {
-      JOptionPane.showMessageDialog(
-          this,
-          PlayerNameValidation.validate(usernameField.getText()),
-          "Invalid name",
-          JOptionPane.ERROR_MESSAGE);
-      return;
+      return Optional.ofNullable(PlayerNameValidation.validate(usernameField.getText()));
     } else if (emailField.getText().isEmpty()) {
-      JOptionPane.showMessageDialog(
-          this, "You must enter an email", "No Email", JOptionPane.ERROR_MESSAGE);
-      return;
+      return Optional.of("You must enter an email");
     } else if (passwordField.getPassword().length == 0) {
-      JOptionPane.showMessageDialog(
-          this, "You must enter a password", "No Password", JOptionPane.ERROR_MESSAGE);
-      return;
-    } else if (passwordField.getPassword().length < 3) {
-      JOptionPane.showMessageDialog(
-          this,
-          "Passwords must be at least three characters long",
-          "Invalid Password",
-          JOptionPane.ERROR_MESSAGE);
-      return;
+      return Optional.of("You must enter a password");
+    } else if (passwordField.getPassword().length < 5) {
+      return Optional.of("Passwords must be at least five characters long");
     }
-
-    returnValue = ReturnValue.OK;
-    close();
+    return Optional.empty();
   }
 
   /**
@@ -275,6 +313,7 @@ public final class CreateAccountPanel extends JPanel {
   }
 
   public String getPassword() {
+    // TODO: Md5-Deprecation SHA512 hash password on client side here
     return new String(passwordField.getPassword());
   }
 
@@ -282,7 +321,7 @@ public final class CreateAccountPanel extends JPanel {
     return emailField.getText();
   }
 
-  String getUserName() {
+  String getUsername() {
     return usernameField.getText();
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -123,7 +123,7 @@ public class LobbyLogin {
                   () ->
                       ClientMessengerFactory.newCreateAccountMessenger(
                           lobbyServerProperties,
-                          panel.getUserName(),
+                          panel.getUsername(),
                           panel.getEmail(),
                           panel.getPassword()),
                   IOException.class);

--- a/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/moderators/ModeratorsTab.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/moderators/ModeratorsTab.java
@@ -87,7 +87,6 @@ public final class ModeratorsTab implements Supplier<Component> {
 
     // This is a very fancy listener that will validate the entered requested new moderator
     // name exists (as the user types) before we enable the submit button.
-    // To avoid sending too many requests to server we have a back-off period to batch requests.
     new KeyTypeValidator()
         .attachKeyTypeValidator(
             addField,

--- a/swing-lib/src/main/java/org/triplea/swing/KeyTypeValidator.java
+++ b/swing-lib/src/main/java/org/triplea/swing/KeyTypeValidator.java
@@ -35,16 +35,16 @@ public class KeyTypeValidator {
                           return;
                         }
                         // release the boolean lock, if we get another validation
-                        // request, allow it to enter queue.
+                        // request, allow it to enter queue. This way even if 'getText()'
+                        // returns us stale data, that new request will have a chance to
+                        // operate on the most recent.
                         validationIsInFlight.set(false);
 
                         final String textData = textComponent.getText().trim();
                         final boolean valid = dataValidation.test(textData);
 
                         SwingUtilities.invokeLater(
-                            () -> {
-                              action.accept(valid);
-                            });
+                            () -> action.accept(valid));
                       }
                     })
                 .start());

--- a/swing-lib/src/main/java/org/triplea/swing/KeyTypeValidator.java
+++ b/swing-lib/src/main/java/org/triplea/swing/KeyTypeValidator.java
@@ -27,7 +27,11 @@ public class KeyTypeValidator {
                     () -> {
                       if (!validationIsInFlight) {
                         validationIsInFlight = true;
-                        Interruptibles.sleep(200);
+
+                        if(!Interruptibles.sleep(200)) {
+                          validationIsInFlight = false;
+                          return;
+                        }
 
                         final String textData = textComponent.getText().trim();
                         final boolean valid = dataValidation.test(textData);

--- a/swing-lib/src/main/java/org/triplea/swing/KeyTypeValidator.java
+++ b/swing-lib/src/main/java/org/triplea/swing/KeyTypeValidator.java
@@ -1,0 +1,44 @@
+package org.triplea.swing;
+
+import java.util.function.Consumer;
+import java.util.function.Predicate;
+import javax.swing.SwingUtilities;
+import javax.swing.text.JTextComponent;
+import org.triplea.java.Interruptibles;
+
+/**
+ * Performs a validation while a user is entering data into a text field. The validation result is
+ * then sent to a consumer with the result of the validation. Validation is done in a background
+ * thread to not interrupt user input and has a back-off so that user input is slightly buffered
+ * before validation is re-executed. This can be useful for example to enable or disable a submit
+ * button depending on the value of a text-field.
+ */
+public class KeyTypeValidator {
+  private boolean validationIsInFlight = false;
+
+  public void attachKeyTypeValidator(
+      final JTextComponent textComponent,
+      final Predicate<String> dataValidation,
+      final Consumer<Boolean> action) {
+    DocumentListenerBuilder.attachDocumentListener(
+        textComponent,
+        () ->
+            new Thread(
+                    () -> {
+                      if (!validationIsInFlight) {
+                        validationIsInFlight = true;
+                        Interruptibles.sleep(200);
+
+                        final String textData = textComponent.getText().trim();
+                        final boolean valid = dataValidation.test(textData);
+
+                        SwingUtilities.invokeLater(
+                            () -> {
+                              action.accept(valid);
+                              validationIsInFlight = false;
+                            });
+                      }
+                    })
+                .start());
+  }
+}

--- a/swing-lib/src/main/java/org/triplea/swing/KeyTypeValidator.java
+++ b/swing-lib/src/main/java/org/triplea/swing/KeyTypeValidator.java
@@ -43,8 +43,7 @@ public class KeyTypeValidator {
                         final String textData = textComponent.getText().trim();
                         final boolean valid = dataValidation.test(textData);
 
-                        SwingUtilities.invokeLater(
-                            () -> action.accept(valid));
+                        SwingUtilities.invokeLater(() -> action.accept(valid));
                       }
                     })
                 .start());


### PR DESCRIPTION
Moves validation of 'create account' from when a user clicks submit
to while they enter data, does not enable 'submit' button until fields are valid.

Update details:
(1) Extract key type validation functionality to a utility class 'KeyTypeValidator'.
(2) Add 'KeyTypeValidator' to CreateAccountPanel
(3) Add a validation label to Create Account Panel to display validation message.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[] No manual testing done
[x] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->

## Screens Shots


### After
![Screenshot from 2019-10-25 22-40-41](https://user-images.githubusercontent.com/12397753/67614950-6a1f0780-f77a-11e9-9aaf-30a9da85988e.png)



<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

