### PR TITLE
Fix copy/paste error in BanTimeUnit

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/BanTimeUnit.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/BanTimeUnit.java
@@ -16,7 +16,7 @@ enum BanTimeUnit {
 
   WEEKS("Weeks", durationUnit -> TimeUnit.DAYS.toMinutes(durationUnit * 7)),
 
-  MONTHS("Weeks", durationUnit -> TimeUnit.DAYS.toMinutes(durationUnit * 30)),
+  MONTHS("Months", durationUnit -> TimeUnit.DAYS.toMinutes(durationUnit * 30)),
 
   FOREVER("Forever", value -> (long) BanDurationDialog.MAX_DURATION);
 


### PR DESCRIPTION
"Weeks" appears twice and appears as the label value for 'MONTHS'.
This update fixes the label to properly be 'Months'


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[] No manual testing done
[x] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

