### PR TITLE
Update CompletableFutureUtils to accept a Consumer

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1930,7 +1930,8 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
               .thenApplyAsync(ImageIcon::new)
               .thenAccept(icon -> SwingUtilities.invokeLater(() -> this.round.setIcon(icon)));
       CompletableFutureUtils.logExceptionWhenComplete(
-          future, "Failed to set round icon for " + player);
+          future,
+          throwable -> log.log(Level.SEVERE, "Failed to set round icon for " + player, throwable));
       lastStepPlayer = currentStepPlayer;
       currentStepPlayer = player;
     }

--- a/game-core/src/main/java/games/strategy/triplea/ui/export/ScreenshotExporter.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/export/ScreenshotExporter.java
@@ -19,13 +19,16 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
 import javax.imageio.ImageIO;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
+import lombok.extern.java.Log;
 import org.triplea.java.concurrency.CompletableFutureUtils;
 import org.triplea.swing.SwingComponents;
 
 /** Provides methods to export a screenshot for a game at a particular point in time. */
+@Log
 public final class ScreenshotExporter {
   private final TripleAFrame frame;
 
@@ -83,7 +86,8 @@ public final class ScreenshotExporter {
                                 JOptionPane.ERROR_MESSAGE);
                           }
                         }));
-    CompletableFutureUtils.logExceptionWhenComplete(future, "Failed to save map snapshot");
+    CompletableFutureUtils.logExceptionWhenComplete(
+        future, throwable -> log.log(Level.SEVERE, "Failed to save map snapshot", throwable));
   }
 
   private void save(final GameData gameData, final HistoryNode node, final File file)

--- a/java-extras/src/main/java/org/triplea/java/concurrency/CompletableFutureUtils.java
+++ b/java-extras/src/main/java/org/triplea/java/concurrency/CompletableFutureUtils.java
@@ -3,10 +3,8 @@ package org.triplea.java.concurrency;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import lombok.experimental.UtilityClass;
-import lombok.extern.java.Log;
 
 /** A collection of useful methods for working with instances of {@link CompletableFuture}. */
-@Log
 @UtilityClass
 public final class CompletableFutureUtils {
 

--- a/java-extras/src/main/java/org/triplea/java/concurrency/CompletableFutureUtils.java
+++ b/java-extras/src/main/java/org/triplea/java/concurrency/CompletableFutureUtils.java
@@ -1,38 +1,26 @@
 package org.triplea.java.concurrency;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import com.google.common.annotations.VisibleForTesting;
 import java.util.concurrent.CompletableFuture;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.util.function.Consumer;
+import lombok.experimental.UtilityClass;
 import lombok.extern.java.Log;
 
 /** A collection of useful methods for working with instances of {@link CompletableFuture}. */
 @Log
+@UtilityClass
 public final class CompletableFutureUtils {
-  private CompletableFutureUtils() {}
 
   /**
-   * Logs any exception thrown by {@code future} when it is complete. If {@code future} completes
-   * normally, no action is taken.
+   * Invokes {@param exceptionHandler} with any exception thrown by {@code future} when it is
+   * complete. If {@code future} completes normally, no action is taken.
    */
-  public static void logExceptionWhenComplete(
-      final CompletableFuture<?> future, final String message) {
-    checkNotNull(future);
-    checkNotNull(message);
-
-    logExceptionWhenComplete(future, message, log);
-  }
-
   @SuppressWarnings("FutureReturnValueIgnored")
-  @VisibleForTesting
-  static void logExceptionWhenComplete(
-      final CompletableFuture<?> future, final String message, final Logger logger) {
+  public static void logExceptionWhenComplete(
+      final CompletableFuture<?> future, final Consumer<Throwable> exceptionHandler) {
     future.whenComplete(
         (result, ex) -> {
           if (ex != null) {
-            logger.log(Level.SEVERE, message, ex);
+            exceptionHandler.accept(ex);
           }
         });
   }

--- a/java-extras/src/test/java/org/triplea/java/concurrency/CompletableFutureUtilsTest.java
+++ b/java-extras/src/test/java/org/triplea/java/concurrency/CompletableFutureUtilsTest.java
@@ -1,44 +1,41 @@
 package org.triplea.java.concurrency;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+@SuppressWarnings("InnerClassMayBeStatic")
 final class CompletableFutureUtilsTest {
   @ExtendWith(MockitoExtension.class)
   @Nested
   final class LogExceptionWhenCompleteTest {
-    private static final String ERROR_MESSAGE = "error message";
-
-    @Mock private Logger logger;
+    @Mock private Consumer<Throwable> exceptionConsumer;
 
     @Test
     void shouldNotWriteLogWhenFutureCompletesNormally() {
       final CompletableFuture<Object> future = new CompletableFuture<>();
-      CompletableFutureUtils.logExceptionWhenComplete(future, ERROR_MESSAGE, logger);
+      CompletableFutureUtils.logExceptionWhenComplete(future, exceptionConsumer);
       future.complete(new Object());
 
-      verify(logger, never()).log(any(Level.class), anyString(), any(Throwable.class));
+      verify(exceptionConsumer, never()).accept(any(Throwable.class));
     }
 
     @Test
     void shouldWriteLogWhenFutureCompletesExceptionally() {
       final CompletableFuture<Object> future = new CompletableFuture<>();
-      CompletableFutureUtils.logExceptionWhenComplete(future, ERROR_MESSAGE, logger);
+      CompletableFutureUtils.logExceptionWhenComplete(future, exceptionConsumer);
       final Exception ex = new Exception();
       future.completeExceptionally(ex);
 
-      verify(logger).log(Level.SEVERE, ERROR_MESSAGE, ex);
+      verify(exceptionConsumer).accept(ex);
     }
   }
 }


### PR DESCRIPTION
Make CompletableFutureUtils more generic by accepting a Consumer instead
of doing a logging action itself. This does two things:
- removes dependency on using java.util logger
- allows for client code to specify the desired logging level, potentially
  warn or info as desired.
