### PR TITLE
Invert deployment ordering of nginx and dropwizard

### DIFF
--- a/infrastructure/ansible/site.yml
+++ b/infrastructure/ansible/site.yml
@@ -31,8 +31,8 @@
   strategy: free
   roles:
     - java
+    - http_server
     - nginx
-    - dropwizard
 
 - hosts: botHosts
   gather_facts: no


### PR DESCRIPTION
Nginx fronts dropwizard (http-server) transparently, we need dropwizard to be
running for the nginx forwarding to work. Nginx depends on dropwizard,
not the other way round. This update inverts deployment ordering so that
dropwizard is deployed before nginx.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manually testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

