### PR TITLE
Deprecate PlayerNameValidation methods & reduce dependency on magic l…

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/PlayerNameValidation.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/PlayerNameValidation.java
@@ -4,8 +4,13 @@ import com.google.common.annotations.VisibleForTesting;
 import lombok.NoArgsConstructor;
 import org.triplea.lobby.common.LobbyConstants;
 
-/** Utility class to verify player names. */
+/**
+ * Utility class to verify player names.
+ *
+ * @deprecated Use PlayerName.validate and PlayerName.isValid instead
+ */
 @NoArgsConstructor
+@Deprecated
 public final class PlayerNameValidation {
   @VisibleForTesting static final int MAX_LENGTH = 40;
   private static final int MIN_LENGTH = 3;
@@ -20,14 +25,6 @@ public final class PlayerNameValidation {
    * @return Error message if username is not valid, otherwise returns an error message.
    */
   public static String validate(final String username) {
-    return username != null
-            && username.toLowerCase().contains(LobbyConstants.LOBBY_WATCHER_NAME.toLowerCase())
-        ? LobbyConstants.LOBBY_WATCHER_NAME + " cannot be part of a name"
-        : serverSideValidate(username);
-  }
-
-  /** Less restrictive validation intended to be done on server side. */
-  public static String serverSideValidate(final String username) {
     if ((username == null) || (username.length() < MIN_LENGTH)) {
       return "Name is too short (minimum " + MIN_LENGTH + " characters)";
     } else if (username.length() > MAX_LENGTH) {

--- a/game-core/src/main/java/games/strategy/net/PlayerNameAssigner.java
+++ b/game-core/src/main/java/games/strategy/net/PlayerNameAssigner.java
@@ -5,7 +5,6 @@ import games.strategy.engine.lobby.PlayerNameValidation;
 import java.util.Collection;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.triplea.lobby.common.LobbyConstants;
 
 /** Utility class that will assign a name to a newly logging in player. */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
@@ -22,16 +21,14 @@ public final class PlayerNameAssigner {
    */
   public static String assignName(
       final String desiredName, final String mac, final Collection<String> loggedInNames) {
-    Preconditions.checkArgument(PlayerNameValidation.serverSideValidate(desiredName) == null);
+    Preconditions.checkArgument(PlayerNameValidation.validate(desiredName) == null);
     Preconditions.checkNotNull(mac);
     Preconditions.checkNotNull(loggedInNames);
 
     String currentName = desiredName;
 
-    if (!isBotName(desiredName)) {
-      if (currentName.length() > 50) {
-        currentName = currentName.substring(0, 50);
-      }
+    if (currentName.length() > 50) {
+      currentName = currentName.substring(0, 50);
     }
 
     final String originalName = currentName;
@@ -39,9 +36,5 @@ public final class PlayerNameAssigner {
       currentName = originalName + " (" + i + ")";
     }
     return currentName;
-  }
-
-  private static boolean isBotName(final String desiredName) {
-    return desiredName.startsWith("Bot") && desiredName.endsWith(LobbyConstants.LOBBY_WATCHER_NAME);
   }
 }

--- a/game-core/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
+++ b/game-core/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
@@ -105,7 +105,7 @@ public class ServerQuarantineConversation extends QuarantineConversation {
                             remoteName,
                             remoteMac,
                             channel.socket().getRemoteSocketAddress()))
-                    .orElseGet(() -> PlayerNameValidation.serverSideValidate(remoteName));
+                    .orElseGet(() -> PlayerNameValidation.validate(remoteName));
             if (error != null && !error.equals(CHANGE_PASSWORD)) {
               step = Step.ACK_ERROR;
               send(error);

--- a/game-core/src/test/java/games/strategy/engine/lobby/PlayerNameValidationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/PlayerNameValidationTest.java
@@ -45,28 +45,25 @@ class PlayerNameValidationTest {
                   not(emptyString()));
             });
 
-    Arrays.asList(LobbyConstants.LOBBY_WATCHER_NAME, LobbyConstants.ADMIN_USERNAME)
-        .forEach(
-            invalidNamePart -> {
-              assertThat(
-                  "user names cannot contain anything from the forbidden name list",
-                  PlayerNameValidation.isValid(invalidNamePart),
-                  is(false));
-              assertThat(
-                  "verify we are doing a contains match to make sure "
-                      + "user name does not contain anything forbidden.",
-                  PlayerNameValidation.isValid("xyz" + invalidNamePart + "abc"),
-                  is(false));
+    final String invalidNamePart = LobbyConstants.ADMIN_USERNAME;
+    assertThat(
+        "user names cannot contain anything from the forbidden name list",
+        PlayerNameValidation.isValid(invalidNamePart),
+        is(false));
+    assertThat(
+        "verify we are doing a contains match to make sure "
+            + "user name does not contain anything forbidden.",
+        PlayerNameValidation.isValid("xyz" + invalidNamePart + "abc"),
+        is(false));
 
-              assertThat(
-                  "case insensitive on our matches.",
-                  PlayerNameValidation.isValid(invalidNamePart.toUpperCase()),
-                  is(false));
-              assertThat(
-                  "case insensitive on our matches.",
-                  PlayerNameValidation.isValid(invalidNamePart.toLowerCase()),
-                  is(false));
-            });
+    assertThat(
+        "case insensitive on our matches.",
+        PlayerNameValidation.isValid(invalidNamePart.toUpperCase()),
+        is(false));
+    assertThat(
+        "case insensitive on our matches.",
+        PlayerNameValidation.isValid(invalidNamePart.toLowerCase()),
+        is(false));
   }
 
   @Test

--- a/lobby/src/main/java/org/triplea/lobby/server/login/LobbyLoginValidator.java
+++ b/lobby/src/main/java/org/triplea/lobby/server/login/LobbyLoginValidator.java
@@ -140,9 +140,9 @@ public final class LobbyLoginValidator implements ILoginValidator {
       }
       final String hostName =
           username.substring(0, username.indexOf(LobbyConstants.LOBBY_WATCHER_NAME));
-      return PlayerNameValidation.serverSideValidate(hostName);
+      return PlayerNameValidation.validate(hostName);
     } else {
-      return PlayerNameValidation.serverSideValidate(username);
+      return PlayerNameValidation.validate(username);
     }
   }
 


### PR DESCRIPTION
With game listings moved to Http-Server, the updated system design
will not rely on naming conventions to identify automated hosts.

With this in mind, validation between server side and client side
becomes unified and can be the same logic.

The validation logic between PlayerName and PlayerNameValidation
then also becomes identical, we should stop using PlayerNameValidation
in favor of PlayerName. PlayerName can be accessed from multiple
projects, hence that is the favored copy.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[x] No manual testing done
[] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

