### PR TITLE
Travis Cache JDK and Remove '--no-daemon'

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,11 +3,6 @@ sudo: false
 language: java
 if: tag is blank
 
-cache:
-  directories:
-    - '$HOME/.gradle'
-    - '.gradle'
-
 # Note: Travis generally does not allocate more than 5 VMs at once.
 # Avoid running more than 5 jobs in parallel. Try to keep the jobs
 # balanced so that they each take about the same amount of time.
@@ -34,6 +29,11 @@ jobs:
     - stage: verify
       env: DESCRIPTION="static verification"
       jdk: openjdk11
+      cache:
+        directories:
+          - '$HOME/.gradle'
+          - '.gradle'
+          - '~/jdk-11.0.5+10'
       before_install:
         - ./.travis/install_java_11.0.5
         - export JAVA_HOME=~/jdk-11.0.5+10
@@ -44,10 +44,15 @@ jobs:
         ## shellcheck all shell scripts
         - find .travis/ -type f | xargs grep -lE "^#\!/bin/bash$" | xargs shellcheck
         - .travis/check-links || travis_terminate 1;
-        - ./gradlew --no-daemon --parallel validateYamls spotlessCheck checkstyleMain checkstyleTest pmdMain pmdTest
+        - ./gradlew --parallel validateYamls spotlessCheck checkstyleMain checkstyleTest pmdMain pmdTest
     - stage: verify
       env: DESCRIPTION="JDK11 tests"
       jdk: openjdk11
+      cache:
+        directories:
+          - '$HOME/.gradle'
+          - '.gradle'
+          - '~/jdk-11.0.5+10'
       addons: {postgresql: "10"}
       before_install:
         - ./.travis/install_java_11.0.5
@@ -57,15 +62,24 @@ jobs:
       install: skip
       script:
         - ./.travis/setup_database &
-        - ./gradlew --no-daemon --parallel test integTest
+        - ./gradlew --parallel test integTest
     - stage: verify
       env: DESCRIPTION="JDK12 unitTests"
       jdk: openjdk12
+      cache:
+        directories:
+          - '$HOME/.gradle'
+          - '.gradle'
       install: skip
       script:
-        - ./gradlew --no-daemon --parallel test
+        - ./gradlew --parallel test
     - stage: verify
       jdk: openjdk11
+      cache:
+        directories:
+          - '$HOME/.gradle'
+          - '.gradle'
+          - '~/jdk-11.0.5+10'
       env: DESCRIPTION="JDK11 Coverage & Sonar"
       if: repo = 'triplea-game/triplea'
       git:
@@ -82,9 +96,14 @@ jobs:
         - java --version
       install: skip
       script:
-        - ./gradlew --no-daemon --parallel test jacocoTestReport sonarqube
+        - ./gradlew --parallel test jacocoTestReport sonarqube
         - bash <(curl -s https://codecov.io/bash)  # upload coverage report - https://github.com/codecov/example-gradle
     - stage: verify
+      cache:
+        directories:
+          - '$HOME/.gradle'
+          - '.gradle'
+          - '~/jdk-11.0.5+10'
       jdk: openjdk11
       env: DESCRIPTION="Smoke Test"
       addons: {postgresql: "10"}
@@ -101,6 +120,11 @@ jobs:
       env: DESCRIPTION="Upload to github releases"
       if: (branch = master) and (repo = 'triplea-game/triplea') and (type != 'pull_request')
       install: skip
+      cache:
+        directories:
+          - '$HOME/.gradle'
+          - '.gradle'
+          - '~/jdk-11.0.5+10'
       before_install:
         - ./.travis/install_java_11.0.5
         - export JAVA_HOME=~/jdk-11.0.5+10
@@ -134,10 +158,20 @@ jobs:
     - stage: deploy artifacts
       env: DESCRIPTION="Deploy to prerelease"
       if: (branch = master) and (repo = 'triplea-game/triplea') and (type != 'pull_request')
+      cache:
+        directories:
+          - '$HOME/.gradle'
+          - '.gradle'
+          - '~/jdk-11.0.5+10'
       addons:
         apt:
           packages:
             - sshpass
+      before_install:
+        - ./.travis/install_java_11.0.5
+        - export JAVA_HOME=~/jdk-11.0.5+10
+        - export PATH=${JAVA_HOME}/bin:$PATH
+        - java --version
       install:
         - pip install ansible
       language: python
@@ -156,6 +190,16 @@ jobs:
         apt:
           packages:
             - sshpass
+      cache:
+        directories:
+          - '$HOME/.gradle'
+          - '.gradle'
+          - '~/jdk-11.0.5+10'
+      before_install:
+        - ./.travis/install_java_11.0.5
+        - export JAVA_HOME=~/jdk-11.0.5+10
+        - export PATH=${JAVA_HOME}/bin:$PATH
+        - java --version
       install:
         - pip install ansible
       language: python


### PR DESCRIPTION
1. Adds JDK 11.0.5 custom install to locations where it is missing
2. Adds JDK 11 artifact to cache
3. Removes gradle --no-daemon flag. With cache, the speedup benefit is negligable


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

