### PR TITLE
Add 'volatile' keyword back to MapDownloadProgressListener download length

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressListener.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressListener.java
@@ -18,7 +18,7 @@ final class MapDownloadProgressListener {
 
   private final DownloadFileDescription download;
   private final JProgressBar progressBar;
-  @Nullable private Long downloadLength;
+  @Nullable private volatile Long downloadLength;
 
   MapDownloadProgressListener(
       final DownloadFileDescription download, final JProgressBar progressBar) {


### PR DESCRIPTION
ssoloff noted that volatile does belong here:
> downloadLength is written by one thread and read by another. While reading/writing an object reference is atomic in the sense that it guarantees no partial read/write from/to memory, changes to the reference made by one thread are not guaranteed to be visible to other threads without some kind of synchronization (so-called "safe publication"). Please see sections 3.4 and 3.5 of Java Concurrency in Practice (specifically, section 3.4.2: Example: Using Volatile to Publish Immutable Objects, applies here).


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 
