### PR TITLE
Isolate OutOfDate UI logic

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/auto/update/EngineVersionCheck.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/update/EngineVersionCheck.java
@@ -5,18 +5,25 @@ import com.google.common.base.Splitter;
 import games.strategy.engine.ClientContext;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.settings.GameSetting;
+import java.io.IOException;
+import java.net.URL;
 import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.List;
+import java.util.Properties;
 import java.util.logging.Level;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
+import lombok.experimental.UtilityClass;
 import lombok.extern.java.Log;
 import org.triplea.swing.EventThreadJOptionPane;
+import org.triplea.util.Version;
 
 @Log
+@UtilityClass
 final class EngineVersionCheck {
-  private EngineVersionCheck() {}
+  private static final String TRIPLEA_VERSION_LINK =
+      "https://raw.githubusercontent.com/triplea-game/triplea/master/latest_version.properties";
 
   static void checkForLatestEngineVersionOut() {
     try {
@@ -24,20 +31,32 @@ final class EngineVersionCheck {
         return;
       }
 
-      final EngineVersionProperties latestEngineOut = new EngineVersionProperties();
+      final Version latestVersionOut =
+          new Version(
+              getProperties().getProperty("LATEST", ClientContext.engineVersion().toString()));
 
-      if (latestEngineOut.getLatestVersionOut().isGreaterThan(ClientContext.engineVersion())) {
+      if (latestVersionOut.isGreaterThan(ClientContext.engineVersion())) {
         SwingUtilities.invokeLater(
             () ->
                 EventThreadJOptionPane.showMessageDialog(
                     null,
-                    latestEngineOut.getOutOfDateComponent(),
+                    OutOfDateDialog.getOutOfDateComponent(latestVersionOut),
                     "Please Update TripleA",
                     JOptionPane.INFORMATION_MESSAGE));
       }
     } catch (final Exception e) {
       log.log(Level.SEVERE, "Error while checking for engine updates", e);
     }
+  }
+
+  private static Properties getProperties() {
+    final Properties props = new Properties();
+    try {
+      props.load(new URL(TRIPLEA_VERSION_LINK).openStream());
+    } catch (final IOException e) {
+      log.info("Failed to get TripleA latest version file, check internet connection, error: " + e);
+    }
+    return props;
   }
 
   private static boolean isEngineUpdateCheckRequired() {

--- a/game-core/src/main/java/games/strategy/engine/auto/update/OutOfDateDialog.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/update/OutOfDateDialog.java
@@ -5,80 +5,48 @@ import games.strategy.triplea.UrlConstants;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
-import java.io.IOException;
-import java.net.URL;
-import java.util.Properties;
 import javax.swing.BorderFactory;
 import javax.swing.JEditorPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.event.HyperlinkEvent;
 import javax.swing.event.HyperlinkListener;
-import lombok.extern.java.Log;
+import lombok.experimental.UtilityClass;
 import org.triplea.awt.OpenFileUtility;
 import org.triplea.util.Version;
 
-@Log
-class EngineVersionProperties {
-  private static final String TRIPLEA_VERSION_LINK =
-      "https://raw.githubusercontent.com/triplea-game/triplea/master/latest_version.properties";
-  private final Version latestVersionOut;
-  private final String link;
-  private final String changelogLink;
+@UtilityClass
+class OutOfDateDialog {
 
-  EngineVersionProperties() {
-    this(getProperties());
-  }
-
-  private EngineVersionProperties(final Properties props) {
-    latestVersionOut =
-        new Version(props.getProperty("LATEST", ClientContext.engineVersion().toString()));
-    link = props.getProperty("LINK", UrlConstants.DOWNLOAD_WEBSITE);
-    changelogLink = props.getProperty("CHANGELOG", UrlConstants.RELEASE_NOTES);
-  }
-
-  private static Properties getProperties() {
-    final Properties props = new Properties();
-    try {
-      props.load(new URL(TRIPLEA_VERSION_LINK).openStream());
-    } catch (final IOException e) {
-      log.info("Failed to get TripleA latest version file, check internet connection, error: " + e);
-    }
-    return props;
-  }
-
-  public Version getLatestVersionOut() {
-    return latestVersionOut;
-  }
-
-  private String getOutOfDateMessage() {
+  // TODO: METHOD-ORDERING re-order methods to depth-first ordering
+  private static String getOutOfDateMessage(final Version latestVersionOut) {
     return "<html>"
         + "<h2>A new version of TripleA is out.  Please Update TripleA!</h2>"
         + "<br />Your current version: "
         + ClientContext.engineVersion()
         + "<br />Latest version available for download: "
-        + getLatestVersionOut()
+        + latestVersionOut
         + "<br /><br />Click to download: <a class=\"external\" href=\""
-        + link
+        + UrlConstants.DOWNLOAD_WEBSITE
         + "\">"
-        + link
+        + UrlConstants.DOWNLOAD_WEBSITE
         + "</a>"
         + "</html>";
   }
 
-  private String getOutOfDateReleaseUpdates() {
+  private static String getOutOfDateReleaseUpdates() {
     return "<html><body>"
         + "Link to full Change Log:<br /><a class=\"external\" href=\""
-        + changelogLink
+        + UrlConstants.RELEASE_NOTES
         + "\">"
-        + changelogLink
+        + UrlConstants.RELEASE_NOTES
         + "</a><br />"
         + "</body></html>";
   }
 
-  Component getOutOfDateComponent() {
+  static Component getOutOfDateComponent(final Version latestVersionOut) {
     final JPanel panel = new JPanel(new BorderLayout());
-    final JEditorPane intro = new JEditorPane("text/html", getOutOfDateMessage());
+    final JEditorPane intro = new JEditorPane("text/html", getOutOfDateMessage(latestVersionOut));
     intro.setEditable(false);
     intro.setOpaque(false);
     intro.setBorder(BorderFactory.createEmptyBorder());


### PR DESCRIPTION
1. Rename class: EngineVersionProperties->OutOfDateDialog.java
2. Replace property values in OutOfDateDialog.java with equivalent UriConstants.
   Turns out most of the data from latest_engine.properties we already have
   hardcoded as constants, everything except for the 'latest version field'
3. Push 'latest version field' up to caller, EngineVersionCheck


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[x] No manual testing done
[] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

