### PR TITLE
Cleanup code and make battle drawable deterministic.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/BattleDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/BattleDrawable.java
@@ -31,32 +31,29 @@ public class BattleDrawable extends TerritoryDrawable {
       final GameData data,
       final Graphics2D graphics,
       final MapData mapData) {
+    final Territory territory = data.getMap().getTerritory(territoryName);
     final Set<PlayerId> players = new HashSet<>();
-    for (final Unit u : data.getMap().getTerritory(territoryName).getUnitCollection()) {
+    for (final Unit u : territory.getUnitCollection()) {
       if (!TripleAUnit.get(u).getSubmerged()) {
         players.add(u.getOwner());
       }
     }
-    final Territory territory = data.getMap().getTerritory(territoryName);
     PlayerId attacker = null;
     boolean draw = false;
-    for (final PlayerId p : players) {
-      if (!territory.isWater()) {
+
+    if (!territory.isWater()) {
+      for (final PlayerId p : players) {
         if (data.getRelationshipTracker().isAtWar(p, territory.getOwner())) {
           attacker = p;
           draw = true;
           break;
         }
+      }
+    }
 
-        // O(n^2), but n is usually 2, and almost always < 10
-        for (final PlayerId p2 : players) {
-          if (data.getRelationshipTracker().isAtWar(p, p2)) {
-            draw = true;
-            break;
-          }
-        }
-      } else {
-        // O(n^2), but n is usually 2, and almost always < 10
+    if (!draw) {
+      // O(n^2), but n is usually 2, and almost always < 10
+      for (final PlayerId p : players) {
         for (final PlayerId p2 : players) {
           if (data.getRelationshipTracker().isAtWar(p, p2)) {
             draw = true;
@@ -65,6 +62,7 @@ public class BattleDrawable extends TerritoryDrawable {
         }
       }
     }
+
     if (draw) {
       final Color stripeColor;
       if (attacker == null || territory.isWater()) {


### PR DESCRIPTION
Cleans up some code in BattleDrawable and removes some nondeterminism.

The nondeterminism was due to the fact that Set does not have a deterministic iteration order. With the previous logic, for non-water territories it was not deterministic whether the stripe color of the attacker would be used or not - if there are two other warring players there. Now, if there is an attacker (i.e. someone at war with territory owner), their stripe color will be used.

(Though there is still nondeterminism if there is more than one attacker player.)

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[X] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
[] Manual testing done
