### PR TITLE
Break long chat lines

### DIFF
--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/events/server/ChatMessage.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/events/server/ChatMessage.java
@@ -1,7 +1,10 @@
 package org.triplea.http.client.lobby.chat.events.server;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Ascii;
+import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
 import lombok.Value;
 import org.triplea.domain.data.PlayerName;
 
@@ -10,8 +13,18 @@ public class ChatMessage {
   private final PlayerName from;
   private final String message;
 
+  @VisibleForTesting static final int MAX_MESSAGE_LENGTH = 200;
+  @VisibleForTesting static final int MAX_LINE_LENGTH = 100;
+  @VisibleForTesting static final String ELLIPSES = "..";
+
   public ChatMessage(final PlayerName from, final String message) {
     this.from = Preconditions.checkNotNull(from);
-    this.message = Ascii.truncate(Preconditions.checkNotNull(message), 200, "..");
+    this.message =
+        Joiner.on("\n")
+            .join(
+                Splitter.fixedLength(MAX_LINE_LENGTH)
+                    .splitToList(
+                        Ascii.truncate(
+                            Preconditions.checkNotNull(message), MAX_MESSAGE_LENGTH, ELLIPSES)));
   }
 }

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/events/server/ChatMessage.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/events/server/ChatMessage.java
@@ -10,12 +10,12 @@ import org.triplea.domain.data.PlayerName;
 
 @Value
 public class ChatMessage {
-  private final PlayerName from;
-  private final String message;
-
   @VisibleForTesting static final int MAX_MESSAGE_LENGTH = 200;
   @VisibleForTesting static final int MAX_LINE_LENGTH = 100;
   @VisibleForTesting static final String ELLIPSES = "..";
+
+  private final PlayerName from;
+  private final String message;
 
   public ChatMessage(final PlayerName from, final String message) {
     this.from = Preconditions.checkNotNull(from);

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/chat/events/server/ChatMessageTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/chat/events/server/ChatMessageTest.java
@@ -25,7 +25,7 @@ class ChatMessageTest {
   @Test
   @DisplayName("Verify a message at max line length is left untouched")
   void messageAtMaxLineLength() {
-    String testString = createStringWithLength(ChatMessage.MAX_LINE_LENGTH);
+    final String testString = createStringWithLength(ChatMessage.MAX_LINE_LENGTH);
 
     final String result = chatMessage(testString);
 
@@ -35,7 +35,7 @@ class ChatMessageTest {
   @Test
   @DisplayName("Verify a message over max line length is split untouched")
   void messageOverMaxLineLength() {
-    String testString = createStringWithLength(ChatMessage.MAX_LINE_LENGTH + 1);
+    final String testString = createStringWithLength(ChatMessage.MAX_LINE_LENGTH + 1);
 
     final String result = chatMessage(testString);
 
@@ -52,7 +52,7 @@ class ChatMessageTest {
   @Test
   @DisplayName("Verify message at max length is not truncated")
   void messageAtMaxLimit() {
-    String testString = createStringWithLength(ChatMessage.MAX_MESSAGE_LENGTH);
+    final String testString = createStringWithLength(ChatMessage.MAX_MESSAGE_LENGTH);
 
     final String result = chatMessage(testString);
 
@@ -62,7 +62,7 @@ class ChatMessageTest {
   @Test
   @DisplayName("Verify message over max length is truncated")
   void messageOverMaxLimit() {
-    String testString = createStringWithLength(ChatMessage.MAX_MESSAGE_LENGTH + 1);
+    final String testString = createStringWithLength(ChatMessage.MAX_MESSAGE_LENGTH + 1);
 
     final String result = chatMessage(testString);
 

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/chat/events/server/ChatMessageTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/chat/events/server/ChatMessageTest.java
@@ -1,0 +1,79 @@
+package org.triplea.http.client.lobby.chat.events.server;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsNot.not;
+import static org.hamcrest.core.StringEndsWith.endsWith;
+
+import com.google.common.base.Strings;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.triplea.domain.data.PlayerName;
+
+class ChatMessageTest {
+
+  @Test
+  @DisplayName("Verify a message under max line length is left untouched")
+  void messageUnderMaxLineLength() {
+    final String testString = createStringWithLength(ChatMessage.MAX_LINE_LENGTH - 1);
+
+    final String result = chatMessage(testString);
+
+    assertThat("expecting no difference, string is under the length limit", result, is(testString));
+  }
+
+  @Test
+  @DisplayName("Verify a message at max line length is left untouched")
+  void messageAtMaxLineLength() {
+    String testString = createStringWithLength(ChatMessage.MAX_LINE_LENGTH);
+
+    final String result = chatMessage(testString);
+
+    assertThat("expecting no difference, string is at the limit", result, is(testString));
+  }
+
+  @Test
+  @DisplayName("Verify a message over max line length is split untouched")
+  void messageOverMaxLineLength() {
+    String testString = createStringWithLength(ChatMessage.MAX_LINE_LENGTH + 1);
+
+    final String result = chatMessage(testString);
+
+    assertThat(
+        "String is expected to be split, should see a newline at the max line length",
+        String.valueOf(result.charAt(ChatMessage.MAX_LINE_LENGTH)),
+        is("\n"));
+    assertThat(
+        "Expecting a single new line to have been inserted",
+        result.length(),
+        is(testString.length() + "\n".length()));
+  }
+
+  @Test
+  @DisplayName("Verify message at max length is not truncated")
+  void messageAtMaxLimit() {
+    String testString = createStringWithLength(ChatMessage.MAX_MESSAGE_LENGTH);
+
+    final String result = chatMessage(testString);
+
+    assertThat(result, not(endsWith(ChatMessage.ELLIPSES)));
+  }
+
+  @Test
+  @DisplayName("Verify message over max length is truncated")
+  void messageOverMaxLimit() {
+    String testString = createStringWithLength(ChatMessage.MAX_MESSAGE_LENGTH + 1);
+
+    final String result = chatMessage(testString);
+
+    assertThat(result, endsWith(ChatMessage.ELLIPSES));
+  }
+
+  private static String createStringWithLength(final int length) {
+    return Strings.repeat("a", length);
+  }
+
+  private static String chatMessage(final String inputMessage) {
+    return new ChatMessage(PlayerName.of("player-name"), inputMessage).getMessage();
+  }
+}


### PR DESCRIPTION
Adds new lines to long chat lines. Previously long chat messages would continue on
the same line and cause scrollbars to be added to the chat dialog, and eventually
the message would be truncated. This update breaks long chat messages at every 100
characters and maintains a truncation length at 200.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

