### PR TITLE
Fix run_ansible_vagrant script to build jars

### DIFF
--- a/infrastructure/run_ansible_vagrant
+++ b/infrastructure/run_ansible_vagrant
@@ -1,5 +1,6 @@
 #!/bin/bash
-set -ux
+
+set -eux
 
 CUR_FOLDER=$(basename $(pwd))
 if [ "$CUR_FOLDER" != infrastructure ]; then
@@ -8,27 +9,28 @@ if [ "$CUR_FOLDER" != infrastructure ]; then
 fi
 
 export VERSION=$(sed 's/.*=\s*//' ../game-core/src/main/resources/META-INF/triplea/product.properties)
-echo "Parsed version number: $VERSION"
 
-function buildBotJar() {
-  local jarFile=triplea-game-headless-$VERSION.jar
-  local targetFolder=./ansible/roles/bot/files/
-  mkdir -p "$targetFolder"
-  # check if a bot jar is built, if not build it and copy to location where ansible can find it.
-  if [ ! -e $targetFolder/$jarFile ]; then
-     (
-       cd ../
-       if [ ! -e lobby/build/libs/$jarFile ]; then
-         ./gradlew shadowjar
-       fi
-       cd infrastructure
-       mkdir -p $targetFolder
-       cp ../game-headless/build/libs/$jarFile $targetFolder
-     ) 
-  fi
+function main() {
+  buildJars
+  buildMigrations
+
+  ansible-playbook -D -v \
+      "$@" \
+      ansible/site.yml \
+      -i ansible/inventory/vagrant 
 }
 
-buildBotJar
+function buildJars() {
+  (
+    cd ../
+    ./gradlew :http-server:shadowJar :game-headless:shadowJar
+    
+    local targetFolder="./infrastructure/ansible/roles"
+    mkdir -p "${targetFolder}/bot/files/" "${targetFolder}/http_server/files/"
+    cp "game-headless/build/libs/triplea-game-headless-${VERSION}.jar" "${targetFolder}/bot/files/"
+    cp "http-server/build/libs/triplea-http-server-${VERSION}.jar" "${targetFolder}/http_server/files/"
+  ) 
+}
 
 function buildMigrations() {
   local targetFolder=./ansible/roles/flyway/files/
@@ -46,9 +48,5 @@ function buildMigrations() {
   fi
 }
 
-buildMigrations
+main
 
-ansible-playbook -D -v \
-    "$@" \
-    ansible/site.yml \
-    -i ansible/inventory/vagrant 

--- a/infrastructure/run_ansible_vagrant
+++ b/infrastructure/run_ansible_vagrant
@@ -10,16 +10,6 @@ fi
 
 export VERSION=$(sed 's/.*=\s*//' ../game-core/src/main/resources/META-INF/triplea/product.properties)
 
-function main() {
-  buildJars
-  buildMigrations
-
-  ansible-playbook -D -v \
-      "$@" \
-      ansible/site.yml \
-      -i ansible/inventory/vagrant 
-}
-
 function buildJars() {
   (
     cd ../
@@ -48,5 +38,11 @@ function buildMigrations() {
   fi
 }
 
-main
+buildJars
+buildMigrations
+
+ansible-playbook -D -v \
+    "$@" \
+    ansible/site.yml \
+    -i ansible/inventory/vagrant 
 

--- a/infrastructure/run_ansible_vagrant
+++ b/infrastructure/run_ansible_vagrant
@@ -10,6 +10,16 @@ fi
 
 export VERSION=$(sed 's/.*=\s*//' ../game-core/src/main/resources/META-INF/triplea/product.properties)
 
+function main() {
+  buildJars
+  buildMigrations
+
+  ansible-playbook -D -v \
+      "$@" \
+      ansible/site.yml \
+      -i ansible/inventory/vagrant 
+}
+
 function buildJars() {
   (
     cd ../
@@ -38,11 +48,5 @@ function buildMigrations() {
   fi
 }
 
-buildJars
-buildMigrations
-
-ansible-playbook -D -v \
-    "$@" \
-    ansible/site.yml \
-    -i ansible/inventory/vagrant 
+main
 

--- a/infrastructure/run_ansible_vagrant
+++ b/infrastructure/run_ansible_vagrant
@@ -48,5 +48,5 @@ function buildMigrations() {
   fi
 }
 
-main
+main "$@"
 


### PR DESCRIPTION
1. Invoke all functions from a 'main' method and invoke the main method
at the bottom of the file. This keeps the logic flow at the top of the file.

2. The jar creation commands were not very correct, with this update
we will use gradle to do a no-op if jars are already created rather than
checking for it in shell script, and secondly we'll create jars of only
the suprojects that we need.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done
Ran:
```
./gradlew clean
rm -rf infrastructure/ansible/roles/http_server/files infrastructure/ansible/roles/bot/files
cd infrastructure
vagrant reload
./run_ansible_vagrant
```

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

