### PR TITLE
Wire LobbyChatTransmitter to LobbyChatClient

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/LobbyChatTransmitter.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/LobbyChatTransmitter.java
@@ -1,0 +1,71 @@
+package games.strategy.engine.chat;
+
+import games.strategy.engine.lobby.client.LobbyClient;
+import java.util.Collection;
+import org.triplea.domain.data.PlayerName;
+import org.triplea.http.client.lobby.chat.ChatParticipant;
+import org.triplea.http.client.lobby.chat.LobbyChatClient;
+
+/**
+ * Chat transmitter designed to work with lobby, sends and receives messages over Websocket. This
+ * class provides a send API and does wiring to connect callbacks from a {@code LobbyChatClient} to
+ * a {@code ChatClient}.
+ */
+// TODO: Project#12 test-me
+public class LobbyChatTransmitter implements ChatTransmitter {
+  private final LobbyChatClient lobbyChatClient;
+  private final PlayerName localPlayerName;
+
+  public LobbyChatTransmitter(final LobbyClient lobbyClient) {
+    this.localPlayerName = lobbyClient.getPlayerName();
+    this.lobbyChatClient = lobbyClient.getHttpLobbyClient().getLobbyChatClient();
+  }
+
+  @Override
+  public void setChatClient(final ChatClient chatClient) {
+    lobbyChatClient.addPlayerStatusListener(chatClient::statusUpdated);
+    lobbyChatClient.addPlayerLeftListener(chatClient::participantRemoved);
+    lobbyChatClient.addPlayerJoinedListener(chatClient::participantAdded);
+    lobbyChatClient.addChatMessageListener(chatClient::messageReceived);
+    lobbyChatClient.addConnectedListener(chatClient::connected);
+
+    lobbyChatClient.addPlayerSlappedListener(
+        slapEvent -> {
+          if (slapEvent.getSlapped().equals(localPlayerName)) {
+            chatClient.slappedBy(slapEvent.getSlapper());
+          } else {
+            chatClient.playerSlapped(slapEvent.getSlapper() + " slapped " + slapEvent.getSlapped());
+          }
+        });
+  }
+
+  @Override
+  public Collection<ChatParticipant> connect() {
+    return lobbyChatClient.connect();
+  }
+
+  @Override
+  public void disconnect() {
+    lobbyChatClient.close();
+  }
+
+  @Override
+  public void sendMessage(final String message) {
+    lobbyChatClient.sendChatMessage(message);
+  }
+
+  @Override
+  public void slap(final PlayerName playerName) {
+    lobbyChatClient.slapPlayer(playerName);
+  }
+
+  @Override
+  public void updateStatus(final String status) {
+    lobbyChatClient.updateStatus(status);
+  }
+
+  @Override
+  public PlayerName getLocalPlayerName() {
+    return localPlayerName;
+  }
+}

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/HttpLobbyClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/HttpLobbyClient.java
@@ -1,10 +1,13 @@
 package org.triplea.http.client.lobby;
 
 import java.net.URI;
+import java.util.function.Consumer;
 import lombok.Getter;
 import org.triplea.domain.data.ApiKey;
+import org.triplea.http.client.lobby.chat.LobbyChatClient;
 import org.triplea.http.client.lobby.game.ConnectivityCheckClient;
 import org.triplea.http.client.lobby.game.listing.GameListingClient;
+import org.triplea.http.client.lobby.moderator.ModeratorLobbyClient;
 import org.triplea.http.client.lobby.moderator.toolbox.HttpModeratorToolboxClient;
 import org.triplea.http.client.lobby.user.account.UserAccountClient;
 
