### PR TITLE
Fix potential NPE, return empty collection instead of null

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -614,11 +614,11 @@ public class TerritoryAttachment extends DefaultAttachment {
    * Returns the collection of territories that make up the convoy route containing the specified
    * territory or {@code null} if the specified territory is not part of a convoy route.
    */
-  public static Set<Territory> getWhatTerritoriesThisIsUsedInConvoysFor(
+  public static Collection<Territory> getWhatTerritoriesThisIsUsedInConvoysFor(
       final Territory t, final GameData data) {
     final TerritoryAttachment ta = TerritoryAttachment.get(t);
     if (ta == null || !ta.getConvoyRoute()) {
-      return null;
+      return new HashSet<>();
     }
     final Set<Territory> territories = new HashSet<>();
     for (final Territory current : data.getMap().getTerritories()) {
@@ -696,7 +696,7 @@ public class TerritoryAttachment extends DefaultAttachment {
       if (!convoyAttached.isEmpty()) {
         sb.append("Needs: ").append(MyFormatter.defaultNamedToTextList(convoyAttached)).append(br);
       }
-      final Set<Territory> requiredBy = getWhatTerritoriesThisIsUsedInConvoysFor(t, getData());
+      final Collection<Territory> requiredBy = getWhatTerritoriesThisIsUsedInConvoysFor(t, getData());
       if (!requiredBy.isEmpty()) {
         sb.append("Required By: ")
             .append(MyFormatter.defaultNamedToTextList(requiredBy))

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -696,7 +696,8 @@ public class TerritoryAttachment extends DefaultAttachment {
       if (!convoyAttached.isEmpty()) {
         sb.append("Needs: ").append(MyFormatter.defaultNamedToTextList(convoyAttached)).append(br);
       }
-      final Collection<Territory> requiredBy = getWhatTerritoriesThisIsUsedInConvoysFor(t, getData());
+      final Collection<Territory> requiredBy =
+          getWhatTerritoriesThisIsUsedInConvoysFor(t, getData());
       if (!requiredBy.isEmpty()) {
         sb.append("Required By: ")
             .append(MyFormatter.defaultNamedToTextList(requiredBy))

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -612,21 +612,23 @@ public class TerritoryAttachment extends DefaultAttachment {
 
   /**
    * Returns the collection of territories that make up the convoy route containing the specified
-   * territory or {@code null} if the specified territory is not part of a convoy route.
+   * territory or returns an empty collection if the specified territory is not part of a convoy
+   * route.
    */
   public static Collection<Territory> getWhatTerritoriesThisIsUsedInConvoysFor(
-      final Territory t, final GameData data) {
-    final TerritoryAttachment ta = TerritoryAttachment.get(t);
+      final Territory territory, final GameData data) {
+    final TerritoryAttachment ta = TerritoryAttachment.get(territory);
     if (ta == null || !ta.getConvoyRoute()) {
       return new HashSet<>();
     }
-    final Set<Territory> territories = new HashSet<>();
+
+    final Collection<Territory> territories = new HashSet<>();
     for (final Territory current : data.getMap().getTerritories()) {
       final TerritoryAttachment cta = TerritoryAttachment.get(current);
       if (cta == null || !cta.getConvoyRoute()) {
         continue;
       }
-      if (cta.getConvoyAttached().contains(t)) {
+      if (cta.getConvoyAttached().contains(territory)) {
         territories.add(current);
       }
     }


### PR DESCRIPTION
Usages of `getWhatTerritoriesThisIsUsedInConvoysFor` will NPE if
we return null, the callers do not use `null` checks but instead
`isEmpty` checks that would otherwise NPE.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix: fix potential NPE <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes

Example location that could NPE: https://github.com/DanVanAtta/triplea/blob/ca0f1361a4efe3847aed2e982ac3587694e3a891/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java#L700
