### PR TITLE
Use Mockito timeout in websocket test instead of sleep

### DIFF
--- a/http-clients/src/test/java/org/triplea/http/client/web/socket/GenericWebSocketClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/web/socket/GenericWebSocketClientTest.java
@@ -1,5 +1,6 @@
 package org.triplea.http.client.web.socket;
 
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 
 import com.google.gson.Gson;
@@ -75,13 +76,9 @@ class GenericWebSocketClientTest {
   }
 
   @Test
-  void send() throws Exception {
+  void send() {
     genericWebSocketClient.send(EXAMPLE_CLIENT_MESSAGE);
 
-    // small delay to allow async message send to complete
-    // TODO: Project#12 use awaitility here
-    Thread.sleep(20);
-
-    verify(webSocketClient).sendMessage(gson.toJson(EXAMPLE_CLIENT_MESSAGE));
+    verify(webSocketClient, timeout(150)).sendMessage(gson.toJson(EXAMPLE_CLIENT_MESSAGE));
   }
 }


### PR DESCRIPTION
Previously we had a manual sleep that was set to be as short as possible but 'long' enough
to still be reliable. Turns out the 10ms sleep was extremely optimistic.

We can instead use Mockito 'timeout' to give a longer wait window and make this test
more deterministic. With some manual test, test runtime is between 30ms and 80ms.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[x] Other:  test reliability improvement <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[] No manual testing done
[x] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->
- Ran the test a number of times to verify expected runtimes


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

