### PR TITLE
Automate localhost install of cert from vagrant machine

### DIFF
--- a/infrastructure/README-VAGRANT-DEV.md
+++ b/infrastructure/README-VAGRANT-DEV.md
@@ -45,26 +45,10 @@ sudo chown $USER:$USER -R ~/triplea/infrastructure/.vagrant/
 ### HTTPS Config
 
 Ansible will setup a self-signed certificate to be used by nginx.
-So in order to actually access the server
-without any exception thrown by the TLS layer,
-you'll have to import this certificate into your OS' root certificates.
-To extract the certificate on to your system,
-you'll have to install the vagrant-scp plugin like this:
-```bash
-vagrant plugin install vagrant-scp
-```
-Then you can copy it to a convenient place on your system in order to import it.
-On Ubuntu you'd run:
-```bash
-sudo vagrant scp :/etc/nginx/cert.crt /usr/local/share/ca-certificates/triplea_vagrant.crt
-sudo chmod 644 /usr/local/share/ca-certificates/triplea_vagrant.crt
-sudo update-ca-certificates
-```
-to import the certificate into your local keystore.
-Now you can use the self-signed certificate like any other CA-validated certificate.
-You'll have to do this every time the self-signed certificate expires
-or is replaced manually.
-Currently it's valid for 356 days.
+`run_ansible_vagrant` will symlink this certificate from the vagrant virtual
+machine to your local '/usr/local/share/ca-certificates' where it will
+be picked up and added as a trusted certificate.
+
 
 ## Check Results
 

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -76,7 +76,6 @@ touch vault_password
 # edit 'vault_password' and add the ansible vault password
 ```
 
-
 ## PreRelease and Production Deployments
 
 - Executed as part of travis pipeline build after release artifacts are generated
@@ -102,7 +101,6 @@ lindoe web UI. Add this public key to your linode account profile (via the linod
 
 Then, when creating a new linode, select that public key and it will added to the root user
 'authorized_keys' file.
-
 
 # Ansible Variables
 
@@ -136,7 +134,6 @@ ie: `{{ foo_db_password }}`
 - define shared variables and environment specific overrides in `group_vars`
 - all other variables should be defined in `defaults/main.yml`
 
-
 # Creating Secrets
 
 ### Encrypting variables
@@ -167,7 +164,6 @@ For reference, encrypting a file looks like this:
 ansible-vault encrypt --vault-password-file=vault_password ansible_ssh_key.ed25519
 ```
 
-
 # Https Certificate Installation
 
 Currently done manually.
@@ -188,7 +184,6 @@ sudo certbot --nginx -m tripleabuilderbot@gmail.com --agree-tos
 Create CAA DNS records
 
 ![Screenshot from 2019-11-19 13-06-13](https://user-images.githubusercontent.com/12397753/69196411-48980e00-0ae3-11ea-9130-61e1fd5368b3.png)
-
 
 Everything that goes well, should look like:
 ```

--- a/infrastructure/ansible/group_vars/vagrant.yml
+++ b/infrastructure/ansible/group_vars/vagrant.yml
@@ -3,3 +3,6 @@ ansible_ssh_extra_args: '-o StrictHostKeyChecking=no'
 ansible_host: 127.0.0.1
 ansible_python_interpreter: /usr/bin/python3
 lobby_uri: "http://localhost:8080"
+
+nginx_ssl_certificate: "/vagrant/.vagrant/{{ lookup('env','CRT_FILE') }}"
+

--- a/infrastructure/ansible/roles/nginx/tasks/main.yml
+++ b/infrastructure/ansible/roles/nginx/tasks/main.yml
@@ -16,11 +16,22 @@
     dest: "{{ nginx_ssl_dhparams }}"
     mode: 600
 
+- name: check for nginx cert key
+  stat:
+    path: "{{ nginx_ssl_certificate_key }}"
+  register: cert_key
+  changed_when: false
+
+- name: check for nginx certificate
+  stat:
+    path: "{{ nginx_ssl_certificate }}"
+  register: cert
+  changed_when: false
+
 - name: create SSL keys if needed
   become: true
+  when: (cert_key.stat.exists == false) or (cert.stat.exists == false)
   command: openssl req -x509 -nodes -days 365 -newkey rsa:4096 -keyout {{ nginx_ssl_certificate_key }} -out {{ nginx_ssl_certificate }} -batch -subj '/CN=localhost' -sha256
-  args:
-    creates: "{{ nginx_ssl_certificate_key }}"
 
 - name: deploy nginx sites_enabled configuation
   become: true

--- a/infrastructure/run_ansible_vagrant
+++ b/infrastructure/run_ansible_vagrant
@@ -10,14 +10,26 @@ fi
 
 export VERSION=$(sed 's/.*=\s*//' ../game-core/src/main/resources/META-INF/triplea/product.properties)
 
+export CRT_FILE="triplea-nginx-vagrant.crt"
+
 function main() {
+  symlinkNginxCert
   buildJars
   buildMigrations
 
   ansible-playbook -D -v \
       "$@" \
       ansible/site.yml \
-      -i ansible/inventory/vagrant 
+      -i ansible/inventory/vagrant
+  # Update certs to pick up new or updated certs from nginx
+  sudo update-ca-certificates -f
+}
+
+function symlinkNginxCert() {
+  local link="/usr/local/share/ca-certificates/${CRT_FILE}"
+  if [ ! -L "$link" ]; then
+    sudo ln -s "$(pwd)/.vagrant/${CRT_FILE}" "$link"
+  fi
 }
 
 function buildJars() {


### PR DESCRIPTION
Automates installation of NGINX SSL certificate to localhost (ansible control machine)
when deploying to a vagrant VM. Assumes localhost is linux-flavored. If running on windows OS,
will likely need to do a linux VM to simulate the control machine, and then can use vagrant
from within the VM to simulate a target machine.

Change summary:
1. Use vagrant group_vars to add override for vagrant env to place certs in '/vagrant/.vagrant/'
The '/vagrant/' folder is a special mount on the virtual machine that maps to the local machine:
  'triplea/infrastructure/'. Hence '/vagrant/.vagrant/' maps to 'triplea/infrastructure/.vagrant'

2. Use run_ansible_vagrant script to install generated cert on localhost:
 A) symlink the nginx cert from 'infrastructure/.vagrant/(cert-file)' to '/usr/local/share/ca-certificates/'
 B) when done with ansible deployment, run 'update-ca-certificates -f' to refresh certificates
    and pick up any new or updated certs in '/usr/local/share/ca-certificates/'

3. Update cert installation step to run if either cert file does not exist.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[x] Other:  vagrant deployment automation <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done

### Clean install
```
./gradlew clean
cd infrastructure
vagrant halt
vagrant destroy
vagrant up
./run_ansible_vagrant
```
- Then connected to lobby on "https://localhost:8000"

### Removed key files

#### A
- removed the certifcate file in 'infrastructure/.vagrant/' 
- re-ran automation (`./run_ansible_vagrant`)
- noticed the headed game had to be restarted to pick up the updated certs
- reconnected to lobby (https://localhost:8000)

#### B
- removed the certificate on the VM in /etc/nginx
- re-ran automation (`./run_ansible_vagrant`)
- restarted headed game
- reconnected to lobby (https://localhost:8000)


<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

