### PR TITLE
Fix builds, Hack Travis to use Java 11.0.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,11 @@ if: tag is blank
 #   https://sormuras.github.io/blog/2017-12-08-install-jdk-on-travis.html
 # Java12 does not have this issue, we do not download the Java11 script
 # for that JVM or else we would be overriding Java12 with Java11.  
+#
+# Additional note: The export commands seem to not apply when extracted
+# to a script and seemingly only work when located in the main travis config
+# here.
+#
 
 jobs:
   include:
@@ -25,12 +30,9 @@ jobs:
       env: DESCRIPTION="static verification"
       jdk: openjdk11
       before_install:
-        - cd ~
-        - wget "https://github.com/triplea-game/assets/raw/master/jdk-11.0.5_linux-x64_bin.tar.gz"
-        - tar -xzf jdk-11.0.5_linux-x64_bin.tar.gz
-        - export JAVA_HOME="$(pwd)/jdk-11.0.5"
+        - ./.travis/install_java_11.0.5
+        - export JAVA_HOME=~/jdk-11.0.5
         - export PATH=${JAVA_HOME}/bin:$PATH
-        - cd -
         - java --version
       install: skip
       script:
@@ -42,12 +44,9 @@ jobs:
       jdk: openjdk11
       addons: {postgresql: "10"}
       before_install:
-        - cd ~
-        - wget "https://github.com/triplea-game/assets/raw/master/jdk-11.0.5_linux-x64_bin.tar.gz"
-        - tar -xzf jdk-11.0.5_linux-x64_bin.tar.gz
-        - export JAVA_HOME="$(pwd)/jdk-11.0.5"
+        - ./.travis/install_java_11.0.5
+        - export JAVA_HOME=~/jdk-11.0.5
         - export PATH=${JAVA_HOME}/bin:$PATH
-        - cd -
         - java --version
       install: skip
       script:
@@ -63,12 +62,9 @@ jobs:
       jdk: openjdk11
       env: DESCRIPTION="JDK11 unitTests and Test Coverage"
       before_install:
-        - cd ~
-        - wget "https://github.com/triplea-game/assets/raw/master/jdk-11.0.5_linux-x64_bin.tar.gz"
-        - tar -xzf jdk-11.0.5_linux-x64_bin.tar.gz
-        - export JAVA_HOME="$(pwd)/jdk-11.0.5"
+        - ./.travis/install_java_11.0.5
+        - export JAVA_HOME=~/jdk-11.0.5
         - export PATH=${JAVA_HOME}/bin:$PATH
-        - cd -
         - java --version
       install: skip
       script:
@@ -79,12 +75,9 @@ jobs:
       env: DESCRIPTION="Smoke Test"
       addons: {postgresql: "10"}
       before_install:
-        - cd ~
-        - wget "https://github.com/triplea-game/assets/raw/master/jdk-11.0.5_linux-x64_bin.tar.gz"
-        - tar -xzf jdk-11.0.5_linux-x64_bin.tar.gz
-        - export JAVA_HOME="$(pwd)/jdk-11.0.5"
+        - ./.travis/install_java_11.0.5
+        - export JAVA_HOME=~/jdk-11.0.5
         - export PATH=${JAVA_HOME}/bin:$PATH
-        - cd -
         - java --version
       install: skip
       script:
@@ -94,12 +87,9 @@ jobs:
       if: (branch = master) and (repo = 'triplea-game/triplea') and (type != 'pull_request')
       install: skip
       before_install:
-        - cd ~
-        - wget "https://github.com/triplea-game/assets/raw/master/jdk-11.0.5_linux-x64_bin.tar.gz"
-        - tar -xzf jdk-11.0.5_linux-x64_bin.tar.gz
-        - export JAVA_HOME="$(pwd)/jdk-11.0.5"
+        - ./.travis/install_java_11.0.5
+        - export JAVA_HOME=~/jdk-11.0.5
         - export PATH=${JAVA_HOME}/bin:$PATH
-        - cd -
         - java --version
       script:
         - ./.travis/setup_gpg

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,41 +6,86 @@ if: tag is blank
 # Note: Travis generally does not allocate more than 5 VMs at once.
 # Avoid running more than 5 jobs in parallel. Try to keep the jobs
 # balanced so that they each take about the same amount of time.
