### PR TITLE
Fix pixelated territory name rendering.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
@@ -62,6 +62,8 @@ public class Tile {
             RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
         g.setRenderingHint(
             RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+        g.setRenderingHint(
+            RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
         draw(g, data, mapData);
         g.dispose();
       }

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryNameDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryNameDrawable.java
@@ -14,6 +14,7 @@ import java.awt.Image;
 import java.awt.Point;
 import java.awt.Polygon;
 import java.awt.Rectangle;
+import java.awt.RenderingHints;
 import java.util.List;
 import java.util.Optional;
 
@@ -86,6 +87,9 @@ public class TerritoryNameDrawable extends AbstractDrawable {
 
     graphics.setFont(MapImage.getPropertyMapFont());
     graphics.setColor(MapImage.getPropertyTerritoryNameAndPuAndCommentColor());
+    graphics.setRenderingHint(
+        RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
+
     final FontMetrics fm = graphics.getFontMetrics();
 
     // if we specify a placement point, use it otherwise try to center it

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryNameDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryNameDrawable.java
@@ -14,7 +14,6 @@ import java.awt.Image;
 import java.awt.Point;
 import java.awt.Polygon;
 import java.awt.Rectangle;
-import java.awt.RenderingHints;
 import java.util.List;
 import java.util.Optional;
 
@@ -87,9 +86,6 @@ public class TerritoryNameDrawable extends AbstractDrawable {
 
     graphics.setFont(MapImage.getPropertyMapFont());
     graphics.setColor(MapImage.getPropertyTerritoryNameAndPuAndCommentColor());
-    graphics.setRenderingHint(
-        RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
-
     final FontMetrics fm = graphics.getFontMetrics();
 
     // if we specify a placement point, use it otherwise try to center it


### PR DESCRIPTION
Without this change, territory names look very pixelated. See screenshots.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[X] Problem fix:  pixelated territory names
[] Other:   <!-- Please specify -->


## Testing

[X] Manual testing done

Loaded Great War and looked at territory name rendering.

## Screens Shots

### Before
<img width="687" alt="Screen Shot 2019-11-23 at 10 37 23 AM" src="https://user-images.githubusercontent.com/17648/69481269-dc1c5800-0ddd-11ea-93a7-3aa200704b12.png">


### After
<img width="609" alt="Screen Shot 2019-11-23 at 10 38 07 AM" src="https://user-images.githubusercontent.com/17648/69481274-e3436600-0ddd-11ea-95c0-b1fab1b35649.png">
