### PR TITLE
Switch APIs from List<Unit> to Collection<Unit> and remove List casts.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProAi.java
@@ -311,8 +311,8 @@ public class ProAi extends AbstractAi {
     // If attacker with more unit strength or strafing and isn't land battle with only air left then
     // don't retreat
     final boolean isAttacker = player.equals(battle.getAttacker());
-    final List<Unit> attackers = (List<Unit>) battle.getAttackingUnits();
-    final List<Unit> defenders = (List<Unit>) battle.getDefendingUnits();
+    final Collection<Unit> attackers = battle.getAttackingUnits();
+    final Collection<Unit> defenders = battle.getDefendingUnits();
     final double strengthDifference =
         ProBattleUtils.estimateStrengthDifference(battleTerritory, attackers, defenders);
     final boolean isStrafing = isAttacker && storedStrafingTerritories.contains(battleTerritory);
@@ -395,8 +395,8 @@ public class ProAi extends AbstractAi {
       boolean needToCheck = true;
       final boolean isAttacker = player.equals(battle.getAttacker());
       if (!isAttacker) {
-        final List<Unit> attackers = (List<Unit>) battle.getAttackingUnits();
-        final List<Unit> defenders = (List<Unit>) battle.getDefendingUnits();
+        final Collection<Unit> attackers = battle.getAttackingUnits();
+        final Collection<Unit> defenders = battle.getDefendingUnits();
         defenders.removeAll(defaultCasualties.getKilled());
         final double strengthDifference =
             ProBattleUtils.estimateStrengthDifference(battleSite, attackers, defenders);
@@ -455,8 +455,8 @@ public class ProAi extends AbstractAi {
     if (battle == null) {
       return null;
     }
-    final List<Unit> attackers = (List<Unit>) battle.getAttackingUnits();
-    final List<Unit> defenders = (List<Unit>) battle.getDefendingUnits();
+    final Collection<Unit> attackers = battle.getAttackingUnits();
+    final Collection<Unit> defenders = battle.getDefendingUnits();
     ProLogger.info(
         player.getName()
             + " checking scramble to "
@@ -486,8 +486,8 @@ public class ProAi extends AbstractAi {
     if (battle == null) {
       return false;
     }
-    final List<Unit> attackers = (List<Unit>) battle.getAttackingUnits();
-    final List<Unit> defenders = (List<Unit>) battle.getDefendingUnits();
+    final Collection<Unit> attackers = battle.getAttackingUnits();
+    final Collection<Unit> defenders = battle.getDefendingUnits();
     ProLogger.info(
         player.getName()
             + " checking sub attack in "

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProRetreatAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProRetreatAi.java
@@ -17,7 +17,6 @@ import games.strategy.triplea.delegate.Matches;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.UUID;
 
 /**
@@ -58,8 +57,8 @@ class ProRetreatAi {
 
     // Get units and determine if attacker
     final boolean isAttacker = player.equals(battle.getAttacker());
-    final List<Unit> attackers = (List<Unit>) battle.getAttackingUnits();
-    final List<Unit> defenders = (List<Unit>) battle.getDefendingUnits();
+    final Collection<Unit> attackers = battle.getAttackingUnits();
+    final Collection<Unit> defenders = battle.getDefendingUnits();
 
     // Calculate battle results
     final ProBattleResult result =

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProScrambleAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProScrambleAi.java
@@ -45,8 +45,8 @@ class ProScrambleAi {
         delegate.getBattleTracker().getPendingBattle(scrambleTo, false, BattleType.NORMAL);
 
     // Check if defense already wins
-    final List<Unit> attackers = (List<Unit>) battle.getAttackingUnits();
-    final List<Unit> defenders = (List<Unit>) battle.getDefendingUnits();
+    final Collection<Unit> attackers = battle.getAttackingUnits();
+    final Collection<Unit> defenders = battle.getDefendingUnits();
     final Set<Unit> bombardingUnits = new HashSet<>(battle.getBombardingUnits());
     final ProBattleResult minResult =
         calc.calculateBattleResults(scrambleTo, attackers, defenders, bombardingUnits);
@@ -123,7 +123,7 @@ class ProScrambleAi {
     ProBattleResult result = minResult;
     for (final Unit u : sortedUnitDefendOptions.keySet()) {
       unitsToScramble.add(u);
-      final List<Unit> currentDefenders = (List<Unit>) battle.getDefendingUnits();
+      final Collection<Unit> currentDefenders = battle.getDefendingUnits();
       currentDefenders.addAll(unitsToScramble);
       result =
           calc.calculateBattleResults(scrambleTo, attackers, currentDefenders, bombardingUnits);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProBattleResult.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProBattleResult.java
@@ -2,7 +2,7 @@ package games.strategy.triplea.ai.pro.data;
 
 import games.strategy.engine.data.Unit;
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Collection;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.ToString;
@@ -16,8 +16,8 @@ public class ProBattleResult {
   private final double winPercentage;
   private final double tuvSwing;
   private final boolean hasLandUnitRemaining;
-  private final List<Unit> averageAttackersRemaining;
-  private final List<Unit> averageDefendersRemaining;
+  private final Collection<Unit> averageAttackersRemaining;
+  private final Collection<Unit> averageDefendersRemaining;
   private final double battleRounds;
 
   public ProBattleResult() {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
@@ -59,9 +59,9 @@ public final class ProSimulateTurnUtils {
             battleDelegate
                 .getBattleTracker()
                 .getPendingBattle(t, entry.getKey().isBombingRun(), entry.getKey());
-        final List<Unit> attackers = (List<Unit>) battle.getAttackingUnits();
+        final Collection<Unit> attackers = battle.getAttackingUnits();
         attackers.retainAll(t.getUnits());
-        final List<Unit> defenders = (List<Unit>) battle.getDefendingUnits();
+        final Collection<Unit> defenders = battle.getDefendingUnits();
         defenders.retainAll(t.getUnits());
         final Set<Unit> bombardingUnits = new HashSet<>(battle.getBombardingUnits());
         ProLogger.debug("---" + t);
@@ -71,8 +71,8 @@ public final class ProSimulateTurnUtils {
 
         final ProBattleResult result =
             calc.callBattleCalc(t, attackers, defenders, bombardingUnits);
-        final List<Unit> remainingAttackers = result.getAverageAttackersRemaining();
-        final List<Unit> remainingDefenders = result.getAverageDefendersRemaining();
+        final Collection<Unit> remainingAttackers = result.getAverageAttackersRemaining();
+        final Collection<Unit> remainingDefenders = result.getAverageDefendersRemaining();
         ProLogger.debug("remainingAttackers=" + remainingAttackers);
         ProLogger.debug("remainingDefenders=" + remainingDefenders);
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
@@ -17,6 +17,7 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.delegate.UnitBattleComparator;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -39,7 +40,9 @@ public final class ProBattleUtils {
    * or within a single round of combat.
    */
   public static boolean checkForOverwhelmingWin(
-      final Territory t, final List<Unit> attackingUnits, final List<Unit> defendingUnits) {
+      final Territory t,
+      final Collection<Unit> attackingUnits,
+      final Collection<Unit> defendingUnits) {
     final GameData data = ProData.getData();
 
     if (defendingUnits.isEmpty() && !attackingUnits.isEmpty()) {
@@ -90,7 +93,9 @@ public final class ProBattleUtils {
    *     indicates equal attacker and defender strength.
    */
   public static double estimateStrengthDifference(
-      final Territory t, final List<Unit> attackingUnits, final List<Unit> defendingUnits) {
+      final Territory t,
+      final Collection<Unit> attackingUnits,
+      final Collection<Unit> defendingUnits) {
 
     if (attackingUnits.stream().allMatch(Matches.unitIsInfrastructure())) {
       return 0;
@@ -110,8 +115,8 @@ public final class ProBattleUtils {
    */
   public static double estimateStrength(
       final Territory t,
-      final List<Unit> myUnits,
-      final List<Unit> enemyUnits,
+      final Collection<Unit> myUnits,
+      final Collection<Unit> enemyUnits,
       final boolean attacking) {
     final GameData data = ProData.getData();
 
@@ -130,8 +135,8 @@ public final class ProBattleUtils {
 
   private static double estimatePower(
       final Territory t,
-      final List<Unit> myUnits,
-      final List<Unit> enemyUnits,
+      final Collection<Unit> myUnits,
+      final Collection<Unit> enemyUnits,
       final boolean attacking) {
     final GameData data = ProData.getData();
 
@@ -300,7 +305,7 @@ public final class ProBattleUtils {
       final Territory t,
       final PlayerId player,
       final Map<Territory, ProPurchaseTerritory> purchaseTerritories,
-      final List<Unit> unitsToPlace) {
+      final Collection<Unit> unitsToPlace) {
     final GameData data = ProData.getData();
 
     int landDistance = ProUtils.getClosestEnemyLandTerritoryDistanceOverWater(data, player, t);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProOddsCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProOddsCalculator.java
@@ -13,8 +13,8 @@ import games.strategy.triplea.odds.calculator.AggregateResults;
 import games.strategy.triplea.odds.calculator.IBattleCalculator;
 import games.strategy.triplea.util.TuvUtils;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 import org.triplea.java.collections.CollectionUtils;
 
 /** Pro AI odds calculator. */
@@ -44,9 +44,9 @@ public class ProOddsCalculator {
    */
   public ProBattleResult estimateAttackBattleResults(
       final Territory t,
-      final List<Unit> attackingUnits,
-      final List<Unit> defendingUnits,
-      final Set<Unit> bombardingUnits) {
+      final Collection<Unit> attackingUnits,
+      final Collection<Unit> defendingUnits,
+      final Collection<Unit> bombardingUnits) {
 
     final ProBattleResult result =
         checkIfNoAttackersOrDefenders(t, attackingUnits, defendingUnits, true);
@@ -71,9 +71,9 @@ public class ProOddsCalculator {
    */
   public ProBattleResult estimateDefendBattleResults(
       final Territory t,
-      final List<Unit> attackingUnits,
-      final List<Unit> defendingUnits,
-      final Set<Unit> bombardingUnits) {
+      final Collection<Unit> attackingUnits,
+      final Collection<Unit> defendingUnits,
+      final Collection<Unit> bombardingUnits) {
 
     final ProBattleResult result =
         checkIfNoAttackersOrDefenders(t, attackingUnits, defendingUnits, true);
@@ -102,25 +102,25 @@ public class ProOddsCalculator {
 
   public ProBattleResult calculateBattleResultsNoSubmerge(
       final Territory t,
-      final List<Unit> attackingUnits,
-      final List<Unit> defendingUnits,
-      final Set<Unit> bombardingUnits) {
+      final Collection<Unit> attackingUnits,
+      final Collection<Unit> defendingUnits,
+      final Collection<Unit> bombardingUnits) {
     return calculateBattleResults(t, attackingUnits, defendingUnits, bombardingUnits, false);
   }
 
   public ProBattleResult calculateBattleResults(
       final Territory t,
-      final List<Unit> attackingUnits,
-      final List<Unit> defendingUnits,
-      final Set<Unit> bombardingUnits) {
+      final Collection<Unit> attackingUnits,
+      final Collection<Unit> defendingUnits,
+      final Collection<Unit> bombardingUnits) {
     return calculateBattleResults(t, attackingUnits, defendingUnits, bombardingUnits, true);
   }
 
   private ProBattleResult calculateBattleResults(
       final Territory t,
-      final List<Unit> attackingUnits,
-      final List<Unit> defendingUnits,
-      final Set<Unit> bombardingUnits,
+      final Collection<Unit> attackingUnits,
+      final Collection<Unit> defendingUnits,
+      final Collection<Unit> bombardingUnits,
       final boolean checkSubmerge) {
 
     final ProBattleResult result =
@@ -133,8 +133,8 @@ public class ProOddsCalculator {
 
   private static ProBattleResult checkIfNoAttackersOrDefenders(
       final Territory t,
-      final List<Unit> attackingUnits,
-      final List<Unit> defendingUnits,
+      final Collection<Unit> attackingUnits,
+      final Collection<Unit> defendingUnits,
       final boolean checkSubmerge) {
     final boolean hasNoDefenders =
         defendingUnits.stream().noneMatch(Matches.unitIsNotInfrastructure());
@@ -157,8 +157,8 @@ public class ProOddsCalculator {
   }
 
   private static boolean canSubmergeBeforeBattle(
-      final List<Unit> attackingUnits,
-      final List<Unit> defendingUnits,
+      final Collection<Unit> attackingUnits,
+      final Collection<Unit> defendingUnits,
       final boolean checkSubmerge) {
     final GameData data = ProData.getData();
     return checkSubmerge
@@ -169,25 +169,25 @@ public class ProOddsCalculator {
 
   public ProBattleResult callBattleCalcWithRetreatAir(
       final Territory t,
-      final List<Unit> attackingUnits,
-      final List<Unit> defendingUnits,
-      final Set<Unit> bombardingUnits) {
+      final Collection<Unit> attackingUnits,
+      final Collection<Unit> defendingUnits,
+      final Collection<Unit> bombardingUnits) {
     return callBattleCalc(t, attackingUnits, defendingUnits, bombardingUnits, true, true);
   }
 
   public ProBattleResult callBattleCalc(
       final Territory t,
-      final List<Unit> attackingUnits,
-      final List<Unit> defendingUnits,
-      final Set<Unit> bombardingUnits) {
+      final Collection<Unit> attackingUnits,
+      final Collection<Unit> defendingUnits,
+      final Collection<Unit> bombardingUnits) {
     return callBattleCalc(t, attackingUnits, defendingUnits, bombardingUnits, true);
   }
 
   private ProBattleResult callBattleCalc(
       final Territory t,
-      final List<Unit> attackingUnits,
-      final List<Unit> defendingUnits,
-      final Set<Unit> bombardingUnits,
+      final Collection<Unit> attackingUnits,
+      final Collection<Unit> defendingUnits,
+      final Collection<Unit> bombardingUnits,
       final boolean checkSubmerge) {
     return callBattleCalc(t, attackingUnits, defendingUnits, bombardingUnits, checkSubmerge, false);
   }
@@ -195,9 +195,9 @@ public class ProOddsCalculator {
   /** Simulates the specified battle. */
   private ProBattleResult callBattleCalc(
       final Territory t,
-      final List<Unit> attackingUnits,
-      final List<Unit> defendingUnits,
-      final Set<Unit> bombardingUnits,
+      final Collection<Unit> attackingUnits,
+      final Collection<Unit> defendingUnits,
+      final Collection<Unit> bombardingUnits,
       final boolean checkSubmerge,
       final boolean retreatWhenOnlyAirLeft) {
     final GameData data = ProData.getData();
@@ -208,8 +208,8 @@ public class ProOddsCalculator {
 
     final int minArmySize = Math.min(attackingUnits.size(), defendingUnits.size());
     final int runCount = Math.max(16, 100 - minArmySize);
-    final PlayerId attacker = attackingUnits.get(0).getOwner();
-    final PlayerId defender = defendingUnits.get(0).getOwner();
+    final PlayerId attacker = attackingUnits.iterator().next().getOwner();
+    final PlayerId defender = defendingUnits.iterator().next().getOwner();
     if (retreatWhenOnlyAirLeft) {
       calc.setRetreatWhenOnlyAirLeft(true);
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -590,7 +590,7 @@ public class DiceRoll implements Externalizable {
       final IBattle battle,
       final String annotation,
       final Collection<TerritoryEffect> territoryEffects,
-      final List<Unit> allEnemyUnitsAliveOrWaitingToDie) {
+      final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie) {
 
     // Decide whether to use low luck rules or normal rules.
     if (Properties.getLowLuck(bridge.getData())) {
@@ -645,8 +645,8 @@ public class DiceRoll implements Externalizable {
    *     called, for the actual battle.
    */
   public static Map<Unit, Tuple<Integer, Integer>> getUnitPowerAndRollsForNormalBattles(
-      final List<Unit> unitsGettingPowerFor,
-      final List<Unit> allEnemyUnitsAliveOrWaitingToDie,
+      final Collection<Unit> unitsGettingPowerFor,
+      final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie,
       final boolean defending,
       final GameData data,
       final Territory location,
@@ -674,8 +674,8 @@ public class DiceRoll implements Externalizable {
    *     called, for the actual battle.
    */
   protected static Map<Unit, Tuple<Integer, Integer>> getUnitPowerAndRollsForNormalBattles(
-      final List<Unit> unitsGettingPowerFor,
-      final List<Unit> allEnemyUnitsAliveOrWaitingToDie,
+      final Collection<Unit> unitsGettingPowerFor,
+      final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie,
       final boolean defending,
       final GameData data,
       final Territory location,
@@ -874,14 +874,14 @@ public class DiceRoll implements Externalizable {
 
   /** Roll dice for units using low luck rules. */
   private static DiceRoll rollDiceLowLuck(
-      final List<Unit> unitsList,
+      final Collection<Unit> unitsList,
       final boolean defending,
       final PlayerId player,
       final IDelegateBridge bridge,
       final IBattle battle,
       final String annotation,
       final Collection<TerritoryEffect> territoryEffects,
-      final List<Unit> allEnemyUnitsAliveOrWaitingToDie) {
+      final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie) {
 
     final List<Unit> units = new ArrayList<>(unitsList);
     final GameData data = bridge.getData();
@@ -1263,7 +1263,7 @@ public class DiceRoll implements Externalizable {
   }
 
   static DiceRoll airBattle(
-      final List<Unit> unitsList,
+      final Collection<Unit> unitsList,
       final boolean defending,
       final PlayerId player,
       final IDelegateBridge bridge,
@@ -1382,14 +1382,14 @@ public class DiceRoll implements Externalizable {
 
   /** Roll dice for units per normal rules. */
   private static DiceRoll rollDiceNormal(
-      final List<Unit> unitsList,
+      final Collection<Unit> unitsList,
       final boolean defending,
       final PlayerId player,
       final IDelegateBridge bridge,
       final IBattle battle,
       final String annotation,
       final Collection<TerritoryEffect> territoryEffects,
-      final List<Unit> allEnemyUnitsAliveOrWaitingToDie) {
+      final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie) {
 
     final List<Unit> units = new ArrayList<>(unitsList);
     final GameData data = bridge.getData();
@@ -1513,7 +1513,8 @@ public class DiceRoll implements Externalizable {
     return annotation.split(" ", 2)[0];
   }
 
-  static String getAnnotation(final List<Unit> units, final PlayerId player, final IBattle battle) {
+  static String getAnnotation(
+      final Collection<Unit> units, final PlayerId player, final IBattle battle) {
     final StringBuilder buffer = new StringBuilder(80);
     // Note: This pattern is parsed when loading saved games to restore dice stats to get the player
     // name via the


### PR DESCRIPTION
Following discussion on https://github.com/triplea-game/triplea/pull/5578, it was observed that the casts to List<Unit> were breaking the abstraction could instead be removed by using Collection<Unit> more widely. This PR attempts to do this by changing a bunch of APIs that used List<Unit> to use Collection<Unit> instead. The List<Unit> casts on IBattle attackers/defenders now become unnecessary and have been removed as a result.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[X] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

