### PR TITLE
Add automatic prerelease deployment to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -122,7 +122,7 @@ jobs:
       install:
         - sudo apt update
         - sudo apt -y install sshpass
-        - sudo pip install ansible
+        - pip install ansible
       language: python
       python: "3.6"
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -84,7 +84,7 @@ jobs:
       script:
         - ./.travis/setup_database
         - ./.travis/run_smoke_tests
-    - stage: deploy
+    - stage: upload artifacts
       if: (branch = master) and (repo = 'triplea-game/triplea') and (type != 'pull_request')
       install: skip
       before_install:
@@ -117,6 +117,22 @@ jobs:
           tags: false
           repo: triplea-game/triplea
           branch: master
+    - stage: deploy prerelease
+      if: (branch = master) and (repo = 'triplea-game/triplea') and (type != 'pull_request')
+      install:
+        - sudo apt update
+        - sudo apt -y install sshpass
+        - sudo pip install ansible
+      language: python
+      python: "3.6"
+      script:
+        - eval "$(ssh-agent -s)"
+        - version=$(sed "s/.0$/.$TRAVIS_BUILD_NUMBER/" game-core/src/main/resources/META-INF/triplea/product.properties)
+        - cd infrastructure
+        - export ANSIBLE_HOST_KEY_CHECKING=False
+        - echo "$ANSIBLE_VAULT_PASSWORD" > vault_password
+        - ./run_deployment "$version" -i ansible/inventory/prerelease
+
 after_failure:
   - echo "================ Build step 'after_failure' =================" > /dev/null
   -  test "$TRAVIS_EVENT_TYPE" != "pull_request" && test "$TRAVIS_BRANCH" = master && ./.travis/report_build_status FAILURE

--- a/.travis.yml
+++ b/.travis.yml
@@ -119,9 +119,11 @@ jobs:
           branch: master
     - stage: deploy prerelease
       if: (branch = master) and (repo = 'triplea-game/triplea') and (type != 'pull_request')
+      addons:
+        apt:
+          packages:
+            - sshpass
       install:
-        - sudo apt update
-        - sudo apt -y install sshpass
         - pip install ansible
       language: python
       python: "3.6"

--- a/infrastructure/ansible/site.yml
+++ b/infrastructure/ansible/site.yml
@@ -10,6 +10,7 @@
   gather_facts: no
   serial: 100%
   strategy: free
+  tags: security
   roles:
     - apt_update
     - admin_user
@@ -20,7 +21,7 @@
   gather_facts: no
   serial: 100%
   strategy: free
-  tags: lobbyDb
+  tags: postgres
   roles:
     - postgres
     - flyway
@@ -29,6 +30,7 @@
   gather_facts: no
   serial: 100%
   strategy: free
+  tags: lobby
   roles:
     - java
     - http_server
@@ -37,6 +39,7 @@
 - hosts: botHosts
   gather_facts: no
   serial: 100%
+  tags: bots
   roles:
     - java
     - bot

--- a/infrastructure/run_deployment
+++ b/infrastructure/run_deployment
@@ -6,26 +6,20 @@
 # If the script is updated, upload a new copy to the infrastructure machine
 # to /home/ansible.
 
-
-VERSION=${1-}
-INVENTORY_FILE=${2-}
-
 function usage() {
-  echo "Usage: $0 [Version] [InventoryFile]"
+  echo "Usage: $0 [Version] [ansible args]"
   echo "  Version: The version of tripleA to be downloaded and installed, eg: 1.10.0.141"
   echo "  InventoryFile: The inventory file to run, one of: {production|prerelease}"
   echo "Example: $0 1.10.5252 prerelease"
   exit 1
 }
 
-if [ -e "$VERSION" ] || [ -e "$INVENTORY_FILE" ]; then
+if [ "$#" -lt 2 ]; then
   usage
 fi
-export VERSION=$VERSION
 
-if [ "$INVENTORY_FILE" != production ] && [ "$INVENTORY_FILE" != prerelease ]; then
-  usage
-fi
+export VERSION=${1-}
+shift
 
 VAULT_PASSWORD_FILE="vault_password"
 if [ ! -f "$VAULT_PASSWORD_FILE" ]; then
@@ -47,23 +41,6 @@ HTTP_SERVER_JAR_PATH="ansible/roles/http_server/files/$HTTP_SERVER_JAR"
 
 
 set -x
-
-function main() {
-  if [ ! -e "$HTTP_SERVER_JAR_PATH" ]; then
-    downloadHttpServerJar
-  fi
-
-  if [ ! -e "$BOT_JAR_PATH" ]; then
-      downloadBotJar
-  fi
-
-  downloadMigrations
-
-  ansible-playbook -D -v \
-      --vault-password-file "$VAULT_PASSWORD_FILE" \
-     ansible/site.yml \
-     -i "ansible/inventory/$INVENTORY_FILE"
-}
 
 function downloadHttpServerJar() {
   HTTP_SERVER_ZIP="triplea-http-server-$VERSION.zip"
@@ -111,4 +88,17 @@ function downloadMigrations() {
   mv "$migrationsZip" ansible/roles/flyway/files/
 }
 
-main
+if [ ! -e "$HTTP_SERVER_JAR_PATH" ]; then
+downloadHttpServerJar
+fi
+
+if [ ! -e "$BOT_JAR_PATH" ]; then
+  downloadBotJar
+fi
+
+downloadMigrations
+
+ansible-playbook \
+  --vault-password-file "$VAULT_PASSWORD_FILE" \
+ $@ \
+ ansible/site.yml


### PR DESCRIPTION
- Sets up Travis to do a post-release task to deploy prerelease.
This is done in short by running ansible for the prerelease hosts.

- Update README with some ansible quick overview notes and typical
commands for running deployments.

- Update 'run_deployment' script to be more generic and allow
passing of arbitrary args to ansible. This way we can choose to
use the '-d' flag on local but not in travis. '-d' shows file
diffs of what will change on remote servers, very useful for
development and debugging, but would otherwise be dangerous
as any passwords that are written to files on remote servers
would show up in that diff.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[x] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manually testing done
- tested on forked travis build: https://travis-ci.org/DanVanAtta/triplea/jobs/614915797 (I added a hack to set the stage to be 'verify' so that the job would run concurrently allowing for faster development iterations. The 'deploy' stage being defined last should be the last thing run)

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes
- README diff is not very clean. The running ansible section was moved up and combined with new examples of how to execute 'run_deployment. The first section, overview is brand new. Those are the first two sections, the rest of the README is mostly unchanged (but the diff shows additions/removal because of the re-ordering), so pay attention to just the overview and the running ansible sections.
- I've updated travis to have the new required "ANSIBLE_VAULT_PASSWORD" env variable. That unlocks ansible-vault which decrypts the deployment SSH key. Deployment in ansible is done via SSH commands, the SSH key allows for server-to-server communication. Eventually we'll also embed encrypted secrets in the ansible configuration, ansible-vault will use the same key to decrypt those values.