### PR TITLE
[Optimization] Collections.reverse() -> Comparator.reversed().

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
@@ -57,8 +57,13 @@ public final class ProBattleUtils {
     final List<Unit> sortedUnitsList = new ArrayList<>(attackingUnits);
     sortedUnitsList.sort(
         new UnitBattleComparator(
-            false, ProData.unitValueMap, TerritoryEffectHelper.getEffects(t), data, false, false));
-    Collections.reverse(sortedUnitsList);
+                false,
+                ProData.unitValueMap,
+                TerritoryEffectHelper.getEffects(t),
+                data,
+                false,
+                false)
+            .reversed());
     final int attackPower =
         DiceRoll.getTotalPower(
             DiceRoll.getUnitPowerAndRollsForNormalBattles(

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
@@ -17,7 +17,6 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.delegate.UnitBattleComparator;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -142,13 +141,13 @@ public final class ProBattleUtils {
     final List<Unit> sortedUnitsList = new ArrayList<>(unitsThatCanFight);
     sortedUnitsList.sort(
         new UnitBattleComparator(
-            !attacking,
-            ProData.unitValueMap,
-            TerritoryEffectHelper.getEffects(t),
-            data,
-            false,
-            false));
-    Collections.reverse(sortedUnitsList);
+                !attacking,
+                ProData.unitValueMap,
+                TerritoryEffectHelper.getEffects(t),
+                data,
+                false,
+                false)
+            .reversed());
     final int myPower =
         DiceRoll.getTotalPower(
             DiceRoll.getUnitPowerAndRollsForNormalBattles(

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
@@ -12,7 +12,6 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.delegate.UnitBattleComparator;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -184,13 +183,13 @@ public final class ProSortMoveOptionsUtils {
               final List<Unit> sortedUnitsList = new ArrayList<>(attackMap.get(t).getUnits());
               sortedUnitsList.sort(
                   new UnitBattleComparator(
-                      false,
-                      ProData.unitValueMap,
-                      TerritoryEffectHelper.getEffects(t),
-                      data,
-                      false,
-                      false));
-              Collections.reverse(sortedUnitsList);
+                          false,
+                          ProData.unitValueMap,
+                          TerritoryEffectHelper.getEffects(t),
+                          data,
+                          false,
+                          false)
+                      .reversed());
               final int powerWithout =
                   DiceRoll.getTotalPower(
                       DiceRoll.getUnitPowerAndRollsForNormalBattles(
@@ -206,13 +205,13 @@ public final class ProSortMoveOptionsUtils {
               sortedUnitsList.add(o1.getKey());
               sortedUnitsList.sort(
                   new UnitBattleComparator(
-                      false,
-                      ProData.unitValueMap,
-                      TerritoryEffectHelper.getEffects(t),
-                      data,
-                      false,
-                      false));
-              Collections.reverse(sortedUnitsList);
+                          false,
+                          ProData.unitValueMap,
+                          TerritoryEffectHelper.getEffects(t),
+                          data,
+                          false,
+                          false)
+                      .reversed());
               final int powerWith =
                   DiceRoll.getTotalPower(
                       DiceRoll.getUnitPowerAndRollsForNormalBattles(
@@ -245,13 +244,13 @@ public final class ProSortMoveOptionsUtils {
               final List<Unit> sortedUnitsList = new ArrayList<>(attackMap.get(t).getUnits());
               sortedUnitsList.sort(
                   new UnitBattleComparator(
-                      false,
-                      ProData.unitValueMap,
-                      TerritoryEffectHelper.getEffects(t),
-                      data,
-                      false,
-                      false));
-              Collections.reverse(sortedUnitsList);
+                          false,
+                          ProData.unitValueMap,
+                          TerritoryEffectHelper.getEffects(t),
+                          data,
+                          false,
+                          false)
+                      .reversed());
               final int powerWithout =
                   DiceRoll.getTotalPower(
                       DiceRoll.getUnitPowerAndRollsForNormalBattles(
@@ -267,13 +266,13 @@ public final class ProSortMoveOptionsUtils {
               sortedUnitsList.add(o2.getKey());
               sortedUnitsList.sort(
                   new UnitBattleComparator(
-                      false,
-                      ProData.unitValueMap,
-                      TerritoryEffectHelper.getEffects(t),
-                      data,
-                      false,
-                      false));
-              Collections.reverse(sortedUnitsList);
+                          false,
+                          ProData.unitValueMap,
+                          TerritoryEffectHelper.getEffects(t),
+                          data,
+                          false,
+                          false)
+                      .reversed());
               final int powerWith =
                   DiceRoll.getTotalPower(
                       DiceRoll.getUnitPowerAndRollsForNormalBattles(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleTracker.java
@@ -32,7 +32,6 @@ import games.strategy.triplea.util.TuvUtils;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -1381,13 +1380,13 @@ public class BattleTracker implements Serializable {
                 defenders, Matches.unitCanBeInBattle(false, !territory.isWater(), 1, true)));
     sortedUnitsList.sort(
         new UnitBattleComparator(
-            true,
-            TuvUtils.getCostsForTuv(bridge.getPlayerId(), gameData),
-            TerritoryEffectHelper.getEffects(territory),
-            gameData,
-            false,
-            false));
-    Collections.reverse(sortedUnitsList);
+                true,
+                TuvUtils.getCostsForTuv(bridge.getPlayerId(), gameData),
+                TerritoryEffectHelper.getEffects(territory),
+                gameData,
+                false,
+                false)
+            .reversed());
     return sortedUnitsList;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/CasualtySelector.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/CasualtySelector.java
@@ -952,9 +952,9 @@ public class CasualtySelector {
     // Sort enough units to kill off
     final List<Unit> sortedUnitsList = new ArrayList<>(targetsToPickFrom);
     sortedUnitsList.sort(
-        new UnitBattleComparator(defending, costs, territoryEffects, data, bonus, false));
+        new UnitBattleComparator(defending, costs, territoryEffects, data, bonus, false)
+            .reversed());
     // Sort units starting with strongest so that support gets added to them first
-    Collections.reverse(sortedUnitsList);
     final UnitBattleComparator unitComparatorWithoutPrimaryPower =
         new UnitBattleComparator(defending, costs, territoryEffects, data, bonus, true);
     final Map<Unit, IntegerMap<Unit>> unitSupportPowerMap = new HashMap<>();

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -30,7 +30,6 @@ import java.awt.event.WindowEvent;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -1429,8 +1428,8 @@ class BattleCalculatorPanel extends JPanel {
       defenderUnitsTotalHitpoints.setText("HP: " + defenseHitPoints);
       final Collection<TerritoryEffect> territoryEffects = getTerritoryEffects();
       final IntegerMap<UnitType> costs = TuvUtils.getCostsForTuv(getAttacker(), data);
-      attackers.sort(new UnitBattleComparator(false, costs, territoryEffects, data, false, false));
-      Collections.reverse(attackers);
+      attackers.sort(
+          new UnitBattleComparator(false, costs, territoryEffects, data, false, false).reversed());
       final int attackPower =
           DiceRoll.getTotalPower(
               DiceRoll.getUnitPowerAndRollsForNormalBattles(

--- a/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -693,13 +693,13 @@ class EditPanel extends ActionPanel {
             sortUnitsToRemove(units);
             units.sort(
                 new UnitBattleComparator(
-                    false,
-                    TuvUtils.getCostsForTuv(player, getData()),
-                    null,
-                    getData(),
-                    true,
-                    false));
-            Collections.reverse(units);
+                        false,
+                        TuvUtils.getCostsForTuv(player, getData()),
+                        null,
+                        getData(),
+                        true,
+                        false)
+                    .reversed());
             // unit mapped to <max, min, current>
             final Map<Unit, Triple<Integer, Integer, Integer>> currentDamageMap = new HashMap<>();
             for (final Unit u : units) {
@@ -772,13 +772,13 @@ class EditPanel extends ActionPanel {
             sortUnitsToRemove(units);
             units.sort(
                 new UnitBattleComparator(
-                    false,
-                    TuvUtils.getCostsForTuv(player, getData()),
-                    null,
-                    getData(),
-                    true,
-                    false));
-            Collections.reverse(units);
+                        false,
+                        TuvUtils.getCostsForTuv(player, getData()),
+                        null,
+                        getData(),
+                        true,
+                        false)
+                    .reversed());
             // unit mapped to <max, min, current>
             final Map<Unit, Triple<Integer, Integer, Integer>> currentDamageMap = new HashMap<>();
             for (final Unit u : units) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -105,7 +105,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
 import java.util.List;
@@ -1485,13 +1484,13 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
             final List<Unit> units = new ArrayList<>(entry.getValue());
             units.sort(
                 new UnitBattleComparator(
-                    false,
-                    TuvUtils.getCostsForTuv(units.get(0).getOwner(), data),
-                    TerritoryEffectHelper.getEffects(entry.getKey()),
-                    data,
-                    true,
-                    false));
-            Collections.reverse(units);
+                        false,
+                        TuvUtils.getCostsForTuv(units.get(0).getOwner(), data),
+                        TerritoryEffectHelper.getEffects(entry.getKey()),
+                        data,
+                        true,
+                        false)
+                    .reversed());
             possibleUnitsToAttackStringForm.put(entry.getKey().getName(), units);
           }
           mapPanel.centerOn(


### PR DESCRIPTION
Changes many places where we were sorting a collection and then calling reverse() on it to instead use the .reversed() comparator. This avoids having to reverse the collection after sorting it and just sorts it in the desired order to begin with.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[X] Feature update or enhancement
[] Feature Removal
[X] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing

[] Manual testing done