### PR TITLE
Fix arithmetic expressions done as integer

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -121,7 +121,7 @@ public class InGameLobbyWatcher {
     // message is lost or missed, we have time to send another one before reaching the cut-off time.
     keepAliveTimer =
         Timers.fixedRateTimer("lobby-watcher-keep-alive")
-            .period((GameListingClient.KEEP_ALIVE_SECONDS / 2) - 1, TimeUnit.SECONDS)
+            .period((GameListingClient.KEEP_ALIVE_SECONDS / 2L) - 1, TimeUnit.SECONDS)
             .task(
                 LobbyWatcherKeepAliveTask.builder()
                     .gameId(gameId)

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
@@ -66,7 +66,7 @@ public class GameChooser extends JDialog {
     leftPanel.setLayout(new GridBagLayout());
     final JLabel gamesLabel = new JLabel("Games");
     gamesLabel.setFont(
-        gamesLabel.getFont().deriveFont(Font.BOLD, gamesLabel.getFont().getSize() + 2));
+        gamesLabel.getFont().deriveFont(Font.BOLD, gamesLabel.getFont().getSize() + 2.0F));
     leftPanel.add(
         gamesLabel,
         new GridBagConstraints(

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/BanTimeUnit.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/BanTimeUnit.java
@@ -14,9 +14,9 @@ enum BanTimeUnit {
 
   DAYS("Days", TimeUnit.DAYS::toMinutes),
 
-  WEEKS("Weeks", durationUnit -> TimeUnit.DAYS.toMinutes(durationUnit * 7)),
+  WEEKS("Weeks", durationUnit -> TimeUnit.DAYS.toMinutes(durationUnit * 7L)),
 
-  MONTHS("Months", durationUnit -> TimeUnit.DAYS.toMinutes(durationUnit * 30)),
+  MONTHS("Months", durationUnit -> TimeUnit.DAYS.toMinutes(durationUnit * 30L)),
 
   FOREVER("Forever", value -> (long) BanDurationDialog.MAX_DURATION);
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
@@ -78,9 +78,9 @@ public class ProPurchaseOption {
     if (isInfra) {
       hitPoints = 0;
     }
-    attack = unitAttachment.getAttack(player) * quantity;
+    attack = (double) unitAttachment.getAttack(player) * quantity;
     amphibAttack = attack + 0.5 * unitAttachment.getIsMarine() * quantity;
-    defense = unitAttachment.getDefense(player) * quantity;
+    defense = (double) unitAttachment.getDefense(player) * quantity;
     transportCost = unitAttachment.getTransportCost() * quantity;
     carrierCost = unitAttachment.getCarrierCost() * quantity;
     isAir = unitAttachment.getIsAir();
@@ -255,7 +255,8 @@ public class ProPurchaseOption {
     final double distance = Math.max(0, enemyDistance - 1.5);
     final int moveValue = isLandTransport ? (movement + 1) : movement;
     // 1, 2, 2.5, 2.75, etc
-    final double moveFactor = 1 + 2 * (Math.pow(2, moveValue - 1) - 1) / Math.pow(2, moveValue - 1);
+    final double moveFactor =
+        1.0 + 2.0 * (Math.pow(2, moveValue - 1.0) - 1.0) / Math.pow(2, moveValue - 1.0);
     return Math.pow(moveFactor, distance / 5);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -659,16 +659,17 @@ public class MapPanel extends ImageScrollerLargeView {
       if (drawHorizontalOverlap && x < 0) {
         if (drawVerticalOverlap && y < 0) {
           final Rectangle2D.Double leftUpperBounds =
-              new Rectangle2D.Double(model.getMaxWidth() + x, model.getMaxHeight() + y, -x, -y);
+              new Rectangle2D.Double(
+                  model.getMaxWidth() + (double) x, model.getMaxHeight() + (double) y, -x, -y);
           drawTiles(g2d, images, data, leftUpperBounds, undrawnTiles);
         }
         final Rectangle2D.Double leftBounds =
-            new Rectangle2D.Double(model.getMaxWidth() + x, y, -x, getScaledHeight());
+            new Rectangle2D.Double(model.getMaxWidth() + (double) x, y, -x, getScaledHeight());
         drawTiles(g2d, images, data, leftBounds, undrawnTiles);
       }
       if (drawVerticalOverlap && y < 0) {
         final Rectangle2D.Double upperBounds =
-            new Rectangle2D.Double(x, model.getMaxHeight() + y, getScaledWidth(), -y);
+            new Rectangle2D.Double(x, model.getMaxHeight() + (double) y, getScaledWidth(), -y);
         drawTiles(g2d, images, data, upperBounds, undrawnTiles);
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/ui/RouteDescription.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/RouteDescription.java
@@ -53,7 +53,7 @@ class RouteDescription {
     diffX *= diffX;
     int diffY = end.y - other.end.y;
     diffY *= diffY;
-    final int endDiff = (int) Math.sqrt(diffX + diffY);
+    final int endDiff = (int) Math.sqrt((double) diffX + diffY);
     return endDiff < 6;
   }
 }

--- a/game-core/src/main/java/tools/map/making/ConnectionFinder.java
+++ b/game-core/src/main/java/tools/map/making/ConnectionFinder.java
@@ -441,7 +441,7 @@ public final class ConnectionFinder {
       if (arg.startsWith(LINE_THICKNESS)) {
         final int lineThickness = Integer.parseInt(value);
         scalePixels = lineThickness * 4;
-        minOverlap = scalePixels * 4;
+        minOverlap = scalePixels * 4.0;
         dimensionsSet = true;
       }
       if (arg.startsWith(MIN_OVERLAP)) {
@@ -467,7 +467,7 @@ public final class ConnectionFinder {
     if (value != null && value.length() > 0) {
       final int lineThickness = Integer.parseInt(value);
       scalePixels = lineThickness * 4;
-      minOverlap = scalePixels * 4;
+      minOverlap = scalePixels * 4.0;
       dimensionsSet = true;
     }
     value = System.getProperty(MIN_OVERLAP);


### PR DESCRIPTION
Fixes a few bugs flagged by sonar.

> When arithmetic is performed on integers, the result will always be an integer. You can assign that result to a long, double, or float with automatic type conversion, but having started as an int or long, the result will likely not be what you expect.

> For instance, if the result of int division is assigned to a floating-point variable, precision will have been lost before the assignment. Likewise, if the result of multiplication is assigned to a long, it may have already overflowed before the assignment.

> In either case, the result will not be what was expected. Instead, at least one operand should be cast or promoted to the final type before the operation takes place.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

