### PR TITLE
Remove 'ifPresentOrElse' utility

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -36,7 +36,6 @@ import javax.swing.SwingUtilities;
 import javax.swing.event.ListSelectionListener;
 import lombok.extern.java.Log;
 import org.triplea.java.Interruptibles;
-import org.triplea.java.OptionalUtils;
 import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.JFrameBuilder;
 import org.triplea.swing.SwingComponents;
@@ -77,10 +76,8 @@ public class DownloadMapsWindow extends JFrame {
     final Set<DownloadFileDescription> pendingDownloads = new HashSet<>();
     final Collection<String> unknownMapNames = new ArrayList<>();
     for (final String mapName : pendingDownloadMapNames) {
-      OptionalUtils.ifPresentOrElse(
-          findMap(mapName, allDownloads),
-          pendingDownloads::add,
-          () -> unknownMapNames.add(mapName));
+      findMap(mapName, allDownloads)
+          .ifPresentOrElse(pendingDownloads::add, () -> unknownMapNames.add(mapName));
     }
     final Collection<String> installedMapNames = removeInstalledDownloads(pendingDownloads);
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/UnitIconProperties.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UnitIconProperties.java
@@ -21,7 +21,6 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.extern.java.Log;
-import org.triplea.java.OptionalUtils;
 import org.triplea.util.FileNameUtils;
 
 /** Loads unit icons from unit_icons.properties. */
@@ -155,8 +154,7 @@ public final class UnitIconProperties extends PropertyFile {
     final String gameName = normalizeGameName(gameData);
     for (final UnitIconDescriptor unitIconDescriptor : unitIconDescriptors) {
       if (unitIconDescriptor.matches(gameName, playerName, unitTypeName)) {
-        OptionalUtils.ifPresentOrElse(
-            unitIconDescriptor.conditionName,
+        unitIconDescriptor.conditionName.ifPresentOrElse(
             conditionName -> {
               if (conditionsStatus.get(
                   conditionSupplier.getCondition(playerName, conditionName, gameData))) {

--- a/java-extras/src/main/java/org/triplea/java/OptionalUtils.java
+++ b/java-extras/src/main/java/org/triplea/java/OptionalUtils.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Optional;
 import java.util.function.BiConsumer;
-import java.util.function.Consumer;
 
 /** A collection of useful methods for working with instances of {@link Optional}. */
 public final class OptionalUtils {
@@ -32,31 +31,6 @@ public final class OptionalUtils {
 
     if (optional.isEmpty()) {
       action.run();
-    }
-  }
-
-  /**
-   * If a value is present in the specified {@code Optional}, performs the given action with the
-   * value, otherwise performs the given empty-based action.
-   *
-   * @param optional The {@code Optional} on which to operate; must not be {@code null}.
-   * @param presentAction The action to be performed, if a value is present; must not be {@code
-   *     null}.
-   * @param emptyAction The empty-based action to be performed, if no value is present; must not be
-   *     {@code null}.
-   */
-  public static <T> void ifPresentOrElse(
-      final Optional<T> optional,
-      final Consumer<? super T> presentAction,
-      final Runnable emptyAction) {
-    checkNotNull(optional);
-    checkNotNull(presentAction);
-    checkNotNull(emptyAction);
-
-    if (optional.isPresent()) {
-      presentAction.accept(optional.get());
-    } else {
-      emptyAction.run();
     }
   }
 }

--- a/java-extras/src/test/java/org/triplea/java/OptionalUtilsTest.java
+++ b/java-extras/src/test/java/org/triplea/java/OptionalUtilsTest.java
@@ -73,35 +73,4 @@ final class OptionalUtilsTest {
       verify(action).run();
     }
   }
-
-  @Nested
-  final class IfPresentOrElseTest {
-    @Test
-    void shouldInvokePresentActionWhenValueIsPresent() {
-      final Object value = new Object();
-      final AtomicBoolean presentActionInvoked = new AtomicBoolean(false);
-
-      OptionalUtils.ifPresentOrElse(
-          Optional.of(value),
-          it -> {
-            presentActionInvoked.set(true);
-            assertThat(it, is(value));
-          },
-          () -> fail("empty action should not have been invoked"));
-
-      assertThat(presentActionInvoked.get(), is(true));
-    }
-
-    @Test
-    void shouldInvokeEmptyActionWhenValueIsAbsent() {
-      final AtomicBoolean emptyActionInvoked = new AtomicBoolean(false);
-
-      OptionalUtils.ifPresentOrElse(
-          Optional.empty(),
-          it -> fail("present action should not have been invoked"),
-          () -> emptyActionInvoked.set(true));
-
-      assertThat(emptyActionInvoked.get(), is(true));
-    }
-  }
 }

--- a/java-extras/src/test/java/org/triplea/java/OptionalUtilsTest.java
+++ b/java-extras/src/test/java/org/triplea/java/OptionalUtilsTest.java
@@ -1,14 +1,10 @@
 package org.triplea.java;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiConsumer;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;


### PR DESCRIPTION
    The feature is now built in directly to the JDK, we can use
    'Optional.ifPresentOrElse' instead of our own helper method.

<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

