### PR TITLE
Make MoveDescription do basic validation on the route parameter.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/MoveDescription.java
+++ b/game-core/src/main/java/games/strategy/engine/data/MoveDescription.java
@@ -26,7 +26,7 @@ public class MoveDescription extends AbstractMoveDescription {
       final Map<Unit, Collection<Unit>> dependentUnits) {
     super(Collections.unmodifiableCollection(units));
     this.route = Preconditions.checkNotNull(route);
-    if (route.getEnd() == null || route.getStart() == null || route.hasNoSteps()) {
+    if (route.hasNoSteps()) {
       throw new IllegalStateException("Invalid route: " + route);
     }
     this.unitsToTransports = Collections.unmodifiableMap(unitsToTransports);

--- a/game-core/src/main/java/games/strategy/engine/data/MoveDescription.java
+++ b/game-core/src/main/java/games/strategy/engine/data/MoveDescription.java
@@ -26,6 +26,9 @@ public class MoveDescription extends AbstractMoveDescription {
       final Map<Unit, Collection<Unit>> dependentUnits) {
     super(Collections.unmodifiableCollection(units));
     this.route = Preconditions.checkNotNull(route);
+    if (route.getEnd() == null || route.getStart() == null || route.hasNoSteps()) {
+      throw new IllegalStateException("Invalid route: " + route);
+    }
     this.unitsToTransports = Collections.unmodifiableMap(unitsToTransports);
     this.dependentUnits =
         Collections.unmodifiableMap(

--- a/game-core/src/main/java/games/strategy/engine/data/MoveDescription.java
+++ b/game-core/src/main/java/games/strategy/engine/data/MoveDescription.java
@@ -26,9 +26,7 @@ public class MoveDescription extends AbstractMoveDescription {
       final Map<Unit, Collection<Unit>> dependentUnits) {
     super(Collections.unmodifiableCollection(units));
     this.route = Preconditions.checkNotNull(route);
-    if (route.hasNoSteps()) {
-      throw new IllegalStateException("Invalid route: " + route);
-    }
+    Preconditions.checkArgument(route.hasSteps());
     this.unitsToTransports = Collections.unmodifiableMap(unitsToTransports);
     this.dependentUnits =
         Collections.unmodifiableMap(

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -438,18 +438,6 @@ public final class ProMoveUtils {
 
     // Move units
     for (final MoveDescription move : moves) {
-      // TODO: #5499 Validate this when MoveDescription is constructed.
-      if (move.getRoute().getEnd() == null || move.getRoute().getStart() == null) {
-        ProLogger.warn(
-            data.getSequence().getRound()
-                + "-"
-                + data.getSequence().getStep().getName()
-                + ": route not valid "
-                + move.getRoute()
-                + " units: "
-                + move.getUnits());
-        continue;
-      }
       final String result = moveDel.performMove(move);
       if (result != null) {
         ProLogger.warn(

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -223,13 +223,6 @@ public class WeakAi extends AbstractAi {
 
   private static void doMove(final List<MoveDescription> moves, final IMoveDelegate moveDel) {
     for (final MoveDescription move : moves) {
-      // TODO: #5499 Validate this when MoveDescription is constructed.
-      if (move.getRoute().getEnd() == null
-          || move.getRoute().getStart() == null
-          || move.getRoute().hasNoSteps()) {
-        continue;
-      }
-
       moveDel.performMove(move);
       pause();
     }

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -257,7 +257,7 @@ public class WeakAi extends AbstractAi {
       unitsToMove.addAll(transports.subList(0, 1));
     }
     final List<Unit> landUnits = load2Transports(unitsToMove);
-    final Route r = getMaxSeaRoute(data, firstSeaZoneOnAmphib, lastSeaZoneOnAmphib, player);
+    final @Nullable Route r = getMaxSeaRoute(data, firstSeaZoneOnAmphib, lastSeaZoneOnAmphib, player);
     if (r != null) {
       unitsToMove.addAll(landUnits);
       moves.add(new MoveDescription(unitsToMove, r));
@@ -286,7 +286,7 @@ public class WeakAi extends AbstractAi {
           // move along amphi route
           if (lastSeaZoneOnAmphib != null) {
             // two move route to end
-            final Route r = getMaxSeaRoute(data, t, lastSeaZoneOnAmphib, player);
+            final @Nullable Route r = getMaxSeaRoute(data, t, lastSeaZoneOnAmphib, player);
             if (r != null) {
               final List<Unit> unitsToMove =
                   t.getUnitCollection().getMatches(Matches.unitIsOwnedBy(player));
@@ -297,7 +297,7 @@ public class WeakAi extends AbstractAi {
         if (nonCombat && t.getUnitCollection().anyMatch(ownedAndNotMoved)) {
           // move toward the start of the amphib route
           if (firstSeaZoneOnAmphib != null) {
-            final Route r = getMaxSeaRoute(data, t, firstSeaZoneOnAmphib, player);
+            final @Nullable Route r = getMaxSeaRoute(data, t, firstSeaZoneOnAmphib, player);
             if (r != null) {
               moves.add(new MoveDescription(t.getUnitCollection().getMatches(ownedAndNotMoved), r));
             }
@@ -308,7 +308,7 @@ public class WeakAi extends AbstractAi {
     return moves;
   }
 
-  private static Route getMaxSeaRoute(
+  private static @Nullable Route getMaxSeaRoute(
       final GameData data,
       final Territory start,
       final Territory destination,

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -257,7 +257,8 @@ public class WeakAi extends AbstractAi {
       unitsToMove.addAll(transports.subList(0, 1));
     }
     final List<Unit> landUnits = load2Transports(unitsToMove);
-    final @Nullable Route r = getMaxSeaRoute(data, firstSeaZoneOnAmphib, lastSeaZoneOnAmphib, player);
+    final @Nullable Route r =
+        getMaxSeaRoute(data, firstSeaZoneOnAmphib, lastSeaZoneOnAmphib, player);
     if (r != null) {
       unitsToMove.addAll(landUnits);
       moves.add(new MoveDescription(unitsToMove, r));

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -258,8 +258,10 @@ public class WeakAi extends AbstractAi {
     }
     final List<Unit> landUnits = load2Transports(unitsToMove);
     final Route r = getMaxSeaRoute(data, firstSeaZoneOnAmphib, lastSeaZoneOnAmphib, player);
-    unitsToMove.addAll(landUnits);
-    moves.add(new MoveDescription(unitsToMove, r));
+    if (r != null) {
+      unitsToMove.addAll(landUnits);
+      moves.add(new MoveDescription(unitsToMove, r));
+    }
     return moves;
   }
 
@@ -285,7 +287,7 @@ public class WeakAi extends AbstractAi {
           if (lastSeaZoneOnAmphib != null) {
             // two move route to end
             final Route r = getMaxSeaRoute(data, t, lastSeaZoneOnAmphib, player);
-            if (r != null && r.numberOfSteps() > 0) {
+            if (r != null) {
               final List<Unit> unitsToMove =
                   t.getUnitCollection().getMatches(Matches.unitIsOwnedBy(player));
               moves.add(new MoveDescription(unitsToMove, r));
@@ -296,7 +298,9 @@ public class WeakAi extends AbstractAi {
           // move toward the start of the amphib route
           if (firstSeaZoneOnAmphib != null) {
             final Route r = getMaxSeaRoute(data, t, firstSeaZoneOnAmphib, player);
-            moves.add(new MoveDescription(t.getUnitCollection().getMatches(ownedAndNotMoved), r));
+            if (r != null) {
+              moves.add(new MoveDescription(t.getUnitCollection().getMatches(ownedAndNotMoved), r));
+            }
           }
         }
       }
@@ -314,7 +318,7 @@ public class WeakAi extends AbstractAi {
             .and(Matches.territoryHasEnemyUnits(player, data).negate())
             .and(Matches.territoryHasNonAllowedCanal(player, null, data).negate());
     Route r = data.getMap().getRoute(start, destination, routeCond);
-    if (r == null || !routeCond.test(destination)) {
+    if (r == null || r.hasNoSteps() || !routeCond.test(destination)) {
       return null;
     }
     if (r.numberOfSteps() > 2) {


### PR DESCRIPTION
Make MoveDescription do basic validation on the route parameter. This addresses a TODO from the MoveDescription refactoring, removing this validation from the AI code and moving it to the MoveDescription ctor.

Making this change revealed some cases where WeakAI could be generating such invalid moves, which this PR is also fixing.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[X] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing

[X] Manual testing done

Made AIs play a game on Revised and verified no errors raised.