### PR TITLE
Remove client-side password hashing on change password

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/ChangePasswordPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/ChangePasswordPanel.java
@@ -18,7 +18,6 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPasswordField;
 import org.triplea.http.client.lobby.HttpLobbyClient;
-import org.triplea.lobby.common.login.RsaAuthenticator;
 import org.triplea.swing.DocumentListenerBuilder;
 import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.JCheckBoxBuilder;
@@ -169,11 +168,9 @@ public final class ChangePasswordPanel extends JPanel {
       final AllowCancelMode allowCancelMode) {
     return new ChangePasswordPanel(allowCancelMode)
         .show(lobbyFrame)
-        .map(RsaAuthenticator::hashPasswordWithSalt)
         .map(
             pass -> {
               lobbyClient.getUserAccountClient().changePassword(pass);
-
               return true;
             })
         .orElse(false);


### PR DESCRIPTION
When md5 is completely removed, then we will SHA512 passwords
on the client side instead of doing so on the server side.

With HTTPS coming online, we no longer need to do md5 hashing.
The server side does currently expect a plain-text password
(this enables us to update legacy passwords by re-hashing them,
hence why we cannot yet hash passwords on client side).


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[x] No manual testing done
[] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

