### PR TITLE
Fix flaky test with Mockito.timeout

### DIFF
--- a/http-clients/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
@@ -2,6 +2,7 @@ package org.triplea.http.client.web.socket;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -80,15 +81,13 @@ class WebSocketConnectionTest {
     }
 
     @Test
-    void close() throws Exception {
+    void close() {
       when(webSocketClient.getConnection()).thenReturn(webSocket);
       when(webSocketClient.isOpen()).thenReturn(true);
 
       webSocketConnection.close();
 
-      // small delay to allow async 'close' to complete
-      Thread.sleep(10);
-      verify(webSocket).close();
+      verify(webSocket, timeout(150)).close();
     }
 
     @Test


### PR DESCRIPTION
Replace a sleep wait for a mockito timeout. The mockito timeout
is a larger value and should still allow the test to still complete
reasonably fast and be more deterministic.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[] No manual testing done
[x] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->

Ran test manually to verify no significant difference in runtime.

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

