### PR TITLE
Fix role allowed for 'fetchGames'

### DIFF
--- a/http-server/src/main/java/org/triplea/server/lobby/game/listing/GameListingController.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/game/listing/GameListingController.java
@@ -80,6 +80,7 @@ public class GameListingController extends HttpController {
       rates = {@Rate(limit = 5, duration = 1, timeUnit = TimeUnit.SECONDS)})
   @GET
   @Path(GameListingClient.FETCH_GAMES_PATH)
+  @RolesAllowed(UserRole.ANONYMOUS)
   public Collection<LobbyGameListing> fetchGames() {
     return gameListing.getGames();
   }

--- a/http-server/src/test/java/org/triplea/server/lobby/game/listing/GameListingControllerTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/game/listing/GameListingControllerTest.java
@@ -39,7 +39,8 @@ class GameListingControllerTest extends ProtectedEndpointTest<GameListingClient>
   @Test
   void fetchGames() {
     verifyEndpoint(client -> client.postGame(LOBBY_GAME));
-    verifyEndpointReturningCollection(GameListingClient::fetchGameListing);
+    verifyEndpointReturningCollection(
+        AllowedUserRole.ANONYMOUS, GameListingClient::fetchGameListing);
   }
 
   @Test


### PR DESCRIPTION
'fetchGames' is used by players that have connected and needs Anonymous role authorization.
Recently 'role authorization' was set to enforcing, hence this problem comes ups.
The other endpoints in GameListingController are accessed by the game-hosting-processing,
'fetch-games' is an exception.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done
- connect to a local lobby, before this fix you get a 403, after you can connect. 
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

