### PR TITLE
Remove moderator boot-game button in favor of context menu

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -41,7 +41,6 @@ class LobbyGamePanel extends JPanel {
 
     final JButton hostGame = new JButton("Host Game");
     joinGame = new JButton("Join Game");
-    final JButton bootGame = new JButton("Boot Game");
 
     gameTable = new LobbyGameTable(gameTableModel);
     // only allow one row to be selected
@@ -95,15 +94,11 @@ class LobbyGamePanel extends JPanel {
     final JToolBar toolBar = new JToolBar();
     toolBar.add(hostGame);
     toolBar.add(joinGame);
-    if (lobbyClient.isModerator()) {
-      toolBar.add(bootGame);
-    }
     toolBar.setFloatable(false);
     add(toolBar, BorderLayout.SOUTH);
 
     hostGame.addActionListener(e -> hostGame(serverProperties));
     joinGame.addActionListener(e -> joinGame());
-    bootGame.addActionListener(e -> bootGame());
     gameTable
         .getSelectionModel()
         .addListSelectionListener(


### PR DESCRIPTION
To simplify, avoid the potential for mis-click, this update removes
the moderator 'Boot Game' button and leaves just the right click
context menu that has a boot-game option.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[x] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[] No manual testing done
[x] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
## Screens Shots

### Before
![Screenshot from 2019-11-13 15-12-24](https://user-images.githubusercontent.com/12397753/68812577-425bea80-0628-11ea-922f-8a5d6a1a6ca6.png)


### After
![Screenshot from 2019-11-13 15-11-40](https://user-images.githubusercontent.com/12397753/68812583-46880800-0628-11ea-9e27-a5c8ddec5f51.png)


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

