### PR TITLE
Fix ban time unit in BanDurationDialog

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/BanDurationDialog.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/BanDurationDialog.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.awt.Frame;
 import java.util.Optional;
-import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import javax.swing.JComboBox;
 import javax.swing.JDialog;
@@ -22,7 +21,7 @@ public final class BanDurationDialog extends JDialog {
 
   private final JSpinner durationSpinner =
       new JSpinner(new SpinnerNumberModel(1, 1, MAX_DURATION, 1));
-  private final JComboBox<TimeUnit> timeUnitComboBox = new JComboBox<>(TimeUnit.values());
+  private final JComboBox<BanTimeUnit> timeUnitComboBox = new JComboBox<>(BanTimeUnit.values());
   private Result result = Result.CANCEL;
 
   private BanDurationDialog(final Frame owner, final String title, final String message) {


### PR DESCRIPTION
We want to use our custom 'BanTimeUnit' enum and not 'TimeUnit'
as the ban duration units in the ban duration dialog.

This update corrects this, the ban duration display is becomes
the expected "days/weeks/etc.." found in 'BanTimeUnit'


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


