### PR TITLE
Fix paratroopers.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -400,20 +400,21 @@ public class MovePerformer implements Serializable {
         arrived.stream().anyMatch(paratroopNAirTransports)
             && MoveValidator.allLandUnitsAreBeingParatroopered(arrived);
     final Map<Unit, Collection<Unit>> dependentAirTransportableUnits =
-        MoveValidator.getDependents(
-            CollectionUtils.getMatches(arrived, Matches.unitCanTransport()));
+        new HashMap<>(
+            MoveValidator.getDependents(
+                CollectionUtils.getMatches(arrived, Matches.unitCanTransport())));
     // add newly created dependents
-    if (newDependents != null) {
-      for (final Entry<Unit, Collection<Unit>> entry : newDependents.entrySet()) {
-        Collection<Unit> dependents = dependentAirTransportableUnits.get(entry.getKey());
-        if (dependents != null) {
-          dependents.addAll(entry.getValue());
-        } else {
-          dependents = entry.getValue();
-        }
-        dependentAirTransportableUnits.put(entry.getKey(), dependents);
+    for (final Entry<Unit, Collection<Unit>> entry : newDependents.entrySet()) {
+      Collection<Unit> dependents = dependentAirTransportableUnits.get(entry.getKey());
+      if (dependents != null) {
+        dependents = new ArrayList<>(dependents);
+        dependents.addAll(entry.getValue());
+      } else {
+        dependents = entry.getValue();
       }
+      dependentAirTransportableUnits.put(entry.getKey(), dependents);
     }
+
     // If paratroops moved normally (within their normal movement) remove their dependency to the
     // airTransports
     // So they can all continue to move normally

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -299,7 +299,7 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
                       candidateAirTransportsMatch);
               // candidateAirTransports.removeAll(selectedUnits);
               candidateAirTransports.removeAll(dependentUnits.keySet());
-              if (unitsToLoad.size() > 0 && candidateAirTransports.size() > 0) {
+              if (!unitsToLoad.isEmpty() && !candidateAirTransports.isEmpty()) {
                 final Collection<Unit> airTransportsToLoad =
                     getAirTransportsToLoad(candidateAirTransports);
                 selectedUnits.addAll(airTransportsToLoad);
@@ -307,12 +307,6 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
                   final Collection<Unit> loadedAirTransports =
                       getLoadedAirTransports(route, unitsToLoad, airTransportsToLoad, player);
                   selectedUnits.addAll(loadedAirTransports);
-                  final Map<Unit, Unit> unitsToTransports =
-                      TransportUtils.mapTransportsToLoad(loadedAirTransports, airTransportsToLoad);
-                  final MoveDescription message =
-                      new MoveDescription(
-                          loadedAirTransports, route, unitsToTransports, dependentUnits);
-                  setMoveMessage(message);
                 }
               }
             }


### PR DESCRIPTION
Paratroopers were broken by some recent commits.
This fixes the issues.

There were two problems:
  1. MoveDescription was not allowed to be constructed with a Route with no steps, but turns out that it was not needed at all and that codepath could just be removed.
  2. We were trying to modify some unmodifiable collections, which is fixed by making copies.

Additional, cleans up a couple things in related code - using isEmpty() instead of size() checks and removing an unnecessary null check.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[X] Problem fix:  https://github.com/triplea-game/triplea/issues/5720
[] Other:   <!-- Please specify -->

## Testing

[X] Manual testing done

Loading paratrooper as described in the issue.
