### PR TITLE
Wire moderator shutdown-host option

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -5,6 +5,7 @@ import games.strategy.engine.framework.startup.ui.ServerOptions;
 import games.strategy.engine.lobby.client.LobbyClient;
 import java.awt.BorderLayout;
 import java.awt.event.MouseEvent;
+import java.net.InetAddress;
 import java.net.URI;
 import java.util.Collection;
 import java.util.List;
@@ -165,7 +166,8 @@ class LobbyGamePanel extends JPanel {
   }
 
   private Collection<Action> getGeneralAdminGamesListContextActions() {
-    return List.of(SwingAction.of("Boot Game", e -> bootGame()));
+    return List.of(
+        SwingAction.of("Boot Game", e -> bootGame()), SwingAction.of("Shutdown", e -> shutdown()));
   }
 
   private void joinGame() {
@@ -216,5 +218,25 @@ class LobbyGamePanel extends JPanel {
     lobbyClient.getHttpLobbyClient().getGameListingClient().bootGame(gameId);
     JOptionPane.showMessageDialog(
         null, "The game you selected has been disconnected from the lobby.");
+  }
+
+  private void shutdown() {
+    final int selectedIndex = gameTable.getSelectedRow();
+    if (selectedIndex == -1) {
+      return;
+    }
+    final int result =
+        JOptionPane.showConfirmDialog(
+            null,
+            "Are you sure you want to shutdown the selected game?",
+            "Send Shutdown Signal?",
+            JOptionPane.OK_CANCEL_OPTION);
+    if (result != JOptionPane.OK_OPTION) {
+      return;
+    }
+
+    final InetAddress ipAddress = gameTableModel.get(selectedIndex).getHostedBy().getAddress();
+    lobbyClient.getHttpLobbyClient().getRemoteActionsClient().sendShutdownRequest(ipAddress);
+    JOptionPane.showMessageDialog(null, "The game you selected was sent a shutdown signal");
   }
 }

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/HttpLobbyClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/HttpLobbyClient.java
@@ -10,6 +10,7 @@ import org.triplea.http.client.lobby.game.listing.GameListingClient;
 import org.triplea.http.client.lobby.moderator.ModeratorChatClient;
 import org.triplea.http.client.lobby.moderator.toolbox.HttpModeratorToolboxClient;
 import org.triplea.http.client.lobby.user.account.UserAccountClient;
+import org.triplea.http.client.remote.actions.RemoteActionsClient;
 
 /** Holder class for the various http clients that access lobby resources. */
 @Getter
@@ -20,6 +21,7 @@ public class HttpLobbyClient {
   private final LobbyChatClient lobbyChatClient;
   private final ModeratorChatClient moderatorLobbyClient;
   private final UserAccountClient userAccountClient;
+  private final RemoteActionsClient remoteActionsClient;
 
   private HttpLobbyClient(final URI lobbyUri, final ApiKey apiKey) {
     connectivityCheckClient = ConnectivityCheckClient.newClient(lobbyUri, apiKey);
@@ -28,6 +30,7 @@ public class HttpLobbyClient {
     lobbyChatClient = LobbyChatClient.newClient(lobbyUri, apiKey);
     moderatorLobbyClient = ModeratorChatClient.newClient(lobbyUri, apiKey);
     userAccountClient = UserAccountClient.newClient(lobbyUri, apiKey);
+    remoteActionsClient = new RemoteActionsClient(lobbyUri, apiKey);
   }
 
   public static HttpLobbyClient newClient(final URI lobbyUri, final ApiKey apiKey) {


### PR DESCRIPTION
Adds a game table right click menu for moderators to send a shutdown
request to a game host. Note, the shutdown is by IP, all games
hosted on that IP will receive the shutdown signal.

The backend parts of this update are in place, just needed to
add the front-end components.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done
- on a local lobby shutdown a headless game and a headed game
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

