### PR TITLE
Fix Node null address when using unresolved IP addresses

### DIFF
--- a/game-core/src/main/java/games/strategy/net/Node.java
+++ b/game-core/src/main/java/games/strategy/net/Node.java
@@ -8,6 +8,7 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.ToString;
+import org.triplea.http.client.IpAddressParser;
 
 /** Class to hold information about a packet destination or source. */
 @ToString
@@ -31,7 +32,9 @@ public class Node implements INode {
   }
 
   public Node(final String name, final InetSocketAddress address) {
-    this(name, address.getAddress(), address.getPort());
+    // Note: we use `InetSocketAddress.getHostString()` and not `InetSocketAddress.getAddress()`.
+    // `InetSocketAddress.getAddress()` returns null when we are using an unresolved IP address.
+    this(name, IpAddressParser.fromString(address.getHostString()), address.getPort());
   }
 
   /** Returns the localhost InetAddress. */

--- a/game-core/src/test/java/games/strategy/net/NodeTest.java
+++ b/game-core/src/test/java/games/strategy/net/NodeTest.java
@@ -1,0 +1,45 @@
+package games.strategy.net;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import java.net.InetSocketAddress;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.triplea.http.client.IpAddressParser;
+
+class NodeTest {
+
+  private static final String NAME = "name";
+  private static final String IP = "99.99.99.99";
+  private static final int PORT = 3000;
+
+  @Test
+  @DisplayName("Verify data from InetSocketAddress is preserved on construction")
+  void verifyConstructionUsingInetSocketAddress() {
+    final Node node = new Node(NAME, InetSocketAddress.createUnresolved(IP, PORT));
+
+    assertThat(node.getName(), is(NAME));
+    assertThat(node.getAddress(), is(IpAddressParser.fromString(IP)));
+    assertThat(node.getIpAddress(), is(IP));
+    assertThat(node.getPort(), is(PORT));
+  }
+
+  @Test
+  @DisplayName("Verify we can use hostnames")
+  void verifyConstructionUsingHostName() {
+    final Node node = new Node(NAME, InetSocketAddress.createUnresolved("localhost", PORT));
+
+    assertThat(node.getAddress(), is(IpAddressParser.fromString("localhost")));
+  }
+
+  @Test
+  @DisplayName("Verify socket address is well constructed when returned")
+  void verifyRetrievalOfSocketAddress() {
+    final InetSocketAddress address =
+        new Node(NAME, InetSocketAddress.createUnresolved(IP, PORT)).getSocketAddress();
+
+    assertThat(address.getAddress(), is(IpAddressParser.fromString(IP)));
+    assertThat(address.getPort(), is(PORT));
+  }
+}


### PR DESCRIPTION
`InetSocketAddress.getAddress()` returns null if the address being
returned is unresolved. An easy way to create an `InetSocketAddress`
is to use: `InetSocketAddress.createUnresolved("localhost")`, though
doing this will cause the IP address passed in to be converted to
null and not stored.  IE:  `Node.getIpAddress()` will return null
instead of "localhost"

To fix this, we use a different InetSocketAddress to get the host
address as a string and we then convert that string to an InetAddress.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