+
+# Note: We download Java 11.0.5 for a few reasons:
+# - jcenter no longer allows https TLS1.0 connection (this is seen as
+#   a gradle failed to download plugin error)
+# - Travis has Java 11.0.2 baked in to it, 11.0.2 does not have a
+#   recent patch (2019-10) to allow Java 11 to use a compatible version
+#   of TLS.
+# To overcome this situation, we emulate the travis 'install-jdk' script
+# and install a latest Java 11. For reference:
+#   https://sormuras.github.io/blog/2017-12-08-install-jdk-on-travis.html
+# Java12 does not have this issue, we do not download the Java11 script
+# for that JVM or else we would be overriding Java12 with Java11.  
+
 jobs:
   include:
     - stage: verify
       env: DESCRIPTION="static verification"
       jdk: openjdk11
+      before_install:
+        - cd ~
+        - wget "https://github.com/triplea-game/assets/raw/master/jdk-11.0.5_linux-x64_bin.tar.gz"
+        - tar -xzf jdk-11.0.5_linux-x64_bin.tar.gz
+        - export JAVA_HOME="$(pwd)/jdk-11.0.5"
+        - export PATH=${JAVA_HOME}/bin:$PATH
+        - cd -
+        - java --version
       install: skip
       script:
         ## shellcheck all shell scripts
         - find .travis/ -type f | xargs grep -lE "^#\!/bin/bash$" | xargs shellcheck
-        - ./gradlew --parallel validateYamls spotlessCheck checkstyleMain checkstyleTest pmdMain
+        - ./gradlew --no-daemon --parallel validateYamls spotlessCheck checkstyleMain checkstyleTest pmdMain
     - stage: verify
-      env: DESCRIPTION=integTest
+      env: DESCRIPTION="JDK11 integTest"
       jdk: openjdk11
       addons: {postgresql: "10"}
+      before_install:
+        - cd ~
+        - wget "https://github.com/triplea-game/assets/raw/master/jdk-11.0.5_linux-x64_bin.tar.gz"
+        - tar -xzf jdk-11.0.5_linux-x64_bin.tar.gz
+        - export JAVA_HOME="$(pwd)/jdk-11.0.5"
+        - export PATH=${JAVA_HOME}/bin:$PATH
+        - cd -
+        - java --version
       install: skip
       script:
         - ./.travis/setup_database &
-        - ./gradlew --parallel integTest
+        - ./gradlew --no-daemon --parallel integTest
     - stage: verify
       env: DESCRIPTION="JDK12 unitTests"
       jdk: openjdk12
       install: skip
       script:
-        - ./gradlew --parallel test
+        - ./gradlew --no-daemon --parallel test
     - stage: verify
       jdk: openjdk11
       env: DESCRIPTION="JDK11 unitTests and Test Coverage"
+      before_install:
+        - cd ~
+        - wget "https://github.com/triplea-game/assets/raw/master/jdk-11.0.5_linux-x64_bin.tar.gz"
+        - tar -xzf jdk-11.0.5_linux-x64_bin.tar.gz
+        - export JAVA_HOME="$(pwd)/jdk-11.0.5"
+        - export PATH=${JAVA_HOME}/bin:$PATH
+        - cd -
+        - java --version
       install: skip
       script:
