### PR TITLE
Small optimization: use Integer.parseInt() directly.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -376,13 +376,13 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
         // See if the first entry contains the number of territories needed to meet the criteria
         try {
           // check if this is an integer, and if so set territory count
-          getInt(name);
+          Integer.parseInt(name);
           if (mustSetTerritoryCount) {
             haveSetCount = true;
             setTerritoryCount(name);
           }
           continue;
-        } catch (final Exception e) {
+        } catch (final NumberFormatException e) {
           // territory name is not an integer; fall through
         }
       }


### PR DESCRIPTION
Small optimization: use Integer.parseInt() directly when checking for exception, instead of getInt() which rethrows a different exception. This was showing up in profiles when profiling unit movement UI - as this is called often from territoryIsPassableAndNotRestricted() -> getListedTerritories().

I was seeing the IllegalStateException ctor that the previous code called through taking up ~700ms on a given profile - which went away with this change.

<img width="1424" alt="Screen Shot 2019-12-08 at 4 10 24 PM" src="https://user-images.githubusercontent.com/17648/70396276-50a5e800-19d5-11ea-868b-24e5d47c7ab3.png">

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[X] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing

[] Manual testing done
