### PR TITLE
Travis build improvement: Only install JDK if not cached

### DIFF
--- a/.travis/install_java_11.0.5
+++ b/.travis/install_java_11.0.5
@@ -1,8 +1,10 @@
 #!/bin/bash
 
 (
-  cd ~ || exit 1
-  wget "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.5%2B10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.5_10.tar.gz"
-  tar -xzf OpenJDK11U-jdk_x64_linux_hotspot_11.0.5_10.tar.gz
+  if [ ! -d "/home/travis/jdk-11.0.5+10" ]; then
+    cd ~ || exit 1
+    wget "https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.5%2B10/OpenJDK11U-jdk_x64_linux_hotspot_11.0.5_10.tar.gz"
+    tar -xzf OpenJDK11U-jdk_x64_linux_hotspot_11.0.5_10.tar.gz
+  fi
 )
 


### PR DESCRIPTION
- Check for cached JDK folder on travis build.
If the cached folder is not present *then* we'll install it.

Benefit: somewhat marginal as the download and install of JDK
is pretty fast. The main benefit FWIW is reduction of bandwidth
when we skip he JDK download.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[x] Other: build update  <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done

Check in forked travis branch build that JDK 11.0.5 download and install is skipped and that JAVA_HOME is still set.
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

