### PR TITLE
Add ansible playbook tags

### DIFF
--- a/infrastructure/ansible/site.yml
+++ b/infrastructure/ansible/site.yml
@@ -12,7 +12,11 @@
   strategy: free
   tags: security
   roles:
-    - apt_update
+    - role: apt_update
+      tags:
+        - bot
+        - nginx
+        - http_server
     - admin_user
     - firewall
     - security
@@ -34,8 +38,10 @@
   tags: lobby
   roles:
     - java
-    - http_server
-    - nginx
+    - role: http_server
+      tags: [ http_server ]
+    - role: nginx
+      tags: [ nginx ]
 
 - hosts: botHosts
   gather_facts: no
@@ -43,4 +49,5 @@
   tags: bots
   roles:
     - java
-    - bot
+    - role: bot
+      tags: [ bot ]


### PR DESCRIPTION
Add tags so we can install 'nginx', 'bot' or 'http_server'
on their own with, eg: `./run_ansible_vagrant -t nginx`

The apt-update command needs to be run (usually) before apt install,
hence the apt-update role in playbook is tagged with each role. Arguably
we could tag the java role as well, this tagging more or less assumes
we're doing an update and that we've already run the deployment
automation and that we're iterating on a specific role to fine-tune
the deployment for that role.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 

