### PR TITLE
Batch AI amphibious moves.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -346,7 +346,7 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer {
         moveDel.move(
             moveDescription.getUnits(),
             moveDescription.getRoute(),
-            moveDescription.getTransportsThatCanBeLoaded(),
+            moveDescription.getUnitsToTransports(),
             moveDescription.getDependentUnits());
     if (error != null) {
       ui.notifyError(error);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -168,7 +168,7 @@ public class ProCombatMoveAi {
 
     moveUnits.clear();
     moveRoutes.clear();
-    final List<Collection<Unit>> transportsToLoad = new ArrayList<>();
+    final var transportsToLoad = new ArrayList<Map<Unit, Unit>>();
     ProMoveUtils.calculateAmphibRoutes(
         player, moveUnits, moveRoutes, transportsToLoad, attackMap, true);
     ProMoveUtils.doMove(moveUnits, moveRoutes, transportsToLoad, moveDel);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -218,7 +218,7 @@ class ProNonCombatMoveAi {
     // Calculate amphib move routes and perform moves
     moveUnits.clear();
     moveRoutes.clear();
-    final List<Collection<Unit>> transportsToLoad = new ArrayList<>();
+    final var transportsToLoad = new ArrayList<Map<Unit, Unit>>();
     ProMoveUtils.calculateAmphibRoutes(
         player, moveUnits, moveRoutes, transportsToLoad, moveMap, false);
     ProMoveUtils.doMove(moveUnits, moveRoutes, transportsToLoad, moveDel);
@@ -2527,14 +2527,7 @@ class ProNonCombatMoveAi {
                       player);
           final MoveValidationResult mvr =
               MoveValidator.validateMove(
-                  Collections.singletonList(u),
-                  r,
-                  player,
-                  new ArrayList<>(),
-                  new HashMap<>(),
-                  true,
-                  null,
-                  data);
+                  Collections.singletonList(u), r, player, Map.of(), Map.of(), true, null, data);
           if (!mvr.isMoveValid()) {
             continue;
           }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/MoveBatcher.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/MoveBatcher.java
@@ -1,0 +1,157 @@
+package games.strategy.triplea.ai.pro.util;
+
+import games.strategy.engine.data.Route;
+import games.strategy.engine.data.Unit;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+
+/**
+ * MoveBatcher implements an algorithm that batches AI moves together, reducing the number of
+ * distinct moves the AI does (and thus the visual delay) by combining moves together.
+ */
+public class MoveBatcher {
+  private static class Move {
+    private final ArrayList<Unit> units;
+    private final Route route;
+    private final HashSet<Unit> transportsToLoad;
+
+    Move(final ArrayList<Unit> units, final Route route, final HashSet<Unit> transportsToLoad) {
+      this.units = units;
+      this.route = route;
+      this.transportsToLoad = transportsToLoad;
+    }
+
+    Move(final ArrayList<Unit> units, final Route route) {
+      this(units, route, null);
+    }
+
+    Move(final Unit unit, final Route route, final Unit transportToLoad) {
+      this(mutableSingletonList(unit), route, new HashSet<Unit>(List.of(transportToLoad)));
+    }
+
+    private static ArrayList<Unit> mutableSingletonList(final Unit unit) {
+      return new ArrayList<>(Collections.singletonList(unit));
+    }
+
+    boolean isTransportLoad() {
+      return this.transportsToLoad != null;
+    }
+
+    boolean canMergeWith(final Move other) {
+      return other.isTransportLoad() == isTransportLoad() && route.equals(other.route);
+    }
+
+    boolean mergeWith(final Move other) {
+      if (canMergeWith(other)) {
+        // Merge units and transports.
+        units.addAll(other.units);
+        if (isTransportLoad()) {
+          transportsToLoad.addAll(other.transportsToLoad);
+        }
+        return true;
+      }
+      return false;
+    }
+
+    void addTo(
+        final List<Collection<Unit>> moveUnits,
+        final List<Route> moveRoutes,
+        final List<Collection<Unit>> transportsToLoad) {
+      moveUnits.add(units);
+      moveRoutes.add(route);
+      transportsToLoad.add(this.transportsToLoad);
+    }
+  }
+
+  private final ArrayList<ArrayList<Move>> moveSequences = new ArrayList<ArrayList<Move>>();
+
+  /**
+   * Starts a new sequence. This must be called before calling any add*() methods. A sequence
+   * indicates a logical dependency relationship between the moves in that sequence.
+   */
+  public void newSequence() {
+    moveSequences.add(new ArrayList<Move>());
+  }
+
+  /**
+   * Adds a transport load move. Ownership of the params is transferred to this object.
+   *
+   * @param unit The unit to move.
+   * @param route The route to move on.
+   * @param transport The transport to load.
+   */
+  public void addTransportLoad(final Unit unit, final Route route, final Unit transport) {
+    addMove(new Move(unit, route, transport));
+  }
+
+  /**
+   * Adds a move for the specified units. Ownership of the params is transferred to this object.
+   *
+   * @param units The units to move. Note that type is ArrayList explicitly to prevent an
+   *     unmodifiable List.of() being passed.
+   * @param route The route to move on.
+   */
+  public void addMove(final ArrayList<Unit> units, final Route route) {
+    addMove(new Move(units, route));
+  }
+
+  private void addMove(final Move newMove) {
+    final ArrayList<Move> sequence = moveSequences.get(moveSequences.size() - 1);
+    if (!sequence.isEmpty() && sequence.get(sequence.size() - 1).mergeWith(newMove)) {
+      return;
+    }
+    sequence.add(newMove);
+  }
+
+  /**
+   * Emits the accumulated moves to the passed output params.
+   *
+   * @param moveUnits The units to move.
+   * @param moveRoutes The routes to move along
+   * @param transportsToLoad The transports to be loaded.
+   */
+  public void batchAndEmit(
+      final List<Collection<Unit>> moveUnits,
+      final List<Route> moveRoutes,
+      final List<Collection<Unit>> transportsToLoad) {
+    int i = 0;
+    for (final var sequence : moveSequences) {
+      if (!sequence.isEmpty()) {
+        mergeSequences(sequence, moveSequences.subList(i + 1, moveSequences.size()));
+        for (final Move move : sequence) {
+          move.addTo(moveUnits, moveRoutes, transportsToLoad);
+        }
+      }
+      i++;
+    }
+  }
+
+  /**
+   * Attempts to merge a sequence of moves with other sequences. Any sequence merged into this
+   * sequence will have its moves cleared.
+   *
+   * @param sequence The sequence to merge other sequences into.
+   * @param sequences The sequences to try to merge into the sequence.
+   */
+  private static void mergeSequences(
+      final ArrayList<Move> sequence, final List<ArrayList<Move>> sequences) {
+    for (final var otherSequence : sequences) {
+      boolean merge = (otherSequence.size() == sequence.size());
+      for (int j = 0; merge && j < sequence.size(); j++) {
+        merge = sequence.get(j).canMergeWith(otherSequence.get(j));
+      }
+      if (!merge) {
+        continue;
+      }
+      for (int j = 0; j < sequence.size(); j++) {
+        if (!sequence.get(j).mergeWith(otherSequence.get(j))) {
+          throw new RuntimeException("Unexpected");
+        }
+      }
+      otherSequence.clear();
+    }
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/MoveBatcher.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/MoveBatcher.java
@@ -4,10 +4,10 @@ import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Unit;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 /**
  * MoveBatcher implements an algorithm that batches AI moves together, reducing the number of
@@ -17,12 +17,12 @@ public class MoveBatcher {
   private static class Move {
     private final ArrayList<Unit> units;
     private final Route route;
-    private final HashMap<Unit, Unit> unitsToTransports;
+    private final @Nullable HashMap<Unit, Unit> unitsToTransports;
 
     private Move(
         final ArrayList<Unit> units,
         final Route route,
-        final HashMap<Unit, Unit> unitsToTransports) {
+        final @Nullable HashMap<Unit, Unit> unitsToTransports) {
       this.units = units;
       this.route = route;
       this.unitsToTransports = unitsToTransports;
@@ -33,14 +33,10 @@ public class MoveBatcher {
     }
 
     Move(final Unit unit, final Route route, final Unit transportToLoad) {
-      this(mutableSingletonList(unit), route, new HashMap<>(Map.of(unit, transportToLoad)));
+      this(new ArrayList<>(List.of(unit)), route, new HashMap<>(Map.of(unit, transportToLoad)));
     }
 
-    private static ArrayList<Unit> mutableSingletonList(final Unit unit) {
-      return new ArrayList<>(Collections.singletonList(unit));
-    }
-
-    boolean isTransportLoad() {
+    private boolean isTransportLoad() {
       return this.unitsToTransports != null;
     }
 
@@ -81,7 +77,7 @@ public class MoveBatcher {
   }
 
   /**
-   * Adds a transport load move. Ownership of the params is transferred to this object.
+   * Adds a transport load move.
    *
    * @param unit The unit to move.
    * @param route The route to move on.
@@ -92,7 +88,7 @@ public class MoveBatcher {
   }
 
   /**
-   * Adds a move for the specified units. Ownership of the params is transferred to this object.
+   * Adds a move for the specified units. The units list must not be changed after adding the move.
    *
    * @param units The units to move. Note that type is ArrayList explicitly to prevent an
    *     unmodifiable List.of() being passed.
@@ -112,6 +108,9 @@ public class MoveBatcher {
 
   /**
    * Emits the accumulated moves to the passed output params.
+   *
+   * <p>TODO: #5416 Refactor the IMoveDelegate and ProMoveUtils code to use a List of Move objects,
+   * instead of these parallel lists.
    *
    * @param moveUnits The units to move.
    * @param moveRoutes The routes to move along

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/MoveBatcher.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/MoveBatcher.java
@@ -33,10 +33,7 @@ public class MoveBatcher {
     }
 
     Move(final Unit unit, final Route route, final Unit transportToLoad) {
-      this(
-          mutableSingletonList(unit),
-          route,
-          new HashMap<>(Map.of(unit, transportToLoad)));
+      this(mutableSingletonList(unit), route, new HashMap<>(Map.of(unit, transportToLoad)));
     }
 
     private static ArrayList<Unit> mutableSingletonList(final Unit unit) {
@@ -155,7 +152,8 @@ public class MoveBatcher {
       }
       for (int j = 0; j < sequence.size(); j++) {
         if (!sequence.get(j).mergeWith(otherSequence.get(j))) {
-          throw new RuntimeException("Unexpected");
+          throw new IlegalStateException(
+              "Could not merge move despite checking canMergeWith() earlier.");
         }
       }
       otherSequence.clear();

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/MoveBatcher.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/MoveBatcher.java
@@ -36,7 +36,7 @@ public class MoveBatcher {
       this(
           mutableSingletonList(unit),
           route,
-          new HashMap<Unit, Unit>(Map.of(unit, transportToLoad)));
+          new HashMap<>(Map.of(unit, transportToLoad)));
     }
 
     private static ArrayList<Unit> mutableSingletonList(final Unit unit) {
@@ -73,14 +73,14 @@ public class MoveBatcher {
     }
   }
 
-  private final ArrayList<ArrayList<Move>> moveSequences = new ArrayList<ArrayList<Move>>();
+  private final ArrayList<ArrayList<Move>> moveSequences = new ArrayList<>();
 
   /**
    * Starts a new sequence. This must be called before calling any add*() methods. A sequence
    * indicates a logical dependency relationship between the moves in that sequence.
    */
   public void newSequence() {
-    moveSequences.add(new ArrayList<Move>());
+    moveSequences.add(new ArrayList<>());
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/MoveBatcher.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/MoveBatcher.java
@@ -152,7 +152,7 @@ public class MoveBatcher {
       }
       for (int j = 0; j < sequence.size(); j++) {
         if (!sequence.get(j).mergeWith(otherSequence.get(j))) {
-          throw new IlegalStateException(
+          throw new IllegalStateException(
               "Could not merge move despite checking canMergeWith() earlier.");
         }
       }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/MoveBatcher.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/MoveBatcher.java
@@ -144,14 +144,14 @@ public class MoveBatcher {
       final ArrayList<Move> sequence, final List<ArrayList<Move>> sequences) {
     for (final var otherSequence : sequences) {
       boolean merge = (otherSequence.size() == sequence.size());
-      for (int j = 0; merge && j < sequence.size(); j++) {
-        merge = sequence.get(j).canMergeWith(otherSequence.get(j));
+      for (int i = 0; merge && i < sequence.size(); i++) {
+        merge = sequence.get(i).canMergeWith(otherSequence.get(i));
       }
       if (!merge) {
         continue;
       }
-      for (int j = 0; j < sequence.size(); j++) {
-        if (!sequence.get(j).mergeWith(otherSequence.get(j))) {
+      for (int i = 0; i < sequence.size(); i++) {
+        if (!sequence.get(i).mergeWith(otherSequence.get(i))) {
           throw new IllegalStateException(
               "Could not merge move despite checking canMergeWith() earlier.");
         }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -245,7 +245,6 @@ public final class ProMoveUtils {
         final var loadedUnits = new ArrayList<Unit>();
         final var remainingUnitsToLoad = new ArrayList<Unit>();
 
-
         if (TransportTracker.isTransporting(transport)) {
           loadedUnits.addAll(amphibAttackMap.get(transport));
         } else {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -162,7 +162,7 @@ public final class ProMoveUtils {
    *
    * @param moveUnits Receives the unit groups to move.
    * @param moveRoutes Receives the routes for each unit group in {@code moveUnits}.
-   * @param transportsToLoad Receives the transport groups for each unit group in {@code moveUnits}.
+   * @param unitsToTransports Receives the maps from units to transports to load.
    * @param attackMap Specifies the territories to be attacked. Will be updated to reflect any
    *     transports unloading in a specific territory.
    */
@@ -170,7 +170,7 @@ public final class ProMoveUtils {
       final PlayerId player,
       final List<Collection<Unit>> moveUnits,
       final List<Route> moveRoutes,
-      final List<Collection<Unit>> transportsToLoad,
+      final List<Map<Unit, Unit>> unitsToTransports,
       final Map<Territory, ProTerritory> attackMap,
       final boolean isCombatMove) {
 
@@ -315,7 +315,7 @@ public final class ProMoveUtils {
       }
     }
 
-    moves.batchAndEmit(moveUnits, moveRoutes, transportsToLoad);
+    moves.batchAndEmit(moveUnits, moveRoutes, unitsToTransports);
   }
 
   /**
@@ -434,7 +434,7 @@ public final class ProMoveUtils {
   public static void doMove(
       final List<Collection<Unit>> moveUnits,
       final List<Route> moveRoutes,
-      final List<Collection<Unit>> transportsToLoad,
+      final List<Map<Unit, Unit>> transportsToLoad,
       final IMoveDelegate moveDel) {
 
     final GameData data = ProData.getData();

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -30,17 +30,17 @@ public final class ProMoveUtils {
   private ProMoveUtils() {}
 
   private static class Move {
-    private final ArrayList<Unit> units;
+    private final List<Unit> units;
     private final Route route;
-    private final ArrayList<Unit> transportsToLoad;
+    private final List<Unit> transportsToLoad;
 
-    Move(final ArrayList<Unit> units, final Route route, final ArrayList<Unit> transportsToLoad) {
+    Move(final List<Unit> units, final Route route, final List<Unit> transportsToLoad) {
       this.units = units;
       this.route = route;
       this.transportsToLoad = transportsToLoad;
     }
 
-    Move(final ArrayList<Unit> units, final Route route) {
+    Move(final List<Unit> units, final Route route) {
       this(units, route, null);
     }
 
@@ -48,7 +48,7 @@ public final class ProMoveUtils {
       this(mutableSingletonList(unit), route, mutableSingletonList(transportToLoad));
     }
 
-    private static ArrayList<Unit> mutableSingletonList(final Unit unit) {
+    private static List<Unit> mutableSingletonList(final Unit unit) {
       return new ArrayList<>(Collections.singletonList(unit));
     }
 
@@ -126,7 +126,7 @@ public final class ProMoveUtils {
         }
 
         // Add unit to move list
-        final List<Unit> unitList = new ArrayList<>();
+        final var unitList = new ArrayList<Unit>();
         unitList.add(u);
         moveUnits.add(unitList);
         if (Matches.unitIsLandTransport().test(u)) {
@@ -238,7 +238,8 @@ public final class ProMoveUtils {
       for (final Unit transport : amphibAttackMap.keySet()) {
         int movesLeft = TripleAUnit.get(transport).getMovementLeft().intValue();
         Territory transportTerritory = ProData.unitTerritoryMap.get(transport);
-        ArrayList<Move> moves = movesMap.computeIfAbsent(transportTerritory, k -> new ArrayList<Move>());
+        final List<Move> moves =
+            movesMap.computeIfAbsent(transportTerritory, k -> new ArrayList<Move>());
 
         // Check if units are already loaded or not
         final var loadedUnits = new ArrayList<Unit>();
@@ -257,10 +258,9 @@ public final class ProMoveUtils {
           if (Matches.territoryHasEnemyUnits(player, data).negate().test(transportTerritory)) {
             final var unitsToRemove = new ArrayList<Unit>();
             for (final Unit amphibUnit : remainingUnitsToLoad) {
-              if (map.getDistance(transportTerritory, ProData.unitTerritoryMap.get(amphibUnit))
-                  == 1) {
-                final Route route =
-                    new Route(ProData.unitTerritoryMap.get(amphibUnit), transportTerritory);
+              final Territory unitTerritory = ProData.unitTerritoryMap.get(amphibUnit);
+              if (map.getDistance(transportTerritory, unitTerritory) == 1) {
+                final Route route = new Route(unitTerritory, transportTerritory);
                 moves.add(new Move(amphibUnit, route, transport));
                 loadedUnits.add(amphibUnit);
               }
@@ -369,7 +369,7 @@ public final class ProMoveUtils {
 
     // Re-order and batch the moves. That is, move all the units together, then
     // move all the transports together, then unload them all.
-    for (final ArrayList<Move> moves : movesMap.values()) {
+    for (final var moves : movesMap.values()) {
       // First, add all the transport loads.
       int i = 0;
       for (final Move move : moves) {
@@ -396,6 +396,16 @@ public final class ProMoveUtils {
     }
   }
 
+  /**
+   * Merges move with subsequent moves in the list.
+   *
+   * <p>Merged moves are set to null in the list, to mark them as merged. This is done rather than
+   * removing them, to avoid O(n^2) complexity.
+   *
+   * @param move The move to merge other eligible moves into.
+   * @param moves The list of candidate moves. ArrayList since elements are accessed by index.
+   * @param startIndex The starting index in the moves list to evaluate moves for merging.
+   */
   private static void mergeMoves(
       final Move move, final ArrayList<Move> moves, final int startIndex) {
     for (int i = startIndex; i < moves.size(); i++) {
@@ -435,7 +445,7 @@ public final class ProMoveUtils {
         }
 
         // Add unit to move list
-        final List<Unit> unitList = new ArrayList<>();
+        final var unitList = new ArrayList<Unit>();
         unitList.add(u);
         moveUnits.add(unitList);
 
@@ -487,7 +497,7 @@ public final class ProMoveUtils {
         }
 
         // Add unit to move list
-        final List<Unit> unitList = new ArrayList<>();
+        final var unitList = new ArrayList<Unit>();
         unitList.add(u);
         moveUnits.add(unitList);
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -229,7 +229,7 @@ public final class ProMoveUtils {
     final GameData data = ProData.getData();
     final GameMap map = data.getMap();
 
-    final HashMap<Territory, ArrayList<Move>> movesMap = new HashMap<>();
+    final var movesMap = new HashMap<Territory, ArrayList<Move>>();
     // Loop through all territories to attack
     for (final Territory t : attackMap.keySet()) {
 
@@ -238,15 +238,12 @@ public final class ProMoveUtils {
       for (final Unit transport : amphibAttackMap.keySet()) {
         int movesLeft = TripleAUnit.get(transport).getMovementLeft().intValue();
         Territory transportTerritory = ProData.unitTerritoryMap.get(transport);
-        ArrayList<Move> moves = movesMap.get(transportTerritory);
-        if (moves == null) {
-          moves = new ArrayList<>();
-          movesMap.put(transportTerritory, moves);
-        }
+        ArrayList<Move> moves = movesMap.computeIfAbsent(transportTerritory, k -> new ArrayList<Move>());
 
         // Check if units are already loaded or not
-        final ArrayList<Unit> loadedUnits = new ArrayList<>();
-        final ArrayList<Unit> remainingUnitsToLoad = new ArrayList<>();
+        final var loadedUnits = new ArrayList<Unit>();
+        final var remainingUnitsToLoad = new ArrayList<Unit>();
+
         if (TransportTracker.isTransporting(transport)) {
           loadedUnits.addAll(amphibAttackMap.get(transport));
         } else {
@@ -258,7 +255,7 @@ public final class ProMoveUtils {
 
           // Load adjacent units if no enemies present in transport territory
           if (Matches.territoryHasEnemyUnits(player, data).negate().test(transportTerritory)) {
-            final List<Unit> unitsToRemove = new ArrayList<>();
+            final var unitsToRemove = new ArrayList<Unit>();
             for (final Unit amphibUnit : remainingUnitsToLoad) {
               if (map.getDistance(transportTerritory, ProData.unitTerritoryMap.get(amphibUnit))
                   == 1) {
@@ -338,7 +335,7 @@ public final class ProMoveUtils {
               }
             }
             if (territoryToMoveTo != null) {
-              final ArrayList<Unit> unitsToMove = new ArrayList<>();
+              final var unitsToMove = new ArrayList<Unit>();
               unitsToMove.add(transport);
               unitsToMove.addAll(loadedUnits);
               final Route route = new Route(transportTerritory, territoryToMoveTo);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -407,26 +407,6 @@ public final class ProMoveUtils {
    * @param moves The list of candidate moves. ArrayList since elements are accessed by index.
    * @param startIndex The starting index in the moves list to evaluate moves for merging.
    */
-=======
-        }
-        i++;
-      }
-
-      // Then, add all the transport and unload moves, merging moves together.
-      // Since we process the moves in order, no special logic is needed to make
-      // sure transports move before unloading.
-      i = 0;
-      for (final Move move : moves) {
-        if (move != null) {
-          mergeMoves(move, moves, i + 1);
-          move.addTo(moveUnits, moveRoutes, transportsToLoad);
-        }
-        i++;
-      }
-    }
-  }
-
->>>>>>> a006fbdf0db91a3eff19a698f0aa9281395d5f1e
   private static void mergeMoves(
       final Move move, final ArrayList<Move> moves, final int startIndex) {
     for (int i = startIndex; i < moves.size(); i++) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -122,28 +122,28 @@ public class WeakAi extends AbstractAi {
       final IMoveDelegate moveDel, final PlayerId player, final GameData data) {
     final List<Collection<Unit>> moveUnits = new ArrayList<>();
     final List<Route> moveRoutes = new ArrayList<>();
-    final List<Collection<Unit>> transportsToLoad = new ArrayList<>();
+    final var unitsToTransport = new ArrayList<Map<Unit, Unit>>();
     // load the transports first
     // they may be able to move farther
-    populateTransportLoad(data, moveUnits, moveRoutes, transportsToLoad, player);
-    doMove(moveUnits, moveRoutes, transportsToLoad, moveDel);
+    populateTransportLoad(data, moveUnits, moveRoutes, unitsToTransport, player);
+    doMove(moveUnits, moveRoutes, unitsToTransport, moveDel);
     moveRoutes.clear();
     moveUnits.clear();
-    transportsToLoad.clear();
+    unitsToTransport.clear();
     // do the rest of the moves
     populateNonCombat(data, moveUnits, moveRoutes, player);
     populateNonCombatSea(true, data, moveUnits, moveRoutes, player);
     doMove(moveUnits, moveRoutes, null, moveDel);
     moveUnits.clear();
     moveRoutes.clear();
-    transportsToLoad.clear();
+    unitsToTransport.clear();
     // load the transports again if we can
     // they may be able to move farther
-    populateTransportLoad(data, moveUnits, moveRoutes, transportsToLoad, player);
-    doMove(moveUnits, moveRoutes, transportsToLoad, moveDel);
+    populateTransportLoad(data, moveUnits, moveRoutes, unitsToTransport, player);
+    doMove(moveUnits, moveRoutes, unitsToTransport, moveDel);
     moveRoutes.clear();
     moveUnits.clear();
-    transportsToLoad.clear();
+    unitsToTransport.clear();
     // unload the transports that can be unloaded
     populateTransportUnloadNonCom(data, moveUnits, moveRoutes, player);
     doMove(moveUnits, moveRoutes, null, moveDel);
@@ -153,11 +153,11 @@ public class WeakAi extends AbstractAi {
       final IMoveDelegate moveDel, final PlayerId player, final GameData data) {
     final List<Collection<Unit>> moveUnits = new ArrayList<>();
     final List<Route> moveRoutes = new ArrayList<>();
-    final List<Collection<Unit>> transportsToLoad = new ArrayList<>();
+    final var unitsToTransports = new ArrayList<Map<Unit, Unit>>();
     // load the transports first
     // they may be able to take part in a battle
-    populateTransportLoad(data, moveUnits, moveRoutes, transportsToLoad, player);
-    doMove(moveUnits, moveRoutes, transportsToLoad, moveDel);
+    populateTransportLoad(data, moveUnits, moveRoutes, unitsToTransports, player);
+    doMove(moveUnits, moveRoutes, unitsToTransports, moveDel);
     moveRoutes.clear();
     moveUnits.clear();
     // we want to move loaded transports before we try to fight our battles
@@ -170,7 +170,7 @@ public class WeakAi extends AbstractAi {
     doMove(moveUnits, moveRoutes, null, moveDel);
     moveUnits.clear();
     moveRoutes.clear();
-    transportsToLoad.clear();
+    unitsToTransports.clear();
     // fight
     populateCombatMove(data, moveUnits, moveRoutes, player);
     populateCombatMoveSea(data, moveUnits, moveRoutes, player);
@@ -181,7 +181,7 @@ public class WeakAi extends AbstractAi {
       final GameData data,
       final List<Collection<Unit>> moveUnits,
       final List<Route> moveRoutes,
-      final List<Collection<Unit>> transportsToLoad,
+      final List<Map<Unit, Unit>> unitsToTransports,
       final PlayerId player) {
     if (!isAmphibAttack(player, data)) {
       return;
@@ -199,6 +199,7 @@ public class WeakAi extends AbstractAi {
         continue;
       }
       final List<Unit> units = new ArrayList<>();
+      final Map<Unit, Unit> transportMap = new HashMap<>();
       for (final Unit transport :
           neighbor.getUnitCollection().getMatches(Matches.unitIsOwnedBy(player))) {
         int free = TransportTracker.getAvailableCapacity(transport);
@@ -216,6 +217,7 @@ public class WeakAi extends AbstractAi {
             iter.remove();
             free -= ua.getTransportCost();
             units.add(current);
+            transportMap.put(current, transport);
           }
         }
       }
@@ -223,7 +225,7 @@ public class WeakAi extends AbstractAi {
         final Route route = new Route(capitol, neighbor);
         moveUnits.add(units);
         moveRoutes.add(route);
-        transportsToLoad.add(neighbor.getUnitCollection().getMatches(Matches.unitIsTransport()));
+        unitsToTransports.add(transportMap);
       }
     }
   }
@@ -262,7 +264,7 @@ public class WeakAi extends AbstractAi {
   private static void doMove(
       final List<Collection<Unit>> moveUnits,
       final List<Route> moveRoutes,
-      final List<Collection<Unit>> transportsToLoad,
+      final List<Map<Unit, Unit>> unitsToTransports,
       final IMoveDelegate moveDel) {
     for (int i = 0; i < moveRoutes.size(); i++) {
       pause();
@@ -273,10 +275,10 @@ public class WeakAi extends AbstractAi {
         continue;
       }
 
-      if (transportsToLoad == null) {
+      if (unitsToTransports == null) {
         moveDel.move(moveUnits.get(i), moveRoutes.get(i));
       } else {
-        moveDel.move(moveUnits.get(i), moveRoutes.get(i), transportsToLoad.get(i));
+        moveDel.move(moveUnits.get(i), moveRoutes.get(i), unitsToTransports.get(i));
       }
     }
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -617,7 +617,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
   public String move(
       final Collection<Unit> units,
       final Route route,
-      final Collection<Unit> transportsThatCanBeLoaded,
+      final Map<Unit, Unit> unitsToTransports,
       final Map<Unit, Collection<Unit>> newDependents) {
     final GameData data = getData();
 
@@ -629,7 +629,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
             units,
             route,
             player,
-            transportsThatCanBeLoaded,
+            unitsToTransports,
             newDependents,
             GameStepPropertiesHelper.isNonCombatMove(data, false),
             movesToUndo,
@@ -699,7 +699,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     tempMovePerformer = new MovePerformer();
     tempMovePerformer.initialize(this);
     tempMovePerformer.moveUnits(
-        units, route, player, transportsThatCanBeLoaded, newDependents, currentMove);
+        units, route, player, unitsToTransports, newDependents, currentMove);
     tempMovePerformer = null;
     return null;
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -73,12 +73,12 @@ public class MovePerformer implements Serializable {
       final Collection<Unit> units,
       final Route route,
       final PlayerId id,
-      final Collection<Unit> transportsToLoad,
+      final Map<Unit, Unit> unitsToTransports,
       final Map<Unit, Collection<Unit>> newDependents,
       final UndoableMove currentMove) {
     this.currentMove = currentMove;
     this.newDependents = newDependents;
-    populateStack(units, route, id, transportsToLoad);
+    populateStack(units, route, id, unitsToTransports);
     executionStack.execute(bridge);
   }
 
@@ -91,7 +91,7 @@ public class MovePerformer implements Serializable {
       final Collection<Unit> units,
       final Route route,
       final PlayerId id,
-      final Collection<Unit> transportsToLoad) {
+      final Map<Unit, Unit> unitsToTransports) {
     final IExecutable preAaFire =
         new IExecutable() {
           private static final long serialVersionUID = -7945930782650355037L;
@@ -156,8 +156,6 @@ public class MovePerformer implements Serializable {
             // Reset Optional
             arrivingUnits = new ArrayList<>();
             final Collection<Unit> arrivedCopyForBattles = new ArrayList<>(arrived);
-            final Map<Unit, Unit> transporting =
-                TransportUtils.mapTransports(route, arrived, transportsToLoad);
             // If we have paratrooper land units being carried by air units, they should be dropped
             // off in the last
             // territory. This means they are still dependent during the middle steps of the route.
@@ -178,7 +176,7 @@ public class MovePerformer implements Serializable {
             // markFuelCostResourceChange must be done before we load/unload units
             change.add(Route.getFuelChanges(units, route, id, data));
 
-            markTransportsMovement(arrived, transporting, route);
+            markTransportsMovement(arrived, unitsToTransports, route);
             if (route.anyMatch(mustFightThrough) && arrived.size() != 0) {
               boolean ignoreBattle = false;
               // could it be a bombing raid

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -156,6 +156,10 @@ public class MovePerformer implements Serializable {
             // Reset Optional
             arrivingUnits = new ArrayList<>();
             final Collection<Unit> arrivedCopyForBattles = new ArrayList<>(arrived);
+            final Map<Unit, Unit> transporting =
+                route.isLoad()
+                    ? unitsToTransports
+                    : TransportUtils.mapTransports(route, arrived, null);
             // If we have paratrooper land units being carried by air units, they should be dropped
             // off in the last
             // territory. This means they are still dependent during the middle steps of the route.
@@ -176,7 +180,7 @@ public class MovePerformer implements Serializable {
             // markFuelCostResourceChange must be done before we load/unload units
             change.add(Route.getFuelChanges(units, route, id, data));
 
-            markTransportsMovement(arrived, unitsToTransports, route);
+            markTransportsMovement(arrived, transporting, route);
             if (route.anyMatch(mustFightThrough) && arrived.size() != 0) {
               boolean ignoreBattle = false;
               // could it be a bombing raid

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -1167,11 +1167,11 @@ public class MoveValidator {
       return result;
     }
     // If there are non-sea transports return
-    final boolean seaOrNoTransportsPresent =
-        unitsToTransports.isEmpty()
-            || unitsToTransports.values().stream()
-                .anyMatch(Matches.unitIsSea().and(Matches.unitCanTransport()));
-    if (!seaOrNoTransportsPresent) {
+    final boolean loadingNonSeaTransportsOnly =
+        !unitsToTransports.isEmpty()
+            && unitsToTransports.values().stream()
+                .noneMatch(Matches.unitIsSea().and(Matches.unitCanTransport()));
+    if (loadingNonSeaTransportsOnly) {
       return result;
     }
     final Territory routeEnd = route.getEnd();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -93,7 +93,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
   public String move(
       final Collection<Unit> units,
       final Route route,
-      final Collection<Unit> transportsThatCanBeLoaded,
+      final Map<Unit, Unit> unitsToTransports,
       final Map<Unit, Collection<Unit>> newDependents) {
     if (!allowAirborne(player, getData())) {
       return "No Airborne Movement Allowed Yet";
@@ -168,7 +168,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
     tempMovePerformer = new MovePerformer();
     tempMovePerformer.initialize(this);
     tempMovePerformer.moveUnits(
-        units, route, player, transportsThatCanBeLoaded, newDependents, currentMove);
+        units, route, player, unitsToTransports, newDependents, currentMove);
     tempMovePerformer = null;
     return null;
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/data/MoveDescription.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/data/MoveDescription.java
@@ -7,13 +7,14 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
+import lombok.Getter;
 
 /** Describes an action that moves one or more units along a specific route. */
 public class MoveDescription extends AbstractMoveDescription {
   private static final long serialVersionUID = 2199608152808948043L;
-  private final Route route;
-  private final Map<Unit, Unit> unitsToTransports;
-  private final Map<Unit, Collection<Unit>> dependentUnits;
+  @Getter private final Route route;
+  @Getter private final Map<Unit, Unit> unitsToTransports;
+  @Getter private final Map<Unit, Collection<Unit>> dependentUnits;
 
   public MoveDescription(
       final Collection<Unit> units,
@@ -23,40 +24,22 @@ public class MoveDescription extends AbstractMoveDescription {
     super(units);
     this.route = route;
     this.unitsToTransports = unitsToTransports;
-    if (dependentUnits != null && !dependentUnits.isEmpty()) {
+    if (!dependentUnits.isEmpty()) {
       this.dependentUnits = new HashMap<>();
       for (final Entry<Unit, Collection<Unit>> entry : dependentUnits.entrySet()) {
         this.dependentUnits.put(entry.getKey(), new HashSet<>(entry.getValue()));
       }
     } else {
-      this.dependentUnits = null;
+      this.dependentUnits = Map.of();
     }
   }
 
   public MoveDescription(final Collection<Unit> units, final Route route) {
-    this(units, route, null, null);
-  }
-
-  public Route getRoute() {
-    return route;
+    this(units, route, Map.of(), Map.of());
   }
 
   @Override
   public String toString() {
     return "Move message route:" + route + " units:" + getUnits();
-  }
-
-  public Map<Unit, Unit> getUnitsToTransports() {
-    if (unitsToTransports == null) {
-      return Map.of();
-    }
-    return unitsToTransports;
-  }
-
-  public Map<Unit, Collection<Unit>> getDependentUnits() {
-    if (dependentUnits == null) {
-      return new HashMap<>();
-    }
-    return dependentUnits;
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/data/MoveDescription.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/data/MoveDescription.java
@@ -3,7 +3,6 @@ package games.strategy.triplea.delegate.data;
 import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Unit;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -13,17 +12,17 @@ import java.util.Map.Entry;
 public class MoveDescription extends AbstractMoveDescription {
   private static final long serialVersionUID = 2199608152808948043L;
   private final Route route;
-  private final Collection<Unit> transportsThatCanBeLoaded;
+  private final Map<Unit, Unit> unitsToTransports;
   private final Map<Unit, Collection<Unit>> dependentUnits;
 
   public MoveDescription(
       final Collection<Unit> units,
       final Route route,
-      final Collection<Unit> transportsThatCanBeLoaded,
+      final Map<Unit, Unit> unitsToTransports,
       final Map<Unit, Collection<Unit>> dependentUnits) {
     super(units);
     this.route = route;
-    this.transportsThatCanBeLoaded = transportsThatCanBeLoaded;
+    this.unitsToTransports = unitsToTransports;
     if (dependentUnits != null && !dependentUnits.isEmpty()) {
       this.dependentUnits = new HashMap<>();
       for (final Entry<Unit, Collection<Unit>> entry : dependentUnits.entrySet()) {
@@ -35,10 +34,7 @@ public class MoveDescription extends AbstractMoveDescription {
   }
 
   public MoveDescription(final Collection<Unit> units, final Route route) {
-    super(units);
-    this.route = route;
-    transportsThatCanBeLoaded = null;
-    dependentUnits = null;
+    this(units, route, null, null);
   }
 
   public Route getRoute() {
@@ -50,11 +46,11 @@ public class MoveDescription extends AbstractMoveDescription {
     return "Move message route:" + route + " units:" + getUnits();
   }
 
-  public Collection<Unit> getTransportsThatCanBeLoaded() {
-    if (transportsThatCanBeLoaded == null) {
-      return Collections.emptyList();
+  public Map<Unit, Unit> getUnitsToTransports() {
+    if (unitsToTransports == null) {
+      return Map.of();
     }
-    return transportsThatCanBeLoaded;
+    return unitsToTransports;
   }
 
   public Map<Unit, Collection<Unit>> getDependentUnits() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/remote/IMoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/remote/IMoveDelegate.java
@@ -16,17 +16,17 @@ public interface IMoveDelegate
    *
    * @param units - the units to move.
    * @param route - the route to move along
-   * @param transportsThatCanBeLoaded - transports that can be loaded while moving, must be non null
+   * @param unitsToTransports - mapping from units to transports to load, must be non null
    * @return an error message if the move can't be made, null otherwise
    */
-  String move(Collection<Unit> units, Route route, Collection<Unit> transportsThatCanBeLoaded);
+  String move(Collection<Unit> units, Route route, Map<Unit, Unit> unitsToTransports);
 
   /**
    * Moves the specified units along the specified route accounting for dependents.
    *
    * @param units - the units to move.
    * @param route - the route to move along
-   * @param transportsThatCanBeLoaded - transports that can be loaded while moving, must be non null
+   * @param unitsToTransports - mapping from units to transports to load, must be non null
    * @param newDependents - units that will be made into new dependents if this move is successful,
    *     must be non null
    * @return an error message if the move can't be made, null otherwise
@@ -34,7 +34,7 @@ public interface IMoveDelegate
   String move(
       Collection<Unit> units,
       Route route,
-      Collection<Unit> transportsThatCanBeLoaded,
+      Map<Unit, Unit> unitsToTransports,
       Map<Unit, Collection<Unit>> newDependents);
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -595,7 +595,7 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
             }
           }
           final Map<Unit, Unit> unitsToTransports =
-              TransportUtils.mapTransports(route, units, transports);
+              transports == null ? null : TransportUtils.mapTransports(route, units, transports);
           final MoveDescription message =
               new MoveDescription(units, route, unitsToTransports, dependentUnits);
           setMoveMessage(message);

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -299,9 +299,11 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
                   final Collection<Unit> loadedAirTransports =
                       getLoadedAirTransports(route, unitsToLoad, airTransportsToLoad, player);
                   selectedUnits.addAll(loadedAirTransports);
+                  final Map<Unit, Unit> unitsToTransports =
+                      TransportUtils.mapTransportsToLoad(loadedAirTransports, airTransportsToLoad);
                   final MoveDescription message =
                       new MoveDescription(
-                          loadedAirTransports, route, airTransportsToLoad, dependentUnits);
+                          loadedAirTransports, route, unitsToTransports, dependentUnits);
                   setMoveMessage(message);
                 }
               }
@@ -592,8 +594,10 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
               return;
             }
           }
+          final Map<Unit, Unit> unitsToTransports =
+              TransportUtils.mapTransports(route, units, transports);
           final MoveDescription message =
-              new MoveDescription(units, route, transports, dependentUnits);
+              new MoveDescription(units, route, unitsToTransports, dependentUnits);
           setMoveMessage(message);
           setFirstSelectedTerritory(null);
           setSelectedEndpointTerritory(null);
@@ -1061,14 +1065,15 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
     }
     getMap().hideMouseCursor();
     // TODO kev check for already loaded airTransports
-    Collection<Unit> transportsToLoad = Collections.emptyList();
+    Map<Unit, Unit> unitsToTransports = Map.of();
     if (MoveValidator.isLoad(units, dependentUnits, route, getData(), getCurrentPlayer())) {
-      transportsToLoad =
+      final Collection<Unit> transportsToLoad =
           route
               .getEnd()
               .getUnitCollection()
               .getMatches(
                   Matches.unitIsTransport().and(Matches.alliedUnit(getCurrentPlayer(), getData())));
+      unitsToTransports = TransportUtils.mapTransports(route, units, transportsToLoad);
     }
     List<Unit> best = new ArrayList<>(units);
     // if the player selects a land unit and other units when the
@@ -1094,7 +1099,7 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
               bestWithDependents,
               route,
               getCurrentPlayer(),
-              transportsToLoad,
+              unitsToTransports,
               dependentUnits,
               nonCombat,
               getUndoableMoves(),
@@ -1116,7 +1121,7 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
                 bestWithDependents,
                 route,
                 getCurrentPlayer(),
-                transportsToLoad,
+                unitsToTransports,
                 dependentUnits,
                 nonCombat,
                 getUndoableMoves(),
@@ -1131,7 +1136,7 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
                 bestWithDependents,
                 route,
                 getCurrentPlayer(),
-                transportsToLoad,
+                unitsToTransports,
                 dependentUnits,
                 nonCombat,
                 getUndoableMoves(),

--- a/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -123,14 +123,18 @@ class PlacePanel extends AbstractMovePanel implements GameDataChangeListener {
       }
       // Note: This doesn't use getCurrentPlayer() as that may not be updated yet.
       final PlayerId player = step.getPlayerId();
-      final boolean isFirstTurn = (player == null || !player.equals(lastPlayer));
-      if (isFirstTurn) {
+      if (player == null) {
+        return;
+      }
+      final boolean isNewPlayerTurn = !player.equals(lastPlayer);
+      if (isNewPlayerTurn) {
         postProductionStep = false;
       }
+      final Collection<Unit> playerUnits = player.getUnits();
       // If we're past the production step (even if player didn't produce anything) or
       // there are units that are available to place, show the panel (set unitsToPlace).
-      showUnitsToPlace = (postProductionStep || (player != null && !player.getUnits().isEmpty()));
-      unitsToPlace = showUnitsToPlace ? UnitSeparator.categorize(player.getUnits()) : null;
+      showUnitsToPlace = (postProductionStep || !playerUnits.isEmpty());
+      unitsToPlace = showUnitsToPlace ? UnitSeparator.categorize(playerUnits) : null;
       if (GameStep.isPurchaseOrBidStep(step.getName())) {
         postProductionStep = true;
       }

--- a/game-core/src/test/java/games/strategy/triplea/ai/pro/util/MoveBatcherTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ai/pro/util/MoveBatcherTest.java
@@ -1,0 +1,129 @@
+package games.strategy.triplea.ai.pro.util;
+
+import static games.strategy.triplea.delegate.GameDataTestUtil.americans;
+import static games.strategy.triplea.delegate.GameDataTestUtil.armour;
+import static games.strategy.triplea.delegate.GameDataTestUtil.infantry;
+import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
+import static games.strategy.triplea.delegate.GameDataTestUtil.transport;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.Route;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class MoveBatcherTest {
+  private final GameData gameData = TestMapGameData.REVISED.getGameData();
+  private final Territory brazil = territory("Brazil", gameData);
+  private final Territory sz19 = territory("19 Sea Zone", gameData);
+  private final Territory sz18 = territory("18 Sea Zone", gameData);
+  private final Territory sz12 = territory("12 Sea Zone", gameData);
+  private final Territory algeria = territory("Algeria", gameData);
+  private final Route brazilToSz18 = new Route(brazil, sz18);
+  private final Route sz19ToSz18 = new Route(sz19, sz18);
+  private final Route sz18ToSz12 = new Route(sz18, sz12);
+  private final Route sz12ToAlgeria = new Route(sz12, algeria);
+  private final Route algeriaToSz18 = new Route(sz12, algeria);
+  private final Unit inf1 = infantry(gameData).create(americans(gameData));
+  private final Unit inf2 = infantry(gameData).create(americans(gameData));
+  private final Unit tank1 = armour(gameData).create(americans(gameData));
+  private final Unit tank2 = armour(gameData).create(americans(gameData));
+  private final Unit transport1 = transport(gameData).create(americans(gameData));
+  private final Unit transport2 = transport(gameData).create(americans(gameData));
+
+  public MoveBatcherTest() throws Exception {}
+
+  private static ArrayList<Unit> unitList(final Unit... units) {
+    return new ArrayList<Unit>(List.of(units));
+  }
+
+  private static HashSet<Unit> unitSet(final Unit... units) {
+    return new HashSet<Unit>(List.of(units));
+  }
+
+  @Test
+  public void testMoveUnitsWithMultipleTransports() {
+    final MoveBatcher moves = new MoveBatcher();
+
+    moves.newSequence();
+    moves.addTransportLoad(inf1, brazilToSz18, transport1);
+    moves.addTransportLoad(tank1, brazilToSz18, transport1);
+    moves.addMove(unitList(transport1, tank1, inf1), sz18ToSz12);
+    moves.addMove(unitList(tank1, inf1), sz12ToAlgeria);
+
+    moves.newSequence();
+    moves.addTransportLoad(tank2, brazilToSz18, transport2);
+    moves.addTransportLoad(inf2, brazilToSz18, transport2);
+    moves.addMove(unitList(transport2, inf2, tank2), sz18ToSz12);
+    moves.addMove(unitList(inf2, tank2), sz12ToAlgeria);
+
+    final List<Collection<Unit>> moveUnits = new ArrayList<>();
+    final List<Route> moveRoutes = new ArrayList<>();
+    final List<Collection<Unit>> transportsToLoad = new ArrayList<>();
+    moves.batchAndEmit(moveUnits, moveRoutes, transportsToLoad);
+
+    assertEquals(3, moveUnits.size());
+    assertEquals(3, moveRoutes.size());
+    assertEquals(3, transportsToLoad.size());
+
+    assertEquals(unitList(inf1, tank1, tank2, inf2), moveUnits.get(0));
+    assertEquals(brazilToSz18, moveRoutes.get(0));
+    assertEquals(unitSet(transport1, transport2), transportsToLoad.get(0));
+
+    assertEquals(unitList(transport1, tank1, inf1, transport2, inf2, tank2), moveUnits.get(1));
+    assertEquals(sz18ToSz12, moveRoutes.get(1));
+    assertEquals(null, transportsToLoad.get(1));
+
+    assertEquals(unitList(tank1, inf1, inf2, tank2), moveUnits.get(2));
+    assertEquals(sz12ToAlgeria, moveRoutes.get(2));
+    assertEquals(null, transportsToLoad.get(2));
+  }
+
+  @Test
+  public void testTransportsPickingUpUnitsOnTheWay() {
+    final MoveBatcher moves = new MoveBatcher();
+
+    moves.newSequence();
+    moves.addMove(unitList(transport1), sz19ToSz18);
+    moves.addTransportLoad(tank1, brazilToSz18, transport1);
+    moves.addMove(unitList(transport1, tank1), sz18ToSz12);
+    moves.addMove(unitList(tank1), sz12ToAlgeria);
+    moves.newSequence();
+    moves.addMove(unitList(transport2), sz19ToSz18);
+    moves.addTransportLoad(inf1, brazilToSz18, transport2);
+    moves.addTransportLoad(inf2, brazilToSz18, transport2);
+    moves.addMove(unitList(transport2, inf1, inf2), sz18ToSz12);
+    moves.addMove(unitList(inf1, inf2), sz12ToAlgeria);
+
+    final List<Collection<Unit>> moveUnits = new ArrayList<>();
+    final List<Route> moveRoutes = new ArrayList<>();
+    final List<Collection<Unit>> transportsToLoad = new ArrayList<>();
+    moves.batchAndEmit(moveUnits, moveRoutes, transportsToLoad);
+
+    assertEquals(4, moveUnits.size());
+    assertEquals(4, moveRoutes.size());
+    assertEquals(4, transportsToLoad.size());
+
+    assertEquals(unitList(transport1, transport2), moveUnits.get(0));
+    assertEquals(sz19ToSz18, moveRoutes.get(0));
+    assertEquals(null, transportsToLoad.get(0));
+
+    assertEquals(unitList(tank1, inf1, inf2), moveUnits.get(1));
+    assertEquals(brazilToSz18, moveRoutes.get(1));
+    assertEquals(unitSet(transport1, transport2), transportsToLoad.get(1));
+
+    assertEquals(unitList(transport1, tank1, transport2, inf1, inf2), moveUnits.get(2));
+    assertEquals(sz18ToSz12, moveRoutes.get(2));
+    assertEquals(null, transportsToLoad.get(2));
+
+    assertEquals(unitList(tank1, inf1, inf2), moveUnits.get(3));
+    assertEquals(sz12ToAlgeria, moveRoutes.get(3));
+    assertEquals(null, transportsToLoad.get(3));
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/ai/pro/util/MoveBatcherTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ai/pro/util/MoveBatcherTest.java
@@ -42,7 +42,7 @@ public class MoveBatcherTest {
   public MoveBatcherTest() throws Exception {}
 
   private static ArrayList<Unit> unitList(final Unit... units) {
-    return new ArrayList<Unit>(List.of(units));
+    return new ArrayList<>(List.of(units));
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/triplea/ai/pro/util/MoveBatcherTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ai/pro/util/MoveBatcherTest.java
@@ -6,7 +6,9 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.infantry;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static games.strategy.triplea.delegate.GameDataTestUtil.transport;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.common.collect.Maps;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
@@ -14,8 +16,8 @@ import games.strategy.engine.data.Unit;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 public class MoveBatcherTest {
@@ -43,10 +45,6 @@ public class MoveBatcherTest {
     return new ArrayList<Unit>(List.of(units));
   }
 
-  private static HashSet<Unit> unitSet(final Unit... units) {
-    return new HashSet<Unit>(List.of(units));
-  }
-
   @Test
   public void testMoveUnitsWithMultipleTransports() {
     final MoveBatcher moves = new MoveBatcher();
@@ -65,24 +63,26 @@ public class MoveBatcherTest {
 
     final List<Collection<Unit>> moveUnits = new ArrayList<>();
     final List<Route> moveRoutes = new ArrayList<>();
-    final List<Collection<Unit>> transportsToLoad = new ArrayList<>();
-    moves.batchAndEmit(moveUnits, moveRoutes, transportsToLoad);
+    final List<Map<Unit, Unit>> unitsToTransports = new ArrayList<>();
+    moves.batchAndEmit(moveUnits, moveRoutes, unitsToTransports);
 
     assertEquals(3, moveUnits.size());
     assertEquals(3, moveRoutes.size());
-    assertEquals(3, transportsToLoad.size());
+    assertEquals(3, unitsToTransports.size());
 
     assertEquals(unitList(inf1, tank1, tank2, inf2), moveUnits.get(0));
     assertEquals(brazilToSz18, moveRoutes.get(0));
-    assertEquals(unitSet(transport1, transport2), transportsToLoad.get(0));
+    final var expected =
+        Map.of(inf1, transport1, tank1, transport1, inf2, transport2, tank2, transport2);
+    assertTrue(Maps.difference(expected, unitsToTransports.get(0)).areEqual());
 
     assertEquals(unitList(transport1, tank1, inf1, transport2, inf2, tank2), moveUnits.get(1));
     assertEquals(sz18ToSz12, moveRoutes.get(1));
-    assertEquals(null, transportsToLoad.get(1));
+    assertEquals(null, unitsToTransports.get(1));
 
     assertEquals(unitList(tank1, inf1, inf2, tank2), moveUnits.get(2));
     assertEquals(sz12ToAlgeria, moveRoutes.get(2));
-    assertEquals(null, transportsToLoad.get(2));
+    assertEquals(null, unitsToTransports.get(2));
   }
 
   @Test
@@ -103,27 +103,28 @@ public class MoveBatcherTest {
 
     final List<Collection<Unit>> moveUnits = new ArrayList<>();
     final List<Route> moveRoutes = new ArrayList<>();
-    final List<Collection<Unit>> transportsToLoad = new ArrayList<>();
-    moves.batchAndEmit(moveUnits, moveRoutes, transportsToLoad);
+    final List<Map<Unit, Unit>> unitsToTransports = new ArrayList<>();
+    moves.batchAndEmit(moveUnits, moveRoutes, unitsToTransports);
 
     assertEquals(4, moveUnits.size());
     assertEquals(4, moveRoutes.size());
-    assertEquals(4, transportsToLoad.size());
+    assertEquals(4, unitsToTransports.size());
 
     assertEquals(unitList(transport1, transport2), moveUnits.get(0));
     assertEquals(sz19ToSz18, moveRoutes.get(0));
-    assertEquals(null, transportsToLoad.get(0));
+    assertEquals(null, unitsToTransports.get(0));
 
     assertEquals(unitList(tank1, inf1, inf2), moveUnits.get(1));
     assertEquals(brazilToSz18, moveRoutes.get(1));
-    assertEquals(unitSet(transport1, transport2), transportsToLoad.get(1));
+    final var expected = Map.of(tank1, transport1, inf1, transport2, inf2, transport2);
+    assertTrue(Maps.difference(expected, unitsToTransports.get(1)).areEqual());
 
     assertEquals(unitList(transport1, tank1, transport2, inf1, inf2), moveUnits.get(2));
     assertEquals(sz18ToSz12, moveRoutes.get(2));
-    assertEquals(null, transportsToLoad.get(2));
+    assertEquals(null, unitsToTransports.get(2));
 
     assertEquals(unitList(tank1, inf1, inf2), moveUnits.get(3));
     assertEquals(sz12ToAlgeria, moveRoutes.get(3));
-    assertEquals(null, transportsToLoad.get(3));
+    assertEquals(null, unitsToTransports.get(3));
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/ai/pro/util/MoveBatcherTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ai/pro/util/MoveBatcherTest.java
@@ -49,12 +49,15 @@ public class MoveBatcherTest {
   public void testMoveUnitsWithMultipleTransports() {
     final MoveBatcher moves = new MoveBatcher();
 
+    // Load two units onto transport 1 then move and unload them.
     moves.newSequence();
     moves.addTransportLoad(inf1, brazilToSz18, transport1);
     moves.addTransportLoad(tank1, brazilToSz18, transport1);
     moves.addMove(unitList(transport1, tank1, inf1), sz18ToSz12);
     moves.addMove(unitList(tank1, inf1), sz12ToAlgeria);
 
+    // Load two units onto transport 2 then move and unload them, in
+    // the same territories as the previous sequence.
     moves.newSequence();
     moves.addTransportLoad(tank2, brazilToSz18, transport2);
     moves.addTransportLoad(inf2, brazilToSz18, transport2);
@@ -66,20 +69,27 @@ public class MoveBatcherTest {
     final List<Map<Unit, Unit>> unitsToTransports = new ArrayList<>();
     moves.batchAndEmit(moveUnits, moveRoutes, unitsToTransports);
 
+    // After batching, there should be 3 moves:
+    //   Move to load all the land units onto transports.
+    //   Move transporting all the units.
+    //   Move unloading the land units from the transports.
     assertEquals(3, moveUnits.size());
     assertEquals(3, moveRoutes.size());
     assertEquals(3, unitsToTransports.size());
 
+    // Check move to load all the land units onto transports.
     assertEquals(unitList(inf1, tank1, tank2, inf2), moveUnits.get(0));
     assertEquals(brazilToSz18, moveRoutes.get(0));
     final var expected =
         Map.of(inf1, transport1, tank1, transport1, inf2, transport2, tank2, transport2);
     assertTrue(Maps.difference(expected, unitsToTransports.get(0)).areEqual());
 
+    // Check move transporting all the units.
     assertEquals(unitList(transport1, tank1, inf1, transport2, inf2, tank2), moveUnits.get(1));
     assertEquals(sz18ToSz12, moveRoutes.get(1));
     assertEquals(null, unitsToTransports.get(1));
 
+    // Check move unloading the land units from the transports.
     assertEquals(unitList(tank1, inf1, inf2, tank2), moveUnits.get(2));
     assertEquals(sz12ToAlgeria, moveRoutes.get(2));
     assertEquals(null, unitsToTransports.get(2));
@@ -89,11 +99,14 @@ public class MoveBatcherTest {
   public void testTransportsPickingUpUnitsOnTheWay() {
     final MoveBatcher moves = new MoveBatcher();
 
+    // Move transport1, load a tank, move transport + tank, unload tank.
     moves.newSequence();
     moves.addMove(unitList(transport1), sz19ToSz18);
     moves.addTransportLoad(tank1, brazilToSz18, transport1);
     moves.addMove(unitList(transport1, tank1), sz18ToSz12);
     moves.addMove(unitList(tank1), sz12ToAlgeria);
+
+    // Move transport2, load two infantry, move transport + 2 infantry, unload infantry.
     moves.newSequence();
     moves.addMove(unitList(transport2), sz19ToSz18);
     moves.addTransportLoad(inf1, brazilToSz18, transport2);
@@ -106,23 +119,32 @@ public class MoveBatcherTest {
     final List<Map<Unit, Unit>> unitsToTransports = new ArrayList<>();
     moves.batchAndEmit(moveUnits, moveRoutes, unitsToTransports);
 
+    // After batching, there should be 4 moves:
+    //   Move transports 1 and 2 into position.
+    //   Load tank and two infantry onto the transports.
+    //   Move transporting all the units together.
+    //   Move to unload the loaded units from the transports.
     assertEquals(4, moveUnits.size());
     assertEquals(4, moveRoutes.size());
     assertEquals(4, unitsToTransports.size());
 
+    // Check move of transports 1 and 2 into position.
     assertEquals(unitList(transport1, transport2), moveUnits.get(0));
     assertEquals(sz19ToSz18, moveRoutes.get(0));
     assertEquals(null, unitsToTransports.get(0));
 
+    // Check load of tank and two infantry onto the transports.
     assertEquals(unitList(tank1, inf1, inf2), moveUnits.get(1));
     assertEquals(brazilToSz18, moveRoutes.get(1));
     final var expected = Map.of(tank1, transport1, inf1, transport2, inf2, transport2);
     assertTrue(Maps.difference(expected, unitsToTransports.get(1)).areEqual());
 
+    // Check move transporting all the units together.
     assertEquals(unitList(transport1, tank1, transport2, inf1, inf2), moveUnits.get(2));
     assertEquals(sz18ToSz12, moveRoutes.get(2));
     assertEquals(null, unitsToTransports.get(2));
 
+    // Check move to unload the loaded units from the transports.
     assertEquals(unitList(tank1, inf1, inf2), moveUnits.get(3));
     assertEquals(sz12ToAlgeria, moveRoutes.get(3));
     assertEquals(null, unitsToTransports.get(3));

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.triplea.java.collections.CollectionUtils;
@@ -461,26 +462,24 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
     gameData.performChange(ChangeFactory.addUnits(japan, infantry.create(3, japanese)));
     // Perform the first load
     final Route load = new Route(japan, japanSeaZone);
-    String results =
-        delegate.move(
-            CollectionUtils.getNMatches(japan.getUnits(), 1, Matches.unitIsOfType(infantry)),
-            load,
-            CollectionUtils.getMatches(japanSeaZone.getUnits(), Matches.unitIsOfType(transport)));
+    final List<Unit> transports =
+        CollectionUtils.getMatches(japanSeaZone.getUnits(), Matches.unitIsOfType(transport));
+    final List<Unit> infantry1 =
+        CollectionUtils.getNMatches(japan.getUnits(), 1, Matches.unitIsOfType(infantry));
+    String results = delegate.move(infantry1, load, Map.of(infantry1.get(0), transports.get(0)));
     assertNull(results);
+    assertEquals(
+        infantry1,
+        CollectionUtils.getNMatches(japanSeaZone.getUnits(), 1, Matches.unitIsOfType(infantry)));
     // Perform the first unload
     final Route unload = new Route(japanSeaZone, manchuria);
-    results =
-        delegate.move(
-            CollectionUtils.getNMatches(japanSeaZone.getUnits(), 1, Matches.unitIsOfType(infantry)),
-            unload);
+    results = delegate.move(infantry1, unload);
     assertNull(results);
     // Load another trn
     final Route route2 = new Route(japan, japanSeaZone);
-    results =
-        delegate.move(
-            CollectionUtils.getNMatches(japan.getUnits(), 1, Matches.unitIsOfType(infantry)),
-            route2,
-            CollectionUtils.getMatches(japanSeaZone.getUnits(), Matches.unitIsOfType(transport)));
+    final List<Unit> infantry2 =
+        CollectionUtils.getNMatches(japan.getUnits(), 1, Matches.unitIsOfType(infantry));
+    results = delegate.move(infantry2, route2, Map.of(infantry2.get(0), transports.get(1)));
     assertNull(results);
     // Move remaining units
     final Route route3 = new Route(japanSeaZone, sfeSeaZone);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
@@ -15,13 +15,13 @@ import games.strategy.engine.data.Unit;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.delegate.data.MoveValidationResult;
+import games.strategy.triplea.util.TransportUtils;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 
 class MoveValidatorTest extends AbstractDelegateTestCase {
@@ -117,7 +117,7 @@ class MoveValidatorTest extends AbstractDelegateTestCase {
     List<Unit> toMove = berlin.getUnitCollection().getMatches(Matches.unitCanMove());
     MoveValidationResult results =
         MoveValidator.validateMove(
-            toMove, r, germans, Collections.emptyList(), new HashMap<>(), false, null, twwGameData);
+            toMove, r, germans, Map.of(), Map.of(), false, null, twwGameData);
     assertTrue(results.isMoveValid());
 
     // Add germanTrain to units which fails since it requires germainRail
@@ -125,7 +125,7 @@ class MoveValidatorTest extends AbstractDelegateTestCase {
     toMove = berlin.getUnitCollection().getMatches(Matches.unitCanMove());
     results =
         MoveValidator.validateMove(
-            toMove, r, germans, Collections.emptyList(), new HashMap<>(), false, null, twwGameData);
+            toMove, r, germans, Map.of(), Map.of(), false, null, twwGameData);
     assertFalse(results.isMoveValid());
 
     // Add germanRail to only destination so it fails
@@ -133,21 +133,21 @@ class MoveValidatorTest extends AbstractDelegateTestCase {
     addTo(easternGermany, germanRail);
     results =
         MoveValidator.validateMove(
-            toMove, r, germans, Collections.emptyList(), new HashMap<>(), false, null, twwGameData);
+            toMove, r, germans, Map.of(), Map.of(), false, null, twwGameData);
     assertFalse(results.isMoveValid());
 
     // Add germanRail to start so move succeeds
     addTo(berlin, GameDataTestUtil.germanRail(twwGameData).create(1, germans));
     results =
         MoveValidator.validateMove(
-            toMove, r, germans, Collections.emptyList(), new HashMap<>(), false, null, twwGameData);
+            toMove, r, germans, Map.of(), Map.of(), false, null, twwGameData);
     assertTrue(results.isMoveValid());
 
     // Remove germanRail from destination so move fails
     GameDataTestUtil.removeFrom(easternGermany, germanRail);
     results =
         MoveValidator.validateMove(
-            toMove, r, germans, Collections.emptyList(), new HashMap<>(), false, null, twwGameData);
+            toMove, r, germans, Map.of(), Map.of(), false, null, twwGameData);
     assertFalse(results.isMoveValid());
 
     // Add allied owned germanRail to destination so move succeeds
@@ -155,7 +155,7 @@ class MoveValidatorTest extends AbstractDelegateTestCase {
     addTo(easternGermany, GameDataTestUtil.germanRail(twwGameData).create(1, japan));
     results =
         MoveValidator.validateMove(
-            toMove, r, germans, Collections.emptyList(), new HashMap<>(), false, null, twwGameData);
+            toMove, r, germans, Map.of(), Map.of(), false, null, twwGameData);
     assertTrue(results.isMoveValid());
   }
 
@@ -175,84 +175,42 @@ class MoveValidatorTest extends AbstractDelegateTestCase {
     addTo(berlin, GameDataTestUtil.truck(twwGameData).create(1, germans));
     MoveValidationResult results =
         MoveValidator.validateMove(
-            berlin.getUnitCollection(),
-            r,
-            germans,
-            Collections.emptyList(),
-            new HashMap<>(),
-            true,
-            null,
-            twwGameData);
+            berlin.getUnitCollection(), r, germans, Map.of(), Map.of(), true, null, twwGameData);
     assertTrue(results.isMoveValid());
 
     // Add an infantry for truck to transport
     addTo(berlin, GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
     results =
         MoveValidator.validateMove(
-            berlin.getUnitCollection(),
-            r,
-            germans,
-            Collections.emptyList(),
-            new HashMap<>(),
-            true,
-            null,
-            twwGameData);
+            berlin.getUnitCollection(), r, germans, Map.of(), Map.of(), true, null, twwGameData);
     assertTrue(results.isMoveValid());
 
     // Add an infantry and the truck can't transport both
     addTo(berlin, GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
     results =
         MoveValidator.validateMove(
-            berlin.getUnitCollection(),
-            r,
-            germans,
-            Collections.emptyList(),
-            new HashMap<>(),
-            true,
-            null,
-            twwGameData);
+            berlin.getUnitCollection(), r, germans, Map.of(), Map.of(), true, null, twwGameData);
     assertFalse(results.isMoveValid());
 
     // Add a large truck (has capacity for 2 infantry) to transport second infantry
     addTo(berlin, GameDataTestUtil.largeTruck(twwGameData).create(1, germans));
     results =
         MoveValidator.validateMove(
-            berlin.getUnitCollection(),
-            r,
-            germans,
-            Collections.emptyList(),
-            new HashMap<>(),
-            true,
-            null,
-            twwGameData);
+            berlin.getUnitCollection(), r, germans, Map.of(), Map.of(), true, null, twwGameData);
     assertTrue(results.isMoveValid());
 
     // Add an infantry that the large truck can also transport
     addTo(berlin, GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
     results =
         MoveValidator.validateMove(
-            berlin.getUnitCollection(),
-            r,
-            germans,
-            Collections.emptyList(),
-            new HashMap<>(),
-            true,
-            null,
-            twwGameData);
+            berlin.getUnitCollection(), r, germans, Map.of(), Map.of(), true, null, twwGameData);
     assertTrue(results.isMoveValid());
 
     // Add an infantry that can't be transported
     addTo(berlin, GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
     results =
         MoveValidator.validateMove(
-            berlin.getUnitCollection(),
-            r,
-            germans,
-            Collections.emptyList(),
-            new HashMap<>(),
-            true,
-            null,
-            twwGameData);
+            berlin.getUnitCollection(), r, germans, Map.of(), Map.of(), true, null, twwGameData);
     assertFalse(results.isMoveValid());
   }
 
@@ -274,8 +232,8 @@ class MoveValidatorTest extends AbstractDelegateTestCase {
             northernGermany.getUnitCollection(),
             r,
             germans,
-            transport,
-            new HashMap<>(),
+            TransportUtils.mapTransports(r, northernGermany.getUnitCollection(), transport),
+            Map.of(),
             false,
             null,
             twwGameData);
@@ -289,8 +247,8 @@ class MoveValidatorTest extends AbstractDelegateTestCase {
             northernGermany.getUnitCollection(),
             r,
             germans,
-            transport,
-            new HashMap<>(),
+            TransportUtils.mapTransports(r, northernGermany.getUnitCollection(), transport),
+            Map.of(),
             false,
             null,
             twwGameData);
@@ -303,8 +261,8 @@ class MoveValidatorTest extends AbstractDelegateTestCase {
             northernGermany.getUnitCollection(),
             r,
             germans,
-            transport,
-            new HashMap<>(),
+            TransportUtils.mapTransports(r, northernGermany.getUnitCollection(), transport),
+            Map.of(),
             false,
             null,
             twwGameData);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -85,8 +85,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -1428,14 +1428,7 @@ class WW2V3Year41Test {
     assertFalse(paratroopers.isEmpty());
     final MoveValidationResult results =
         MoveValidator.validateMove(
-            paratroopers,
-            r,
-            germans,
-            Collections.emptyList(),
-            new HashMap<>(),
-            false,
-            null,
-            gameData);
+            paratroopers, r, germans, Map.of(), Map.of(), false, null, gameData);
     assertFalse(results.isMoveValid());
   }
 
@@ -1456,8 +1449,7 @@ class WW2V3Year41Test {
     toMove.addAll(germany.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()));
     assertEquals(2, toMove.size());
     final MoveValidationResult results =
-        MoveValidator.validateMove(
-            toMove, r, germans, Collections.emptyList(), new HashMap<>(), false, null, gameData);
+        MoveValidator.validateMove(toMove, r, germans, Map.of(), Map.of(), false, null, gameData);
     assertFalse(results.isMoveValid());
   }
 
@@ -1478,8 +1470,7 @@ class WW2V3Year41Test {
     toMove.addAll(germany.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()));
     assertEquals(2, toMove.size());
     final MoveValidationResult results =
-        MoveValidator.validateMove(
-            toMove, r, germans, Collections.emptyList(), new HashMap<>(), false, null, gameData);
+        MoveValidator.validateMove(toMove, r, germans, Map.of(), Map.of(), false, null, gameData);
     assertFalse(results.isMoveValid());
   }
 


### PR DESCRIPTION
Prior to this change, the AI would load and move transports one unit at a time.
So moving 20 units via transports would take 40 moves:
  - 20 x (1 load, 1 load, 1 move, 1 unload).

With this change, it's just 3 moves (when they all have the same destination):
  1. Load 20 units
  2. Move 10 transports
  3. Unload 20 units.

This makes a big difference when playing with AI since this makes
the AI moves be much faster when amphibious moves are involved.

Additionally, the code is changed to make the player pass the mapping from units to transports to the backend, so that the AI could convey this directly without having the backend recalculate it and potentially get it wrong.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[X] Feature update or enhancement
[] Feature Removal
[X] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
[] No manual testing done
[X] Manually tested

Loaded a save game where US has a lot of stuff to move. Observed the moves it made.
Loaded a save game where UK has a combat move involving moving transports, picking up units and landing them. Observed the moves it made.
Also added some unit tests.

## Screens Shots

### Before

![Screen Shot 2019-11-03 at 10 35 17 PM](https://user-images.githubusercontent.com/17648/68098361-42225900-fe8a-11e9-8e3e-10691fc833f7.png)

### After

![Screen Shot 2019-11-03 at 10 38 37 PM](https://user-images.githubusercontent.com/17648/68098444-b8bf5680-fe8a-11e9-8e84-d01a9974f121.png)
