### PR TITLE
Handle zero ban minutes

### DIFF
--- a/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/BanDurationFormatter.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/BanDurationFormatter.java
@@ -8,9 +8,11 @@ import lombok.experimental.UtilityClass;
 public class BanDurationFormatter {
 
   public static String formatBanMinutes(final long banMinutes) {
-    Preconditions.checkState(banMinutes > 0);
+    Preconditions.checkState(banMinutes >= 0);
 
-    if (banMinutes < 60) {
+    if (banMinutes == 0) {
+      return "less than a minute";
+    } else if (banMinutes < 60) {
       return banMinutes + " minutes";
     } else if (TimeUnit.MINUTES.toHours(banMinutes) < 24) {
       return TimeUnit.MINUTES.toHours(banMinutes) + " hours";

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/BanDurationFormatterTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/BanDurationFormatterTest.java
@@ -21,6 +21,7 @@ class BanDurationFormatterTest {
   @SuppressWarnings("unused")
   private static List<Arguments> formattedBanDuration() {
     return List.of(
+        Arguments.of(0, "less than a minute"),
         Arguments.of(1, "1 minutes"),
         Arguments.of(5, "5 minutes"),
         Arguments.of(10, "10 minutes"),


### PR DESCRIPTION
If a player has left than a minute left in their ban, the ban duraton
remaining is '0'. BanDurationFormatter should handle this.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done
- When banned for a minute, this problem can be reproduced readily.

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

