### PR TITLE
Update NGINX config for ciphers & websocket port forwarding

### DIFF
--- a/infrastructure/ansible/roles/nginx/templates/etc_nginx_sites_enabled_default.j2
+++ b/infrastructure/ansible/roles/nginx/templates/etc_nginx_sites_enabled_default.j2
@@ -6,16 +6,14 @@ server {
 server {
     listen 443;
     server_name {{ inventory_hostname }};
-
-    ssl_certificate           {{ nginx_ssl_certificate }};
-    ssl_certificate_key       {{ nginx_ssl_certificate_key }};
+    ssl_certificate /etc/letsencrypt/live/{{ inventory_hostname }}/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/{{ inventory_hostname }}/privkey.pem; # managed by Certbot
 
     ssl on;
     ssl_session_cache  builtin:1000  shared:SSL:10m;
-    ssl_protocols  TLSv1.1 TLSv1.2;
-    ssl_ciphers HIGH:!aNULL:!eNULL:!EXPORT:!CAMELLIA:!DES:!MD5:!PSK:!RC4;
+    ssl_protocols  TLSv1.2 TLSv1.3;
+    ssl_ciphers EECDH+AESGCM:EDH+AESGCM;
     ssl_prefer_server_ciphers on;
-
     access_log            /var/log/nginx/java_server.access.log;
 
     location / {
@@ -26,9 +24,16 @@ server {
       proxy_set_header        X-Forwarded-Proto $scheme;
 
       # Fix the “It appears that your reverse proxy set up is broken" error.
-      proxy_pass          http://localhost:4567;
+      proxy_pass          http://localhost:8080;
       proxy_read_timeout  90;
 
-      proxy_redirect      http://localhost:443 https://localhost:{{ http_server_port }};
+      proxy_redirect      https://localhost:443 https://localhost:{{ http_server_port }};
+    }
+
+    location /lobby/chat/websocket {
+      proxy_pass http://localhost:8080;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
     }
 }


### PR DESCRIPTION
- Add config to forward http upgrade request, enables websocket
- Fix proxy target port to refer to dropwizard 8080
- Update ciphers to secure set
  - From: https://cipherli.st/
  - Verified strong ciphers with:
    https://www.ssllabs.com/ssltest/analyze.html?d=prerelease.triplea-game.org
- Update cert locations to refer to locations generated by certbot


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Bug fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manually testing done
- deployed to prerelease.triplea-game.org and verified connectiity
- used `wscat` to verify configurations for websocket connection
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

