### PR TITLE
Fix TransportTracker.isTransporting().

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
@@ -84,7 +84,7 @@ public class TransportTracker {
   }
 
   public static boolean isTransporting(final Unit transport) {
-    return transporting(transport).isEmpty();
+    return !transporting(transport).isEmpty();
   }
 
   /**

--- a/game-core/src/test/java/games/strategy/triplea/delegate/TransportTrackerTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/TransportTrackerTest.java
@@ -1,0 +1,39 @@
+package games.strategy.triplea.delegate;
+
+import static games.strategy.triplea.delegate.GameDataTestUtil.addTo;
+import static games.strategy.triplea.delegate.GameDataTestUtil.americans;
+import static games.strategy.triplea.delegate.GameDataTestUtil.armour;
+import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
+import static games.strategy.triplea.delegate.GameDataTestUtil.transport;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import games.strategy.engine.data.Change;
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.triplea.TripleAUnit;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TransportTrackerTest {
+  private final GameData gameData = TestMapGameData.REVISED.getGameData();
+  private final Territory brazil = territory("Brazil", gameData);
+  private final Territory sz18 = territory("18 Sea Zone", gameData);
+  private final Unit transport = transport(gameData).create(americans(gameData));
+  private final Unit tank = armour(gameData).create(americans(gameData));
+
+  public TransportTrackerTest() throws Exception {}
+
+  @Test
+  void testIsTransporting() throws Exception {
+    addTo(sz18, List.of(transport));
+    assertThat(TransportTracker.isTransporting(transport), is(false));
+
+    addTo(sz18, List.of(tank));
+    final Change change = TransportTracker.loadTransportChange((TripleAUnit) transport, tank);
+    gameData.performChange(change);
+    assertThat(TransportTracker.isTransporting(transport), is(true));
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/delegate/TransportTrackerTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/TransportTrackerTest.java
@@ -19,12 +19,11 @@ import org.junit.jupiter.api.Test;
 
 class TransportTrackerTest {
   private final GameData gameData = TestMapGameData.REVISED.getGameData();
-  private final Territory brazil = territory("Brazil", gameData);
   private final Territory sz18 = territory("18 Sea Zone", gameData);
   private final Unit transport = transport(gameData).create(americans(gameData));
   private final Unit tank = armour(gameData).create(americans(gameData));
 
-  public TransportTrackerTest() throws Exception {}
+  TransportTrackerTest() throws Exception {}
 
   @Test
   void testIsTransporting() throws Exception {


### PR DESCRIPTION
This was accidentally inverted by #5578.

Adds a unit test.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  https://github.com/triplea-game/triplea/issues/5655
[] Other:   <!-- Please specify -->


## Testing

[X] Manual testing done

Check if NPE no longer triggers with the save in https://github.com/triplea-game/triplea/issues/5655.