### PR TITLE
Allow unit-scroller keybindings only when unit-scroller is visible

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -1600,23 +1600,40 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
   @Override
   public Map<KeyStroke, Runnable> get() {
     final Map<KeyStroke, Runnable> bindings = new HashMap<>();
+
     bindings.put(
-        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_SPACE), unitScroller::skipCurrentUnits);
+        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_SPACE),
+        unitScrollerAction(unitScroller::skipCurrentUnits));
     bindings.put(
-        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_S), unitScroller::sleepCurrentUnits);
+        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_S),
+        unitScrollerAction(unitScroller::sleepCurrentUnits));
     bindings.put(
         KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_C),
-        unitScroller::centerOnCurrentMovableUnit);
+        unitScrollerAction(unitScroller::centerOnCurrentMovableUnit));
     bindings.put(
-        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_N), unitScroller::centerOnNextMovableUnit);
+        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_N),
+        unitScrollerAction(unitScroller::centerOnNextMovableUnit));
     bindings.put(
         KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_M),
-        unitScroller::centerOnPreviousMovableUnit);
+        unitScrollerAction(unitScroller::centerOnPreviousMovableUnit));
     bindings.put(KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_F), this::highlightMovableUnits);
     bindings.put(
         KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_U),
-        () -> undoableMovesPanel.undoMoves(getMap().getHighlightedUnits()));
+        unitScrollerAction(() -> undoableMovesPanel.undoMoves(getMap().getHighlightedUnits())));
     return bindings;
+  }
+
+  /**
+   * Creates an action that only fires when the move panel is visible. Note, the move panel is
+   * considered visible if it is part of a tabbed pane and even if it's not the currently selected
+   * tab.
+   */
+  private Runnable unitScrollerAction(final Runnable scrollerAction) {
+    return () -> {
+      if (this.isVisible()) {
+        scrollerAction.run();
+      }
+    };
   }
 
   @Override


### PR DESCRIPTION
Unit scroller is visible/active when the move panel is visible.
This update checks if the move panel is visible, if so then the
keybindings for unit scroller are enabled. When the move panel
is not visible, the key binding actions are disabled.

An important note is that move panel is not rendered when its
not your turn and move panel is considered visible if it's in
a tabbed pane and is not the currently selected tab.

Motivation/Reason for change:
Keybindings are always active. Pressing 'n' key at any time will for
example highlight to the next unit, pressing 'space' will skip
and pressing 'space' many times will skip all units until
the 'no more units to move' dialog appears. This does not make
sense when it's not your turn or during for example a purchase phase.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[] No manual testing done
[x] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes
Note, 'F' key for highlight all units is intentionally left active during all turn phases.

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

