### PR TITLE
Make client setting test single threaded

### DIFF
--- a/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingAsGameSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingAsGameSettingTest.java
@@ -3,8 +3,11 @@ package games.strategy.triplea.settings;
 import javax.annotation.Nullable;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import org.sonatype.goodies.prefs.memory.MemoryPreferences;
 
+@Execution(ExecutionMode.SAME_THREAD)
 final class ClientSettingAsGameSettingTest extends AbstractGameSettingTestCase {
   @Override
   protected GameSetting<Integer> newGameSetting(


### PR DESCRIPTION
Adds reliability to some of the client setting tests, was seeing a number of errors like:
>     java.lang.IllegalStateException: ClientSetting framework has not been initialized. Did you forget to call ClientSetting#initialize() in production code or ClientSetting#setPreferences() in test code?


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manually testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

