### PR TITLE
Add Http ModeratorLobbyClient

### DIFF
--- a/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/BanPlayerRequest.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/BanPlayerRequest.java
@@ -1,0 +1,24 @@
+package org.triplea.http.client.lobby.moderator;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+import org.triplea.domain.data.PlayerChatId;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+@ToString
+@Getter
+public class BanPlayerRequest {
+  private String playerChatId;
+  private int banMinutes;
+
+  public PlayerChatId getPlayerChatId() {
+    return PlayerChatId.of(playerChatId);
+  }
+}

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/ModeratorLobbyClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/ModeratorLobbyClient.java
@@ -1,0 +1,41 @@
+package org.triplea.http.client.lobby.moderator;
+
+import java.net.URI;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import org.triplea.domain.data.ApiKey;
+import org.triplea.domain.data.PlayerChatId;
+import org.triplea.http.client.AuthenticationHeaders;
+import org.triplea.http.client.HttpClient;
+
+// TODO: Project#12 test-me
+/** Provides access to moderator lobby commands, such as 'disconnect' player, and 'ban' player. */
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ModeratorLobbyClient {
+
+  public static final String DISCONNECT_GAME_PATH = "/lobby/moderator/disconnect-game";
+  public static final String DISCONNECT_PLAYER_PATH = "/lobby/moderator/disconnect-player";
+  public static final String BAN_PLAYER_PATH = "/lobby/moderator/ban-player";
+
+  private AuthenticationHeaders authenticationHeaders;
+  private ModeratorLobbyFeignClient moderatorLobbyFeignClient;
+
+  public static ModeratorLobbyClient newClient(final URI lobbyUri, final ApiKey apiKey) {
+    return new ModeratorLobbyClient(
+        new AuthenticationHeaders(apiKey),
+        new HttpClient<>(ModeratorLobbyFeignClient.class, lobbyUri).get());
+  }
+
+  public void banPlayer(final BanPlayerRequest banPlayerRequest) {
+    moderatorLobbyFeignClient.banPlayer(authenticationHeaders.createHeaders(), banPlayerRequest);
+  }
+
+  public void disconnectPlayer(final PlayerChatId playerChatId) {
+    moderatorLobbyFeignClient.disconnectPlayer(
+        authenticationHeaders.createHeaders(), playerChatId.getValue());
+  }
+
+  public void disconnectGame(final String gameId) {
+    moderatorLobbyFeignClient.disconnectGame(authenticationHeaders.createHeaders(), gameId);
+  }
+}

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/ModeratorLobbyFeignClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/ModeratorLobbyFeignClient.java
@@ -1,0 +1,20 @@
+package org.triplea.http.client.lobby.moderator;
+
+import feign.HeaderMap;
+import feign.Headers;
+import feign.RequestLine;
+import java.util.Map;
+import org.triplea.http.client.HttpConstants;
+
+@Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
+public interface ModeratorLobbyFeignClient {
+
+  @RequestLine("POST " + ModeratorLobbyClient.BAN_PLAYER_PATH)
+  void banPlayer(@HeaderMap Map<String, Object> headers, BanPlayerRequest banPlayerRequest);
+
+  @RequestLine("POST " + ModeratorLobbyClient.DISCONNECT_PLAYER_PATH)
+  void disconnectPlayer(@HeaderMap Map<String, Object> headers, String value);
+
+  @RequestLine("POST " + ModeratorLobbyClient.DISCONNECT_GAME_PATH)
+  void disconnectGame(@HeaderMap Map<String, Object> headers, String gameId);
+}


### PR DESCRIPTION
Adds http client code for sending moderator-specific commands to lobby,
ie: ban+disconnect player

Http backend controller and wiremock test for the client will be added
in future updates.
