### PR TITLE
Don't read the warning/error images each time a move is validated.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -94,6 +94,8 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
   // cache this so we can update it only when territory/units change
   private List<Unit> unitsThatCanMoveOnRoute;
   private Image currentCursorImage;
+  private final Image warningImage;
+  private final Image errorImage;
   private Route routeCached = null;
   private String displayText = "Combat Move";
   private MoveType moveType = MoveType.DEFAULT;
@@ -736,6 +738,8 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
     mouseCurrentTerritory = null;
     unitsThatCanMoveOnRoute = List.of();
     currentCursorImage = null;
+    warningImage = getMap().getWarningImage().orElse(null);
+    errorImage = getMap().getErrorImage().orElse(null);
 
     unitScroller = new UnitScroller(getData(), getMap());
   }
@@ -1191,7 +1195,7 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
         currentCursorImage = null;
       } else {
         setStatusWarningMessage("Not all units can move there");
-        currentCursorImage = getMap().getWarningImage().orElse(null);
+        currentCursorImage = warningImage;
       }
     } else {
       String message = allResults.getError();
@@ -1203,10 +1207,10 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
       }
       if (!lastResults.isMoveValid()) {
         setStatusErrorMessage(message);
-        currentCursorImage = getMap().getErrorImage().orElse(null);
+        currentCursorImage = errorImage;
       } else {
         setStatusWarningMessage(message);
-        currentCursorImage = getMap().getWarningImage().orElse(null);
+        currentCursorImage = warningImage;
       }
     }
     if (unitsThatCanMoveOnRoute.size() != new HashSet<>(unitsThatCanMoveOnRoute).size()) {


### PR DESCRIPTION
Don't read the warning/error images each time a move is validated.

This showed up in profiles - turns out, each time we wanted to show an error or warning icon when moving units (e.g. mouse-over a territory that's too far), the image was read from disk.
This change just reads it once when the panel is created instead to avoid all the extra IO and processing.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[X] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

