### PR TITLE
Infrastructure: Move prod configuration to template

### DIFF
--- a/http-server/configuration.yml
+++ b/http-server/configuration.yml
@@ -1,16 +1,20 @@
-githubRepo: triplea
-githubApiToken: ${GITHUB_API_TOKEN}
+## This is the dropwizard configuration for local development and tests.
+## Keep this configuration in sync with the prerelease/production configuration.
+## The deployed configuration is in 'infrastructure/ansible/.../configuration.yml.j2'
+
+githubRepo: test
+githubApiToken: test
 # if we are using any stubbing, we'll assert that this value is false.
-# this is to help guarantee that we do not accidently use test configuration in prod.
-prod: true
-logRequestAndResponses: false
-logSqlStatements: false
-bcryptSalt: ${BCRYPT_SALT}
+# this is to help guarantee that we do not accidentally use test configuration in prod.
+prod: false
+logRequestAndResponses: true
+logSqlStatements: true
+bcryptSalt: $2a$10$IhIXWg4HkQRWrZqjj9kV0u
 
 database:
   driverClass: org.postgresql.Driver
   user: lobby_user
-  password: ${POSTGRES_PASSWORD}
+  password: postgres
   url: jdbc:postgresql://localhost:5432/lobby_db
   properties:
     charSet: UTF-8

--- a/http-server/src/main/java/org/triplea/server/http/ServerApplication.java
+++ b/http-server/src/main/java/org/triplea/server/http/ServerApplication.java
@@ -56,8 +56,7 @@ import org.triplea.server.user.account.update.UpdateAccountControllerFactory;
  */
 public class ServerApplication extends Application<AppConfig> {
 
-  private static final String[] DEFAULT_ARGS =
-      new String[] {"server", "configuration.yml"};
+  private static final String[] DEFAULT_ARGS = new String[] {"server", "configuration.yml"};
   private ServerEndpointConfig chatSocketConfiguration;
 
   /**

--- a/http-server/src/main/java/org/triplea/server/http/ServerApplication.java
+++ b/http-server/src/main/java/org/triplea/server/http/ServerApplication.java
@@ -57,7 +57,7 @@ import org.triplea.server.user.account.update.UpdateAccountControllerFactory;
 public class ServerApplication extends Application<AppConfig> {
 
   private static final String[] DEFAULT_ARGS =
-      new String[] {"server", "configuration-prerelease.yml"};
+      new String[] {"server", "configuration.yml"};
   private ServerEndpointConfig chatSocketConfiguration;
 
   /**

--- a/infrastructure/ansible/roles/http_server/defaults/main.yml
+++ b/infrastructure/ansible/roles/http_server/defaults/main.yml
@@ -1,25 +1,23 @@
 http_server_user: http_server
+http_server_port: "8080"
+http_server_home_folder: "/home/{{ http_server_user }}"
+http_server_run_file: "{{ http_server_home_folder }}/run_server"
 
-http_server_folder: "/home/{{ http_server_user }}"
-
+## application level parameters
 http_server_jar: "triplea-http-server-{{ lookup('env', 'VERSION') }}.jar"
 
-http_server_port: "8080"
-
+http_server_postgres_host: "127.0.0.1"
+http_server_postgres_port: "5432"
 http_server_postgres_password: "{{ lobby_db_password }}"
 
-http_server_postgres_host: "127.0.0.1"
-
-http_server_postgres_port: "5432"
-
 http_server_error_report_github_org: "triplea-game"
-
 http_server_error_report_github_repo: "test"
-
 http_server_error_report_github_token: "test"
 
-http_server_config_file: configuration-prerelease.yml
-
-http_server_db_user: "{{ lobby_db_user}}"
-
+http_server_db_user: "{{ lobby_db_user }}"
 http_server_db_password: "{{ lobby_db_password }}"
+http_server_db_name: "{{ lobby_db_name }}"
+
+
+## TODO: encrypt all of the below variables
+http_server_bcrypt_salt: $2a$10$IhIXWg4HkQRWrZqjj9kV0u

--- a/infrastructure/ansible/roles/http_server/templates/configuration.yml.j2
+++ b/infrastructure/ansible/roles/http_server/templates/configuration.yml.j2
@@ -1,17 +1,17 @@
-githubRepo: test
-githubApiToken: ${GITHUB_API_TOKEN:-test}
+githubRepo: triplea
+githubApiToken: ${GITHUB_API_TOKEN}
 # if we are using any stubbing, we'll assert that this value is false.
 # this is to help guarantee that we do not accidently use test configuration in prod.
-prod: false
-logRequestAndResponses: true
-logSqlStatements: true
-bcryptSalt: $2a$10$IhIXWg4HkQRWrZqjj9kV0u
+prod: true
+logRequestAndResponses: false
+logSqlStatements: false
+bcryptSalt: {{ http_server_bcrypt_salt }}
 
 database:
   driverClass: org.postgresql.Driver
-  user: lobby_user
-  password: ${POSTGRES_PASSWORD:-postgres}
-  url: jdbc:postgresql://localhost:5432/lobby_db
+  user: {{ http_server_db_user }}
+  password: {{ http_server_db_user }}
+  url: jdbc:postgresql://localhost:5432/{{ http_server_db_name }}
   properties:
     charSet: UTF-8
   # the maximum amount of time to wait on an empty pool before throwing an exception

--- a/infrastructure/ansible/roles/http_server/templates/http_server.service.j2
+++ b/infrastructure/ansible/roles/http_server/templates/http_server.service.j2
@@ -3,20 +3,11 @@ Description=TripleA Http Server
 Documentation=
 
 [Service]
-WorkingDirectory={{ http_server_folder }}
+WorkingDirectory={{ http_server_home_folder }}
 User={{ http_server_user }}
 Group={{ http_server_user }}
-ExecStart={{ http_server_folder }}/run_server
+ExecStart={{ http_server_run_file }}
 Restart=always
-Environment="PORT={{ http_server_port }}"
-Environment="POSTGRES_USER={{ http_server_db_user }}"
-Environment="POSTGRES_PASSWORD={{ http_server_db_password }}"
-Environment="POSTGRES_HOST={{ http_server_postgres_host }}"
-Environment="POSTGRES_PORT={{ http_server_postgres_port }}"
-Environment="POSTGRES_DATABASE={{ lobby_db_name }}"
-Environment="ERROR_REPORTING_GITHUB_ORG={{ http_server_error_report_github_org }}"
-Environment="ERROR_REPORTING_GITHUB_REPO={{ http_server_error_report_github_repo }}"
-Environment="GITHUB_API_AUTH_TOKEN={{ http_server_error_report_github_token }}"
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- Solve problem of deploying configuration file with http-server.
  Instead of downloading configuration file with binary (jar file),
  we'll instead deploy it as a template. This also allows us
  to simplify secret management by encrypting values in the template.
  Previously we would have used environemnt variables, now we can
  deploy decrypted values directly and would only then need
  to keep track of the ansible vault password.
- Unify name of the configuration file to 'configuration.yml',
  allows us to update 'ServerApplication.java' to have hardcoded
  arguments which simplifies invocation of the server.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[x] No manual testing done
[] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

