### PR TITLE
Rename 'ModeratorLobbyClient'->'ModeratorChatclient' & drop disconnect game method

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -219,7 +219,7 @@ class LobbyGamePanel extends JPanel {
     }
 
     final String gameId = gameTableModel.getGameIdForRow(selectedIndex);
-    lobbyClient.getHttpLobbyClient().getModeratorLobbyClient().disconnectGame(gameId);
+    lobbyClient.getHttpLobbyClient().getGameListingClient().bootGame(gameId);
     JOptionPane.showMessageDialog(
         null, "The game you selected has been disconnected from the lobby.");
   }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/BanPlayerModeratorAction.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/BanPlayerModeratorAction.java
@@ -6,12 +6,12 @@ import javax.swing.JFrame;
 import lombok.Builder;
 import org.triplea.domain.data.PlayerChatId;
 import org.triplea.http.client.lobby.moderator.BanPlayerRequest;
-import org.triplea.http.client.lobby.moderator.ModeratorLobbyClient;
+import org.triplea.http.client.lobby.moderator.ModeratorChatClient;
 import org.triplea.swing.SwingAction;
 
 @Builder
 public class BanPlayerModeratorAction {
-  @Nonnull private final ModeratorLobbyClient moderatorLobbyClient;
+  @Nonnull private final ModeratorChatClient moderatorLobbyClient;
   @Nonnull private final JFrame parent;
   @Nonnull private final PlayerChatId playerChatIdToBan;
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/DisconnectPlayerModeratorAction.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/DisconnectPlayerModeratorAction.java
@@ -6,13 +6,13 @@ import javax.swing.JFrame;
 import lombok.Builder;
 import org.triplea.domain.data.PlayerChatId;
 import org.triplea.domain.data.PlayerName;
-import org.triplea.http.client.lobby.moderator.ModeratorLobbyClient;
+import org.triplea.http.client.lobby.moderator.ModeratorChatClient;
 import org.triplea.swing.SwingAction;
 
 @Builder
 public class DisconnectPlayerModeratorAction {
   @Nonnull private final JFrame parent;
-  @Nonnull private final ModeratorLobbyClient moderatorLobbyClient;
+  @Nonnull private final ModeratorChatClient moderatorLobbyClient;
   @Nonnull private final PlayerName playerName;
   @Nonnull private final PlayerChatId playerChatId;
 

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/HttpLobbyClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/HttpLobbyClient.java
@@ -7,7 +7,7 @@ import org.triplea.domain.data.ApiKey;
 import org.triplea.http.client.lobby.chat.LobbyChatClient;
 import org.triplea.http.client.lobby.game.ConnectivityCheckClient;
 import org.triplea.http.client.lobby.game.listing.GameListingClient;
-import org.triplea.http.client.lobby.moderator.ModeratorLobbyClient;
+import org.triplea.http.client.lobby.moderator.ModeratorChatClient;
 import org.triplea.http.client.lobby.moderator.toolbox.HttpModeratorToolboxClient;
 import org.triplea.http.client.lobby.user.account.UserAccountClient;
 
@@ -20,7 +20,7 @@ public class HttpLobbyClient {
   private final GameListingClient gameListingClient;
   private final HttpModeratorToolboxClient httpModeratorToolboxClient;
   private final LobbyChatClient lobbyChatClient;
-  private final ModeratorLobbyClient moderatorLobbyClient;
+  private final ModeratorChatClient moderatorLobbyClient;
   private final UserAccountClient userAccountClient;
 
   private HttpLobbyClient(final URI lobbyUri, final ApiKey apiKey) {
@@ -28,7 +28,7 @@ public class HttpLobbyClient {
     gameListingClient = GameListingClient.newClient(lobbyUri, apiKey);
     httpModeratorToolboxClient = HttpModeratorToolboxClient.newClient(lobbyUri, apiKey);
     lobbyChatClient = LobbyChatClient.newClient(lobbyUri, apiKey);
-    moderatorLobbyClient = ModeratorLobbyClient.newClient(lobbyUri, apiKey);
+    moderatorLobbyClient = ModeratorChatClient.newClient(lobbyUri, apiKey);
     userAccountClient = UserAccountClient.newClient(lobbyUri, apiKey);
   }
 

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/ModeratorChatClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/ModeratorChatClient.java
@@ -11,19 +11,19 @@ import org.triplea.http.client.HttpClient;
 // TODO: Project#12 test-me
 /** Provides access to moderator lobby commands, such as 'disconnect' player, and 'ban' player. */
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class ModeratorLobbyClient {
+public class ModeratorChatClient {
 
   public static final String DISCONNECT_GAME_PATH = "/lobby/moderator/disconnect-game";
   public static final String DISCONNECT_PLAYER_PATH = "/lobby/moderator/disconnect-player";
   public static final String BAN_PLAYER_PATH = "/lobby/moderator/ban-player";
 
   private AuthenticationHeaders authenticationHeaders;
-  private ModeratorLobbyFeignClient moderatorLobbyFeignClient;
+  private ModeratorChatFeignClient moderatorLobbyFeignClient;
 
-  public static ModeratorLobbyClient newClient(final URI lobbyUri, final ApiKey apiKey) {
-    return new ModeratorLobbyClient(
+  public static ModeratorChatClient newClient(final URI lobbyUri, final ApiKey apiKey) {
+    return new ModeratorChatClient(
         new AuthenticationHeaders(apiKey),
-        new HttpClient<>(ModeratorLobbyFeignClient.class, lobbyUri).get());
+        new HttpClient<>(ModeratorChatFeignClient.class, lobbyUri).get());
   }
 
   public void banPlayer(final BanPlayerRequest banPlayerRequest) {
@@ -33,9 +33,5 @@ public class ModeratorLobbyClient {
   public void disconnectPlayer(final PlayerChatId playerChatId) {
     moderatorLobbyFeignClient.disconnectPlayer(
         authenticationHeaders.createHeaders(), playerChatId.getValue());
-  }
-
-  public void disconnectGame(final String gameId) {
-    moderatorLobbyFeignClient.disconnectGame(authenticationHeaders.createHeaders(), gameId);
   }
 }

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/ModeratorChatFeignClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/ModeratorChatFeignClient.java
@@ -7,14 +7,11 @@ import java.util.Map;
 import org.triplea.http.client.HttpConstants;
 
 @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
-public interface ModeratorLobbyFeignClient {
+public interface ModeratorChatFeignClient {
 
-  @RequestLine("POST " + ModeratorLobbyClient.BAN_PLAYER_PATH)
+  @RequestLine("POST " + ModeratorChatClient.BAN_PLAYER_PATH)
   void banPlayer(@HeaderMap Map<String, Object> headers, BanPlayerRequest banPlayerRequest);
 
-  @RequestLine("POST " + ModeratorLobbyClient.DISCONNECT_PLAYER_PATH)
+  @RequestLine("POST " + ModeratorChatClient.DISCONNECT_PLAYER_PATH)
   void disconnectPlayer(@HeaderMap Map<String, Object> headers, String value);
-
-  @RequestLine("POST " + ModeratorLobbyClient.DISCONNECT_GAME_PATH)
-  void disconnectGame(@HeaderMap Map<String, Object> headers, String gameId);
 }


### PR DESCRIPTION
1. GameListingClient already has a 'bootGame' method, we do not need to re-implement it.
2. 'ModeratorLobbyClient' is not very well named, after removing the 'disconnect' game
  method it is solely focused on player chat moderation: boot/disconnect.
  Renaming to 'ModeratorChatClient' to reflect this is the http client interface
  for moderator specific chat actions.

<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[x] No manual testing done
[] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

