### PR TITLE
Improve restart of nginx to use systemctl module

### DIFF
--- a/infrastructure/ansible/roles/nginx/tasks/main.yml
+++ b/infrastructure/ansible/roles/nginx/tasks/main.yml
@@ -20,5 +20,7 @@
 
 - name:  relaunch nginx
   become: true
-  shell: systemctl restart nginx
+  systemd:
+    name: nginx
+    state: restarted
 


### PR DESCRIPTION
Ansible best practice is to avoid using shell commands and
to prefer the built in modules. This update uses the built-in
systemctl module to execute the nginx restart


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes
Note, after this update, we still will fail with nginx restart. There is a chicken-and-egg problem where the installed config requires 'letsencrypt' to have been run. We'll likely need to install a dummy or hardcoded SSL cert on the letsencrypt path so that the path is valid. On new servers, the ordering is tenous, we may need to run letsencrypt after ansible fails to get things to be correct, then run ansible. Ideally we'd bake in the 'letsencrypt' module and not need to manage this ourselves by hand.
