### PR TITLE
Extract ShowDialog with links to generic method

### DIFF
--- a/game-core/src/main/java/games/strategy/debug/error/reporting/ConfirmationDialogController.java
+++ b/game-core/src/main/java/games/strategy/debug/error/reporting/ConfirmationDialogController.java
@@ -3,14 +3,10 @@ package games.strategy.debug.error.reporting;
 import feign.FeignException;
 import games.strategy.triplea.UrlConstants;
 import java.net.URI;
-import javax.swing.JEditorPane;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
-import javax.swing.border.EmptyBorder;
-import javax.swing.event.HyperlinkEvent;
-import org.triplea.awt.OpenFileUtility;
-import org.triplea.swing.jpanel.JPanelBuilder;
+import org.triplea.swing.SwingComponents;
+import org.triplea.swing.SwingComponents.DialogWithLinksParams;
+import org.triplea.swing.SwingComponents.DialogWithLinksTypes;
 
 /**
  * This controller is responsible for showing success/failure confirmation dialogs after an error
@@ -24,28 +20,16 @@ final class ConfirmationDialogController {
   }
 
   private static void doShowFailureConfirmation(final FeignException response) {
-    final JEditorPane editorPane =
-        new JEditorPane(
-            "text/html",
-            "Failure uploading report, please try again or <a href='"
-                + UrlConstants.GITHUB_ISSUES
-                + "'>contact support</a>.<br/><br/>"
-                + response.getMessage());
-    editorPane.setEditable(false);
-    editorPane.setOpaque(false);
-    editorPane.setBorder(new EmptyBorder(10, 0, 20, 0));
-    editorPane.addHyperlinkListener(
-        e -> {
-          if (HyperlinkEvent.EventType.ACTIVATED.equals(e.getEventType())) {
-            OpenFileUtility.openUrl(e.getURL().toString());
-          }
-        });
-
-    final JPanel messageToShow = new JPanelBuilder().border(10).add(editorPane).build();
-
-    // parentComponent == null to avoid pop-up from appearing behind other windows
-    JOptionPane.showMessageDialog(
-        null, messageToShow, "Report Upload Failed", JOptionPane.ERROR_MESSAGE);
+    SwingComponents.showDialogWithLinks(
+        DialogWithLinksParams.builder()
+            .title("Report Upload Failed")
+            .dialogType(DialogWithLinksTypes.ERROR)
+            .dialogText(
+                "Failure uploading report, please try again or <a href='"
+                    + UrlConstants.GITHUB_ISSUES
+                    + "'>contact support</a>.<br/><br/>"
+                    + response.getMessage())
+            .build());
   }
 
   static void showSuccessConfirmation(final URI reportLinkCreated) {
@@ -53,25 +37,14 @@ final class ConfirmationDialogController {
   }
 
   private static void doShowSuccessConfirmation(final URI reportLinkCreated) {
-    final JEditorPane editorPane =
-        new JEditorPane(
-            "text/html",
-            String.format(
-                "Upload success, report created:<br/><br/><a href='%s'>%s</a>",
-                reportLinkCreated, reportLinkCreated));
-    editorPane.setEditable(false);
-    editorPane.setOpaque(false);
-    editorPane.addHyperlinkListener(
-        e -> {
-          if (HyperlinkEvent.EventType.ACTIVATED.equals(e.getEventType())) {
-            OpenFileUtility.openUrl(e.getURL().toString());
-          }
-        });
-
-    final JPanel messageToShow = new JPanelBuilder().border(10).add(editorPane).build();
-
-    // parentComponent == null to avoid pop-up from appearing behind other windows
-    JOptionPane.showMessageDialog(
-        null, messageToShow, "Report Uploaded Successfully", JOptionPane.INFORMATION_MESSAGE);
+    SwingComponents.showDialogWithLinks(
+        DialogWithLinksParams.builder()
+            .title("Report Uploaded Successfully")
+            .dialogType(DialogWithLinksTypes.INFO)
+            .dialogText(
+                String.format(
+                    "Upload success, report created:<br/><br/><a href='%s'>%s</a>",
+                    reportLinkCreated, reportLinkCreated))
+            .build());
   }
 }

--- a/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
+++ b/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
@@ -20,6 +20,7 @@ import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import javax.annotation.Nonnull;
 import javax.swing.AbstractAction;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -33,6 +34,7 @@ import javax.swing.JEditorPane;
 import javax.swing.JFileChooser;
 import javax.swing.JFrame;
 import javax.swing.JOptionPane;
+import javax.swing.JPanel;
 import javax.swing.JRadioButton;
 import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
@@ -41,9 +43,14 @@ import javax.swing.ListModel;
 import javax.swing.RootPaneContainer;
 import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
+import javax.swing.border.EmptyBorder;
+import javax.swing.event.HyperlinkEvent;
 import javax.swing.filechooser.FileFilter;
 import javax.swing.filechooser.FileNameExtensionFilter;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import org.triplea.awt.OpenFileUtility;
+import org.triplea.swing.jpanel.JPanelBuilder;
 
 /**
  * Wrapper/utility class to give Swing components a nicer API. This class is to help extract pure UI
@@ -464,5 +471,44 @@ public final class SwingComponents {
   public static void showError(
       final Component parentWindow, final String title, final String message) {
     JOptionPane.showMessageDialog(parentWindow, message, title, JOptionPane.ERROR_MESSAGE);
+  }
+
+  /** Displays a pop-up dialog with clickable HTML links. */
+  public static void showDialogWithLinks(final DialogWithLinksParams params) {
+    final JEditorPane editorPane = new JEditorPane("text/html", params.dialogText);
+    editorPane.setEditable(false);
+    editorPane.setOpaque(false);
+    editorPane.setBorder(new EmptyBorder(10, 0, 20, 0));
+    editorPane.addHyperlinkListener(
+        e -> {
+          if (HyperlinkEvent.EventType.ACTIVATED.equals(e.getEventType())) {
+            OpenFileUtility.openUrl(e.getURL().toString());
+          }
+        });
+
+    final JPanel messageToShow = new JPanelBuilder().border(10).add(editorPane).build();
+
+    // parentComponent == null to avoid pop-up from appearing behind other windows
+    final Component parentComponent = null;
+    JOptionPane.showMessageDialog(
+        parentComponent,
+        messageToShow,
+        params.title,
+        Optional.ofNullable(params.dialogType).orElse(DialogWithLinksTypes.INFO).optionPaneFlag);
+  }
+
+  @Builder
+  public static class DialogWithLinksParams {
+    @Nonnull private final String title;
+    @Nonnull private final String dialogText;
+    private DialogWithLinksTypes dialogType;
+  }
+
+  @AllArgsConstructor
+  public enum DialogWithLinksTypes {
+    INFO(JOptionPane.INFORMATION_MESSAGE),
+    ERROR(JOptionPane.ERROR_MESSAGE);
+
+    private final int optionPaneFlag;
   }
 }


### PR DESCRIPTION
This update extracts swing specific code that allows
for clickable HTML links to a utility method in 'SwingComponents'

This sets up for future re-use of the same utility method.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[x] No manual testing done
[] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

