### PR TITLE
Move AccessLogDao to package 'dao.access.log'

### DIFF
--- a/http-server/src/main/java/org/triplea/server/moderator/toolbox/access/log/AccessLogControllerFactory.java
+++ b/http-server/src/main/java/org/triplea/server/moderator/toolbox/access/log/AccessLogControllerFactory.java
@@ -3,7 +3,7 @@ package org.triplea.server.moderator.toolbox.access.log;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 import org.jdbi.v3.core.Jdbi;
-import org.triplea.lobby.server.db.dao.AccessLogDao;
+import org.triplea.lobby.server.db.dao.access.log.AccessLogDao;
 import org.triplea.server.http.AppConfig;
 
 /** Factory class, instantiates {@code AccessLogControllerFactory}. */

--- a/http-server/src/main/java/org/triplea/server/moderator/toolbox/access/log/AccessLogService.java
+++ b/http-server/src/main/java/org/triplea/server/moderator/toolbox/access/log/AccessLogService.java
@@ -6,7 +6,7 @@ import javax.annotation.Nonnull;
 import lombok.Builder;
 import org.triplea.http.client.lobby.moderator.toolbox.PagingParams;
 import org.triplea.http.client.lobby.moderator.toolbox.log.AccessLogData;
-import org.triplea.lobby.server.db.dao.AccessLogDao;
+import org.triplea.lobby.server.db.dao.access.log.AccessLogDao;
 
 @Builder
 class AccessLogService {

--- a/http-server/src/test/java/org/triplea/server/moderator/toolbox/access/log/AccessLogServiceTest.java
+++ b/http-server/src/test/java/org/triplea/server/moderator/toolbox/access/log/AccessLogServiceTest.java
@@ -15,8 +15,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.http.client.lobby.moderator.toolbox.PagingParams;
 import org.triplea.http.client.lobby.moderator.toolbox.log.AccessLogData;
-import org.triplea.lobby.server.db.dao.AccessLogDao;
-import org.triplea.lobby.server.db.data.AccessLogRecord;
+import org.triplea.lobby.server.db.dao.access.log.AccessLogDao;
+import org.triplea.lobby.server.db.dao.access.log.AccessLogRecord;
 
 @ExtendWith(MockitoExtension.class)
 class AccessLogServiceTest {

--- a/integration-testing/src/test/java/org/triplea/lobby/server/db/dao/access/log/AccessLogDaoTest.java
+++ b/integration-testing/src/test/java/org/triplea/lobby/server/db/dao/access/log/AccessLogDaoTest.java
@@ -1,4 +1,4 @@
-package org.triplea.lobby.server.db.dao;
+package org.triplea.lobby.server.db.dao.access.log;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
@@ -9,7 +9,7 @@ import java.time.Instant;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.Test;
-import org.triplea.lobby.server.db.data.AccessLogRecord;
+import org.triplea.lobby.server.db.dao.DaoTest;
 
 class AccessLogDaoTest extends DaoTest {
   private final AccessLogDao accessLogDao = DaoTest.newDao(AccessLogDao.class);

--- a/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/JdbiDatabase.java
+++ b/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/JdbiDatabase.java
@@ -9,7 +9,7 @@ import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.statement.SqlLogger;
 import org.jdbi.v3.core.statement.StatementContext;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
-import org.triplea.lobby.server.db.data.AccessLogRecord;
+import org.triplea.lobby.server.db.dao.access.log.AccessLogRecord;
 import org.triplea.lobby.server.db.data.ApiKeyUserData;
 import org.triplea.lobby.server.db.data.ModeratorAuditHistoryDaoData;
 import org.triplea.lobby.server.db.data.ModeratorUserDaoData;

--- a/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/dao/access/log/AccessLogDao.java
+++ b/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/dao/access/log/AccessLogDao.java
@@ -1,15 +1,14 @@
-package org.triplea.lobby.server.db.dao;
+package org.triplea.lobby.server.db.dao.access.log;
 
-import static org.triplea.lobby.server.db.data.AccessLogRecord.ACCESS_TIME_COLUMN;
-import static org.triplea.lobby.server.db.data.AccessLogRecord.IP_COLUMN;
-import static org.triplea.lobby.server.db.data.AccessLogRecord.REGISTERED_COLUMN;
-import static org.triplea.lobby.server.db.data.AccessLogRecord.SYSTEM_ID_COLUMN;
-import static org.triplea.lobby.server.db.data.AccessLogRecord.USERNAME_COLUMN;
+import static org.triplea.lobby.server.db.dao.access.log.AccessLogRecord.ACCESS_TIME_COLUMN;
+import static org.triplea.lobby.server.db.dao.access.log.AccessLogRecord.IP_COLUMN;
+import static org.triplea.lobby.server.db.dao.access.log.AccessLogRecord.REGISTERED_COLUMN;
+import static org.triplea.lobby.server.db.dao.access.log.AccessLogRecord.SYSTEM_ID_COLUMN;
+import static org.triplea.lobby.server.db.dao.access.log.AccessLogRecord.USERNAME_COLUMN;
 
 import java.util.List;
 import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.statement.SqlQuery;
-import org.triplea.lobby.server.db.data.AccessLogRecord;
 
 /**
  * Provides access to the access log table. This is a table that records user data as they enter the

--- a/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/dao/access/log/AccessLogRecord.java
+++ b/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/dao/access/log/AccessLogRecord.java
@@ -1,4 +1,4 @@
-package org.triplea.lobby.server.db.data;
+package org.triplea.lobby.server.db.dao.access.log;
 
 import java.time.Instant;
 import lombok.AllArgsConstructor;

--- a/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/access/log/AccessLogRecordTest.java
+++ b/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/access/log/AccessLogRecordTest.java
@@ -1,4 +1,4 @@
-package org.triplea.lobby.server.db.data;
+package org.triplea.lobby.server.db.dao.access.log;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;


### PR DESCRIPTION
This move allows the DAO class and related query mapping object
to be colated in the same package, improves cohesion.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[x] No manual testing done
[] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

