### PR TITLE
Fix NPEs caused by recent transport refactoring.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -26,6 +26,7 @@ import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -288,7 +289,7 @@ public class MoveValidator {
     String result = null;
     final Set<Unit> unitsThatFailCanal = new HashSet<>();
     final Collection<Unit> unitsWithoutDependents =
-        (units == null) ? List.of(null) : findNonDependentUnits(units, route, newDependents);
+        (units == null) ? Collections.singleton(null) : findNonDependentUnits(units, route, newDependents);
     for (final Unit unit : unitsWithoutDependents) {
       for (final Territory t : route.getAllTerritories()) {
         Optional<String> failureMessage = Optional.empty();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -289,7 +289,9 @@ public class MoveValidator {
     String result = null;
     final Set<Unit> unitsThatFailCanal = new HashSet<>();
     final Collection<Unit> unitsWithoutDependents =
-        (units == null) ? Collections.singleton(null) : findNonDependentUnits(units, route, newDependents);
+        (units == null)
+            ? Collections.singleton(null)
+            : findNonDependentUnits(units, route, newDependents);
     for (final Unit unit : unitsWithoutDependents) {
       for (final Territory t : route.getAllTerritories()) {
         Optional<String> failureMessage = Optional.empty();

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -595,7 +595,7 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
             }
           }
           final Map<Unit, Unit> unitsToTransports =
-              transports == null ? null : TransportUtils.mapTransports(route, units, transports);
+              transports == null ? Map.of() : TransportUtils.mapTransports(route, units, transports);
           final MoveDescription message =
               new MoveDescription(units, route, unitsToTransports, dependentUnits);
           setMoveMessage(message);

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -595,7 +595,9 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
             }
           }
           final Map<Unit, Unit> unitsToTransports =
-              transports == null ? Map.of() : TransportUtils.mapTransports(route, units, transports);
+              transports == null
+                  ? Map.of()
+                  : TransportUtils.mapTransports(route, units, transports);
           final MoveDescription message =
               new MoveDescription(units, route, unitsToTransports, dependentUnits);
           setMoveMessage(message);


### PR DESCRIPTION
Two issues:
  1. The changes to MoveDescription required that params are no longer null, but a code path wasn't update to not pass null.
  2. List.of(null) was used instead of Collections.singleton(null) - the former causes an NPE.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[X] Bug fix:  https://github.com/triplea-game/triplea/issues/5502
[] Other:   <!-- Please specify -->


## Testing

[X] Manually testing done

1. On Revised as Germany, load a transport in Combat move and attempt to unload in non-Combat.
2. Run a Revised game with players set to a variety of Hard/Easy/Fast AIs.
Run