### PR TITLE
Update asset bundle - pick up new unit-scroller image

### DIFF
--- a/game-headed/build.gradle
+++ b/game-headed/build.gradle
@@ -48,7 +48,7 @@ clean.doFirst {
 task downloadAssets {
     doLast {
         download {
-            src "https://github.com/triplea-game/assets/releases/download/18/game_headed_assets.zip"
+            src "https://github.com/triplea-game/assets/releases/download/22/game_headed_assets.zip"
             dest "$projectDir/.assets/assets.zip"
             overwrite false
         }


### PR DESCRIPTION
updated asset bundle replaces the 'unit_sleep' 'moon' icon
for a 'guard' icon. This is motivated to avoid the false
antonym of the 'sun' icon (highlight) and 'moon' icon
(unit_sleep).


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[x] Other:  image update <!-- Please specify -->

