### PR TITLE
Add ansible parameter and variable for nginx certs

### DIFF
--- a/infrastructure/ansible/group_vars/prerelease.yml
+++ b/infrastructure/ansible/group_vars/prerelease.yml
@@ -1,1 +1,3 @@
 lobby_uri: "https://prerelease.triplea-game.org"
+nginx_ssl_certificate: "/etc/letsencrypt/live/{{ inventory_hostname }}/fullchain.pem"
+nginx_ssl_certificate_key: "/etc/letsencrypt/live/{{ inventory_hostname }}/privkey.pem"

--- a/infrastructure/ansible/roles/nginx/defaults/main.yml
+++ b/infrastructure/ansible/roles/nginx/defaults/main.yml
@@ -1,2 +1,4 @@
+nginx_ssl_certificate: /etc/nginx/cert.crt
+nginx_ssl_certificate_key: /etc/nginx/cert.key
 nginx_allowed_ports:
   - 443

--- a/infrastructure/ansible/roles/nginx/tasks/main.yml
+++ b/infrastructure/ansible/roles/nginx/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: create SSL keys if needed
   become: true
-  command: openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout {{ nginx_ssl_certificate_key }} -out {{ nginx_ssl_certificate }} -batch
+  command: openssl req -x509 -nodes -days 365 -newkey rsa:4096 -keyout {{ nginx_ssl_certificate_key }} -out {{ nginx_ssl_certificate }} -batch
   args:
     creates: "{{ nginx_ssl_certificate_key }}"
 

--- a/infrastructure/ansible/roles/nginx/tasks/main.yml
+++ b/infrastructure/ansible/roles/nginx/tasks/main.yml
@@ -4,6 +4,12 @@
     name: nginx
     state: present
 
+- name: create SSL keys if needed
+  become: true
+  command: openssl req -x509 -nodes -days 365 -newkey rsa:2048 -keyout {{ nginx_ssl_certificate_key }} -out {{ nginx_ssl_certificate }} -batch
+  args:
+    creates: "{{ nginx_ssl_certificate_key }}"
+
 - name: deploy nginx sites_enabled configuation
   become: true
   template:

--- a/infrastructure/ansible/roles/nginx/templates/etc_nginx_sites_enabled_default.j2
+++ b/infrastructure/ansible/roles/nginx/templates/etc_nginx_sites_enabled_default.j2
@@ -6,8 +6,8 @@ server {
 server {
     listen 443;
     server_name {{ inventory_hostname }};
-    ssl_certificate /etc/letsencrypt/live/{{ inventory_hostname }}/fullchain.pem; # managed by Certbot
-    ssl_certificate_key /etc/letsencrypt/live/{{ inventory_hostname }}/privkey.pem; # managed by Certbot
+    ssl_certificate {{ nginx_ssl_certificate }};
+    ssl_certificate_key {{ nginx_ssl_certificate_key }};
 
     ssl on;
     ssl_session_cache  builtin:1000  shared:SSL:10m;


### PR DESCRIPTION
Make nginx certs a variable. If cert file does not exist,
a cert is generated.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes
After this update, the full ansible deploy to a vagrant VM completes successfully.
