### PR TITLE
Fix dependent territory scramble and unmodifiable collection error.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -875,7 +875,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             }
             // after that is applied, we have to make a map of all dependencies
             final Map<Unit, Collection<Unit>> dependenciesForMfb =
-                TransportTracker.transportingWithAllPossibleUnits(attackingUnits);
+                new HashMap<>(TransportTracker.transportingWithAllPossibleUnits(attackingUnits));
             for (final Unit transport :
                 CollectionUtils.getMatches(attackingUnits, Matches.unitIsTransport())) {
               // however, the map we add to the newly created battle, cannot hold any units that are
@@ -945,14 +945,15 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       // dependencies set.
       if (to.isWater()) {
         for (final Territory t : data.getMap().getNeighbors(to, Matches.territoryIsLand())) {
-          final IBattle battleAmphib = battleTracker.getPendingBattle(t, false, BattleType.NORMAL);
-          if (battleAmphib != null) {
-            if (!battleTracker.getDependentOn(battle).contains(battleAmphib)) {
-              battleTracker.addDependency(battleAmphib, battle);
+          final IBattle adjacentBattle =
+              battleTracker.getPendingBattle(t, false, BattleType.NORMAL);
+          if (adjacentBattle != null) {
+            if (Matches.battleIsAmphibiousWithUnitsAttackingFrom(to).test(adjacentBattle)) {
+              battleTracker.addDependency(adjacentBattle, battle);
             }
-            if (battleAmphib instanceof MustFightBattle) {
+            if (adjacentBattle instanceof MustFightBattle) {
               // and we want to reset the defenders if the scrambling air has left that battle
-              ((MustFightBattle) battleAmphib).resetDefendingUnits(player, data);
+              ((MustFightBattle) adjacentBattle).resetDefendingUnits(player, data);
             }
           }
         }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1083,6 +1083,14 @@ public final class Matches {
     return IBattle::isAmphibious;
   }
 
+  static Predicate<IBattle> battleIsAmphibiousWithUnitsAttackingFrom(final Territory from) {
+    return battleIsAmphibious()
+        .and(
+            b ->
+                (b instanceof DependentBattle)
+                    && ((DependentBattle) b).getAmphibiousAttackTerritories().contains(from));
+  }
+
   public static Predicate<Unit> unitHasEnoughMovementForRoute(final Route route) {
     return unit -> {
       BigDecimal left = TripleAUnit.get(unit).getMovementLeft();


### PR DESCRIPTION
This PR fixes https://github.com/triplea-game/triplea/issues/5646, where an incorrect battle dependency was being added due to scrambling, which also caused dependent error popups with AI players.

The old logic was as follows:

```When scrambling to a sea territory, mark all adjacent land battles as dependent on it.```

That was not correct, as it did not take into account if adjacent land battles actually were amphibious battles from the sea territory to which units were being scrambled. This was a long standing bug that started to be triggered in turn 1 of Global 2nd edition due to new AI decisions.

In addition to this fix, also fixes a different recent bug with an unmodifiable collection being modified.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[X] Problem fix:  https://github.com/triplea-game/triplea/issues/5646
[] Other:   <!-- Please specify -->


## Testing

[X] Manual testing done

Did the following manual tests:

On Global 2nd edition:

1. As Germany on 1st turn, send a ship to Sea Zone 110 and a land unit to Normandy.
2. As UK, scramble planes to defend.
3. In combat move, make sure that Normandy battle is not dependent on Sea Battle by doing it first.

Second test also on Global 2nd edition:

1. As Germany on 1st turn, use edit mode to remove enemy units from Sea Zone 110 and add a german transport to adjacent sea zone.
2. As combat move, load a unit on the transport, move to SZ110 and attack Normandy with it.
3. As UK, scramble planes to defend.
4. In this case, the Normandy battle should depend on SZ110 battle unlike in the previous case.

