### PR TITLE
Fix message sender to check for an open session

### DIFF
--- a/http-server/src/main/java/org/triplea/server/lobby/chat/MessageSender.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/chat/MessageSender.java
@@ -20,7 +20,9 @@ public class MessageSender implements BiConsumer<Session, ServerMessageEnvelope>
                 Interruptibles.await(
                     () -> {
                       try {
-                        session.getAsyncRemote().sendText(gson.toJson(message)).get();
+                        if (session.isOpen()) {
+                          session.getAsyncRemote().sendText(gson.toJson(message)).get();
+                        }
                       } catch (final ExecutionException e) {
                         log.warn("Failed to send message: " + message.getMessageType(), e);
                       }


### PR DESCRIPTION
A session can close for a number of reasons, like if users
are disconnected, or on shutdown. Fix message sender to verify
a session is open before sending a message to it.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[] No manual testing done
[x] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

