### PR TITLE
PR Auto-Correct

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,7 +38,8 @@ jobs:
       script:
         ## shellcheck all shell scripts
         - find .travis/ -type f | xargs grep -lE "^#\!/bin/bash$" | xargs shellcheck
-        - ./gradlew --no-daemon --parallel validateYamls spotlessCheck checkstyleMain checkstyleTest pmdMain
+        - ./.travis/auto-correct
+        - ./gradlew --parallel validateYamls spotlessCheck checkstyleMain checkstyleTest pmdMain
     - stage: verify
       env: DESCRIPTION="JDK11 integTest"
       jdk: openjdk11

--- a/.travis/auto-correct
+++ b/.travis/auto-correct
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+CURRENT_BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
+
+
+function main() {
+  runSpotless
+  removeUnusedLombokLogAnnotations
+}
+
+function runSpotless() {
+  ./gradlew spotlessApply
+  commitIfNeeded "Formatting - run spotlessApply"
+}
+  
+
+function removeUnusedLombokLogAnnotations() {
+  find . -print0 -type f -name "*.java" \
+    | xargs --null grep -lE "@Log|@slf4j" \
+    | while read -r file; do \
+        grep -q "log." "$file" \
+        || (
+          sed -i '/^import lombok.extern.java.Log;/d' "$file";
+          sed -i '/^import lombok.extern.slf4j.Slf4j;/d' "$file";
+          sed -i '/@Log/d' "$file"
+          sed -i '/@Slf4j/d' "$file"
+        )
+        done
+  commitIfNeeded "Remove unused lombok log annotations"
+}
+
+function commit() {
+  local -r message="$1"
+  git config --global user.email "tripleabuilderbot@gmail.com"
+  git config --global user.name "tripleabuilderbot"
+
+  local -r gitRepo="https://$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS@github.com/triplea-game/triplea"
+  git remote set-url origin "$gitRepo"
+  git checkout "$CURRENT_BRANCH" 
+  git commit . -m "$message"
+  git push origin "$CURRENT_BRANCH"
+}
+
+function commitIfNeeded() {
+  local -r message="$1"
+  
+  git add .
+  local -r fileCount=$(git diff --cached --numstat | wc -l)
+
+  if [ "$fileCount" -gt 0 ]; then
+    commit "$message"
+  fi
+}
+
+main
+


### PR DESCRIPTION
Assuming maintainer edits is enabled, this update will have the builder-bot
run spotlessApply and push any updates back to the PR branch. Also, builder-bot
will look for any unnecessary lombok '@Log' tags and remove them if there
is no logging in the respective class file.

This opens up a framework for additional auto-corrections as we can think
of them.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manually testing done

- dry-run: https://github.com/triplea-game/triplea/pull/5498
- tested on a forked repo with travis
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->

## Additional Review Notes

For discussion and to be decided:
- edits from maintainers is required for this to work, perhaps it gives us a point of pause. Then again, 'spotlessCheck' fails if there are not updates, and if there are auto-corrections and we can't update the branch to fix them, the branch will fail all the same
- I added the auto-correction to be as a first step of static analysis while all the tests run in parallel. It may make sense to add the auto-correction as a first step before we then run all tests and checks in parallel. This would slow down build time. To consider, it could make sense to have the auto-correct to merge to the latest master, that way when we test/build we'll be testing from the head of master. If we do that, then it probably makes even more sense to do the auto-correction as first step to everything else.


