### PR TITLE
Add additional API to ContentReader

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/ContentReader.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/ContentReader.java
@@ -54,7 +54,7 @@ public final class ContentReader {
     checkNotNull(action);
 
     try {
-      return Optional.of(downloadInternal(uri, action::apply));
+      return Optional.of(downloadInternal(uri, action));
     } catch (final IOException e) {
       log.log(Level.SEVERE, "Error while downloading file", e);
       return Optional.empty();
@@ -62,8 +62,7 @@ public final class ContentReader {
   }
 
   // TODO: METHOD-ORDERING re-order methods to depth-first ordering
-  @VisibleForTesting
-  static <T> T download(
+  private static <T> T download(
       final String uri,
       final ThrowingFunction<InputStream, T, IOException> action,
       final CloseableHttpClient client)
@@ -71,7 +70,7 @@ public final class ContentReader {
     return action.apply(readInputStream(uri, client));
   }
 
-  static InputStream readInputStream(final String uri, final CloseableHttpClient client)
+  private static InputStream readInputStream(final String uri, final CloseableHttpClient client)
       throws IOException {
 
     final HttpGet request = new HttpGet(uri);

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/ContentReader.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/ContentReader.java
@@ -3,7 +3,6 @@ package games.strategy.engine.framework.map.download;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.annotations.VisibleForTesting;
 import games.strategy.engine.framework.system.HttpProxy;
 import java.io.File;
 import java.io.FileOutputStream;


### PR DESCRIPTION
In case a client wants to consume a downloaded InputStream,
but not necessary apply an action to it, this update adds an
API to ContentReader to return an InputStream.

This update is forward-looking, the new API will be used
in future commits.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[x] No manual testing done
[] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

