### PR TITLE
Implement User-Ban Filter

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -13,6 +13,7 @@ import javax.annotation.Nullable;
 import org.triplea.domain.data.ApiKey;
 import org.triplea.domain.data.PlayerName;
 import org.triplea.http.client.HttpInteractionException;
+import org.triplea.http.client.SystemIdHeader;
 import org.triplea.http.client.forgot.password.ForgotPasswordClient;
 import org.triplea.http.client.forgot.password.ForgotPasswordRequest;
 import org.triplea.http.client.lobby.HttpLobbyClient;
@@ -244,6 +245,7 @@ public class LobbyLogin {
                   () ->
                       ForgotPasswordClient.newClient(serverProperties.getUri())
                           .sendForgotPasswordRequest(
+                              SystemIdHeader.headers(),
                               ForgotPasswordRequest.builder()
                                   .username(panel.getUserName())
                                   .email(panel.getEmail())

--- a/game-core/src/main/java/org/triplea/debug/error/reporting/ErrorReportUploadAction.java
+++ b/game-core/src/main/java/org/triplea/debug/error/reporting/ErrorReportUploadAction.java
@@ -6,6 +6,7 @@ import java.util.function.Consumer;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import lombok.Builder;
+import org.triplea.http.client.SystemIdHeader;
 import org.triplea.http.client.error.report.ErrorReportClient;
 import org.triplea.http.client.error.report.ErrorReportRequest;
 import org.triplea.http.client.error.report.ErrorReportResponse;
@@ -21,7 +22,8 @@ class ErrorReportUploadAction implements Predicate<ErrorReportRequest> {
   @Override
   public boolean test(final ErrorReportRequest errorReport) {
     try {
-      final ErrorReportResponse response = serviceClient.uploadErrorReport(errorReport);
+      final ErrorReportResponse response =
+          serviceClient.uploadErrorReport(SystemIdHeader.headers(), errorReport);
       successConfirmation.accept(URI.create(response.getGithubIssueLink()));
       return true;
     } catch (final FeignException e) {

--- a/game-core/src/test/java/org/triplea/debug/error/reporting/ErrorReportUploadActionTest.java
+++ b/game-core/src/test/java/org/triplea/debug/error/reporting/ErrorReportUploadActionTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.http.client.SystemIdHeader;
 import org.triplea.http.client.error.report.ErrorReportClient;
 import org.triplea.http.client.error.report.ErrorReportRequest;
 import org.triplea.http.client.error.report.ErrorReportResponse;
@@ -51,7 +52,8 @@ class ErrorReportUploadActionTest {
 
   @Test
   void failureResponse() {
-    when(errorReportClient.uploadErrorReport(ERROR_REPORT)).thenThrow(feignException);
+    when(errorReportClient.uploadErrorReport(SystemIdHeader.headers(), ERROR_REPORT))
+        .thenThrow(feignException);
 
     final boolean result = errorReportUploadAction.test(ERROR_REPORT);
 
@@ -63,7 +65,8 @@ class ErrorReportUploadActionTest {
 
   @Test
   void successCase() {
-    when(errorReportClient.uploadErrorReport(ERROR_REPORT)).thenReturn(SUCCESS_RESPONSE);
+    when(errorReportClient.uploadErrorReport(SystemIdHeader.headers(), ERROR_REPORT))
+        .thenReturn(SUCCESS_RESPONSE);
 
     final boolean result = errorReportUploadAction.test(ERROR_REPORT);
 

--- a/http-clients/src/main/java/org/triplea/http/client/error/report/ErrorReportClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/error/report/ErrorReportClient.java
@@ -1,15 +1,19 @@
 package org.triplea.http.client.error.report;
 
 import feign.FeignException;
+import feign.HeaderMap;
 import feign.Headers;
 import feign.RequestLine;
 import java.net.URI;
+import java.util.Map;
 import org.triplea.http.client.HttpClient;
 import org.triplea.http.client.HttpConstants;
 
 /** Http client to upload error reports to the http lobby server. */
 @SuppressWarnings("InterfaceNeverImplemented")
 @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
+// TODO: Project#12 Hide the raw feign client, make consistent with other http clients that
+//  have a wrapper to hide the headers.
 public interface ErrorReportClient {
 
   String ERROR_REPORT_PATH = "/error-report";
@@ -22,7 +26,8 @@ public interface ErrorReportClient {
    * @throws FeignException Thrown on non-2xx responses.
    */
   @RequestLine("POST " + ERROR_REPORT_PATH)
-  ErrorReportResponse uploadErrorReport(ErrorReportRequest request);
+  ErrorReportResponse uploadErrorReport(
+      @HeaderMap Map<String, Object> headers, ErrorReportRequest request);
 
   /** Creates an error report uploader clients, sends error reports and gets a response back. */
   static ErrorReportClient newClient(final URI uri) {

--- a/http-clients/src/main/java/org/triplea/http/client/forgot/password/ForgotPasswordClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/forgot/password/ForgotPasswordClient.java
@@ -1,9 +1,11 @@
 package org.triplea.http.client.forgot.password;
 
 import feign.FeignException;
+import feign.HeaderMap;
 import feign.Headers;
 import feign.RequestLine;
 import java.net.URI;
+import java.util.Map;
 import org.triplea.http.client.HttpClient;
 import org.triplea.http.client.HttpConstants;
 
@@ -13,6 +15,8 @@ import org.triplea.http.client.HttpConstants;
  */
 @SuppressWarnings("InterfaceNeverImplemented")
 @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
+// TODO: Project#12 Hide the raw feign client, make consistent with other http clients that
+//  have a wrapper to hide the headers.
 public interface ForgotPasswordClient {
 
   String FORGOT_PASSWORD_PATH = "/forgot-password";
@@ -23,7 +27,8 @@ public interface ForgotPasswordClient {
    * @throws FeignException Thrown on non-2xx responses.
    */
   @RequestLine("POST " + FORGOT_PASSWORD_PATH)
-  ForgotPasswordResponse sendForgotPasswordRequest(ForgotPasswordRequest request);
+  ForgotPasswordResponse sendForgotPasswordRequest(
+      @HeaderMap Map<String, Object> headers, ForgotPasswordRequest request);
 
   /** Creates an error report uploader clients, sends error reports and gets a response back. */
   static ForgotPasswordClient newClient(final URI uri) {

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/game/hosting/GameHostingClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/game/hosting/GameHostingClient.java
@@ -4,6 +4,7 @@ import java.net.URI;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import org.triplea.http.client.HttpClient;
+import org.triplea.http.client.SystemIdHeader;
 
 /**
  * Use this client to request a connection to lobby and to post a game. If the request is
@@ -21,6 +22,6 @@ public class GameHostingClient {
   }
 
   public GameHostingResponse sendGameHostingRequest() {
-    return gameHostingFeignClient.sendGameHostingRequest();
+    return gameHostingFeignClient.sendGameHostingRequest(SystemIdHeader.headers());
   }
 }

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/game/hosting/GameHostingFeignClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/game/hosting/GameHostingFeignClient.java
@@ -1,12 +1,14 @@
 package org.triplea.http.client.lobby.game.hosting;
 
+import feign.HeaderMap;
 import feign.Headers;
 import feign.RequestLine;
+import java.util.Map;
 import org.triplea.http.client.HttpConstants;
 
 @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
 public interface GameHostingFeignClient {
 
   @RequestLine("POST " + GameHostingClient.GAME_HOSTING_REQUEST_PATH)
-  GameHostingResponse sendGameHostingRequest();
+  GameHostingResponse sendGameHostingRequest(@HeaderMap Map<String, Object> headers);
 }

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/BanDurationFormatter.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/BanDurationFormatter.java
@@ -1,0 +1,23 @@
+package org.triplea.http.client.lobby.moderator;
+
+import com.google.common.base.Preconditions;
+import java.util.concurrent.TimeUnit;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class BanDurationFormatter {
+
+  public static String formatBanMinutes(final long banMinutes) {
+    Preconditions.checkState(banMinutes > 0);
+
+    if (banMinutes < 60) {
+      return banMinutes + " minutes";
+    } else if (TimeUnit.MINUTES.toHours(banMinutes) < 24) {
+      return TimeUnit.MINUTES.toHours(banMinutes) + " hours";
+    } else if (TimeUnit.MINUTES.toDays(banMinutes) < 1000) {
+      return TimeUnit.MINUTES.toDays(banMinutes) + " days";
+    } else {
+      return "permanently";
+    }
+  }
+}

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/BanPlayerRequest.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/BanPlayerRequest.java
@@ -1,7 +1,5 @@
 package org.triplea.http.client.lobby.moderator;
 
-import com.google.common.base.Preconditions;
-import java.util.concurrent.TimeUnit;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -18,22 +16,4 @@ import lombok.ToString;
 public class BanPlayerRequest {
   private String playerChatId;
   private long banMinutes;
-
-  /**
-   * Returns a formatted text of the 'banMinutes', this converts ban minutes to minutes, hours or
-   * days as appropriate, or uses the label "permanently" if ban duration is effectively permanent.
-   */
-  public String formattedBanDuration() {
-    Preconditions.checkState(banMinutes > 0);
-
-    if (banMinutes < 60) {
-      return banMinutes + " minutes";
-    } else if (TimeUnit.MINUTES.toHours(banMinutes) < 24) {
-      return TimeUnit.MINUTES.toHours(banMinutes) + " hours";
-    } else if (TimeUnit.MINUTES.toDays(banMinutes) < 1000) {
-      return TimeUnit.MINUTES.toDays(banMinutes) + " days";
-    } else {
-      return "permanently";
-    }
-  }
 }

--- a/http-clients/src/test/java/org/triplea/http/client/error/report/ErrorReportClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/error/report/ErrorReportClientTest.java
@@ -9,6 +9,7 @@ import java.net.URI;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.triplea.http.client.HttpClientTesting;
+import org.triplea.http.client.SystemIdHeader;
 import org.triplea.http.client.WireMockTest;
 import ru.lanwen.wiremock.ext.WiremockResolver;
 
@@ -37,6 +38,7 @@ class ErrorReportClientTest extends WireMockTest {
   private static ErrorReportResponse doServiceCall(final URI hostUri) {
     return ErrorReportClient.newClient(hostUri)
         .uploadErrorReport(
+            SystemIdHeader.headers(),
             ErrorReportRequest.builder()
                 .title("Guttuss cadunt in germanus oenipons!")
                 .body(MESSAGE_FROM_USER)

--- a/http-clients/src/test/java/org/triplea/http/client/forgot/password/ForgotPasswordClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/forgot/password/ForgotPasswordClientTest.java
@@ -9,6 +9,7 @@ import java.net.URI;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.triplea.http.client.HttpClientTesting;
+import org.triplea.http.client.SystemIdHeader;
 import org.triplea.http.client.WireMockTest;
 import ru.lanwen.wiremock.ext.WiremockResolver;
 
@@ -35,7 +36,8 @@ class ForgotPasswordClientTest extends WireMockTest {
   }
 
   private static ForgotPasswordResponse doServiceCall(final URI hostUri) {
-    return ForgotPasswordClient.newClient(hostUri).sendForgotPasswordRequest(REQUEST);
+    return ForgotPasswordClient.newClient(hostUri)
+        .sendForgotPasswordRequest(SystemIdHeader.headers(), REQUEST);
   }
 
   @Test

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/BanDurationFormatterTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/BanDurationFormatterTest.java
@@ -7,20 +7,13 @@ import java.util.List;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-import org.triplea.domain.data.PlayerChatId;
 
-class BanPlayerRequestTest {
+class BanDurationFormatterTest {
 
   @ParameterizedTest
   @MethodSource
   void formattedBanDuration(final long banMinutes, final String expectedOutput) {
-    final BanPlayerRequest banPlayerRequest =
-        BanPlayerRequest.builder()
-            .playerChatId(PlayerChatId.of("chat-id").getValue())
-            .banMinutes(banMinutes)
-            .build();
-
-    final String result = banPlayerRequest.formattedBanDuration();
+    final String result = BanDurationFormatter.formatBanMinutes(banMinutes);
 
     assertThat(result, is(expectedOutput));
   }

--- a/http-server/src/main/java/org/triplea/server/access/BannedPlayerFilter.java
+++ b/http-server/src/main/java/org/triplea/server/access/BannedPlayerFilter.java
@@ -1,0 +1,64 @@
+package org.triplea.server.access;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Strings;
+import java.time.Clock;
+import java.time.Duration;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.PreMatching;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.Provider;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.jdbi.v3.core.Jdbi;
+import org.triplea.http.client.SystemIdHeader;
+import org.triplea.http.client.lobby.moderator.BanDurationFormatter;
+import org.triplea.lobby.server.db.dao.user.ban.BanLookupRecord;
+import org.triplea.lobby.server.db.dao.user.ban.UserBanDao;
+
+@Provider
+@PreMatching
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PACKAGE, onConstructor_ = @VisibleForTesting)
+public class BannedPlayerFilter implements ContainerRequestFilter {
+
+  private final UserBanDao userBanDao;
+  private final Clock clock;
+
+  @Context private HttpServletRequest request;
+
+  public static BannedPlayerFilter newBannedPlayerFilter(final Jdbi jdbi) {
+    return new BannedPlayerFilter(jdbi.onDemand(UserBanDao.class), Clock.systemUTC());
+  }
+
+  @Override
+  public void filter(final ContainerRequestContext requestContext) {
+    if (Strings.emptyToNull(request.getHeader(SystemIdHeader.SYSTEM_ID_HEADER)) == null) {
+      // missing system id header, abort the request
+      requestContext.abortWith(Response.status(Status.FORBIDDEN).entity("Invalid request").build());
+
+    } else {
+      // check if user is banned, if so abort the request
+      userBanDao
+          .lookupBan(request.getRemoteAddr(), request.getHeader(SystemIdHeader.SYSTEM_ID_HEADER))
+          .map(this::formatBanMessage)
+          .ifPresent(
+              banMessage ->
+                  requestContext.abortWith(
+                      Response.status(Status.FORBIDDEN).entity(banMessage).build()));
+    }
+  }
+
+  private String formatBanMessage(final BanLookupRecord banLookupRecord) {
+    final long banMinutes =
+        Duration.between(clock.instant(), banLookupRecord.getBanExpiry()).toMinutes();
+    final String banDuration = BanDurationFormatter.formatBanMinutes(banMinutes);
+
+    return String.format("Banned %s, (ID: %s)", banDuration, banLookupRecord.getPublicBanId());
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/http/ServerApplication.java
+++ b/http-server/src/main/java/org/triplea/server/http/ServerApplication.java
@@ -30,6 +30,7 @@ import org.triplea.lobby.server.db.JdbiDatabase;
 import org.triplea.lobby.server.db.dao.api.key.LobbyApiKeyDaoWrapper;
 import org.triplea.server.access.ApiKeyAuthenticator;
 import org.triplea.server.access.AuthenticatedUser;
+import org.triplea.server.access.BannedPlayerFilter;
 import org.triplea.server.access.RoleAuthorizer;
 import org.triplea.server.error.reporting.ErrorReportControllerFactory;
 import org.triplea.server.forgot.password.ForgotPasswordControllerFactory;
@@ -112,6 +113,8 @@ public class ServerApplication extends Application<AppConfig> {
 
     final MetricRegistry metrics = new MetricRegistry();
     final Jdbi jdbi = createJdbi(configuration, environment);
+
+    environment.jersey().register(BannedPlayerFilter.newBannedPlayerFilter(jdbi));
 
     enableAuthentication(environment, metrics, jdbi);
 

--- a/http-server/src/main/java/org/triplea/server/lobby/chat/moderation/ModeratorActionPersistence.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/chat/moderation/ModeratorActionPersistence.java
@@ -4,6 +4,7 @@ import java.util.UUID;
 import javax.annotation.Nonnull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import org.triplea.http.client.lobby.moderator.BanDurationFormatter;
 import org.triplea.http.client.lobby.moderator.BanPlayerRequest;
 import org.triplea.lobby.server.db.dao.ModeratorAuditHistoryDao;
 import org.triplea.lobby.server.db.dao.ModeratorAuditHistoryDao.AuditAction;
@@ -33,7 +34,7 @@ class ModeratorActionPersistence {
             .actionTarget(
                 playerIdLookup.getPlayerName().getValue()
                     + " "
-                    + banPlayerRequest.formattedBanDuration())
+                    + BanDurationFormatter.formatBanMinutes(banPlayerRequest.getBanMinutes()))
             .build());
   }
 

--- a/http-server/src/main/java/org/triplea/server/lobby/chat/moderation/ModeratorChatService.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/chat/moderation/ModeratorChatService.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.domain.data.PlayerChatId;
 import org.triplea.domain.data.PlayerName;
+import org.triplea.http.client.lobby.moderator.BanDurationFormatter;
 import org.triplea.http.client.lobby.moderator.BanPlayerRequest;
 import org.triplea.lobby.server.db.dao.api.key.LobbyApiKeyDaoWrapper;
 import org.triplea.lobby.server.db.dao.api.key.PlayerIdLookup;
@@ -52,14 +53,14 @@ class ModeratorChatService {
   private static String playerBannedMessage(final BanPlayerRequest banPlayerRequest) {
     return String.format(
         "You have been banned for %s for violating lobby rules",
-        banPlayerRequest.formattedBanDuration());
+        BanDurationFormatter.formatBanMinutes(banPlayerRequest.getBanMinutes()));
   }
 
   private static String playerBannedNotification(
       final PlayerName bannedPlayerName, final BanPlayerRequest banPlayerRequest) {
     return String.format(
         "%s violated lobby rules and was banned for %s",
-        bannedPlayerName, banPlayerRequest.formattedBanDuration());
+        bannedPlayerName, BanDurationFormatter.formatBanMinutes(banPlayerRequest.getBanMinutes()));
   }
 
   /**

--- a/http-server/src/test/java/org/triplea/server/access/BannedPlayerFilterTest.java
+++ b/http-server/src/test/java/org/triplea/server/access/BannedPlayerFilterTest.java
@@ -1,0 +1,132 @@
+package org.triplea.server.access;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import org.hamcrest.core.StringContains;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.http.client.SystemIdHeader;
+import org.triplea.lobby.server.db.dao.user.ban.BanLookupRecord;
+import org.triplea.lobby.server.db.dao.user.ban.UserBanDao;
+
+@SuppressWarnings("SameParameterValue")
+@ExtendWith(MockitoExtension.class)
+class BannedPlayerFilterTest {
+
+  private static final Instant NOW_TIME = Instant.parse("2001-01-01T23:59:59.0Z");
+  private static final String BAN_ID = "public-id";
+  private static final String IP = "sample-ip";
+  private static final String SYSTEM_ID = "system-id";
+
+  @Mock private UserBanDao userBanDao;
+  @Mock private Clock clock;
+  @Mock private HttpServletRequest request;
+
+  @InjectMocks private BannedPlayerFilter bannedPlayerFilter;
+
+  @Mock private ContainerRequestContext containerRequestContext;
+
+  void givenIpAndSystemId() {
+    when(request.getRemoteAddr()).thenReturn(IP);
+    when(request.getHeader(SystemIdHeader.SYSTEM_ID_HEADER)).thenReturn(SYSTEM_ID);
+  }
+
+  @Nested
+  class NotBanned {
+    @Test
+    @DisplayName("IP and System ID are ok, verify request is *not* aborted")
+    void notBanned() {
+      givenIpAndSystemId();
+      givenIpIsNotBanned();
+
+      bannedPlayerFilter.filter(containerRequestContext);
+
+      verifyRequestIsAllowed();
+    }
+
+    private void givenIpIsNotBanned() {
+      when(userBanDao.lookupBan(IP, SYSTEM_ID)).thenReturn(Optional.empty());
+    }
+
+    private void verifyRequestIsAllowed() {
+      verify(containerRequestContext, never()).abortWith(any());
+    }
+  }
+
+  @Nested
+  class Banned {
+    @Test
+    @DisplayName("IP or System ID are banned, verify request is aborted")
+    void ipIsBanned() {
+      givenIpAndSystemId();
+      givenCurrentTimeIs(NOW_TIME);
+      givenBannedWithExpiryAndBanIdentifier(NOW_TIME.plus(5, ChronoUnit.MINUTES), BAN_ID);
+
+      bannedPlayerFilter.filter(containerRequestContext);
+
+      verifyForbiddenRequest();
+    }
+
+    private void givenCurrentTimeIs(final Instant nowTime) {
+      when(clock.instant()).thenReturn(nowTime);
+    }
+
+    private void givenBannedWithExpiryAndBanIdentifier(
+        final Instant banExpiry, final String banId) {
+      when(userBanDao.lookupBan(IP, SYSTEM_ID))
+          .thenReturn(
+              Optional.of(
+                  BanLookupRecord.builder().banExpiry(banExpiry).publicBanId(banId).build()));
+    }
+
+    private void verifyForbiddenRequest() {
+      final ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+      verify(containerRequestContext).abortWith(responseCaptor.capture());
+
+      final Response response = responseCaptor.getValue();
+      assertThat(response.getStatus(), is(Status.FORBIDDEN.getStatusCode()));
+      assertThat((String) response.getEntity(), StringContains.containsString("5 minutes"));
+      assertThat((String) response.getEntity(), StringContains.containsString(BAN_ID));
+    }
+  }
+
+  @Nested
+  class MissingSystemId {
+    @Test
+    @DisplayName("Missing system ID is a bad request and should be rejected")
+    void noSystemId() {
+      when(request.getHeader(SystemIdHeader.SYSTEM_ID_HEADER)).thenReturn(null);
+
+      bannedPlayerFilter.filter(containerRequestContext);
+
+      verifyForbiddenRequest();
+    }
+
+    private void verifyForbiddenRequest() {
+      final ArgumentCaptor<Response> responseCaptor = ArgumentCaptor.forClass(Response.class);
+      verify(containerRequestContext).abortWith(responseCaptor.capture());
+
+      final Response response = responseCaptor.getValue();
+      assertThat(response.getStatus(), is(Status.FORBIDDEN.getStatusCode()));
+    }
+  }
+}

--- a/http-server/src/test/java/org/triplea/server/lobby/chat/moderation/ModeratorChatServiceTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/chat/moderation/ModeratorChatServiceTest.java
@@ -28,6 +28,7 @@ import org.triplea.domain.data.PlayerName;
 import org.triplea.domain.data.SystemId;
 import org.triplea.http.client.lobby.chat.events.server.ServerMessageEnvelope;
 import org.triplea.http.client.lobby.chat.events.server.ServerMessageEnvelope.ServerMessageType;
+import org.triplea.http.client.lobby.moderator.BanDurationFormatter;
 import org.triplea.http.client.lobby.moderator.BanPlayerRequest;
 import org.triplea.lobby.server.db.dao.api.key.LobbyApiKeyDaoWrapper;
 import org.triplea.lobby.server.db.dao.api.key.PlayerIdLookup;
@@ -112,7 +113,8 @@ class ModeratorChatServiceTest {
       assertThat(
           "Make sure ban message has ban duration",
           disconnectMessageCaptor.getValue().toLowerCase(),
-          containsString(BAN_PLAYER_REQUEST.formattedBanDuration()));
+          containsString(
+              BanDurationFormatter.formatBanMinutes(BAN_PLAYER_REQUEST.getBanMinutes())));
     }
 
     private void verifyEveryoneElseIsNotifiedOfPlayerBan() {

--- a/integration-testing/src/test/java/org/triplea/http/client/lobby/login/UserBannedFilterIntegrationTest.java
+++ b/integration-testing/src/test/java/org/triplea/http/client/lobby/login/UserBannedFilterIntegrationTest.java
@@ -1,0 +1,45 @@
+package org.triplea.http.client.lobby.login;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.triplea.http.client.HttpClient;
+import org.triplea.http.client.HttpInteractionException;
+import org.triplea.http.client.SystemIdHeader;
+import org.triplea.server.http.DropwizardTest;
+
+/**
+ * In this test we'll verify that user-banned filter is configured. We'll do ban by system-id as
+ * that is easier to control and does not need us to ban localhost. We'll verify the ban against the
+ * login endpoint as that will be a common first endpoint for banned users to attempt to access
+ * after being booted and banned.
+ */
+class UserBannedFilterIntegrationTest extends DropwizardTest {
+
+  private static final LoginRequest LOGIN_REQUEST =
+      LoginRequest.builder().password("pass").name("name").build();
+
+  private static final String BANNED_SYSTEM_ID = "system-id";
+
+  private final LobbyLoginFeignClient loginClient =
+      new HttpClient<>(LobbyLoginFeignClient.class, localhost).get();
+
+  @Test
+  void banned() {
+    assertThrows(
+        HttpInteractionException.class,
+        () -> loginClient.login(headersWithSystemId(BANNED_SYSTEM_ID), LOGIN_REQUEST));
+  }
+
+  private static Map<String, Object> headersWithSystemId(final String systemId) {
+    return Map.of(SystemIdHeader.SYSTEM_ID_HEADER, systemId);
+  }
+
+  @Test
+  void notBanned() {
+    assertDoesNotThrow(
+        () -> loginClient.login(headersWithSystemId("some other system-id"), LOGIN_REQUEST));
+  }
+}

--- a/integration-testing/src/test/java/org/triplea/server/error/reporting/ErrorReportControllerIntegrationTest.java
+++ b/integration-testing/src/test/java/org/triplea/server/error/reporting/ErrorReportControllerIntegrationTest.java
@@ -1,6 +1,7 @@
 package org.triplea.server.error.reporting;
 
 import org.junit.jupiter.api.Test;
+import org.triplea.http.client.SystemIdHeader;
 import org.triplea.http.client.error.report.ErrorReportClient;
 import org.triplea.http.client.error.report.ErrorReportRequest;
 import org.triplea.server.http.BasicEndpointTest;
@@ -16,6 +17,7 @@ class ErrorReportControllerIntegrationTest extends BasicEndpointTest<ErrorReport
     verifyEndpointReturningObject(
         client ->
             client.uploadErrorReport(
+                SystemIdHeader.headers(),
                 ErrorReportRequest.builder().body("body").title("title").build()));
   }
 }

--- a/integration-testing/src/test/java/org/triplea/server/forgot/password/ForgotPasswordControllerIntegrationTest.java
+++ b/integration-testing/src/test/java/org/triplea/server/forgot/password/ForgotPasswordControllerIntegrationTest.java
@@ -1,6 +1,7 @@
 package org.triplea.server.forgot.password;
 
 import org.junit.jupiter.api.Test;
+import org.triplea.http.client.SystemIdHeader;
 import org.triplea.http.client.forgot.password.ForgotPasswordClient;
 import org.triplea.http.client.forgot.password.ForgotPasswordRequest;
 import org.triplea.server.http.BasicEndpointTest;
@@ -16,6 +17,7 @@ class ForgotPasswordControllerIntegrationTest extends BasicEndpointTest<ForgotPa
     verifyEndpointReturningObject(
         client ->
             client.sendForgotPasswordRequest(
+                SystemIdHeader.headers(),
                 ForgotPasswordRequest.builder().username("user").email("email").build()));
   }
 }

--- a/integration-testing/src/test/resources/datasets/user_ban/lookup_bans.yml
+++ b/integration-testing/src/test/resources/datasets/user_ban/lookup_bans.yml
@@ -13,3 +13,10 @@ banned_user:
     ip: 127.0.0.2
     date_created: 2020-01-01 23:59:59
     ban_expiry: 2100-01-01 23:59:59
+  - id: 3
+    public_id: expired-ban
+    username: username2
+    system_id: system-id2
+    ip: 127.0.0.2
+    date_created: 2000-01-01 23:59:59
+    ban_expiry: 2000-01-01 23:59:59

--- a/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/JdbiDatabase.java
+++ b/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/JdbiDatabase.java
@@ -12,6 +12,7 @@ import org.jdbi.v3.sqlobject.SqlObjectPlugin;
 import org.triplea.lobby.server.db.dao.access.log.AccessLogRecord;
 import org.triplea.lobby.server.db.dao.api.key.PlayerIdLookup;
 import org.triplea.lobby.server.db.dao.api.key.UserWithRoleRecord;
+import org.triplea.lobby.server.db.dao.user.ban.BanLookupRecord;
 import org.triplea.lobby.server.db.dao.user.ban.UserBanRecord;
 import org.triplea.lobby.server.db.dao.username.ban.UsernameBanRecord;
 import org.triplea.lobby.server.db.data.ModeratorAuditHistoryDaoData;
@@ -49,6 +50,7 @@ public final class JdbiDatabase {
    */
   public static void registerRowMappers(final Jdbi jdbi) {
     jdbi.registerRowMapper(AccessLogRecord.class, AccessLogRecord.buildResultMapper());
+    jdbi.registerRowMapper(BanLookupRecord.class, BanLookupRecord.buildResultMapper());
     jdbi.registerRowMapper(PlayerIdLookup.class, PlayerIdLookup.buildResultMapper());
     jdbi.registerRowMapper(UserWithRoleRecord.class, UserWithRoleRecord.buildResultMapper());
     jdbi.registerRowMapper(UserBanRecord.class, UserBanRecord.buildResultMapper());

--- a/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/dao/user/ban/BanLookupRecord.java
+++ b/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/dao/user/ban/BanLookupRecord.java
@@ -1,0 +1,37 @@
+package org.triplea.lobby.server.db.dao.user.ban;
+
+import static org.triplea.lobby.server.db.dao.user.ban.BanTableColumns.BAN_EXPIRY_COLUMN;
+import static org.triplea.lobby.server.db.dao.user.ban.BanTableColumns.PUBLIC_ID_COLUMN;
+
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.triplea.lobby.server.db.TimestampMapper;
+
+/**
+ * Lookup record to determine if a player is banned. If so, gives enough information to inform the
+ * player of the ban duration and the 'public id' of the ban.
+ */
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@EqualsAndHashCode
+public class BanLookupRecord {
+
+  private String publicBanId;
+  private Instant banExpiry;
+
+  /** Returns a JDBI row mapper used to convert results into an instance of this bean object. */
+  public static RowMapper<BanLookupRecord> buildResultMapper() {
+    return (rs, ctx) ->
+        BanLookupRecord.builder()
+            .publicBanId(rs.getString(PUBLIC_ID_COLUMN))
+            .banExpiry(TimestampMapper.map(rs, BAN_EXPIRY_COLUMN))
+            .build();
+  }
+}

--- a/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/dao/user/ban/BanTableColumns.java
+++ b/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/dao/user/ban/BanTableColumns.java
@@ -1,0 +1,13 @@
+package org.triplea.lobby.server.db.dao.user.ban;
+
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+class BanTableColumns {
+  public static final String PUBLIC_ID_COLUMN = "public_id";
+  public static final String USERNAME_COLUMN = "username";
+  public static final String SYSTEM_ID_COLUMN = "system_id";
+  public static final String IP_COLUMN = "ip";
+  public static final String BAN_EXPIRY_COLUMN = "ban_expiry";
+  public static final String DATE_CREATED_COLUMN = "date_created";
+}

--- a/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/dao/user/ban/UserBanDao.java
+++ b/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/dao/user/ban/UserBanDao.java
@@ -1,6 +1,10 @@
 package org.triplea.lobby.server.db.dao.user.ban;
 
-import static org.triplea.lobby.server.db.dao.user.ban.UserBanRecord.DATE_CREATED_COLUMN;
+import static org.triplea.lobby.server.db.dao.user.ban.BanTableColumns.BAN_EXPIRY_COLUMN;
+import static org.triplea.lobby.server.db.dao.user.ban.BanTableColumns.DATE_CREATED_COLUMN;
+import static org.triplea.lobby.server.db.dao.user.ban.BanTableColumns.IP_COLUMN;
+import static org.triplea.lobby.server.db.dao.user.ban.BanTableColumns.PUBLIC_ID_COLUMN;
+import static org.triplea.lobby.server.db.dao.user.ban.BanTableColumns.SYSTEM_ID_COLUMN;
 
 import java.util.List;
 import java.util.Optional;
@@ -16,10 +20,34 @@ public interface UserBanDao {
           + UserBanRecord.SELECT_CLAUSE
           + "\n"
           + "from banned_user\n"
+          + "where "
+          + BAN_EXPIRY_COLUMN
+          + " > now()\n"
           + "order by "
           + DATE_CREATED_COLUMN
           + " desc")
   List<UserBanRecord> lookupBans();
+
+  @SqlQuery(
+      "select "
+          + PUBLIC_ID_COLUMN
+          + ", "
+          + BAN_EXPIRY_COLUMN
+          + "\n"
+          + "from banned_user\n"
+          + "where \n"
+          + IP_COLUMN
+          + " = :ip::inet"
+          + " or "
+          + SYSTEM_ID_COLUMN
+          + " = :systemId"
+          + " and "
+          + BAN_EXPIRY_COLUMN
+          + " > now() "
+          + "order by "
+          + BAN_EXPIRY_COLUMN
+          + " desc limit 1")
+  Optional<BanLookupRecord> lookupBan(@Bind("ip") String ip, @Bind("systemId") String systemId);
 
   @SqlQuery(
       "select username\n" //

--- a/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/dao/user/ban/UserBanRecord.java
+++ b/lobby-db-dao/src/main/java/org/triplea/lobby/server/db/dao/user/ban/UserBanRecord.java
@@ -1,5 +1,12 @@
 package org.triplea.lobby.server.db.dao.user.ban;
 
+import static org.triplea.lobby.server.db.dao.user.ban.BanTableColumns.BAN_EXPIRY_COLUMN;
+import static org.triplea.lobby.server.db.dao.user.ban.BanTableColumns.DATE_CREATED_COLUMN;
+import static org.triplea.lobby.server.db.dao.user.ban.BanTableColumns.IP_COLUMN;
+import static org.triplea.lobby.server.db.dao.user.ban.BanTableColumns.PUBLIC_ID_COLUMN;
+import static org.triplea.lobby.server.db.dao.user.ban.BanTableColumns.SYSTEM_ID_COLUMN;
+import static org.triplea.lobby.server.db.dao.user.ban.BanTableColumns.USERNAME_COLUMN;
+
 import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,12 +25,6 @@ import org.triplea.lobby.server.db.TimestampMapper;
 @NoArgsConstructor
 @Getter
 public class UserBanRecord {
-  public static final String PUBLIC_ID_COLUMN = "public_id";
-  public static final String USERNAME_COLUMN = "username";
-  public static final String SYSTEM_ID_COLUMN = "system_id";
-  public static final String IP_COLUMN = "ip";
-  public static final String BAN_EXPIRY_COLUMN = "ban_expiry";
-  public static final String DATE_CREATED_COLUMN = "date_created";
 
   static final String SELECT_CLAUSE =
       PUBLIC_ID_COLUMN

--- a/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/user/ban/BanLookupRecordTest.java
+++ b/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/user/ban/BanLookupRecordTest.java
@@ -1,0 +1,37 @@
+package org.triplea.lobby.server.db.dao.user.ban;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import java.sql.ResultSet;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Calendar;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BanLookupRecordTest {
+  private static final Instant NOW = Instant.now();
+  private static final Timestamp timestamp = Timestamp.from(NOW);
+  private static final String PUBLIC_ID = "public-id";
+
+  @Mock private ResultSet resultSet;
+
+  @Test
+  void buildResultMapper() throws Exception {
+    when(resultSet.getTimestamp(eq(BanTableColumns.BAN_EXPIRY_COLUMN), any(Calendar.class)))
+        .thenReturn(timestamp);
+    when(resultSet.getString(BanTableColumns.PUBLIC_ID_COLUMN)).thenReturn(PUBLIC_ID);
+
+    final BanLookupRecord result = BanLookupRecord.buildResultMapper().map(resultSet, null);
+
+    assertThat(result.getBanExpiry(), is(NOW));
+    assertThat(result.getPublicBanId(), is(PUBLIC_ID));
+  }
+}

--- a/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/user/ban/UserBanRecordTest.java
+++ b/lobby-db-dao/src/test/java/org/triplea/lobby/server/db/dao/user/ban/UserBanRecordTest.java
@@ -33,14 +33,14 @@ class UserBanRecordTest {
 
   @Test
   void buildResultMapper() throws Exception {
-    when(resultSet.getTimestamp(eq(UserBanRecord.BAN_EXPIRY_COLUMN), any(Calendar.class)))
+    when(resultSet.getTimestamp(eq(BanTableColumns.BAN_EXPIRY_COLUMN), any(Calendar.class)))
         .thenReturn(timestamp);
-    when(resultSet.getTimestamp(eq(UserBanRecord.DATE_CREATED_COLUMN), any(Calendar.class)))
+    when(resultSet.getTimestamp(eq(BanTableColumns.DATE_CREATED_COLUMN), any(Calendar.class)))
         .thenReturn(yesterdayTimestamp);
-    when(resultSet.getString(UserBanRecord.SYSTEM_ID_COLUMN)).thenReturn(MAC);
-    when(resultSet.getString(UserBanRecord.IP_COLUMN)).thenReturn(IP);
-    when(resultSet.getString(UserBanRecord.PUBLIC_ID_COLUMN)).thenReturn(PUBLIC_ID);
-    when(resultSet.getString(UserBanRecord.USERNAME_COLUMN)).thenReturn(USERNAME);
+    when(resultSet.getString(BanTableColumns.SYSTEM_ID_COLUMN)).thenReturn(MAC);
+    when(resultSet.getString(BanTableColumns.IP_COLUMN)).thenReturn(IP);
+    when(resultSet.getString(BanTableColumns.PUBLIC_ID_COLUMN)).thenReturn(PUBLIC_ID);
+    when(resultSet.getString(BanTableColumns.USERNAME_COLUMN)).thenReturn(USERNAME);
 
     final UserBanRecord result = UserBanRecord.buildResultMapper().map(resultSet, null);
 

--- a/lobby-db/src/main/resources/db/migration/V2.00.00.2019.11.23__user_ban_updates.sql
+++ b/lobby-db/src/main/resources/db/migration/V2.00.00.2019.11.23__user_ban_updates.sql
@@ -1,0 +1,2 @@
+alter table banned_user drop constraint banned_user_ban_expiry_check;
+create index banned_user_ip on banned_user(ip, system_id);


### PR DESCRIPTION
Adds a filter to the dropwizard http-server to check if a user is
banned by IP or system-id. If so, their request is rejected.

TODO: future iterations should consider caching a white list
and/or black list so that we are not sending a request to DB
on every http request.

After this update, http-server will reject requests from banned users.

<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes

- Existing http clients/requests had to be updated to send a system-id header, so the updates are beyond adding just the filter.
- 'BanDurationFormatter' is moved code so that we can re-use that logic
- The main update is adding: BannedPlayerFilter, updating UserBanDao to provide a lookup method
- DB is updated to remove a constraint for ban expiries, enables test code to insert expired bans, and second we add an index for faster ban lookup
- UserBanDao has the table column names extracted to a new class so that we can share those column names for multiple record lookup objects.