### PR TITLE
Remove some unnecessary collection copies.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -170,8 +170,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
       for (final ICondition subCondition : condition.getConditions()) {
         if (!allConditionsNeededSoFar.contains(subCondition)) {
           allConditionsNeededSoFar.addAll(
-              getAllConditionsRecursive(
-                  new HashSet<>(Set.of(subCondition)), allConditionsNeededSoFar));
+              getAllConditionsRecursive(Set.of(subCondition), allConditionsNeededSoFar));
         }
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -243,7 +243,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       final Map<ICondition, Boolean> allConditionsTestedSoFar) {
     final Set<ICondition> allConditionsNeeded =
         AbstractConditionsAttachment.getAllConditionsRecursive(
-            new HashSet<>(toFirePossible), allConditionsNeededSoFar);
+            Set.copyOf(toFirePossible), allConditionsNeededSoFar);
     return AbstractConditionsAttachment.testAllConditionsRecursive(
         allConditionsNeeded, allConditionsTestedSoFar, bridge);
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -105,7 +105,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
       // get all possible triggers based on this match.
       final Set<TriggerAttachment> toFirePossible =
           TriggerAttachment.collectForAllTriggersMatching(
-              new HashSet<>(data.getPlayerList().getPlayers()), endRoundDelegateTriggerMatch);
+              Set.copyOf(data.getPlayerList().getPlayers()), endRoundDelegateTriggerMatch);
       if (!toFirePossible.isEmpty()) {
         // get all conditions possibly needed by these triggers, and then test them.
         final Map<ICondition, Boolean> testedConditions =

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -367,7 +367,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
               .and(TriggerAttachment.resourceMatch());
       triggers.addAll(
           TriggerAttachment.collectForAllTriggersMatching(
-              new HashSet<>(Set.of(player)), endTurnDelegateTriggerMatch));
+              Set.of(player), endTurnDelegateTriggerMatch));
       allConditionsNeeded.addAll(
           AbstractConditionsAttachment.getAllConditionsRecursive(new HashSet<>(triggers), null));
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -94,7 +94,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
       if (GameStepPropertiesHelper.isCombatMove(data) && Properties.getTriggers(data)) {
         final Set<TriggerAttachment> toFirePossible =
             TriggerAttachment.collectForAllTriggersMatching(
-                new HashSet<>(Set.of(player)), moveCombatDelegateAllTriggerMatch);
+                Set.of(player), moveCombatDelegateAllTriggerMatch);
         if (!toFirePossible.isEmpty()) {
 
           // collect conditions and test them for ALL triggers, both those that we will fire before
@@ -103,7 +103,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
           testedConditions = TriggerAttachment.collectTestsForAllTriggers(toFirePossible, bridge);
           final Set<TriggerAttachment> toFireBeforeBonus =
               TriggerAttachment.collectForAllTriggersMatching(
-                  new HashSet<>(Set.of(player)), moveCombatDelegateBeforeBonusTriggerMatch);
+                  Set.of(player), moveCombatDelegateBeforeBonusTriggerMatch);
           if (!toFireBeforeBonus.isEmpty()) {
 
             // get all triggers that are satisfied based on the tested conditions.
@@ -156,7 +156,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
       if (GameStepPropertiesHelper.isCombatMove(data) && Properties.getTriggers(data)) {
         final Set<TriggerAttachment> toFireAfterBonus =
             TriggerAttachment.collectForAllTriggersMatching(
-                new HashSet<>(Set.of(player)), moveCombatDelegateAfterBonusTriggerMatch);
+                Set.of(player), moveCombatDelegateAfterBonusTriggerMatch);
         if (!toFireAfterBonus.isEmpty()) {
 
           // get all triggers that are satisfied based on the tested conditions.

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -53,7 +53,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
       // get all possible triggers based on this match.
       final Set<TriggerAttachment> toFirePossible =
           TriggerAttachment.collectForAllTriggersMatching(
-              new HashSet<>(Set.of(player)), politicsDelegateTriggerMatch);
+              Set.of(player), politicsDelegateTriggerMatch);
       if (!toFirePossible.isEmpty()) {
         // get all conditions possibly needed by these triggers, and then test them.
         final Map<ICondition, Boolean> testedConditions =

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -74,7 +74,7 @@ public class PurchaseDelegate extends BaseTripleADelegate
         // get all possible triggers based on this match.
         final Set<TriggerAttachment> toFirePossible =
             TriggerAttachment.collectForAllTriggersMatching(
-                new HashSet<>(Set.of(player)), purchaseDelegateTriggerMatch);
+                Set.of(player), purchaseDelegateTriggerMatch);
         if (!toFirePossible.isEmpty()) {
           // get all conditions possibly needed by these triggers, and then test them.
           final Map<ICondition, Boolean> testedConditions =

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
@@ -63,7 +63,7 @@ public class TechActivationDelegate extends BaseTripleADelegate {
       // get all possible triggers based on this match.
       final Set<TriggerAttachment> toFirePossible =
           TriggerAttachment.collectForAllTriggersMatching(
-              new HashSet<>(Set.of(player)), techActivationDelegateTriggerMatch);
+              Set.of(player), techActivationDelegateTriggerMatch);
       if (!toFirePossible.isEmpty()) {
         // get all conditions possibly needed by these triggers, and then test them.
         final Map<ICondition, Boolean> testedConditions =

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -78,7 +78,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
       // get all possible triggers based on this match.
       final Set<TriggerAttachment> toFirePossible =
           TriggerAttachment.collectForAllTriggersMatching(
-              new HashSet<>(Set.of(player)), technologyDelegateTriggerMatch);
+              Set.of(player), technologyDelegateTriggerMatch);
       if (!toFirePossible.isEmpty()) {
         // get all conditions possibly needed by these triggers, and then test them.
         final Map<ICondition, Boolean> testedConditions =


### PR DESCRIPTION
In some cases, the collection was not quite the same type, so Set.copyOf() is used to still make a copy.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[X] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing

[] Manually testing done

Checked the code being called to ensure that it doesn't modify the params being changed.