@@ -16,16 +19,24 @@ public class HttpLobbyClient {
   private final ConnectivityCheckClient connectivityCheckClient;
   private final GameListingClient gameListingClient;
   private final HttpModeratorToolboxClient httpModeratorToolboxClient;
+  private final LobbyChatClient lobbyChatClient;
+  private final ModeratorLobbyClient moderatorLobbyClient;
   private final UserAccountClient userAccountClient;
 
   private HttpLobbyClient(final URI lobbyUri, final ApiKey apiKey) {
     connectivityCheckClient = ConnectivityCheckClient.newClient(lobbyUri, apiKey);
     gameListingClient = GameListingClient.newClient(lobbyUri, apiKey);
     httpModeratorToolboxClient = HttpModeratorToolboxClient.newClient(lobbyUri, apiKey);
+    lobbyChatClient = LobbyChatClient.newClient(lobbyUri, apiKey);
+    moderatorLobbyClient = ModeratorLobbyClient.newClient(lobbyUri, apiKey);
     userAccountClient = UserAccountClient.newClient(lobbyUri, apiKey);
   }
 
   public static HttpLobbyClient newClient(final URI lobbyUri, final ApiKey apiKey) {
     return new HttpLobbyClient(lobbyUri, apiKey);
+  }
+
+  public void addConnectionLostListener(final Consumer<String> connectionClosedListener) {
+    lobbyChatClient.addConnectionLostListener(connectionClosedListener);
   }
 }

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/InboundChat.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/InboundChat.java
@@ -1,0 +1,66 @@
+package org.triplea.http.client.lobby.chat;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.function.Consumer;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.extern.java.Log;
+import org.triplea.domain.data.PlayerName;
+import org.triplea.http.client.lobby.chat.events.client.ClientMessageEnvelope;
+import org.triplea.http.client.lobby.chat.events.server.ChatMessage;
+import org.triplea.http.client.lobby.chat.events.server.PlayerSlapped;
+import org.triplea.http.client.lobby.chat.events.server.ServerMessageEnvelope;
+import org.triplea.http.client.lobby.chat.events.server.StatusUpdate;
+import org.triplea.http.client.web.socket.GenericWebSocketClient;
+
+/** Utility component for {@code LobbyChatClient} to wire inbound messages to callback logic. */
+@Log
+class InboundChat {
+
+  @Getter(AccessLevel.PACKAGE)
+  private final GenericWebSocketClient<ServerMessageEnvelope, ClientMessageEnvelope>
+      webSocketClient;
+
+  private final InboundEventHandler inboundEventHandler = new InboundEventHandler();
+
+  InboundChat(final URI chatWebsocketUri) {
+    webSocketClient =
+        new GenericWebSocketClient<>(
+            chatWebsocketUri,
+            ServerMessageEnvelope.class,
+            inboundEventHandler::handleServerMessage);
+  }
+
+  void addPlayerStatusListener(final Consumer<StatusUpdate> playerStatusListener) {
+    inboundEventHandler.addPlayerStatusListener(playerStatusListener);
+  }
+
+  void addPlayerLeftListener(final Consumer<PlayerName> playerLeftListener) {
+    inboundEventHandler.addPlayerLeftListener(playerLeftListener);
+  }
+
+  void addPlayerJoinedListener(final Consumer<ChatParticipant> playerJoinedListener) {
+    inboundEventHandler.addPlayerJoinedListener(playerJoinedListener);
+  }
+
+  void addPlayerSlappedListener(final Consumer<PlayerSlapped> playerSlappedListener) {
+    inboundEventHandler.addPlayerSlappedListener(playerSlappedListener);
+  }
+
+  void addMessageListener(final Consumer<ChatMessage> messageListener) {
+    inboundEventHandler.addMessageListener(messageListener);
+  }
+
+  void addConnectedListener(final Consumer<Collection<ChatParticipant>> connectedListener) {
+    inboundEventHandler.addConnectedListener(connectedListener);
+  }
+
+  void addChatEventListener(final Consumer<String> chatEventListener) {
+    inboundEventHandler.addChatEventListener(chatEventListener);
+  }
+
+  void addConnectionLostListener(final Consumer<String> connectionLostListener) {
+    webSocketClient.addConnectionClosedListener(connectionLostListener);
+  }
+}

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/InboundEventHandler.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/InboundEventHandler.java
@@ -1,0 +1,104 @@
+package org.triplea.http.client.lobby.chat;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.function.Consumer;
+import lombok.extern.java.Log;
+import org.triplea.domain.data.PlayerName;
+import org.triplea.http.client.lobby.chat.events.server.ChatMessage;
+import org.triplea.http.client.lobby.chat.events.server.PlayerSlapped;
+import org.triplea.http.client.lobby.chat.events.server.ServerMessageEnvelope;
+import org.triplea.http.client.lobby.chat.events.server.StatusUpdate;
+
+/** Interprets and handles routing of inbound messages to the appropriate callback listener. */
+@Log
+class InboundEventHandler {
+
+  private final Collection<Consumer<StatusUpdate>> playerStatusListeners = new ArrayList<>();
+  private final Collection<Consumer<PlayerName>> playerLeftListeners = new ArrayList<>();
+  private final Collection<Consumer<ChatParticipant>> playerJoinedListeners = new ArrayList<>();
+  private final Collection<Consumer<PlayerSlapped>> playerSlappedListeners = new ArrayList<>();
+  private final Collection<Consumer<ChatMessage>> messageListeners = new ArrayList<>();
+  private final Collection<Consumer<Collection<ChatParticipant>>> connectedListeners =
+      new ArrayList<>();
+  private final Collection<Consumer<String>> chatEventListeners = new ArrayList<>();
+
+  void addPlayerStatusListener(final Consumer<StatusUpdate> playerStatusListener) {
+    playerStatusListeners.add(playerStatusListener);
+  }
+
+  void addPlayerLeftListener(final Consumer<PlayerName> playerLeftListener) {
+    playerLeftListeners.add(playerLeftListener);
+  }
+
+  void addPlayerJoinedListener(final Consumer<ChatParticipant> playerJoinedListener) {
+    playerJoinedListeners.add(playerJoinedListener);
+  }
+
+  void addPlayerSlappedListener(final Consumer<PlayerSlapped> playerSlappedListener) {
+    playerSlappedListeners.add(playerSlappedListener);
+  }
+
+  void addMessageListener(final Consumer<ChatMessage> messageListener) {
+    messageListeners.add(messageListener);
+  }
+
+  void addConnectedListener(final Consumer<Collection<ChatParticipant>> connectedListener) {
+    connectedListeners.add(connectedListener);
+  }
+
+  void addChatEventListener(final Consumer<String> chatEventListener) {
+    chatEventListeners.add(chatEventListener);
+  }
+
+  void handleServerMessage(final ServerMessageEnvelope inboundMessage) {
+    // ensure we have all listeners fully wired
+    Preconditions.checkState(!playerStatusListeners.isEmpty());
+    Preconditions.checkState(!playerLeftListeners.isEmpty());
+    Preconditions.checkState(!playerJoinedListeners.isEmpty());
+    Preconditions.checkState(!playerSlappedListeners.isEmpty());
+    Preconditions.checkState(!messageListeners.isEmpty());
+    Preconditions.checkState(!connectedListeners.isEmpty());
+
+    switch (inboundMessage.getMessageType()) {
+      case PLAYER_LISTING:
+        connectedListeners.forEach(
+            connectedListener ->
+                connectedListener.accept(inboundMessage.toPlayerListing().getChatters()));
+        break;
+      case STATUS_CHANGED:
+        playerStatusListeners.forEach(
+            statusListener -> statusListener.accept(inboundMessage.toPlayerStatusChange()));
+        break;
+      case PLAYER_LEFT:
+        playerLeftListeners.forEach(
+            playerLeftListener ->
+                playerLeftListener.accept(inboundMessage.toPlayerLeft().getPlayerName()));
+        break;
+      case PLAYER_JOINED:
+        playerJoinedListeners.forEach(
+            playerJoinedListener ->
+                playerJoinedListener.accept(inboundMessage.toPlayerJoined().getChatParticipant()));
+        break;
+      case PLAYER_SLAPPED:
+        playerSlappedListeners.forEach(
+            playerSlappedListener ->
+                playerSlappedListener.accept(inboundMessage.toPlayerSlapped()));
+        break;
+      case CHAT_MESSAGE:
+        messageListeners.forEach(
+            chatMessageListener -> chatMessageListener.accept(inboundMessage.toChatMessage()));
+        break;
+      case CHAT_EVENT:
+        chatEventListeners.forEach(
+            chatEventListener -> chatEventListener.accept(inboundMessage.toChatEvent()));
+        break;
+      case SERVER_ERROR:
+        log.severe(inboundMessage.toErrorMessage());
+        break;
+      default:
+        log.info("Unrecognized server message type: " + inboundMessage.getMessageType());
+    }
+  }
+}

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/LobbyChatClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/LobbyChatClient.java
@@ -1,10 +1,98 @@
 package org.triplea.http.client.lobby.chat;
 
