### PR TITLE
Ansible over Vagrant fixes - fix hostname and paths

### DIFF
--- a/infrastructure/README-VAGRANT-DEV.md
+++ b/infrastructure/README-VAGRANT-DEV.md
@@ -7,11 +7,22 @@ updates and/or build new roles.
 
 ## Installation
 
-### (1) Install Vagrant, VirtualBox and Ansible
+### (1.A) Install, VirtualBox and Ansible
 
 ```bash
-sudo apt install -y virtualbox vagrant ansible
-```
+sudo apt install -y virtualbox ansible
+``
+
+### (1.B) Install Vagrant
+
+Install from the download site: https://www.vagrantup.com/downloads.html
+
+The version in 'apt' is likely to be out of date and could have Ruby errors.
+
+Once downloaded, unzip somewhere, add that somewhere to your path so the command 
+"vagrant" is available. If not added to your path, fully quality the command 'vagrant'
+in the steps below to match.
+
 
 ### (2) Launch Vagrant virtual machine
 ```bash

--- a/infrastructure/README-VAGRANT-DEV.md
+++ b/infrastructure/README-VAGRANT-DEV.md
@@ -19,9 +19,9 @@ Install from the download site: https://www.vagrantup.com/downloads.html
 
 The version in 'apt' is likely to be out of date and could have Ruby errors.
 
-Once downloaded, unzip somewhere, add that somewhere to your path so the command 
-"vagrant" is available. If not added to your path, fully quality the command 'vagrant'
-in the steps below to match.
+Once downloaded, unzip somewhere, add that somewhere to your path so the
+command "vagrant" is available. If not added to your path, fully quality
+the command 'vagrant' in the steps below to match.
 
 
 ### (2) Launch Vagrant virtual machine

--- a/infrastructure/ansible.cfg
+++ b/infrastructure/ansible.cfg
@@ -5,6 +5,7 @@ host_key_checking = False
 pipelining = True
 control_path = /tmp/ansible-ssh-%%h-%%p-%%r
 ControlPersist = 60s
+ssh_args = -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
 
 [persistent_connection]
 connect_timeout = 30

--- a/infrastructure/ansible/inventory/vagrant
+++ b/infrastructure/ansible/inventory/vagrant
@@ -1,11 +1,11 @@
 [postgresHosts]
-vagrant ansible_hostname=vagrantHost  ansible_port=2010 ansible_ssh_private_key_file=./.vagrant/machines/lobby/virtualbox/private_key
+127.0.0.1 ansible_port=2010 ansible_ssh_private_key_file=./.vagrant/machines/vagrantHost/virtualbox/private_key
 
 [dropwizardHosts]
-vagrant ansible_hostname=vagrantHost ansible_port=2010 ansible_ssh_private_key_file=./.vagrant/machines/lobby/virtualbox/private_key
+127.0.0.1 ansible_port=2010 ansible_ssh_private_key_file=./.vagrant/machines/vagrantHost/virtualbox/private_key
 
 [botHosts]
-vagrant ansible_hostname=vagrantHost ansible_port=2010 ansible_ssh_private_key_file=./.vagrant/machines/lobby/virtualbox/private_key
+127.0.0.1 ansible_port=2010 ansible_ssh_private_key_file=./.vagrant/machines/vagrantHost/virtualbox/private_key
 
 [vagrant:children]
 postgresHosts


### PR DESCRIPTION
- Ansible hostname is not needed in inventory
- For reference, infrastructure/VagrantFile defines the key port mappings and
the name of the ansible host machine as known to virtual box
- Fix path to private key file


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

