### PR TITLE
Wire 'ChatEvent'

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/Chat.java
@@ -15,6 +15,7 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import org.triplea.domain.data.PlayerName;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
+import org.triplea.http.client.lobby.chat.events.server.ChatEvent;
 import org.triplea.http.client.lobby.chat.events.server.ChatMessage;
 import org.triplea.http.client.lobby.chat.events.server.StatusUpdate;
 
@@ -74,6 +75,11 @@ public class Chat implements ChatClient {
     }
     chatHistory.add(chatMessage);
     chatMessageListeners.forEach(listener -> listener.messageReceived(chatMessage));
+  }
+
+  @Override
+  public void eventReceived(final ChatEvent chatEvent) {
+    chatMessageListeners.forEach(listener -> listener.eventReceived(chatEvent));
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatClient.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatClient.java
@@ -3,6 +3,7 @@ package games.strategy.engine.chat;
 import java.util.Collection;
 import org.triplea.domain.data.PlayerName;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
+import org.triplea.http.client.lobby.chat.events.server.ChatEvent;
 import org.triplea.http.client.lobby.chat.events.server.ChatMessage;
 import org.triplea.http.client.lobby.chat.events.server.StatusUpdate;
 
@@ -22,6 +23,8 @@ public interface ChatClient {
 
   /** A chat message has been received. */
   void messageReceived(ChatMessage chatMessage);
+
+  void eventReceived(ChatEvent chatEvent);
 
   /**
    * A new chatter has joined.

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatMessageListener.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatMessageListener.java
@@ -1,11 +1,12 @@
 package games.strategy.engine.chat;
 
 import org.triplea.domain.data.PlayerName;
+import org.triplea.http.client.lobby.chat.events.server.ChatEvent;
 import org.triplea.http.client.lobby.chat.events.server.ChatMessage;
 
 /** Callback interface for a component that is interested in chat messages. */
 public interface ChatMessageListener {
-  void eventReceived(String eventText);
+  void eventReceived(ChatEvent eventText);
 
   void messageReceived(ChatMessage chatMessage);
 

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
@@ -27,6 +27,7 @@ import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
 import lombok.extern.java.Log;
 import org.triplea.domain.data.PlayerName;
+import org.triplea.http.client.lobby.chat.events.server.ChatEvent;
 import org.triplea.http.client.lobby.chat.events.server.ChatMessage;
 import org.triplea.java.Interruptibles;
 import org.triplea.java.TimeManager;
@@ -316,8 +317,8 @@ public class ChatMessagePanel extends JPanel implements ChatMessageListener {
   }
 
   @Override
-  public void eventReceived(final String eventText) {
-    addGenericMessage(eventText);
+  public void eventReceived(final ChatEvent chatEvent) {
+    addGenericMessage(chatEvent.getMessage());
   }
 
   private void addGenericMessage(final String message) {

--- a/game-core/src/main/java/games/strategy/engine/chat/HeadlessChat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/HeadlessChat.java
@@ -3,6 +3,7 @@ package games.strategy.engine.chat;
 import com.google.common.base.Ascii;
 import org.triplea.domain.data.PlayerName;
 import org.triplea.game.chat.ChatModel;
+import org.triplea.http.client.lobby.chat.events.server.ChatEvent;
 import org.triplea.http.client.lobby.chat.events.server.ChatMessage;
 import org.triplea.java.TimeManager;
 
@@ -34,8 +35,8 @@ public class HeadlessChat implements ChatMessageListener, ChatModel {
   }
 
   @Override
-  public void eventReceived(final String eventText) {
-    allText.append(eventText);
+  public void eventReceived(final ChatEvent eventText) {
+    allText.append(eventText.getMessage());
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/chat/LobbyChatTransmitter.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/LobbyChatTransmitter.java
@@ -28,7 +28,7 @@ public class LobbyChatTransmitter implements ChatTransmitter {
     lobbyChatClient.addPlayerJoinedListener(chatClient::participantAdded);
     lobbyChatClient.addChatMessageListener(chatClient::messageReceived);
     lobbyChatClient.addConnectedListener(chatClient::connected);
-
+    lobbyChatClient.addChatEventListener(chatClient::eventReceived);
     lobbyChatClient.addPlayerSlappedListener(
         slapEvent -> {
           if (slapEvent.getSlapped().equals(localPlayerName)) {

--- a/game-core/src/test/java/games/strategy/engine/chat/ChatIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/chat/ChatIntegrationTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.triplea.domain.data.PlayerName;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
+import org.triplea.http.client.lobby.chat.events.server.ChatEvent;
 import org.triplea.http.client.lobby.chat.events.server.ChatMessage;
 import org.triplea.test.common.Integration;
 
@@ -202,7 +203,7 @@ final class ChatIntegrationTest {
     public void slap(final String message) {}
 
     @Override
-    public void eventReceived(final String eventText) {}
+    public void eventReceived(final ChatEvent event) {}
 
     @Override
     public void messageReceived(final ChatMessage chatMessage) {

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/InboundChat.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/InboundChat.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 import lombok.extern.java.Log;
 import org.triplea.domain.data.PlayerName;
 import org.triplea.http.client.lobby.chat.events.client.ClientMessageEnvelope;
+import org.triplea.http.client.lobby.chat.events.server.ChatEvent;
 import org.triplea.http.client.lobby.chat.events.server.ChatMessage;
 import org.triplea.http.client.lobby.chat.events.server.PlayerSlapped;
 import org.triplea.http.client.lobby.chat.events.server.ServerMessageEnvelope;
@@ -48,7 +49,7 @@ class InboundChat {
     inboundEventHandler.addPlayerSlappedListener(playerSlappedListener);
   }
 
-  void addMessageListener(final Consumer<ChatMessage> messageListener) {
+  void addChatMessageListener(final Consumer<ChatMessage> messageListener) {
     inboundEventHandler.addMessageListener(messageListener);
   }
 
@@ -56,7 +57,7 @@ class InboundChat {
     inboundEventHandler.addConnectedListener(connectedListener);
   }
 
-  void addChatEventListener(final Consumer<String> chatEventListener) {
+  void addChatEventListener(final Consumer<ChatEvent> chatEventListener) {
     inboundEventHandler.addChatEventListener(chatEventListener);
   }
 

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/InboundEventHandler.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/InboundEventHandler.java
@@ -6,6 +6,7 @@ import java.util.Collection;
 import java.util.function.Consumer;
 import lombok.extern.java.Log;
 import org.triplea.domain.data.PlayerName;
+import org.triplea.http.client.lobby.chat.events.server.ChatEvent;
 import org.triplea.http.client.lobby.chat.events.server.ChatMessage;
 import org.triplea.http.client.lobby.chat.events.server.PlayerSlapped;
 import org.triplea.http.client.lobby.chat.events.server.ServerMessageEnvelope;
@@ -22,7 +23,7 @@ class InboundEventHandler {
   private final Collection<Consumer<ChatMessage>> messageListeners = new ArrayList<>();
   private final Collection<Consumer<Collection<ChatParticipant>>> connectedListeners =
       new ArrayList<>();
-  private final Collection<Consumer<String>> chatEventListeners = new ArrayList<>();
+  private final Collection<Consumer<ChatEvent>> chatEventListeners = new ArrayList<>();
 
   void addPlayerStatusListener(final Consumer<StatusUpdate> playerStatusListener) {
     playerStatusListeners.add(playerStatusListener);
@@ -48,7 +49,7 @@ class InboundEventHandler {
     connectedListeners.add(connectedListener);
   }
 
-  void addChatEventListener(final Consumer<String> chatEventListener) {
+  void addChatEventListener(final Consumer<ChatEvent> chatEventListener) {
     chatEventListeners.add(chatEventListener);
   }
 

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/LobbyChatClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/LobbyChatClient.java
@@ -10,6 +10,7 @@ import org.triplea.domain.data.ApiKey;
 import org.triplea.domain.data.PlayerName;
 import org.triplea.http.client.lobby.chat.events.client.ClientMessageEnvelope;
 import org.triplea.http.client.lobby.chat.events.client.ClientMessageFactory;
+import org.triplea.http.client.lobby.chat.events.server.ChatEvent;
 import org.triplea.http.client.lobby.chat.events.server.ChatMessage;
 import org.triplea.http.client.lobby.chat.events.server.PlayerSlapped;
 import org.triplea.http.client.lobby.chat.events.server.ServerMessageEnvelope;
@@ -75,7 +76,7 @@ public class LobbyChatClient {
   }
 
   public void addChatMessageListener(final Consumer<ChatMessage> messageListener) {
-    inboundChat.addMessageListener(messageListener);
+    inboundChat.addChatMessageListener(messageListener);
   }
 
   public void addConnectedListener(final Consumer<Collection<ChatParticipant>> connectedListener) {
@@ -86,12 +87,10 @@ public class LobbyChatClient {
     inboundChat.addPlayerSlappedListener(playerSlappedListener);
   }
 
-  // TODO: Project#12 test-me
-  public void addChatEventListener(final Consumer<String> chatEventListener) {
+  public void addChatEventListener(final Consumer<ChatEvent> chatEventListener) {
     inboundChat.addChatEventListener(chatEventListener);
   }
 
-  // TODO: Project#12 test-me
   public void addConnectionLostListener(final Consumer<String> connectionClosedListener) {
     inboundChat.addConnectionLostListener(connectionClosedListener);
   }

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/events/server/ChatEvent.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/events/server/ChatEvent.java
@@ -1,0 +1,9 @@
+package org.triplea.http.client.lobby.chat.events.server;
+
+import javax.annotation.Nonnull;
+import lombok.Value;
+
+@Value
+public class ChatEvent {
+  @Nonnull private final String message;
+}

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/events/server/ServerMessageEnvelope.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/events/server/ServerMessageEnvelope.java
@@ -61,9 +61,9 @@ public class ServerMessageEnvelope {
     return gson.fromJson(payload, String.class);
   }
 
-  public String toChatEvent() {
+  public ChatEvent toChatEvent() {
     Preconditions.checkState(messageType == ServerMessageType.CHAT_EVENT);
-    return gson.fromJson(payload, String.class);
+    return gson.fromJson(payload, ChatEvent.class);
   }
 
   /** Message type is used by client to know what kind of JSOn message has been received. */

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/chat/LobbyChatClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/chat/LobbyChatClientTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collection;
+import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -14,7 +15,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.domain.data.PlayerName;
 import org.triplea.http.client.lobby.chat.events.client.ClientMessageEnvelope;
 import org.triplea.http.client.lobby.chat.events.client.ClientMessageFactory;
+import org.triplea.http.client.lobby.chat.events.server.ChatEvent;
+import org.triplea.http.client.lobby.chat.events.server.ChatMessage;
+import org.triplea.http.client.lobby.chat.events.server.PlayerSlapped;
 import org.triplea.http.client.lobby.chat.events.server.ServerMessageEnvelope;
+import org.triplea.http.client.lobby.chat.events.server.StatusUpdate;
 import org.triplea.http.client.web.socket.GenericWebSocketClient;
 
 @ExtendWith(MockitoExtension.class)
@@ -88,5 +93,77 @@ class LobbyChatClientTest {
     lobbyChatClient.updateStatus(STATUS);
 
     verify(webSocketClient).send(clientEnvelope);
+  }
+
+  @Test
+  void addPlayerStatusListener() {
+    final Consumer<StatusUpdate> listener = data -> {};
+
+    lobbyChatClient.addPlayerStatusListener(listener);
+
+    verify(inboundChat).addPlayerStatusListener(listener);
+  }
+
+  @Test
+  void addPlayerLeftListene() {
+    final Consumer<PlayerName> listener = data -> {};
+
+    lobbyChatClient.addPlayerLeftListener(listener);
+
+    verify(inboundChat).addPlayerLeftListener(listener);
+  }
+
+  @Test
+  void addPlayerJoinedListener() {
+    final Consumer<ChatParticipant> listener = data -> {};
+
+    lobbyChatClient.addPlayerJoinedListener(listener);
+
+    verify(inboundChat).addPlayerJoinedListener(listener);
+  }
+
+  @Test
+  void addChatMessageListener() {
+    final Consumer<ChatMessage> listener = data -> {};
+
+    lobbyChatClient.addChatMessageListener(listener);
+
+    verify(inboundChat).addChatMessageListener(listener);
+  }
+
+  @Test
+  void addConnectedListener() {
+    final Consumer<Collection<ChatParticipant>> listener = data -> {};
+
+    lobbyChatClient.addConnectedListener(listener);
+
+    verify(inboundChat).addConnectedListener(listener);
+  }
+
+  @Test
+  void addPlayerSlappedListener() {
+    final Consumer<PlayerSlapped> listener = data -> {};
+
+    lobbyChatClient.addPlayerSlappedListener(listener);
+
+    verify(inboundChat).addPlayerSlappedListener(listener);
+  }
+
+  @Test
+  void addChatEventListener() {
+    final Consumer<ChatEvent> listener = data -> {};
+
+    lobbyChatClient.addChatEventListener(listener);
+
+    verify(inboundChat).addChatEventListener(listener);
+  }
+
+  @Test
+  void addConnectionLostListener() {
+    final Consumer<String> listener = data -> {};
+
+    lobbyChatClient.addConnectionLostListener(listener);
+
+    verify(inboundChat).addConnectionLostListener(listener);
   }
 }

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/chat/events/server/ServerMessageEnvelopeTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/chat/events/server/ServerMessageEnvelopeTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.is;
 import com.google.gson.Gson;
 import java.util.Collections;
 import org.junit.jupiter.api.Test;
+import org.triplea.domain.data.PlayerChatId;
 import org.triplea.domain.data.PlayerName;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
 
@@ -18,7 +19,11 @@ class ServerMessageEnvelopeTest {
 
   private static final PlayerName PLAYER_NAME = PlayerName.of("player");
   private static final ChatParticipant CHAT_PARTICIPANT =
-      ChatParticipant.builder().playerName(PLAYER_NAME).isModerator(true).build();
+      ChatParticipant.builder()
+          .playerName(PLAYER_NAME)
+          .isModerator(true)
+          .playerChatId(PlayerChatId.of("player-chat-id"))
+          .build();
 
   private final StatusUpdate statusUpdate = new StatusUpdate(PLAYER_NAME, STATUS);
   private final PlayerLeft playerLeft = new PlayerLeft(PLAYER_NAME);

--- a/http-server/src/main/java/org/triplea/server/lobby/chat/event/processing/ServerMessageEnvelopeFactory.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/chat/event/processing/ServerMessageEnvelopeFactory.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.experimental.UtilityClass;
 import org.triplea.domain.data.PlayerName;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
+import org.triplea.http.client.lobby.chat.events.server.ChatEvent;
 import org.triplea.http.client.lobby.chat.events.server.ChatMessage;
 import org.triplea.http.client.lobby.chat.events.server.PlayerJoined;
 import org.triplea.http.client.lobby.chat.events.server.PlayerLeft;
@@ -17,7 +18,8 @@ import org.triplea.http.client.lobby.chat.events.server.StatusUpdate;
 public class ServerMessageEnvelopeFactory {
 
   public ServerMessageEnvelope newEventMessage(final String eventMessage) {
-    return ServerMessageEnvelope.packageMessage(ServerMessageType.CHAT_EVENT, eventMessage);
+    return ServerMessageEnvelope.packageMessage(
+        ServerMessageType.CHAT_EVENT, new ChatEvent(eventMessage));
   }
 
   ServerMessageEnvelope newChatMessage(final ChatMessage chatMessage) {


### PR DESCRIPTION
1. 'ChatEvent' listeners were not fully wired on the client side down to 'Chat'. This
   update completes this wiring so that if a chat event is fired, it will be propagated
   to the chat UI.
2. For consistency and strong typing, replace chat-event 'String' type with a 'ChatEvent' type.
3. Rename 'addMessageListener' to 'addChatMessageListener', helps disambiguate which message
   types are recieved.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[x] No manual testing done
[] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

