### PR TITLE
Use Map.of/List.of/Set.of over Collections and Arrays.asList

### DIFF
--- a/domain-data/src/test/java/org/triplea/domain/data/PlayerNameTest.java
+++ b/domain-data/src/test/java/org/triplea/domain/data/PlayerNameTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsNull.notNullValue;
 
 import com.google.common.base.Strings;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -15,8 +14,7 @@ class PlayerNameTest {
 
   @SuppressWarnings("unused")
   static List<String> usernameValidationWithInvalidNames() {
-    return Arrays.asList(
-        null,
+    return List.of(
         "",
         "a",
         "ab", // still too short
@@ -51,7 +49,7 @@ class PlayerNameTest {
 
   @SuppressWarnings("unused")
   private static List<String> usernameValidationWithValidNames() {
-    return Arrays.asList("abc", Strings.repeat("a", PlayerName.MAX_LENGTH), "a12", "a--");
+    return List.of("abc", Strings.repeat("a", PlayerName.MAX_LENGTH), "a12", "a--");
   }
 
   @ParameterizedTest

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
@@ -10,9 +10,7 @@ import java.awt.event.MouseEvent;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -88,7 +86,7 @@ public class ChatPlayerPanel extends JPanel implements ChatPlayerListener {
       chat.addStatusUpdateListener(statusUpdateListener);
     } else {
       // empty our player list
-      updatePlayerList(Collections.emptyList());
+      updatePlayerList(List.of());
     }
     repaint();
   }
@@ -164,7 +162,7 @@ public class ChatPlayerPanel extends JPanel implements ChatPlayerListener {
         clickedOn -> {
           // you can't slap or ignore yourself
           if (clickedOn.getPlayerName().equals(chat.getLocalPlayerName())) {
-            return Collections.emptyList();
+            return List.of();
           }
           final boolean isIgnored = chat.isIgnored(clickedOn.getPlayerName());
           final Action ignore =
@@ -178,7 +176,7 @@ public class ChatPlayerPanel extends JPanel implements ChatPlayerListener {
               SwingAction.of(
                   "Slap " + clickedOn.getPlayerName(),
                   e -> chat.sendSlap(clickedOn.getPlayerName()));
-          return Arrays.asList(slap, ignore);
+          return List.of(slap, ignore);
         });
   }
 

--- a/game-core/src/main/java/games/strategy/engine/chat/PlayerChatRenderer.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/PlayerChatRenderer.java
@@ -9,7 +9,6 @@ import games.strategy.triplea.image.FlagIconImageFactory;
 import games.strategy.triplea.ui.UiContext;
 import java.awt.Component;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -64,7 +63,7 @@ public class PlayerChatRenderer extends DefaultListCellRenderer {
       final boolean cellHasFocus) {
     final ChatParticipant chatParticipant = (ChatParticipant) value;
     final List<Icon> icons =
-        iconMap.getOrDefault(chatParticipant.getPlayerName().getValue(), Collections.emptyList());
+        iconMap.getOrDefault(chatParticipant.getPlayerName().getValue(), List.of());
     if (icons.isEmpty()) {
       super.getListCellRendererComponent(
           list,
@@ -82,8 +81,7 @@ public class PlayerChatRenderer extends DefaultListCellRenderer {
   }
 
   private String getNodeLabelWithPlayers(final PlayerName playerName) {
-    final Set<String> playerNames =
-        playerMap.getOrDefault(playerName.getValue(), Collections.emptySet());
+    final Set<String> playerNames = playerMap.getOrDefault(playerName.getValue(), Set.of());
     return playerName
         + (playerNames.isEmpty()
             ? ""

--- a/game-core/src/main/java/games/strategy/engine/data/AllianceTracker.java
+++ b/game-core/src/main/java/games/strategy/engine/data/AllianceTracker.java
@@ -5,7 +5,6 @@ import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
 import java.io.Serializable;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -81,9 +80,7 @@ public class AllianceTracker implements Serializable {
 
   public Collection<String> getAlliancesPlayerIsIn(final PlayerId player) {
     final Collection<String> alliancesPlayerIsIn = alliances.get(player);
-    return !alliancesPlayerIsIn.isEmpty()
-        ? alliancesPlayerIsIn
-        : Collections.singleton(player.getName());
+    return !alliancesPlayerIsIn.isEmpty() ? alliancesPlayerIsIn : Set.of(player.getName());
   }
 
   Set<PlayerId> getAllies(final PlayerId currentPlayer) {

--- a/game-core/src/main/java/games/strategy/engine/data/GameDataVariableParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameDataVariableParser.java
@@ -1,6 +1,5 @@
 package games.strategy.engine.data;
 
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -14,7 +13,7 @@ class GameDataVariableParser {
 
   Map<String, List<String>> parseVariables(final Element root) throws GameParseException {
     final Element variableList = nodeFinder.getOptionalSingleChild("variableList", root);
-    return variableList != null ? parseVariableElement(variableList) : Collections.emptyMap();
+    return variableList != null ? parseVariableElement(variableList) : Map.of();
   }
 
   private Map<String, List<String>> parseVariableElement(final Element root) {

--- a/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -73,7 +73,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
       throw new IllegalArgumentException("Map already contains " + t1.getName());
     }
     territories.add(t1);
-    connections.put(t1, Collections.emptySet());
+    connections.put(t1, Set.of());
     territoryLookup.put(t1.getName(), t1);
   }
 
@@ -130,7 +130,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
       return getNeighbors(territory);
     }
     return connections
-        .getOrDefault(territory, Collections.emptySet())
+        .getOrDefault(territory, Set.of())
         .parallelStream()
         .filter(cond)
         .collect(Collectors.toSet());
@@ -152,7 +152,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
       final Territory territory, final int distance, final Predicate<Territory> cond) {
     Preconditions.checkArgument(distance >= 0, "Distance must be non-negative: " + distance);
     if (distance == 0) {
-      return Collections.emptySet();
+      return Set.of();
     }
     final Set<Territory> neighbors = getNeighbors(territory, cond);
     if (distance == 1) {
@@ -204,7 +204,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
       final Territory territory, final int distance, final Predicate<Territory> cond) {
     Preconditions.checkArgument(distance >= 0, "Distance must be non-negative: " + distance);
     if (distance == 0) {
-      return Collections.emptySet();
+      return Set.of();
     }
     final Set<Territory> neighbors = new HashSet<>(getNeighbors(territory));
     if (distance == 1) {
@@ -266,7 +266,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
         movementLeft.compareTo(BigDecimal.ZERO) >= 0,
         "MovementLeft must be non-negative: " + movementLeft);
     if (movementLeft.compareTo(BigDecimal.ZERO) == 0) {
-      return Collections.emptySet();
+      return Set.of();
     }
     final Set<Territory> neighbors = getNeighbors(territory, cond);
     if (movementLeft.compareTo(BigDecimal.ONE) <= 0) {
@@ -353,7 +353,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
     if (t1.equals(t2)) {
       return 0;
     }
-    return getDistance(0, new HashSet<>(), Collections.singleton(t1), t2, cond);
+    return getDistance(0, new HashSet<>(), Set.of(t1), t2, cond);
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameParser.java
@@ -27,7 +27,6 @@ import java.io.File;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -1244,7 +1243,7 @@ public final class GameParser {
     for (final Element current : getChildren("attachment", root)) {
       final String foreach = current.getAttribute("foreach");
       if (foreach.isEmpty()) {
-        parseAttachment(current, variables, Collections.emptyMap());
+        parseAttachment(current, variables, Map.of());
       } else {
         final List<String> nestedForeach = Splitter.on("^").splitToList(foreach);
         if (nestedForeach.isEmpty() || nestedForeach.size() > 2) {
@@ -1256,7 +1255,7 @@ public final class GameParser {
         final List<String> foreachVariables2 =
             nestedForeach.size() == 2
                 ? Splitter.on(":").splitToList(nestedForeach.get(1))
-                : Collections.emptyList();
+                : List.of();
         validateForeachVariables(foreachVariables1, variables, foreach);
         validateForeachVariables(foreachVariables2, variables, foreach);
         final int length1 = variables.get(foreachVariables1.get(0)).size();

--- a/game-core/src/main/java/games/strategy/engine/data/ProductionFrontier.java
+++ b/game-core/src/main/java/games/strategy/engine/data/ProductionFrontier.java
@@ -15,7 +15,7 @@ public class ProductionFrontier extends DefaultNamed implements Iterable<Product
   private List<ProductionRule> cachedRules;
 
   public ProductionFrontier(final String name, final GameData data) {
-    this(name, data, Collections.emptyList());
+    this(name, data, List.of());
   }
 
   public ProductionFrontier(

--- a/game-core/src/main/java/games/strategy/engine/data/RepairFrontier.java
+++ b/game-core/src/main/java/games/strategy/engine/data/RepairFrontier.java
@@ -15,7 +15,7 @@ public class RepairFrontier extends DefaultNamed implements Iterable<RepairRule>
   private List<RepairRule> cachedRules;
 
   public RepairFrontier(final String name, final GameData data) {
-    this(name, data, Collections.emptyList());
+    this(name, data, List.of());
   }
 
   public RepairFrontier(final String name, final GameData data, final List<RepairRule> rules) {

--- a/game-core/src/main/java/games/strategy/engine/data/Resource.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Resource.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.data;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /** A measurement of value used by players to purchase units. */
@@ -11,7 +10,7 @@ public class Resource extends NamedAttachable {
   private final List<PlayerId> players;
 
   public Resource(final String resourceName, final GameData data) {
-    this(resourceName, data, Collections.emptyList());
+    this(resourceName, data, List.of());
   }
 
   public Resource(final String resourceName, final GameData data, final List<PlayerId> players) {

--- a/game-core/src/main/java/games/strategy/engine/data/Route.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Route.java
@@ -373,10 +373,9 @@ public class Route implements Serializable, Iterable<Territory> {
     for (final Unit unit : units) {
       final PlayerId player = unit.getOwner();
       final ResourceCollection cost = new ResourceCollection(data);
-      cost.add(getMovementFuelCostCharge(Collections.singleton(unit), toRoute, player, data));
+      cost.add(getMovementFuelCostCharge(Set.of(unit), toRoute, player, data));
       cost.add(
-          getFuelCostsAndUnitsChargedFlatFuelCost(
-                  Collections.singleton(unit), returnRoute, player, data, true)
+          getFuelCostsAndUnitsChargedFlatFuelCost(Set.of(unit), returnRoute, player, data, true)
               .getFirst());
       if (map.containsKey(player)) {
         map.get(player).add(cost);

--- a/game-core/src/main/java/games/strategy/engine/data/RouteFinder.java
+++ b/game-core/src/main/java/games/strategy/engine/data/RouteFinder.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Queue;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 
@@ -24,7 +25,7 @@ class RouteFinder {
   private final PlayerId player;
 
   RouteFinder(final GameMap map, final Predicate<Territory> condition) {
-    this(map, condition, Collections.emptySet(), null);
+    this(map, condition, Set.of(), null);
   }
 
   RouteFinder(

--- a/game-core/src/main/java/games/strategy/engine/data/RouteScripted.java
+++ b/game-core/src/main/java/games/strategy/engine/data/RouteScripted.java
@@ -1,6 +1,5 @@
 package games.strategy.engine.data;
 
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -32,7 +31,7 @@ public class RouteScripted extends Route {
   @Override
   public List<Territory> getSteps() {
     if (numberOfSteps() <= 0) {
-      return Collections.singletonList(getStart());
+      return List.of(getStart());
     }
     return super.getSteps();
   }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/ChangeFactory.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/ChangeFactory.java
@@ -21,9 +21,9 @@ import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.delegate.TechAdvance;
 import games.strategy.triplea.delegate.data.BattleRecords;
 import java.math.BigDecimal;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
+import java.util.Set;
 import org.triplea.java.collections.IntegerMap;
 
 /**
@@ -75,7 +75,7 @@ public class ChangeFactory {
 
   public static Change changeOwner(
       final Unit unit, final PlayerId owner, final Territory location) {
-    return new PlayerOwnerChange(Collections.singleton(unit), owner, location);
+    return new PlayerOwnerChange(Set.of(unit), owner, location);
   }
 
   public static Change addUnits(final Territory territory, final Collection<Unit> units) {
@@ -96,7 +96,7 @@ public class ChangeFactory {
 
   public static Change moveUnits(
       final Territory start, final Territory end, final Collection<Unit> units) {
-    return new CompositeChange(Arrays.asList(removeUnits(start, units), addUnits(end, units)));
+    return new CompositeChange(List.of(removeUnits(start, units), addUnits(end, units)));
   }
 
   public static Change changeProductionFrontier(

--- a/game-core/src/main/java/games/strategy/engine/data/gameparser/XmlGameElementMapper.java
+++ b/game-core/src/main/java/games/strategy/engine/data/gameparser/XmlGameElementMapper.java
@@ -66,7 +66,7 @@ public final class XmlGameElementMapper {
   private final ImmutableMap<String, AttachmentFactory> attachmentFactoriesByTypeName;
 
   public XmlGameElementMapper() {
-    this(Collections.emptyMap(), Collections.emptyMap());
+    this(Map.of(), Collections.emptyMap());
   }
 
   @VisibleForTesting

--- a/game-core/src/main/java/games/strategy/engine/framework/GameDataFileUtils.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameDataFileUtils.java
@@ -3,8 +3,8 @@ package games.strategy.engine.framework;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.Arrays;
 import java.util.Collection;
+import java.util.List;
 import org.apache.commons.io.IOCase;
 
 /** A collection of utilities for working with game data files. */
@@ -51,7 +51,7 @@ public final class GameDataFileUtils {
     // files.
     final String macOsAlternativeExtension = "tsvg.gz";
 
-    return Arrays.asList(getExtension(), legacyExtension, macOsAlternativeExtension);
+    return List.of(getExtension(), legacyExtension, macOsAlternativeExtension);
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
@@ -6,9 +6,8 @@ import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.settings.SettingsWindow;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
 import javax.swing.JOptionPane;
@@ -62,13 +61,13 @@ public final class LookAndFeel {
   }
 
   private static Collection<UIManager.LookAndFeelInfo> getSystemLookAndFeels() {
-    return Arrays.asList(UIManager.getInstalledLookAndFeels());
+    return List.of(UIManager.getInstalledLookAndFeels());
   }
 
   private static Collection<UIManager.LookAndFeelInfo> getSubstanceLookAndFeels() {
     return getSubstanceLookAndFeelManager()
         .map(SubstanceLookAndFeelManager::getInstalledLookAndFeels)
-        .orElseGet(Collections::emptyList);
+        .orElseGet(List::of);
   }
 
   public static String getDefaultLookAndFeelClassName() {

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -15,7 +15,6 @@ import java.awt.Dimension;
 import java.awt.Rectangle;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -135,7 +134,7 @@ public class DownloadMapsWindow extends JFrame {
   public static void showDownloadMapsWindow() {
     checkState(SwingUtilities.isEventDispatchThread());
 
-    showDownloadMapsWindowAndDownload(Collections.emptyList());
+    showDownloadMapsWindowAndDownload(List.of());
   }
 
   /**
@@ -151,7 +150,7 @@ public class DownloadMapsWindow extends JFrame {
     checkState(SwingUtilities.isEventDispatchThread());
     checkNotNull(mapName);
 
-    showDownloadMapsWindowAndDownload(Collections.singletonList(mapName));
+    showDownloadMapsWindowAndDownload(List.of(mapName));
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
@@ -4,7 +4,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import lombok.extern.java.Log;
@@ -25,7 +24,7 @@ public class DownloadRunnable {
   public static List<DownloadFileDescription> download(final String url) {
     return DownloadConfiguration.contentReader()
         .download(url, DownloadFileParser::parse)
-        .orElseGet(Collections::emptyList);
+        .orElseGet(List::of);
   }
 
   /**
@@ -37,7 +36,7 @@ public class DownloadRunnable {
       return DownloadFileParser.parse(inputStream);
     } catch (final IOException e) {
       log.log(Level.SEVERE, "Failed to read file at: " + path.toAbsolutePath(), e);
-      return Collections.emptyList();
+      return List.of();
     }
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/message/PlayerListing.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/message/PlayerListing.java
@@ -6,7 +6,6 @@ import games.strategy.engine.framework.startup.ui.PlayerType;
 import games.strategy.triplea.NetworkData;
 import java.io.Serializable;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -69,8 +68,7 @@ public class PlayerListing implements Serializable {
         Optional.ofNullable(playersAllowedToBeDisabled).map(HashSet::new).orElseGet(HashSet::new);
 
     this.playerNamesAndAlliancesInTurnOrder =
-        Optional.ofNullable(playerNamesAndAlliancesInTurnOrder).orElse(Collections.emptyMap())
-            .entrySet().stream()
+        Optional.ofNullable(playerNamesAndAlliancesInTurnOrder).orElse(Map.of()).entrySet().stream()
             .collect(
                 Collectors.toMap(
                     Entry::getKey,

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/login/HmacSha512Authenticator.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/login/HmacSha512Authenticator.java
@@ -8,7 +8,6 @@ import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.security.spec.KeySpec;
 import java.util.Base64;
-import java.util.Collections;
 import java.util.Map;
 import javax.crypto.Mac;
 import javax.crypto.SecretKey;
@@ -96,7 +95,7 @@ final class HmacSha512Authenticator {
     final byte[] nonce = decodeOptionalProperty(challenge, ChallengePropertyNames.NONCE);
     final byte[] salt = decodeOptionalProperty(challenge, ChallengePropertyNames.SALT);
     if (nonce == null || salt == null) {
-      return Collections.emptyMap();
+      return Map.of();
     }
 
     try {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -41,7 +41,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -575,7 +574,7 @@ public class ServerModel extends Observable implements IConnectionChangeListener
 
   private Map<String, PlayerType> getLocalPlayerTypes() {
     if (data == null) {
-      return Collections.emptyMap();
+      return Map.of();
     }
 
     final Map<String, PlayerType> localPlayerMappings = new HashMap<>();

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
@@ -9,7 +9,6 @@ import java.awt.GridBagConstraints;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -80,7 +79,7 @@ public class PlayerSelectorRow implements PlayerCountrySelection {
     if (previousSelection.equalsIgnoreCase("Client")) {
       previousSelection = PlayerType.HUMAN_PLAYER.name();
     }
-    if (Arrays.asList(PlayerType.playerTypes()).contains(previousSelection)) {
+    if (List.of(PlayerType.playerTypes()).contains(previousSelection)) {
       playerTypes.setSelectedItem(previousSelection);
     } else {
       setDefaultPlayerType();

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -26,7 +26,6 @@ import java.awt.event.ActionEvent;
 import java.awt.event.ActionListener;
 import java.net.URI;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -478,8 +477,7 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
       if (previousSelection.equalsIgnoreCase("Client")) {
         previousSelection = playerTypes[0];
       }
-      if (!previousSelection.equals("no_one")
-          && Arrays.asList(playerTypes).contains(previousSelection)) {
+      if (!previousSelection.equals("no_one") && List.of(playerTypes).contains(previousSelection)) {
         type.setSelectedItem(previousSelection);
         model.setLocalPlayerType(
             nameLabel.getText(), PlayerType.fromLabel((String) type.getSelectedItem()));

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/CreateAccountPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/CreateAccountPanel.java
@@ -11,6 +11,7 @@ import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.Window;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.swing.BorderFactory;
@@ -237,7 +238,7 @@ public final class CreateAccountPanel extends JPanel {
           }
         });
 
-    Arrays.asList(passwordField, passwordConfirmField, emailField)
+    List.of(passwordField, passwordConfirmField, emailField)
         .forEach(
             inputField ->
                 new KeyTypeValidator()

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LoginPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LoginPanel.java
@@ -9,7 +9,7 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
 import java.awt.Window;
-import java.util.Arrays;
+import java.util.List;
 import javax.annotation.Nullable;
 import javax.swing.BorderFactory;
 import javax.swing.ImageIcon;
@@ -252,7 +252,7 @@ final class LoginPanel extends JPanel {
   }
 
   private void updateComponents() {
-    Arrays.asList(rememberPassword, passwordLabel, password)
+    List.of(rememberPassword, passwordLabel, password)
         .forEach(component -> component.setEnabled(!anonymousLogin.isSelected()));
     if (anonymousLogin.isSelected()) {
       password.setText("");

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -15,7 +15,6 @@ import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.util.Collections;
 import java.util.List;
 import javax.swing.Action;
 import javax.swing.JFrame;
@@ -103,11 +102,11 @@ public class LobbyFrame extends JFrame {
 
   private List<Action> newModeratorActions(final ChatParticipant clickedOn) {
     if (!lobbyClient.isModerator()) {
-      return Collections.emptyList();
+      return List.of();
     }
 
     if (clickedOn.getPlayerName().equals(lobbyClient.getPlayerName())) {
-      return Collections.emptyList();
+      return List.of();
     }
 
     final var moderatorLobbyClient = lobbyClient.getHttpLobbyClient().getModeratorLobbyClient();

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -6,9 +6,8 @@ import games.strategy.engine.lobby.client.LobbyClient;
 import java.awt.BorderLayout;
 import java.awt.event.MouseEvent;
 import java.net.URI;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 import javax.swing.Action;
 import javax.swing.JButton;
 import javax.swing.JOptionPane;
@@ -147,7 +146,7 @@ class LobbyGamePanel extends JPanel {
 
     final JPopupMenu menu = new JPopupMenu();
 
-    Arrays.asList(
+    List.of(
             SwingAction.of("Join Game", this::joinGame),
             SwingAction.of("Host Game", () -> hostGame(lobbyUri)))
         .forEach(menu::add);
@@ -166,7 +165,7 @@ class LobbyGamePanel extends JPanel {
   }
 
   private Collection<Action> getGeneralAdminGamesListContextActions() {
-    return Collections.singletonList(SwingAction.of("Boot Game", e -> bootGame()));
+    return List.of(SwingAction.of("Boot Game", e -> bootGame()));
   }
 
   private void joinGame() {

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTable.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTable.java
@@ -2,7 +2,7 @@ package games.strategy.engine.lobby.client.ui;
 
 import java.awt.Component;
 import java.awt.Font;
-import java.util.Collections;
+import java.util.List;
 import javax.swing.JTable;
 import javax.swing.RowSorter;
 import javax.swing.SortOrder;
@@ -21,8 +21,7 @@ class LobbyGameTable extends JTable {
     final TableRowSorter<LobbyGameTableModel> tableSorter = new TableRowSorter<>(gameTableModel);
     // by default, sort by host
     final int hostColumn = gameTableModel.getColumnIndex(LobbyGameTableModel.Column.Host);
-    tableSorter.setSortKeys(
-        Collections.singletonList(new RowSorter.SortKey(hostColumn, SortOrder.DESCENDING)));
+    tableSorter.setSortKeys(List.of(new RowSorter.SortKey(hostColumn, SortOrder.DESCENDING)));
     setRowSorter(tableSorter);
   }
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/access/log/AccessLogTabActions.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/access/log/AccessLogTabActions.java
@@ -4,7 +4,6 @@ import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.lobby.moderator.toolbox.MessagePopup;
 import games.strategy.engine.lobby.moderator.toolbox.tabs.Pager;
 import java.awt.Component;
-import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
@@ -157,7 +156,7 @@ class AccessLogTabActions {
                             () -> {
                               dialog.dispose();
                               final String selectedDuration =
-                                  getSelection(Arrays.asList(oneHour, oneDay, oneWeek, threeWeeks));
+                                  getSelection(List.of(oneHour, oneDay, oneWeek, threeWeeks));
                               confirmBan(selectedDuration, banData);
                             })
                         .build())

--- a/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/access/log/AccessLogTabModel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/access/log/AccessLogTabModel.java
@@ -1,6 +1,5 @@
 package games.strategy.engine.lobby.moderator.toolbox.tabs.access.log;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -17,14 +16,14 @@ class AccessLogTabModel {
   private final ToolboxUsernameBanClient toolboxUsernameBanClient;
 
   static List<String> fetchTableHeaders() {
-    return Arrays.asList("Access Date", "Username", "IP", "System Id", "Registered", "", "");
+    return List.of("Access Date", "Username", "IP", "System Id", "Registered", "", "");
   }
 
   List<List<String>> fetchTableData(final PagingParams pagingParams) {
     return toolboxAccessLogClient.getAccessLog(pagingParams).stream()
         .map(
             accessLogData ->
-                Arrays.asList(
+                List.of(
                     accessLogData.getAccessDate().toString(),
                     accessLogData.getUsername(),
                     accessLogData.getIp(),

--- a/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/bad/words/BadWordsTabModel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/bad/words/BadWordsTabModel.java
@@ -1,7 +1,5 @@
 package games.strategy.engine.lobby.moderator.toolbox.tabs.bad.words;
 
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -15,7 +13,7 @@ class BadWordsTabModel {
   @Nonnull private final ToolboxBadWordsClient toolboxBadWordsClient;
 
   static List<String> fetchTableHeaders() {
-    return Arrays.asList("Bad Word", "");
+    return List.of("Bad Word", "");
   }
 
   /**
@@ -25,10 +23,10 @@ class BadWordsTabModel {
   List<List<String>> fetchTableData() {
     try {
       return toolboxBadWordsClient.getBadWords().stream()
-          .map(word -> Arrays.asList(word, BadWordsTabActions.REMOVE_BUTTON_TEXT))
+          .map(word -> List.of(word, BadWordsTabActions.REMOVE_BUTTON_TEXT))
           .collect(Collectors.toList());
     } catch (final RuntimeException e) {
-      return Collections.emptyList();
+      return List.of();
     }
   }
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/banned/names/BannedUsernamesTabModel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/banned/names/BannedUsernamesTabModel.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.lobby.moderator.toolbox.tabs.banned.names;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -17,14 +16,12 @@ class BannedUsernamesTabModel {
   @Nonnull private final ToolboxUsernameBanClient toolboxUsernameBanClient;
 
   static List<String> fetchTableHeaders() {
-    return Arrays.asList("Username", "Date Banned", "");
+    return List.of("Username", "Date Banned", "");
   }
 
   List<List<String>> fetchTableData() {
     return toolboxUsernameBanClient.getUsernameBans().stream()
-        .map(
-            banData ->
-                Arrays.asList(banData.getBannedName(), banData.getBanDate().toString(), "Remove"))
+        .map(banData -> List.of(banData.getBannedName(), banData.getBanDate().toString(), "Remove"))
         .collect(Collectors.toList());
   }
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/banned/users/BannedUsersTabModel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/banned/users/BannedUsersTabModel.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.lobby.moderator.toolbox.tabs.banned.users;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
@@ -14,14 +13,14 @@ class BannedUsersTabModel {
   private final ToolboxUserBanClient toolboxUserBanClient;
 
   static List<String> fetchTableHeaders() {
-    return Arrays.asList("Ban ID", "Username", "Date Banned", "IP", "Hashed Mac", "Ban Expiry", "");
+    return List.of("Ban ID", "Username", "Date Banned", "IP", "Hashed Mac", "Ban Expiry", "");
   }
 
   List<List<String>> fetchTableData() {
     return toolboxUserBanClient.getUserBans().stream()
         .map(
             userBan ->
-                Arrays.asList(
+                List.of(
                     userBan.getBanId(),
                     userBan.getUsername(),
                     String.valueOf(userBan.getBanDate()),

--- a/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/event/log/EventLogTabModel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/event/log/EventLogTabModel.java
@@ -1,6 +1,5 @@
 package games.strategy.engine.lobby.moderator.toolbox.tabs.event.log;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -18,14 +17,14 @@ class EventLogTabModel {
   private final ToolboxEventLogClient toolboxEventLogClient;
 
   static List<String> fetchTableHeaders() {
-    return Arrays.asList("Date", "Moderator", "Action", "Target");
+    return List.of("Date", "Moderator", "Action", "Target");
   }
 
   List<List<String>> fetchTableData(final PagingParams pagingParams) {
     return toolboxEventLogClient.lookupModeratorEvents(pagingParams).stream()
         .map(
             event ->
-                Arrays.asList(
+                List.of(
                     event.getDate().toString(),
                     event.getModeratorName(),
                     event.getModeratorAction(),

--- a/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/moderators/ModeratorsTabModel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/moderators/ModeratorsTabModel.java
@@ -2,7 +2,6 @@ package games.strategy.engine.lobby.moderator.toolbox.tabs.moderators;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -10,11 +9,11 @@ import lombok.Getter;
 import org.triplea.http.client.lobby.moderator.toolbox.management.ToolboxModeratorManagementClient;
 
 class ModeratorsTabModel {
-  @VisibleForTesting static final List<String> HEADERS = Arrays.asList("Name", "Last Login");
+  @VisibleForTesting static final List<String> HEADERS = List.of("Name", "Last Login");
 
   @VisibleForTesting
   static final List<String> SUPER_MOD_HEADERS =
-      Arrays.asList("Name", "Last Login", "Remove Mod", "Add Super-Mod");
+      List.of("Name", "Last Login", "Remove Mod", "Add Super-Mod");
 
   @VisibleForTesting static final String REMOVE_MOD_BUTTON_TEXT = "Remove Mod";
   @VisibleForTesting static final String ADD_SUPER_MOD_BUTTON = "Add Super-Mod";
@@ -37,14 +36,14 @@ class ModeratorsTabModel {
         .map(
             modInfo ->
                 isSuperMod
-                    ? Arrays.asList(
+                    ? List.of(
                         modInfo.getName(),
                         Optional.ofNullable(modInfo.getLastLogin())
                             .map(Instant::toString)
                             .orElse(""),
                         REMOVE_MOD_BUTTON_TEXT,
                         ADD_SUPER_MOD_BUTTON)
-                    : Arrays.asList(
+                    : List.of(
                         modInfo.getName(),
                         Optional.ofNullable(modInfo.getLastLogin())
                             .map(Instant::toString)

--- a/game-core/src/main/java/games/strategy/engine/pbem/NodeBbForumPoster.java
+++ b/game-core/src/main/java/games/strategy/engine/pbem/NodeBbForumPoster.java
@@ -6,7 +6,6 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -74,7 +73,7 @@ abstract class NodeBbForumPoster implements IForumPoster {
     addTokenHeader(post, token);
     post.setEntity(
         new UrlEncodedFormEntity(
-            Collections.singletonList(
+            List.of(
                 new BasicNameValuePair(
                     "content", text + ((path != null) ? uploadSaveGame(client, token, path) : ""))),
             StandardCharsets.UTF_8));
@@ -163,8 +162,7 @@ abstract class NodeBbForumPoster implements IForumPoster {
   private String getToken(final CloseableHttpClient client, final int userId) throws IOException {
     final HttpPost post = new HttpPost(getForumUrl() + "/api/v2/users/" + userId + "/tokens");
     post.setEntity(
-        new UrlEncodedFormEntity(
-            Collections.singletonList(newPasswordParameter()), StandardCharsets.UTF_8));
+        new UrlEncodedFormEntity(List.of(newPasswordParameter()), StandardCharsets.UTF_8));
     HttpProxy.addProxy(post);
     try (CloseableHttpResponse response = client.execute(post)) {
       final String rawJson = EntityUtils.toString(response.getEntity());

--- a/game-core/src/main/java/games/strategy/net/MacFinder.java
+++ b/game-core/src/main/java/games/strategy/net/MacFinder.java
@@ -10,7 +10,6 @@ import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.nio.charset.Charset;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
@@ -103,7 +102,7 @@ public final class MacFinder {
      */
     try {
       final String results = executeCommandAndGetResults("getmac");
-      final String mac = tryToParseMacFromOutput(results, Arrays.asList("-", ":", "."), false);
+      final String mac = tryToParseMacFromOutput(results, List.of("-", ":", "."), false);
       if (isMacValid(mac)) {
         return mac;
       }
@@ -119,7 +118,7 @@ public final class MacFinder {
      */
     try {
       final String results = executeCommandAndGetResults("ipconfig -all");
-      final String mac = tryToParseMacFromOutput(results, Arrays.asList("-", ":", "."), false);
+      final String mac = tryToParseMacFromOutput(results, List.of("-", ":", "."), false);
       if (isMacValid(mac)) {
         return mac;
       }
@@ -130,7 +129,7 @@ public final class MacFinder {
       // ipconfig -all does not work on my computer, while ipconfig /all does not work on others
       // computers
       final String results = executeCommandAndGetResults("ipconfig /all");
-      final String mac = tryToParseMacFromOutput(results, Arrays.asList("-", ":", "."), false);
+      final String mac = tryToParseMacFromOutput(results, List.of("-", ":", "."), false);
       if (isMacValid(mac)) {
         return mac;
       }
@@ -148,7 +147,7 @@ public final class MacFinder {
     try {
       final String results = executeCommandAndGetResults("ifconfig -a");
       // Allow the parser to try adding a zero to the beginning
-      final String mac = tryToParseMacFromOutput(results, Arrays.asList(":", "-", "."), true);
+      final String mac = tryToParseMacFromOutput(results, List.of(":", "-", "."), true);
       if (isMacValid(mac)) {
         return mac;
       }
@@ -166,7 +165,7 @@ public final class MacFinder {
     try {
       final String results = executeCommandAndGetResults("/sbin/ifconfig -a");
       // Allow the parser to try adding a zero to the beginning
-      final String mac = tryToParseMacFromOutput(results, Arrays.asList(":", "-", "."), true);
+      final String mac = tryToParseMacFromOutput(results, List.of(":", "-", "."), true);
       if (isMacValid(mac)) {
         return mac;
       }
@@ -184,7 +183,7 @@ public final class MacFinder {
      */
     try {
       final String results = executeCommandAndGetResults("dmesg");
-      final String mac = tryToParseMacFromOutput(results, Arrays.asList(":", "-", "."), false);
+      final String mac = tryToParseMacFromOutput(results, List.of(":", "-", "."), false);
       if (isMacValid(mac)) {
         return mac;
       }

--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -15,7 +15,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -119,7 +118,7 @@ public class ResourceLoader implements Closeable {
     final File userMapsFolder = ClientFileSystemHelper.getUserMapsFolder();
     final String dirName = File.separator + mapName;
     final String normalizedMapName = File.separator + normalizeMapName(mapName) + "-master";
-    return Arrays.asList(
+    return List.of(
         new File(userMapsFolder, dirName + File.separator + "map"),
         new File(userMapsFolder, dirName),
         new File(userMapsFolder, normalizedMapName + File.separator + "map"),
@@ -141,7 +140,7 @@ public class ResourceLoader implements Closeable {
 
     final File userMapsFolder = ClientFileSystemHelper.getUserMapsFolder();
     final String normalizedMapName = normalizeMapName(mapName);
-    return Arrays.asList(
+    return List.of(
         new File(userMapsFolder, mapName + ".zip"),
         new File(userMapsFolder, normalizedMapName + "-master.zip"),
         new File(userMapsFolder, normalizedMapName + ".zip"));

--- a/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -17,7 +17,6 @@ import games.strategy.triplea.delegate.Matches;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
@@ -55,7 +54,7 @@ public class TripleAUnit extends Unit {
   // the transport that is currently transporting us
   private TripleAUnit transportedBy = null;
   // the units we have unloaded this turn
-  private List<Unit> unloaded = Collections.emptyList();
+  private List<Unit> unloaded = List.of();
   // was this unit loaded this turn?
   private boolean wasLoadedThisTurn = false;
   // the territory this unit was unloaded to this turn
@@ -120,7 +119,7 @@ public class TripleAUnit extends Unit {
         }
       }
     }
-    return Collections.emptyList();
+    return List.of();
   }
 
   public List<Unit> getTransporting(final Collection<Unit> transportedUnitsPossible) {
@@ -136,7 +135,7 @@ public class TripleAUnit extends Unit {
 
   private void setUnloaded(final List<Unit> unloaded) {
     if (unloaded == null || unloaded.isEmpty()) {
-      this.unloaded = Collections.emptyList();
+      this.unloaded = List.of();
     } else {
       this.unloaded = new ArrayList<>(unloaded);
     }

--- a/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
@@ -28,7 +28,6 @@ import games.strategy.triplea.delegate.remote.ITechDelegate;
 import games.strategy.triplea.player.AbstractBasePlayer;
 import games.strategy.triplea.settings.ClientSetting;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -233,7 +232,7 @@ public abstract class AbstractAi extends AbstractBasePlayer {
     }
     // would we normally be allies?
     final List<String> allies =
-        Arrays.asList(
+        List.of(
             Constants.PLAYER_NAME_AMERICANS,
             Constants.PLAYER_NAME_AUSTRALIANS,
             Constants.PLAYER_NAME_BRITISH,
@@ -246,7 +245,7 @@ public abstract class AbstractAi extends AbstractBasePlayer {
       return true;
     }
     final List<String> axis =
-        Arrays.asList(
+        List.of(
             Constants.PLAYER_NAME_GERMANS,
             Constants.PLAYER_NAME_ITALIANS,
             Constants.PLAYER_NAME_JAPANESE,

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -1563,11 +1563,7 @@ class ProNonCombatMoveAi {
             final Route route =
                 data.getMap()
                     .getRouteForUnits(
-                        currentTerritory,
-                        patd.getTerritory(),
-                        match,
-                        Collections.singletonList(transport),
-                        player);
+                        currentTerritory, patd.getTerritory(), match, List.of(transport), player);
             if (route == null) {
               break;
             }
@@ -2527,7 +2523,7 @@ class ProNonCombatMoveAi {
                       player);
           final MoveValidationResult mvr =
               MoveValidator.validateMove(
-                  Collections.singletonList(u), r, player, Map.of(), Map.of(), true, null, data);
+                  List.of(u), r, player, Map.of(), Map.of(), true, null, data);
           if (!mvr.isMoveValid()) {
             continue;
           }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -35,7 +35,6 @@ import games.strategy.triplea.delegate.remote.IPurchaseDelegate;
 import games.strategy.triplea.util.TuvUtils;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -1052,7 +1051,7 @@ class ProPurchaseAi {
       for (final Iterator<Unit> it = unplacedUnits.iterator(); it.hasNext(); ) {
         final Unit u = it.next();
         if (remainingUnitProduction > 0
-            && ProPurchaseUtils.canUnitsBePlaced(Collections.singletonList(u), player, t, isBid)) {
+            && ProPurchaseUtils.canUnitsBePlaced(List.of(u), player, t, isBid)) {
           remainingUnitProduction--;
           unitsToPlace.add(u);
           it.remove();
@@ -2565,10 +2564,7 @@ class ProPurchaseAi {
       final Territory t, final Collection<Unit> toPlace, final IAbstractPlaceDelegate del) {
     for (final Unit unit : toPlace) {
       final String message =
-          del.placeUnits(
-              new ArrayList<>(Collections.singletonList(unit)),
-              t,
-              IAbstractPlaceDelegate.BidMode.NOT_BID);
+          del.placeUnits(new ArrayList<>(List.of(unit)), t, IAbstractPlaceDelegate.BidMode.NOT_BID);
       if (message != null) {
         ProLogger.warn(message);
         ProLogger.warn("Attempt was at: " + t + " with: " + unit);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProScrambleAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProScrambleAi.java
@@ -16,7 +16,6 @@ import games.strategy.triplea.delegate.IBattle;
 import games.strategy.triplea.delegate.IBattle.BattleType;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -74,7 +73,7 @@ class ProScrambleAi {
             Comparator.<Unit>comparingDouble(
                     o ->
                         ProBattleUtils.estimateStrength(
-                            scrambleTo, Collections.singletonList(o), new ArrayList<>(), false))
+                            scrambleTo, List.of(o), new ArrayList<>(), false))
                 .reversed());
         canScrambleAir = canScrambleAir.subList(0, maxCanScramble);
       }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -428,7 +428,7 @@ public class ProTerritoryManager {
                 Comparator.<Unit>comparingDouble(
                         o ->
                             ProBattleUtils.estimateStrength(
-                                to, Collections.singletonList(o), new ArrayList<>(), false))
+                                to, List.of(o), new ArrayList<>(), false))
                     .reversed());
             canScrambleAir = canScrambleAir.subList(0, maxCanScramble);
           }
@@ -1235,7 +1235,7 @@ public class ProTerritoryManager {
             for (final Territory possibleNeighborTerritory : possibleNeighborTerritories) {
               if (MoveValidator.validateCanal(
                       new Route(currentTerritory, possibleNeighborTerritory),
-                      Collections.singletonList(myTransportUnit),
+                      List.of(myTransportUnit),
                       player,
                       data)
                   == null) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -16,7 +16,6 @@ import games.strategy.triplea.delegate.TransportTracker;
 import games.strategy.triplea.delegate.remote.IMoveDelegate;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -240,10 +239,7 @@ public final class ProMoveUtils {
                 Integer.MIN_VALUE; // Used to move to farthest away loading territory first
             for (final Territory neighbor : neighbors) {
               if (MoveValidator.validateCanal(
-                      new Route(transportTerritory, neighbor),
-                      Collections.singletonList(transport),
-                      player,
-                      data)
+                      new Route(transportTerritory, neighbor), List.of(transport), player, data)
                   != null) {
                 continue;
               }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
@@ -224,7 +224,7 @@ public final class ProTransportUtils {
   public static List<Unit> findBestUnitsToLandTransport(
       final Unit unit, final Territory t, final List<Unit> usedUnits) {
     if (usedUnits.contains(unit)) {
-      return Collections.emptyList();
+      return List.of();
     }
     final PlayerId player = unit.getOwner();
     final List<Unit> units =
@@ -237,7 +237,7 @@ public final class ProTransportUtils {
     if (Matches.unitIsLandTransport().negate().test(unit)
         || !TechAttachment.isMechanizedInfantry(player)
         || units.isEmpty()) {
-      return Collections.singletonList(unit);
+      return List.of(unit);
     }
     final List<Unit> results = new ArrayList<>();
     results.add(unit);

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -685,7 +685,7 @@ public class WeakAi extends AbstractAi {
                 moveUnits.add(CollectionUtils.difference(units, unitsAlreadyMoved));
                 unitsAlreadyMoved.addAll(units);
               } else {
-                moveUnits.add(Collections.singleton(unit));
+                moveUnits.add(Set.of(unit));
               }
               unitsAlreadyMoved.add(unit);
               taken = true;

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -17,7 +17,6 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.formatter.MyFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -172,7 +171,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
         if (!allConditionsNeededSoFar.contains(subCondition)) {
           allConditionsNeededSoFar.addAll(
               getAllConditionsRecursive(
-                  new HashSet<>(Collections.singleton(subCondition)), allConditionsNeededSoFar));
+                  new HashSet<>(Set.of(subCondition)), allConditionsNeededSoFar));
         }
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -13,7 +13,6 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.OriginalOwnerTracker;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -68,9 +67,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
   }
 
   protected List<PlayerId> getPlayers() {
-    return players.isEmpty()
-        ? new ArrayList<>(Collections.singletonList((PlayerId) getAttachedTo()))
-        : players;
+    return players.isEmpty() ? new ArrayList<>(List.of((PlayerId) getAttachedTo())) : players;
   }
 
   private void resetPlayers() {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
@@ -11,7 +11,6 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Constants;
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -81,7 +80,7 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
           "combatDefenseEffect and combatOffenseEffect must have a count and at least one unitType"
               + thisErrorMsg());
     }
-    final Iterator<String> iter = Arrays.asList(s).iterator();
+    final Iterator<String> iter = List.of(s).iterator();
     final int effect = getInt(iter.next());
     while (iter.hasNext()) {
       final String unitTypeToProduce = iter.next();
@@ -107,7 +106,7 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
       throw new GameParseException(
           "movementCostModifier must have a count and at least one unitType" + thisErrorMsg());
     }
-    final Iterator<String> iter = Arrays.asList(s).iterator();
+    final Iterator<String> iter = List.of(s).iterator();
     final BigDecimal effect = getBigDecimal(iter.next());
     while (iter.hasNext()) {
       final String unitTypeToProduce = iter.next();

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -38,7 +38,6 @@ import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.ui.NotificationMessages;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -905,9 +904,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
   }
 
   private List<PlayerId> getPlayers() {
-    return players.isEmpty()
-        ? new ArrayList<>(Collections.singletonList((PlayerId) getAttachedTo()))
-        : players;
+    return players.isEmpty() ? new ArrayList<>(List.of((PlayerId) getAttachedTo())) : players;
   }
 
   private void resetPlayers() {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -1021,10 +1021,10 @@ public class UnitAttachment extends DefaultAttachment {
 
   public boolean canInvadeFrom(final Unit transport) {
     return canInvadeOnlyFrom == null
-        || Arrays.asList(canInvadeOnlyFrom).isEmpty()
+        || List.of(canInvadeOnlyFrom).isEmpty()
         || canInvadeOnlyFrom[0].isEmpty()
         || canInvadeOnlyFrom[0].equals("all")
-        || Arrays.asList(canInvadeOnlyFrom).contains(transport.getType().getName());
+        || List.of(canInvadeOnlyFrom).contains(transport.getType().getName());
   }
 
   private void resetCanInvadeOnlyFrom() {
@@ -3474,7 +3474,7 @@ public class UnitAttachment extends DefaultAttachment {
         && Properties.getUnitPlacementRestrictions(getData())) {
       final List<String> totalUnitsListed = new ArrayList<>();
       for (final String[] list : getRequiresUnits()) {
-        totalUnitsListed.addAll(Arrays.asList(list));
+        totalUnitsListed.addAll(List.of(list));
       }
       if (totalUnitsListed.size() > 4) {
         tuples.add(Tuple.of("Has Placement Requirements", ""));
@@ -3486,7 +3486,7 @@ public class UnitAttachment extends DefaultAttachment {
     if (getRequiresUnitsToMove() != null && !getRequiresUnitsToMove().isEmpty()) {
       final List<String> totalUnitsListed = new ArrayList<>();
       for (final String[] list : getRequiresUnitsToMove()) {
-        totalUnitsListed.addAll(Arrays.asList(list));
+        totalUnitsListed.addAll(List.of(list));
       }
       if (totalUnitsListed.size() > 4) {
         tuples.add(Tuple.of("Has Movement Requirements", ""));

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -12,7 +12,6 @@ import games.strategy.triplea.Constants;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -360,7 +359,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
     rule.setImpArtTech(true);
     rule.setNumber(first ? 0 : 1);
     rule.setSide("offence");
-    rule.addUnitTypes(first ? Collections.singleton(type) : getTargets(data));
+    rule.addUnitTypes(first ? Set.of(type) : getTargets(data));
     if (!first) {
       rule.setPlayers(new ArrayList<>(data.getPlayerList().getPlayers()));
     }
@@ -406,7 +405,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
     boolean first = true;
     for (final UnitSupportAttachment rule : get(data)) {
       if (rule.getBonusType().isOldArtilleryRule()) {
-        rule.addUnitTypes(Collections.singleton(type));
+        rule.addUnitTypes(Set.of(type));
         first = false;
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
@@ -225,12 +225,12 @@ class AaInMoveUtil implements Serializable {
     final boolean alwaysOnAa = isAlwaysOnAaEnabled();
     // Just the attacked territory will have AA firing
     if (!alwaysOnAa && isAaTerritoryRestricted()) {
-      return Collections.emptyList();
+      return List.of();
     }
     final GameData data = getData();
     // No AA in nonCombat unless 'Always on AA'
     if (GameStepPropertiesHelper.isNonCombatMove(data, false) && !alwaysOnAa) {
-      return Collections.emptyList();
+      return List.of();
     }
     // can't rely on player being the unit owner in Edit Mode
     // look at the units being moved to determine allies and enemies

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractBattle.java
@@ -16,7 +16,6 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.data.BattleRecord.BattleResultDescription;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -115,9 +114,9 @@ abstract class AbstractBattle implements IBattle {
   /** Figure out what units a transport is transporting and has to unloaded. */
   Collection<Unit> getTransportDependents(final Collection<Unit> targets) {
     if (headless) {
-      return Collections.emptyList();
+      return List.of();
     } else if (targets.stream().noneMatch(Matches.unitCanTransport())) {
-      return Collections.emptyList();
+      return List.of();
     }
     return ImmutableList.copyOf(
         targets.stream()

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -22,7 +22,6 @@ import games.strategy.triplea.formatter.MyFormatter;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
@@ -271,8 +270,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       bridge
           .getDisplayChannelBroadcaster()
           .reportMessageToPlayers(
-              Collections.singletonList(player),
-              Collections.emptyList(),
+              List.of(player),
+              List.of(),
               "Not enough unit production territories available",
               "Unit Placement Canceled");
     }
@@ -1519,7 +1518,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       }
       if (!doNotCountNeighbors && to.isWater()) {
         for (final Territory current :
-            getAllProducers(to, player, Collections.singletonList(unitWhichRequiresUnits), true)) {
+            getAllProducers(to, player, List.of(unitWhichRequiresUnits), true)) {
           final Collection<Unit> unitsAtStartOfTurnInCurrent =
               unitsAtStartOfStepInTerritory(current);
           if (Matches.unitWhichRequiresUnitsHasRequiredUnitsInList(unitsAtStartOfTurnInCurrent)

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirBattle.java
@@ -362,20 +362,18 @@ public class AirBattle extends AbstractBattle {
                 && Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(gameData)) {
               while (target == null) {
                 target =
-                    getRemote(bridge)
-                        .whatShouldBomberBomb(
-                            battleSite, enemyTargets, Collections.singletonList(unit));
+                    getRemote(bridge).whatShouldBomberBomb(battleSite, enemyTargets, List.of(unit));
               }
             } else {
               target = enemyTargets.iterator().next();
             }
             if (target != null) {
               targets = new HashMap<>();
-              targets.put(target, new HashSet<>(Collections.singleton(unit)));
+              targets.put(target, new HashSet<>(Set.of(unit)));
             }
             battleTracker.addBattle(
                 new RouteScripted(battleSite),
-                Collections.singleton(unit),
+                Set.of(unit),
                 true,
                 attacker,
                 bridge,
@@ -477,7 +475,7 @@ public class AirBattle extends AbstractBattle {
     // move during non combat to their landing site, or be scrapped if they can't find one.
     // retreat planes
     if (!attackingUnits.isEmpty()) {
-      queryRetreat(false, bridge, Collections.singleton(battleSite));
+      queryRetreat(false, bridge, Set.of(battleSite));
     }
   }
 
@@ -486,7 +484,7 @@ public class AirBattle extends AbstractBattle {
     // move during non combat to their landing site, or be scrapped if they can't find one.
     // retreat planes
     if (!defendingUnits.isEmpty()) {
-      queryRetreat(true, bridge, Collections.singleton(battleSite));
+      queryRetreat(true, bridge, Set.of(battleSite));
     }
   }
 
@@ -563,12 +561,12 @@ public class AirBattle extends AbstractBattle {
             null,
             null,
             null,
-            Collections.emptyMap(),
+            Map.of(),
             attacker,
             defender,
             isAmphibious(),
             getBattleType(),
-            Collections.emptySet());
+            Set.of());
     bridge.getDisplayChannelBroadcaster().listBattleSteps(battleId, steps);
   }
 
@@ -936,7 +934,7 @@ public class AirBattle extends AbstractBattle {
             hitPlayer,
             details.getKilled(),
             details.getDamaged(),
-            Collections.emptyMap());
+            Map.of());
     // execute in a separate thread to allow either player to click continue first.
     final Thread t =
         new Thread(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -14,7 +14,6 @@ import games.strategy.triplea.delegate.data.MoveValidationResult;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -129,7 +128,7 @@ public final class AirMovementValidator {
     // TODO: consider each carrier unit separately with movement costs
     final int maxMovementLeftForAllOwnedCarriers =
         maxMovementLeftForAllOwnedCarriers(player, data).intValue();
-    final List<Territory> landingSpots = new ArrayList<>(Collections.singleton(routeEnd));
+    final List<Territory> landingSpots = new ArrayList<>(Set.of(routeEnd));
     landingSpots.addAll(
         data.getMap()
             .getNeighbors(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleCalculator.java
@@ -602,7 +602,7 @@ public class BattleCalculator {
     final Player tripleaPlayer =
         player.isNull() ? new WeakAi(player.getName()) : bridge.getRemotePlayer(player);
     final Map<Unit, Collection<Unit>> dependents =
-        headLess ? Collections.emptyMap() : getDependents(targetsToPickFrom);
+        headLess ? Map.of() : getDependents(targetsToPickFrom);
     if (isEditMode && !headLess) {
       final CasualtyDetails editSelection =
           tripleaPlayer.selectCasualties(
@@ -628,7 +628,7 @@ public class BattleCalculator {
       return editSelection;
     }
     if (dice.getHits() == 0) {
-      return new CasualtyDetails(Collections.emptyList(), Collections.emptyList(), true);
+      return new CasualtyDetails(List.of(), List.of(), true);
     }
     int hitsRemaining = dice.getHits();
     if (isTransportCasualtiesRestricted(data)) {
@@ -643,7 +643,7 @@ public class BattleCalculator {
         }
         killed.add(iter.next());
       }
-      return new CasualtyDetails(killed, Collections.emptyList(), true);
+      return new CasualtyDetails(killed, List.of(), true);
     }
     // Create production cost map, Maybe should do this elsewhere, but in case prices change, we do
     // it here.
@@ -987,9 +987,7 @@ public class BattleCalculator {
         }
         unitTypes.add(u.getType());
         // Find unit power
-        int power =
-            DiceRoll.getTotalPower(
-                Collections.singletonMap(u, originalUnitPowerAndRollsMap.get(u)), data);
+        int power = DiceRoll.getTotalPower(Map.of(u, originalUnitPowerAndRollsMap.get(u)), data);
         // Add any support power that it provides to other units
         final IntegerMap<Unit> unitSupportPowerMapForUnit = unitSupportPowerMap.get(u);
         if (unitSupportPowerMapForUnit != null) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -36,7 +36,6 @@ import java.io.Serializable;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -917,9 +916,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
           for (final Unit u : scrambling) {
             change.add(ChangeFactory.unitPropertyChange(u, t, TripleAUnit.ORIGINATED_FROM));
             change.add(ChangeFactory.unitPropertyChange(u, true, TripleAUnit.WAS_SCRAMBLED));
-            change.add(
-                Route.getFuelChanges(
-                    Collections.singleton(u), new Route(t, to), u.getOwner(), data));
+            change.add(Route.getFuelChanges(Set.of(u), new Route(t, to), u.getOwner(), data));
           }
           // should we mark combat, or call setupUnitsInSameTerritoryBattles again?
           change.add(ChangeFactory.moveUnits(t, to, scrambling));
@@ -1123,13 +1120,12 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
                         "Select territory for air units to land. (Current territory is "
                             + t.getName()
                             + "): "
-                            + MyFormatter.unitsToText(Collections.singletonList(u)));
+                            + MyFormatter.unitsToText(List.of(u)));
           } else if (possible.size() == 1) {
             landingTerr = possible.iterator().next();
           }
           if (landingTerr == null || landingTerr.equals(t)) {
-            carrierCostOfCurrentTerr +=
-                AirMovementValidator.carrierCost(Collections.singletonList(u));
+            carrierCostOfCurrentTerr += AirMovementValidator.carrierCost(List.of(u));
             historyText = "Scrambled unit stays in territory " + t.getName();
           } else {
             historyText =
@@ -1144,10 +1140,9 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
                   + landingTerr.getName();
         }
         if (landingTerr != null && !landingTerr.equals(t)) {
-          change.add(ChangeFactory.moveUnits(t, landingTerr, Collections.singletonList(u)));
+          change.add(ChangeFactory.moveUnits(t, landingTerr, List.of(u)));
           change.add(
-              Route.getFuelChanges(
-                  Collections.singleton(u), new Route(t, landingTerr), u.getOwner(), data));
+              Route.getFuelChanges(Set.of(u), new Route(t, landingTerr), u.getOwner(), data));
         }
         change.add(ChangeFactory.unitPropertyChange(u, null, TripleAUnit.ORIGINATED_FROM));
         change.add(ChangeFactory.unitPropertyChange(u, false, TripleAUnit.WAS_SCRAMBLED));
@@ -1621,8 +1616,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       }
     }
     final String title =
-        "Kamikaze Suicide Attack attacks "
-            + MyFormatter.unitsToText(Collections.singleton(unitUnderFire));
+        "Kamikaze Suicide Attack attacks " + MyFormatter.unitsToText(Set.of(unitUnderFire));
     final String dice = " scoring " + hits + " hits.  Rolls: " + MyFormatter.asDice(rolls);
     bridge.getHistoryWriter().startEvent(title + dice, unitUnderFire);
     if (hits > 0) {
@@ -1630,7 +1624,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       final int currentHits = unitUnderFire.getHits();
       if (ua.getHitPoints() <= currentHits + hits) {
         // TODO: kill dependents
-        change.add(ChangeFactory.removeUnits(location, Collections.singleton(unitUnderFire)));
+        change.add(ChangeFactory.removeUnits(location, Set.of(unitUnderFire)));
       } else {
         final IntegerMap<Unit> hitMap = new IntegerMap<>();
         hitMap.put(unitUnderFire, hits);
@@ -1687,7 +1681,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
 
     final int maxDistance = UnitAttachment.get(strandedAir.getType()).getMaxScrambleDistance();
     if (maxDistance <= 0) {
-      return Collections.singletonList(currentTerr);
+      return List.of(currentTerr);
     }
     final boolean areNeutralsPassableByAir =
         (Properties.getNeutralFlyoverAllowed(data) && !Properties.getNeutralsImpassable(data));

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -998,7 +998,7 @@ public class BattleTracker implements Serializable {
                 changes.add(translate);
               }
             }
-            changes.add(ChangeFactory.removeUnits(territory, Collections.singleton(u)));
+            changes.add(ChangeFactory.removeUnits(territory, Set.of(u)));
             changes.add(ChangeFactory.addUnits(territory, toAdd));
             changes.add(ChangeFactory.markNoMovementChange(toAdd));
             bridge
@@ -1197,7 +1197,7 @@ public class BattleTracker implements Serializable {
   public Collection<IBattle> getDependentOn(final IBattle blocked) {
     final Collection<IBattle> dependent = dependencies.get(blocked);
     if (dependent == null) {
-      return Collections.emptyList();
+      return List.of();
     }
     return CollectionUtils.getMatches(dependent, Matches.battleIsEmpty().negate());
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -22,7 +22,6 @@ import java.io.ObjectInput;
 import java.io.ObjectOutput;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -204,7 +203,7 @@ public class DiceRoll implements Externalizable {
     // Check that there are valid AA and targets to roll for
     final int totalAaAttacks = getTotalAaAttacks(unitPowerAndRollsMap, validTargets);
     if (totalAaAttacks <= 0) {
-      return new DiceRoll(Collections.emptyList(), 0, 0);
+      return new DiceRoll(List.of(), 0, 0);
     }
 
     // Determine dice sides (doesn't handle the possibility of different dice sides within the same
@@ -433,9 +432,7 @@ public class DiceRoll implements Externalizable {
       final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap) {
     units.sort(
         Comparator.comparing(
-            unit ->
-                getMaxAaAttackAndDiceSides(
-                    Collections.singleton(unit), data, defending, unitPowerAndRollsMap),
+            unit -> getMaxAaAttackAndDiceSides(Set.of(unit), data, defending, unitPowerAndRollsMap),
             Comparator.<Tuple<Integer, Integer>, Boolean>comparing(tuple -> tuple.getFirst() == 0)
                 .thenComparingDouble(tuple -> -tuple.getFirst() / (float) tuple.getSecond())));
   }
@@ -904,7 +901,7 @@ public class DiceRoll implements Externalizable {
 
     final int power = getTotalPower(unitPowerAndRollsMap, data);
     if (power == 0) {
-      return new DiceRoll(Collections.emptyList(), 0, 0);
+      return new DiceRoll(List.of(), 0, 0);
     }
 
     // Roll dice for the fractional part of the dice

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -27,7 +27,6 @@ import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.ui.ObjectiveDummyDelegateBridge;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -368,7 +367,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
               .and(TriggerAttachment.resourceMatch());
       triggers.addAll(
           TriggerAttachment.collectForAllTriggersMatching(
-              new HashSet<>(Collections.singleton(player)), endTurnDelegateTriggerMatch));
+              new HashSet<>(Set.of(player)), endTurnDelegateTriggerMatch));
       allConditionsNeeded.addAll(
           AbstractConditionsAttachment.getAllConditionsRecursive(new HashSet<>(triggers), null));
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Fire.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Fire.java
@@ -9,7 +9,6 @@ import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -195,7 +194,7 @@ public class Fire implements IExecutable {
                   Matches.unitIsTransportButNotCombatTransport()));
         }
         killed = nonTransports;
-        damaged = Collections.emptyList();
+        damaged = List.of();
         if (extraHits > transportsOnly.size()) {
           extraHits = transportsOnly.size();
         }
@@ -221,7 +220,7 @@ public class Fire implements IExecutable {
         confirmOwnCasualties = true;
       } else if (hitCount == numPossibleHits) { // exact number of combat units
         killed = nonTransports;
-        damaged = Collections.emptyList();
+        damaged = List.of();
         confirmOwnCasualties = true;
       } else { // less than possible number
         message =
@@ -250,7 +249,7 @@ public class Fire implements IExecutable {
       // they all die
       if (hitCount >= AbstractBattle.getMaxHits(attackableUnits)) {
         killed = attackableUnits;
-        damaged = Collections.emptyList();
+        damaged = List.of();
         // everything died, so we need to confirm
         confirmOwnCasualties = true;
       } else { // Choose casualties

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -94,7 +94,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
       if (GameStepPropertiesHelper.isCombatMove(data) && Properties.getTriggers(data)) {
         final Set<TriggerAttachment> toFirePossible =
             TriggerAttachment.collectForAllTriggersMatching(
-                new HashSet<>(Collections.singleton(player)), moveCombatDelegateAllTriggerMatch);
+                new HashSet<>(Set.of(player)), moveCombatDelegateAllTriggerMatch);
         if (!toFirePossible.isEmpty()) {
 
           // collect conditions and test them for ALL triggers, both those that we will fire before
@@ -103,8 +103,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
           testedConditions = TriggerAttachment.collectTestsForAllTriggers(toFirePossible, bridge);
           final Set<TriggerAttachment> toFireBeforeBonus =
               TriggerAttachment.collectForAllTriggersMatching(
-                  new HashSet<>(Collections.singleton(player)),
-                  moveCombatDelegateBeforeBonusTriggerMatch);
+                  new HashSet<>(Set.of(player)), moveCombatDelegateBeforeBonusTriggerMatch);
           if (!toFireBeforeBonus.isEmpty()) {
 
             // get all triggers that are satisfied based on the tested conditions.
@@ -157,8 +156,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
       if (GameStepPropertiesHelper.isCombatMove(data) && Properties.getTriggers(data)) {
         final Set<TriggerAttachment> toFireAfterBonus =
             TriggerAttachment.collectForAllTriggersMatching(
-                new HashSet<>(Collections.singleton(player)),
-                moveCombatDelegateAfterBonusTriggerMatch);
+                new HashSet<>(Set.of(player)), moveCombatDelegateAfterBonusTriggerMatch);
         if (!toFireAfterBonus.isEmpty()) {
 
           // get all triggers that are satisfied based on the tested conditions.
@@ -514,7 +512,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     for (final Unit carrier : damagedCarriers) {
       final CompositeChange change =
           TransportTracker.clearTransportedByForAlliedAirOnCarrier(
-              Collections.singleton(carrier), fullyRepaired.get(carrier), carrier.getOwner(), data);
+              Set.of(carrier), fullyRepaired.get(carrier), carrier.getOwner(), data);
       if (!change.isEmpty()) {
         clearAlliedAir.add(change);
       }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -105,7 +105,7 @@ public class MovePerformer implements Serializable {
                 final Route routeUnitUsedToMove =
                     moveDelegate.getRouteUsedToMoveInto(unit, route.getStart());
                 if (battle != null) {
-                  battle.removeAttack(routeUnitUsedToMove, Collections.singleton(unit));
+                  battle.removeAttack(routeUnitUsedToMove, Set.of(unit));
                 }
               }
             }
@@ -384,7 +384,7 @@ public class MovePerformer implements Serializable {
     if (GameStepPropertiesHelper.isCombatMove(data)
         && (MoveDelegate.getEmptyNeutral(route).size() != 0 || hasConqueredNonBlitzed(route))) {
       for (final Unit unit : CollectionUtils.getMatches(units, Matches.unitIsLand())) {
-        change.add(ChangeFactory.markNoMovementChange(Collections.singleton(unit)));
+        change.add(ChangeFactory.markNoMovementChange(Set.of(unit)));
       }
     }
     if (routeEnd != null
@@ -398,7 +398,7 @@ public class MovePerformer implements Serializable {
       // can't keep moving them if there is an enemy destroyer there
       for (final Unit unit :
           CollectionUtils.getMatches(units, Matches.unitCanMoveThroughEnemies())) {
-        change.add(ChangeFactory.markNoMovementChange(Collections.singleton(unit)));
+        change.add(ChangeFactory.markNoMovementChange(Set.of(unit)));
       }
     }
     return change;
@@ -501,7 +501,7 @@ public class MovePerformer implements Serializable {
         currentMove.unload(unit);
         bridge.addChange(change1);
         // set noMovement
-        final Change change2 = ChangeFactory.markNoMovementChange(Collections.singleton(unit));
+        final Change change2 = ChangeFactory.markNoMovementChange(Set.of(unit));
         currentMove.addChange(change2);
         bridge.addChange(change2);
       }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -24,7 +24,6 @@ import games.strategy.triplea.util.UnitCategory;
 import games.strategy.triplea.util.UnitSeparator;
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -1836,7 +1835,7 @@ public class MoveValidator {
     final Predicate<Territory> noAa = Matches.territoryHasEnemyAaForFlyOver(player, data).negate();
     final List<Predicate<Territory>> prioritizedMovePreferences =
         new ArrayList<>(
-            Arrays.asList(
+            List.of(
                 hasRequiredUnitsToMove.and(notEnemyOwned).and(noEnemyUnits),
                 hasRequiredUnitsToMove.and(noEnemyUnits),
                 hasRequiredUnitsToMove.and(noAa),

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -533,7 +533,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   private void removeFromNonCombatLandings(
       final Collection<Unit> units, final IDelegateBridge bridge) {
     for (final Unit transport : CollectionUtils.getMatches(units, Matches.unitIsTransport())) {
-      final Collection<Unit> lost = getTransportDependents(Collections.singleton(transport));
+      final Collection<Unit> lost = getTransportDependents(Set.of(transport));
       if (lost.isEmpty()) {
         continue;
       }
@@ -1049,7 +1049,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (headless
         || (!attackingUnits.isEmpty() && attackingUnits.stream().allMatch(Matches.unitIsAir()))
         || Properties.getRetreatingUnitsRemainInPlace(gameData)) {
-      return Collections.singleton(battleSite);
+      return Set.of(battleSite);
     }
     // its possible that a sub retreated to a territory we came from, if so we can no longer retreat
     // there
@@ -2305,7 +2305,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     // their landing site,
     // or be scrapped if they can't find one.
     if (attackingUnits.stream().anyMatch(Matches.unitIsAir())) {
-      queryRetreat(false, RetreatType.PLANES, bridge, Collections.singleton(battleSite));
+      queryRetreat(false, RetreatType.PLANES, bridge, Set.of(battleSite));
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -23,7 +23,6 @@ import games.strategy.triplea.ui.PoliticsText;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
 import java.util.Map;
@@ -54,7 +53,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
       // get all possible triggers based on this match.
       final Set<TriggerAttachment> toFirePossible =
           TriggerAttachment.collectForAllTriggersMatching(
-              new HashSet<>(Collections.singleton(player)), politicsDelegateTriggerMatch);
+              new HashSet<>(Set.of(player)), politicsDelegateTriggerMatch);
       if (!toFirePossible.isEmpty()) {
         // get all conditions possibly needed by these triggers, and then test them.
         final Map<ICondition, Boolean> testedConditions =

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -29,7 +29,6 @@ import games.strategy.triplea.formatter.MyFormatter;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Map;
@@ -75,7 +74,7 @@ public class PurchaseDelegate extends BaseTripleADelegate
         // get all possible triggers based on this match.
         final Set<TriggerAttachment> toFirePossible =
             TriggerAttachment.collectForAllTriggersMatching(
-                new HashSet<>(Collections.singleton(player)), purchaseDelegateTriggerMatch);
+                new HashSet<>(Set.of(player)), purchaseDelegateTriggerMatch);
         if (!toFirePossible.isEmpty()) {
           // get all conditions possibly needed by these triggers, and then test them.
           final Map<ICondition, Boolean> testedConditions =

--- a/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -22,7 +22,6 @@ import games.strategy.triplea.formatter.MyFormatter;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -542,16 +541,14 @@ public class RocketsFireHelper implements Serializable {
     if (attackFrom != null) {
       if (!rockets.isEmpty()) {
         // TODO: only a certain number fired...
-        final Change change =
-            ChangeFactory.markNoMovementChange(Collections.singleton(rockets.iterator().next()));
+        final Change change = ChangeFactory.markNoMovementChange(Set.of(rockets.iterator().next()));
         bridge.addChange(change);
       } else {
         throw new IllegalStateException("No rockets?" + attackFrom.getUnits());
       }
     }
     // kill any units that can die if they have reached max damage (veqryn)
-    final Collection<Unit> targetUnitCol =
-        taUnit == null ? enemyTargetsTotal : Collections.singleton(taUnit);
+    final Collection<Unit> targetUnitCol = taUnit == null ? enemyTargetsTotal : Set.of(taUnit);
     if (targetUnitCol.stream().anyMatch(Matches.unitCanDieFromReachingMaxDamage())) {
       final List<Unit> unitsCanDie =
           CollectionUtils.getMatches(targetUnitCol, Matches.unitCanDieFromReachingMaxDamage());

--- a/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -411,12 +411,12 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
             null,
             null,
             null,
-            Collections.emptyMap(),
+            Map.of(),
             attacker,
             defender,
             isAmphibious(),
             getBattleType(),
-            Collections.emptySet());
+            Set.of());
     bridge.getDisplayChannelBroadcaster().listBattleSteps(battleId, steps);
   }
 
@@ -435,7 +435,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     }
 
     FireAa() {
-      validAttackingUnitsForThisRoll = Collections.emptyList();
+      validAttackingUnitsForThisRoll = List.of();
       determineAttackers = true;
     }
 
@@ -662,7 +662,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
             attacker,
             new ArrayList<>(casualties.getKilled()),
             new ArrayList<>(casualties.getDamaged()),
-            Collections.emptyMap());
+            Map.of());
     final Thread t =
         new Thread(
             () -> {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
@@ -10,7 +10,6 @@ import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.TriggerAttachment;
 import java.io.Serializable;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -64,7 +63,7 @@ public class TechActivationDelegate extends BaseTripleADelegate {
       // get all possible triggers based on this match.
       final Set<TriggerAttachment> toFirePossible =
           TriggerAttachment.collectForAllTriggersMatching(
-              new HashSet<>(Collections.singleton(player)), techActivationDelegateTriggerMatch);
+              new HashSet<>(Set.of(player)), techActivationDelegateTriggerMatch);
       if (!toFirePossible.isEmpty()) {
         // get all conditions possibly needed by these triggers, and then test them.
         final Map<ICondition, Boolean> testedConditions =

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
@@ -10,7 +10,6 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.TechAttachment;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -52,7 +51,7 @@ public abstract class TechAdvance extends NamedAttachable {
   public static final String TECH_PROPERTY_DESTROYER_BOMBARD = "destroyerBombard";
   public static final List<String> ALL_PREDEFINED_TECHNOLOGY_NAMES =
       Collections.unmodifiableList(
-          Arrays.asList(
+          List.of(
               TECH_NAME_SUPER_SUBS,
               TECH_NAME_JET_POWER,
               TECH_NAME_IMPROVED_SHIPYARDS,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -24,7 +24,6 @@ import games.strategy.triplea.formatter.MyFormatter;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -79,7 +78,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
       // get all possible triggers based on this match.
       final Set<TriggerAttachment> toFirePossible =
           TriggerAttachment.collectForAllTriggersMatching(
-              new HashSet<>(Collections.singleton(player)), technologyDelegateTriggerMatch);
+              new HashSet<>(Set.of(player)), technologyDelegateTriggerMatch);
       if (!toFirePossible.isEmpty()) {
         // get all conditions possibly needed by these triggers, and then test them.
         final Map<ICondition, Boolean> testedConditions =
@@ -268,9 +267,9 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
     final Collection<TechAdvance> advances;
     if (isRevisedModel) {
       if (techHits > 0) {
-        advances = Collections.singletonList(techToRollFor.getTechs().get(0));
+        advances = List.of(techToRollFor.getTechs().get(0));
       } else {
-        advances = Collections.emptyList();
+        advances = List.of();
       }
     } else {
       advances = getTechAdvances(techHits);
@@ -377,13 +376,13 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
       available = getAvailableAdvances();
     }
     if (available.isEmpty()) {
-      return Collections.emptyList();
+      return List.of();
     }
     if (hits >= available.size()) {
       return available;
     }
     if (hits == 0) {
-      return Collections.emptyList();
+      return List.of();
     }
     final Collection<TechAdvance> newAdvances = new ArrayList<>(hits);
     final String annotation = player.getName() + " rolling to see what tech advances are acquired";

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TerritoryEffectHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TerritoryEffectHelper.java
@@ -11,7 +11,6 @@ import games.strategy.triplea.attachments.TerritoryEffectAttachment;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -86,7 +85,7 @@ public final class TerritoryEffectHelper {
   }
 
   public static BigDecimal getMovementCost(final Territory t, final Unit unit) {
-    return getMaxMovementCost(t, Collections.singleton(unit));
+    return getMaxMovementCost(t, Set.of(unit));
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
@@ -13,7 +13,6 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.data.MoveDescription;
 import games.strategy.triplea.ui.MovePanel;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -109,8 +108,7 @@ public class UndoableMove extends AbstractUndoableMove {
           // moved out. Undoing
           // this last move, the route used to move into the battle zone will be null
           if (routeUnitUsedToMove != null) {
-            final Change change =
-                battle.addAttackChange(routeUnitUsedToMove, Collections.singleton(unit), null);
+            final Change change = battle.addAttackChange(routeUnitUsedToMove, Set.of(unit), null);
             bridge.addChange(change);
           }
         } else {
@@ -130,7 +128,7 @@ public class UndoableMove extends AbstractUndoableMove {
                     Matches.unitIsOfTypes(
                         UnitAttachment.getAllowedBombingTargetsIntersection(
                             CollectionUtils.getMatches(
-                                Collections.singleton(unit), Matches.unitIsStrategicBomber()),
+                                Set.of(unit), Matches.unitIsStrategicBomber()),
                             data)));
             if (enemyTargets.size() > 1
                 && Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)
@@ -139,18 +137,17 @@ public class UndoableMove extends AbstractUndoableMove {
                 target =
                     bridge
                         .getRemotePlayer(bridge.getPlayerId())
-                        .whatShouldBomberBomb(end, enemyTargets, Collections.singletonList(unit));
+                        .whatShouldBomberBomb(end, enemyTargets, List.of(unit));
               }
             } else if (!enemyTargets.isEmpty()) {
               target = enemyTargets.iterator().next();
             }
             if (target != null) {
               targets = new HashMap<>();
-              targets.put(target, new HashSet<>(Collections.singleton(unit)));
+              targets.put(target, new HashSet<>(Set.of(unit)));
             }
           }
-          final Change change =
-              battle.addAttackChange(routeUnitUsedToMove, Collections.singleton(unit), targets);
+          final Change change = battle.addAttackChange(routeUnitUsedToMove, Set.of(unit), targets);
           bridge.addChange(change);
         }
       }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/data/MoveValidationResult.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/data/MoveValidationResult.java
@@ -5,7 +5,6 @@ import games.strategy.engine.data.Unit;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -84,7 +83,7 @@ public class MoveValidationResult implements Serializable, Comparable<MoveValida
   public Collection<Unit> getUnresolvedUnits(final String warning) {
     final int index = unresolvedUnitWarnings.indexOf(warning);
     if (index == -1) {
-      return Collections.emptyList();
+      return List.of();
     }
     return ImmutableList.copyOf(unresolvedUnitsList.get(index));
   }

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OddsCalculatorPanel.java
@@ -1343,7 +1343,7 @@ class OddsCalculatorPanel extends JPanel {
   }
 
   private void setAttackingUnits(final List<Unit> initialUnits) {
-    final List<Unit> units = Optional.ofNullable(initialUnits).orElseGet(Collections::emptyList);
+    final List<Unit> units = Optional.ofNullable(initialUnits).orElseGet(List::of);
     attackingUnitsPanel.init(
         getAttacker(),
         CollectionUtils.getMatches(
@@ -1360,7 +1360,7 @@ class OddsCalculatorPanel extends JPanel {
   }
 
   private void setDefendingUnits(final List<Unit> initialUnits) {
-    final List<Unit> units = Optional.ofNullable(initialUnits).orElseGet(Collections::emptyList);
+    final List<Unit> units = Optional.ofNullable(initialUnits).orElseGet(List::of);
     defendingUnitsPanel.init(
         getDefender(),
         CollectionUtils.getMatches(units, Matches.unitCanBeInBattle(false, isLand(), 1, false)),

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
@@ -12,7 +12,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -585,7 +584,7 @@ final class SelectionComponentFactory {
     return new SelectionComponent<>() {
 
       private final List<IEmailSender.EmailProviderSetting> knownProviders =
-          Arrays.asList(
+          List.of(
               new IEmailSender.EmailProviderSetting("Gmail", "smtp.gmail.com", 587, true),
               new IEmailSender.EmailProviderSetting("Hotmail", "smtp.live.com", 587, true));
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -47,7 +47,7 @@ abstract class AbstractMovePanel extends ActionPanel {
     super(data, map);
     this.frame = frame;
     disableCancelButton();
-    undoableMoves = Collections.emptyList();
+    undoableMoves = List.of();
   }
 
   @Override
@@ -247,7 +247,7 @@ abstract class AbstractMovePanel extends ActionPanel {
   }
 
   protected List<Component> getAdditionalButtons() {
-    return Collections.emptyList();
+    return List.of();
   }
 
   protected abstract boolean setCancelButton();

--- a/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
@@ -41,7 +41,7 @@ abstract class AbstractUndoableMovesPanel extends JPanel {
 
   protected AbstractUndoableMovesPanel(final AbstractMovePanel movePanel) {
     this.movePanel = movePanel;
-    moves = Collections.emptyList();
+    moves = List.of();
   }
 
   void setMoves(final List<AbstractUndoableMove> undoableMoves) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/ActionButtons.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ActionButtons.java
@@ -20,7 +20,6 @@ import java.awt.CardLayout;
 import java.awt.event.InputEvent;
 import java.awt.event.KeyEvent;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -284,7 +283,7 @@ public class ActionButtons extends JPanel implements KeyBindingSupplier {
    */
   @Override
   public Map<KeyStroke, Runnable> get() {
-    return Collections.singletonMap(
+    return Map.of(
         KeyStroke.getKeyStroke(KeyEvent.VK_D, InputEvent.SHIFT_DOWN_MASK),
         () -> Optional.ofNullable(actionPanel).ifPresent(ActionPanel::performDone));
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -37,10 +37,10 @@ import java.awt.Window;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.CountDownLatch;
@@ -138,7 +138,7 @@ public class BattleDisplay extends JPanel {
             battleLocation,
             territoryEffects,
             isAmphibious,
-            Collections.emptySet(),
+            Set.of(),
             this.mapPanel.getUiContext());
     attackerModel =
         new BattleModel(
@@ -878,7 +878,7 @@ public class BattleDisplay extends JPanel {
       final Map<Unit, Tuple<Integer, Integer>> unitPowerAndRollsMap;
       final boolean isAirPreBattleOrPreRaid = battleType.isAirPreBattleOrPreRaid();
       if (isAirPreBattleOrPreRaid) {
-        unitPowerAndRollsMap = Collections.emptyMap();
+        unitPowerAndRollsMap = Map.of();
       } else {
         gameData.acquireReadLock();
         try {

--- a/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -222,7 +222,7 @@ class EditPanel extends ActionPanel {
         if (!isActive() || currentAction != null) {
           return;
         }
-        getMap().setUnitHighlight(Collections.singleton(Collections.unmodifiableList(units)));
+        getMap().setUnitHighlight(Set.of(Collections.unmodifiableList(units)));
       };
 
   private final MapSelectionListener mapSelectionListener =

--- a/game-core/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
@@ -15,7 +15,6 @@ import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TechAdvance;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Predicate;
 
@@ -62,7 +61,7 @@ public class ExtendedStats extends StatPanel {
 
       final GenericResourceStat resourceStat = new GenericResourceStat();
       resourceStat.init(r.getName());
-      final List<IStat> statsExtended = new ArrayList<>(Arrays.asList(this.statsExtended));
+      final List<IStat> statsExtended = new ArrayList<>(List.of(this.statsExtended));
       statsExtended.add(resourceStat);
       this.statsExtended = statsExtended.toArray(new IStat[0]);
     }
@@ -70,12 +69,12 @@ public class ExtendedStats extends StatPanel {
     if (Properties.getTechDevelopment(data)) {
       // add tech tokens
       if (data.getResourceList().getResource(Constants.TECH_TOKENS) != null) {
-        final List<IStat> statsExtended = new ArrayList<>(Arrays.asList(this.statsExtended));
+        final List<IStat> statsExtended = new ArrayList<>(List.of(this.statsExtended));
         statsExtended.add(new TechTokenStat());
         this.statsExtended = statsExtended.toArray(new IStat[0]);
       }
       // add number of techs
-      final List<IStat> techStatsExtended = new ArrayList<>(Arrays.asList(statsExtended));
+      final List<IStat> techStatsExtended = new ArrayList<>(List.of(statsExtended));
       techStatsExtended.add(new TechCountStat());
       statsExtended = techStatsExtended.toArray(new IStat[0]);
 
@@ -83,7 +82,7 @@ public class ExtendedStats extends StatPanel {
       for (final TechAdvance ta : TechAdvance.getTechAdvances(gameData)) {
         final GenericTechNameStat techNameStat = new GenericTechNameStat();
         techNameStat.init(ta);
-        final List<IStat> statsExtended = new ArrayList<>(Arrays.asList(this.statsExtended));
+        final List<IStat> statsExtended = new ArrayList<>(List.of(this.statsExtended));
         statsExtended.add(techNameStat);
         this.statsExtended = statsExtended.toArray(new IStat[0]);
       }
@@ -93,7 +92,7 @@ public class ExtendedStats extends StatPanel {
     for (final UnitType ut : allUnitTypes) {
       final GenericUnitNameStat unitNameStat = new GenericUnitNameStat();
       unitNameStat.init(ut);
-      final List<IStat> statsExtended = new ArrayList<>(Arrays.asList(this.statsExtended));
+      final List<IStat> statsExtended = new ArrayList<>(List.of(this.statsExtended));
       statsExtended.add(unitNameStat);
       this.statsExtended = statsExtended.toArray(new IStat[0]);
     }

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -51,7 +51,6 @@ import java.awt.image.BufferedImage;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
@@ -99,7 +98,7 @@ public class MapPanel extends ImageScrollerLargeView {
   private final UiContext uiContext;
   private final ExecutorService executor =
       Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
-  @Getter private Collection<Collection<Unit>> highlightedUnits = Collections.emptyList();
+  @Getter private Collection<Collection<Unit>> highlightedUnits = List.of();
   private Cursor hiddenCursor = null;
   private final MapRouteDrawer routeDrawer;
 
@@ -107,20 +106,20 @@ public class MapPanel extends ImageScrollerLargeView {
       new TerritoryListener() {
         @Override
         public void unitsChanged(final Territory territory) {
-          updateCountries(Collections.singleton(territory));
+          updateCountries(Set.of(territory));
           SwingUtilities.invokeLater(MapPanel.this::repaint);
         }
 
         @Override
         public void ownerChanged(final Territory territory) {
           smallMapImageManager.updateTerritoryOwner(territory, gameData, uiContext.getMapData());
-          updateCountries(Collections.singleton(territory));
+          updateCountries(Set.of(territory));
           SwingUtilities.invokeLater(MapPanel.this::repaint);
         }
 
         @Override
         public void attachmentChanged(final Territory territory) {
-          updateCountries(Collections.singleton(territory));
+          updateCountries(Set.of(territory));
           SwingUtilities.invokeLater(MapPanel.this::repaint);
         }
       };
@@ -194,7 +193,7 @@ public class MapPanel extends ImageScrollerLargeView {
           public void mouseExited(final MouseEvent e) {
             if (unitsChanged(null)) {
               currentUnits = null;
-              notifyMouseEnterUnit(Collections.emptyList(), getTerritory(e.getX(), e.getY()));
+              notifyMouseEnterUnit(List.of(), getTerritory(e.getX(), e.getY()));
             }
           }
 
@@ -223,7 +222,7 @@ public class MapPanel extends ImageScrollerLargeView {
             if (!unitSelectionListeners.isEmpty()) {
               Tuple<Territory, List<Unit>> tuple = tileManager.getUnitsAtPoint(x, y, gameData);
               if (tuple == null) {
-                tuple = Tuple.of(getTerritory(x, y), Collections.emptyList());
+                tuple = Tuple.of(getTerritory(x, y), List.of());
               }
               notifyUnitSelected(tuple.getSecond(), tuple.getFirst(), md);
             }
@@ -319,7 +318,7 @@ public class MapPanel extends ImageScrollerLargeView {
     if (unitsChanged(tuple)) {
       currentUnits = tuple;
       if (tuple == null) {
-        notifyMouseEnterUnit(Collections.emptyList(), getTerritory(x, y));
+        notifyMouseEnterUnit(List.of(), getTerritory(x, y));
       } else {
         notifyMouseEnterUnit(tuple.getSecond(), tuple.getFirst());
       }

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -348,7 +348,7 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
                   null,
                   null);
           if (option != JOptionPane.OK_OPTION) {
-            return Collections.emptyList();
+            return List.of();
           }
           return chooser.getSelected(true);
         }
@@ -426,8 +426,7 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
             final List<Unit> initialUnits, final Territory t, final MouseDetails me) {
           final Collection<Unit> unitsToRemove = new ArrayList<>(selectedUnits.size());
           // we have right clicked on a unit stack in a different territory
-          final List<Unit> units =
-              getFirstSelectedTerritory().equals(t) ? initialUnits : Collections.emptyList();
+          final List<Unit> units = getFirstSelectedTerritory().equals(t) ? initialUnits : List.of();
           // remove the dependent units so we don't have to micromanage them
           final List<Unit> unitsWithoutDependents = new ArrayList<>(selectedUnits);
           for (final Unit unit : selectedUnits) {
@@ -623,10 +622,9 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
           final boolean isCorrectTerritory =
               (firstSelectedTerritory == null) || firstSelectedTerritory.equals(territory);
           if (someOwned && isCorrectTerritory) {
-            getMap()
-                .setUnitHighlight(Collections.singletonList(Collections.unmodifiableList(units)));
+            getMap().setUnitHighlight(List.of(Collections.unmodifiableList(units)));
           } else {
-            getMap().setUnitHighlight(Collections.emptySet());
+            getMap().setUnitHighlight(Set.of());
           }
         }
       };
@@ -677,7 +675,7 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
     super(data, map, frame);
     undoableMovesPanel = new UndoableMovesPanel(this);
     mouseCurrentTerritory = null;
-    unitsThatCanMoveOnRoute = Collections.emptyList();
+    unitsThatCanMoveOnRoute = List.of();
     currentCursorImage = null;
 
     unitScroller = new UnitScroller(getData(), getMap());
@@ -776,7 +774,7 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
             candidateTransports, Matches.transportCannotUnload(route.getEnd()));
     candidateTransports.removeAll(incapableTransports);
     if (candidateTransports.size() == 0) {
-      return Collections.emptyList();
+      return List.of();
     }
 
     // Just one transport, don't bother to ask
@@ -836,7 +834,7 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
               while (unitIter.hasNext()) {
                 final Unit unit = unitIter.next();
                 final Collection<UnitCategory> unitCategory =
-                    UnitSeparator.categorize(Collections.singleton(unit));
+                    UnitSeparator.categorize(Set.of(unit));
 
                 // Is one of the transported units of the same type we want to unload?
                 if (!Collections.disjoint(transCategories, unitCategory)) {
@@ -880,7 +878,7 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
             null,
             null);
     if (option != JOptionPane.OK_OPTION) {
-      return Collections.emptyList();
+      return List.of();
     }
     final Collection<Unit> chosenTransports =
         CollectionUtils.getMatches(chooser.getSelected(), Matches.unitIsTransport());
@@ -1212,10 +1210,10 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
   private Collection<Unit> getTransportsToLoad(
       final Route route, final Collection<Unit> unitsToLoad, final boolean disablePrompts) {
     if (!route.isLoad()) {
-      return Collections.emptyList();
+      return List.of();
     }
     if (unitsToLoad.stream().anyMatch(Matches.unitIsAir())) {
-      return Collections.emptyList();
+      return List.of();
     }
     final Collection<Unit> endOwnedUnits = route.getEnd().getUnits();
     final PlayerId unitOwner = getUnitOwner(unitsToLoad);
@@ -1244,7 +1242,7 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
 
     // nothing to choose
     if (candidateTransports.isEmpty()) {
-      return Collections.emptyList();
+      return List.of();
     }
 
     // sort transports in preferred load order
@@ -1377,7 +1375,7 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
             null,
             null);
     if (option != JOptionPane.OK_OPTION) {
-      return Collections.emptyList();
+      return List.of();
     }
     return chooser.getSelected(false);
   }
@@ -1551,7 +1549,7 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
             null,
             null);
     if (option != JOptionPane.OK_OPTION) {
-      return Collections.emptyList();
+      return List.of();
     }
     return chooser.getSelected(true);
   }
@@ -1561,7 +1559,7 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
     getMap().removeMapSelectionListener(mapSelectionListener);
     getMap().removeUnitSelectionListener(unitSelectionListener);
     getMap().removeMouseOverUnitListener(mouseOverUnitListener);
-    getMap().setUnitHighlight(Collections.emptySet());
+    getMap().setUnitHighlight(Set.of());
     selectedUnits.clear();
     updateRouteAndMouseShadowUnits(null);
     forced = null;

--- a/game-core/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ObjectivePanel.java
@@ -16,7 +16,6 @@ import games.strategy.triplea.attachments.TriggerAttachment;
 import java.awt.Color;
 import java.awt.Component;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -161,7 +160,7 @@ public class ObjectivePanel extends AbstractStatPanel {
           continue;
         }
         sectionsSorters.add(sorter.get(1) + ";" + key.get(1));
-        sectionsUnsorted.put(key.get(1), Arrays.asList(value.split(";")));
+        sectionsUnsorted.put(key.get(1), List.of(value.split(";")));
       }
       final Map<String, Map<ICondition, String>> statsObjectiveUnsorted = new HashMap<>();
       for (final String section : sectionsSorters) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
@@ -8,9 +8,9 @@ import games.strategy.engine.data.Unit;
 import games.strategy.triplea.delegate.Matches;
 import java.awt.Color;
 import java.awt.event.ActionEvent;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import javax.swing.AbstractAction;
@@ -53,7 +53,7 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
           currentAction = selectUnitsAction;
           setWidgetActivation();
           final UnitChooser unitChooser =
-              new UnitChooser(unitChoices, Collections.emptyMap(), false, getMap().getUiContext());
+              new UnitChooser(unitChoices, Map.of(), false, getMap().getUiContext());
           unitChooser.setMaxAndShowMaxButton(unitsPerPick);
           if (JOptionPane.OK_OPTION
               == EventThreadJOptionPane.showConfirmDialog(

--- a/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -23,7 +23,8 @@ import java.awt.Dimension;
 import java.awt.Toolkit;
 import java.awt.event.MouseEvent;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
+import java.util.Map;
 import java.util.function.Predicate;
 import javax.swing.BorderFactory;
 import javax.swing.JComponent;
@@ -59,7 +60,7 @@ class PlacePanel extends AbstractMovePanel implements GameDataChangeListener {
             return;
           }
           final UnitChooser chooser =
-              new UnitChooser(units, Collections.emptyMap(), false, getMap().getUiContext());
+              new UnitChooser(units, Map.of(), false, getMap().getUiContext());
           final String messageText = "Place units in " + territory.getName();
           if (maxUnits[0] >= 0) {
             chooser.setMaxAndShowMaxButton(maxUnits[0]);
@@ -234,10 +235,10 @@ class PlacePanel extends AbstractMovePanel implements GameDataChangeListener {
               && !territory
                   .getUnitCollection()
                   .anyMatch(Matches.unitIsOwnedBy(getCurrentPlayer()))) {
-            return Collections.emptyList();
+            return List.of();
           }
         } else {
-          return Collections.emptyList();
+          return List.of();
         }
       }
       // get the units that can be placed on this territory.
@@ -257,7 +258,7 @@ class PlacePanel extends AbstractMovePanel implements GameDataChangeListener {
         units = CollectionUtils.getMatches(units, Matches.unitIsNotSea());
       }
       if (units.isEmpty()) {
-        return Collections.emptyList();
+        return List.of();
       }
       final IAbstractPlaceDelegate placeDel =
           (IAbstractPlaceDelegate) getPlayerBridge().getRemoteDelegate();
@@ -268,7 +269,7 @@ class PlacePanel extends AbstractMovePanel implements GameDataChangeListener {
             production.getErrorMessage(),
             "No units",
             JOptionPane.INFORMATION_MESSAGE);
-        return Collections.emptyList();
+        return List.of();
       }
       maxUnits[0] = production.getMaxUnits();
       return production.getUnits();

--- a/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
@@ -21,10 +21,10 @@ import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 import java.awt.font.TextAttribute;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import javax.swing.Action;
@@ -336,9 +336,7 @@ class ProductionPanel extends JPanel {
 
       final JLabel name = new JLabel("  ");
       name.setFont(
-          name.getFont()
-              .deriveFont(
-                  Collections.singletonMap(TextAttribute.WEIGHT, TextAttribute.WEIGHT_BOLD)));
+          name.getFont().deriveFont(Map.of(TextAttribute.WEIGHT, TextAttribute.WEIGHT_BOLD)));
       final JLabel info = new JLabel("  ");
       final Color defaultForegroundLabelColor = name.getForeground();
       Optional<ImageIcon> icon = Optional.empty();

--- a/game-core/src/main/java/games/strategy/triplea/ui/ProductionTabsProperties.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ProductionTabsProperties.java
@@ -7,7 +7,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
@@ -78,7 +77,7 @@ class ProductionTabsProperties {
     for (int i = 1; i <= numberOfTabs; i++) {
       final String tabName = properties.getProperty(TAB_NAME + "." + i);
       final List<String> tabValues =
-          Arrays.asList(properties.getProperty(TAB_UNITS + "." + i).split(":"));
+          List.of(properties.getProperty(TAB_UNITS + "." + i).split(":"));
       final List<Rule> ruleList = new ArrayList<>();
       for (final Rule rule : rules) {
         if (tabValues.contains(

--- a/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -155,13 +155,13 @@ class StatPanel extends AbstractStatPanel {
     void setStatColumns() {
       stats = new IStat[] {new PuStat(), new ProductionStat(), new UnitsStat(), new TuvStat()};
       if (gameData.getMap().getTerritories().stream().anyMatch(Matches.territoryIsVictoryCity())) {
-        final List<IStat> stats = new ArrayList<>(Arrays.asList(StatPanel.this.stats));
+        final List<IStat> stats = new ArrayList<>(List.of(StatPanel.this.stats));
         stats.add(new VictoryCityStat());
         StatPanel.this.stats = stats.toArray(new IStat[0]);
       }
       // only add the vps in pacific
       if (gameData.getProperties().get(Constants.PACIFIC_THEATER, false)) {
-        final List<IStat> stats = new ArrayList<>(Arrays.asList(StatPanel.this.stats));
+        final List<IStat> stats = new ArrayList<>(List.of(StatPanel.this.stats));
         stats.add(new VpStat());
         StatPanel.this.stats = stats.toArray(new IStat[0]);
       }

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -524,9 +524,7 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
     territoryInfo.setPreferredSize(new Dimension(0, 0));
     resourceBar = new ResourceBar(data, uiContext);
     message.setFont(
-        message
-            .getFont()
-            .deriveFont(Collections.singletonMap(TextAttribute.WEIGHT, TextAttribute.WEIGHT_BOLD)));
+        message.getFont().deriveFont(Map.of(TextAttribute.WEIGHT, TextAttribute.WEIGHT_BOLD)));
     status.setPreferredSize(new Dimension(0, 0));
     status.setText("");
 
@@ -807,9 +805,7 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
     SwingComponents.addKeyListenerWithMetaAndCtrlMasks(
         this,
         hotkey,
-        () ->
-            tabsPanel.setSelectedIndex(
-                Arrays.asList(tabsPanel.getComponents()).indexOf(component)));
+        () -> tabsPanel.setSelectedIndex(List.of(tabsPanel.getComponents()).indexOf(component)));
   }
 
   public LocalPlayers getLocalPlayers() {
@@ -1633,8 +1629,7 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
                 Math.min(
                     BattleDelegate.getMaxScrambleCount(possibleScramblers.get(from).getFirst()),
                     possible.size());
-            final UnitChooser chooser =
-                new UnitChooser(possible, Collections.emptyMap(), false, uiContext);
+            final UnitChooser chooser = new UnitChooser(possible, Map.of(), false, uiContext);
             chooser.setMaxAndShowMaxButton(maxAllowed);
             chooser.addChangeListener(
                 field -> {
@@ -1780,8 +1775,7 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
           panelChooser.add(new JLabel(" "));
           final int maxAllowed =
               Math.min(AirBattle.getMaxInterceptionCount(current, possible), possible.size());
-          final UnitChooser chooser =
-              new UnitChooser(possible, Collections.emptyMap(), false, uiContext);
+          final UnitChooser chooser = new UnitChooser(possible, Map.of(), false, uiContext);
           chooser.setMaxAndShowMaxButton(maxAllowed);
           panelChooser.add(chooser);
           final JScrollPane chooserScrollPane = new JScrollPane(panelChooser);
@@ -2447,8 +2441,7 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
         () ->
             SwingAction.invokeAndWait(
                 () -> {
-                  final UnitChooser chooser =
-                      new UnitChooser(fighters, Collections.emptyMap(), false, uiContext);
+                  final UnitChooser chooser = new UnitChooser(fighters, Map.of(), false, uiContext);
                   final Dimension screenResolution = Toolkit.getDefaultToolkit().getScreenSize();
                   final int availHeight = screenResolution.height - 120;
                   final int availWidth = screenResolution.width - 40;

--- a/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -16,7 +16,6 @@ import java.awt.Insets;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -58,7 +57,7 @@ final class UnitChooser extends JPanel {
       final Map<Unit, Collection<Unit>> dependent,
       final boolean allowTwoHit,
       final UiContext uiContext) {
-    this(units, Collections.emptyList(), dependent, allowTwoHit, uiContext);
+    this(units, List.of(), dependent, allowTwoHit, uiContext);
   }
 
   private UnitChooser(

--- a/game-core/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
@@ -13,7 +13,6 @@ import java.awt.Insets;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import javax.swing.AbstractAction;
@@ -41,7 +40,7 @@ public class UserActionPanel extends ActionPanel {
   private UserActionAttachment choice = null;
   private final TripleAFrame parent;
   private boolean firstRun = true;
-  private List<UserActionAttachment> validUserActions = Collections.emptyList();
+  private List<UserActionAttachment> validUserActions = List.of();
 
   /**
    * Fires up a JDialog showing valid actions, choosing an action will release this model and
@@ -229,7 +228,7 @@ public class UserActionPanel extends ActionPanel {
           ae -> {
             selectUserActionButton.setEnabled(false);
             doneButton.setEnabled(false);
-            validUserActions = Collections.emptyList();
+            validUserActions = List.of();
             choice = uaa;
             parent.setVisible(false);
             release();

--- a/game-core/src/main/java/games/strategy/triplea/ui/logic/MapScrollUtil.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/logic/MapScrollUtil.java
@@ -2,7 +2,6 @@ package games.strategy.triplea.ui.logic;
 
 import java.awt.geom.AffineTransform;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -35,7 +34,7 @@ public final class MapScrollUtil {
     result.add(new AffineTransform());
     if (isInfiniteX && isInfiniteY) {
       result.addAll(
-          Arrays.asList(
+          List.of(
               AffineTransform.getTranslateInstance(-mapWidth, -mapHeight),
               AffineTransform.getTranslateInstance(-mapWidth, +mapHeight),
               AffineTransform.getTranslateInstance(+mapWidth, -mapHeight),
@@ -43,13 +42,13 @@ public final class MapScrollUtil {
     }
     if (isInfiniteX) {
       result.addAll(
-          Arrays.asList(
+          List.of(
               AffineTransform.getTranslateInstance(-mapWidth, 0),
               AffineTransform.getTranslateInstance(+mapWidth, 0)));
     }
     if (isInfiniteY) {
       result.addAll(
-          Arrays.asList(
+          List.of(
               AffineTransform.getTranslateInstance(0, -mapHeight),
               AffineTransform.getTranslateInstance(0, +mapHeight)));
     }

--- a/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -372,7 +371,7 @@ public class MapData implements Closeable {
   public boolean ignoreTransformingUnit(final String unitName) {
     if (ignoreTransformingUnits == null) {
       final String property = mapProperties.getProperty(PROPERTY_UNITS_TRANSFORM_IGNORE, "");
-      ignoreTransformingUnits = new HashSet<>(Arrays.asList(property.split(",")));
+      ignoreTransformingUnits = new HashSet<>(List.of(property.split(",")));
     }
     return ignoreTransformingUnits.contains(unitName);
   }
@@ -380,7 +379,7 @@ public class MapData implements Closeable {
   public boolean shouldDrawUnit(final String unitName) {
     if (undrawnUnits == null) {
       final String property = mapProperties.getProperty(PROPERTY_DONT_DRAW_UNITS, "");
-      undrawnUnits = new HashSet<>(Arrays.asList(property.split(",")));
+      undrawnUnits = new HashSet<>(List.of(property.split(",")));
     }
     return !undrawnUnits.contains(unitName);
   }
@@ -388,7 +387,7 @@ public class MapData implements Closeable {
   public boolean shouldDrawTerritoryName(final String territoryName) {
     if (undrawnTerritoriesNames == null) {
       final String property = mapProperties.getProperty(PROPERTY_DONT_DRAW_TERRITORY_NAMES, "");
-      undrawnTerritoriesNames = new HashSet<>(Arrays.asList(property.split(",")));
+      undrawnTerritoriesNames = new HashSet<>(List.of(property.split(",")));
     }
     return !undrawnTerritoriesNames.contains(territoryName);
   }
@@ -830,7 +829,7 @@ public class MapData implements Closeable {
 
   public List<Point> getTerritoryEffectPoints(final Territory territory) {
     if (territoryEffects.get(territory.getName()) == null) {
-      return Collections.singletonList(getCenter(territory));
+      return List.of(getCenter(territory));
     }
     return territoryEffects.get(territory.getName());
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -36,6 +36,7 @@ import java.time.format.DateTimeFormatter;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Enumeration;
+import java.util.List;
 import java.util.Objects;
 import java.util.SortedSet;
 import java.util.TreeSet;
@@ -271,8 +272,7 @@ final class ExportMenu extends JMenu {
       // tokens or # techs, etc.
       final Iterable<IStat> stats =
           Iterables.concat(
-              Arrays.asList(statPanel.getStats()),
-              Arrays.asList(statPanel.getStatsExtended(gameData)));
+              List.of(statPanel.getStats()), List.of(statPanel.getStatsExtended(gameData)));
       for (final IStat stat : stats) {
         for (final PlayerId player : players) {
           writer.append(stat.getName()).append(' ');

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -18,6 +18,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Supplier;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
@@ -275,7 +276,7 @@ public class UnitScroller {
   public void centerOnCurrentMovableUnit() {
     if (lastFocusedTerritory != null && !getMovableUnits(lastFocusedTerritory).isEmpty()) {
       mapPanel.setUnitHighlight(
-          Collections.singleton(
+          Set.of(
               UnitScrollerModel.getMoveableUnits(
                   lastFocusedTerritory,
                   movePhaseSupplier.get(),
@@ -297,7 +298,7 @@ public class UnitScroller {
 
   private List<Unit> getMovableUnits(final Territory territory) {
     if (territory == null) {
-      return Collections.emptyList();
+      return List.of();
     }
     return UnitScrollerModel.getMoveableUnits(
         territory, movePhaseSupplier.get(), currentPlayerSupplier.get(), getAllSkippedUnits());
@@ -395,7 +396,7 @@ public class UnitScroller {
       if (!matchedUnits.isEmpty()) {
         drawUnitAvatarPane(t);
         newFocusedTerritory = t;
-        mapPanel.setUnitHighlight(Collections.singleton(matchedUnits));
+        mapPanel.setUnitHighlight(Set.of(matchedUnits));
         break;
       }
       // make sure to cycle through the front half of territories

--- a/game-core/src/main/java/games/strategy/triplea/util/UnitCategory.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/UnitCategory.java
@@ -8,7 +8,6 @@ import games.strategy.triplea.attachments.UnitTypeComparator;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
@@ -46,7 +45,7 @@ public class UnitCategory implements Comparable<UnitCategory> {
 
   public UnitCategory(final UnitType type, final PlayerId owner) {
     this.type = type;
-    dependents = Collections.emptyList();
+    dependents = List.of();
     movement = new BigDecimal(-1);
     transportCost = -1;
     this.owner = owner;

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -25,7 +25,6 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.settings.ClientSetting;
 import java.io.File;
 import java.io.InputStream;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -56,7 +55,7 @@ public class HeadlessGameServer {
   private ServerGame game = null;
   private boolean shutDown = false;
   private final List<Runnable> shutdownListeners =
-      Arrays.asList(
+      List.of(
           lobbyWatcherResetupThread::shutdown,
           () -> Optional.ofNullable(game).ifPresent(ServerGame::stopGame),
           () ->

--- a/game-core/src/main/java/org/triplea/live/servers/FetchingCache.java
+++ b/game-core/src/main/java/org/triplea/live/servers/FetchingCache.java
@@ -7,7 +7,7 @@ import games.strategy.triplea.settings.ClientSetting;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
-import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import lombok.Builder;
@@ -39,7 +39,7 @@ class FetchingCache implements ThrowingSupplier<LiveServers, IOException> {
     return LiveServers.builder()
         .latestEngineVersion(ClientContext.engineVersion())
         .servers(
-            Collections.singletonList(
+            List.of(
                 ServerProperties.builder()
                     .message("Override server")
                     .minEngineVersion(ClientContext.engineVersion())

--- a/game-core/src/main/java/org/triplea/lobby/common/login/RsaAuthenticator.java
+++ b/game-core/src/main/java/org/triplea/lobby/common/login/RsaAuthenticator.java
@@ -12,7 +12,6 @@ import java.security.NoSuchAlgorithmException;
 import java.security.PublicKey;
 import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
-import java.util.Collections;
 import java.util.Map;
 import java.util.function.Function;
 import javax.crypto.BadPaddingException;
@@ -47,7 +46,7 @@ public final class RsaAuthenticator {
    *     sends the lobby client.
    */
   public Map<String, String> newChallenge() {
-    return Collections.singletonMap(
+    return Map.of(
         LobbyLoginChallengeKeys.RSA_PUBLIC_KEY,
         Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded()));
   }

--- a/game-core/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/game-core/src/main/java/tools/image/AutoPlacementFinder.java
@@ -18,7 +18,6 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -374,8 +373,7 @@ public final class AutoPlacementFinder {
         } else {
           x--;
         }
-        isPlacement(
-            countryPolygons, Collections.emptySet(), placementRects, placementPoints, place, x, y);
+        isPlacement(countryPolygons, Set.of(), placementRects, placementPoints, place, x, y);
       }
       for (int j = 0; j < Math.abs(step); j++) {
         if (step > 0) {
@@ -383,8 +381,7 @@ public final class AutoPlacementFinder {
         } else {
           y--;
         }
-        isPlacement(
-            countryPolygons, Collections.emptySet(), placementRects, placementPoints, place, x, y);
+        isPlacement(countryPolygons, Set.of(), placementRects, placementPoints, place, x, y);
       }
       step = -step;
       if (step > 0) {

--- a/game-core/src/test/java/games/strategy/engine/data/ChangeTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/ChangeTest.java
@@ -13,7 +13,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.triplea.io.IoUtils;
@@ -319,7 +319,7 @@ class ChangeTest {
     compositeChange.add(new CompositeChange());
     assertTrue(compositeChange.isEmpty());
     final Territory can = gameData.getMap().getTerritory("canada");
-    final Collection<Unit> units = Collections.emptyList();
+    final Collection<Unit> units = List.of();
     compositeChange.add(ChangeFactory.removeUnits(can, units));
     assertFalse(compositeChange.isEmpty());
   }

--- a/game-core/src/test/java/games/strategy/engine/data/DefaultAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/DefaultAttachmentTest.java
@@ -8,7 +8,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
 import java.util.Map;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -47,7 +46,7 @@ final class DefaultAttachmentTest {
 
       @Override
       public Map<String, MutableProperty<?>> getPropertyMap() {
-        return Collections.emptyMap();
+        return Map.of();
       }
 
       @Override

--- a/game-core/src/test/java/games/strategy/engine/data/GameDataVariableParserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/GameDataVariableParserTest.java
@@ -1,8 +1,6 @@
 package games.strategy.engine.data;
 
 import static com.google.common.base.Preconditions.checkState;
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
@@ -13,7 +11,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -53,7 +50,7 @@ class GameDataVariableParserTest {
 
     final Map<String, List<String>> result = parser.parseVariables(xmlSample);
 
-    assertThat(result, hasEntry("$key$", singletonList("value")));
+    assertThat(result, hasEntry("$key$", List.of("value")));
     assertThat(result.keySet(), hasSize(1));
   }
 
@@ -63,10 +60,10 @@ class GameDataVariableParserTest {
 
     final Map<String, List<String>> result = parser.parseVariables(xmlSample);
 
-    assertThat(result, hasEntry("$key1$", asList("value1", "value2")));
-    assertThat(result, hasEntry("$key2$", asList("value3", "value4")));
-    assertThat(result, hasEntry("$no-values$", Collections.emptyList()));
-    assertThat(result, hasEntry("$empty-value$", singletonList("")));
+    assertThat(result, hasEntry("$key1$", List.of("value1", "value2")));
+    assertThat(result, hasEntry("$key2$", List.of("value3", "value4")));
+    assertThat(result, hasEntry("$no-values$", List.of()));
+    assertThat(result, hasEntry("$empty-value$", List.of("")));
     assertThat(result.keySet(), hasSize(4));
   }
 
@@ -76,9 +73,9 @@ class GameDataVariableParserTest {
 
     final Map<String, List<String>> result = parser.parseVariables(xmlSample);
 
-    assertThat(result, hasEntry("$nested$", singletonList("nested-value")));
-    assertThat(result, hasEntry("$contains-nested$", singletonList("nested-value")));
-    assertThat(result, hasEntry("$many-nested$", asList("nested-value", "nested-value")));
+    assertThat(result, hasEntry("$nested$", List.of("nested-value")));
+    assertThat(result, hasEntry("$contains-nested$", List.of("nested-value")));
+    assertThat(result, hasEntry("$many-nested$", List.of("nested-value", "nested-value")));
     assertThat(result.keySet(), hasSize(3));
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/data/GameParserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/GameParserTest.java
@@ -7,6 +7,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -17,7 +18,7 @@ final class GameParserTest {
   final class DecapitalizeTest {
     @Test
     void shouldReturnValueWithFirstCharacterDecapitalized() {
-      Arrays.asList(
+      List.of(
               Tuple.of("", ""),
               Tuple.of("N", "n"),
               Tuple.of("name", "name"),

--- a/game-core/src/test/java/games/strategy/engine/data/PlayerIdTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/PlayerIdTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.Arrays;
+import java.util.List;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -19,8 +19,7 @@ final class PlayerIdTest {
   final class GetPlayerTypeTest {
     @Test
     void shouldReturnType() {
-      Arrays.asList(
-              Tuple.of("AI", "Hard (AI)"), Tuple.of("Human", "Patton"), Tuple.of("null", "Bot"))
+      List.of(Tuple.of("AI", "Hard (AI)"), Tuple.of("Human", "Patton"), Tuple.of("null", "Bot"))
           .forEach(
               idAndName -> {
                 playerId.setWhoAmI(idAndName.getFirst() + ":" + idAndName.getSecond());
@@ -36,7 +35,7 @@ final class PlayerIdTest {
   final class IsAiTest {
     @Test
     void shouldReturnTrueWhenTypeIsAi() {
-      Arrays.asList("AI:Hard (AI)", "ai:hard (ai)")
+      List.of("AI:Hard (AI)", "ai:hard (ai)")
           .forEach(
               encodedType -> {
                 playerId.setWhoAmI(encodedType);
@@ -47,7 +46,7 @@ final class PlayerIdTest {
 
     @Test
     void shouldReturnFalseWhenTypeIsNotAi() {
-      Arrays.asList("Human:Patton", "null:Bot")
+      List.of("Human:Patton", "null:Bot")
           .forEach(
               encodedType -> {
                 playerId.setWhoAmI(encodedType);
@@ -61,7 +60,7 @@ final class PlayerIdTest {
   final class SetWhoAmITest {
     @Test
     void shouldSetWhoAmIWhenEncodedTypeIsLegal() {
-      Arrays.asList(
+      List.of(
               "AI:Hard (AI)",
               "ai:Hard (AI)",
               "Human:Patton",

--- a/game-core/src/test/java/games/strategy/engine/data/RouteFinderTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/RouteFinderTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.when;
 
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
@@ -92,14 +91,14 @@ class RouteFinderTest {
         routeFinder.findRouteByDistance(territories.get(0), territories.get(0));
     assertTrue(optRoute.isPresent());
     final Route route = optRoute.get();
-    assertEquals(Collections.singletonList(territories.get(0)), route.getAllTerritories());
+    assertEquals(List.of(territories.get(0)), route.getAllTerritories());
   }
 
   @Test
   void testNoRouteOnInvalidGraph() {
     final GameMap map = mock(GameMap.class);
     when(map.getNeighborsValidatingCanals(eq(territories.get(0)), any(), any(), any()))
-        .thenReturn(Collections.singleton(territories.get(1)));
+        .thenReturn(Set.of(territories.get(1)));
     final RouteFinder routeFinder = new RouteFinder(map, t -> true, new ArrayList<>(), player);
     final Optional<Route> optRoute =
         routeFinder.findRouteByDistance(
@@ -163,14 +162,14 @@ class RouteFinderTest {
         routeFinder.findRouteByCost(territories.get(0), territories.get(0));
     assertTrue(optRoute.isPresent());
     final Route route = optRoute.get();
-    assertEquals(Collections.singletonList(territories.get(0)), route.getAllTerritories());
+    assertEquals(List.of(territories.get(0)), route.getAllTerritories());
   }
 
   @Test
   void testNoRouteByCostOnInvalidGraph() {
     final GameMap map = mock(GameMap.class);
     when(map.getNeighborsValidatingCanals(eq(territories.get(0)), any(), any(), any()))
-        .thenReturn(Collections.singleton(territories.get(1)));
+        .thenReturn(Set.of(territories.get(1)));
     final RouteFinder routeFinder = new RouteFinder(map, t -> true, new ArrayList<>(), player);
     final Optional<Route> optRoute =
         routeFinder.findRouteByCost(territories.get(0), territories.get(territories.size() - 1));

--- a/game-core/src/test/java/games/strategy/engine/data/gameparser/XmlGameElementMapperTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/gameparser/XmlGameElementMapperTest.java
@@ -12,7 +12,7 @@ import games.strategy.engine.delegate.IDelegate;
 import games.strategy.triplea.attachments.CanalAttachment;
 import games.strategy.triplea.delegate.BattleDelegate;
 import games.strategy.triplea.delegate.TestDelegate;
-import java.util.Collections;
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -43,8 +43,7 @@ final class XmlGameElementMapperTest {
     void shouldReturnDelegateWhenNamePresentInAuxiliaryMap() {
       final String typeName = "TestDelegate";
       final XmlGameElementMapper xmlGameElementMapper =
-          new XmlGameElementMapper(
-              Collections.singletonMap(typeName, TestDelegate::new), Collections.emptyMap());
+          new XmlGameElementMapper(Map.of(typeName, TestDelegate::new), Map.of());
 
       final Optional<IDelegate> result = xmlGameElementMapper.newDelegate(typeName);
 
@@ -83,8 +82,7 @@ final class XmlGameElementMapperTest {
     void shouldReturnAttachmentWhenNamePresentInAuxiliaryMap() {
       final String typeName = "TestAttachment";
       final XmlGameElementMapper xmlGameElementMapper =
-          new XmlGameElementMapper(
-              Collections.emptyMap(), Collections.singletonMap(typeName, TestAttachment::new));
+          new XmlGameElementMapper(Map.of(), Map.of(typeName, TestAttachment::new));
 
       final Optional<IAttachment> result =
           xmlGameElementMapper.newAttachment(typeName, "", null, null);

--- a/game-core/src/test/java/games/strategy/engine/data/properties/GamePropertiesTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/properties/GamePropertiesTest.java
@@ -3,7 +3,6 @@ package games.strategy.engine.data.properties;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -14,7 +13,7 @@ final class GamePropertiesTest {
     @Test
     void shouldBeAbleToRoundTripEditableProperties() throws Exception {
       final List<StringProperty> expected =
-          Arrays.asList(
+          List.of(
               new StringProperty("name1", "description1", "value1"),
               new StringProperty("name2", "description2", "value2"),
               new StringProperty("name3", "description3", "value3"));

--- a/game-core/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListTest.java
@@ -7,8 +7,6 @@ import static org.mockito.Mockito.when;
 
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -64,12 +62,12 @@ class MapDownloadListTest extends AbstractClientSettingTestCase {
     final DownloadFileDescription download2 = newDownloadWithUrl("url2");
     final DownloadFileDescription download3 = newDownloadWithUrl("url3");
     final MapDownloadList testObj =
-        new MapDownloadList(Arrays.asList(download1, download2, download3), strategy);
+        new MapDownloadList(List.of(download1, download2, download3), strategy);
 
     final List<DownloadFileDescription> available =
-        testObj.getAvailableExcluding(Arrays.asList(download1, download3));
+        testObj.getAvailableExcluding(List.of(download1, download3));
 
-    assertThat(available, is(Collections.singletonList(download2)));
+    assertThat(available, is(List.of(download2)));
   }
 
   private static DownloadFileDescription newDownloadWithUrl(final String url) {
@@ -119,12 +117,12 @@ class MapDownloadListTest extends AbstractClientSettingTestCase {
     final DownloadFileDescription download2 = newDownloadWithUrl("url2");
     final DownloadFileDescription download3 = newDownloadWithUrl("url3");
     final MapDownloadList testObj =
-        new MapDownloadList(Arrays.asList(download1, download2, download3), strategy);
+        new MapDownloadList(List.of(download1, download2, download3), strategy);
 
     final List<DownloadFileDescription> outOfDate =
-        testObj.getOutOfDateExcluding(Arrays.asList(download1, download3));
+        testObj.getOutOfDateExcluding(List.of(download1, download3));
 
-    assertThat(outOfDate, is(Collections.singletonList(download2)));
+    assertThat(outOfDate, is(List.of(download2)));
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/engine/framework/startup/ui/PlayerTypeTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/startup/ui/PlayerTypeTest.java
@@ -1,12 +1,12 @@
 package games.strategy.engine.framework.startup.ui;
 
-import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import games.strategy.engine.player.Player;
+import java.util.List;
 import org.hamcrest.Matchers;
 import org.hamcrest.core.IsCollectionContaining;
 import org.junit.jupiter.api.Test;
@@ -17,12 +17,12 @@ class PlayerTypeTest {
   void playerTypes() {
     assertThat(
         "Ensure we do not have an example invisible player type in the selection list",
-        asList(PlayerType.playerTypes()),
+        List.of(PlayerType.playerTypes()),
         Matchers.not(IsCollectionContaining.hasItem(PlayerType.CLIENT_PLAYER.getLabel())));
 
     assertThat(
         "Ensure we have a visible player type in the selection list",
-        asList(PlayerType.playerTypes()),
+        List.of(PlayerType.playerTypes()),
         IsCollectionContaining.hasItem(PlayerType.HUMAN_PLAYER.getLabel()));
   }
 

--- a/game-core/src/test/java/games/strategy/engine/framework/ui/GameChooserModelTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/ui/GameChooserModelTest.java
@@ -4,8 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
-import java.util.HashSet;
+import java.util.Set;
 import javax.swing.SwingUtilities;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,8 +25,7 @@ class GameChooserModelTest {
           when(entry2.compareTo(entry1)).thenReturn(1);
           when(entry1.compareTo(entry3)).thenReturn(-1);
           when(entry3.compareTo(entry1)).thenReturn(1);
-          final GameChooserModel model =
-              new GameChooserModel(new HashSet<>(Arrays.asList(entry1, entry2, entry3)));
+          final GameChooserModel model = new GameChooserModel(Set.of(entry1, entry2, entry3));
           assertEquals(entry1, model.get(0));
           assertEquals(entry2, model.get(1));
           assertEquals(entry3, model.get(2));

--- a/game-core/src/test/java/games/strategy/engine/lobby/PlayerNameValidationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/PlayerNameValidationTest.java
@@ -7,15 +7,14 @@ import static org.hamcrest.Matchers.emptyString;
 import static org.hamcrest.Matchers.not;
 
 import com.google.common.base.Strings;
-import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.triplea.lobby.common.LobbyConstants;
 
 class PlayerNameValidationTest {
   @Test
   void usernameValidationWithInvalidNames() {
-    Arrays.asList(
-            null,
+    List.of(
             "",
             "a",
             "ab", // still too short
@@ -68,7 +67,7 @@ class PlayerNameValidationTest {
 
   @Test
   void usernameValidationWithValidNames() {
-    Arrays.asList("abc", Strings.repeat("a", PlayerNameValidation.MAX_LENGTH), "a12", "a--")
+    List.of("abc", Strings.repeat("a", PlayerNameValidation.MAX_LENGTH), "a12", "a--")
         .forEach(
             validName -> {
               assertThat(

--- a/game-core/src/test/java/games/strategy/engine/lobby/client/ui/GamePollerTaskTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/client/ui/GamePollerTaskTest.java
@@ -1,7 +1,5 @@
 package games.strategy.engine.lobby.client.ui;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -9,7 +7,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import feign.FeignException;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
@@ -67,10 +64,10 @@ class GamePollerTaskTest {
   /** No games in model, listing returns 1 game, should be found as new. */
   @Test
   void newGame() {
-    when(localGameListingFetcher.get()).thenReturn(Collections.emptyMap());
+    when(localGameListingFetcher.get()).thenReturn(Map.of());
     when(lobbyGameListingFetcher.get())
         .thenReturn(
-            asList(
+            List.of(
                 LobbyGameListing.builder().gameId(ID_0).lobbyGame(GAME_0).build(),
                 LobbyGameListing.builder().gameId(ID_1).lobbyGame(GAME_1).build()));
 
@@ -84,7 +81,7 @@ class GamePollerTaskTest {
   @Test
   void removedGame() {
     when(localGameListingFetcher.get()).thenReturn(Map.of(ID_0, GAME_0, ID_1, GAME_1));
-    when(lobbyGameListingFetcher.get()).thenReturn(Collections.emptyList());
+    when(lobbyGameListingFetcher.get()).thenReturn(List.of());
 
     gamePollerTask.run();
 
@@ -97,8 +94,7 @@ class GamePollerTaskTest {
   void gameUpdated() {
     when(localGameListingFetcher.get()).thenReturn(Map.of(ID_0, GAME_0));
     when(lobbyGameListingFetcher.get())
-        .thenReturn(
-            singletonList(LobbyGameListing.builder().gameId(ID_0).lobbyGame(GAME_1).build()));
+        .thenReturn(List.of(LobbyGameListing.builder().gameId(ID_0).lobbyGame(GAME_1).build()));
 
     gamePollerTask.run();
 
@@ -113,8 +109,7 @@ class GamePollerTaskTest {
     final LobbyGame gameEqualToGame0 = GAME_0.withComments(GAME_0.getComments());
     when(lobbyGameListingFetcher.get())
         .thenReturn(
-            singletonList(
-                LobbyGameListing.builder().gameId(ID_0).lobbyGame(gameEqualToGame0).build()));
+            List.of(LobbyGameListing.builder().gameId(ID_0).lobbyGame(gameEqualToGame0).build()));
 
     gamePollerTask.run();
 
@@ -127,7 +122,7 @@ class GamePollerTaskTest {
         .thenReturn(Map.of(ID_0, GAME_0, ID_1, GAME_1, ID_2, GAME_2));
     when(lobbyGameListingFetcher.get())
         .thenReturn(
-            asList(
+            List.of(
                 // id0 is not updated
                 LobbyGameListing.builder().gameId(ID_0).lobbyGame(GAME_0).build(),
                 // id1 is updated
@@ -157,10 +152,8 @@ class GamePollerTaskTest {
 
     @Test
     void reportsErrorAfterFirstSuccess() {
-      when(localGameListingFetcher.get()).thenReturn(Collections.emptyMap());
-      when(lobbyGameListingFetcher.get())
-          .thenReturn(Collections.emptyList())
-          .thenThrow(feignException);
+      when(localGameListingFetcher.get()).thenReturn(Map.of());
+      when(lobbyGameListingFetcher.get()).thenReturn(List.of()).thenThrow(feignException);
 
       gamePollerTask.run();
       gamePollerTask.run();
@@ -170,9 +163,9 @@ class GamePollerTaskTest {
 
     @Test
     void reportsErrorOnlyOnce() {
-      when(localGameListingFetcher.get()).thenReturn(Collections.emptyMap());
+      when(localGameListingFetcher.get()).thenReturn(Map.of());
       when(lobbyGameListingFetcher.get())
-          .thenReturn(Collections.emptyList())
+          .thenReturn(List.of())
           .thenThrow(feignException)
           .thenThrow(feignException);
 
@@ -185,11 +178,11 @@ class GamePollerTaskTest {
 
     @Test
     void reportsErrorAfterRecoveryAndSubsequentError() {
-      when(localGameListingFetcher.get()).thenReturn(Collections.emptyMap());
+      when(localGameListingFetcher.get()).thenReturn(Map.of());
       when(lobbyGameListingFetcher.get())
-          .thenReturn(Collections.emptyList())
+          .thenReturn(List.of())
           .thenThrow(feignException)
-          .thenReturn(Collections.emptyList())
+          .thenReturn(List.of())
           .thenThrow(feignException);
 
       gamePollerTask.run();

--- a/game-core/src/test/java/games/strategy/engine/lobby/moderator/toolbox/tabs/ToolboxTabModelTestUtil.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/moderator/toolbox/tabs/ToolboxTabModelTestUtil.java
@@ -3,7 +3,6 @@ package games.strategy.engine.lobby.moderator.toolbox.tabs;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
-import java.util.Arrays;
 import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -40,7 +39,7 @@ public final class ToolboxTabModelTestUtil {
       assertThat(
           String.format(
               "Mismatch at column %s, rowData: %s, expectedData: %s",
-              i, rowData, Arrays.asList(expectedData)),
+              i, rowData, List.of(expectedData)),
           rowData.get(i),
           is(expectedData[i]));
     }

--- a/game-core/src/test/java/games/strategy/engine/lobby/moderator/toolbox/tabs/access/log/AccessLogTabModelTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/moderator/toolbox/tabs/access/log/AccessLogTabModelTest.java
@@ -1,6 +1,5 @@
 package games.strategy.engine.lobby.moderator.toolbox.tabs.access.log;
 
-import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.mockito.Mockito.verify;
@@ -62,7 +61,7 @@ class AccessLogTabModelTest {
   @Test
   void fetchData() {
     when(toolboxAccessLogClient.getAccessLog(PAGING_PARAMS))
-        .thenReturn(asList(ACCESS_LOG_DATA_1, ACCESS_LOG_DATA_2));
+        .thenReturn(List.of(ACCESS_LOG_DATA_1, ACCESS_LOG_DATA_2));
 
     final List<List<String>> tableData = accessLogTabModel.fetchTableData(PAGING_PARAMS);
 

--- a/game-core/src/test/java/games/strategy/engine/lobby/moderator/toolbox/tabs/bad/words/BadWordsTabModelTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/moderator/toolbox/tabs/bad/words/BadWordsTabModelTest.java
@@ -4,7 +4,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import games.strategy.engine.lobby.moderator.toolbox.tabs.ToolboxTabModelTestUtil;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,7 +17,7 @@ class BadWordsTabModelTest {
 
   private static final String BAD_WORD = "Die loudly like a rough kraken.";
   private static final List<String> badWords =
-      Arrays.asList(
+      List.of(
           "O, gar.",
           "How dead. You rob like a sail.",
           "When the freebooter stutters for jamaica, all waves view warm, mighty swabbies.");

--- a/game-core/src/test/java/games/strategy/engine/lobby/moderator/toolbox/tabs/banned/names/BannedUsernamesTabModelTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/moderator/toolbox/tabs/banned/names/BannedUsernamesTabModelTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.when;
 
 import games.strategy.engine.lobby.moderator.toolbox.tabs.ToolboxTabModelTestUtil;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,8 +30,7 @@ class BannedUsernamesTabModelTest {
 
   @Test
   void fetchTableData() {
-    when(toolboxUsernameBanClient.getUsernameBans())
-        .thenReturn(Collections.singletonList(BANNED_USERNAME_DATA));
+    when(toolboxUsernameBanClient.getUsernameBans()).thenReturn(List.of(BANNED_USERNAME_DATA));
 
     final List<List<String>> tableData = bannedUsernamesTabModel.fetchTableData();
 

--- a/game-core/src/test/java/games/strategy/engine/lobby/moderator/toolbox/tabs/banned/users/BannedUsersTabModelTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/moderator/toolbox/tabs/banned/users/BannedUsersTabModelTest.java
@@ -5,7 +5,6 @@ import static org.mockito.Mockito.when;
 
 import games.strategy.engine.lobby.moderator.toolbox.tabs.ToolboxTabModelTestUtil;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -35,8 +34,7 @@ class BannedUsersTabModelTest {
 
   @Test
   void fetchTableData() {
-    when(toolboxUserBanClient.getUserBans())
-        .thenReturn(Collections.singletonList(BANNED_USER_DATA));
+    when(toolboxUserBanClient.getUserBans()).thenReturn(List.of(BANNED_USER_DATA));
 
     final List<List<String>> tableData = bannedUsersTabModel.fetchTableData();
 

--- a/game-core/src/test/java/games/strategy/engine/lobby/moderator/toolbox/tabs/event/log/EventLogTabModelTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/moderator/toolbox/tabs/event/log/EventLogTabModelTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.when;
 
 import games.strategy.engine.lobby.moderator.toolbox.tabs.ToolboxTabModelTestUtil;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,7 +48,7 @@ class EventLogTabModelTest {
   @Test
   void getEventLogTableData() {
     when(toolboxEventLogClient.lookupModeratorEvents(PAGING_PARAMS))
-        .thenReturn(Arrays.asList(EVENT_1, EVENT_2));
+        .thenReturn(List.of(EVENT_1, EVENT_2));
 
     final List<List<String>> tableData = eventLogTabModel.fetchTableData(PAGING_PARAMS);
 

--- a/game-core/src/test/java/games/strategy/engine/lobby/moderator/toolbox/tabs/moderators/ModeratorsTabModelTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/moderator/toolbox/tabs/moderators/ModeratorsTabModelTest.java
@@ -7,7 +7,6 @@ import static org.mockito.Mockito.when;
 
 import games.strategy.engine.lobby.moderator.toolbox.tabs.ToolboxTabModelTestUtil;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -57,7 +56,7 @@ class ModeratorsTabModelTest {
     void superModerator() {
       when(toolboxModeratorManagementClient.isCurrentUserSuperMod()).thenReturn(true);
       when(toolboxModeratorManagementClient.fetchModeratorList())
-          .thenReturn(Arrays.asList(MODERATOR_INFO, MODERATOR_INFO_WITH_NULL));
+          .thenReturn(List.of(MODERATOR_INFO, MODERATOR_INFO_WITH_NULL));
 
       moderatorsTabModel = new ModeratorsTabModel(toolboxModeratorManagementClient);
 
@@ -85,7 +84,7 @@ class ModeratorsTabModelTest {
     void moderator() {
       when(toolboxModeratorManagementClient.isCurrentUserSuperMod()).thenReturn(false);
       when(toolboxModeratorManagementClient.fetchModeratorList())
-          .thenReturn(Arrays.asList(MODERATOR_INFO, MODERATOR_INFO_WITH_NULL));
+          .thenReturn(List.of(MODERATOR_INFO, MODERATOR_INFO_WITH_NULL));
 
       moderatorsTabModel = new ModeratorsTabModel(toolboxModeratorManagementClient);
 

--- a/game-core/src/test/java/games/strategy/net/MacFinderTest.java
+++ b/game-core/src/test/java/games/strategy/net/MacFinderTest.java
@@ -5,10 +5,12 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.startsWith;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.Arrays;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
+@SuppressWarnings("InnerClassMayBeStatic")
 final class MacFinderTest {
   @Nested
   final class GetHashedMacAddressForBytesTest {
@@ -36,16 +38,16 @@ final class MacFinderTest {
       assertThat(MacFinder.isValidHashedMacAddress("$1$MH$ABCDWXYZabcdwxyz0189./"), is(true));
     }
 
-    @Test
-    void shouldReturnFalseWhenNotValidMd5CryptedValue() {
-      Arrays.asList(
-              "$1$MH$ABCDWXYZabcdwxyz0189.",
-              "$1$MH$ABCDWXYZabcdwxyz0189./1",
-              "1$MH$ABCDWXYZabcdwxyz0189./1",
-              "$1$MH$ABCDWXYZabcdwxyz0189._")
-          .forEach(
-              hashedMacAddress ->
-                  assertThat(MacFinder.isValidHashedMacAddress(hashedMacAddress), is(false)));
+    @ParameterizedTest
+    @ValueSource(
+        strings = {
+          "$1$MH$ABCDWXYZabcdwxyz0189.",
+          "$1$MH$ABCDWXYZabcdwxyz0189./1",
+          "1$MH$ABCDWXYZabcdwxyz0189./1",
+          "$1$MH$ABCDWXYZabcdwxyz0189._"
+        })
+    void shouldReturnFalseWhenNotValidMd5CryptedValue(final String hashedMacAddress) {
+      assertThat(MacFinder.isValidHashedMacAddress(hashedMacAddress), is(false));
     }
 
     @Test

--- a/game-core/src/test/java/games/strategy/net/PlayerNameAssignerTest.java
+++ b/game-core/src/test/java/games/strategy/net/PlayerNameAssignerTest.java
@@ -1,12 +1,11 @@
 package games.strategy.net;
 
-import static java.util.Arrays.asList;
-import static java.util.Collections.emptySet;
-import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -27,7 +26,7 @@ class PlayerNameAssignerTest {
   @Test
   void errorCasesWithNullArguments() {
     assertThrows(
-        NullPointerException.class, () -> PlayerNameAssigner.assignName(NAME_1, null, emptySet()));
+        NullPointerException.class, () -> PlayerNameAssigner.assignName(NAME_1, null, Set.of()));
 
     assertThrows(
         NullPointerException.class, () -> PlayerNameAssigner.assignName(NAME_1, MAC, null));
@@ -37,12 +36,12 @@ class PlayerNameAssignerTest {
   void assignNameShouldGetAssignedNameWhenNotTaken() {
     assertThat(
         "no nodes to match against, we should get the desired name",
-        PlayerNameAssigner.assignName(NAME_1, MAC, emptySet()),
+        PlayerNameAssigner.assignName(NAME_1, MAC, Set.of()),
         is(NAME_1));
 
     assertThat(
         "name and address do not match, should get the desired name",
-        PlayerNameAssigner.assignName(NAME_1, MAC, singletonList(NAME_2)),
+        PlayerNameAssigner.assignName(NAME_1, MAC, List.of(NAME_2)),
         is(NAME_1));
   }
 
@@ -50,12 +49,12 @@ class PlayerNameAssignerTest {
   void assignNameWithMatchingNames() {
     assertThat(
         "name match, should be assigned a numeral name",
-        PlayerNameAssigner.assignName(NAME_1, MAC, singletonList(NAME_1)),
+        PlayerNameAssigner.assignName(NAME_1, MAC, List.of(NAME_1)),
         is(NAME_1 + " (1)"));
 
     assertThat(
         "name match, matching against multiple nodes",
-        PlayerNameAssigner.assignName(NAME_1, MAC, asList(NAME_2, NAME_1)),
+        PlayerNameAssigner.assignName(NAME_1, MAC, List.of(NAME_2, NAME_1)),
         is(NAME_1 + " (1)"));
   }
 
@@ -67,7 +66,7 @@ class PlayerNameAssignerTest {
   void assignNameMultipleNumerals() {
     assertThat(
         "name match, should get next sequential numeral appended",
-        PlayerNameAssigner.assignName(NAME_1, MAC, asList(NAME_1, NAME_1 + " (1)")),
+        PlayerNameAssigner.assignName(NAME_1, MAC, List.of(NAME_1, NAME_1 + " (1)")),
         is(NAME_1 + " (2)"));
   }
 
@@ -79,24 +78,24 @@ class PlayerNameAssignerTest {
   void assignNameShouldFillInMissingNumerals() {
     assertThat(
         "name does not actually match",
-        PlayerNameAssigner.assignName(NAME_1, MAC, singletonList(NAME_1 + " (1)")),
+        PlayerNameAssigner.assignName(NAME_1, MAC, List.of(NAME_1 + " (1)")),
         is(NAME_1));
 
     assertThat(
         "name matches and there is gap in numbering",
-        PlayerNameAssigner.assignName(NAME_1, MAC, asList(NAME_1, NAME_1 + " (2)")),
+        PlayerNameAssigner.assignName(NAME_1, MAC, List.of(NAME_1, NAME_1 + " (2)")),
         is(NAME_1 + " (1)"));
 
     assertThat(
         "name matches and there is gap in numbering, ordering should not matter",
         PlayerNameAssigner.assignName(
-            NAME_1, MAC, asList(NAME_1 + " (3)", NAME_1 + " (1)", NAME_1)),
+            NAME_1, MAC, List.of(NAME_1 + " (3)", NAME_1 + " (1)", NAME_1)),
         is(NAME_1 + " (2)"));
 
     assertThat(
         "should get next ascending numeral",
         PlayerNameAssigner.assignName(
-            NAME_1, MAC, asList(NAME_1 + " (2)", NAME_1 + " (1)", NAME_1)),
+            NAME_1, MAC, List.of(NAME_1 + " (2)", NAME_1 + " (1)", NAME_1)),
         is(NAME_1 + " (3)"));
   }
 
@@ -108,13 +107,13 @@ class PlayerNameAssignerTest {
 
     assertThat(
         "with a bot logged in already, mac check should ignore the already logged in bot",
-        PlayerNameAssigner.assignName(bot01, MAC, singletonList(bot02)),
+        PlayerNameAssigner.assignName(bot01, MAC, List.of(bot02)),
         is(bot01));
 
     assertThat(
         "again, even with multiple bots logged in, mac check should ignore existing logins "
             + "that have a bot lobby watch name",
-        PlayerNameAssigner.assignName(bot01, MAC, asList(bot02, bot03)),
+        PlayerNameAssigner.assignName(bot01, MAC, List.of(bot02, bot03)),
         is(bot01));
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/attachments/TechAbilityAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/TechAbilityAttachmentTest.java
@@ -20,8 +20,8 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.UnitTypeList;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.delegate.TechAdvance;
-import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
@@ -48,7 +48,7 @@ class TechAbilityAttachmentTest {
     final TechnologyFrontier fron = mock(TechnologyFrontier.class);
     when(data.getTechnologyFrontier()).thenReturn(fron);
     final TechAdvance advance = mock(TechAdvance.class);
-    when(fron.getTechs()).thenReturn(Arrays.asList(advance, advance, advance, advance));
+    when(fron.getTechs()).thenReturn(List.of(advance, advance, advance, advance));
     when(advance.hasTech(any())).thenReturn(Boolean.TRUE);
     when(advance.getAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME))
         .thenReturn(attachment, null, attachment, attachment);

--- a/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
@@ -41,7 +41,6 @@ import games.strategy.triplea.delegate.EndRoundDelegate;
 import games.strategy.triplea.delegate.TechAdvance;
 import games.strategy.triplea.ui.NotificationMessages;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -116,7 +115,7 @@ class TriggerAttachmentTest {
       final TriggerAttachment triggerAttachment =
           new TriggerAttachment(
               "triggerAttachment", new PlayerId("somePlayerName", gameData), gameData);
-      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+      final Set<TriggerAttachment> satisfiedTriggers = Set.of(triggerAttachment);
 
       final String notificationMessageKey = "BlackIce";
       final String notificationMessage =
@@ -146,7 +145,7 @@ class TriggerAttachmentTest {
       final GameData gameData = bridge.getData();
       final TriggerAttachment triggerAttachment =
           new TriggerAttachment("triggerAttachment", null, gameData);
-      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+      final Set<TriggerAttachment> satisfiedTriggers = Set.of(triggerAttachment);
 
       final ProductionRuleList productionRuleList = gameData.getProductionRuleList();
       productionRuleList.addProductionRule(new ProductionRule("rule1", gameData));
@@ -156,7 +155,7 @@ class TriggerAttachmentTest {
 
       final ProductionFrontierList productionFrontierList = gameData.getProductionFrontierList();
       productionFrontierList.addProductionFrontier(
-          new ProductionFrontier("frontier", gameData, Collections.singletonList(productionRule2)));
+          new ProductionFrontier("frontier", gameData, List.of(productionRule2)));
 
       final Map<String, MutableProperty<?>> propertyMap = triggerAttachment.getPropertyMap();
       final MutableProperty<?> productionRuleProperty = propertyMap.get("productionRule");
@@ -182,7 +181,7 @@ class TriggerAttachmentTest {
       final GameData gameData = bridge.getData();
       final TriggerAttachment triggerAttachment =
           new TriggerAttachment("triggerAttachment", null, gameData);
-      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+      final Set<TriggerAttachment> satisfiedTriggers = Set.of(triggerAttachment);
 
       final PlayerId playerId = new PlayerId("somePlayer", gameData);
       playerId.addAttachment("rulesAttachment", new RulesAttachment(null, null, gameData));
@@ -204,7 +203,7 @@ class TriggerAttachmentTest {
       final GameData gameData = bridge.getData();
       final TriggerAttachment triggerAttachment =
           new TriggerAttachment("triggerAttachment", null, gameData);
-      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+      final Set<TriggerAttachment> satisfiedTriggers = Set.of(triggerAttachment);
 
       final RelationshipType relationshipType =
           new RelationshipType("someRelationshipType", gameData);
@@ -230,7 +229,7 @@ class TriggerAttachmentTest {
       final GameData gameData = bridge.getData();
       final TriggerAttachment triggerAttachment =
           new TriggerAttachment("triggerAttachment", null, gameData);
-      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+      final Set<TriggerAttachment> satisfiedTriggers = Set.of(triggerAttachment);
 
       final String territoryName = "Sea Zone 9";
       final Territory territory = new Territory(territoryName, gameData);
@@ -255,7 +254,7 @@ class TriggerAttachmentTest {
       final GameData gameData = bridge.getData();
       final TriggerAttachment triggerAttachment =
           new TriggerAttachment("triggerAttachment", null, gameData);
-      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+      final Set<TriggerAttachment> satisfiedTriggers = Set.of(triggerAttachment);
 
       final String territoryEffectName = "someTerritoryEffect";
       final TerritoryEffect territoryEffect = new TerritoryEffect(territoryEffectName, gameData);
@@ -283,7 +282,7 @@ class TriggerAttachmentTest {
       final GameData gameData = bridge.getData();
       final TriggerAttachment triggerAttachment =
           new TriggerAttachment("triggerAttachment", null, gameData);
-      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+      final Set<TriggerAttachment> satisfiedTriggers = Set.of(triggerAttachment);
 
       final UnitType unitType = new UnitType("someUnit", gameData);
       gameData.getUnitTypeList().addUnitType(unitType);
@@ -305,7 +304,7 @@ class TriggerAttachmentTest {
       final GameData gameData = bridge.getData();
       final TriggerAttachment triggerAttachment =
           new TriggerAttachment("triggerAttachment", null, gameData);
-      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+      final Set<TriggerAttachment> satisfiedTriggers = Set.of(triggerAttachment);
 
       final PlayerId playerKeoland = new PlayerId("Keoland", gameData);
       final PlayerId playerFuryondy = new PlayerId("Furyondy", gameData);
@@ -348,7 +347,7 @@ class TriggerAttachmentTest {
 
       final TriggerAttachment triggerAttachment =
           new TriggerAttachment("triggerAttachment", playerId, gameData);
-      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+      final Set<TriggerAttachment> satisfiedTriggers = Set.of(triggerAttachment);
 
       final TechnologyFrontier gameTechnologyFrontier = gameData.getTechnologyFrontier();
       gameTechnologyFrontier.addAdvance(
@@ -376,7 +375,7 @@ class TriggerAttachmentTest {
 
       final TriggerAttachment triggerAttachment =
           new TriggerAttachment("triggerAttachment", playerId, gameData);
-      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+      final Set<TriggerAttachment> satisfiedTriggers = Set.of(triggerAttachment);
 
       final TechnologyFrontier gameTechnologyFrontier = gameData.getTechnologyFrontier();
       gameTechnologyFrontier.addAdvance(
@@ -408,7 +407,7 @@ class TriggerAttachmentTest {
 
       final TriggerAttachment triggerAttachment =
           new TriggerAttachment("triggerAttachment", playerId, gameData);
-      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+      final Set<TriggerAttachment> satisfiedTriggers = Set.of(triggerAttachment);
 
       triggerAttachment
           .getPropertyMap()
@@ -434,7 +433,7 @@ class TriggerAttachmentTest {
 
       final TriggerAttachment triggerAttachment =
           new TriggerAttachment("triggerAttachment", playerId, gameData);
-      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+      final Set<TriggerAttachment> satisfiedTriggers = Set.of(triggerAttachment);
 
       triggerAttachment
           .getPropertyMap()
@@ -452,7 +451,7 @@ class TriggerAttachmentTest {
 
       final TriggerAttachment triggerAttachment =
           new TriggerAttachment("triggerAttachment", null, gameData);
-      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+      final Set<TriggerAttachment> satisfiedTriggers = Set.of(triggerAttachment);
 
       final PlayerId playerChina = new PlayerId("China", gameData);
       final PlayerId playerRussia = new PlayerId("Russia", gameData);
@@ -488,7 +487,7 @@ class TriggerAttachmentTest {
 
       final TriggerAttachment triggerAttachment =
           new TriggerAttachment("triggerAttachment", playerId, gameData);
-      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+      final Set<TriggerAttachment> satisfiedTriggers = Set.of(triggerAttachment);
 
       gameData.getUnitTypeList().addUnitType(new UnitType("brigantine", gameData));
       gameData.getUnitTypeList().addUnitType(new UnitType("sellsword", gameData));
@@ -510,7 +509,7 @@ class TriggerAttachmentTest {
       final PlayerId player = new PlayerId("somePlayer", gameData);
       final TriggerAttachment triggerAttachment =
           new TriggerAttachment("triggerAttachment", player, gameData);
-      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+      final Set<TriggerAttachment> satisfiedTriggers = Set.of(triggerAttachment);
 
       final Territory territoryCorusk = addTerritory("Corusk Pass");
       final Territory territoryHraak = addTerritory("Hraak Pass");
@@ -559,7 +558,7 @@ class TriggerAttachmentTest {
       final PlayerId player = new PlayerId("somePlayer", gameData);
       final TriggerAttachment triggerAttachment =
           new TriggerAttachment("triggerAttachment", player, gameData);
-      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+      final Set<TriggerAttachment> satisfiedTriggers = Set.of(triggerAttachment);
 
       addUnitType("conscript");
       addUnitType("sellsword");
@@ -584,7 +583,7 @@ class TriggerAttachmentTest {
       final PlayerId player = new PlayerId("somePlayer", gameData);
       final TriggerAttachment triggerAttachment =
           new TriggerAttachment("triggerAttachment", player, gameData);
-      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+      final Set<TriggerAttachment> satisfiedTriggers = Set.of(triggerAttachment);
 
       gameData.getResourceList().addResource(new Resource(Constants.PUS, gameData));
 
@@ -627,8 +626,7 @@ class TriggerAttachmentTest {
 
       final TriggerAttachment activateTriggerTriggerAttachment =
           new TriggerAttachment("activateTrigger", null, gameData);
-      final Set<TriggerAttachment> satisfiedTriggers =
-          Collections.singleton(activateTriggerTriggerAttachment);
+      final Set<TriggerAttachment> satisfiedTriggers = Set.of(activateTriggerTriggerAttachment);
 
       activateTriggerTriggerAttachment
           .getPropertyMap()
@@ -638,7 +636,7 @@ class TriggerAttachmentTest {
                   "%s:1:false:false:false:false", triggerToBeFiredTriggerAttachment.getName()));
 
       TriggerAttachment.triggerActivateTriggerOther(
-          Collections.emptyMap(), satisfiedTriggers, bridge, defaultFireTriggerParams);
+          Map.of(), satisfiedTriggers, bridge, defaultFireTriggerParams);
       verify(bridge, times(2)).addChange(not(argThat(Change::isEmpty)));
     }
 
@@ -649,7 +647,7 @@ class TriggerAttachmentTest {
       final PlayerId player = new PlayerId("somePlayer", gameData);
       final TriggerAttachment triggerAttachment =
           new TriggerAttachment("triggerAttachment", player, gameData);
-      final Set<TriggerAttachment> satisfiedTriggers = Collections.singleton(triggerAttachment);
+      final Set<TriggerAttachment> satisfiedTriggers = Set.of(triggerAttachment);
 
       final String notificationMessageKey = "IndomitableCenterVictory";
       final String notificationMessage =

--- a/game-core/src/test/java/games/strategy/triplea/delegate/AbstractEndTurnDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/AbstractEndTurnDelegateTest.java
@@ -12,8 +12,9 @@ import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.Territory;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.xml.TestMapGameData;
-import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.triplea.java.collections.IntegerMap;
@@ -37,7 +38,7 @@ final class AbstractEndTurnDelegateTest {
     private final GameData gameData = new GameData();
     private final Comparator<Territory> comparator =
         AbstractEndTurnDelegate.getSingleNeighborBlockadesThenHighestToLowestProduction(
-            Collections.emptyList(), gameData.getMap());
+            List.of(), gameData.getMap());
     private final Territory territory = new Territory("territoryName", gameData);
 
     @Test
@@ -71,8 +72,7 @@ final class AbstractEndTurnDelegateTest {
   final class GetSingleBlockadeThenHighestToLowestBlockadeDamageTest {
     private final GameData gameData = new GameData();
     private final Comparator<Territory> comparator =
-        AbstractEndTurnDelegate.getSingleBlockadeThenHighestToLowestBlockadeDamage(
-            Collections.emptyMap());
+        AbstractEndTurnDelegate.getSingleBlockadeThenHighestToLowestBlockadeDamage(Map.of());
     private final Territory territory = new Territory("territoryName", gameData);
 
     @Test

--- a/game-core/src/test/java/games/strategy/triplea/delegate/BattleTrackerTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/BattleTrackerTest.java
@@ -15,8 +15,8 @@ import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.TripleAUnit;
-import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.function.BiFunction;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -53,7 +53,7 @@ class BattleTrackerTest {
 
     // need at least one attacker for there to be considered a battle.
     final Unit unit = new TripleAUnit(new UnitType("unit", mockGameData), playerId, mockGameData);
-    final List<Unit> attackers = Collections.singletonList(unit);
+    final List<Unit> attackers = List.of(unit);
 
     when(mockDelegateBridge.getData()).thenReturn(mockGameData);
     when(mockGameData.getProperties()).thenReturn(mockGameProperties);
@@ -70,7 +70,7 @@ class BattleTrackerTest {
         route, attackers, true, playerId, mockDelegateBridge, null, null, null, false);
 
     testObj.fightAirRaidsAndStrategicBombing(
-        mockDelegateBridge, () -> Collections.singleton(territory), mockGetBattleFunction);
+        mockDelegateBridge, () -> Set.of(territory), mockGetBattleFunction);
 
     verify(mockBattle).fight(mockDelegateBridge);
   }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -30,7 +30,6 @@ import games.strategy.triplea.xml.TestMapGameData;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -264,7 +263,7 @@ class DiceRollTest {
     final IDelegateBridge bridge = newDelegateBridge(americans);
     whenGetRandom(bridge).thenAnswer(withValues(1));
     final IBattle battle = mock(IBattle.class);
-    when(battle.getAmphibiousLandAttackers()).thenReturn(Collections.emptyList());
+    when(battle.getAmphibiousLandAttackers()).thenReturn(List.of());
     when(battle.isAmphibious()).thenReturn(true);
     final DiceRoll roll =
         DiceRoll.rollDice(

--- a/game-core/src/test/java/games/strategy/triplea/delegate/ExecutionStackTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/ExecutionStackTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.verify;
 
 import games.strategy.engine.delegate.IDelegateBridge;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -24,7 +23,7 @@ class ExecutionStackTest {
   void testStackIsProcessedInRightOrder() {
     final List<Integer> orderCheck = new ArrayList<>();
     executionStack.push(
-        Arrays.asList((stack, bridge) -> orderCheck.add(4), (stack, bridge) -> orderCheck.add(3)));
+        List.of((stack, bridge) -> orderCheck.add(4), (stack, bridge) -> orderCheck.add(3)));
     executionStack.push(
         (stack, bridge) -> {
           // Prevent infinite loop
@@ -64,7 +63,7 @@ class ExecutionStackTest {
     executionStack.execute(null);
     assertThat(executionStack.isEmpty(), is(true));
 
-    executionStack.push(Arrays.asList(mock, mock));
+    executionStack.push(List.of(mock, mock));
     assertThat(executionStack.isEmpty(), is(false));
     executionStack.execute(null);
     assertThat(executionStack.isEmpty(), is(true));

--- a/game-core/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
@@ -24,8 +24,8 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.xml.TestMapGameData;
-import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
@@ -67,7 +67,7 @@ class LhtrTest {
         easternEurope.getUnitCollection().getMatches(Matches.unitIsOfType(fighterType)), route);
     // add a carrier to be produced in germany
     final TripleAUnit carrier = new TripleAUnit(carrirType, germans, gameData);
-    gameData.performChange(ChangeFactory.addUnits(germans, Collections.singleton(carrier)));
+    gameData.performChange(ChangeFactory.addUnits(germans, Set.of(carrier)));
     // end the move phase
     delegate.end();
     // make sure the fighter is still there
@@ -182,7 +182,7 @@ class LhtrTest {
     final PlayerId british = GameDataTestUtil.british(gameData);
     // add a unit
     final Unit bomber = GameDataTestUtil.bomber(gameData).create(british);
-    final Change change = ChangeFactory.addUnits(uk, Collections.singleton(bomber));
+    final Change change = ChangeFactory.addUnits(uk, Set.of(bomber));
     gameData.performChange(change);
     final BattleTracker tracker = new BattleTracker();
     final IBattle battle = new StrategicBombingRaidBattle(germany, gameData, british, tracker);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MatchesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MatchesTest.java
@@ -13,7 +13,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.xml.TestMapGameData;
-import java.util.Arrays;
+import java.util.List;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import org.hamcrest.Description;
@@ -133,7 +133,7 @@ final class MatchesTest {
       territory
           .getUnitCollection()
           .addAll(
-              Arrays.asList(
+              List.of(
                   newLandUnitFor(player),
                   newLandUnitFor(enemyPlayer),
                   newAirUnitFor(enemyPlayer),
@@ -147,7 +147,7 @@ final class MatchesTest {
       territory
           .getUnitCollection()
           .addAll(
-              Arrays.asList(
+              List.of(
                   newSeaUnitFor(player),
                   newSeaUnitFor(enemyPlayer),
                   newAirUnitFor(enemyPlayer),

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -21,7 +21,6 @@ import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.attachments.UnitAttachment;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -53,7 +52,7 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
   void testNotUnique() {
     final Route route = new Route(egypt, eastAfrica);
     final Unit unit = armour.create(british);
-    final List<Unit> units = Arrays.asList(unit, unit);
+    final List<Unit> units = List.of(unit, unit);
     final String results = delegate.move(units, route);
     assertError(results);
   }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -70,9 +70,7 @@ import games.strategy.triplea.delegate.data.PlaceableUnits;
 import games.strategy.triplea.delegate.data.TechResults;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
@@ -439,7 +437,7 @@ class RevisedTest {
     assertEquals(2, infantry.size());
     final TripleAUnit transport =
         (TripleAUnit) sz5.getUnitCollection().getMatches(Matches.unitIsTransport()).get(0);
-    final String error = moveDelegate.move(infantry, eeToSz5, Collections.singletonList(transport));
+    final String error = moveDelegate.move(infantry, eeToSz5, List.of(transport));
     assertNull(error, error);
     // make sure the transport was loaded
     assertTrue(moveDelegate.getMovesMade().get(0).wasTransportLoaded(transport));
@@ -473,7 +471,7 @@ class RevisedTest {
     final TripleAUnit transport =
         (TripleAUnit) sz5.getUnitCollection().getMatches(Matches.unitIsTransport()).get(0);
     // load the transport
-    String error = moveDelegate.move(infantry, eeToSz5, Collections.singletonList(transport));
+    String error = moveDelegate.move(infantry, eeToSz5, List.of(transport));
     assertNull(error, error);
     final Route sz5ToNorway = new Route(sz5, norway);
     // move the infantry in two steps
@@ -518,11 +516,9 @@ class RevisedTest {
         (TripleAUnit) sz5.getUnitCollection().getMatches(Matches.unitIsTransport()).get(0);
     // load the transports
     // in two moves
-    String error =
-        moveDelegate.move(infantry.subList(0, 1), eeToSz5, Collections.singletonList(transport));
+    String error = moveDelegate.move(infantry.subList(0, 1), eeToSz5, List.of(transport));
     assertNull(error, error);
-    error =
-        moveDelegate.move(infantry.subList(1, 2), eeToSz5, Collections.singletonList(transport));
+    error = moveDelegate.move(infantry.subList(1, 2), eeToSz5, List.of(transport));
     assertNull(error, error);
     // make sure the transport was loaded
     assertTrue(moveDelegate.getMovesMade().get(0).wasTransportLoaded(transport));
@@ -559,7 +555,7 @@ class RevisedTest {
     assertEquals(1, infantry.size());
     final TripleAUnit transport =
         (TripleAUnit) sz5.getUnitCollection().getMatches(Matches.unitIsTransport()).get(0);
-    String error = moveDelegate.move(infantry, eeToSz5, Collections.singletonList(transport));
+    String error = moveDelegate.move(infantry, eeToSz5, List.of(transport));
     assertNull(error, error);
     // try to unload
     final Route sz5ToEee = new Route(sz5, eastEurope);
@@ -586,7 +582,7 @@ class RevisedTest {
     assertEquals(2, infantry.size());
     final TripleAUnit transport =
         (TripleAUnit) sz5.getUnitCollection().getMatches(Matches.unitIsTransport()).get(0);
-    String error = moveDelegate.move(infantry, eeToSz5, Collections.singletonList(transport));
+    String error = moveDelegate.move(infantry, eeToSz5, List.of(transport));
     assertNull(error, error);
     // unload one infantry to Norway
     final Territory norway = gameData.getMap().getTerritory("Norway");
@@ -635,7 +631,7 @@ class RevisedTest {
     assertEquals(2, infantry.size());
     final TripleAUnit transport =
         (TripleAUnit) sz5.getUnitCollection().getMatches(Matches.unitIsTransport()).get(0);
-    String error = moveDelegate.move(infantry, eeToSz5, Collections.singletonList(transport));
+    String error = moveDelegate.move(infantry, eeToSz5, List.of(transport));
     assertNull(error, error);
     // unload one infantry to Norway
     final Territory norway = gameData.getMap().getTerritory("Norway");
@@ -986,7 +982,7 @@ class RevisedTest {
             AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings(true);
     assertEquals(
-        Arrays.asList(
+        List.of(
                 attacker + FIRE,
                 defender + SELECT_CASUALTIES,
                 defender + FIRE,
@@ -1017,7 +1013,7 @@ class RevisedTest {
             AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings(true);
     assertEquals(
-        Arrays.asList(
+        List.of(
                 attacker + FIRE,
                 defender + SELECT_CASUALTIES,
                 defender + FIRE,
@@ -1048,7 +1044,7 @@ class RevisedTest {
             AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings(true);
     assertEquals(
-        Arrays.asList(
+        List.of(
                 attacker + SUBS_FIRE,
                 defender + SELECT_SUB_CASUALTIES,
                 defender + SUBS_FIRE,
@@ -1106,7 +1102,7 @@ class RevisedTest {
      * going to the scrap heap.
      */
     assertEquals(
-        Arrays.asList(
+        List.of(
                 attacker + SUBS_FIRE,
                 defender + SELECT_SUB_CASUALTIES,
                 defender + SUBS_FIRE,
@@ -1177,7 +1173,7 @@ class RevisedTest {
      * going to the scrap heap.
      */
     assertEquals(
-        Arrays.asList(
+        List.of(
                 attacker + SUBS_FIRE,
                 defender + SELECT_SUB_CASUALTIES,
                 defender + SUBS_FIRE,
@@ -1234,7 +1230,7 @@ class RevisedTest {
             AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings(true);
     assertEquals(
-        Arrays.asList(
+        List.of(
                 attacker + SUBS_FIRE,
                 defender + SELECT_SUB_CASUALTIES,
                 defender + SUBS_FIRE,
@@ -1302,7 +1298,7 @@ class RevisedTest {
      * on the battle board until step 6, allowing them to fire back before going to the scrap heap.
      */
     assertEquals(
-        Arrays.asList(
+        List.of(
                 attacker + SUBS_FIRE,
                 defender + SELECT_SUB_CASUALTIES,
                 defender + SUBS_FIRE,
@@ -1360,7 +1356,7 @@ class RevisedTest {
             AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings(true);
     assertEquals(
-        Arrays.asList(
+        List.of(
                 attacker + SUBS_FIRE,
                 defender + SELECT_SUB_CASUALTIES,
                 defender + SUBS_FIRE,
@@ -1384,7 +1380,7 @@ class RevisedTest {
         invocation -> {
           final Collection<Unit> selectFrom = invocation.getArgument(0);
           return new CasualtyDetails(
-              Collections.singletonList(selectFrom.iterator().next()), new ArrayList<>(), false);
+              List.of(selectFrom.iterator().next()), new ArrayList<>(), false);
         });
     whenGetRandom(bridge)
         .thenAnswer(withValues(0))

--- a/game-core/src/test/java/games/strategy/triplea/delegate/UndoablePlacementTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/UndoablePlacementTest.java
@@ -8,7 +8,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
-import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -24,8 +24,7 @@ final class UndoablePlacementTest {
         new CompositeChange(),
         producerTerritory,
         placeTerritory,
-        Collections.singletonList(
-            new Unit(new UnitType(UNIT_TYPE_NAME, gameData), null, gameData)));
+        List.of(new Unit(new UnitType(UNIT_TYPE_NAME, gameData), null, gameData)));
   }
 
   @Nested

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -82,9 +82,7 @@ import games.strategy.triplea.delegate.data.TechResults;
 import games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -364,7 +362,7 @@ class WW2V3Year41Test {
     addTo(british(gameData), transport(gameData).create(1, british(gameData)), gameData);
     final String error =
         del.placeUnits(
-            Collections.emptyList(),
+            List.of(),
             territory("United Kingdom", gameData),
             IAbstractPlaceDelegate.BidMode.NOT_BID);
     assertNull(error);
@@ -1009,7 +1007,7 @@ class WW2V3Year41Test {
             AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings(true);
     assertEquals(
-        Arrays.asList(
+        List.of(
                 attacker + SUBS_SUBMERGE,
                 defender + SUBS_SUBMERGE,
                 attacker + SUBS_FIRE,
@@ -1051,7 +1049,7 @@ class WW2V3Year41Test {
             AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings(true);
     assertEquals(
-        Arrays.asList(
+        List.of(
                 defender + SUBS_SUBMERGE,
                 defender + SUBS_FIRE,
                 attacker + SELECT_SUB_CASUALTIES,
@@ -1099,7 +1097,7 @@ class WW2V3Year41Test {
             AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings(true);
     assertEquals(
-        Arrays.asList(
+        List.of(
                 attacker + SUBS_SUBMERGE,
                 attacker + SUBS_FIRE,
                 defender + SELECT_SUB_CASUALTIES,
@@ -1148,7 +1146,7 @@ class WW2V3Year41Test {
             AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings(true);
     assertEquals(
-        Arrays.asList(
+        List.of(
                 attacker + SUBS_FIRE,
                 defender + SELECT_SUB_CASUALTIES,
                 attacker + FIRE,
@@ -1166,7 +1164,7 @@ class WW2V3Year41Test {
         invocation -> {
           final Collection<Unit> selectFrom = invocation.getArgument(0);
           return new CasualtyDetails(
-              Collections.singletonList(selectFrom.iterator().next()), new ArrayList<>(), false);
+              List.of(selectFrom.iterator().next()), new ArrayList<>(), false);
         });
     // attacking subs sneak attack and hit
     // no chance to return fire
@@ -1744,7 +1742,7 @@ class WW2V3Year41Test {
     repairs.put(repair, 1);
     String error =
         del.purchaseRepair(
-            Collections.singletonMap(
+            Map.of(
                 CollectionUtils.getMatches(germany.getUnits(), Matches.unitCanBeDamaged())
                     .iterator()
                     .next(),
@@ -1774,7 +1772,7 @@ class WW2V3Year41Test {
     repairs.put(repair, 2);
     error =
         del.purchaseRepair(
-            Collections.singletonMap(
+            Map.of(
                 CollectionUtils.getMatches(germany.getUnits(), Matches.unitCanBeDamaged())
                     .iterator()
                     .next(),
@@ -1804,7 +1802,7 @@ class WW2V3Year41Test {
     repairs.put(repair, 2);
     final String error =
         del.purchaseRepair(
-            Collections.singletonMap(
+            Map.of(
                 CollectionUtils.getMatches(germany.getUnits(), Matches.unitCanBeDamaged())
                     .iterator()
                     .next(),

--- a/game-core/src/test/java/games/strategy/triplea/formatter/MyFormatterTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/formatter/MyFormatterTest.java
@@ -7,9 +7,8 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -32,7 +31,7 @@ final class MyFormatterTest {
 
     @Test
     void shouldReturnEmptyStringWhenUnitsIsEmpty() {
-      assertThat(MyFormatter.unitsToText(Collections.emptyList()), is(""));
+      assertThat(MyFormatter.unitsToText(List.of()), is(""));
     }
 
     @Test
@@ -42,7 +41,7 @@ final class MyFormatterTest {
       final UnitType unitType1 = newUnitType("unitType1");
       final UnitType unitType2 = newUnitType("unitType2");
       final Collection<Unit> units =
-          Arrays.asList(
+          List.of(
               newUnit(unitType1, playerId1),
               newUnit(unitType2, playerId1),
               newUnit(unitType1, playerId2),
@@ -63,7 +62,7 @@ final class MyFormatterTest {
       final PlayerId playerId = newPlayerId("playerId");
       final UnitType unitType = newUnitType("unitType");
       final Collection<Unit> units =
-          Arrays.asList(newUnit(unitType, playerId), newUnit(unitType, playerId));
+          List.of(newUnit(unitType, playerId), newUnit(unitType, playerId));
 
       assertThat(MyFormatter.unitsToText(units), is("2 unitTypes owned by the playerId"));
     }

--- a/game-core/src/test/java/games/strategy/triplea/odds/calculator/DummyPlayerTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/odds/calculator/DummyPlayerTest.java
@@ -19,7 +19,6 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.MustFightBattle;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
 import games.strategy.triplea.delegate.data.CasualtyList;
-import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -200,8 +199,7 @@ class DummyPlayerTest {
     @Test
     void testSelectCasualties_noLand_fewEntriesInLossOrder() {
       final DummyPlayer player =
-          new DummyPlayer(
-              null, false, "", Collections.singletonList(unitPool.get(0)), false, 0, 0, false);
+          new DummyPlayer(null, false, "", List.of(unitPool.get(0)), false, 0, 0, false);
       final CasualtyDetails details =
           player.selectCasualties(
               unitPool,

--- a/game-core/src/test/java/games/strategy/triplea/odds/calculator/OddsCalculatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/odds/calculator/OddsCalculatorTest.java
@@ -17,7 +17,6 @@ import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,7 +36,7 @@ class OddsCalculatorTest {
     final PlayerId russians = GameDataTestUtil.russians(gameData);
     final PlayerId germans = GameDataTestUtil.germans(gameData);
     final List<Unit> attackingUnits = GameDataTestUtil.infantry(gameData).create(100, russians);
-    final List<Unit> bombardingUnits = Collections.emptyList();
+    final List<Unit> bombardingUnits = List.of();
     final IOddsCalculator calculator = new OddsCalculator(gameData);
     final AggregateResults results =
         calculator.setCalculateDataAndCalculate(
@@ -66,7 +65,7 @@ class OddsCalculatorTest {
     final List<Unit> defendingUnits = GameDataTestUtil.fighter(gameData).create(1, british, false);
     final List<Unit> attackingUnits = GameDataTestUtil.infantry(gameData).create(1, germans, false);
     attackingUnits.addAll(GameDataTestUtil.bomber(gameData).create(1, germans, false));
-    final List<Unit> bombardingUnits = Collections.emptyList();
+    final List<Unit> bombardingUnits = List.of();
     final IOddsCalculator calculator = new OddsCalculator(gameData);
     calculator.setKeepOneAttackingLandUnit(true);
     final AggregateResults results =
@@ -98,7 +97,7 @@ class OddsCalculatorTest {
             sz1,
             attacking,
             defending,
-            Collections.emptyList(),
+            List.of(),
             TerritoryEffectHelper.getEffects(sz1),
             1);
     calculator.shutdown();
@@ -122,7 +121,7 @@ class OddsCalculatorTest {
             sz1,
             attacking,
             defending,
-            Collections.emptyList(),
+            List.of(),
             TerritoryEffectHelper.getEffects(sz1),
             1);
     calculator.shutdown();

--- a/game-core/src/test/java/games/strategy/triplea/settings/SaveFunctionTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/SaveFunctionTest.java
@@ -13,8 +13,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.google.common.util.concurrent.Runnables;
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 import java.util.function.Consumer;
 import javax.swing.JComponent;
 import javax.swing.JOptionPane;
@@ -38,8 +37,7 @@ final class SaveFunctionTest {
 
       final SaveFunction.SaveResult result =
           SaveFunction.saveSettings(
-              Arrays.asList(mockSelectionComponent, mockSelectionComponent2),
-              Runnables.doNothing());
+              List.of(mockSelectionComponent, mockSelectionComponent2), Runnables.doNothing());
 
       assertThat(
           "There will always be a message back to the user",
@@ -92,8 +90,7 @@ final class SaveFunctionTest {
 
       final SaveFunction.SaveResult result =
           SaveFunction.saveSettings(
-              Arrays.asList(mockSelectionComponent, mockSelectionComponent2),
-              Runnables.doNothing());
+              List.of(mockSelectionComponent, mockSelectionComponent2), Runnables.doNothing());
 
       assertThat(result.message, is(not(emptyString())));
       assertThat(result.dialogType, is(JOptionPane.WARNING_MESSAGE));
@@ -105,8 +102,7 @@ final class SaveFunctionTest {
 
       final SaveFunction.SaveResult result =
           SaveFunction.saveSettings(
-              Arrays.asList(mockSelectionComponent, mockSelectionComponent2),
-              Runnables.doNothing());
+              List.of(mockSelectionComponent, mockSelectionComponent2), Runnables.doNothing());
 
       assertThat(result.message, is(not(emptyString())));
       assertThat(
@@ -120,8 +116,7 @@ final class SaveFunctionTest {
       whenSelectionComponentSave(
           mockSelectionComponent, context -> context.setValue(mockSetting, TestData.fakeValue));
 
-      SaveFunction.saveSettings(
-          Collections.singletonList(mockSelectionComponent), flushSettingsAction);
+      SaveFunction.saveSettings(List.of(mockSelectionComponent), flushSettingsAction);
 
       verify(flushSettingsAction).run();
       verify(mockSetting).setValue(TestData.fakeValue);
@@ -133,8 +128,7 @@ final class SaveFunctionTest {
           mockSelectionComponent,
           context -> context.reportError(mockSetting, "failed", TestData.fakeValue));
 
-      SaveFunction.saveSettings(
-          Collections.singletonList(mockSelectionComponent), flushSettingsAction);
+      SaveFunction.saveSettings(List.of(mockSelectionComponent), flushSettingsAction);
 
       verify(flushSettingsAction, never()).run();
       verify(mockSetting, never()).setValue(TestData.fakeValue);

--- a/game-core/src/test/java/games/strategy/triplea/ui/PropertyFileTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/PropertyFileTest.java
@@ -9,7 +9,7 @@ import games.strategy.triplea.ResourceLoader;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -30,7 +30,7 @@ class PropertyFileTest {
 
   @Test
   void testConstructor() throws Exception {
-    Files.write(file.toPath(), Arrays.asList("abc=def", "123: 456"));
+    Files.write(file.toPath(), List.of("abc=def", "123: 456"));
     final PropertyFile instance = new PropertyFile(file.getAbsolutePath(), mock) {};
     assertEquals("def", instance.properties.getProperty("abc"));
     assertEquals("456", instance.properties.getProperty("123"));

--- a/game-core/src/test/java/games/strategy/triplea/ui/UnitIconPropertiesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/UnitIconPropertiesTest.java
@@ -13,7 +13,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.triplea.attachments.ICondition;
 import games.strategy.triplea.ui.UnitIconProperties.MalformedUnitIconDescriptorException;
 import games.strategy.triplea.ui.UnitIconProperties.UnitIconDescriptor;
-import java.util.Collections;
+import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
 import javax.annotation.Nullable;
@@ -56,7 +56,7 @@ final class UnitIconPropertiesTest {
 
     private ICondition givenCondition(final String name, final boolean satisfied) {
       final ICondition condition = mock(ICondition.class);
-      when(condition.getConditions()).thenReturn(Collections.emptyList());
+      when(condition.getConditions()).thenReturn(List.of());
       when(condition.getName()).thenReturn(name);
       when(condition.isSatisfied(any(), any())).thenReturn(satisfied);
       return condition;

--- a/game-core/src/test/java/games/strategy/triplea/ui/UserActionPanelTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ui/UserActionPanelTest.java
@@ -10,9 +10,8 @@ import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.data.Resource;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.UserActionAttachment;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -103,7 +102,7 @@ final class UserActionPanelTest {
   final class CanSpendResourcesOnUserActionsTest {
     @Test
     void shouldReturnFalseWhenNoUserActionsPresent() {
-      final Collection<UserActionAttachment> userActions = Collections.emptyList();
+      final Collection<UserActionAttachment> userActions = List.of();
 
       final boolean canSpendResources = UserActionPanel.canSpendResourcesOnUserActions(userActions);
 
@@ -113,7 +112,7 @@ final class UserActionPanelTest {
     @Test
     void shouldReturnFalseWhenNoUserActionHasCost() {
       final Collection<UserActionAttachment> userActions =
-          Arrays.asList(newUserActionWithCost(0), newUserActionWithCost(0));
+          List.of(newUserActionWithCost(0), newUserActionWithCost(0));
 
       final boolean canSpendResources = UserActionPanel.canSpendResourcesOnUserActions(userActions);
 
@@ -123,7 +122,7 @@ final class UserActionPanelTest {
     @Test
     void shouldReturnTrueWhenAtLeastOneUserActionHasCost() {
       final Collection<UserActionAttachment> userActions =
-          Arrays.asList(newUserActionWithCost(0), newUserActionWithCost(5));
+          List.of(newUserActionWithCost(0), newUserActionWithCost(5));
 
       final boolean canSpendResources = UserActionPanel.canSpendResourcesOnUserActions(userActions);
 

--- a/game-core/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
+++ b/game-core/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
@@ -8,7 +8,7 @@ import games.strategy.triplea.delegate.TestDelegate;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.nio.file.Paths;
-import java.util.Collections;
+import java.util.Map;
 
 /** The available maps for use during testing. */
 public enum TestMapGameData {
@@ -64,8 +64,8 @@ public enum TestMapGameData {
           "game name",
           is,
           new XmlGameElementMapper(
-              Collections.singletonMap("TestDelegate", TestDelegate::new),
-              Collections.singletonMap("TestAttachment", TestAttachment::new)));
+              Map.of("TestDelegate", TestDelegate::new),
+              Map.of("TestAttachment", TestAttachment::new)));
     }
   }
 }

--- a/game-core/src/test/java/org/triplea/live/servers/CurrentVersionSelectorTest.java
+++ b/game-core/src/test/java/org/triplea/live/servers/CurrentVersionSelectorTest.java
@@ -1,6 +1,5 @@
 package org.triplea.live.servers;
 
-import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -51,7 +50,7 @@ class CurrentVersionSelectorTest {
             currentVersionSelector.apply(
                 LiveServers.builder()
                     .latestEngineVersion(new Version("10.0"))
-                    .servers(emptyList())
+                    .servers(List.of())
                     .build()));
   }
 

--- a/game-core/src/test/java/org/triplea/live/servers/LiveServersFetcherTest.java
+++ b/game-core/src/test/java/org/triplea/live/servers/LiveServersFetcherTest.java
@@ -2,7 +2,6 @@ package org.triplea.live.servers;
 
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
-import static java.util.Collections.emptyList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -10,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.net.URI;
+import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,7 +49,7 @@ class LiveServersFetcherTest {
           .thenReturn(
               LiveServers.builder()
                   .latestEngineVersion(new Version("10.0"))
-                  .servers(emptyList())
+                  .servers(List.of())
                   .build());
 
       final Optional<Version> version = liveServersFetcher.latestVersion();

--- a/game-core/src/test/java/org/triplea/lobby/common/GameDescriptionTest.java
+++ b/game-core/src/test/java/org/triplea/lobby/common/GameDescriptionTest.java
@@ -7,7 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import games.strategy.net.Node;
 import java.net.InetAddress;
 import java.time.Instant;
-import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.triplea.game.server.HeadlessGameServer;
@@ -34,7 +34,7 @@ final class GameDescriptionTest {
 
     @Test
     void isBotShouldReturnFalseWhen() throws Exception {
-      Arrays.asList(
+      List.of(
               // host name must have correct prefix
               GameDescription.builder()
                   .comment(HeadlessGameServer.BOT_GAME_HOST_COMMENT)

--- a/game-core/src/test/java/org/triplea/util/Md5CryptTest.java
+++ b/game-core/src/test/java/org/triplea/util/Md5CryptTest.java
@@ -11,7 +11,7 @@ import static org.triplea.util.Md5Crypt.hashPassword;
 import static org.triplea.util.Md5Crypt.isLegalHashedValue;
 import static org.triplea.util.Md5Crypt.newSalt;
 
-import java.util.Arrays;
+import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -34,7 +34,7 @@ final class Md5CryptTest {
   final class HashTest {
     @Test
     void shouldReturnHashedValue() {
-      Arrays.asList(
+      List.of(
               Triple.of("", "ll5ESPtE", "$1$ll5ESPtE$KsXRew.PuhVQTNMKSXQZx0"),
               Triple.of("value", "Eim8FgMk", "$1$Eim8FgMk$TYixIMiLc1BA6XHJBw66y0"),
               Triple.of("the quick brown fox", "XlnQ6h98", "$1$XlnQ6h98$iIDgBB73DNCK/RwmzU0kv."),
@@ -99,7 +99,7 @@ final class Md5CryptTest {
   final class IsLegalHashedValueTest {
     @Test
     void shouldReturnTrueWhenHashedValueIsLegal() {
-      Arrays.asList(
+      List.of(
               "$1$ll5ESPtE$KsXRew.PuhVQTNMKSXQZx0",
               "$1$Eim8FgMk$Y7Rv7y5WCc7rARI/g7xgH1",
               "$1$XlnQ6h98$iIDgBB73DNCK/RwmzU0kv.",
@@ -123,7 +123,7 @@ final class Md5CryptTest {
 
     @Test
     void shouldReturnFalseWhenHashedValueIsIlegal() {
-      Arrays.asList(
+      List.of(
               "1$A$KnCRC85Rudn6P3cpfe3LR/",
               "$$AB$4jo772pXjQ9qCwNdBde3d1",
               "$1ABC$3tP1DHUbEbG4bd67/3fFu/",

--- a/game-core/src/test/java/org/triplea/util/VersionTest.java
+++ b/game-core/src/test/java/org/triplea/util/VersionTest.java
@@ -9,7 +9,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Arrays;
+import java.util.List;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -27,7 +27,7 @@ class VersionTest {
 
   @Test
   void compareTo_ShouldReturnNegativeIntegerWhenFirstIsLessThanSecond() {
-    Arrays.asList(
+    List.of(
             Tuple.of(new Version(1, 0, 0), new Version(2, 0, 0)),
             Tuple.of(new Version(0, 1, 0), new Version(0, 2, 0)),
             Tuple.of(new Version(0, 0, 1), new Version(0, 0, 2)))
@@ -36,7 +36,7 @@ class VersionTest {
 
   @Test
   void compareTo_ShouldReturnZeroWhenFirstIsEqualToSecond() {
-    Arrays.asList(
+    List.of(
             Tuple.of(new Version(1, 0, 0), new Version(1, 0, 0)),
             Tuple.of(new Version(0, 1, 0), new Version(0, 1, 0)),
             Tuple.of(new Version(0, 0, 1), new Version(0, 0, 1)))
@@ -45,7 +45,7 @@ class VersionTest {
 
   @Test
   void compareTo_ShouldReturnPositiveIntegerWhenFirstIsGreaterThanSecond() {
-    Arrays.asList(
+    List.of(
             Tuple.of(new Version(2, 0, 0), new Version(1, 0, 0)),
             Tuple.of(new Version(0, 2, 0), new Version(0, 1, 0)),
             Tuple.of(new Version(0, 0, 2), new Version(0, 0, 1)))
@@ -85,7 +85,7 @@ class VersionTest {
   final class IsCompatibleWithEngineVersionTest {
     @Test
     void shouldReturnTrueWhenOtherVersionIsCompatible() {
-      Arrays.asList(
+      List.of(
               Tuple.of(new Version(1, 2, 3), "equal versions should be compatible"),
               Tuple.of(new Version(1, 2, 0), "smaller point version should be compatible"),
               Tuple.of(new Version(1, 3, 5), "larger minor version should be compatible"))
@@ -98,7 +98,7 @@ class VersionTest {
 
     @Test
     void shouldReturnFalseWhenOtherVersionIsNotCompatible() {
-      Arrays.asList(
+      List.of(
               Tuple.of(new Version(0, 0, 3), "smaller major version should not be compatible"),
               Tuple.of(new Version(2, 9, 3), "larger major version should not be compatible"))
           .forEach(
@@ -113,7 +113,7 @@ class VersionTest {
   final class IsCompatibleWithMapMinimumEngineVersionTest {
     @Test
     void shouldReturnTrueWhenOtherVersionIsCompatible() {
-      Arrays.asList(
+      List.of(
               Tuple.of(new Version(1, 2, 3), "equal versions should be compatible"),
               Tuple.of(new Version(0, 9, 0), "smaller major version should be compatible"),
               Tuple.of(new Version(1, 2, 0), "smaller point version should be compatible"),
@@ -129,7 +129,7 @@ class VersionTest {
 
     @Test
     void shouldReturnFalseWhenOtherVersionIsNotCompatible() {
-      Arrays.asList(
+      List.of(
               Tuple.of(new Version(1, 9, 3), "larger minor version should not be compatible"),
               Tuple.of(new Version(9, 2, 3), "larger major version should not be compatible"))
           .forEach(

--- a/game-headless/src/main/java/org/triplea/game/server/debug/ChatHandler.java
+++ b/game-headless/src/main/java/org/triplea/game/server/debug/ChatHandler.java
@@ -1,7 +1,6 @@
 package org.triplea.game.server.debug;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Consumer;
@@ -72,6 +71,6 @@ public final class ChatHandler extends Handler {
   }
 
   private List<String> formatChatMessage(final LogRecord record) {
-    return Arrays.asList(getFormatter().format(record).trim().split("\\n"));
+    return List.of(getFormatter().format(record).trim().split("\\n"));
   }
 }

--- a/http-clients/src/main/java/org/triplea/http/client/JsonDecoder.java
+++ b/http-clients/src/main/java/org/triplea/http/client/JsonDecoder.java
@@ -8,7 +8,7 @@ import com.google.gson.JsonDeserializer;
 import com.google.gson.JsonElement;
 import feign.gson.GsonDecoder;
 import java.time.Instant;
-import java.util.Arrays;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
 
@@ -53,7 +53,7 @@ final class JsonDecoder {
         "Unexpected JSON {[epoch second].[epoch nano]} timestamp format, value was: "
             + json.getAsJsonPrimitive().getAsString()
             + ", and was split into: "
-            + Arrays.asList(split));
+            + List.of(split));
     return new long[] {Long.parseLong(split[0]), Long.parseLong(split[1])};
   }
 }

--- a/http-clients/src/test/java/org/triplea/http/client/HttpClientTesting.java
+++ b/http-clients/src/test/java/org/triplea/http/client/HttpClientTesting.java
@@ -22,7 +22,6 @@ import com.github.tomakehurst.wiremock.http.Fault;
 import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
 import feign.FeignException;
 import java.net.URI;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
@@ -187,7 +186,7 @@ public final class HttpClientTesting {
       final String expectedRequestPath,
       final RequestType requestType,
       final Function<URI, T> serviceCall) {
-    Arrays.asList(
+    List.of(
             // caution, one of the wiremock faults is known to cause a hang in windows, so to avoid
             // that problem do not use the full available list of of wiremock faults
             Fault.EMPTY_RESPONSE, Fault.RANDOM_DATA_THEN_CLOSE)

--- a/http-clients/src/test/java/org/triplea/http/client/error/report/ErrorReportClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/error/report/ErrorReportClientTest.java
@@ -1,12 +1,12 @@
 package org.triplea.http.client.error.report;
 
-import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.google.gson.Gson;
 import java.net.URI;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.triplea.http.client.HttpClientTesting;
 import org.triplea.http.client.WireMockTest;
@@ -26,7 +26,7 @@ class ErrorReportClientTest extends WireMockTest {
             HttpClientTesting.ServiceCallArgs.<ErrorReportResponse>builder()
                 .wireMockServer(server)
                 .expectedRequestPath(ErrorReportClient.ERROR_REPORT_PATH)
-                .expectedBodyContents(singletonList(MESSAGE_FROM_USER))
+                .expectedBodyContents(List.of(MESSAGE_FROM_USER))
                 .serverReturnValue(new Gson().toJson(SUCCESS_RESPONSE))
                 .serviceCall(ErrorReportClientTest::doServiceCall)
                 .build());

--- a/http-clients/src/test/java/org/triplea/http/client/forgot/password/ForgotPasswordClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/forgot/password/ForgotPasswordClientTest.java
@@ -1,12 +1,12 @@
 package org.triplea.http.client.forgot.password;
 
-import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.google.gson.Gson;
 import java.net.URI;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.triplea.http.client.HttpClientTesting;
 import org.triplea.http.client.WireMockTest;
@@ -26,7 +26,7 @@ class ForgotPasswordClientTest extends WireMockTest {
             HttpClientTesting.ServiceCallArgs.<ForgotPasswordResponse>builder()
                 .wireMockServer(server)
                 .expectedRequestPath(ForgotPasswordClient.FORGOT_PASSWORD_PATH)
-                .expectedBodyContents(asList(REQUEST.getUsername(), REQUEST.getEmail()))
+                .expectedBodyContents(List.of(REQUEST.getUsername(), REQUEST.getEmail()))
                 .serverReturnValue(new Gson().toJson(SUCCESS_RESPONSE))
                 .serviceCall(ForgotPasswordClientTest::doServiceCall)
                 .build());

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/chat/events/server/ServerMessageEnvelopeTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/chat/events/server/ServerMessageEnvelopeTest.java
@@ -4,7 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import com.google.gson.Gson;
-import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.triplea.domain.data.PlayerChatId;
 import org.triplea.domain.data.PlayerName;
@@ -31,8 +31,7 @@ class ServerMessageEnvelopeTest {
   private final ChatMessage chatMessage = new ChatMessage(PLAYER_NAME, MESSAGE);
   private final PlayerSlapped playerSlapped =
       new PlayerSlapped(PLAYER_NAME, PlayerName.of("slapped"));
-  private final PlayerListing playerListing =
-      new PlayerListing(Collections.singletonList(CHAT_PARTICIPANT));
+  private final PlayerListing playerListing = new PlayerListing(List.of(CHAT_PARTICIPANT));
 
   @Test
   void toPlayerStatusChange() {

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/game/listing/GameListingClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/game/listing/GameListingClientTest.java
@@ -11,7 +11,6 @@ import static org.triplea.http.client.HttpClientTesting.EXPECTED_API_KEY;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
-import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.triplea.http.client.AuthenticationHeaders;
@@ -39,7 +38,7 @@ class GameListingClientTest extends WireMockTest {
             .willReturn(
                 WireMock.aResponse()
                     .withStatus(200)
-                    .withBody(toJson(Collections.singletonList(LOBBY_GAME_LISTING)))));
+                    .withBody(toJson(List.of(LOBBY_GAME_LISTING)))));
 
     final List<LobbyGameListing> results = newClient(server).fetchGameListing();
 

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/banned/name/ToolboxUsernameBanClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/banned/name/ToolboxUsernameBanClientTest.java
@@ -10,7 +10,6 @@ import static org.triplea.http.client.HttpClientTesting.serve200ForToolboxPostWi
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.triplea.http.client.AuthenticationHeaders;
@@ -54,7 +53,7 @@ class ToolboxUsernameBanClientTest extends WireMockTest {
             .willReturn(
                 WireMock.aResponse()
                     .withStatus(200)
-                    .withBody(toJson(Collections.singletonList(BANNED_USERNAME_DATA)))));
+                    .withBody(toJson(List.of(BANNED_USERNAME_DATA)))));
 
     final List<UsernameBanData> results = newClient(server).getUsernameBans();
 

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/banned/user/ToolboxUserBanClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/banned/user/ToolboxUserBanClientTest.java
@@ -11,7 +11,6 @@ import static org.triplea.http.client.HttpClientTesting.serve200ForToolboxPostWi
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.triplea.http.client.AuthenticationHeaders;
@@ -50,9 +49,7 @@ class ToolboxUserBanClientTest extends WireMockTest {
         WireMock.get(ToolboxUserBanClient.GET_USER_BANS_PATH)
             .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
             .willReturn(
-                WireMock.aResponse()
-                    .withStatus(200)
-                    .withBody(toJson(Collections.singletonList(BANNED_USER_DATA)))));
+                WireMock.aResponse().withStatus(200).withBody(toJson(List.of(BANNED_USER_DATA)))));
 
     final List<UserBanData> result = newClient(server).getUserBans();
 

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/log/ToolboxAccessLogClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/log/ToolboxAccessLogClientTest.java
@@ -9,7 +9,6 @@ import static org.triplea.http.client.HttpClientTesting.EXPECTED_API_KEY;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.List;
 import org.hamcrest.collection.IsCollectionWithSize;
 import org.junit.jupiter.api.Test;
@@ -39,9 +38,7 @@ class ToolboxAccessLogClientTest extends WireMockTest {
             .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
             .withRequestBody(equalToJson(toJson(HttpClientTesting.PAGING_PARAMS)))
             .willReturn(
-                WireMock.aResponse()
-                    .withStatus(200)
-                    .withBody(toJson(Collections.singletonList(ACCESS_LOG_DATA)))));
+                WireMock.aResponse().withStatus(200).withBody(toJson(List.of(ACCESS_LOG_DATA)))));
 
     final List<AccessLogData> results =
         newClient(server).getAccessLog(HttpClientTesting.PAGING_PARAMS);

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/log/ToolboxEventLogClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/log/ToolboxEventLogClientTest.java
@@ -11,7 +11,6 @@ import static org.triplea.http.client.HttpClientTesting.PAGING_PARAMS;
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.triplea.http.client.AuthenticationHeaders;
@@ -39,9 +38,7 @@ class ToolboxEventLogClientTest extends WireMockTest {
             .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
             .withRequestBody(equalToJson(toJson(PAGING_PARAMS)))
             .willReturn(
-                WireMock.aResponse()
-                    .withStatus(200)
-                    .withBody(toJson(Collections.singletonList(MODERATOR_EVENT)))));
+                WireMock.aResponse().withStatus(200).withBody(toJson(List.of(MODERATOR_EVENT)))));
 
     final List<ModeratorEvent> results = newClient(server).lookupModeratorEvents(PAGING_PARAMS);
 

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/management/ToolboxModeratorManagementClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/management/ToolboxModeratorManagementClientTest.java
@@ -10,7 +10,6 @@ import static org.triplea.http.client.HttpClientTesting.serve200ForToolboxPostWi
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import java.time.Instant;
-import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -35,9 +34,7 @@ class ToolboxModeratorManagementClientTest extends WireMockTest {
         WireMock.get(ToolboxModeratorManagementClient.FETCH_MODERATORS_PATH)
             .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
             .willReturn(
-                WireMock.aResponse()
-                    .withStatus(200)
-                    .withBody(toJson(Collections.singletonList(MODERATOR_INFO)))));
+                WireMock.aResponse().withStatus(200).withBody(toJson(List.of(MODERATOR_INFO)))));
 
     final List<ModeratorInfo> results = newClient(server).fetchModeratorList();
 

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/words/ToolboxBadWordsClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/words/ToolboxBadWordsClientTest.java
@@ -8,7 +8,6 @@ import static org.triplea.http.client.HttpClientTesting.serve200ForToolboxPostWi
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.triplea.http.client.AuthenticationHeaders;
@@ -17,7 +16,7 @@ import ru.lanwen.wiremock.ext.WiremockResolver;
 
 class ToolboxBadWordsClientTest extends WireMockTest {
   private static final String BAD_WORD = "Damn yer bilge rat, feed the corsair.";
-  private static final List<String> badWords = Arrays.asList("one", "two", "three");
+  private static final List<String> badWords = List.of("one", "two", "three");
 
   private static ToolboxBadWordsClient newClient(final WireMockServer wireMockServer) {
     return newClient(wireMockServer, ToolboxBadWordsClient::newClient);

--- a/http-server/src/test/java/org/triplea/server/access/AuthenticatedUserTest.java
+++ b/http-server/src/test/java/org/triplea/server/access/AuthenticatedUserTest.java
@@ -2,7 +2,6 @@ package org.triplea.server.access;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -23,7 +22,7 @@ class AuthenticatedUserTest {
   private static final int USER_ID = 10;
 
   private static final List<String> rolesWithUserNames =
-      Arrays.asList(UserRole.ADMIN, UserRole.MODERATOR, UserRole.PLAYER, UserRole.ANONYMOUS);
+      List.of(UserRole.ADMIN, UserRole.MODERATOR, UserRole.PLAYER, UserRole.ANONYMOUS);
 
   @Nested
   class GetName {

--- a/http-server/src/test/java/org/triplea/server/lobby/chat/MessagingServiceTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/chat/MessagingServiceTest.java
@@ -6,8 +6,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.google.gson.Gson;
-import java.util.Arrays;
-import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.function.BiConsumer;
@@ -110,7 +109,7 @@ class MessagingServiceTest {
       when(apiKeyDaoWrapper.lookupByApiKey(TestData.API_KEY))
           .thenReturn(Optional.of(MODERATOR_DATA));
       when(eventProcessing.process(session, CHAT_PARTICIPANT, CLIENT_EVENT_ENVELOPE))
-          .thenReturn(Collections.emptyList());
+          .thenReturn(List.of());
       when(session.getUserProperties()).thenReturn(userPropertiesMap);
 
       messagingService.handleMessage(session, JSON_MESSAGE);
@@ -131,7 +130,7 @@ class MessagingServiceTest {
       when(apiKeyDaoWrapper.lookupByApiKey(TestData.API_KEY))
           .thenReturn(Optional.of(MODERATOR_DATA));
       when(eventProcessing.process(session, CHAT_PARTICIPANT, CLIENT_EVENT_ENVELOPE))
-          .thenReturn(Arrays.asList(responses));
+          .thenReturn(List.of(responses));
     }
 
     @Test

--- a/http-server/src/test/java/org/triplea/server/lobby/chat/event/processing/ChatEventProcessorTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/chat/event/processing/ChatEventProcessorTest.java
@@ -2,7 +2,6 @@ package org.triplea.server.lobby.chat.event.processing;
 
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
-import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
@@ -73,8 +72,7 @@ class ChatEventProcessorTest {
           responses.get(0),
           is(
               ServerResponse.backToClient(
-                  ServerMessageEnvelopeFactory.newPlayerListing(
-                      singletonList(CHAT_PARTICIPANT_0)))));
+                  ServerMessageEnvelopeFactory.newPlayerListing(List.of(CHAT_PARTICIPANT_0)))));
 
       assertThat(
           "Second message is player joined",

--- a/http-server/src/test/java/org/triplea/server/lobby/chat/event/processing/ServerMessageEnvelopeFactoryTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/chat/event/processing/ServerMessageEnvelopeFactoryTest.java
@@ -4,7 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 
-import java.util.Collections;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.triplea.domain.data.PlayerName;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
@@ -30,8 +30,7 @@ class ServerMessageEnvelopeFactoryTest {
   private final ChatMessage chatMessage = new ChatMessage(PLAYER_NAME, MESSAGE);
   private final PlayerSlapped playerSlapped =
       PlayerSlapped.builder().slapper(PLAYER_NAME).slapped(PlayerName.of("slapped")).build();
-  private final PlayerListing playerListing =
-      new PlayerListing(Collections.singletonList(CHAT_PARTICIPANT));
+  private final PlayerListing playerListing = new PlayerListing(List.of(CHAT_PARTICIPANT));
 
   @Test
   void newChatMessage() {
@@ -91,7 +90,7 @@ class ServerMessageEnvelopeFactoryTest {
   @Test
   void newPlayerListing() {
     final ServerMessageEnvelope serverEventEnvelope =
-        ServerMessageEnvelopeFactory.newPlayerListing(Collections.singletonList(CHAT_PARTICIPANT));
+        ServerMessageEnvelopeFactory.newPlayerListing(List.of(CHAT_PARTICIPANT));
 
     assertThat(
         serverEventEnvelope.getMessageType(),

--- a/http-server/src/test/java/org/triplea/server/moderator/toolbox/access/log/AccessLogControllerTest.java
+++ b/http-server/src/test/java/org/triplea/server/moderator/toolbox/access/log/AccessLogControllerTest.java
@@ -2,7 +2,7 @@ package org.triplea.server.moderator.toolbox.access.log;
 
 import static org.mockito.Mockito.when;
 
-import java.util.Collections;
+import java.util.List;
 import javax.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -26,11 +26,10 @@ class AccessLogControllerTest {
 
   @Test
   void fetchAccessLog() {
-    when(accessLogService.fetchAccessLog(PAGING_PARAMS))
-        .thenReturn(Collections.singletonList(accessLogData));
+    when(accessLogService.fetchAccessLog(PAGING_PARAMS)).thenReturn(List.of(accessLogData));
 
     final Response response = accessLogController.fetchAccessLog(PAGING_PARAMS);
 
-    ControllerTestUtil.verifyResponse(response, Collections.singletonList(accessLogData));
+    ControllerTestUtil.verifyResponse(response, List.of(accessLogData));
   }
 }

--- a/http-server/src/test/java/org/triplea/server/moderator/toolbox/access/log/AccessLogServiceTest.java
+++ b/http-server/src/test/java/org/triplea/server/moderator/toolbox/access/log/AccessLogServiceTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
-import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -39,7 +38,7 @@ class AccessLogServiceTest {
   @Test
   void fetchAccessLog() {
     when(accessLogDao.fetchAccessLogRows(PAGING_PARAMS.getRowNumber(), PAGING_PARAMS.getPageSize()))
-        .thenReturn(Collections.singletonList(ACCESS_LOG_DAO_DATA));
+        .thenReturn(List.of(ACCESS_LOG_DAO_DATA));
 
     final List<AccessLogData> results = accessLogService.fetchAccessLog(PAGING_PARAMS);
 

--- a/http-server/src/test/java/org/triplea/server/moderator/toolbox/banned/names/UsernameBanControllerTest.java
+++ b/http-server/src/test/java/org/triplea/server/moderator/toolbox/banned/names/UsernameBanControllerTest.java
@@ -1,11 +1,11 @@
 package org.triplea.server.moderator.toolbox.banned.names;
 
-import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
+import java.util.List;
 import javax.ws.rs.core.Response;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -87,10 +87,10 @@ class UsernameBanControllerTest {
 
   @Test
   void getBannedUserNames() {
-    when(bannedNamesService.getBannedUserNames()).thenReturn(singletonList(USERNAME_BAN_DATA));
+    when(bannedNamesService.getBannedUserNames()).thenReturn(List.of(USERNAME_BAN_DATA));
 
     final Response response = bannedUsernamesController.getBannedUsernames();
 
-    ControllerTestUtil.verifyResponse(response, singletonList(USERNAME_BAN_DATA));
+    ControllerTestUtil.verifyResponse(response, List.of(USERNAME_BAN_DATA));
   }
 }

--- a/http-server/src/test/java/org/triplea/server/moderator/toolbox/banned/names/UsernameBanServiceTest.java
+++ b/http-server/src/test/java/org/triplea/server/moderator/toolbox/banned/names/UsernameBanServiceTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.time.Instant;
-import java.util.Collections;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -95,8 +94,7 @@ class UsernameBanServiceTest {
 
   @Test
   void getBannedUserNames() {
-    when(bannedUsernamesDao.getBannedUserNames())
-        .thenReturn(Collections.singletonList(USERNAME_BAN_RECORD));
+    when(bannedUsernamesDao.getBannedUserNames()).thenReturn(List.of(USERNAME_BAN_RECORD));
 
     final List<UsernameBanData> results = usernameBanService.getBannedUserNames();
     assertThat(results, hasSize(1));

--- a/http-server/src/test/java/org/triplea/server/moderator/toolbox/banned/users/UserBanControllerTest.java
+++ b/http-server/src/test/java/org/triplea/server/moderator/toolbox/banned/users/UserBanControllerTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.when;
 import static org.triplea.server.moderator.toolbox.ControllerTestUtil.verifyResponse;
 
-import java.util.Collections;
+import java.util.List;
 import javax.ws.rs.core.Response;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -40,11 +40,11 @@ class UserBanControllerTest {
 
   @Test
   void getUserBans() {
-    when(bannedUsersService.getBannedUsers()).thenReturn(Collections.singletonList(bannedUserData));
+    when(bannedUsersService.getBannedUsers()).thenReturn(List.of(bannedUserData));
 
     final Response response = bannedUsersController.getUserBans();
 
-    verifyResponse(response, Collections.singletonList(bannedUserData));
+    verifyResponse(response, List.of(bannedUserData));
   }
 
   @Nested

--- a/http-server/src/test/java/org/triplea/server/moderator/toolbox/banned/users/UserBanServiceTest.java
+++ b/http-server/src/test/java/org/triplea/server/moderator/toolbox/banned/users/UserBanServiceTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.when;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Supplier;
@@ -68,8 +67,7 @@ class UserBanServiceTest {
 
   @Test
   void getBannedUsers() {
-    when(bannedUserDao.lookupBans())
-        .thenReturn(Arrays.asList(USER_BAN_RECORD_1, USER_BAN_RECORD_2));
+    when(bannedUserDao.lookupBans()).thenReturn(List.of(USER_BAN_RECORD_1, USER_BAN_RECORD_2));
 
     final List<UserBanData> result = bannedUsersService.getBannedUsers();
 

--- a/http-server/src/test/java/org/triplea/server/moderator/toolbox/moderators/ModeratorsControllerTest.java
+++ b/http-server/src/test/java/org/triplea/server/moderator/toolbox/moderators/ModeratorsControllerTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.triplea.server.moderator.toolbox.ControllerTestUtil.verifyResponse;
 
-import java.util.Collections;
+import java.util.List;
 import javax.ws.rs.core.Response;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -44,11 +44,11 @@ class ModeratorsControllerTest {
 
   @Test
   void getModerators() {
-    when(moderatorsService.fetchModerators()).thenReturn(Collections.singletonList(MODERATOR_INFO));
+    when(moderatorsService.fetchModerators()).thenReturn(List.of(MODERATOR_INFO));
 
     final Response response = moderatorsController.getModerators();
 
-    verifyResponse(response, Collections.singletonList(MODERATOR_INFO));
+    verifyResponse(response, List.of(MODERATOR_INFO));
   }
 
   @Test

--- a/http-server/src/test/java/org/triplea/server/user/account/login/LoginModuleTest.java
+++ b/http-server/src/test/java/org/triplea/server/user/account/login/LoginModuleTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
@@ -68,7 +67,7 @@ class LoginModuleTest {
 
   @SuppressWarnings("unused")
   static List<Arguments> rejectLoginOnBadArgs() {
-    return Arrays.asList(
+    return List.of(
         Arguments.of(LoginRequest.builder().password("no-name").build(), "system-id-string", IP),
         Arguments.of(LOGIN_REQUEST, null, IP));
   }

--- a/integration-testing/src/test/java/org/triplea/lobby/server/db/dao/BadWordsDaoTest.java
+++ b/integration-testing/src/test/java/org/triplea/lobby/server/db/dao/BadWordsDaoTest.java
@@ -6,7 +6,6 @@ import static org.hamcrest.core.Is.is;
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -14,7 +13,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 
 @DataSet(cleanBefore = true, value = "bad_words/select.yml")
 class BadWordsDaoTest extends DaoTest {
-  private static final List<String> expectedBadWords = Arrays.asList("aaa", "one", "two", "zzz");
+  private static final List<String> expectedBadWords = List.of("aaa", "one", "two", "zzz");
 
   private final BadWordsDao badWordsDao = DaoTest.newDao(BadWordsDao.class);
 
@@ -41,7 +40,7 @@ class BadWordsDaoTest extends DaoTest {
 
   @SuppressWarnings("unused")
   private static List<String> badWordContains() {
-    final List<String> badWords = new ArrayList<>(Arrays.asList("zzZz", "_two_"));
+    final List<String> badWords = new ArrayList<>(List.of("zzZz", "_two_"));
     badWords.addAll(expectedBadWords);
     return badWords;
   }
@@ -54,7 +53,7 @@ class BadWordsDaoTest extends DaoTest {
 
   @SuppressWarnings("unused")
   private static List<String> notBadWordContains() {
-    return Arrays.asList("zz", "", null, "some word not containing any bad words");
+    return List.of("zz", "", "some word not containing any bad words");
   }
 
   @ParameterizedTest

--- a/java-extras/src/main/java/org/triplea/io/FileUtils.java
+++ b/java-extras/src/main/java/org/triplea/io/FileUtils.java
@@ -3,10 +3,9 @@ package org.triplea.io;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.File;
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
-import javax.annotation.Nullable;
+import java.util.List;
+import java.util.Optional;
 
 /** A collection of useful methods related to files. */
 public final class FileUtils {
@@ -23,10 +22,6 @@ public final class FileUtils {
    */
   public static Collection<File> listFiles(final File directory) {
     checkNotNull(directory);
-
-    final @Nullable File[] files = directory.listFiles();
-    return files != null
-        ? Collections.unmodifiableList(Arrays.asList(files))
-        : Collections.emptyList();
+    return Optional.ofNullable(directory.listFiles()).map(List::of).orElseGet(List::of);
   }
 }

--- a/java-extras/src/main/java/org/triplea/java/ArgChecker.java
+++ b/java-extras/src/main/java/org/triplea/java/ArgChecker.java
@@ -15,6 +15,7 @@ public class ArgChecker {
    * @param arg The value to validate.
    */
   public static void checkNotEmpty(final String arg) {
+    Preconditions.checkNotNull(arg);
     Preconditions.checkArgument(!Strings.nullToEmpty(arg).trim().isEmpty());
   }
 }

--- a/java-extras/src/test/java/org/triplea/java/ArgCheckerTest.java
+++ b/java-extras/src/test/java/org/triplea/java/ArgCheckerTest.java
@@ -1,32 +1,27 @@
 package org.triplea.java;
 
-import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class ArgCheckerTest {
 
-  @Nested
-  final class CheckNotEmptyTest {
-    @Test
-    void notEmptyArgCases() {
-      ArgChecker.checkNotEmpty("not empty");
-      ArgChecker.checkNotEmpty("a");
-      ArgChecker.checkNotEmpty(" - ");
-    }
+  @ParameterizedTest
+  @ValueSource(strings = {"not empty", "a", " - "})
+  void notEmptyArgCases(final String notEmpty) {
+    ArgChecker.checkNotEmpty(notEmpty);
+  }
 
-    @Test
-    void emptyArgCases() {
-      asList("", null, "  ", "\n", "\t", "  \n")
-          .forEach(
-              emptyArg ->
-                  assertThrows(
-                      IllegalArgumentException.class,
-                      () -> ArgChecker.checkNotEmpty(emptyArg),
-                      "expecting empty arg to trigger arg check to throw illegal arg exception: "
-                          + emptyArg));
-    }
+  @Test
+  void nullArgCase() {
+    assertThrows(NullPointerException.class, () -> ArgChecker.checkNotEmpty(null));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "  ", "\n", "\t", "  \n"})
+  void emptyArgCases(final String emptyArg) {
+    assertThrows(IllegalArgumentException.class, () -> ArgChecker.checkNotEmpty(emptyArg));
   }
 }

--- a/java-extras/src/test/java/org/triplea/java/CollectionUtilsTest.java
+++ b/java-extras/src/test/java/org/triplea/java/CollectionUtilsTest.java
@@ -9,9 +9,8 @@ import static org.triplea.java.collections.CollectionUtils.getMatches;
 import static org.triplea.java.collections.CollectionUtils.getNMatches;
 import static org.triplea.java.collections.CollectionUtils.haveEqualSizeAndEquivalentElements;
 
-import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 import java.util.function.Predicate;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -25,13 +24,13 @@ final class CollectionUtilsTest {
   final class CountMatchesTest {
     @Test
     void shouldReturnCountOfMatches() {
-      assertEquals(0, countMatches(Collections.emptyList(), IS_ZERO));
+      assertEquals(0, countMatches(List.of(), IS_ZERO));
 
-      assertEquals(1, countMatches(Collections.singletonList(0), IS_ZERO));
-      assertEquals(1, countMatches(Arrays.asList(-1, 0, 1), IS_ZERO));
+      assertEquals(1, countMatches(List.of(0), IS_ZERO));
+      assertEquals(1, countMatches(List.of(-1, 0, 1), IS_ZERO));
 
-      assertEquals(2, countMatches(Arrays.asList(0, 0), IS_ZERO));
-      assertEquals(2, countMatches(Arrays.asList(-1, 0, 1, 0), IS_ZERO));
+      assertEquals(2, countMatches(List.of(0, 0), IS_ZERO));
+      assertEquals(2, countMatches(List.of(-1, 0, 1, 0), IS_ZERO));
     }
   }
 
@@ -39,13 +38,12 @@ final class CollectionUtilsTest {
   final class GetMatchesTest {
     @Test
     void shouldFilterOutNonMatchingElementsAndReturnAllMatches() {
-      final Collection<Integer> input = Arrays.asList(-1, 0, 1);
+      final Collection<Integer> input = List.of(-1, 0, 1);
 
-      assertEquals(
-          Collections.emptyList(), getMatches(Collections.emptyList(), ALWAYS), "empty collection");
-      assertEquals(Collections.emptyList(), getMatches(input, NEVER), "none match");
-      assertEquals(Arrays.asList(-1, 1), getMatches(input, IS_ZERO.negate()), "some match");
-      assertEquals(Arrays.asList(-1, 0, 1), getMatches(input, ALWAYS), "all match");
+      assertEquals(List.of(), getMatches(List.of(), ALWAYS), "empty collection");
+      assertEquals(List.of(), getMatches(input, NEVER), "none match");
+      assertEquals(List.of(-1, 1), getMatches(input, IS_ZERO.negate()), "some match");
+      assertEquals(List.of(-1, 0, 1), getMatches(input, ALWAYS), "all match");
     }
   }
 
@@ -53,36 +51,23 @@ final class CollectionUtilsTest {
   final class GetNMatchesTest {
     @Test
     void shouldFilterOutNonMatchingElementsAndReturnMaxMatches() {
-      final Collection<Integer> input = Arrays.asList(-1, 0, 1);
+      final Collection<Integer> input = List.of(-1, 0, 1);
 
+      assertEquals(List.of(), getNMatches(List.of(), 999, ALWAYS), "empty collection");
+      assertEquals(List.of(), getNMatches(input, 0, NEVER), "max = 0");
+      assertEquals(List.of(), getNMatches(input, input.size(), NEVER), "none match");
       assertEquals(
-          Collections.emptyList(),
-          getNMatches(Collections.emptyList(), 999, ALWAYS),
-          "empty collection");
-      assertEquals(Collections.emptyList(), getNMatches(input, 0, NEVER), "max = 0");
-      assertEquals(Collections.emptyList(), getNMatches(input, input.size(), NEVER), "none match");
+          List.of(0), getNMatches(List.of(-1, 0, 0, 1), 1, IS_ZERO), "some match; max < count");
       assertEquals(
-          Collections.singletonList(0),
-          getNMatches(Arrays.asList(-1, 0, 0, 1), 1, IS_ZERO),
-          "some match; max < count");
+          List.of(0, 0), getNMatches(List.of(-1, 0, 0, 1), 2, IS_ZERO), "some match; max = count");
       assertEquals(
-          Arrays.asList(0, 0),
-          getNMatches(Arrays.asList(-1, 0, 0, 1), 2, IS_ZERO),
-          "some match; max = count");
+          List.of(0, 0), getNMatches(List.of(-1, 0, 0, 1), 3, IS_ZERO), "some match; max > count");
       assertEquals(
-          Arrays.asList(0, 0),
-          getNMatches(Arrays.asList(-1, 0, 0, 1), 3, IS_ZERO),
-          "some match; max > count");
+          List.of(-1, 0), getNMatches(input, input.size() - 1, ALWAYS), "all match; max < count");
       assertEquals(
-          Arrays.asList(-1, 0),
-          getNMatches(input, input.size() - 1, ALWAYS),
-          "all match; max < count");
+          List.of(-1, 0, 1), getNMatches(input, input.size(), ALWAYS), "all match; max = count");
       assertEquals(
-          Arrays.asList(-1, 0, 1),
-          getNMatches(input, input.size(), ALWAYS),
-          "all match; max = count");
-      assertEquals(
-          Arrays.asList(-1, 0, 1),
+          List.of(-1, 0, 1),
           getNMatches(input, input.size() + 1, ALWAYS),
           "all match; max > count");
     }
@@ -90,7 +75,7 @@ final class CollectionUtilsTest {
     @Test
     void shouldThrowExceptionWhenMaxIsNegative() {
       assertThrows(
-          IllegalArgumentException.class, () -> getNMatches(Arrays.asList(-1, 0, 1), -1, ALWAYS));
+          IllegalArgumentException.class, () -> getNMatches(List.of(-1, 0, 1), -1, ALWAYS));
     }
   }
 
@@ -98,33 +83,23 @@ final class CollectionUtilsTest {
   final class HaveEqualSizeAndEquivalentElementsTest {
     @Test
     void shouldReturnTrueWhenCollectionsAreEqual() {
-      assertThat(
-          haveEqualSizeAndEquivalentElements(Arrays.asList(1, 2, 3), Arrays.asList(1, 2, 3)),
-          is(true));
+      assertThat(haveEqualSizeAndEquivalentElements(List.of(1, 2, 3), List.of(1, 2, 3)), is(true));
     }
 
     @Test
     void shouldReturnTrueWhenCollectionsAreNotEqualButHaveSameSizeAndEquivalentElements() {
-      assertThat(
-          haveEqualSizeAndEquivalentElements(Arrays.asList(1, 2, 1), Arrays.asList(2, 1, 2)),
-          is(true));
+      assertThat(haveEqualSizeAndEquivalentElements(List.of(1, 2, 1), List.of(2, 1, 2)), is(true));
     }
 
     @Test
     void shouldReturnFalseWhenCollectionsHaveEquivalentElementsButDifferentSize() {
-      assertThat(
-          haveEqualSizeAndEquivalentElements(Arrays.asList(1, 2), Arrays.asList(1, 2, 2)),
-          is(false));
+      assertThat(haveEqualSizeAndEquivalentElements(List.of(1, 2), List.of(1, 2, 2)), is(false));
     }
 
     @Test
     void shouldReturnFalseWhenCollectionsHaveSameSizeButElementsAreNotEquivalent() {
-      assertThat(
-          haveEqualSizeAndEquivalentElements(Arrays.asList(1, 2, 3), Arrays.asList(1, 2, 2)),
-          is(false));
-      assertThat(
-          haveEqualSizeAndEquivalentElements(Arrays.asList(1, 2, 2), Arrays.asList(1, 2, 3)),
-          is(false));
+      assertThat(haveEqualSizeAndEquivalentElements(List.of(1, 2, 3), List.of(1, 2, 2)), is(false));
+      assertThat(haveEqualSizeAndEquivalentElements(List.of(1, 2, 2), List.of(1, 2, 3)), is(false));
     }
   }
 }

--- a/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/api/key/UserWithRoleRecordTest.java
+++ b/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/api/key/UserWithRoleRecordTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import java.sql.ResultSet;
-import java.util.Arrays;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -77,7 +76,7 @@ class UserWithRoleRecordTest {
 
   @SuppressWarnings("unused")
   private static List<Arguments> mustHaveUserName() {
-    return Arrays.asList(
+    return List.of(
         Arguments.of(0, UserRole.ANONYMOUS), //
         Arguments.of(USER_ID, UserRole.PLAYER), //
         Arguments.of(USER_ID, UserRole.MODERATOR), //

--- a/swing-lib/src/main/java/org/triplea/swing/JTableBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/JTableBuilder.java
@@ -3,7 +3,6 @@ package org.triplea.swing;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.common.base.Preconditions;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.IntStream;
@@ -80,7 +79,7 @@ public class JTableBuilder {
   }
 
   public JTableBuilder columnNames(final String... columnNames) {
-    return columnNames(Arrays.asList(columnNames));
+    return columnNames(List.of(columnNames));
   }
 
   public JTableBuilder columnNames(final List<String> columnNames) {

--- a/swing-lib/src/test/java/org/triplea/swing/JComboBoxBuilderTest.java
+++ b/swing-lib/src/test/java/org/triplea/swing/JComboBoxBuilderTest.java
@@ -6,7 +6,7 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.awt.Component;
-import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 import javax.swing.JComboBox;
 import javax.swing.text.JTextComponent;
@@ -78,7 +78,7 @@ class JComboBoxBuilderTest {
     void shouldSetSelectedItem() {
       final JComboBox<String> comboBox =
           JComboBoxBuilder.builder(String.class)
-              .items(Arrays.asList("A", "B", "C"))
+              .items(List.of("A", "B", "C"))
               .selectedItem("B")
               .build();
 
@@ -92,7 +92,7 @@ class JComboBoxBuilderTest {
     void shouldSetSelectedItemWhenNonNull() {
       final JComboBox<String> comboBox =
           JComboBoxBuilder.builder(String.class)
-              .items(Arrays.asList("A", "B", "C"))
+              .items(List.of("A", "B", "C"))
               .nullableSelectedItem("B")
               .build();
 
@@ -103,7 +103,7 @@ class JComboBoxBuilderTest {
     void shouldNotSetSelectedItemWhenNull() {
       final JComboBox<String> comboBox =
           JComboBoxBuilder.builder(String.class)
-              .items(Arrays.asList("A", "B", "C"))
+              .items(List.of("A", "B", "C"))
               .nullableSelectedItem(null)
               .build();
 

--- a/swing-lib/src/test/java/org/triplea/swing/jpanel/JPanelBuilderTest.java
+++ b/swing-lib/src/test/java/org/triplea/swing/jpanel/JPanelBuilderTest.java
@@ -10,7 +10,7 @@ import java.awt.FlowLayout;
 import java.awt.GridBagLayout;
 import java.awt.GridLayout;
 import java.awt.Insets;
-import java.util.Arrays;
+import java.util.List;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -34,7 +34,7 @@ class JPanelBuilderTest {
 
     assertThat(
         "Panel children should contain the label we added.",
-        Arrays.asList(panel.getComponents()),
+        List.of(panel.getComponents()),
         contains(label));
   }
 


### PR DESCRIPTION
As discussed in: https://github.com/triplea-game/triplea/issues/5524

Favor using List.of instead Collections.emptyList, Collections.singletonList,
and Arrays.asList.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manually testing done

- Ran through 2 AI vs AI games 

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes

- Not entirely safe as `Arrays.asList` is mutable.  The manual testing hopefully found everywhere we would have a problem. I've some concern we may see issues in the file menus, with luck we'll find those, if any, with further prerelease testing
- Not 100% of usagse of emtpyList/emptySet were converted, some tests relied on being able to add `null`, in those cases those tests were left alone.