### PR TITLE
Convert Optional(Long) data member to @Nullable Long

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressListener.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressListener.java
@@ -1,10 +1,10 @@
 package games.strategy.engine.framework.map.download;
 
 import java.util.Optional;
+import javax.annotation.Nullable;
 import javax.swing.JProgressBar;
 import javax.swing.SwingUtilities;
 import org.apache.commons.io.FileUtils;
-import org.triplea.java.OptionalUtils;
 
 /**
  * A listener of map download progress events that updates the associated controls in the UI.
@@ -17,8 +17,8 @@ final class MapDownloadProgressListener {
   private static final int MAX_PROGRESS_VALUE = 100;
 
   private final DownloadFileDescription download;
-  private volatile Optional<Long> downloadLength = Optional.empty();
   private final JProgressBar progressBar;
+  @Nullable private Long downloadLength;
 
   MapDownloadProgressListener(
       final DownloadFileDescription download, final JProgressBar progressBar) {
@@ -42,7 +42,8 @@ final class MapDownloadProgressListener {
             () ->
                 downloadLength =
                     DownloadConfiguration.downloadLengthReader()
-                        .getDownloadLength(download.getUrl()))
+                        .getDownloadLength(download.getUrl())
+                        .orElse(null))
         .start();
   }
 
@@ -73,12 +74,13 @@ final class MapDownloadProgressListener {
 
   void downloadUpdated(final long currentLength) {
     final String toolTipText = String.format("Installing to: %s", download.getInstallLocation());
-    OptionalUtils.ifPresentOrElse(
-        downloadLength,
-        totalLength ->
-            updateProgressBarWithPercentComplete(
-                toolTipText, percentComplete(currentLength, totalLength)),
-        () -> updateProgressBarWithCurrentLength(toolTipText, currentLength));
+
+    Optional.ofNullable(downloadLength)
+        .ifPresentOrElse(
+            totalLength ->
+                updateProgressBarWithPercentComplete(
+                    toolTipText, percentComplete(currentLength, totalLength)),
+            () -> updateProgressBarWithCurrentLength(toolTipText, currentLength));
   }
 
   private static int percentComplete(final long currentLength, final long totalLength) {


### PR DESCRIPTION
For class member variables, nullable is preferred over optional.
We also remove the volatile keyword as that does not have
the desired effect on mutable objects (the reference to the object
will be volatile but the state of the object can still get out of date)


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix: remove volatile keyword that was not doing what we expected <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

