### PR TITLE
AI fix v3 naval bombard

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -1674,7 +1674,7 @@ public class ProCombatMoveAi {
                     final double strengthDifference =
                         ProBattleUtils.estimateStrengthDifference(
                             territoryToMoveTransport, attackers, defenders);
-                    if (strengthDifference < minStrengthDifference) {
+                    if (strengthDifference <= minStrengthDifference) {
                       minStrengthDifference = strengthDifference;
                       minUnloadFromTerritory = territoryToMoveTransport;
                     }


### PR DESCRIPTION
Fix comparison check to include equal to since strengthDifference can be infinity for v3 subs that have no defense. Otherwise the AI will never try to bombard with v3 transports if enemy ships are in range.