### PR TITLE
Use toJson test util from WireMockTest

### DIFF
--- a/http-clients/src/test/java/org/triplea/http/client/HttpClientTesting.java
+++ b/http-clients/src/test/java/org/triplea/http/client/HttpClientTesting.java
@@ -13,7 +13,6 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlMatching;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.github.tomakehurst.wiremock.WireMockServer;
@@ -73,22 +72,8 @@ public final class HttpClientTesting {
     server.stubFor(
         WireMock.post(path)
             .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
-            .withRequestBody(equalToJson(toJson(jsonObject)))
+            .withRequestBody(equalToJson(WireMockTest.toJson(jsonObject)))
             .willReturn(WireMock.aResponse().withStatus(200)));
-  }
-
-  /**
-   * Utility method to convert objects to JSON. Serialization of Instant classes is customized so
-   * that instant is serialized as "epoch_second.nanos". Without this default Instants are
-   * serialized to be JSON objects (example of what we do not want: Instant: {"second":value,
-   * "nano":value"})
-   */
-  public static <T> String toJson(final T object) {
-    try {
-      return objectMapper.writeValueAsString(object);
-    } catch (final JsonProcessingException e) {
-      throw new RuntimeException("Failed to convert to JSON string: " + object, e);
-    }
   }
 
   /**

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/game/hosting/GameHostingClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/game/hosting/GameHostingClientTest.java
@@ -7,7 +7,6 @@ import static org.hamcrest.core.Is.is;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import org.junit.jupiter.api.Test;
-import org.triplea.http.client.HttpClientTesting;
 import org.triplea.http.client.WireMockTest;
 import ru.lanwen.wiremock.ext.WiremockResolver;
 
@@ -24,9 +23,7 @@ class GameHostingClientTest extends WireMockTest {
     wireMockServer.stubFor(
         post(GameHostingClient.GAME_HOSTING_REQUEST_PATH)
             .willReturn(
-                WireMock.aResponse()
-                    .withStatus(200)
-                    .withBody(HttpClientTesting.toJson(GAME_HOSTING_RESPONSE))));
+                WireMock.aResponse().withStatus(200).withBody(toJson(GAME_HOSTING_RESPONSE))));
 
     final GameHostingResponse result = newClient(wireMockServer).sendGameHostingRequest();
 

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/game/listing/GameListingClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/game/listing/GameListingClientTest.java
@@ -15,7 +15,6 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.triplea.http.client.AuthenticationHeaders;
-import org.triplea.http.client.HttpClientTesting;
 import org.triplea.http.client.TestData;
 import org.triplea.http.client.WireMockTest;
 import ru.lanwen.wiremock.ext.WiremockResolver;
@@ -40,8 +39,7 @@ class GameListingClientTest extends WireMockTest {
             .willReturn(
                 WireMock.aResponse()
                     .withStatus(200)
-                    .withBody(
-                        HttpClientTesting.toJson(Collections.singletonList(LOBBY_GAME_LISTING)))));
+                    .withBody(toJson(Collections.singletonList(LOBBY_GAME_LISTING)))));
 
     final List<LobbyGameListing> results = newClient(server).fetchGameListing();
 
@@ -54,7 +52,7 @@ class GameListingClientTest extends WireMockTest {
     server.stubFor(
         post(GameListingClient.POST_GAME_PATH)
             .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
-            .withRequestBody(equalToJson(HttpClientTesting.toJson(LOBBY_GAME)))
+            .withRequestBody(equalToJson(toJson(LOBBY_GAME)))
             .willReturn(WireMock.aResponse().withStatus(200).withBody(GAME_ID)));
 
     final String gameId = newClient(server).postGame(LOBBY_GAME);
@@ -69,7 +67,7 @@ class GameListingClientTest extends WireMockTest {
             .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
             .withRequestBody(
                 equalToJson(
-                    HttpClientTesting.toJson(
+                    toJson(
                         UpdateGameRequest.builder().gameId(GAME_ID).gameData(LOBBY_GAME).build())))
             .willReturn(WireMock.aResponse().withStatus(200)));
 

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/banned/name/ToolboxUsernameBanClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/banned/name/ToolboxUsernameBanClientTest.java
@@ -14,7 +14,6 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.triplea.http.client.AuthenticationHeaders;
-import org.triplea.http.client.HttpClientTesting;
 import org.triplea.http.client.WireMockTest;
 import ru.lanwen.wiremock.ext.WiremockResolver;
 
@@ -55,9 +54,7 @@ class ToolboxUsernameBanClientTest extends WireMockTest {
             .willReturn(
                 WireMock.aResponse()
                     .withStatus(200)
-                    .withBody(
-                        HttpClientTesting.toJson(
-                            Collections.singletonList(BANNED_USERNAME_DATA)))));
+                    .withBody(toJson(Collections.singletonList(BANNED_USERNAME_DATA)))));
 
     final List<UsernameBanData> results = newClient(server).getUsernameBans();
 

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/banned/user/ToolboxUserBanClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/banned/user/ToolboxUserBanClientTest.java
@@ -15,7 +15,6 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.triplea.http.client.AuthenticationHeaders;
-import org.triplea.http.client.HttpClientTesting;
 import org.triplea.http.client.WireMockTest;
 import ru.lanwen.wiremock.ext.WiremockResolver;
 
@@ -53,8 +52,7 @@ class ToolboxUserBanClientTest extends WireMockTest {
             .willReturn(
                 WireMock.aResponse()
                     .withStatus(200)
-                    .withBody(
-                        HttpClientTesting.toJson(Collections.singletonList(BANNED_USER_DATA)))));
+                    .withBody(toJson(Collections.singletonList(BANNED_USER_DATA)))));
 
     final List<UserBanData> result = newClient(server).getUserBans();
 

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/log/ToolboxAccessLogClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/log/ToolboxAccessLogClientTest.java
@@ -37,12 +37,11 @@ class ToolboxAccessLogClientTest extends WireMockTest {
     server.stubFor(
         WireMock.post(ToolboxAccessLogClient.FETCH_ACCESS_LOG_PATH)
             .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
-            .withRequestBody(equalToJson(HttpClientTesting.toJson(HttpClientTesting.PAGING_PARAMS)))
+            .withRequestBody(equalToJson(toJson(HttpClientTesting.PAGING_PARAMS)))
             .willReturn(
                 WireMock.aResponse()
                     .withStatus(200)
-                    .withBody(
-                        HttpClientTesting.toJson(Collections.singletonList(ACCESS_LOG_DATA)))));
+                    .withBody(toJson(Collections.singletonList(ACCESS_LOG_DATA)))));
 
     final List<AccessLogData> results =
         newClient(server).getAccessLog(HttpClientTesting.PAGING_PARAMS);

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/log/ToolboxEventLogClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/log/ToolboxEventLogClientTest.java
@@ -7,7 +7,6 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.triplea.http.client.HttpClientTesting.EXPECTED_API_KEY;
 import static org.triplea.http.client.HttpClientTesting.PAGING_PARAMS;
-import static org.triplea.http.client.HttpClientTesting.toJson;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -16,7 +15,6 @@ import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.triplea.http.client.AuthenticationHeaders;
-import org.triplea.http.client.HttpClientTesting;
 import org.triplea.http.client.WireMockTest;
 import ru.lanwen.wiremock.ext.WiremockResolver;
 
@@ -43,8 +41,7 @@ class ToolboxEventLogClientTest extends WireMockTest {
             .willReturn(
                 WireMock.aResponse()
                     .withStatus(200)
-                    .withBody(
-                        HttpClientTesting.toJson(Collections.singletonList(MODERATOR_EVENT)))));
+                    .withBody(toJson(Collections.singletonList(MODERATOR_EVENT)))));
 
     final List<ModeratorEvent> results = newClient(server).lookupModeratorEvents(PAGING_PARAMS);
 

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/management/ToolboxModeratorManagementClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/management/ToolboxModeratorManagementClientTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.triplea.http.client.HttpClientTesting.EXPECTED_API_KEY;
 import static org.triplea.http.client.HttpClientTesting.serve200ForToolboxPostWithBody;
-import static org.triplea.http.client.HttpClientTesting.toJson;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -19,6 +18,7 @@ import org.triplea.http.client.AuthenticationHeaders;
 import org.triplea.http.client.WireMockTest;
 import ru.lanwen.wiremock.ext.WiremockResolver;
 
+@SuppressWarnings("InnerClassMayBeStatic")
 class ToolboxModeratorManagementClientTest extends WireMockTest {
 
   private static final String MODERATOR_NAME = "Ooh! Pieces o' urchin are forever coal-black.";

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/words/ToolboxBadWordsClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/words/ToolboxBadWordsClientTest.java
@@ -12,7 +12,6 @@ import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.triplea.http.client.AuthenticationHeaders;
-import org.triplea.http.client.HttpClientTesting;
 import org.triplea.http.client.WireMockTest;
 import ru.lanwen.wiremock.ext.WiremockResolver;
 
@@ -43,8 +42,7 @@ class ToolboxBadWordsClientTest extends WireMockTest {
     server.stubFor(
         WireMock.get(ToolboxBadWordsClient.BAD_WORD_GET_PATH)
             .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
-            .willReturn(
-                WireMock.aResponse().withStatus(200).withBody(HttpClientTesting.toJson(badWords))));
+            .willReturn(WireMock.aResponse().withStatus(200).withBody(toJson(badWords))));
 
     final List<String> result = newClient(server).getBadWords();
 

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/user/account/UserAccountClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/user/account/UserAccountClientTest.java
@@ -9,7 +9,6 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import org.junit.jupiter.api.Test;
 import org.triplea.http.client.AuthenticationHeaders;
-import org.triplea.http.client.HttpClientTesting;
 import org.triplea.http.client.WireMockTest;
 import ru.lanwen.wiremock.ext.WiremockResolver;
 
@@ -40,7 +39,7 @@ class UserAccountClientTest extends WireMockTest {
             .willReturn(
                 WireMock.aResponse()
                     .withStatus(200)
-                    .withBody(HttpClientTesting.toJson(new FetchEmailResponse(EMAIL)))));
+                    .withBody(toJson(new FetchEmailResponse(EMAIL)))));
 
     final String result = newClient(server).fetchEmail();
 


### PR DESCRIPTION
Removes (legacy) toJson on HttpClientTesting.java and switches
to using the same method on WireMockTest.java


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[x] No manual testing done
[] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

