### PR TITLE
Wire HttpLobbyClient to LobbyGameTableModel

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -52,9 +52,7 @@ public class LobbyFrame extends JFrame {
 
     final LobbyGameTableModel tableModel =
         new LobbyGameTableModel(
-            client.isAdmin(),
-            client.getHttpLobbyClient().getGameListingClient(),
-            this::reportErrorMessage);
+            client.isAdmin(), client.getHttpLobbyClient(), this::reportErrorMessage);
     final LobbyGamePanel gamePanel = new LobbyGamePanel(client, lobbyServerProperties, tableModel);
 
     final JSplitPane leftSplit = new JSplitPane();

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
@@ -16,7 +16,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.swing.SwingUtilities;
 import javax.swing.table.AbstractTableModel;
-import org.triplea.http.client.lobby.game.listing.GameListingClient;
+import org.triplea.http.client.lobby.HttpLobbyClient;
 import org.triplea.http.client.lobby.game.listing.LobbyGame;
 import org.triplea.http.client.lobby.game.listing.LobbyGameListing;
 import org.triplea.java.Timers;
@@ -41,7 +41,7 @@ class LobbyGameTableModel extends AbstractTableModel {
   }
 
   private final boolean admin;
-  private final Timer gamePoller;
+  private final transient Timer gamePoller;
 
   // these must only be accessed in the swing event thread
   private final List<Tuple<String, GameDescription>> gameList = new ArrayList<>();
@@ -62,7 +62,7 @@ class LobbyGameTableModel extends AbstractTableModel {
 
   LobbyGameTableModel(
       final boolean admin,
-      final GameListingClient gameListingClient,
+      final HttpLobbyClient httpLobbyClient,
       final Consumer<String> errorMessageReporter) {
     this.admin = admin;
 
@@ -76,11 +76,11 @@ class LobbyGameTableModel extends AbstractTableModel {
                 new GamePollerTask(
                     lobbyGameBroadcaster,
                     gameListingSupplier(),
-                    gameListingClient::fetchGameListing,
+                    () -> httpLobbyClient.getGameListingClient().fetchGameListing(),
                     errorMessageReporter));
 
     final Map<String, GameDescription> games =
-        gameListingClient.fetchGameListing().stream()
+        httpLobbyClient.getGameListingClient().fetchGameListing().stream()
             .collect(Collectors.toMap(LobbyGameListing::getGameId, GameDescription::fromLobbyGame));
 
     for (final Map.Entry<String, GameDescription> entry : games.entrySet()) {

--- a/game-core/src/test/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModelTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModelTest.java
@@ -19,6 +19,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.http.client.lobby.HttpLobbyClient;
 import org.triplea.http.client.lobby.game.listing.GameListingClient;
 import org.triplea.http.client.lobby.game.listing.LobbyGameListing;
 import org.triplea.java.Interruptibles;
@@ -26,6 +27,7 @@ import org.triplea.lobby.common.GameDescription;
 import org.triplea.swing.SwingAction;
 import org.triplea.util.Tuple;
 
+@SuppressWarnings("InnerClassMayBeStatic")
 final class LobbyGameTableModelTest {
 
   private static final String id0 = "id0";
@@ -57,6 +59,7 @@ final class LobbyGameTableModelTest {
   @Nested
   final class RemoveAndUpdateGameTest {
     private LobbyGameTableModel testObj;
+    @Mock private HttpLobbyClient httpLobbyClient;
     @Mock private GameListingClient gameListingClient;
 
     private List<LobbyGameListing> fakeGameListing = new ArrayList<>();
@@ -71,8 +74,9 @@ final class LobbyGameTableModelTest {
               .lobbyGame(gameDescription0.toLobbyGame())
               .build());
 
+      when(httpLobbyClient.getGameListingClient()).thenReturn(gameListingClient);
       when(gameListingClient.fetchGameListing()).thenReturn(fakeGameListing);
-      testObj = new LobbyGameTableModel(true, gameListingClient, errMsg -> {});
+      testObj = new LobbyGameTableModel(true, httpLobbyClient, errMsg -> {});
       waitForSwingThreads();
     }
 


### PR DESCRIPTION
Currently game table model has only a game listing, we'll also want to later
add a connection lost listener that comes from http-lobby-client. This is
a forward looking update to wire instead http-lobby-client to enable
that future change.

