### PR TITLE
Fix incorrect units loaded when loading a transport.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -766,7 +766,7 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
         : getCurrentPlayer();
   }
 
-  /** Sort sthe specified units in preferred movement or unload order. */
+  /** Sorts the specified units in preferred movement or unload order. */
   private void sortUnitsToMove(final List<Unit> units, final Route route) {
     if (!units.isEmpty()) {
       units.sort(getUnitsToMoveComparator(units, route));

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -769,12 +769,16 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
 
   /** Sorts the specified units in preferred movement or unload order. */
   private void sortUnitsToMove(final List<Unit> units, final Route route) {
-    units.sort(getUnitsToMoveComparator(units, route));
+    if (!units.isEmpty()) {
+      units.sort(getUnitsToMoveComparator(units, route));
+    }
   }
 
   /** Sorts the specified units in reverse preferred movement or unload order. */
   private void sortUnitsToMoveReverse(final List<Unit> units, final Route route) {
-    units.sort(getUnitsToMoveComparator(units, route).reversed());
+    if (!units.isEmpty()) {
+      units.sort(getUnitsToMoveComparator(units, route).reversed());
+    }
   }
 
   private Comparator<Unit> getUnitsToMoveComparator(final List<Unit> units, final Route route) {


### PR DESCRIPTION
This regressed in #5416, because that commit caused unitsToTransports to only be computed once, instead of updated each time the unit list was filtered in the function.

This fixes #5706.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[X] Problem fix: #5706
[] Other:   <!-- Please specify -->


## Testing

[X] Manual testing done

On Global 40 2nd edition...
As germany, select 3 infantry and 1 tank in poland
Try to load them on the transport

1 infantry and 1 tank should be loaded.