### PR TITLE
AI unit purchase upgrade logic improvements

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -2338,11 +2338,16 @@ class ProPurchaseAi {
     }
   }
 
+  /**
+   * Determine efficiency value for upgrading to the given purchase option. If the strategic value
+   * of the territory is low then favor high movement units as its far from the enemy otherwise
+   * favor high defense.
+   */
   private static double findUpgradeUnitEfficiency(
       final ProPurchaseOption ppo, final double strategicValue) {
-    return strategicValue >= 1
-        ? ppo.getAttackEfficiency() * ppo.getDefenseEfficiency() * ppo.getCost() / ppo.getQuantity()
-        : ppo.getAttackEfficiency() * ppo.getMovement() * ppo.getCost() / ppo.getQuantity();
+    final double multiplier =
+        (strategicValue >= 1) ? ppo.getDefenseEfficiency() : ppo.getMovement();
+    return ppo.getAttackEfficiency() * multiplier * ppo.getCost() / ppo.getQuantity();
   }
 
   private IntegerMap<ProductionRule> populateProductionRuleMap(


### PR DESCRIPTION
Address some of the feedback here: https://forums.triplea-game.org/topic/1518/ai-interesting-moves-and-points-of-improvement-on-revised/11

Specifically: Round 18: Russia is fighting for its life. It decides to buy Cavalry instead of defensive units.

The AI now considers the strategic value of the factory territory and if its high (close to enemies) then prefer strong units rather than high movement units.