### PR TITLE
Fix bad lag when trying to move lots of units from a territory.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/UnitComparator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UnitComparator.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.delegate;
 import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.util.TransportUtils;
@@ -105,6 +106,20 @@ public final class UnitComparator {
       // Sort by increasing movement normally, but by decreasing movement during loading
       if (left1.compareTo(left2) != 0) {
         return (route != null && route.isLoad()) ? left2.compareTo(left1) : left1.compareTo(left2);
+      }
+
+      // Sort units by type first.
+      final UnitType t1 = u1.getType();
+      final UnitType t2 = u2.getType();
+      if (!t1.equals(t2)) {
+        // Land transportable units should have higher priority than non-land transportable ones,
+        // when all else is equal.
+        final int isLandTransportable1 = UnitAttachment.get(t1).getIsLandTransportable() ? 1 : 0;
+        final int isLandTransportable2 = UnitAttachment.get(t2).getIsLandTransportable() ? 1 : 0;
+        if (isLandTransportable1 != isLandTransportable2) {
+          return isLandTransportable2 - isLandTransportable1;
+        }
+        return Integer.compare(t1.hashCode(), t2.hashCode());
       }
 
       return Integer.compare(u1.hashCode(), u2.hashCode());

--- a/game-core/src/main/java/games/strategy/triplea/util/MovableUnitsFilter.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/MovableUnitsFilter.java
@@ -135,8 +135,8 @@ public final class MovableUnitsFilter {
       while (!best.isEmpty() && !lastResult.getResult().isMoveValid()) {
         final Unit firstSkipUnit = best.get(0);
         int startIndex = 1;
-        // Check if we can skip more than unit if they are equivalent (e.g. all units of
-        // the same type that have equivalent movement left). Don't do this if there are
+        // Check if we can skip more than one unit if they are equivalent (e.g. all units
+        // of the same type that have equivalent movement left). Don't do this if there are
         // land transports (mech infantry), though.
         while (startIndex < best.size()
             && (!hasLandTransports || !isLandTransportable.test(best.get(startIndex)))

--- a/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -189,6 +189,11 @@ public final class GameDataTestUtil {
     return unitType(Constants.UNIT_TYPE_INFANTRY, data);
   }
 
+  /** Returns an artillery UnitType object for the specified GameData object. */
+  public static UnitType artillery(final GameData data) {
+    return unitType(Constants.UNIT_TYPE_ARTILLERY, data);
+  }
+
   /** Returns a germanInfantry UnitType object for the specified GameData object. */
   public static UnitType germanInfantry(final GameData data) {
     return unitType("germanInfantry", data);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/UnitComparatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/UnitComparatorTest.java
@@ -1,7 +1,9 @@
 package games.strategy.triplea.delegate;
 
 import static games.strategy.triplea.delegate.GameDataTestUtil.armour;
+import static games.strategy.triplea.delegate.GameDataTestUtil.artillery;
 import static games.strategy.triplea.delegate.GameDataTestUtil.germans;
+import static games.strategy.triplea.delegate.GameDataTestUtil.infantry;
 import static games.strategy.triplea.delegate.GameDataTestUtil.load;
 import static games.strategy.triplea.delegate.GameDataTestUtil.moveDelegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
@@ -54,6 +56,35 @@ final class UnitComparatorTest {
               units, new Route(seaZone5, kareliaSsr), germans));
 
       assertThat(sortedUnits.get(0), is(transportedUnits.get(0)));
+    }
+
+    @Test
+    void unitsOfSameTypeAreSortedTogether() throws Exception {
+      final GameData gameData = TestMapGameData.REVISED.getGameData();
+
+      final List<Unit> units = new ArrayList<>();
+      for (int i = 0; i < 10; i++) {
+        units.add(infantry(gameData).create(germans(gameData)));
+      }
+      for (int i = 0; i < 10; i++) {
+        units.add(artillery(gameData).create(germans(gameData)));
+      }
+      for (int i = 0; i < 10; i++) {
+        units.add(armour(gameData).create(germans(gameData)));
+      }
+
+      final Territory germany = territory("Germany", gameData);
+      final Territory balkans = territory("Balkans", gameData);
+      units.sort(UnitComparator.getMovableUnitsComparator(units, new Route(germany, balkans)));
+      Unit lastUnit = units.get(0);
+      int transitions = 0;
+      for (final Unit unit : units) {
+        if (!unit.getType().equals(lastUnit.getType())) {
+          transitions++;
+        }
+        lastUnit = unit;
+      }
+      assertThat("expected 2 transitions between 3 unit types", transitions, is(2));
     }
   }
 }


### PR DESCRIPTION
On some maps, like Great War, it's often the case that a very large amount of units is accumulated on some borders, such as between Italy and Austria - e.g. 200+ units.

When trying to move these units, before this change, the game UI lags a lot. This change improves that.

When a complete move is invalid, the existing algorithm tries every tail sublist of the sorted unit list. This change improves that by having the sublist logic skip equivalent units (i.e. skip over all infantry that have same movement).

A few other improvements are made - such as the existing code being inconsistent about whether it took a read lock while performing move validation - this duplicated code is moved into a helper function and made to take the lock consistently.


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[X] Code Cleanup or refactor
[] Configuration Change
[X] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing

[X] Manual testing done

I didn't have a compatible save game ready, so used edit mode to add a bunch of units to a German territory on the western front in Great War. Tested moving these units in the UI and
observed it is much less laggy (though still noticeably slow, but not freezing for many
seconds anymore). Save game attached:

[ww1_test.tsvg.zip](https://github.com/triplea-game/triplea/files/3935367/ww1_test.tsvg.zip)

With the above save game, I did some measurements of how long it takes to validate a move to the following territories:

Before the change:
 Time to: Bastogne = 4189 ms
 Time to: Picardy = 2800 ms
 Time to: Compeigne = 2748 ms
 Time to: Aisne River = 2737 ms

After the change:
 Time to: Bastogne = 183 ms
 Time to: Picardy = 51 ms
 Time to: Compeigne = 56 ms
 Time to: Aisne River = 58 ms