### PR TITLE
Add SHA/Version to bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -10,6 +10,9 @@ assignees: ''
 **Describe the bug**
 <!-- A clear and concise description of what the bug is. -->
 
+**Engine Version or SHA**
+<!-- Exact game engine version, or the latest SHA if building from source -->
+
 **To Reproduce**
 <!--
 Steps to reproduce the behavior:


### PR DESCRIPTION
In case we break engine compatibility, it's really good to know which version or SHA was used. This can be used to help debug/repro.