-        - ./gradlew --parallel test jacocoTestReport
+        - ./gradlew --no-daemon --parallel test jacocoTestReport
         - bash <(curl -s https://codecov.io/bash)  # upload coverage report - https://github.com/codecov/example-gradle
     - stage: verify
       jdk: openjdk11
       env: DESCRIPTION="Smoke Test"
       addons: {postgresql: "10"}
+      before_install:
+        - cd ~
+        - wget "https://github.com/triplea-game/assets/raw/master/jdk-11.0.5_linux-x64_bin.tar.gz"
+        - tar -xzf jdk-11.0.5_linux-x64_bin.tar.gz
+        - export JAVA_HOME="$(pwd)/jdk-11.0.5"
+        - export PATH=${JAVA_HOME}/bin:$PATH
+        - cd -
+        - java --version
       install: skip
       script:
         - ./.travis/setup_database
@@ -48,6 +93,14 @@ jobs:
     - stage: deploy
       if: (branch = master) and (repo = 'triplea-game/triplea') and (type != 'pull_request')
       install: skip
+      before_install:
+        - cd ~
+        - wget "https://github.com/triplea-game/assets/raw/master/jdk-11.0.5_linux-x64_bin.tar.gz"
+        - tar -xzf jdk-11.0.5_linux-x64_bin.tar.gz
+        - export JAVA_HOME="$(pwd)/jdk-11.0.5"
+        - export PATH=${JAVA_HOME}/bin:$PATH
+        - cd -
+        - java --version
       script:
         - ./.travis/setup_gpg
         ## Update product version to include build number.

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
       jdk: openjdk11
       before_install:
         - ./.travis/install_java_11.0.5
-        - export JAVA_HOME=~/jdk-11.0.5
+        - export JAVA_HOME=~/jdk-11.0.5+10
         - export PATH=${JAVA_HOME}/bin:$PATH
         - java --version
       install: skip
@@ -45,7 +45,7 @@ jobs:
       addons: {postgresql: "10"}
       before_install:
         - ./.travis/install_java_11.0.5
-        - export JAVA_HOME=~/jdk-11.0.5
+        - export JAVA_HOME=~/jdk-11.0.5+10
         - export PATH=${JAVA_HOME}/bin:$PATH
         - java --version
       install: skip
@@ -63,7 +63,7 @@ jobs:
       env: DESCRIPTION="JDK11 unitTests and Test Coverage"
       before_install:
         - ./.travis/install_java_11.0.5
-        - export JAVA_HOME=~/jdk-11.0.5
+        - export JAVA_HOME=~/jdk-11.0.5+10
         - export PATH=${JAVA_HOME}/bin:$PATH
         - java --version
       install: skip
@@ -76,7 +76,7 @@ jobs:
       addons: {postgresql: "10"}
       before_install:
         - ./.travis/install_java_11.0.5
-        - export JAVA_HOME=~/jdk-11.0.5
+        - export JAVA_HOME=~/jdk-11.0.5+10
         - export PATH=${JAVA_HOME}/bin:$PATH
         - java --version
       install: skip
@@ -88,7 +88,7 @@ jobs:
       install: skip
       before_install:
         - ./.travis/install_java_11.0.5
-        - export JAVA_HOME=~/jdk-11.0.5
+        - export JAVA_HOME=~/jdk-11.0.5+10
         - export PATH=${JAVA_HOME}/bin:$PATH
         - java --version
       script:

--- a/.travis/do_release
+++ b/.travis/do_release
@@ -34,8 +34,11 @@ function installInstall4j() {
 
 function buildReleaseArtifacts() {
   (
-     ./gradlew --parallel -Pinstall4jHomeDir="$INSTALL4J_HOME" release  2> errors && \
-         echo "INSTALL4J finished with $(wc -l errors)"
+     ./gradlew \
+           --no-daemon \
+           --parallel \
+           -Pinstall4jHomeDir="$INSTALL4J_HOME" release  2> errors \
+        && echo "INSTALL4J finished with $(wc -l errors)"
   ) || 
   (echo "INSTALL4J FAILED" && tail -500 errors)
 }

--- a/.travis/install_java_11.0.5
+++ b/.travis/install_java_11.0.5
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+(
+  cd ~ || exit 1
+  wget "https://github.com/triplea-game/assets/raw/master/jdk-11.0.5_linux-x64_bin.tar.gz"
+  tar -xzf jdk-11.0.5_linux-x64_bin.tar.gz
+)
+

--- a/.travis/install_java_11.0.5
+++ b/.travis/install_java_11.0.5
@@ -2,7 +2,7 @@
 
 (
   cd ~ || exit 1
-  wget "https://github.com/triplea-game/assets/raw/master/jdk-11.0.5_linux-x64_bin.tar.gz"
+  wget "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.5%2B10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.5_10.tar.gz"
   tar -xzf jdk-11.0.5_linux-x64_bin.tar.gz
 )
 

--- a/.travis/install_java_11.0.5
+++ b/.travis/install_java_11.0.5
@@ -3,6 +3,6 @@
 (
   cd ~ || exit 1
   wget "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.5%2B10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.5_10.tar.gz"
-  tar -xzf jdk-11.0.5_linux-x64_bin.tar.gz
+  tar -xzf OpenJDK11U-jdk_x64_linux_hotspot_11.0.5_10.tar.gz
 )
 


### PR DESCRIPTION
<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
--> 
    1. Custom install Java 11.0.5 on the JDK11 builds.
      The version of Java11 that is installed by travis seems baked
      in, oracle Java 11 does not help, nor does using apt to
      try and upgrade the java package to a more recent version.
      The custom install uses a Java 11.0.5 hosted in triplea-game/assets
      and installs it in a similar way that travis would install java.
    
    2. For runtime, use '--no-daemon' on gradle scripts, shaves about a minute.
      The DL of JDK11 slows things down (177MB DL), this second part of the
      update is to try and help compensate for the slowdown.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!-- Place an X next to one of the below -->

[] No manual testing done
[x] Manually tested
<!-- If manually tested, summarize the testing done below this line. -->

- Verified travis build of branch for forked repo passed and checked the output.

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

<!--
Code standards and PR guidelines can be found at:
- https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
- https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

