### PR TITLE
Add PlayerChatId to ChatParticipant

### DIFF
--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/ChatParticipant.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/ChatParticipant.java
@@ -9,6 +9,7 @@ import lombok.Getter;
 import lombok.NonNull;
 import lombok.Setter;
 import lombok.ToString;
+import org.triplea.domain.data.PlayerChatId;
 import org.triplea.domain.data.PlayerName;
 
 @Builder
@@ -17,8 +18,18 @@ import org.triplea.domain.data.PlayerName;
 @ToString
 public class ChatParticipant implements Serializable {
   private static final long serialVersionUID = 7103177780407531008L;
+
   @NonNull private final PlayerName playerName;
+  /**
+   * Identifier attached to players when joining chat so that front-end can pass values to backend
+   * to identify players, specifically useful example for moderator actions.
+   */
+  // TODO: Project#12 make playerChatId @Nonnull
+  private final PlayerChatId playerChatId;
+  /** True if the player has moderator privileges. */
   private final boolean isModerator;
+
+  /** Status is custom text set by players, eg: "AFK" or "Looking for a game". */
   @Setter @Nullable private String status;
 
   public String getStatus() {

--- a/http-server/src/main/java/org/triplea/server/lobby/chat/ChatParticipantAdapter.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/chat/ChatParticipantAdapter.java
@@ -1,6 +1,7 @@
 package org.triplea.server.lobby.chat;
 
 import java.util.function.Function;
+import org.triplea.domain.data.PlayerChatId;
 import org.triplea.domain.data.PlayerName;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
 import org.triplea.lobby.server.db.data.UserRole;
@@ -14,6 +15,7 @@ public class ChatParticipantAdapter implements Function<UserWithRoleRecord, Chat
         .isModerator(
             userWithRoleRecord.getRole().equals(UserRole.ADMIN)
                 || userWithRoleRecord.getRole().equals(UserRole.MODERATOR))
+        .playerChatId(PlayerChatId.newId())
         .build();
   }
 }

--- a/http-server/src/test/java/org/triplea/server/lobby/chat/ChatParticipantAdapterTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/chat/ChatParticipantAdapterTest.java
@@ -2,7 +2,10 @@ package org.triplea.server.lobby.chat;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
 
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.triplea.domain.data.PlayerName;
@@ -15,8 +18,20 @@ class ChatParticipantAdapterTest {
   private static final String USERNAME = "username-value";
   private final ChatParticipantAdapter chatParticipantAdapter = new ChatParticipantAdapter();
 
+  @Test
+  @DisplayName("Verify player chat Id will be generated")
+  void playerChatIdIsGenerated() {
+    final var userWithRoleRecord =
+        UserWithRoleRecord.builder().username(USERNAME).role(UserRole.PLAYER).build();
+
+    final ChatParticipant result = chatParticipantAdapter.apply(userWithRoleRecord);
+
+    assertThat(result.getPlayerChatId(), notNullValue());
+  }
+
   @ParameterizedTest
   @ValueSource(strings = {UserRole.ADMIN, UserRole.MODERATOR})
+  @DisplayName("Verify moderator flag is set for moderator user roles")
   void moderatorUsers(final String moderatorUserRole) {
     final var userWithRoleRecord = givenUserRecordWithRole(moderatorUserRole);
 
@@ -37,6 +52,7 @@ class ChatParticipantAdapterTest {
 
   @ParameterizedTest
   @ValueSource(strings = {UserRole.ANONYMOUS, UserRole.PLAYER})
+  @DisplayName("Verify moderator flag is false for non-moderator roles")
   void nonModeratorUsers(final String notModeratorUserRole) {
     final var userWithRoleRecord = givenUserRecordWithRole(notModeratorUserRole);
 


### PR DESCRIPTION
First steps to adding an identifier for chat participants. Later
will be used to identify players and specifically for executing
moderator actions.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[x] No manual testing done
[] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

