### PR TITLE
Unit Scroller Updates: "station", rename images + wake-all button

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -67,7 +67,6 @@ public class UnitScroller {
   private static final String WAKE_ALL_TOOLTIP =
       "Press 'w' or click this button to activate all skipped or stationed units";
 
-
   private static final String HIGHLIGHT_MOVABLE_TOOLTIP =
       "Press 'F' key or click this button to highlight movable units";
   private static final String FLAG_TOGGLE_BUTTON_TOOLTIP =

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -58,9 +58,9 @@ public class UnitScroller {
       "Press 'n' or click this button to center the screen on the 'next' units with movement left";
   private static final String CENTER_UNITS_TOOLTIP =
       "Press 'c' or click this button to center the screen on current units.";
-  private static final String SLEEP_UNITS_TOOLTIP =
-      "Press 's' or click this button to sleep the current units, they will be automatically "
-          + "skipped until you move them.";
+  private static final String STATION_UNITS_TOOLTIP =
+      "Press 's' or click this button to station the current units, they will be automatically "
+          + "skipped until you move or wake them.";
   private static final String SKIP_UNITS_TOOLTIP =
       "Press 'space' or click this button to skip the current units and not move them during the "
           + "current move phase";
@@ -239,12 +239,12 @@ public class UnitScroller {
 
     panel.add(Box.createVerticalStrut(2));
 
-    final JButton skipButton = new JButton(UnitScrollerIcon.UNIT_SKIP.get());
+    final JButton skipButton = new JButton(UnitScrollerIcon.SKIP.get());
     skipButton.setToolTipText(SKIP_UNITS_TOOLTIP);
     skipButton.addActionListener(e -> skipCurrentUnits());
 
-    final JButton sleepButton = new JButton(UnitScrollerIcon.UNIT_SLEEP.get());
-    sleepButton.setToolTipText(SLEEP_UNITS_TOOLTIP);
+    final JButton sleepButton = new JButton(UnitScrollerIcon.STATION.get());
+    sleepButton.setToolTipText(STATION_UNITS_TOOLTIP);
     sleepButton.addActionListener(e -> sleepCurrentUnits());
 
     final JPanel skipAndSleepPanel =

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -64,6 +64,9 @@ public class UnitScroller {
   private static final String SKIP_UNITS_TOOLTIP =
       "Press 'space' or click this button to skip the current units and not move them during the "
           + "current move phase";
+  private static final String WAKE_ALL_TOOLTIP =
+      "Press 'w' or click this button to activate all skipped or stationed units";
+
 
   private static final String HIGHLIGHT_MOVABLE_TOOLTIP =
       "Press 'F' key or click this button to highlight movable units";
@@ -243,16 +246,22 @@ public class UnitScroller {
     skipButton.setToolTipText(SKIP_UNITS_TOOLTIP);
     skipButton.addActionListener(e -> skipCurrentUnits());
 
-    final JButton sleepButton = new JButton(UnitScrollerIcon.STATION.get());
-    sleepButton.setToolTipText(STATION_UNITS_TOOLTIP);
-    sleepButton.addActionListener(e -> sleepCurrentUnits());
+    final JButton stationButton = new JButton(UnitScrollerIcon.STATION.get());
+    stationButton.setToolTipText(STATION_UNITS_TOOLTIP);
+    stationButton.addActionListener(e -> sleepCurrentUnits());
+
+    final JButton wakeAllButton = new JButton(UnitScrollerIcon.WAKE_ALL.get());
+    wakeAllButton.setToolTipText(WAKE_ALL_TOOLTIP);
+    wakeAllButton.addActionListener(e -> wakeAllUnits());
 
     final JPanel skipAndSleepPanel =
         new JPanelBuilder()
             .boxLayoutHorizontal()
             .add(skipButton)
             .addHorizontalStrut(HORIZONTAL_BUTTON_GAP)
-            .add(sleepButton)
+            .add(stationButton)
+            .addHorizontalStrut(HORIZONTAL_BUTTON_GAP)
+            .add(wakeAllButton)
             .build();
     skipAndSleepPanel.setAlignmentX(JComponent.CENTER_ALIGNMENT);
 
@@ -313,6 +322,13 @@ public class UnitScroller {
       updateMovesLeftLabel();
     }
     centerOnNextMovableUnit();
+  }
+
+  private void wakeAllUnits() {
+    sleepingUnits.clear();
+    skippedUnits.clear();
+    updateMovesLeftLabel();
+    centerOnCurrentMovableUnit();
   }
 
   public void centerOnNextMovableUnit() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScrollerIcon.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScrollerIcon.java
@@ -19,8 +19,8 @@ class UnitScrollerIcon implements Supplier<Icon> {
 
   static final UnitScrollerIcon LEFT_ARROW = new UnitScrollerIcon("left_arrow.png");
   static final UnitScrollerIcon RIGHT_ARROW = new UnitScrollerIcon("right_arrow.png");
-  static final UnitScrollerIcon UNIT_SKIP = new UnitScrollerIcon("skip.png");
-  static final UnitScrollerIcon UNIT_SLEEP = new UnitScrollerIcon("station.png");
+  static final UnitScrollerIcon SKIP = new UnitScrollerIcon("skip.png");
+  static final UnitScrollerIcon STATION = new UnitScrollerIcon("station.png");
 
   private static final File IMAGE_PATH = new File(ResourceLoader.RESOURCE_FOLDER, "unit_scroller");
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScrollerIcon.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScrollerIcon.java
@@ -21,6 +21,7 @@ class UnitScrollerIcon implements Supplier<Icon> {
   static final UnitScrollerIcon RIGHT_ARROW = new UnitScrollerIcon("right_arrow.png");
   static final UnitScrollerIcon SKIP = new UnitScrollerIcon("skip.png");
   static final UnitScrollerIcon STATION = new UnitScrollerIcon("station.png");
+  static final UnitScrollerIcon WAKE_ALL = new UnitScrollerIcon("wake_all.png");
 
   private static final File IMAGE_PATH = new File(ResourceLoader.RESOURCE_FOLDER, "unit_scroller");
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScrollerIcon.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScrollerIcon.java
@@ -13,14 +13,14 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 class UnitScrollerIcon implements Supplier<Icon> {
 
-  static final UnitScrollerIcon CENTER_ON_UNIT = new UnitScrollerIcon("unit_center.png");
+  static final UnitScrollerIcon CENTER_ON_UNIT = new UnitScrollerIcon("center.png");
   static final UnitScrollerIcon UNIT_HIGHLIGHT = new UnitScrollerIcon("highlight.png");
   static final UnitScrollerIcon UNIT_FLAGS = new UnitScrollerIcon("flag.png");
 
   static final UnitScrollerIcon LEFT_ARROW = new UnitScrollerIcon("left_arrow.png");
   static final UnitScrollerIcon RIGHT_ARROW = new UnitScrollerIcon("right_arrow.png");
-  static final UnitScrollerIcon UNIT_SKIP = new UnitScrollerIcon("unit_skip.png");
-  static final UnitScrollerIcon UNIT_SLEEP = new UnitScrollerIcon("unit_sleep.png");
+  static final UnitScrollerIcon UNIT_SKIP = new UnitScrollerIcon("skip.png");
+  static final UnitScrollerIcon UNIT_SLEEP = new UnitScrollerIcon("station.png");
 
   private static final File IMAGE_PATH = new File(ResourceLoader.RESOURCE_FOLDER, "unit_scroller");
 

--- a/game-headed/build.gradle
+++ b/game-headed/build.gradle
@@ -48,7 +48,7 @@ clean.doFirst {
 task downloadAssets {
     doLast {
         download {
-            src "https://github.com/triplea-game/assets/releases/download/23/game_headed_assets.zip"
+            src "https://github.com/triplea-game/assets/releases/download/25/game_headed_assets.zip"
             dest "$projectDir/.assets/assets.zip"
             overwrite false
         }


### PR DESCRIPTION
1. Rename "sleep" concept to "station"
2. Update button names, slightly simpler names and use "station.png"
3. Add a wake-all button to activate stationed and skipped units.

<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manually testing done

- launched a napoleonic wars map:
 -  skipped all units, then waked them
 - did a mix of station+skip units, then waked them
 - skipped+stationed unit in one move phase, proceeded to next move phase, verified wake-all

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

