### PR TITLE
Simplify scrambling code. No functional changes.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -815,13 +815,13 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       }
       boolean scrambledHere = false;
 
-      // Remove any units that were already scrambled.
+      // Remove any units that were already scrambled to other territories.
       int unitsLeft = 0;
       final var scramblers = scramblersByTerritoryPlayer.get(terrPlayer);
-      for (final Territory from : scramblers.entrySet()) {
+      for (final Territory from : scramblers.keySet()) {
         final Collection<Unit> unitsToScramble = scramblers.get(from).getSecond();
         unitsToScramble.retainAll(from.getUnitCollection());
-        unitsLeft += unitsToScramble.getSecond().size();
+        unitsLeft += unitsToScramble.size();
       }
 
       if (unitsLeft > 0) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -745,8 +745,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       }
       final IBattle battle = battleTracker.getPendingBattle(battleTerr, false, BattleType.NORMAL);
       // do not forget we may already have the territory in the list, so we need to add to the
-      // collection, not overwrite
-      // it.
+      // collection, not overwrite it.
       if (battle != null && battle.isAmphibious() && battle instanceof DependentBattle) {
         final Collection<Territory> amphibFromTerrs =
             ((DependentBattle) battle).getAmphibiousAttackTerritories();
@@ -819,23 +818,22 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       // Remove any units that were already scrambled.
       int unitsLeft = 0;
       final var scramblers = scramblersByTerritoryPlayer.get(terrPlayer);
-      for (final Territory from : scramblers.keySet()) {
-        scramblers.get(from).getSecond().retainAll(from.getUnitCollection());
-        unitsLeft += scramblers.get(from).getSecond().size();
+      for (final Territory from : scramblers.entrySet()) {
+        final Collection<Unit> unitsToScramble = scramblers.get(from).getSecond();
+        unitsToScramble.retainAll(from.getUnitCollection());
+        unitsLeft += unitsToScramble.getSecond().size();
       }
-      if (unitsLeft == 0) {
-        continue;
-      }
-      {
+
+      if (unitsLeft > 0) {
         final Map<Territory, Collection<Unit>> toScramble =
             getRemotePlayer(defender).scrambleUnitsQuery(to, scramblers);
         if (toScramble == null) {
           continue;
         }
-        // verify max allowed
         if (!scramblers.keySet().containsAll(toScramble.keySet())) {
           throw new IllegalStateException("Trying to scramble from illegal territory");
         }
+        // verify max allowed
         for (final Territory t : scramblers.keySet()) {
           if (toScramble.get(t) == null) {
             continue;
@@ -945,8 +943,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
           attackingUnits.removeAll(bombing.getAttackingUnits());
         }
         // no need to create a "bombing" battle or air battle, because those are set up
-        // automatically whenever the map
-        // allows scrambling into an air battle / air raid
+        // automatically whenever the map allows scrambling into an air battle / air raid
         if (attackingUnits.isEmpty()) {
           continue;
         }
@@ -955,14 +952,12 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             .startEvent(
                 defender.getName() + " scrambles to create a battle in territory " + to.getName());
         // TODO: the attacking sea units do not remember where they came from, so they cannot
-        // retreat anywhere. Need to
-        // fix.
+        // retreat anywhere. Need to fix.
         battleTracker.addBattle(new RouteScripted(to), attackingUnits, player, bridge, null, null);
         battle = battleTracker.getPendingBattle(to, false, BattleType.NORMAL);
         if (battle instanceof MustFightBattle) {
           // this is an ugly mess of hacks, but will have to stay here till all transport related
-          // code is gutted and
-          // refactored.
+          // code is gutted and refactored.
           final MustFightBattle mfb = (MustFightBattle) battle;
           final Collection<Territory> neighborsLand =
               data.getMap().getNeighbors(to, Matches.territoryIsLand());
@@ -980,8 +975,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             for (final Unit transport :
                 CollectionUtils.getMatches(attackingUnits, Matches.unitIsTransport())) {
               // however, the map we add to the newly created battle, cannot hold any units that are
-              // NOT in this
-              // territory.
+              // NOT in this territory.
               // BUT it must still hold all transports
               if (!dependenciesForMfb.containsKey(transport)) {
                 dependenciesForMfb.put(transport, new ArrayList<>());
@@ -1022,8 +1016,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
           }
           if (attackingUnits.stream().anyMatch(Matches.unitIsAir().negate())) {
             // TODO: for now, we will hack and say that the attackers came from Everywhere, and hope
-            // the user will
-            // choose the correct place to retreat to! (TODO: Fix this)
+            // the user will choose the correct place to retreat to! (TODO: Fix this)
             final Map<Territory, Collection<Unit>> attackingFromMap = new HashMap<>();
             final Collection<Territory> neighbors =
                 data.getMap()

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -815,16 +815,18 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       }
       boolean scrambledHere = false;
 
-      // Remove any units that were already scrambled to other territories.
-      int unitsLeft = 0;
       final var scramblers = scramblersByTerritoryPlayer.get(terrPlayer);
-      for (final Territory from : scramblers.keySet()) {
-        final Collection<Unit> unitsToScramble = scramblers.get(from).getSecond();
-        unitsToScramble.retainAll(from.getUnitCollection());
-        unitsLeft += unitsToScramble.size();
-      }
+      // Remove any units that were already scrambled to other territories.
+      scramblers
+          .entrySet()
+          .removeIf(
+              e -> {
+                final Collection<Unit> unitsToScramble = e.getValue().getSecond();
+                unitsToScramble.retainAll(e.getKey().getUnitCollection());
+                return unitsToScramble.isEmpty();
+              });
 
-      if (unitsLeft > 0) {
+      if (!scramblers.isEmpty()) {
         final Map<Territory, Collection<Unit>> toScramble =
             getRemotePlayer(defender).scrambleUnitsQuery(to, scramblers);
         if (toScramble == null) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -771,9 +771,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     if (scrambleTerrs.isEmpty()) {
       return;
     }
-    final Map<
-            Tuple<Territory, PlayerId>,
-            Collection<Map<Territory, Tuple<Collection<Unit>, Collection<Unit>>>>>
+    final Map<Tuple<Territory, PlayerId>, Map<Territory, Tuple<Collection<Unit>, Collection<Unit>>>>
         scramblersByTerritoryPlayer = new HashMap<>();
     for (final Territory to : scrambleTerrs.keySet()) {
       // find who we should ask
@@ -807,9 +805,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       if (defender == null || scramblers.isEmpty()) {
         continue;
       }
-      scramblersByTerritoryPlayer
-          .computeIfAbsent(Tuple.of(to, defender), k -> new ArrayList<>())
-          .add(scramblers);
+      scramblersByTerritoryPlayer.put(Tuple.of(to, defender), scramblers);
     }
     // now scramble them
     for (final Tuple<Territory, PlayerId> terrPlayer : scramblersByTerritoryPlayer.keySet()) {
@@ -819,123 +815,120 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         continue;
       }
       boolean scrambledHere = false;
-      for (final var scramblers : scramblersByTerritoryPlayer.get(terrPlayer)) {
-        // verify that we didn't already scramble any of these units
-        final Iterator<Territory> territoryIter = scramblers.keySet().iterator();
-        while (territoryIter.hasNext()) {
-          final Territory t = territoryIter.next();
-          scramblers.get(t).getSecond().retainAll(t.getUnitCollection());
-          if (scramblers.get(t).getSecond().isEmpty()) {
-            territoryIter.remove();
-          }
-        }
-        if (scramblers.isEmpty()) {
+
+      // Remove any units that were already scrambled.
+      int unitsLeft = 0;
+      final var scramblers = scramblersByTerritoryPlayer.get(terrPlayer);
+      for (final Territory from : scramblers.keySet()) {
+        scramblers.get(from).getSecond().retainAll(from.getUnitCollection());
+        unitsLeft += scramblers.get(from).getSecond().size();
+      }
+      if (unitsLeft == 0) {
+        continue;
+      }
+      final Map<Territory, Collection<Unit>> toScramble =
+          getRemotePlayer(defender).scrambleUnitsQuery(to, scramblers);
+      if (toScramble == null) {
+        continue;
+      }
+      // verify max allowed
+      if (!scramblers.keySet().containsAll(toScramble.keySet())) {
+        throw new IllegalStateException("Trying to scramble from illegal territory");
+      }
+      for (final Territory t : scramblers.keySet()) {
+        if (toScramble.get(t) == null) {
           continue;
         }
-        final Map<Territory, Collection<Unit>> toScramble =
-            getRemotePlayer(defender).scrambleUnitsQuery(to, scramblers);
-        if (toScramble == null) {
+        if (toScramble.get(t).size() > getMaxScrambleCount(scramblers.get(t).getFirst())) {
+          throw new IllegalStateException(
+              "Trying to scramble "
+                  + toScramble.get(t).size()
+                  + " out of "
+                  + t.getName()
+                  + ", but max allowed is "
+                  + scramblers.get(t).getFirst());
+        }
+      }
+
+      // Validate players have enough fuel to move there and back
+      final Map<PlayerId, ResourceCollection> playerFuelCost = new HashMap<>();
+      for (final Entry<Territory, Collection<Unit>> entry : toScramble.entrySet()) {
+        final Map<PlayerId, ResourceCollection> map =
+            Route.getScrambleFuelCostCharge(entry.getValue(), entry.getKey(), to, data);
+        for (final var playerAndCostEntry : map.entrySet()) {
+          if (playerFuelCost.containsKey(playerAndCostEntry.getKey())) {
+            playerFuelCost.get(playerAndCostEntry.getKey()).add(playerAndCostEntry.getValue());
+          } else {
+            playerFuelCost.put(playerAndCostEntry.getKey(), playerAndCostEntry.getValue());
+          }
+        }
+      }
+      for (final Entry<PlayerId, ResourceCollection> playerAndCost : playerFuelCost.entrySet()) {
+        if (!playerAndCost
+            .getKey()
+            .getResources()
+            .has(playerAndCost.getValue().getResourcesCopy())) {
+          throw new IllegalStateException(
+              "Not enough fuel to scramble, player: "
+                  + playerAndCost.getKey()
+                  + ", needs: "
+                  + playerAndCost.getValue());
+        }
+      }
+
+      final CompositeChange change = new CompositeChange();
+      for (final Territory t : toScramble.keySet()) {
+        final Collection<Unit> scrambling = toScramble.get(t);
+        if (scrambling == null || scrambling.isEmpty()) {
           continue;
         }
-        // verify max allowed
-        if (!scramblers.keySet().containsAll(toScramble.keySet())) {
-          throw new IllegalStateException("Trying to scramble from illegal territory");
-        }
-        for (final Territory t : scramblers.keySet()) {
-          if (toScramble.get(t) == null) {
-            continue;
+        int numberScrambled = scrambling.size();
+        final Collection<Unit> airbases = t.getUnitCollection().getMatches(airbasesCanScramble);
+        final int maxCanScramble = getMaxScrambleCount(airbases);
+        if (maxCanScramble != Integer.MAX_VALUE) {
+          // TODO: maybe sort from biggest to smallest first?
+          for (final Unit airbase : airbases) {
+            final int allowedScramble = ((TripleAUnit) airbase).getMaxScrambleCount();
+            if (allowedScramble > 0) {
+              final int newAllowed;
+              if (allowedScramble >= numberScrambled) {
+                newAllowed = allowedScramble - numberScrambled;
+                numberScrambled = 0;
+              } else {
+                newAllowed = 0;
+                numberScrambled -= allowedScramble;
+              }
+              change.add(
+                  ChangeFactory.unitPropertyChange(
+                      airbase, newAllowed, TripleAUnit.MAX_SCRAMBLE_COUNT));
+            }
+            if (numberScrambled <= 0) {
+              break;
+            }
           }
-          if (toScramble.get(t).size() > getMaxScrambleCount(scramblers.get(t).getFirst())) {
-            throw new IllegalStateException(
-                "Trying to scramble "
-                    + toScramble.get(t).size()
-                    + " out of "
+        }
+        for (final Unit u : scrambling) {
+          change.add(ChangeFactory.unitPropertyChange(u, t, TripleAUnit.ORIGINATED_FROM));
+          change.add(ChangeFactory.unitPropertyChange(u, true, TripleAUnit.WAS_SCRAMBLED));
+          change.add(Route.getFuelChanges(Set.of(u), new Route(t, to), u.getOwner(), data));
+        }
+        // should we mark combat, or call setupUnitsInSameTerritoryBattles again?
+        change.add(ChangeFactory.moveUnits(t, to, scrambling));
+        bridge
+            .getHistoryWriter()
+            .startEvent(
+                defender.getName()
+                    + " scrambles "
+                    + scrambling.size()
+                    + " units out of "
                     + t.getName()
-                    + ", but max allowed is "
-                    + scramblers.get(t).getFirst());
-          }
-        }
-
-        // Validate players have enough fuel to move there and back
-        final Map<PlayerId, ResourceCollection> playerFuelCost = new HashMap<>();
-        for (final Entry<Territory, Collection<Unit>> entry : toScramble.entrySet()) {
-          final Map<PlayerId, ResourceCollection> map =
-              Route.getScrambleFuelCostCharge(entry.getValue(), entry.getKey(), to, data);
-          for (final var playerAndCostEntry : map.entrySet()) {
-            if (playerFuelCost.containsKey(playerAndCostEntry.getKey())) {
-              playerFuelCost.get(playerAndCostEntry.getKey()).add(playerAndCostEntry.getValue());
-            } else {
-              playerFuelCost.put(playerAndCostEntry.getKey(), playerAndCostEntry.getValue());
-            }
-          }
-        }
-        for (final Entry<PlayerId, ResourceCollection> playerAndCost : playerFuelCost.entrySet()) {
-          if (!playerAndCost
-              .getKey()
-              .getResources()
-              .has(playerAndCost.getValue().getResourcesCopy())) {
-            throw new IllegalStateException(
-                "Not enough fuel to scramble, player: "
-                    + playerAndCost.getKey()
-                    + ", needs: "
-                    + playerAndCost.getValue());
-          }
-        }
-
-        final CompositeChange change = new CompositeChange();
-        for (final Territory t : toScramble.keySet()) {
-          final Collection<Unit> scrambling = toScramble.get(t);
-          if (scrambling == null || scrambling.isEmpty()) {
-            continue;
-          }
-          int numberScrambled = scrambling.size();
-          final Collection<Unit> airbases = t.getUnitCollection().getMatches(airbasesCanScramble);
-          final int maxCanScramble = getMaxScrambleCount(airbases);
-          if (maxCanScramble != Integer.MAX_VALUE) {
-            // TODO: maybe sort from biggest to smallest first?
-            for (final Unit airbase : airbases) {
-              final int allowedScramble = ((TripleAUnit) airbase).getMaxScrambleCount();
-              if (allowedScramble > 0) {
-                final int newAllowed;
-                if (allowedScramble >= numberScrambled) {
-                  newAllowed = allowedScramble - numberScrambled;
-                  numberScrambled = 0;
-                } else {
-                  newAllowed = 0;
-                  numberScrambled -= allowedScramble;
-                }
-                change.add(
-                    ChangeFactory.unitPropertyChange(
-                        airbase, newAllowed, TripleAUnit.MAX_SCRAMBLE_COUNT));
-              }
-              if (numberScrambled <= 0) {
-                break;
-              }
-            }
-          }
-          for (final Unit u : scrambling) {
-            change.add(ChangeFactory.unitPropertyChange(u, t, TripleAUnit.ORIGINATED_FROM));
-            change.add(ChangeFactory.unitPropertyChange(u, true, TripleAUnit.WAS_SCRAMBLED));
-            change.add(Route.getFuelChanges(Set.of(u), new Route(t, to), u.getOwner(), data));
-          }
-          // should we mark combat, or call setupUnitsInSameTerritoryBattles again?
-          change.add(ChangeFactory.moveUnits(t, to, scrambling));
-          bridge
-              .getHistoryWriter()
-              .startEvent(
-                  defender.getName()
-                      + " scrambles "
-                      + scrambling.size()
-                      + " units out of "
-                      + t.getName()
-                      + " to defend against the attack in "
-                      + to.getName(),
-                  scrambling);
-          scrambledHere = true;
-        }
-        if (!change.isEmpty()) {
-          bridge.addChange(change);
-        }
+                    + " to defend against the attack in "
+                    + to.getName(),
+                scrambling);
+        scrambledHere = true;
+      }
+      if (!change.isEmpty()) {
+        bridge.addChange(change);
       }
       if (!scrambledHere) {
         continue;


### PR DESCRIPTION
I was working on another PR that was refactoring this code to a helper class that can be used in another context (I want to use it from the UI code to warn a player when attacking a territory where the defender can scramble) and noticed that the current code is more complex than it needs to be. I decided to do this simplification first rather than coupling it with my other change.

In particular, it was using a data structure that had an extra inner collection for no reason (it always ever had one entry). This change simplifies that and also fixes some comments that were badly formatted.

Behaviour should not change.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[X] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing

[X] Manual testing done

Tested out scrambling on WWII Global 2nd Edition, with german subs attacking 3 territories around UK where planes from Scotland and London (which has UK and French planes) can scramble.
