### PR TITLE
Fix None label displayed in casualties panel after casualties added.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -204,10 +204,14 @@ public class BattleDisplay extends JPanel {
     final JPanel casualtyPanel;
     if (playerId.equals(defender)) {
       casualtyPanel = casualtiesInstantPanelDefender;
-      casualtyPanel.remove(labelNoneDefender);
+      if (!killedUnits.isEmpty()) {
+        casualtyPanel.remove(labelNoneDefender);
+      }
     } else {
       casualtyPanel = casualtiesInstantPanelAttacker;
-      casualtyPanel.remove(labelNoneAttacker);
+      if (!killedUnits.isEmpty()) {
+        casualtyPanel.remove(labelNoneAttacker);
+      }
     }
     final Map<Unit, Collection<Unit>> dependentsMap;
     gameData.acquireReadLock();

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -204,8 +204,10 @@ public class BattleDisplay extends JPanel {
     final JPanel casualtyPanel;
     if (playerId.equals(defender)) {
       casualtyPanel = casualtiesInstantPanelDefender;
+      casualtyPanel.remove(labelNoneDefender);
     } else {
       casualtyPanel = casualtiesInstantPanelAttacker;
+      casualtyPanel.remove(labelNoneAttacker);
     }
     final Map<Unit, Collection<Unit>> dependentsMap;
     gameData.acquireReadLock();


### PR DESCRIPTION
See before/after screenshots. This bug exists in 1.9 too.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[X] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing


[X] Manual testing done

Do a battle and observe what the casualties panels show after first round.

## Screens Shots

### Before

![Screen Shot 2019-12-10 at 1 49 32 AM](https://user-images.githubusercontent.com/17648/70502767-b1294800-1aef-11ea-814a-411e0b330ef9.png)

### After

![Screen Shot 2019-12-10 at 1 55 18 AM](https://user-images.githubusercontent.com/17648/70502952-3a407f00-1af0-11ea-8c50-9029b89e9462.png)
