### PR TITLE
Remove parallel testing from game-core

### DIFF
--- a/game-core/src/test/resources/junit-platform.properties
+++ b/game-core/src/test/resources/junit-platform.properties
@@ -1,8 +1,0 @@
-# documentation on parallelism config: https://junit.org/junit5/docs/snapshot/user-guide/#writing-tests-parallel-execution
-# Runs all top-level classes in parallel, methods in order
-junit.jupiter.execution.parallel.enabled = true
-junit.jupiter.execution.parallel.mode.default = same_thread
-junit.jupiter.execution.parallel.mode.classes.default = concurrent
-
-# chooses number of threads based on available cores
-junit.jupiter.execution.parallel.config.strategy=dynamic


### PR DESCRIPTION
Removes parallel test config in game-core to favor deterministic tests.

- Parallel tests were a major win for game-core for performance, 45s -> 15s
- The parallel tests introduce non-determinism for clients settings. The
setup and tear-down overrides static accessors and then nulls out those
accessors. Seemingly even making tests that rely on this single-threaded
is not enough to avoid the non-determinism
- Running all sub-projects in parallel reduces the gains of the paralell
tests, the overall runtime when running all tests across all projects
is about the same (because we can still keep any idle CPU cores busy).
Hence, the benefit of parallel was really only when running tests
from IDE and for game-core, otherwise we get parallelism and
take advantage of incremental builds.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done

Tests that were failing repeatedly with the parallel test config no longer fail.
An example of such a failing test:
> games.strategy.triplea.settings.ProtectedStringClientSettingTest > games.strategy.triplea.settings.ProtectedStringClientSettingTest$RoundTripTest > shouldBeAbleToRoundTripValue() FAILED
    java.lang.IllegalStateException: ClientSetting framework has not been initialized. Did you forget to call ClientSetting#initialize() in production code or ClientSetting#setPreferences() in test code?


<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

