### PR TITLE
Fix flyway install apt user

### DIFF
--- a/infrastructure/ansible/roles/flyway/tasks/main.yml
+++ b/infrastructure/ansible/roles/flyway/tasks/main.yml
@@ -79,7 +79,6 @@
 
 - name: install unzip
   become: true
-  become_user: flyway
   apt:
     state: present
     name: unzip


### PR DESCRIPTION
Need to run 'apt' as root, not as 'flyway'. Running as non-root user
yields a permission-denied error.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[x] Other: Deployment infrastructure change  <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

