### PR TITLE
Update port mappings in VagrantFile

### DIFF
--- a/infrastructure/Vagrantfile
+++ b/infrastructure/Vagrantfile
@@ -3,8 +3,8 @@ Vagrant.configure("2") do |config|
 
   config.vm.define "vagrantHost" do |vagrantHost|
     vagrantHost.vm.network "forwarded_port", guest: 22, host: 2010, host_ip: "127.0.0.1", id: "ssh"
-    vagrantHost.vm.network "forwarded_port", guest: 3304, host: 3304, host_ip: "127.0.0.1"
-    vagrantHost.vm.network "forwarded_port", guest: 443, host: 4430, host_ip: "127.0.0.1"
+    vagrantHost.vm.network "forwarded_port", guest: 4001, host: 4100, host_ip: "127.0.0.1"
+    vagrantHost.vm.network "forwarded_port", guest: 8080, host: 9090, host_ip: "127.0.0.1"
   end
 end
 


### PR DESCRIPTION
Update:
- localhost:9090 will port forward to vagrant port 8080 (spitfire)
- localhost: 4100 will forward to vagrant 4001 (bot)

Remove port 3304 forwarding, that was the old lobby.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done
- Not tested.

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

