### PR TITLE
Allow build or download of deployment artifacts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,7 +96,7 @@ jobs:
         - ./.travis/setup_gpg
         ## Update product version to include build number.
         ## EG: replace "2.0.0" to be "2.0.15555";
-        - sed -i "s/.0$/.$TRAVIS_BUILD_NUMBER/" game-core/src/main/resources/META-INF/triplea/product.properties
+        - sed -i "s/.0 *$/.$TRAVIS_BUILD_NUMBER/" game-core/src/main/resources/META-INF/triplea/product.properties
         - ./.travis/do_release
       deploy:
         jdk: openjdk11
@@ -129,7 +129,7 @@ jobs:
       python: "3.6"
       script:
         - sed -i "s/.0$/.$TRAVIS_BUILD_NUMBER/" game-core/src/main/resources/META-INF/triplea/product.properties
-        - version=$(cat game-core/src/main/resources/META-INF/triplea/product.properties | sed 's/.* //')
+        - version=$(cat game-core/src/main/resources/META-INF/triplea/product.properties | tr -d ' ' | sed 's/.*=//')
         - eval "$(ssh-agent -s)"
         - cd infrastructure
         - ./build_artifacts

--- a/.travis.yml
+++ b/.travis.yml
@@ -128,13 +128,30 @@ jobs:
       language: python
       python: "3.6"
       script:
+        - sed -i "s/.0$/.$TRAVIS_BUILD_NUMBER/" game-core/src/main/resources/META-INF/triplea/product.properties
+        - version=$(cat game-core/src/main/resources/META-INF/triplea/product.properties | sed 's/.* //')
         - eval "$(ssh-agent -s)"
-        - version=$(sed "s/.0$/.$TRAVIS_BUILD_NUMBER/" game-core/src/main/resources/META-INF/triplea/product.properties)
         - cd infrastructure
-        - export ANSIBLE_HOST_KEY_CHECKING=False
+        - ./build_artifacts
         - echo "$ANSIBLE_VAULT_PASSWORD" > vault_password
         - ./run_deployment "$version" -i ansible/inventory/prerelease
-
+    - stage: deploy production
+      if: (branch = master) and (repo = 'triplea-game/triplea') and (type != 'pull_request')
+      addons:
+        apt:
+          packages:
+            - sshpass
+      install:
+        - pip install ansible
+      language: python
+      python: "3.6"
+      script:
+        - version="2.0.16817"
+        - ./.travis/download_artifacts "$version" 
+        - eval "$(ssh-agent -s)"
+        - cd infrastructure
+        - echo "$ANSIBLE_VAULT_PASSWORD" > vault_password
+        # - ./run_deployment "$version" -i ansible/inventory/production
 after_failure:
   - echo "================ Build step 'after_failure' =================" > /dev/null
-  -  test "$TRAVIS_EVENT_TYPE" != "pull_request" && test "$TRAVIS_BRANCH" = master && ./.travis/report_build_status FAILURE
+  - test "$TRAVIS_EVENT_TYPE" != "pull_request" && test "$TRAVIS_BRANCH" = master && ./.travis/report_build_status FAILURE

