### PR TITLE
AI Improve Defend Territory Check

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -1170,7 +1170,8 @@ class ProNonCombatMoveAi {
         }
 
         // Check if its worth defending
-        if ((result.getTuvSwing() - holdValue) > patd.getMinBattleResult().getTuvSwing()
+        if ((result.getTuvSwing() - holdValue)
+                > Math.max(0, patd.getMinBattleResult().getTuvSwing())
             || (!hasHigherStrategicValue
                 && (result.getTuvSwing() + extraUnitValue / 2)
                     >= patd.getMinBattleResult().getTuvSwing())) {


### PR DESCRIPTION
Address round 7 example from https://forums.triplea-game.org/topic/1518/ai-interesting-moves-and-points-of-improvement-on-revised/16

The AI sometimes will be too cautious when determining which territories to defend so update the TUV check to check the max of min TUV swing and 0. Essentially defend the territory as long as it ends up with a negative TUV for the attacker (<0) or its less than the min result (have a bunch of units that attacked into a territory so want to reinforce it for a better result).