### PR TITLE
Http-Server Chat Components

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,6 +72,7 @@ subprojects {
         commonsMathVersion = '3.6.1'
         databaseRiderVersion = '1.7.3'
         dropwizardVersion = '1.3.15'
+        dropwizardWebsocketsVersion = '1.3.14'
         equalsVerifierVersion = '3.1.10'
         errorProneVersion = '2.3.3'
         guavaVersion = "28.1-jre"
@@ -80,6 +81,7 @@ subprojects {
         hamcrestVersion = '2.0.0.0'
         jakartaMailVersion = '1.6.4'
         javafxVersion = '11'
+        javaWebsocketVersoin = '1.4.0'
         javaxActivationVersion = '1.1.1'
         jaxbApiVersion = '2.3.1'
         jaxbCoreVersion = '2.3.0'

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/LobbyChatClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/LobbyChatClient.java
@@ -1,0 +1,10 @@
+package org.triplea.http.client.lobby.chat;
+
+import lombok.experimental.UtilityClass;
+
+/** Core websocket client to communicate with lobby chat API. */
+@UtilityClass // TODO: Project#12 remove utility class annotation
+public class LobbyChatClient {
+  public static final String WEBSOCKET_PATH = "/lobby/chat/websocket";
+  // TODO: Project#12 add implementation
+}

--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -20,9 +20,11 @@ configurations {
 }
 
 dependencies {
+    implementation "com.liveperson:dropwizard-websockets:$dropwizardWebsocketsVersion"
     implementation "com.sun.mail:jakarta.mail:$jakartaMailVersion"
     implementation "com.sun.xml.bind:jaxb-core:$jaxbCoreVersion"
     implementation "com.sun.xml.bind:jaxb-impl:$jaxbImplVersion"
+    implementation "commons-codec:commons-codec:$commonsCodecVersion" // TODO: Md5-Deprecation - used for md5crypt
     implementation "es.moki.ratelimitj:ratelimitj-dropwizard:$rateLimitjVersion"
     implementation "es.moki.ratelimitj:ratelimitj-inmemory:$rateLimitjVersion"
     implementation "io.dropwizard:dropwizard-auth:$dropwizardVersion"
@@ -31,7 +33,6 @@ dependencies {
     implementation "io.github.openfeign:feign-gson:$openFeignVersion"
     implementation "javax.activation:activation:$javaxActivationVersion"
     implementation "javax.xml.bind:jaxb-api:$jaxbApiVersion"
-    implementation "commons-codec:commons-codec:$commonsCodecVersion" // TODO: Md5-Deprecation - used for md5crypt
     implementation "org.jdbi:jdbi3-core:$jdbiVersion"
     implementation "org.jdbi:jdbi3-sqlobject:$jdbiVersion"
     implementation "org.mindrot:jbcrypt:$jbcryptVersion"
@@ -42,6 +43,7 @@ dependencies {
     runtimeOnly "org.postgresql:postgresql:$postgresqlVersion"
     testImplementation "com.github.database-rider:rider-junit5:$databaseRiderVersion"
     testImplementation "io.dropwizard:dropwizard-testing:$dropwizardVersion"
+    testImplementation "org.java-websocket:Java-WebSocket:$javaWebsocketVersoin"
     testImplementation project(":test-common")
 }
 

--- a/http-server/src/main/java/org/triplea/server/lobby/chat/ChatParticipantAdapter.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/chat/ChatParticipantAdapter.java
@@ -1,0 +1,19 @@
+package org.triplea.server.lobby.chat;
+
+import java.util.function.Function;
+import org.triplea.domain.data.PlayerName;
+import org.triplea.http.client.lobby.chat.ChatParticipant;
+import org.triplea.lobby.server.db.data.ApiKeyUserData;
+import org.triplea.lobby.server.db.data.UserRole;
+
+public class ChatParticipantAdapter implements Function<ApiKeyUserData, ChatParticipant> {
+  @Override
+  public ChatParticipant apply(final ApiKeyUserData apiKeyUserData) {
+    return ChatParticipant.builder()
+        .playerName(PlayerName.of(apiKeyUserData.getUsername()))
+        .isModerator(
+            apiKeyUserData.getRole().equals(UserRole.ADMIN)
+                || apiKeyUserData.getRole().equals(UserRole.MODERATOR))
+        .build();
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/lobby/chat/ChatSocketController.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/chat/ChatSocketController.java
@@ -1,0 +1,56 @@
+package org.triplea.server.lobby.chat;
+
+import javax.websocket.CloseReason;
+import javax.websocket.OnClose;
+import javax.websocket.OnError;
+import javax.websocket.OnMessage;
+import javax.websocket.OnOpen;
+import javax.websocket.Session;
+import javax.websocket.server.ServerEndpoint;
+import lombok.extern.slf4j.Slf4j;
+import org.triplea.http.client.lobby.chat.LobbyChatClient;
+
+/**
+ * Handles chat connections. Largely delegates to {@see MessagingService}. A shared {@code
+ * MessagingService} is injected into each user session and is available from {@code Session}
+ * objects.
+ */
+@Slf4j
+@ServerEndpoint(LobbyChatClient.WEBSOCKET_PATH)
+public class ChatSocketController {
+  public static final String MESSAGING_SERVICE_KEY = "messaging_service";
+
+  @OnOpen
+  public void open(final Session session) {
+    log.info(
+        "New websocket connection from IP: " + InetExtractor.extract(session.getUserProperties()));
+    // TODO: Project#12 do filtering for banned IPs (check if filter can kick in first)
+    // TODO: Project#12 make sure failed api key validation attempts become blacklisted
+  }
+
+  @OnMessage
+  public void message(final Session session, final String message) {
+    log.info("Chat message received: " + message);
+    ((MessagingService) session.getUserProperties().get(MESSAGING_SERVICE_KEY))
+        .handleMessage(session, message);
+  }
+
+  @OnClose
+  public void close(final Session session, final CloseReason closeReason) {
+    log.info(
+        "IP disconnected: {}, {}", InetExtractor.extract(session.getUserProperties()), closeReason);
+    ((MessagingService) session.getUserProperties().get(MESSAGING_SERVICE_KEY))
+        .handleDisconnect(session);
+  }
+
+  /**
+   * This error handler is called automatically when server processing encounters an uncaught
+   * exception. We use it to notify the user that an error occurred.
+   */
+  @OnError
+  public void handleError(final Session session, final Throwable throwable) {
+    log.warn("Notifying user of an error", throwable);
+    ((MessagingService) session.getUserProperties().get(MESSAGING_SERVICE_KEY))
+        .handleError(session, throwable);
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/lobby/chat/InetExtractor.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/chat/InetExtractor.java
@@ -1,0 +1,29 @@
+package org.triplea.server.lobby.chat;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Splitter;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.Map;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class InetExtractor {
+
+  @VisibleForTesting
+  public static final String IP_ADDRESS_KEY = "javax.websocket.endpoint.remoteAddress";
+
+  @SuppressWarnings("UnstableApiUsage")
+  public static InetAddress extract(final Map<String, Object> userSession) {
+    // expected format '/127.0.0.1:42840'
+    final String ipString = String.valueOf(userSession.get(IP_ADDRESS_KEY)).substring(1);
+    try {
+      final String ip = Splitter.on(':').splitToList(ipString).get(0);
+
+      return InetAddress.getByName(ip);
+    } catch (final UnknownHostException e) {
+      // not expected
+      throw new AssertionError("Unexpected bad hostname: " + userSession.get(IP_ADDRESS_KEY), e);
+    }
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/lobby/chat/MessageBroadcaster.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/chat/MessageBroadcaster.java
@@ -1,0 +1,24 @@
+package org.triplea.server.lobby.chat;
+
+import java.util.function.BiConsumer;
+import javax.websocket.Session;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.triplea.http.client.lobby.chat.events.server.ServerMessageEnvelope;
+
+@Slf4j
+@AllArgsConstructor
+public class MessageBroadcaster implements BiConsumer<Session, ServerMessageEnvelope> {
+
+  private final BiConsumer<Session, ServerMessageEnvelope> messageSender;
+
+  @Override
+  public void accept(final Session session, final ServerMessageEnvelope serverEventEnvelope) {
+    log.info("Broadcasting: {}", serverEventEnvelope);
+    session
+        .getOpenSessions()
+        .parallelStream()
+        .filter(Session::isOpen)
+        .forEach(s -> messageSender.accept(s, serverEventEnvelope));
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/lobby/chat/MessageSender.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/chat/MessageSender.java
@@ -1,0 +1,32 @@
+package org.triplea.server.lobby.chat;
+
+import com.google.gson.Gson;
+import java.util.concurrent.ExecutionException;
+import java.util.function.BiConsumer;
+import javax.websocket.Session;
+import lombok.extern.slf4j.Slf4j;
+import org.triplea.http.client.lobby.chat.events.server.ServerMessageEnvelope;
+import org.triplea.java.Interruptibles;
+
+@Slf4j
+public class MessageSender implements BiConsumer<Session, ServerMessageEnvelope> {
+  private final Gson gson = new Gson();
+
+  @Override
+  public void accept(final Session session, final ServerMessageEnvelope message) {
+    if (session.isOpen()) {
+      new Thread(
+              () -> {
+                Interruptibles.await(
+                    () -> {
+                      try {
+                        session.getAsyncRemote().sendText(gson.toJson(message)).get();
+                      } catch (final ExecutionException e) {
+                        log.warn("Failed to send message: " + message.getMessageType(), e);
+                      }
+                    });
+              })
+          .start();
+    }
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/lobby/chat/MessagingService.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/chat/MessagingService.java
@@ -1,0 +1,93 @@
+package org.triplea.server.lobby.chat;
+
+import com.google.gson.JsonSyntaxException;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+import javax.websocket.Session;
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+import org.triplea.http.client.lobby.chat.ChatParticipant;
+import org.triplea.http.client.lobby.chat.events.client.ClientMessageEnvelope;
+import org.triplea.http.client.lobby.chat.events.server.ServerMessageEnvelope;
+import org.triplea.lobby.server.db.dao.api.key.LobbyApiKeyDaoWrapper;
+import org.triplea.lobby.server.db.data.ApiKeyUserData;
+import org.triplea.server.lobby.chat.event.processing.ChatEventProcessor;
+import org.triplea.server.lobby.chat.event.processing.ServerResponse;
+
+@Slf4j
+@Builder
+class MessagingService {
+  @Nonnull private final LobbyApiKeyDaoWrapper apiKeyDaoWrapper;
+  @Nonnull private final ChatEventProcessor chatEventProcessor;
+  /** Sends to a single session. */
+  @Nonnull private final BiConsumer<Session, ServerMessageEnvelope> messageSender;
+  /** Sends to all connected sessions. */
+  @Nonnull private final BiConsumer<Session, ServerMessageEnvelope> messageBroadcaster;
+
+  @Nonnull private final Function<ApiKeyUserData, ChatParticipant> chatParticipantAdapter;
+
+  void handleMessage(final Session session, final String message) {
+    // TODO: Project#12 Bans: check API key
+    deserializeFromJson(session, message)
+        .ifPresent(envelope -> handleClientEnvelope(session, envelope));
+  }
+
+  private Optional<ClientMessageEnvelope> deserializeFromJson(
+      final Session session, final String message) {
+    try {
+      return Optional.of(ClientMessageEnvelope.fromJson(message));
+    } catch (final JsonSyntaxException e) {
+      log.warn(
+          "Ignoring badly formatted JSON request from: {}",
+          InetExtractor.extract(session.getUserProperties()));
+      return Optional.empty();
+    }
+  }
+
+  private void handleClientEnvelope(
+      final Session session, final ClientMessageEnvelope clientEventEnvelope) {
+    apiKeyDaoWrapper
+        .lookupByApiKey(clientEventEnvelope.getApiKey())
+        .map(chatParticipantAdapter)
+        .map(
+            chatParticipant ->
+                chatEventProcessor.process(session, chatParticipant, clientEventEnvelope))
+        .ifPresentOrElse(
+            responses -> sendMessages(session, responses), () -> logRequestIgnoredWarning(session));
+  }
+
+  private void sendMessages(final Session session, final List<ServerResponse> responses) {
+    if (responses.isEmpty()) {
+      logRequestIgnoredWarning(session);
+    }
+
+    responses.forEach(
+        response -> {
+          if (response.isBroadcast()) {
+            messageBroadcaster.accept(session, response.getServerEventEnvelope());
+          } else {
+            messageSender.accept(session, response.getServerEventEnvelope());
+          }
+        });
+  }
+
+  private void logRequestIgnoredWarning(final Session session) {
+    log.warn(
+        "Ignoring message from client (invalid API key or invalid client message type) from IP: "
+            + InetExtractor.extract(session.getUserProperties()));
+  }
+
+  void handleError(final Session session, final Throwable throwable) {
+    final ServerMessageEnvelope error = chatEventProcessor.createErrorMessage();
+    messageSender.accept(session, error);
+  }
+
+  void handleDisconnect(final Session session) {
+    chatEventProcessor
+        .disconnect(session)
+        .ifPresent(envelope -> messageBroadcaster.accept(session, envelope));
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/lobby/chat/MessagingServiceFactory.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/chat/MessagingServiceFactory.java
@@ -1,0 +1,21 @@
+package org.triplea.server.lobby.chat;
+
+import lombok.experimental.UtilityClass;
+import org.jdbi.v3.core.Jdbi;
+import org.triplea.lobby.server.db.dao.api.key.LobbyApiKeyDaoWrapper;
+import org.triplea.server.lobby.chat.event.processing.ChatEventProcessor;
+import org.triplea.server.lobby.chat.event.processing.Chatters;
+
+@UtilityClass
+public class MessagingServiceFactory {
+
+  public MessagingService build(final Jdbi jdbi, final Chatters chatters) {
+    return MessagingService.builder()
+        .apiKeyDaoWrapper(new LobbyApiKeyDaoWrapper(jdbi))
+        .chatEventProcessor(new ChatEventProcessor(chatters))
+        .messageSender(new MessageSender())
+        .messageBroadcaster(new MessageBroadcaster(new MessageSender()))
+        .chatParticipantAdapter(new ChatParticipantAdapter())
+        .build();
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/lobby/chat/event/processing/ChatEventProcessor.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/chat/event/processing/ChatEventProcessor.java
@@ -1,0 +1,84 @@
+package org.triplea.server.lobby.chat.event.processing;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import javax.websocket.Session;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.triplea.domain.data.PlayerName;
+import org.triplea.http.client.lobby.chat.ChatParticipant;
+import org.triplea.http.client.lobby.chat.events.client.ClientMessageEnvelope;
+import org.triplea.http.client.lobby.chat.events.server.ChatMessage;
+import org.triplea.http.client.lobby.chat.events.server.PlayerSlapped;
+import org.triplea.http.client.lobby.chat.events.server.ServerMessageEnvelope;
+import org.triplea.http.client.lobby.chat.events.server.StatusUpdate;
+import org.triplea.server.lobby.chat.InetExtractor;
+
+/**
+ * Handles processing logic when receiving chat messages and retains state of the currently
+ * connected chatters. The class is responsible for receiving client messages, updating local
+ * chatter state, and returns a list of server responses to broadcast or send back to users.
+ */
+@Slf4j
+@AllArgsConstructor
+public class ChatEventProcessor {
+
+  private final Chatters chatters;
+
+  public List<ServerResponse> process(
+      final Session session,
+      final ChatParticipant sender,
+      final ClientMessageEnvelope clientEventEnvelope) {
+
+    final List<ServerResponse> responses = new ArrayList<>();
+
+    switch (clientEventEnvelope.getMessageType()) {
+      case CONNECT:
+        chatters.put(session, sender);
+        responses.add(
+            ServerResponse.backToClient(
+                ServerMessageEnvelopeFactory.newPlayerListing(
+                    new ArrayList<>(chatters.getAllParticipants()))));
+        responses.add(
+            ServerResponse.broadcast(ServerMessageEnvelopeFactory.newPlayerJoined(sender)));
+        return responses;
+      case SLAP:
+        final PlayerName slapped = PlayerName.of(clientEventEnvelope.getPayload());
+        responses.add(
+            ServerResponse.broadcast(
+                ServerMessageEnvelopeFactory.newSlap(
+                    PlayerSlapped.builder()
+                        .slapper(sender.getPlayerName())
+                        .slapped(slapped)
+                        .build())));
+        return responses;
+      case MESSAGE:
+        responses.add(
+            ServerResponse.broadcast(
+                ServerMessageEnvelopeFactory.newChatMessage(
+                    new ChatMessage(sender.getPlayerName(), clientEventEnvelope.getPayload()))));
+        return responses;
+      case UPDATE_MY_STATUS:
+        responses.add(
+            ServerResponse.broadcast(
+                ServerMessageEnvelopeFactory.newStatusUpdate(
+                    new StatusUpdate(sender.getPlayerName(), clientEventEnvelope.getPayload()))));
+        return responses;
+      default:
+        log.warn(
+            "Ignored message type: {}, from IP: {}",
+            clientEventEnvelope.getMessageType(),
+            InetExtractor.extract(session.getUserProperties()));
+        return responses;
+    }
+  }
+
+  public Optional<ServerMessageEnvelope> disconnect(final Session session) {
+    return chatters.removeSession(session).map(ServerMessageEnvelopeFactory::newPlayerLeft);
+  }
+
+  public ServerMessageEnvelope createErrorMessage() {
+    return ServerMessageEnvelopeFactory.newErrorMessage();
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/lobby/chat/event/processing/Chatters.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/chat/event/processing/Chatters.java
@@ -1,0 +1,42 @@
+package org.triplea.server.lobby.chat.event.processing;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.websocket.Session;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.triplea.domain.data.PlayerName;
+import org.triplea.http.client.lobby.chat.ChatParticipant;
+
+public class Chatters {
+  @AllArgsConstructor
+  @Getter
+  private static class ChatterSession {
+    private final ChatParticipant chatParticipant;
+    private final Session session;
+  }
+
+  @Getter(value = AccessLevel.PACKAGE, onMethod_ = @VisibleForTesting)
+  private final Map<String, ChatterSession> participants = new HashMap<>();
+
+  Optional<PlayerName> removeSession(final Session session) {
+    return Optional.ofNullable(participants.remove(session.getId()))
+        .map(ChatterSession::getChatParticipant)
+        .map(ChatParticipant::getPlayerName);
+  }
+
+  void put(final Session session, final ChatParticipant chatter) {
+    participants.put(session.getId(), new ChatterSession(chatter, session));
+  }
+
+  Collection<ChatParticipant> getAllParticipants() {
+    return participants.values().stream()
+        .map(ChatterSession::getChatParticipant)
+        .collect(Collectors.toSet());
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/lobby/chat/event/processing/ServerResponse.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/chat/event/processing/ServerResponse.java
@@ -1,0 +1,25 @@
+package org.triplea.server.lobby.chat.event.processing;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+import org.triplea.http.client.lobby.chat.events.server.ServerMessageEnvelope;
+
+@Getter
+@EqualsAndHashCode
+@ToString
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class ServerResponse {
+  private final boolean broadcast;
+  private final ServerMessageEnvelope serverEventEnvelope;
+
+  public static ServerResponse broadcast(final ServerMessageEnvelope serverEventEnvelope) {
+    return new ServerResponse(true, serverEventEnvelope);
+  }
+
+  public static ServerResponse backToClient(final ServerMessageEnvelope serverEventEnvelope) {
+    return new ServerResponse(false, serverEventEnvelope);
+  }
+}

--- a/http-server/src/test/java/org/triplea/server/lobby/chat/ChatParticipantAdapterTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/chat/ChatParticipantAdapterTest.java
@@ -1,0 +1,53 @@
+package org.triplea.server.lobby.chat;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.triplea.domain.data.PlayerName;
+import org.triplea.http.client.lobby.chat.ChatParticipant;
+import org.triplea.lobby.server.db.data.ApiKeyUserData;
+import org.triplea.lobby.server.db.data.UserRole;
+
+class ChatParticipantAdapterTest {
+
+  private static final String USERNAME = "username-value";
+  private final ChatParticipantAdapter chatParticipantAdapter = new ChatParticipantAdapter();
+
+  @ParameterizedTest
+  @ValueSource(strings = {UserRole.ADMIN, UserRole.MODERATOR})
+  void moderatorUsers(final String moderatorUserRole) {
+    final ApiKeyUserData apiKeyUserData = givenUserDataWithRole(moderatorUserRole);
+
+    final ChatParticipant result = chatParticipantAdapter.apply(apiKeyUserData);
+
+    assertThat(
+        result,
+        is(
+            ChatParticipant.builder()
+                .isModerator(true)
+                .playerName(PlayerName.of(USERNAME))
+                .build()));
+  }
+
+  private ApiKeyUserData givenUserDataWithRole(final String userRole) {
+    return ApiKeyUserData.builder().username(USERNAME).role(userRole).build();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {UserRole.ANONYMOUS, UserRole.PLAYER})
+  void nonModeratorUsers(final String notModeratorUserRole) {
+    final ApiKeyUserData apiKeyUserData = givenUserDataWithRole(notModeratorUserRole);
+
+    final ChatParticipant result = chatParticipantAdapter.apply(apiKeyUserData);
+
+    assertThat(
+        result,
+        is(
+            ChatParticipant.builder()
+                .isModerator(true)
+                .playerName(PlayerName.of(USERNAME))
+                .build()));
+  }
+}

--- a/http-server/src/test/java/org/triplea/server/lobby/chat/ChatSocketControllerTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/chat/ChatSocketControllerTest.java
@@ -1,0 +1,59 @@
+package org.triplea.server.lobby.chat;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import javax.websocket.CloseReason;
+import javax.websocket.Session;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ChatSocketControllerTest {
+
+  private static final String MESSAGE = "Vandalize the fortress until it waves.";
+  private static final CloseReason CLOSE_REASON =
+      new CloseReason(CloseReason.CloseCodes.CLOSED_ABNORMALLY, "close reason phrase");
+
+  @Mock private Session session;
+  @Mock private MessagingService messagingService;
+  @Mock private Throwable throwable;
+
+  private final ChatSocketController chatSocketController = new ChatSocketController();
+
+  @BeforeEach
+  void setup() {
+    when(session.getUserProperties())
+        .thenReturn(
+            Map.of(
+                ChatSocketController.MESSAGING_SERVICE_KEY,
+                messagingService,
+                InetExtractor.IP_ADDRESS_KEY,
+                "/127.0.0.1:555"));
+  }
+
+  @Test
+  void message() {
+    chatSocketController.message(session, MESSAGE);
+
+    verify(messagingService).handleMessage(session, MESSAGE);
+  }
+
+  @Test
+  void close() {
+    chatSocketController.close(session, CLOSE_REASON);
+
+    verify(messagingService).handleDisconnect(session);
+  }
+
+  @Test
+  void handleError() {
+    chatSocketController.handleError(session, throwable);
+
+    verify(messagingService).handleError(session, throwable);
+  }
+}

--- a/http-server/src/test/java/org/triplea/server/lobby/chat/InetExtractorTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/chat/InetExtractorTest.java
@@ -1,0 +1,21 @@
+package org.triplea.server.lobby.chat;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.net.InetAddress;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class InetExtractorTest {
+
+  private static final String IP_ADDRESS = "127.0.0.1";
+
+  @Test
+  void verify() throws Exception {
+    final Map<String, Object> propertiesMap =
+        Map.of(InetExtractor.IP_ADDRESS_KEY, "/" + IP_ADDRESS + ":42840");
+
+    assertThat(InetExtractor.extract(propertiesMap), is(InetAddress.getByName(IP_ADDRESS)));
+  }
+}

--- a/http-server/src/test/java/org/triplea/server/lobby/chat/MessageBroadcasterTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/chat/MessageBroadcasterTest.java
@@ -4,7 +4,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.common.collect.Sets;
+import java.util.Set;
 import java.util.function.BiConsumer;
 import javax.websocket.Session;
 import org.junit.jupiter.api.Test;
@@ -27,7 +27,7 @@ class MessageBroadcasterTest {
 
   @Test
   void accept() {
-    when(session0.getOpenSessions()).thenReturn(Sets.newHashSet(session0, session1, session2));
+    when(session0.getOpenSessions()).thenReturn(Set.of(session0, session1, session2));
     when(session0.isOpen()).thenReturn(true);
     when(session1.isOpen()).thenReturn(true);
     when(session2.isOpen()).thenReturn(false);

--- a/http-server/src/test/java/org/triplea/server/lobby/chat/MessageBroadcasterTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/chat/MessageBroadcasterTest.java
@@ -1,0 +1,42 @@
+package org.triplea.server.lobby.chat;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.common.collect.Sets;
+import java.util.function.BiConsumer;
+import javax.websocket.Session;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.http.client.lobby.chat.events.server.ServerMessageEnvelope;
+
+@ExtendWith(MockitoExtension.class)
+class MessageBroadcasterTest {
+
+  @Mock private Session session0;
+  @Mock private Session session1;
+  @Mock private Session session2;
+  @Mock private ServerMessageEnvelope serverEventEnvelope;
+
+  @Mock private BiConsumer<Session, ServerMessageEnvelope> singleMessageSender;
+  @InjectMocks private MessageBroadcaster messageBroadcaster;
+
+  @Test
+  void accept() {
+    when(session0.getOpenSessions()).thenReturn(Sets.newHashSet(session0, session1, session2));
+    when(session0.isOpen()).thenReturn(true);
+    when(session1.isOpen()).thenReturn(true);
+    when(session2.isOpen()).thenReturn(false);
+
+    messageBroadcaster.accept(session0, serverEventEnvelope);
+
+    verify(singleMessageSender).accept(session0, serverEventEnvelope);
+    verify(singleMessageSender).accept(session1, serverEventEnvelope);
+    // session2 is not open, should not be used
+    verify(singleMessageSender, never()).accept(session2, serverEventEnvelope);
+  }
+}

--- a/http-server/src/test/java/org/triplea/server/lobby/chat/MessagingServiceTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/chat/MessagingServiceTest.java
@@ -1,0 +1,186 @@
+package org.triplea.server.lobby.chat;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.google.gson.Gson;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.BiConsumer;
+import javax.websocket.Session;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.http.client.lobby.chat.ChatParticipant;
+import org.triplea.http.client.lobby.chat.events.client.ClientMessageEnvelope;
+import org.triplea.http.client.lobby.chat.events.server.ServerMessageEnvelope;
+import org.triplea.lobby.server.db.dao.api.key.LobbyApiKeyDaoWrapper;
+import org.triplea.lobby.server.db.data.ApiKeyUserData;
+import org.triplea.lobby.server.db.data.UserRole;
+import org.triplea.server.TestData;
+import org.triplea.server.lobby.chat.event.processing.ChatEventProcessor;
+import org.triplea.server.lobby.chat.event.processing.ServerResponse;
+
+@ExtendWith(MockitoExtension.class)
+class MessagingServiceTest {
+  private static final String MALFORMED_MESSAGE = "not-a-json-message";
+
+  private static final Map<String, Object> userPropertiesMap =
+      Map.of(InetExtractor.IP_ADDRESS_KEY, "/127.0.0.1:123");
+
+  private static final ClientMessageEnvelope CLIENT_EVENT_ENVELOPE =
+      ClientMessageEnvelope.builder()
+          .apiKey(TestData.API_KEY.getValue())
+          .messageType(ClientMessageEnvelope.ClientMessageType.MESSAGE.name())
+          .payload("payload-message")
+          .build();
+
+  private static final String JSON_MESSAGE = new Gson().toJson(CLIENT_EVENT_ENVELOPE);
+
+  private static final ChatParticipantAdapter chatParticipantAdapter = new ChatParticipantAdapter();
+
+  private static final ApiKeyUserData API_KEY_USER_DATA =
+      ApiKeyUserData.builder().role(UserRole.MODERATOR).username("player-name-moderator").build();
+
+  private static final ChatParticipant CHAT_PARTICIPANT =
+      chatParticipantAdapter.apply(API_KEY_USER_DATA);
+
+  @Mock private LobbyApiKeyDaoWrapper apiKeyDaoWrapper;
+  @Mock private ChatEventProcessor eventProcessing;
+  @Mock private BiConsumer<Session, ServerMessageEnvelope> messageSender;
+  @Mock private BiConsumer<Session, ServerMessageEnvelope> messageBroadcaster;
+
+  private MessagingService messagingService;
+
+  @Mock private ServerMessageEnvelope serverEventEnvelope;
+  @Mock private Session session;
+
+  @BeforeEach
+  void setup() {
+    messagingService =
+        MessagingService.builder()
+            .apiKeyDaoWrapper(apiKeyDaoWrapper)
+            .chatEventProcessor(eventProcessing)
+            .messageSender(messageSender)
+            .messageBroadcaster(messageBroadcaster)
+            .chatParticipantAdapter(new ChatParticipantAdapter())
+            .build();
+  }
+
+  @Nested
+  class HandleMessage {
+    @Test
+    void handleMalformedMessage() {
+      when(session.getUserProperties()).thenReturn(userPropertiesMap);
+
+      messagingService.handleMessage(session, MALFORMED_MESSAGE);
+
+      verify(apiKeyDaoWrapper, never()).lookupByApiKey(any());
+      verify(messageBroadcaster, never()).accept(any(), any());
+    }
+
+    @Test
+    void apiKeyNotFound() {
+      when(apiKeyDaoWrapper.lookupByApiKey(TestData.API_KEY)).thenReturn(Optional.empty());
+      when(session.getUserProperties()).thenReturn(userPropertiesMap);
+
+      messagingService.handleMessage(session, JSON_MESSAGE);
+
+      verify(messageBroadcaster, never()).accept(any(), any());
+    }
+
+    /**
+     * In this case we have a valid API key, though the ClientEnvelope we de-serialized from JSON
+     * string is invalid. This is represented by teh eventProcessing returning zero server messages.
+     * This is an unlikely scenario, though could happen with version differences or a
+     * custom/malicious client.
+     */
+    @Test
+    void eventProcessingFails() {
+      when(apiKeyDaoWrapper.lookupByApiKey(TestData.API_KEY))
+          .thenReturn(Optional.of(API_KEY_USER_DATA));
+      when(eventProcessing.process(session, CHAT_PARTICIPANT, CLIENT_EVENT_ENVELOPE))
+          .thenReturn(Collections.emptyList());
+      when(session.getUserProperties()).thenReturn(userPropertiesMap);
+
+      messagingService.handleMessage(session, JSON_MESSAGE);
+
+      verify(messageBroadcaster, never()).accept(any(), any());
+    }
+
+    @Test
+    void broadCastResponse() {
+      givenServerResponse(ServerResponse.broadcast(serverEventEnvelope));
+      messagingService.handleMessage(session, JSON_MESSAGE);
+
+      verify(messageBroadcaster).accept(session, serverEventEnvelope);
+      verify(messageSender, never()).accept(any(), any());
+    }
+
+    private void givenServerResponse(final ServerResponse... responses) {
+      when(apiKeyDaoWrapper.lookupByApiKey(TestData.API_KEY))
+          .thenReturn(Optional.of(API_KEY_USER_DATA));
+      when(eventProcessing.process(session, CHAT_PARTICIPANT, CLIENT_EVENT_ENVELOPE))
+          .thenReturn(Arrays.asList(responses));
+    }
+
+    @Test
+    void sendResponse() {
+      givenServerResponse(ServerResponse.backToClient(serverEventEnvelope));
+
+      messagingService.handleMessage(session, JSON_MESSAGE);
+
+      verify(messageSender).accept(session, serverEventEnvelope);
+      verify(messageBroadcaster, never()).accept(any(), any());
+    }
+
+    @Test
+    void sendMultipleResponses() {
+      givenServerResponse(
+          ServerResponse.broadcast(serverEventEnvelope),
+          ServerResponse.backToClient(serverEventEnvelope));
+
+      messagingService.handleMessage(session, JSON_MESSAGE);
+
+      verify(messageBroadcaster).accept(session, serverEventEnvelope);
+      verify(messageSender).accept(session, serverEventEnvelope);
+    }
+  }
+
+  @Test
+  void handleError() {
+    when(eventProcessing.createErrorMessage()).thenReturn(serverEventEnvelope);
+
+    messagingService.handleError(session, null);
+
+    verify(messageSender).accept(session, serverEventEnvelope);
+  }
+
+  @Nested
+  class Disconnect {
+    @Test
+    void disconnect() {
+      when(eventProcessing.disconnect(session)).thenReturn(Optional.of(serverEventEnvelope));
+
+      messagingService.handleDisconnect(session);
+
+      verify(messageBroadcaster).accept(session, serverEventEnvelope);
+    }
+
+    @Test
+    void alreadyDisconnectedIsNoOp() {
+      when(eventProcessing.disconnect(session)).thenReturn(Optional.empty());
+
+      messagingService.handleDisconnect(session);
+
+      verify(messageBroadcaster, never()).accept(any(), any());
+    }
+  }
+}

--- a/http-server/src/test/java/org/triplea/server/lobby/chat/MessagingServiceTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/chat/MessagingServiceTest.java
@@ -98,7 +98,7 @@ class MessagingServiceTest {
 
     /**
      * In this case we have a valid API key, though the ClientEnvelope we de-serialized from JSON
-     * string is invalid. This is represented by teh eventProcessing returning zero server messages.
+     * string is invalid. This is represented by the eventProcessing returning zero server messages.
      * This is an unlikely scenario, though could happen with version differences or a
      * custom/malicious client.
      */

--- a/http-server/src/test/java/org/triplea/server/lobby/chat/event/processing/ChatEventProcessorTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/chat/event/processing/ChatEventProcessorTest.java
@@ -1,0 +1,213 @@
+package org.triplea.server.lobby.chat.event.processing;
+
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
+import static java.util.Collections.singletonList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.core.IsCollectionContaining.hasItems;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.websocket.Session;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.domain.data.ApiKey;
+import org.triplea.domain.data.PlayerName;
+import org.triplea.http.client.lobby.chat.ChatParticipant;
+import org.triplea.http.client.lobby.chat.events.client.ClientMessageEnvelope;
+import org.triplea.http.client.lobby.chat.events.client.ClientMessageFactory;
+import org.triplea.http.client.lobby.chat.events.server.ChatMessage;
+import org.triplea.http.client.lobby.chat.events.server.PlayerSlapped;
+import org.triplea.http.client.lobby.chat.events.server.ServerMessageEnvelope;
+import org.triplea.http.client.lobby.chat.events.server.StatusUpdate;
+import org.triplea.server.lobby.chat.InetExtractor;
+
+@SuppressWarnings("InnerClassMayBeStatic")
+@ExtendWith(MockitoExtension.class)
+class ChatEventProcessorTest {
+
+  private static final String SESSION_ID = "session-id";
+  private static final String MESSAGE = "chat-message";
+  private static final String STATUS = "status";
+
+  private static final PlayerName PLAYER_NAME_0 = PlayerName.of("playerName");
+  private static final ChatParticipant CHAT_PARTICIPANT_0 =
+      ChatParticipant.builder().playerName(PLAYER_NAME_0).isModerator(true).build();
+
+  private static final PlayerName PLAYER_NAME_1 = PlayerName.of("playerName");
+  private static final ChatParticipant CHAT_PARTICIPANT_1 =
+      ChatParticipant.builder().playerName(PLAYER_NAME_1).isModerator(true).build();
+
+  private final ChatEventProcessor chatEventProcessor = new ChatEventProcessor(new Chatters());
+
+  @Mock private Chatters chatters;
+
+  @InjectMocks private ChatEventProcessor chatEventProcessorWithMocks;
+
+  @Mock private Session session;
+
+  private final ClientMessageFactory clientEventFactory =
+      new ClientMessageFactory(ApiKey.of("key"));
+
+  @Nested
+  class ProcessConnectMessage {
+    @Test
+    void connect() {
+      final List<ServerResponse> responses =
+          chatEventProcessor.process(
+              session, CHAT_PARTICIPANT_0, clientEventFactory.connectToChat());
+
+      assertThat("Expect a player-listing and player-joined message", responses, hasSize(2));
+
+      assertThat(
+          "First message should be player-listing",
+          responses.get(0),
+          is(
+              ServerResponse.backToClient(
+                  ServerMessageEnvelopeFactory.newPlayerListing(
+                      singletonList(CHAT_PARTICIPANT_0)))));
+
+      assertThat(
+          "Second message is player joined",
+          responses.get(1),
+          is(
+              ServerResponse.broadcast(
+                  ServerMessageEnvelopeFactory.newPlayerJoined(CHAT_PARTICIPANT_0))));
+    }
+
+    @Test
+    void multiplePlayersConnect() {
+      chatEventProcessor.process(session, CHAT_PARTICIPANT_0, clientEventFactory.connectToChat());
+
+      final List<ServerResponse> responses =
+          chatEventProcessor.process(
+              session, CHAT_PARTICIPANT_0, clientEventFactory.connectToChat());
+
+      assertThat("Expect a player-listing and player-joined message", responses, hasSize(2));
+
+      assertThat(
+          "First message should be player-listing with both participants",
+          responses.get(0).getServerEventEnvelope().toPlayerListing().getChatters(),
+          hasItems(CHAT_PARTICIPANT_0, CHAT_PARTICIPANT_1));
+
+      assertThat(
+          "Player listing message should not be broadcast to all",
+          responses.get(0).isBroadcast(),
+          is(false));
+
+      assertThat(
+          "Second message is player joined",
+          responses.get(1),
+          is(
+              ServerResponse.broadcast(
+                  ServerMessageEnvelopeFactory.newPlayerJoined(CHAT_PARTICIPANT_1))));
+    }
+
+    @Test
+    void slap() {
+      final List<ServerResponse> responses =
+          chatEventProcessor.process(
+              session, CHAT_PARTICIPANT_0, clientEventFactory.slapMessage(PLAYER_NAME_1));
+
+      assertThat(responses, hasSize(1));
+      assertThat(
+          responses.get(0),
+          is(
+              ServerResponse.broadcast(
+                  ServerMessageEnvelopeFactory.newSlap(
+                      PlayerSlapped.builder()
+                          .slapper(CHAT_PARTICIPANT_0.getPlayerName())
+                          .slapped(PLAYER_NAME_1)
+                          .build()))));
+    }
+
+    @Test
+    void message() {
+      final List<ServerResponse> responses =
+          chatEventProcessor.process(
+              session, CHAT_PARTICIPANT_0, clientEventFactory.sendMessage(MESSAGE));
+
+      assertThat(responses, hasSize(1));
+      assertThat(
+          responses.get(0),
+          is(
+              ServerResponse.broadcast(
+                  ServerMessageEnvelopeFactory.newChatMessage(
+                      new ChatMessage(CHAT_PARTICIPANT_0.getPlayerName(), MESSAGE)))));
+    }
+
+    @Test
+    void updateStatus() {
+      final List<ServerResponse> responses =
+          chatEventProcessor.process(
+              session, CHAT_PARTICIPANT_0, clientEventFactory.updateMyPlayerStatus(STATUS));
+
+      assertThat(responses, hasSize(1));
+      assertThat(
+          responses.get(0),
+          is(
+              ServerResponse.broadcast(
+                  ServerMessageEnvelopeFactory.newStatusUpdate(
+                      new StatusUpdate(CHAT_PARTICIPANT_0.getPlayerName(), STATUS)))));
+    }
+
+    @Test
+    void unknownType() {
+      when(session.getUserProperties())
+          .thenReturn(Map.of(InetExtractor.IP_ADDRESS_KEY, "/127.0.0.1:99"));
+
+      final List<ServerResponse> responses =
+          chatEventProcessor.process(
+              session,
+              CHAT_PARTICIPANT_0,
+              ClientMessageEnvelope.builder()
+                  .messageType("unknown-type")
+                  .apiKey("api-key")
+                  .payload("")
+                  .build());
+
+      assertThat(responses, empty());
+    }
+  }
+
+  @Nested
+  class Disconnect {
+    @Test
+    void userNotConnected() {
+      when(session.getId()).thenReturn(SESSION_ID);
+
+      final Optional<ServerMessageEnvelope> result = chatEventProcessor.disconnect(session);
+
+      assertThat(result, isEmpty());
+    }
+
+    @Test
+    void userConnected() {
+      when(chatters.removeSession(session)).thenReturn(Optional.of(PLAYER_NAME_0));
+
+      final Optional<ServerMessageEnvelope> result =
+          chatEventProcessorWithMocks.disconnect(session);
+
+      assertThat(result, isPresentAndIs(ServerMessageEnvelopeFactory.newPlayerLeft(PLAYER_NAME_0)));
+    }
+  }
+
+  @Nested
+  class ErrorMessage {
+    @Test
+    void createErrorMessage() {
+      final ServerMessageEnvelope serverEventEnvelope = chatEventProcessor.createErrorMessage();
+
+      assertThat(serverEventEnvelope, is(ServerMessageEnvelopeFactory.newErrorMessage()));
+    }
+  }
+}

--- a/http-server/src/test/java/org/triplea/server/lobby/chat/event/processing/ServerResponseTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/chat/event/processing/ServerResponseTest.java
@@ -1,0 +1,34 @@
+package org.triplea.server.lobby.chat.event.processing;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.http.client.lobby.chat.events.server.ServerMessageEnvelope;
+
+@ExtendWith(MockitoExtension.class)
+class ServerResponseTest {
+
+  @Mock private ServerMessageEnvelope serverEventEnvelope;
+
+  @Test
+  void broadCastMessage() {
+    final ServerResponse serverResponse = ServerResponse.broadcast(serverEventEnvelope);
+
+    final boolean result = serverResponse.isBroadcast();
+
+    assertThat(result, is(true));
+  }
+
+  @Test
+  void backToClientMessage() {
+    final ServerResponse serverResponse = ServerResponse.backToClient(serverEventEnvelope);
+
+    final boolean result = serverResponse.isBroadcast();
+
+    assertThat(result, is(false));
+  }
+}


### PR DESCRIPTION
Adds backend http-server components for chat. Note, the endpoint powering
this functionality will land in a future change, for now these are just
the implementation classes that will eventually be wired to the server.

Design notes:
- "chatters" is a main data structure to keep track of the current chat participants.
- "ChatSocketController" is a thin controller class that opens a websocket, listens
  for messages and connections. This class is not yet registered with the server
  configuration, and is not yet active. Websockets are registered via static class
  reference, injecting objects into it is difficult and is done by injecting such
  objects into the user session. Thus, this class tries to be thin, it provides
  the websocket endpoints, grabs a 'MessagingService' from user properties, then
  delegates all further actions to the 'MessagingService'
- "ChatEventProcessor" is an important command and control class to identify
  the message that has been received and initiate the appropriate processing.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 