### PR TITLE
Set min-size of action panel to 240px

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/ActionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ActionPanel.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.ui;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerId;
 import games.strategy.triplea.Properties;
+import java.awt.Dimension;
 import java.util.concurrent.CountDownLatch;
 import javax.swing.BoxLayout;
 import javax.swing.JPanel;
@@ -44,6 +45,7 @@ public abstract class ActionPanel extends JPanel {
     this.map = map;
     setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
     setBorder(new EmptyBorder(5, 5, 0, 0));
+    setMinimumSize(new Dimension(240, 0));
   }
 
   protected final boolean isWW2V2() {


### PR DESCRIPTION
Allows enough space for unit-scroller and unit-move-history
to typically not be cut-off on the right hand side.

Additionally, if there is not enough room for unit scroller,
re-sizing will yield a min-size, so you will not be able to get
the action panel back to it's original (cut-off) width.

This update sets the min width of the action panel to match the
effective min width.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manually testing done

<!-- If manually tested, summarize the testing done below this line. -->
- checked action panel sizing on napoleanic wars (has perhaps the smallest known mini-map, which
typically controls the initial width of the action panel)

<!-- If there are UI updates, uncomment and include screenshots below -->
## Screens Shots

### Before

### After
![Screenshot from 2019-11-17 19-15-52](https://user-images.githubusercontent.com/12397753/69022068-da323f00-096e-11ea-92b1-fa9e94f8385a.png)


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

