### PR TITLE
ContentReader updates

### DIFF
--- a/game-core/src/test/java/games/strategy/engine/framework/map/download/ContentReaderTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/map/download/ContentReaderTest.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.framework.map.download;
 
+import static com.google.common.base.Preconditions.checkNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
@@ -10,7 +11,9 @@ import static org.mockito.Mockito.when;
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.channels.Channels;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.apache.http.HttpEntity;
@@ -69,7 +72,24 @@ final class ContentReaderTest extends AbstractClientSettingTestCase {
     }
 
     private void downloadToFile() throws Exception {
-      new ContentReader(() -> client).downloadToFile(URI, file);
+      downloadToFile(file);
+    }
+
+    /**
+     * Downloads the resource at the specified URI to the specified file.
+     *
+     * @param file The file that will receive the resource; must not be {@code null}.
+     * @throws IOException If an error occurs during the download.
+     */
+    void downloadToFile(final File file) throws IOException {
+      checkNotNull(file);
+
+      try (FileOutputStream os = new FileOutputStream(file)) {
+        new ContentReader(() -> client)
+            .downloadInternal(
+                ContentReaderTest.URI,
+                is -> os.getChannel().transferFrom(Channels.newChannel(is), 0L, Long.MAX_VALUE));
+      }
     }
 
     private byte[] fileContent() throws Exception {


### PR DESCRIPTION
1. Update javadoc to clarify why an action is passed to the download function
   rather than returning an InputStream (answer: so that the InputStream may be
   closed without passing that responsibility to the caller)
2. Move test-only method to test, fix scopes and '@VisibleForTesting' marking


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[x] No manual testing done
[] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

