### PR TITLE
Remove volatile keyword on mutable objects

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
@@ -25,7 +25,7 @@ final class DownloadFile {
 
   private final DownloadFileDescription download;
   private final DownloadListener downloadListener;
-  private volatile DownloadState state = DownloadState.NOT_STARTED;
+  private DownloadState state = DownloadState.NOT_STARTED;
 
   DownloadFile(final DownloadFileDescription download, final DownloadListener downloadListener) {
     this.download = download;

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -97,7 +97,7 @@ public class ServerModel extends Observable implements IConnectionChangeListener
   private ChatController chatController;
   private final Map<String, PlayerType> localPlayerTypes = new HashMap<>();
   // while our server launcher is not null, delegate new/lost connections to it
-  private volatile ServerLauncher serverLauncher;
+  private ServerLauncher serverLauncher;
   private CountDownLatch removeConnectionsLatch = null;
   private final Observer gameSelectorObserver = (observable, value) -> gameDataChanged();
   private final IServerStartupRemote serverStartupRemote =

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcherWrapper.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcherWrapper.java
@@ -9,7 +9,7 @@ import org.triplea.lobby.common.GameDescription.GameStatus;
  * lobby watcher as games are started and stopped on the host.
  */
 public class InGameLobbyWatcherWrapper {
-  private volatile InGameLobbyWatcher lobbyWatcher = null;
+  private InGameLobbyWatcher lobbyWatcher;
 
   public void setInGameLobbyWatcher(final InGameLobbyWatcher watcher) {
     lobbyWatcher = watcher;

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -54,7 +54,7 @@ public final class BattlePanel extends ActionPanel {
   // if we are showing a battle, then this will be set to the currently displayed battle. This will
   // only be set after
   // the display is shown on the screen
-  private volatile UUID currentBattleDisplayed;
+  private UUID currentBattleDisplayed;
   private final JFrame battleFrame =
       JFrameBuilder.builder()
           .windowClosedAction(() -> PbemDiceRoller.setFocusWindow(null))


### PR DESCRIPTION
Being flagged as a bug by sonar analysis

> Marking an array volatile means that the array itself will always be read fresh and never thread cached, but the items in the array will not be. Similarly, marking a mutable object field volatile means the object reference is volatile but the object itself is not, and other threads may not see updates to the object state.

> This can be salvaged with arrays by using the relevant AtomicArray class, such as AtomicIntegerArray, instead. For mutable objects, the volatile should be removed, and some other method should be used to ensure thread-safety, such as synchronization, or ThreadLocal storage.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

