### PR TITLE
Fix ansible.cfg and add props

### DIFF
--- a/infrastructure/ansible.cfg
+++ b/infrastructure/ansible.cfg
@@ -1,6 +1,10 @@
-callback_whitelist = profile_tasks
+[defaults]
+host_key_checking = False
 
 [ssh_connection]
 pipelining = True
 control_path = /tmp/ansible-ssh-%%h-%%p-%%r
 ControlPersist = 60s
+
+[persistent_connection]
+connect_timeout = 30


### PR DESCRIPTION
The ansible.cfg override file should not be dot-prefixed for it
to be picked up. This update corrects that.

Props added:
- host_key_checking: prevously was passed via CLI, this prevents
ssh connections from failing when a different host is present
under the same DNS address.
- connect_timeout: configures timeout for persistent connection,
no activity after 30s will close a persistent SSH connection


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

