### PR TITLE
[Mac] Fix about handler not being reset back after exiting a map.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MacOsIntegration.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MacOsIntegration.java
@@ -19,6 +19,11 @@ public final class MacOsIntegration {
     Desktop.getDesktop().setAboutHandler(aboutEvent -> handler.run());
   }
 
+  /** Resets the about handler to the default one for the application. */
+  public static void clearAboutHandler() {
+    Desktop.getDesktop().setAboutHandler(null);
+  }
+
   /** Sets the specified open URI handler to the application. */
   public static void setOpenUriHandler(final Consumer<URI> handler) {
     checkNotNull(handler);

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -30,6 +30,7 @@ import games.strategy.engine.framework.IGame;
 import games.strategy.engine.framework.LocalPlayers;
 import games.strategy.engine.framework.ServerGame;
 import games.strategy.engine.framework.startup.ui.InGameLobbyWatcherWrapper;
+import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.engine.history.HistoryNode;
 import games.strategy.engine.history.Renderable;
 import games.strategy.engine.history.Round;
@@ -880,6 +881,11 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
       ((ClientGame) game).shutDown();
       // an ugly hack, we need a better way to get the main frame
       new Thread(GameRunner::clientLeftGame).start();
+    }
+    if (SystemProperties.isMac()) {
+      // When leaving a game, reset the about handler to the default one, rather
+      // than the map-specific one set by HelpMenu.
+      MacOsIntegration.clearAboutHandler();
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/triplea-game/triplea/issues/4517

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[X] Bug fix: https://github.com/triplea-game/triplea/issues/4517
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[] No manual testing done
[X] Manually tested

Exited a game and checked the about dialog.