-import lombok.experimental.UtilityClass;
+import com.google.common.annotations.VisibleForTesting;
+import java.net.URI;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.function.Consumer;
+import lombok.extern.java.Log;
+import org.triplea.domain.data.ApiKey;
+import org.triplea.domain.data.PlayerName;
+import org.triplea.http.client.lobby.chat.events.client.ClientMessageEnvelope;
+import org.triplea.http.client.lobby.chat.events.client.ClientMessageFactory;
+import org.triplea.http.client.lobby.chat.events.server.ChatMessage;
+import org.triplea.http.client.lobby.chat.events.server.PlayerSlapped;
+import org.triplea.http.client.lobby.chat.events.server.ServerMessageEnvelope;
+import org.triplea.http.client.lobby.chat.events.server.StatusUpdate;
+import org.triplea.http.client.web.socket.GenericWebSocketClient;
 
 /** Core websocket client to communicate with lobby chat API. */
-@UtilityClass // TODO: Project#12 remove utility class annotation
+@Log
 public class LobbyChatClient {
   public static final String WEBSOCKET_PATH = "/lobby/chat/websocket";
-  // TODO: Project#12 add implementation
+
+  private final GenericWebSocketClient<ServerMessageEnvelope, ClientMessageEnvelope>
+      webSocketClient;
+  private final ClientMessageFactory outboundMessageFactory;
+  private final InboundChat inboundChat;
+
+  public LobbyChatClient(final URI lobbyUri, final ApiKey apiKey) {
+    this(new InboundChat(URI.create(lobbyUri + WEBSOCKET_PATH)), new ClientMessageFactory(apiKey));
+  }
+
+  @VisibleForTesting
+  LobbyChatClient(final InboundChat inboundChat, final ClientMessageFactory clientEventFactory) {
+    this.inboundChat = inboundChat;
+    webSocketClient = inboundChat.getWebSocketClient();
+    outboundMessageFactory = clientEventFactory;
+  }
+
+  public static LobbyChatClient newClient(final URI lobbyUri, final ApiKey apiKey) {
+    return new LobbyChatClient(lobbyUri, apiKey);
+  }
+
+  public void slapPlayer(final PlayerName playerName) {
+    webSocketClient.send(outboundMessageFactory.slapMessage(playerName));
+  }
+
+  public void sendChatMessage(final String message) {
+    webSocketClient.send(outboundMessageFactory.sendMessage(message));
+  }
+
+  public void close() {
+    webSocketClient.close();
+  }
+
+  public Collection<ChatParticipant> connect() {
+    webSocketClient.send(outboundMessageFactory.connectToChat());
+    return new HashSet<>();
+  }
+
+  public void updateStatus(final String status) {
+    webSocketClient.send(outboundMessageFactory.updateMyPlayerStatus(status));
+  }
+
+  public void addPlayerStatusListener(final Consumer<StatusUpdate> playerStatusListener) {
+    inboundChat.addPlayerStatusListener(playerStatusListener);
+  }
+
+  public void addPlayerLeftListener(final Consumer<PlayerName> playerLeftListener) {
+    inboundChat.addPlayerLeftListener(playerLeftListener);
+  }
+
+  public void addPlayerJoinedListener(final Consumer<ChatParticipant> playerJoinedListener) {
+    inboundChat.addPlayerJoinedListener(playerJoinedListener);
+  }
+
+  public void addChatMessageListener(final Consumer<ChatMessage> messageListener) {
+    inboundChat.addMessageListener(messageListener);
+  }
+
+  public void addConnectedListener(final Consumer<Collection<ChatParticipant>> connectedListener) {
+    inboundChat.addConnectedListener(connectedListener);
+  }
+
+  public void addPlayerSlappedListener(final Consumer<PlayerSlapped> playerSlappedListener) {
+    inboundChat.addPlayerSlappedListener(playerSlappedListener);
+  }
+
+  // TODO: Project#12 test-me
+  public void addChatEventListener(final Consumer<String> chatEventListener) {
+    inboundChat.addChatEventListener(chatEventListener);
+  }
+
+  // TODO: Project#12 test-me
+  public void addConnectionLostListener(final Consumer<String> connectionClosedListener) {
+    inboundChat.addConnectionLostListener(connectionClosedListener);
+  }
 }

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/chat/InboundEventHandlerTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/chat/InboundEventHandlerTest.java
@@ -1,0 +1,116 @@
+package org.triplea.http.client.lobby.chat;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.domain.data.PlayerName;
+import org.triplea.http.client.lobby.chat.events.server.ChatMessage;
+import org.triplea.http.client.lobby.chat.events.server.PlayerLeft;
+import org.triplea.http.client.lobby.chat.events.server.PlayerListing;
+import org.triplea.http.client.lobby.chat.events.server.PlayerSlapped;
+import org.triplea.http.client.lobby.chat.events.server.ServerMessageEnvelope;
+import org.triplea.http.client.lobby.chat.events.server.ServerMessageEnvelope.ServerMessageType;
+import org.triplea.http.client.lobby.chat.events.server.StatusUpdate;
+
+@ExtendWith(MockitoExtension.class)
+class InboundEventHandlerTest {
+  private static final List<ChatParticipant> chatters = new ArrayList<>();
+  private static final PlayerListing PLAYER_LISTING = new PlayerListing(chatters);
+  private static final PlayerName PLAYER_NAME = PlayerName.of("player");
+  private static final StatusUpdate STATUS_UPDATE = new StatusUpdate(PLAYER_NAME, "");
+  private static final PlayerLeft PLAYER_LEFT = new PlayerLeft(PLAYER_NAME);
+  private static final PlayerSlapped PLAYER_SLAPPED =
+      PlayerSlapped.builder().slapper(PLAYER_NAME).slapped(PlayerName.of("slapped")).build();
+  private static final ChatMessage CHAT_MESSAGE = new ChatMessage(PLAYER_NAME, "message");
+
+  @Mock private Consumer<StatusUpdate> playerStatusListener;
+  @Mock private Consumer<PlayerName> playerLeftListener;
+  @Mock private Consumer<ChatParticipant> playerJoinedListener;
+  @Mock private Consumer<PlayerSlapped> playerSlappedListener;
+  @Mock private Consumer<ChatMessage> messageListener;
+  @Mock private Consumer<Collection<ChatParticipant>> connectedListener;
+
+  private InboundEventHandler inboundEventHandler;
+
+  @Mock private ServerMessageEnvelope serverEventEnvelope;
+
+  @BeforeEach
+  void setup() {
+    inboundEventHandler = new InboundEventHandler();
+    inboundEventHandler.addPlayerStatusListener(playerStatusListener);
+    inboundEventHandler.addPlayerLeftListener(playerLeftListener);
+    inboundEventHandler.addPlayerJoinedListener(playerJoinedListener);
+    inboundEventHandler.addPlayerSlappedListener(playerSlappedListener);
+    inboundEventHandler.addMessageListener(messageListener);
+    inboundEventHandler.addConnectedListener(connectedListener);
+  }
+
+  @Test
+  void playerListing() {
+    when(serverEventEnvelope.getMessageType()).thenReturn(ServerMessageType.PLAYER_LISTING);
+    when(serverEventEnvelope.toPlayerListing()).thenReturn(PLAYER_LISTING);
+
+    inboundEventHandler.handleServerMessage(serverEventEnvelope);
+
+    verify(connectedListener).accept(chatters);
+  }
+
+  @Test
+  void statusChanged() {
+    when(serverEventEnvelope.getMessageType()).thenReturn(ServerMessageType.STATUS_CHANGED);
+    when(serverEventEnvelope.toPlayerStatusChange()).thenReturn(STATUS_UPDATE);
+
+    inboundEventHandler.handleServerMessage(serverEventEnvelope);
+
+    verify(playerStatusListener).accept(STATUS_UPDATE);
+  }
+
+  @Test
+  void playerLeft() {
+    when(serverEventEnvelope.getMessageType()).thenReturn(ServerMessageType.PLAYER_LEFT);
+    when(serverEventEnvelope.toPlayerLeft()).thenReturn(PLAYER_LEFT);
+
+    inboundEventHandler.handleServerMessage(serverEventEnvelope);
+
+    verify(playerLeftListener).accept(PLAYER_LEFT.getPlayerName());
+  }
+
+  @Test
+  void playerSlapped() {
+    when(serverEventEnvelope.getMessageType()).thenReturn(ServerMessageType.PLAYER_SLAPPED);
+    when(serverEventEnvelope.toPlayerSlapped()).thenReturn(PLAYER_SLAPPED);
+
+    inboundEventHandler.handleServerMessage(serverEventEnvelope);
+
+    verify(playerSlappedListener).accept(PLAYER_SLAPPED);
+  }
+
+  @Test
+  void chatMessage() {
+    when(serverEventEnvelope.getMessageType()).thenReturn(ServerMessageType.CHAT_MESSAGE);
+    when(serverEventEnvelope.toChatMessage()).thenReturn(CHAT_MESSAGE);
+
+    inboundEventHandler.handleServerMessage(serverEventEnvelope);
+
+    verify(messageListener).accept(CHAT_MESSAGE);
+  }
+
+  @Test
+  void serverError() {
+    when(serverEventEnvelope.getMessageType()).thenReturn(ServerMessageType.SERVER_ERROR);
+    when(serverEventEnvelope.toErrorMessage()).thenReturn("error-message");
+
+    inboundEventHandler.handleServerMessage(serverEventEnvelope);
+
+    verify(serverEventEnvelope).toErrorMessage();
+  }
+}

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/chat/LobbyChatClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/chat/LobbyChatClientTest.java
@@ -1,0 +1,92 @@
+package org.triplea.http.client.lobby.chat;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Collection;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.domain.data.PlayerName;
+import org.triplea.http.client.lobby.chat.events.client.ClientMessageEnvelope;
+import org.triplea.http.client.lobby.chat.events.client.ClientMessageFactory;
+import org.triplea.http.client.lobby.chat.events.server.ServerMessageEnvelope;
+import org.triplea.http.client.web.socket.GenericWebSocketClient;
+
+@ExtendWith(MockitoExtension.class)
+class LobbyChatClientTest {
+
+  private static final PlayerName PLAYER_NAME = PlayerName.of("player_name");
+  private static final String MESSAGE = "message";
+  private static final String STATUS = "status";
+
+  @Mock private InboundChat inboundChat;
+
+  @Mock
+  private GenericWebSocketClient<ServerMessageEnvelope, ClientMessageEnvelope> webSocketClient;
+
+  @Mock private ClientMessageFactory clientEventFactory;
+  @Mock private ClientMessageEnvelope clientEnvelope;
+
+  private LobbyChatClient lobbyChatClient;
+
+  @BeforeEach
+  void setup() {
+    when(inboundChat.getWebSocketClient()).thenReturn(webSocketClient);
+
+    lobbyChatClient = new LobbyChatClient(inboundChat, clientEventFactory);
+  }
+
+  @Test
+  void slapPlayer() {
+    when(clientEventFactory.slapMessage(PLAYER_NAME)).thenReturn(clientEnvelope);
+
+    lobbyChatClient.slapPlayer(PLAYER_NAME);
+
+    verify(webSocketClient).send(clientEnvelope);
+  }
+
+  @Test
+  void sendChatMessage() {
+    when(clientEventFactory.sendMessage(MESSAGE)).thenReturn(clientEnvelope);
+
+    lobbyChatClient.sendChatMessage(MESSAGE);
+
+    verify(webSocketClient).send(clientEnvelope);
+  }
+
+  @Test
+  void close() {
+    lobbyChatClient.close();
+
+    verify(webSocketClient).close();
+  }
+
+  @Test
+  void connect() {
+    when(clientEventFactory.connectToChat()).thenReturn(clientEnvelope);
+
+    final Collection<ChatParticipant> result = lobbyChatClient.connect();
+
+    assertThat(
+        "Async connections should return empty results. The 'connect' listener will"
+            + "be called when a connection is established instead.",
+        result,
+        empty());
+
+    verify(webSocketClient).send(clientEnvelope);
+  }
+
+  @Test
+  void updateStatus() {
+    when(clientEventFactory.updateMyPlayerStatus(STATUS)).thenReturn(clientEnvelope);
+
+    lobbyChatClient.updateStatus(STATUS);
+
+    verify(webSocketClient).send(clientEnvelope);
+  }
+}


### PR DESCRIPTION
Adds client side infrastructure for lobby websocket chat.
LobbyChatTransmitter is a new class that can be swapped out for a
'MessengersChatTransmitters' as they both implement the same chat API.

The ChatTransmitter is wired to a set of listener APIs and send
APIs that are backed by an http component that eventually sends
and receives requests from the GenericWebsocket connection.

As part of this wiring is an event handler that handles server
messages and routes them back to the appropriate listener.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[x] No manual testing done
[] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

