### PR TITLE
Enable HTTP/2 and IPv6 for spitfire nginx config

### DIFF
--- a/infrastructure/ansible/roles/nginx/tasks/main.yml
+++ b/infrastructure/ansible/roles/nginx/tasks/main.yml
@@ -31,7 +31,7 @@
 - name: create SSL keys if needed
   become: true
   when: (cert_key.stat.exists == false) or (cert.stat.exists == false)
-  command: openssl req -x509 -nodes -days 365 -newkey rsa:4096 -keyout {{ nginx_ssl_certificate_key }} -out {{ nginx_ssl_certificate }} -batch -subj '/CN=localhost' -sha256
+  command: openssl req -x509 -nodes -days 365 -newkey rsa:4096 -keyout {{ nginx_ssl_certificate_key }} -out {{ nginx_ssl_certificate }} -batch -subj '/CN=localhost' -sha256 -addext "subjectAltName = IP:127.0.0.1, IP:::1"
 
 - name: deploy nginx sites_enabled configuation
   become: true

--- a/infrastructure/ansible/roles/nginx/templates/etc_nginx_sites_enabled_default.j2
+++ b/infrastructure/ansible/roles/nginx/templates/etc_nginx_sites_enabled_default.j2
@@ -1,10 +1,12 @@
 server {
     listen 80;
+    listen [::]:80;
     return 301 https://$host$request_uri;
 }
 
 server {
-    listen 443;
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
     server_name {{ inventory_hostname }};
     ssl_certificate {{ nginx_ssl_certificate }};
     ssl_certificate_key {{ nginx_ssl_certificate_key }};


### PR DESCRIPTION
<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 
This adjusts the nginx config to also support HTTP 2 and IPv6.
It also updates the certificate generation step, so that `[::1]` and `127.0.0.1` are valid hostnames.

Note that for some reason vagrant doesn't port-forward IPv6 (there are some open issues on the repository, but it looks like it's broken for now), so you can't access the server via IPv6 outside of the vagrant guest system. (An internal curl works though, I verified that.)
But the nginx config becomes important once the server goes live.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

