### PR TITLE
Add ServerMessageEnvelope & Factory

### DIFF
--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/events/server/PlayerJoined.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/events/server/PlayerJoined.java
@@ -1,0 +1,9 @@
+package org.triplea.http.client.lobby.chat.events.server;
+
+import lombok.Value;
+import org.triplea.http.client.lobby.chat.ChatParticipant;
+
+@Value
+public class PlayerJoined {
+  private final ChatParticipant chatParticipant;
+}

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/events/server/PlayerLeft.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/events/server/PlayerLeft.java
@@ -1,0 +1,9 @@
+package org.triplea.http.client.lobby.chat.events.server;
+
+import lombok.Value;
+import org.triplea.domain.data.PlayerName;
+
+@Value
+public class PlayerLeft {
+  private final PlayerName playerName;
+}

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/events/server/PlayerListing.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/events/server/PlayerListing.java
@@ -1,0 +1,10 @@
+package org.triplea.http.client.lobby.chat.events.server;
+
+import java.util.List;
+import lombok.Value;
+import org.triplea.http.client.lobby.chat.ChatParticipant;
+
+@Value
+public class PlayerListing {
+  private final List<ChatParticipant> chatters;
+}

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/events/server/PlayerSlapped.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/events/server/PlayerSlapped.java
@@ -1,0 +1,14 @@
+package org.triplea.http.client.lobby.chat.events.server;
+
+import javax.annotation.Nonnull;
+import lombok.Builder;
+import lombok.Value;
+import org.triplea.domain.data.PlayerName;
+
+/** Payload indicating someone slapped another other player (that was not the local player). */
+@Builder
+@Value
+public class PlayerSlapped {
+  @Nonnull private final PlayerName slapper;
+  @Nonnull private final PlayerName slapped;
+}

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/events/server/ServerMessageEnvelope.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/events/server/ServerMessageEnvelope.java
@@ -1,0 +1,80 @@
+package org.triplea.http.client.lobby.chat.events.server;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import javax.annotation.Nonnull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+/** A message sent from the server to client. */
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@ToString
+@EqualsAndHashCode
+public class ServerMessageEnvelope {
+  private static final Gson gson = new Gson();
+
+  @Getter @Nonnull private final ServerMessageType messageType;
+  /** Payload itself may be a JSON string */
+  @Nonnull private final String payload;
+
+  public static <T> ServerMessageEnvelope packageMessage(
+      final ServerMessageType messageType, final T data) {
+    return new ServerMessageEnvelope(messageType, gson.toJson(data));
+  }
+
+  public StatusUpdate toPlayerStatusChange() {
+    Preconditions.checkState(messageType == ServerMessageType.STATUS_CHANGED);
+    return gson.fromJson(payload, StatusUpdate.class);
+  }
+
+  public PlayerLeft toPlayerLeft() {
+    Preconditions.checkState(messageType == ServerMessageType.PLAYER_LEFT);
+    return gson.fromJson(payload, PlayerLeft.class);
+  }
+
+  public PlayerJoined toPlayerJoined() {
+    Preconditions.checkState(messageType == ServerMessageType.PLAYER_JOINED);
+    return gson.fromJson(payload, PlayerJoined.class);
+  }
+
+  // TODO: Project#12 apply truncation at chat message level here.
+  public ChatMessage toChatMessage() {
+    Preconditions.checkState(messageType == ServerMessageType.CHAT_MESSAGE);
+    return gson.fromJson(payload, ChatMessage.class);
+  }
+
+  public PlayerSlapped toPlayerSlapped() {
+    Preconditions.checkState(messageType == ServerMessageType.PLAYER_SLAPPED);
+    return gson.fromJson(payload, PlayerSlapped.class);
+  }
+
+  public PlayerListing toPlayerListing() {
+    Preconditions.checkState(messageType == ServerMessageType.PLAYER_LISTING);
+    return gson.fromJson(payload, PlayerListing.class);
+  }
+
+  public String toErrorMessage() {
+    Preconditions.checkState(messageType == ServerMessageType.SERVER_ERROR);
+    return gson.fromJson(payload, String.class);
+  }
+
+  public String toChatEvent() {
+    Preconditions.checkState(messageType == ServerMessageType.CHAT_EVENT);
+    return gson.fromJson(payload, String.class);
+  }
+
+  /** Message type is used by client to know what kind of JSOn message has been received. */
+  public enum ServerMessageType {
+    CHAT_EVENT,
+    CHAT_MESSAGE,
+    PLAYER_JOINED,
+    PLAYER_LEFT,
+    PLAYER_LISTING,
+    PLAYER_SLAPPED,
+    SERVER_ERROR,
+    STATUS_CHANGED,
+  }
+}

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/chat/events/server/ServerMessageEnvelopeTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/chat/events/server/ServerMessageEnvelopeTest.java
@@ -1,0 +1,114 @@
+package org.triplea.http.client.lobby.chat.events.server;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.google.gson.Gson;
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.triplea.domain.data.PlayerName;
+import org.triplea.http.client.lobby.chat.ChatParticipant;
+
+class ServerMessageEnvelopeTest {
+  private static final Gson gson = new Gson();
+
+  private static final String STATUS = "status";
+  private static final String MESSAGE = "message";
+  private static final String ERROR_MESSAGE = "error-message";
+
+  private static final PlayerName PLAYER_NAME = PlayerName.of("player");
+  private static final ChatParticipant CHAT_PARTICIPANT =
+      ChatParticipant.builder().playerName(PLAYER_NAME).isModerator(true).build();
+
+  private final StatusUpdate statusUpdate = new StatusUpdate(PLAYER_NAME, STATUS);
+  private final PlayerLeft playerLeft = new PlayerLeft(PLAYER_NAME);
+  private final PlayerJoined playerJoined = new PlayerJoined(CHAT_PARTICIPANT);
+  private final ChatMessage chatMessage = new ChatMessage(PLAYER_NAME, MESSAGE);
+  private final PlayerSlapped playerSlapped =
+      new PlayerSlapped(PLAYER_NAME, PlayerName.of("slapped"));
+  private final PlayerListing playerListing =
+      new PlayerListing(Collections.singletonList(CHAT_PARTICIPANT));
+
+  @Test
+  void toPlayerStatusChange() {
+    final ServerMessageEnvelope serverEventEnvelope =
+        ServerMessageEnvelope.packageMessage(
+            ServerMessageEnvelope.ServerMessageType.STATUS_CHANGED, statusUpdate);
+
+    final StatusUpdate result = toAndFromJson(serverEventEnvelope).toPlayerStatusChange();
+
+    assertThat(result, is(statusUpdate));
+  }
+
+  private static ServerMessageEnvelope toAndFromJson(
+      final ServerMessageEnvelope serverEventEnvelope) {
+    final String jsonString = gson.toJson(serverEventEnvelope);
+    return gson.fromJson(jsonString, ServerMessageEnvelope.class);
+  }
+
+  @Test
+  void toPlayerLeft() {
+    final ServerMessageEnvelope serverEventEnvelope =
+        ServerMessageEnvelope.packageMessage(
+            ServerMessageEnvelope.ServerMessageType.PLAYER_LEFT, playerLeft);
+
+    final PlayerLeft result = toAndFromJson(serverEventEnvelope).toPlayerLeft();
+
+    assertThat(result, is(playerLeft));
+  }
+
+  @Test
+  void toPlayerJoined() {
+    final ServerMessageEnvelope serverEventEnvelope =
+        ServerMessageEnvelope.packageMessage(
+            ServerMessageEnvelope.ServerMessageType.PLAYER_JOINED, playerJoined);
+
+    final PlayerJoined result = toAndFromJson(serverEventEnvelope).toPlayerJoined();
+
+    assertThat(result, is(playerJoined));
+  }
+
+  @Test
+  void toChatMessage() {
+    final ServerMessageEnvelope serverEventEnvelope =
+        ServerMessageEnvelope.packageMessage(
+            ServerMessageEnvelope.ServerMessageType.CHAT_MESSAGE, chatMessage);
+
+    final ChatMessage result = toAndFromJson(serverEventEnvelope).toChatMessage();
+
+    assertThat(result, is(chatMessage));
+  }
+
+  @Test
+  void toSlapEvent() {
+    final ServerMessageEnvelope serverEventEnvelope =
+        ServerMessageEnvelope.packageMessage(
+            ServerMessageEnvelope.ServerMessageType.PLAYER_SLAPPED, playerSlapped);
+
+    final PlayerSlapped result = toAndFromJson(serverEventEnvelope).toPlayerSlapped();
+
+    assertThat(result, is(playerSlapped));
+  }
+
+  @Test
+  void toPlayerListing() {
+    final ServerMessageEnvelope serverEventEnvelope =
+        ServerMessageEnvelope.packageMessage(
+            ServerMessageEnvelope.ServerMessageType.PLAYER_LISTING, playerListing);
+
+    final PlayerListing result = toAndFromJson(serverEventEnvelope).toPlayerListing();
+
+    assertThat(result, is(playerListing));
+  }
+
+  @Test
+  void toErrorMessge() {
+    final ServerMessageEnvelope serverEventEnvelope =
+        ServerMessageEnvelope.packageMessage(
+            ServerMessageEnvelope.ServerMessageType.SERVER_ERROR, ERROR_MESSAGE);
+
+    final String result = toAndFromJson(serverEventEnvelope).toErrorMessage();
+
+    assertThat(result, is(ERROR_MESSAGE));
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/lobby/chat/event/processing/ServerMessageEnvelopeFactory.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/chat/event/processing/ServerMessageEnvelopeFactory.java
@@ -1,0 +1,54 @@
+package org.triplea.server.lobby.chat.event.processing;
+
+import java.util.List;
+import lombok.experimental.UtilityClass;
+import org.triplea.domain.data.PlayerName;
+import org.triplea.http.client.lobby.chat.ChatParticipant;
+import org.triplea.http.client.lobby.chat.events.server.ChatMessage;
+import org.triplea.http.client.lobby.chat.events.server.PlayerJoined;
+import org.triplea.http.client.lobby.chat.events.server.PlayerLeft;
+import org.triplea.http.client.lobby.chat.events.server.PlayerListing;
+import org.triplea.http.client.lobby.chat.events.server.PlayerSlapped;
+import org.triplea.http.client.lobby.chat.events.server.ServerMessageEnvelope;
+import org.triplea.http.client.lobby.chat.events.server.ServerMessageEnvelope.ServerMessageType;
+import org.triplea.http.client.lobby.chat.events.server.StatusUpdate;
+
+@UtilityClass
+public class ServerMessageEnvelopeFactory {
+
+  public ServerMessageEnvelope newEventMessage(final String eventMessage) {
+    return ServerMessageEnvelope.packageMessage(ServerMessageType.CHAT_EVENT, eventMessage);
+  }
+
+  ServerMessageEnvelope newChatMessage(final ChatMessage chatMessage) {
+    return ServerMessageEnvelope.packageMessage(ServerMessageType.CHAT_MESSAGE, chatMessage);
+  }
+
+  ServerMessageEnvelope newPlayerJoined(final ChatParticipant chatParticipant) {
+    return ServerMessageEnvelope.packageMessage(
+        ServerMessageType.PLAYER_JOINED, new PlayerJoined(chatParticipant));
+  }
+
+  ServerMessageEnvelope newPlayerLeft(final PlayerName playerLeft) {
+    return ServerMessageEnvelope.packageMessage(
+        ServerMessageType.PLAYER_LEFT, new PlayerLeft(playerLeft));
+  }
+
+  ServerMessageEnvelope newSlap(final PlayerSlapped playerSlapped) {
+    return ServerMessageEnvelope.packageMessage(ServerMessageType.PLAYER_SLAPPED, playerSlapped);
+  }
+
+  ServerMessageEnvelope newStatusUpdate(final StatusUpdate statusUpdate) {
+    return ServerMessageEnvelope.packageMessage(ServerMessageType.STATUS_CHANGED, statusUpdate);
+  }
+
+  ServerMessageEnvelope newPlayerListing(final List<ChatParticipant> chatters) {
+    return ServerMessageEnvelope.packageMessage(
+        ServerMessageType.PLAYER_LISTING, new PlayerListing(chatters));
+  }
+
+  ServerMessageEnvelope newErrorMessage() {
+    return ServerMessageEnvelope.packageMessage(
+        ServerMessageType.SERVER_ERROR, "Message processing failed, error on server");
+  }
+}

--- a/http-server/src/test/java/org/triplea/server/lobby/chat/event/processing/ServerMessageEnvelopeFactoryTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/chat/event/processing/ServerMessageEnvelopeFactoryTest.java
@@ -1,0 +1,112 @@
+package org.triplea.server.lobby.chat.event.processing;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+
+import java.util.Collections;
+import org.junit.jupiter.api.Test;
+import org.triplea.domain.data.PlayerName;
+import org.triplea.http.client.lobby.chat.ChatParticipant;
+import org.triplea.http.client.lobby.chat.events.server.ChatMessage;
+import org.triplea.http.client.lobby.chat.events.server.PlayerJoined;
+import org.triplea.http.client.lobby.chat.events.server.PlayerLeft;
+import org.triplea.http.client.lobby.chat.events.server.PlayerListing;
+import org.triplea.http.client.lobby.chat.events.server.PlayerSlapped;
+import org.triplea.http.client.lobby.chat.events.server.ServerMessageEnvelope;
+import org.triplea.http.client.lobby.chat.events.server.StatusUpdate;
+
+class ServerMessageEnvelopeFactoryTest {
+  private static final String STATUS = "status";
+  private static final String MESSAGE = "message";
+
+  private static final PlayerName PLAYER_NAME = PlayerName.of("player");
+  private static final ChatParticipant CHAT_PARTICIPANT =
+      ChatParticipant.builder().playerName(PLAYER_NAME).isModerator(true).build();
+
+  private final StatusUpdate statusUpdate = new StatusUpdate(PLAYER_NAME, STATUS);
+  private final PlayerLeft playerLeft = new PlayerLeft(PLAYER_NAME);
+  private final PlayerJoined playerJoined = new PlayerJoined(CHAT_PARTICIPANT);
+  private final ChatMessage chatMessage = new ChatMessage(PLAYER_NAME, MESSAGE);
+  private final PlayerSlapped playerSlapped =
+      PlayerSlapped.builder().slapper(PLAYER_NAME).slapped(PlayerName.of("slapped")).build();
+  private final PlayerListing playerListing =
+      new PlayerListing(Collections.singletonList(CHAT_PARTICIPANT));
+
+  @Test
+  void newChatMessage() {
+    final ServerMessageEnvelope serverEventEnvelope =
+        ServerMessageEnvelopeFactory.newChatMessage(chatMessage);
+
+    assertThat(
+        serverEventEnvelope.getMessageType(),
+        is(ServerMessageEnvelope.ServerMessageType.CHAT_MESSAGE));
+    assertThat(serverEventEnvelope.toChatMessage(), is(chatMessage));
+  }
+
+  @Test
+  void newPlayerJoined() {
+    final ServerMessageEnvelope serverEventEnvelope =
+        ServerMessageEnvelopeFactory.newPlayerJoined(CHAT_PARTICIPANT);
+
+    assertThat(
+        serverEventEnvelope.getMessageType(),
+        is(ServerMessageEnvelope.ServerMessageType.PLAYER_JOINED));
+    assertThat(serverEventEnvelope.toPlayerJoined(), is(playerJoined));
+  }
+
+  @Test
+  void newPlayerLeft() {
+    final ServerMessageEnvelope serverEventEnvelope =
+        ServerMessageEnvelopeFactory.newPlayerLeft(PLAYER_NAME);
+
+    assertThat(
+        serverEventEnvelope.getMessageType(),
+        is(ServerMessageEnvelope.ServerMessageType.PLAYER_LEFT));
+    assertThat(serverEventEnvelope.toPlayerLeft(), is(playerLeft));
+  }
+
+  @Test
+  void newSlap() {
+    final ServerMessageEnvelope serverEventEnvelope =
+        ServerMessageEnvelopeFactory.newSlap(playerSlapped);
+
+    assertThat(
+        serverEventEnvelope.getMessageType(),
+        is(ServerMessageEnvelope.ServerMessageType.PLAYER_SLAPPED));
+    assertThat(serverEventEnvelope.toPlayerSlapped(), is(playerSlapped));
+  }
+
+  @Test
+  void newStatusUpdate() {
+    final ServerMessageEnvelope serverEventEnvelope =
+        ServerMessageEnvelopeFactory.newStatusUpdate(statusUpdate);
+
+    assertThat(
+        serverEventEnvelope.getMessageType(),
+        is(ServerMessageEnvelope.ServerMessageType.STATUS_CHANGED));
+    assertThat(serverEventEnvelope.toPlayerStatusChange(), is(statusUpdate));
+  }
+
+  @Test
+  void newPlayerListing() {
+    final ServerMessageEnvelope serverEventEnvelope =
+        ServerMessageEnvelopeFactory.newPlayerListing(Collections.singletonList(CHAT_PARTICIPANT));
+
+    assertThat(
+        serverEventEnvelope.getMessageType(),
+        is(ServerMessageEnvelope.ServerMessageType.PLAYER_LISTING));
+    assertThat(serverEventEnvelope.toPlayerListing(), is(playerListing));
+  }
+
+  @Test
+  void newErrorMessage() {
+    final ServerMessageEnvelope serverEventEnvelope =
+        ServerMessageEnvelopeFactory.newErrorMessage();
+
+    assertThat(
+        serverEventEnvelope.getMessageType(),
+        is(ServerMessageEnvelope.ServerMessageType.SERVER_ERROR));
+    assertThat(serverEventEnvelope.toErrorMessage(), notNullValue());
+  }
+}


### PR DESCRIPTION
ServerMessageEnvelope is a unified java object that will be sent from server
to client over websocket. The ServerMessageEnvelope is designed to be JSON
encoded, it contains primarly two fields, a message type field and a payload
field. This is designed so clients can receive a ServerMessageEnvelope
as a JSON formatted String, clients can then convert it to a JSON object,
then based on the message type extract a java object from the message payload.

ServerMessageEnvelope objects should only be created by the corresponding
factory to ensure payload type is consistent and as expected.
