### PR TITLE
Cancel game polling on http lobby disconnect

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
@@ -77,7 +77,7 @@ class LobbyGameTableModel extends AbstractTableModel {
                 new GamePollerTask(
                     lobbyGameBroadcaster,
                     gameListingSupplier(),
-                    () -> httpLobbyClient.getGameListingClient().fetchGameListing(),
+                    httpLobbyClient.getGameListingClient()::fetchGameListing,
                     errorMessageReporter));
     httpLobbyClient.addConnectionLostListener(msg -> gamePoller.cancel());
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
@@ -79,6 +79,7 @@ class LobbyGameTableModel extends AbstractTableModel {
                     gameListingSupplier(),
                     () -> httpLobbyClient.getGameListingClient().fetchGameListing(),
                     errorMessageReporter));
+    httpLobbyClient.addConnectionLostListener(msg -> gamePoller.cancel());
 
     try {
       final Map<String, GameDescription> games =


### PR DESCRIPTION
1. This update kills game polling when there is a disconnect event with
the lobby. This can happen for example when a user is removed by moderator.

2. Quick cleanup to replace lambda for method reference

<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[] No manual testing done
[x] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->

Tested as part of another branch with user being removed by ban.

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

