### PR TITLE
Specify full type instead of var.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -815,7 +815,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       }
       boolean scrambledHere = false;
 
-      final var scramblers = scramblersByTerritoryPlayer.get(terrPlayer);
+      final Map<Territory, Tuple<Collection<Unit>, Collection<Unit>>> scramblers =
+          scramblersByTerritoryPlayer.get(terrPlayer);
       // Remove any units that were already scrambled to other territories.
       scramblers
           .entrySet()


### PR DESCRIPTION
Small followup to https://github.com/triplea-game/triplea/pull/5573#discussion_r349934728 to specify the complete type instead of var.

Note: This should be ideally refactored more to use dedicated types rather than Tuple, but for now spell out the type which helps to understand what it is.