### PR TITLE
Improve 'Timers' Builder and Fix Websocket Inactivity Disconnect

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
@@ -9,7 +9,6 @@ import java.time.format.DateTimeFormatterBuilder;
 import java.time.format.FormatStyle;
 import java.util.List;
 import java.util.Map;
-import java.util.Timer;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -20,7 +19,8 @@ import javax.swing.table.AbstractTableModel;
 import org.triplea.http.client.lobby.HttpLobbyClient;
 import org.triplea.http.client.lobby.game.listing.LobbyGame;
 import org.triplea.http.client.lobby.game.listing.LobbyGameListing;
-import org.triplea.java.Timers;
+import org.triplea.java.timer.ScheduledTimer;
+import org.triplea.java.timer.Timers;
 import org.triplea.lobby.common.GameDescription;
 import org.triplea.lobby.common.LobbyGameUpdateListener;
 import org.triplea.util.Tuple;
@@ -44,7 +44,7 @@ class LobbyGameTableModel extends AbstractTableModel {
   }
 
   private final boolean admin;
-  private final transient Timer gamePoller;
+  private final transient ScheduledTimer gamePoller;
 
   // these must only be accessed in the swing event thread
   private final List<Tuple<String, GameDescription>> gameList = new CopyOnWriteArrayList<>();
@@ -73,7 +73,7 @@ class LobbyGameTableModel extends AbstractTableModel {
     // delay when games are updated, yet still as infrequent as possible to keep server load to
     // a minimum.
     gamePoller =
-        Timers.fixedRateTimer()
+        Timers.fixedRateTimer("game-poller")
             .period(GAME_POLLER_FREQUENCY_SECONDS, TimeUnit.SECONDS)
             .delay(GAME_POLLER_FREQUENCY_SECONDS, TimeUnit.SECONDS)
             .task(
@@ -81,7 +81,8 @@ class LobbyGameTableModel extends AbstractTableModel {
                     lobbyGameBroadcaster,
                     gameListingSupplier(),
                     httpLobbyClient.getGameListingClient()::fetchGameListing,
-                    errorMessageReporter));
+                    errorMessageReporter))
+            .start();
     httpLobbyClient.addConnectionLostListener(msg -> gamePoller.cancel());
 
     try {

--- a/java-extras/src/main/java/org/triplea/java/timer/ScheduledTimer.java
+++ b/java-extras/src/main/java/org/triplea/java/timer/ScheduledTimer.java
@@ -1,0 +1,63 @@
+package org.triplea.java.timer;
+
+import java.util.Optional;
+import java.util.Timer;
+import java.util.TimerTask;
+
+/**
+ * Class for creating a class to be executed periodically. Sample usage:
+ *
+ * <pre><code>
+ *   ScheduledTimer timer = Timers.newFixedRateTimer("thread-name")
+ *      .period(20, TimeUnit.SECONDS)
+ *      .delay(10, TimeUnit.SECONDS)
+ *      .task(() -> executeTask());
+ *   timer.start();
+ *   timer.cancel();
+ * </code></pre>
+ *
+ * The scheduled timer can also be started at time of creation:
+ *
+ * <pre><code>
+ *   ScheduledTimer timer = Timers.newFixedRateTimer("thread-name")
+ *      .period(20, TimeUnit.SECONDS)
+ *      .task(() -> executeTask())
+ *      .start();
+ *   timer.cancel();
+ * </code></pre>
+ */
+public class ScheduledTimer {
+  private final Runnable task;
+  private final long delayMillis;
+  private final long periodMillis;
+
+  private final Timer timer;
+
+  ScheduledTimer(
+      final String threadName,
+      final Runnable task,
+      final long delayMillis,
+      final long periodMillis) {
+    timer = Optional.ofNullable(threadName).map(Timer::new).orElseGet(Timer::new);
+    this.task = task;
+    this.delayMillis = delayMillis;
+    this.periodMillis = periodMillis;
+  }
+
+  public ScheduledTimer start() {
+    timer.scheduleAtFixedRate(
+        new TimerTask() {
+          @Override
+          public void run() {
+            task.run();
+          }
+        },
+        delayMillis,
+        periodMillis);
+    return this;
+  }
+
+  public void cancel() {
+    timer.cancel();
+  }
+}


### PR DESCRIPTION
1. Websocket disconnects after 60s of inactivity. We can use
the websocket client to send a 'ping' to avoid this. This update
adds a Timed task to send a 'ping' to keep the websocket connection
open even when otherwise idle.

2. Improve 'Timers' type-safe builder to allow timer to be defined
without starting and to require a thread name.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[x] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manually testing done

- Verified that chat connection no longer closes after 60s of inactivity

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

