### PR TITLE
Cleanup: remove api key and change password flags from socket connection

### DIFF
--- a/game-core/src/main/java/games/strategy/net/ClientMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ClientMessenger.java
@@ -23,13 +23,10 @@ import java.net.Socket;
 import java.nio.channels.SocketChannel;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.logging.Level;
-import lombok.Getter;
 import lombok.extern.java.Log;
-import org.triplea.domain.data.ApiKey;
 import org.triplea.java.Interruptibles;
 
 /** Default implementation of {@link IClientMessenger}. */
@@ -45,25 +42,6 @@ public class ClientMessenger implements IClientMessenger, NioSocketListener {
   private INode serverNode;
   private volatile boolean shutDown = false;
 
-  @Getter(onMethod_ = {@Override})
-  private boolean passwordChangeRequired;
-
-  private ApiKey apiKey;
-
-  /**
-   * Note, the name parameter passed in here may not match the name of the ClientMessenger after it
-   * has been constructed.
-   */
-  ClientMessenger(
-      final String host,
-      final int port,
-      final String name,
-      final String mac,
-      final IConnectionLogin login)
-      throws IOException {
-    this(host, port, name, mac, new DefaultObjectStreamFactory(), login);
-  }
-
   /**
    * Note, the name parameter passed in here may not match the name of the ClientMessenger after it
    * has been constructed.
@@ -78,7 +56,6 @@ public class ClientMessenger implements IClientMessenger, NioSocketListener {
    * Note, the name parameter passed in here may not match the name of the ClientMessenger after it
    * has been constructed.
    */
-  @VisibleForTesting
   public ClientMessenger(
       final String host,
       final int port,
@@ -139,8 +116,6 @@ public class ClientMessenger implements IClientMessenger, NioSocketListener {
         // ignore
       }
     }
-    passwordChangeRequired = conversation.isPasswordChangeRequired();
-    apiKey = conversation.getApiKey();
 
     if (conversation.getErrorMessage() != null
         && conversation
@@ -335,15 +310,5 @@ public class ClientMessenger implements IClientMessenger, NioSocketListener {
   @Override
   public String toString() {
     return "ClientMessenger LocalNode:" + node + " ServerNodes:" + serverNode;
-  }
-
-  @Override
-  public ApiKey getApiKey() {
-    return Optional.ofNullable(apiKey)
-        .orElseThrow(
-            () ->
-                new UnsupportedOperationException(
-                    "Unexpected missing api key, programmer error. "
-                        + "Likely caused by trying to access API key for a non-lobby connection."));
   }
 }

--- a/game-core/src/main/java/games/strategy/net/IClientMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/IClientMessenger.java
@@ -2,7 +2,6 @@ package games.strategy.net;
 
 import games.strategy.engine.framework.HeadlessAutoSaveType;
 import java.io.File;
-import org.triplea.domain.data.ApiKey;
 
 /** A client messenger. Additional methods for selecting the game on the server. */
 public interface IClientMessenger extends IMessenger {
@@ -19,12 +18,4 @@ public interface IClientMessenger extends IMessenger {
 
   /** Stop listening for errors. */
   void removeErrorListener(IMessengerErrorListener listener);
-
-  boolean isPasswordChangeRequired();
-
-  /**
-   * When connecting to lobby, lobby will provide an API key. <br>
-   * When connecting to a game host, an API key will not be provided.
-   */
-  ApiKey getApiKey();
 }

--- a/game-core/src/main/java/games/strategy/net/Messengers.java
+++ b/game-core/src/main/java/games/strategy/net/Messengers.java
@@ -39,11 +39,6 @@ public class Messengers implements IMessenger, IRemoteMessenger, IChannelMesseng
     this.channelMessenger = channelMessenger;
   }
 
-  public boolean isPasswordChangeRequired() {
-    return messenger instanceof IClientMessenger
-        && ((IClientMessenger) messenger).isPasswordChangeRequired();
-  }
-
   // TODO: API could be improved, perhaps return an optional, and/or store exact instance types from
   // constructor.
   public IServerMessenger getServerMessenger() {

--- a/game-core/src/main/java/games/strategy/net/nio/ClientQuarantineConversation.java
+++ b/game-core/src/main/java/games/strategy/net/nio/ClientQuarantineConversation.java
@@ -7,13 +7,10 @@ import java.io.Serializable;
 import java.net.InetSocketAddress;
 import java.nio.channels.SocketChannel;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.CountDownLatch;
 import java.util.logging.Level;
-import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.extern.java.Log;
-import org.triplea.domain.data.ApiKey;
 import org.triplea.java.Interruptibles;
 import org.triplea.swing.DialogBuilder;
 
@@ -41,13 +38,6 @@ public class ClientQuarantineConversation extends QuarantineConversation {
   private Map<String, String> challengeResponse;
   private volatile boolean isClosed = false;
   @Getter private volatile String errorMessage;
-  /**
-   * On login to lobby, server will respond with an API key that can be used for interacting with
-   * the http server. Game hosts will not provide an API key.
-   */
-  @Nullable @Getter private volatile ApiKey apiKey;
-
-  @Getter private boolean passwordChangeRequired = false;
 
   public ClientQuarantineConversation(
       final IConnectionLogin login,
@@ -140,14 +130,6 @@ public class ClientQuarantineConversation extends QuarantineConversation {
           }
           localName = strings[0];
           serverName = strings[1];
-          if (strings.length > 2) {
-            passwordChangeRequired =
-                strings[2] != null
-                    && strings[2].equals(ServerQuarantineConversation.CHANGE_PASSWORD);
-          }
-          if (strings.length > 3) {
-            apiKey = Optional.ofNullable(strings[3]).map(ApiKey::of).orElse(null);
-          }
           step = Step.READ_ADDRESS;
           return Action.NONE;
         case READ_ADDRESS:


### PR DESCRIPTION
Socket connections are no longer made to the lobby, the lobby was
the component that would send back the api key and change password
flags. Hence, the api key and change password flags are now dead
code and can be removed.

- Also removing an unused `ClientMessage` constructor

<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