--- a/infrastructure/build_deployment_artifacts
+++ b/infrastructure/build_deployment_artifacts
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -x
+(
+  cd ../ || exit 1
+  ./gradlew :http-server:shadowJar :game-headless:shadowJar :lobby-db:release
+
+  ANSIBLE_ROLES_FOLDER="infrastructure/ansible/roles"
+
+  function deployShadowJar() {
+    local -r gradleProjectName="$1"
+    local -r ansibleRoleName="$2"
+
+    mkdir -p "$ANSIBLE_ROLES_FOLDER/$ansibleRoleName/files/"
+    cp "$gradleProjectName"/build/libs/* "$ANSIBLE_ROLES_FOLDER/$ansibleRoleName/files/"
+  }
+
+  deployShadowJar "http-server" "http_server"
+  deployShadowJar "game-headless" "bot"
+
+  cp lobby-db/build/artifacts/* "$ANSIBLE_ROLES_FOLDER/flyway/files/"
+)

--- a/infrastructure/download_deployment_artifacts
+++ b/infrastructure/download_deployment_artifacts
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Downloads artifacts that are deployed to TripleA servers
+# Places artifacts in ansible folder structure where ansible can then find those files.
+
+set -eu
+
+if [ "$#" -lt 1 ]; then
+  echo "Usage: $0 [Version]"
+  exit 1
+fi
+
+VERSION=${1-}
+
+DOWNLOAD_URL="https://github.com/triplea-game/triplea/releases/download/$VERSION"
+
+function downloadZippedJarFile() {
+  local -r fileName="$1"
+  local -r installPath="$2"
+  local -r tempDir=$(mktemp -d)
+
+  wget -P "$tempDir" "$DOWNLOAD_URL/$fileName.zip"
+  unzip "$tempDir/$fileName.zip" -d "$tempDir/"
+  mkdir -p "$installPath"
+  mv "$tempDir/bin/$fileName.jar" "$installPath/"
+  rm -rf "$tempDir"
+}
+
+downloadZippedJarFile "triplea-game-headless-$VERSION" "ansible/roles/bot/files"
+downloadZippedJarFile "triplea-http-server-$VERSION" "ansible/roles/http_server/files"
+
+wget "$DOWNLOAD_URL/migrations.zip"
+mkdir -p ansible/roles/flyway/files/
+mv migrations.zip ansible/roles/flyway/files/

--- a/infrastructure/run_deployment
+++ b/infrastructure/run_deployment
@@ -7,10 +7,11 @@
 # to /home/ansible.
 
 function usage() {
-  echo "Usage: $0 [Version] [ansible args]"
-  echo "  Version: The version of tripleA to be downloaded and installed, eg: 1.10.0.141"
-  echo "  InventoryFile: The inventory file to run, one of: {production|prerelease}"
-  echo "Example: $0 1.10.5252 prerelease"
+  echo "Usage: $0 [Version] [ansible_args]"
+  echo "  version: The version of tripleA we will deploy eg: 1.10.5252"
+  echo "  ansible_args: Args passed to ansible-playbook"
+  echo "Example: $0 1.10.5252 -i ansible/inventory/prerelease"
+  echo "Example: $0 1.10.5252 --diff -v -i ansible/inventory/prerelease"
   exit 1
 }
 
@@ -27,78 +28,27 @@ if [ ! -f "$VAULT_PASSWORD_FILE" ]; then
   exit 1
 fi
 
-if [ ! -f "ansible_ssh_key.ed25519" ]; then
-  echo "Could not find file ansible_ssh_key.ed25519 at current directory"
+HTTP_SERVER_JAR="ansible/roles/http_server/files/triplea-http-server-$VERSION.jar"
+if [ ! -f "$HTTP_SERVER_JAR" ]; then
+  echo "Error: File does not exist: $HTTP_SERVER_JAR"
+  exit 1
+fi
+
+BOT_JAR="ansible/roles/bot/files/triplea-game-headless-$VERSION.jar"
+if [ ! -f "$BOT_JAR" ]; then
+  echo "Error: File does not exist: $BOT_JAR"
+  exit 1
+fi
+
+MIGRATIONS_ZIP="ansible/roles/flyway/files/migrations.zip"
+if [ ! -f "$MIGRATIONS_ZIP" ]; then
+  echo "Error: File does not exist: $MIGRATIONS_ZIP"
   exit 1
 fi
 
 ansible-vault view --vault-password-file="$VAULT_PASSWORD_FILE" ansible_ssh_key.ed25519 | ssh-add -
 
-BOT_JAR="triplea-game-headless-$VERSION.jar"
-BOT_JAR_PATH="ansible/roles/bot/files/$BOT_JAR"
-HTTP_SERVER_JAR="triplea-http-server-$VERSION.jar"
-HTTP_SERVER_JAR_PATH="ansible/roles/http_server/files/$HTTP_SERVER_JAR"
-
-
-set -x
-
-function downloadHttpServerJar() {
-  HTTP_SERVER_ZIP="triplea-http-server-$VERSION.zip"
-  rm -f "$HTTP_SERVER_ZIP"
-  HTTP_SERVER_DL_LOCATION="https://github.com/triplea-game/triplea/releases/download/$VERSION/$HTTP_SERVER_ZIP"
-  wget "$HTTP_SERVER_DL_LOCATION"
-  if [ ! -f "$HTTP_SERVER_ZIP" ]; then
-    echo "ERROR: failed to download http server zip from: $HTTP_SERVER_ZIP"
-    exit 1
-  fi
-
-  unzip "$HTTP_SERVER_ZIP" -d http-server
-  rm "$HTTP_SERVER_ZIP"
-
-  mkdir -p ansible/roles/http_server/files/
-  mv "http-server/bin/$HTTP_SERVER_JAR" "$HTTP_SERVER_JAR_PATH"
-}
-
-function downloadBotJar() {
-  local -r botZip="triplea-game-headless-$VERSION.zip"
-  rm -f "$botZip"
-  BOT_DL_LOCATION="https://github.com/triplea-game/triplea/releases/download/$VERSION/$botZip"
-  wget $BOT_DL_LOCATION
-  if [ ! -f "$botZip" ]; then
-    echo "ERROR: failed to download bot zip from: $BOT_DL_LOCATION"
-  fi
-  rm -rf bot/
-  unzip "$botZip" -d bot
-  rm "$botZip"
-  mkdir -p ansible/roles/bot/files/
-  mv "bot/bin/$BOT_JAR" "$BOT_JAR_PATH"
-}
-
-function downloadMigrations() {
-  local -r migrationsZip="migrations.zip"
-
-  rm -f "$migrationsZip"
-  local migrationsDlLocation="https://github.com/triplea-game/triplea/releases/download/$VERSION/migrations.zip"
-  wget "$migrationsDlLocation"
-  if [ ! -f "$migrationsZip" ]; then
-    echo "ERROR: failed to download migrations zip from: $migrationsDlLocation"
-  fi
-  
-  mkdir -p ansible/roles/flyway/files/
-  mv "$migrationsZip" ansible/roles/flyway/files/
-}
-
-if [ ! -e "$HTTP_SERVER_JAR_PATH" ]; then
-downloadHttpServerJar
-fi
-
-if [ ! -e "$BOT_JAR_PATH" ]; then
-  downloadBotJar
-fi
-
-downloadMigrations
-
 ansible-playbook \
   --vault-password-file "$VAULT_PASSWORD_FILE" \
- $@ \
+ "$@" \
  ansible/site.yml


### PR DESCRIPTION
- Updates prerelease configuration to build artifacts instead of download
- Sets up for auto-prod deployments, allows for prod artifacts to be downloaded


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done
Did some quick smoke testing, verified works on prerelease:
`./run_deployment 2.0.16821 -v --diff -i ansible/inventory/prerelease`

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

