### PR TITLE
Another speed up to UI lag when moving lots of units.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1458,6 +1458,8 @@ public final class Matches {
       final PlayerId currentPlayer,
       final GameData data,
       final boolean forceLoadParatroopersIfPossible) {
+    final Map<Unit, Unit> paratrooperMap =
+        forceLoadParatroopersIfPossible ? TransportUtils.mapParatroopers(units) : Map.of();
     return dependent -> {
       // transported on a sea transport
       final Unit transportedBy = ((TripleAUnit) dependent).getTransportedBy();
@@ -1467,23 +1469,11 @@ public final class Matches {
       // cargo on a carrier
       final Map<Unit, Collection<Unit>> carrierMustMoveWith =
           MoveValidator.carrierMustMoveWith(units, units, data, currentPlayer);
-      if (carrierMustMoveWith != null) {
-        if (carrierMustMoveWith.values().stream().anyMatch(c -> c.contains(dependent))) {
-          return true;
-        }
+      if (carrierMustMoveWith.values().stream().anyMatch(c -> c.contains(dependent))) {
+        return true;
       }
-      // paratrooper on an air transport
-      if (forceLoadParatroopersIfPossible) {
-        final Collection<Unit> airTransports =
-            CollectionUtils.getMatches(units, unitIsAirTransport());
-        final Collection<Unit> paratroops =
-            CollectionUtils.getMatches(units, unitIsAirTransportable());
-        if (!airTransports.isEmpty() && !paratroops.isEmpty()) {
-          return TransportUtils.mapTransportsToLoad(paratroops, airTransports)
-              .containsKey(dependent);
-        }
-      }
-      return false;
+
+      return paratrooperMap.containsKey(dependent);
     };
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -141,9 +141,8 @@ public class MovePerformer implements Serializable {
 
           @Override
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-            // if any non enemy territories on route
-            // or if any enemy units on route the battles on (note water could have enemy but its
-            // not owned)
+            // if any non enemy territories on route or if any enemy units on route the battles
+            // on (note water could have enemy but its not owned)
             final GameData data = bridge.getData();
             final Predicate<Territory> mustFightThrough = getMustFightThroughMatch(id, data);
             final Collection<Unit> arrived =
@@ -156,18 +155,10 @@ public class MovePerformer implements Serializable {
                     ? unitsToTransports
                     : TransportUtils.mapTransports(route, arrived, null);
             // If we have paratrooper land units being carried by air units, they should be dropped
-            // off in the last
-            // territory. This means they are still dependent during the middle steps of the route.
-            final Collection<Unit> dependentOnSomethingTilTheEndOfRoute = new ArrayList<>();
-            final Collection<Unit> airTransports =
-                CollectionUtils.getMatches(arrived, Matches.unitIsAirTransport());
-            final Collection<Unit> paratroops =
-                CollectionUtils.getMatches(arrived, Matches.unitIsAirTransportable());
-            if (!airTransports.isEmpty() && !paratroops.isEmpty()) {
-              final Map<Unit, Unit> transportingAir =
-                  TransportUtils.mapTransportsToLoad(paratroops, airTransports);
-              dependentOnSomethingTilTheEndOfRoute.addAll(transportingAir.keySet());
-            }
+            // off in the last territory. This means they are still dependent during the middle
+            // steps of the route.
+            final Collection<Unit> dependentOnSomethingTilTheEndOfRoute =
+                TransportUtils.mapParatroopers(arrived).keySet();
             final Collection<Unit> presentFromStartTilEnd = new ArrayList<>(arrived);
             presentFromStartTilEnd.removeAll(dependentOnSomethingTilTheEndOfRoute);
             final CompositeChange change = new CompositeChange();
@@ -282,8 +273,8 @@ public class MovePerformer implements Serializable {
                   && GameStepPropertiesHelper.isNonCombatMove(data, false)
                   && !targetedAttack) {
                 // We are in non-combat move phase, and we are taking over friendly territories. No
-                // need for a battle. (This
-                // could get really difficult if we want these recorded in battle records).
+                // need for a battle. (This could get really difficult if we want these recorded in
+                // battle records).
                 for (final Territory t :
                     route.getMatches(
                         Matches

--- a/game-core/src/main/java/games/strategy/triplea/util/TransportUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/TransportUtils.java
@@ -38,6 +38,18 @@ public final class TransportUtils {
     return mapTransportsAlreadyLoaded(units, units);
   }
 
+  /** Returns a map of paratrooper -> air transport, if paratrooper rules are in effect. */
+  public static Map<Unit, Unit> mapParatroopers(final Collection<Unit> units) {
+    final Collection<Unit> airTransports =
+        CollectionUtils.getMatches(units, Matches.unitIsAirTransport());
+    final Collection<Unit> paratroops =
+        CollectionUtils.getMatches(units, Matches.unitIsAirTransportable());
+    if (!airTransports.isEmpty() && !paratroops.isEmpty()) {
+      return mapTransportsToLoad(paratroops, airTransports);
+    }
+    return Map.of();
+  }
+
   /** Returns a map of unit -> transport. Tries to load units evenly across all transports. */
   public static Map<Unit, Unit> mapTransportsToLoad(
       final Collection<Unit> units, final Collection<Unit> transports) {


### PR DESCRIPTION
After https://github.com/triplea-game/triplea/pull/5692, this is another set of optimizations. In this case, a paratrooper logic calculation is optimized by making that work O(n) rather than O(n^2), by moving it out of the inner "loop" - i.e. once for a list of units, instead processing a list of units for each unit.

Also refactors the code to add a helper method for duplicated code and fixes up formatting of some comments.

After the other PR, this change results in the following speed up:

Before the change:
Time to: Bastogne = 183 ms
Time to: Picardy = 51 ms
Time to: Compeigne = 56 ms
Time to: Aisne River = 58 ms

After the change:
Time to: Bastogne = 38 ms
Time to: Picardy = 30 ms
Time to: Compeigne = 32 ms
Time to: Aisne River = 36 ms

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[X] Code Cleanup or refactor
[] Configuration Change
[X] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing

[X] Manual testing done

Same as in https://github.com/triplea-game/triplea/pull/5692.