### PR TITLE
Add acceptance/integration tests for websocket and websocket chat

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ subprojects {
         hamcrestVersion = '2.0.0.0'
         jakartaMailVersion = '1.6.4'
         javafxVersion = '11'
-        javaWebsocketVersoin = '1.4.0'
+        javaWebsocketVersion = '1.4.0'
         javaxActivationVersion = '1.1.1'
         jaxbApiVersion = '2.3.1'
         jaxbCoreVersion = '2.3.0'

--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     runtimeOnly "org.postgresql:postgresql:$postgresqlVersion"
     testImplementation "com.github.database-rider:rider-junit5:$databaseRiderVersion"
     testImplementation "io.dropwizard:dropwizard-testing:$dropwizardVersion"
-    testImplementation "org.java-websocket:Java-WebSocket:$javaWebsocketVersoin"
+    testImplementation "org.java-websocket:Java-WebSocket:$javaWebsocketVersion"
     testImplementation project(":test-common")
 }
 

--- a/integration-testing/build.gradle
+++ b/integration-testing/build.gradle
@@ -7,6 +7,7 @@ configurations {
 }
 
 dependencies {
+    // https://mvnrepository.com/artifact/org.java-websocket/Java-WebSocket
     runtimeOnly "org.postgresql:postgresql:$postgresqlVersion"
     testImplementation "com.github.database-rider:rider-junit5:$databaseRiderVersion"
     testImplementation "com.sun.mail:jakarta.mail:$jakartaMailVersion"
@@ -25,6 +26,7 @@ dependencies {
     testImplementation "org.jdbi:jdbi3-core:$jdbiVersion"
     testImplementation "org.jdbi:jdbi3-sqlobject:$jdbiVersion"
     testImplementation "org.mindrot:jbcrypt:$jbcryptVersion"
+    testImplementation "org.java-websocket:Java-WebSocket:$javaWebsocketVersion"
     testImplementation project(":test-common")
     testImplementation project(':domain-data')
     testImplementation project(':game-core')

--- a/integration-testing/build.gradle
+++ b/integration-testing/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     testImplementation "io.github.openfeign:feign-gson:$openFeignVersion"
     testImplementation "javax.activation:activation:$javaxActivationVersion"
     testImplementation "javax.xml.bind:jaxb-api:$jaxbApiVersion"
+    testImplementation "org.awaitility:awaitility:$awaitilityVersion"
     testImplementation "org.jdbi:jdbi3-core:$jdbiVersion"
     testImplementation "org.jdbi:jdbi3-sqlobject:$jdbiVersion"
     testImplementation "org.mindrot:jbcrypt:$jbcryptVersion"

--- a/integration-testing/build.gradle
+++ b/integration-testing/build.gradle
@@ -7,7 +7,6 @@ configurations {
 }
 
 dependencies {
-    // https://mvnrepository.com/artifact/org.java-websocket/Java-WebSocket
     runtimeOnly "org.postgresql:postgresql:$postgresqlVersion"
     testImplementation "com.github.database-rider:rider-junit5:$databaseRiderVersion"
     testImplementation "com.sun.mail:jakarta.mail:$jakartaMailVersion"

--- a/integration-testing/src/test/java/org/triplea/http/server/LobbyChatIntegrationTest.java
+++ b/integration-testing/src/test/java/org/triplea/http/server/LobbyChatIntegrationTest.java
@@ -1,0 +1,230 @@
+package org.triplea.http.server;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.core.IsCollectionContaining.hasItems;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.triplea.domain.data.ApiKey;
+import org.triplea.domain.data.PlayerName;
+import org.triplea.http.client.lobby.chat.ChatParticipant;
+import org.triplea.http.client.lobby.chat.LobbyChatClient;
+import org.triplea.http.client.lobby.chat.events.server.ChatMessage;
+import org.triplea.http.client.lobby.chat.events.server.PlayerSlapped;
+import org.triplea.http.client.lobby.chat.events.server.StatusUpdate;
+import org.triplea.server.http.DropwizardTest;
+import org.triplea.test.common.Integration;
+
+/**
+ * End-to-end test where we go through a chat sequence exercising all chat features. Runs through
+ * the following chat sequence:
+ *
+ * <ol>
+ *   <li>Moderator joins
+ *   <li>Chatter joins
+ *   <li>Chatter speaks
+ *   <li>Chatter slaps moderator
+ *   <li>Chatter updates their status
+ *   <li>Chatter leaves
+ * </ol>
+ *
+ * Chat is very listener driven, for each of the above we expect various events to be received. To
+ * execute this test we will create a series of lists for each event respective to each player.
+ * After executing each event we'll wait for the expected list to gain an event (or timeout and
+ * fail). Then, after receiving an event, we'll verify the event data and then continue in the
+ * sequence.
+ *
+ * <p>Of note, when a player joins they will receive two events, a 'join' event and a 'connected'
+ * event. The 'join' event should notify that they themselves haved joined (all players receive
+ * this), and second, only they should receive a 'connected' event that informs them of all players
+ * that have joined. So we expect 'moderator' to be the only player in the connected list, when
+ * chatter joins we expect both moderator and chatter to be in the connected event list.
+ */
+@SuppressWarnings("SameParameterValue")
+class LobbyChatIntegrationTest extends DropwizardTest {
+  private static final int MESSAGE_TIMEOUT = 3000;
+
+  private static final String STATUS = "status";
+  private static final String MESSAGE = "sample";
+
+  // caution: api-key values must match database (integration.yml)
+  private static final ApiKey MODERATOR_API_KEY = ApiKey.of("test");
+  private static final ApiKey CHATTER_API_KEY = ApiKey.of("test1");
+
+  private static final PlayerName MODERATOR_NAME = PlayerName.of("mod");
+  private static final ChatParticipant MODERATOR =
+      ChatParticipant.builder().playerName(MODERATOR_NAME).isModerator(true).status("").build();
+
+  private static final PlayerName CHATTER_NAME = PlayerName.of("chatter");
+  private static final ChatParticipant CHATTER =
+      ChatParticipant.builder().playerName(CHATTER_NAME).isModerator(false).status("").build();
+
+  private List<StatusUpdate> modPlayerStatusEvents = new ArrayList<>();
+  private List<PlayerName> modPlayerLeftEvents = new ArrayList<>();
+  private List<ChatParticipant> modPlayerJoinedEvents = new ArrayList<>();
+  private List<PlayerSlapped> modPlayerSlappedEvents = new ArrayList<>();
+  private List<ChatMessage> modMessageEvents = new ArrayList<>();
+  private List<Collection<ChatParticipant>> modConnectedEvents = new ArrayList<>();
+  private LobbyChatClient moderator;
+
+  private List<StatusUpdate> chatterPlayerStatusEvents = new ArrayList<>();
+  private List<PlayerName> chatterPlayerLeftEvents = new ArrayList<>();
+  private List<ChatParticipant> chatterPlayerJoinedEvents = new ArrayList<>();
+  private List<PlayerSlapped> chatterPlayerSlappedEvents = new ArrayList<>();
+  private List<ChatMessage> chatterMessageEvents = new ArrayList<>();
+  private List<Collection<ChatParticipant>> chatterConnectedEvents = new ArrayList<>();
+  private LobbyChatClient chatter;
+
+  private LobbyChatClient createModerator() {
+    final LobbyChatClient moderator =
+        // caution: api-key must match values in database (integration.yml)
+        new LobbyChatClient(localhost, MODERATOR_API_KEY);
+    moderator.addPlayerStatusListener(modPlayerStatusEvents::add);
+    moderator.addPlayerLeftListener(modPlayerLeftEvents::add);
+    moderator.addPlayerJoinedListener(modPlayerJoinedEvents::add);
+    moderator.addPlayerSlappedListener(modPlayerSlappedEvents::add);
+    moderator.addChatMessageListener(modMessageEvents::add);
+    moderator.addConnectedListener(modConnectedEvents::add);
+    return moderator;
+  }
+
+  private LobbyChatClient createChatter() {
+    final LobbyChatClient chatter = new LobbyChatClient(localhost, CHATTER_API_KEY);
+    chatter.addPlayerStatusListener(chatterPlayerStatusEvents::add);
+    chatter.addPlayerLeftListener(chatterPlayerLeftEvents::add);
+    chatter.addPlayerJoinedListener(chatterPlayerJoinedEvents::add);
+    chatter.addPlayerSlappedListener(chatterPlayerSlappedEvents::add);
+    chatter.addChatMessageListener(chatterMessageEvents::add);
+    chatter.addConnectedListener(chatterConnectedEvents::add);
+    return chatter;
+  }
+
+  @Test
+  @DisplayName("Run through a chat sequence with two players exercising all chat functionality.")
+  void chatTest() {
+    moderator = createModerator();
+    moderatorConnects();
+    chatter = createChatter();
+    chatterConnects();
+    chatterChats();
+    chatterSlapsMod();
+    chatterUpdatesStatus();
+    chatterLeaves();
+  }
+
+  private void moderatorConnects() {
+    moderator.connect();
+    // mod is notified that only 'mod' is in chat
+    verifyConnectedPlayers(modConnectedEvents, MODERATOR);
+    // mod should be notified of their own entry into chat
+    verifyPlayerJoinedEvent(modPlayerJoinedEvents, MODERATOR);
+  }
+
+  private void chatterConnects() {
+    chatter.connect();
+    // chatter should be notified that both 'mod' and 'chatter' are in chat
+    verifyConnectedPlayers(chatterConnectedEvents, MODERATOR, CHATTER);
+    // chatter should be notified of their own entry into chat
+    verifyPlayerJoinedEvent(chatterPlayerJoinedEvents, CHATTER);
+    // wait for moderator to receive message that chatter joined
+    waitForMessage(modPlayerJoinedEvents, 2);
+    // moderator is notified that chatter has joined
+    assertThat(
+        modPlayerJoinedEvents.get(1),
+        is(
+            ChatParticipant.builder()
+                .playerName(CHATTER_NAME)
+                .isModerator(true)
+                .status("")
+                .build()));
+    // moderator should *not* receive a connected event when chatter joins
+    assertThat(modConnectedEvents, hasSize(1));
+  }
+
+  private static void verifyConnectedPlayers(
+      final List<Collection<ChatParticipant>> connectedEvents,
+      final ChatParticipant... participants) {
+    waitForMessage(connectedEvents);
+    assertThat(connectedEvents.get(0), hasItems(participants));
+  }
+
+  private static void verifyPlayerJoinedEvent(
+      final List<ChatParticipant> playerJoinedEvents, final ChatParticipant expectedPlayer) {
+    waitForMessage(playerJoinedEvents);
+    assertThat(playerJoinedEvents.get(0), is(expectedPlayer));
+  }
+
+  private void chatterChats() {
+    // chatter chats
+    chatter.sendChatMessage(MESSAGE);
+    // moderator should receive chat message from chatter
+    verifyChatMessageEvent(modMessageEvents, new ChatMessage(CHATTER_NAME, MESSAGE));
+    // chatter should receive their own chat message
+    verifyChatMessageEvent(chatterMessageEvents, new ChatMessage(CHATTER_NAME, MESSAGE));
+  }
+
+  private static void verifyChatMessageEvent(
+      final List<ChatMessage> chatMessageEvents, final ChatMessage expectedChatMessage) {
+    waitForMessage(chatMessageEvents);
+    assertThat(chatMessageEvents.get(0), is(expectedChatMessage));
+  }
+
+  private void chatterSlapsMod() {
+    // chatter slaps mod
+    chatter.slapPlayer(MODERATOR_NAME);
+    // moderator is notified of the slap
+    waitForMessage(modPlayerSlappedEvents);
+
+    final PlayerSlapped moderatorSlapped =
+        PlayerSlapped.builder().slapper(CHATTER_NAME).slapped(MODERATOR_NAME).build();
+
+    assertThat(modPlayerSlappedEvents.get(0), is(moderatorSlapped));
+    // chatter is notified of the slap
+    waitForMessage(chatterPlayerSlappedEvents);
+    assertThat(chatterPlayerSlappedEvents.get(0), is(moderatorSlapped));
+  }
+
+  private void chatterUpdatesStatus() {
+
+    // chatter updates their status
+    chatter.updateStatus(STATUS);
+    // moderator is notified of the status update
+    waitForMessage(modPlayerStatusEvents);
+    assertThat(modPlayerStatusEvents.get(0), is(new StatusUpdate(CHATTER_NAME, STATUS)));
+    waitForMessage(chatterPlayerStatusEvents);
+    assertThat(chatterPlayerStatusEvents.get(0), is(new StatusUpdate(CHATTER_NAME, STATUS)));
+
+    // chatter is notified of their own status update
+
+  }
+
+  private void chatterLeaves() {
+    // chatter disconnects
+    chatter.close();
+    // chatter is disconnected before they can be notified of their own disconnect
+    assertThat(chatterPlayerLeftEvents, empty());
+
+    // moderator is notified chatter has left
+    waitForMessage(modPlayerLeftEvents);
+    assertThat(modPlayerLeftEvents.get(0), is(CHATTER_NAME));
+  }
+
+  private static <T> void waitForMessage(final Collection<T> messageBuffer) {
+    waitForMessage(messageBuffer, 1);
+  }
+
+  /** Does a busy wait loop until the given collection is at least a given size. */
+  private static <T> void waitForMessage(final Collection<T> messageBuffer, final int minCount) {
+    Awaitility.await()
+        .atMost(MESSAGE_TIMEOUT, TimeUnit.MILLISECONDS)
+        .until(() -> messageBuffer.size() >= minCount);
+  }
+}

--- a/integration-testing/src/test/java/org/triplea/http/server/LobbyChatIntegrationTest.java
+++ b/integration-testing/src/test/java/org/triplea/http/server/LobbyChatIntegrationTest.java
@@ -21,7 +21,6 @@ import org.triplea.http.client.lobby.chat.events.server.ChatMessage;
 import org.triplea.http.client.lobby.chat.events.server.PlayerSlapped;
 import org.triplea.http.client.lobby.chat.events.server.StatusUpdate;
 import org.triplea.server.http.DropwizardTest;
-import org.triplea.test.common.Integration;
 
 /**
  * End-to-end test where we go through a chat sequence exercising all chat features. Runs through

--- a/integration-testing/src/test/java/org/triplea/http/server/LobbyWebsocketClientTest.java
+++ b/integration-testing/src/test/java/org/triplea/http/server/LobbyWebsocketClientTest.java
@@ -1,11 +1,11 @@
 package org.triplea.http.server;
 
+import static org.awaitility.Awaitility.await;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import java.net.URI;
 import java.util.concurrent.TimeUnit;
-import org.awaitility.Awaitility;
 import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.handshake.ServerHandshake;
 import org.junit.jupiter.api.DisplayName;
@@ -38,13 +38,16 @@ class LobbyWebsocketClientTest extends DropwizardTest {
     assertThat(client.isOpen(), is(false));
     client.connect();
 
-    Awaitility.await().atMost(1, TimeUnit.SECONDS).until(client::isOpen);
+    await().pollDelay(10, TimeUnit.MILLISECONDS).atMost(1, TimeUnit.SECONDS).until(client::isOpen);
     client.send("sending! Just to make sure there are no exception here.");
 
     // small wait to process any responses
     Thread.sleep(10);
 
     client.close();
-    Awaitility.await().atMost(100, TimeUnit.MILLISECONDS).until(() -> !client.isOpen());
+    await()
+        .pollDelay(10, TimeUnit.MILLISECONDS)
+        .atMost(100, TimeUnit.MILLISECONDS)
+        .until(() -> !client.isOpen());
   }
 }

--- a/integration-testing/src/test/java/org/triplea/http/server/LobbyWebsocketClientTest.java
+++ b/integration-testing/src/test/java/org/triplea/http/server/LobbyWebsocketClientTest.java
@@ -1,0 +1,50 @@
+package org.triplea.http.server;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
+import org.java_websocket.client.WebSocketClient;
+import org.java_websocket.handshake.ServerHandshake;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.triplea.http.client.lobby.chat.LobbyChatClient;
+import org.triplea.server.http.DropwizardTest;
+
+class LobbyWebsocketClientTest extends DropwizardTest {
+
+  @Test
+  @DisplayName("Verify basic websocket operations: open, send, close")
+  void verifyConnectivity() throws Exception {
+    final URI websocketUri = URI.create(localhost + LobbyChatClient.WEBSOCKET_PATH);
+
+    final WebSocketClient client =
+        new WebSocketClient(websocketUri) {
+          @Override
+          public void onOpen(final ServerHandshake serverHandshake) {}
+
+          @Override
+          public void onMessage(final String message) {}
+
+          @Override
+          public void onClose(final int code, final String reason, final boolean remote) {}
+
+          @Override
+          public void onError(final Exception ex) {}
+        };
+
+    assertThat(client.isOpen(), is(false));
+    client.connect();
+
+    Awaitility.await().atMost(1, TimeUnit.SECONDS).until(client::isOpen);
+    client.send("sending! Just to make sure there are no exception here.");
+
+    // small wait to process any responses
+    Thread.sleep(10);
+
+    client.close();
+    Awaitility.await().atMost(100, TimeUnit.MILLISECONDS).until(() -> !client.isOpen());
+  }
+}

--- a/integration-testing/src/test/java/org/triplea/server/http/DropwizardTest.java
+++ b/integration-testing/src/test/java/org/triplea/server/http/DropwizardTest.java
@@ -18,8 +18,8 @@ import org.triplea.test.common.Integration;
 @ExtendWith(DBUnitExtension.class)
 @ExtendWith(DropwizardTest.DropwizardServerExtension.class)
 @SuppressWarnings("PrivateConstructorForUtilityClass")
-abstract class DropwizardTest {
-  final URI localhost = URI.create("http://localhost:8080");
+public abstract class DropwizardTest {
+  protected final URI localhost = URI.create("http://localhost:8080");
 
   /**
    * Extension to start a drop wizard server before all tests and then shuts it down afterwards.


### PR DESCRIPTION
1. Add a test to verify websocket server can be launched and we can
   use an out-of-the-box client to connect to it. Verify basic
   actions like send text and closing the connection.
2. Add an acceptance test for chat, connect to the chat websocket
   and simulate two chatters connecting and exercise all chat
   functionality (eg: set status, slap, send messages).


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[x] Other: tests  <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[x] No manual testing done
[] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes
- would like review to mostly focus on how easy it is to understand the tests 

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

