### PR TITLE
AI: Pause after moves instead of before.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -460,9 +460,6 @@ public final class ProMoveUtils {
 
     // Move units
     for (int i = 0; i < moveRoutes.size(); i++) {
-      if (!ProData.isSimulation) {
-        ProUtils.pause();
-      }
       if (moveRoutes.get(i) == null
           || moveRoutes.get(i).getEnd() == null
           || moveRoutes.get(i).getStart() == null) {
@@ -493,6 +490,9 @@ public final class ProMoveUtils {
                 + moveRoutes.get(i)
                 + " because: "
                 + result);
+      }
+      if (!ProData.isSimulation) {
+        ProUtils.pause();
       }
     }
   }

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -265,7 +265,6 @@ public class WeakAi extends AbstractAi {
       final List<Collection<Unit>> transportsToLoad,
       final IMoveDelegate moveDel) {
     for (int i = 0; i < moveRoutes.size(); i++) {
-      pause();
       if (moveRoutes.get(i) == null
           || moveRoutes.get(i).getEnd() == null
           || moveRoutes.get(i).getStart() == null
@@ -278,6 +277,7 @@ public class WeakAi extends AbstractAi {
       } else {
         moveDel.move(moveUnits.get(i), moveRoutes.get(i), transportsToLoad.get(i));
       }
+      pause();
     }
   }
 


### PR DESCRIPTION
AI: Pause after moves instead of before.

This makes more sense since the goal of the pause is for players to see the move.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[X] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[X] No manual testing done
[] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

