### PR TITLE
Improve algorithm for loading units onto transports in move UI.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -1103,8 +1103,9 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
     getMap().hideMouseCursor();
 
     final MovableUnitsFilter unitsFilter =
-        new MovableUnitsFilter(getUnitOwner(units), route, nonCombat, moveType, getUndoableMoves());
-    final var result = unitsFilter.filterUnitsThatCanMove(units, dependentUnits);
+        new MovableUnitsFilter(
+            getUnitOwner(units), route, nonCombat, moveType, getUndoableMoves(), dependentUnits);
+    final var result = unitsFilter.filterUnitsThatCanMove(units);
     switch (result.getStatus()) {
       case NO_UNITS_CAN_MOVE:
         setStatusErrorMessage(result.getWarningOrErrorMessage().orElseThrow());

--- a/game-core/src/main/java/games/strategy/triplea/util/MovableUnitsFilter.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/MovableUnitsFilter.java
@@ -147,7 +147,7 @@ public final class MovableUnitsFilter {
     best.sort(getUnitComparator(best).reversed());
     while (!best.isEmpty() && !lastResult.getResult().isMoveValid()) {
       best = nextSublist(best, hasLandTransports);
-      lastResult = validateMoveWithDependents(best, transportsToLoad);
+      lastResult = validateMoveWithDependents(best, List.of());
     }
     return lastResult;
   }

--- a/game-core/src/main/java/games/strategy/triplea/util/MovableUnitsFilter.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/MovableUnitsFilter.java
@@ -111,10 +111,10 @@ public final class MovableUnitsFilter {
    */
   public FilterOperationResult filterUnitsThatCanMove(
       final Collection<Unit> units, final Map<Unit, Collection<Unit>> dependentUnits) {
+    final List<Unit> best = getInitialUnitList(units);
+
     final Collection<Unit> transportsToLoad =
         getPossibleTransportsToLoad(units, dependentUnits, route);
-
-    List<Unit> best = getInitialUnitList(units);
     MoveValidationResultWithDependents lastResult =
         validateMoveWithDependents(best, dependentUnits, transportsToLoad);
     final MoveValidationResult allUnitsResult = lastResult.getResult();
@@ -132,7 +132,7 @@ public final class MovableUnitsFilter {
       final Route route,
       final Map<Unit, Collection<Unit>> dependentUnits,
       final Collection<Unit> transportsToLoad,
-      MoveValidationResultWithDependents lastResult) {
+      final MoveValidationResultWithDependents lastResult) {
     if (!transportsToLoad.isEmpty()) {
       final List<Unit> allUnits = addMustMoveWith(units, dependentUnits);
       final Collection<Unit> loadedUnits =

--- a/game-core/src/main/java/games/strategy/triplea/util/MovableUnitsFilter.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/MovableUnitsFilter.java
@@ -132,13 +132,15 @@ public final class MovableUnitsFilter {
       final Route route,
       final Map<Unit, Collection<Unit>> dependentUnits,
       final Collection<Unit> transportsToLoad,
-      final MoveValidationResultWithDependents lastResult) {
+      final MoveValidationResultWithDependents initialLastResult) {
     if (!transportsToLoad.isEmpty()) {
       final List<Unit> allUnits = addMustMoveWith(units, dependentUnits);
       final Collection<Unit> loadedUnits =
           TransportUtils.mapTransports(route, allUnits, transportsToLoad).keySet();
       return validateMoveWithDependents(loadedUnits, dependentUnits, transportsToLoad);
     }
+
+    MoveValidationResultWithDependents lastResult = initialLastResult;
     List<Unit> best = units;
     // if the player is invading only consider units that can invade
     if (!nonCombat
@@ -198,9 +200,6 @@ public final class MovableUnitsFilter {
     }
     if (route.isUnload()) {
       best = CollectionUtils.getMatches(best, Matches.unitIsNotSea());
-    }
-    if (!best.isEmpty()) {
-      best.sort(getUnitComparator(best).reversed());
     }
     return best;
   }

--- a/game-core/src/main/java/games/strategy/triplea/util/MovableUnitsFilter.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/MovableUnitsFilter.java
@@ -132,7 +132,7 @@ public final class MovableUnitsFilter {
       final Route route,
       final Map<Unit, Collection<Unit>> dependentUnits,
       final Collection<Unit> transportsToLoad,
-      final MoveValidationResultWithDependents initialLastResult) {
+      final MoveValidationResultWithDependents initialResult) {
     if (!transportsToLoad.isEmpty()) {
       final List<Unit> allUnits = addMustMoveWith(units, dependentUnits);
       final Collection<Unit> loadedUnits =
@@ -140,7 +140,7 @@ public final class MovableUnitsFilter {
       return validateMoveWithDependents(loadedUnits, dependentUnits, transportsToLoad);
     }
 
-    MoveValidationResultWithDependents lastResult = initialLastResult;
+    MoveValidationResultWithDependents lastResult = initialResult;
     List<Unit> best = units;
     // if the player is invading only consider units that can invade
     if (!nonCombat

--- a/game-core/src/main/java/games/strategy/triplea/util/MovableUnitsFilter.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/MovableUnitsFilter.java
@@ -121,7 +121,7 @@ public final class MovableUnitsFilter {
 
     if (!allUnitsResult.isMoveValid()) {
       lastResult =
-          chooseSubsetOfUnitsThatCanMove(best, route, dependentUnits, transportsToLoad, lastResult);
+          chooseSubsetOfUnitsThatCanMove(best, dependentUnits, transportsToLoad, lastResult);
     }
 
     return new FilterOperationResult(allUnitsResult, lastResult);
@@ -129,7 +129,6 @@ public final class MovableUnitsFilter {
 
   private MoveValidationResultWithDependents chooseSubsetOfUnitsThatCanMove(
       final List<Unit> units,
-      final Route route,
       final Map<Unit, Collection<Unit>> dependentUnits,
       final Collection<Unit> transportsToLoad,
       final MoveValidationResultWithDependents initialResult) {

--- a/game-core/src/main/java/games/strategy/triplea/util/MovableUnitsFilter.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/MovableUnitsFilter.java
@@ -145,6 +145,7 @@ public final class MovableUnitsFilter {
     if (!nonCombat
         && route.isUnload()
         && Matches.isTerritoryEnemy(player, data).test(route.getEnd())) {
+      best = CollectionUtils.getMatches(best, Matches.unitCanInvade());
       lastResult = validateMoveWithDependents(best, dependentUnits, List.of());
     }
 

--- a/game-core/src/test/java/games/strategy/triplea/util/MovableUnitsFilterTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/util/MovableUnitsFilterTest.java
@@ -149,7 +149,7 @@ public class MovableUnitsFilterTest {
   }
 
   @Test
-  @DisplayName("moving 3 infantry and 2 tanks onto one transport loads 1 tank and one infantry")
+  @DisplayName("moving 3 infantry and 2 tanks onto a transport loads 1 infantry and 1 tank")
   void filterMixedUnitsLoadingOntoTransport() throws Exception {
     final Route route = new Route(germany, sz5);
     final Collection<Unit> units = germanyTanksAndInfantry();
@@ -161,7 +161,7 @@ public class MovableUnitsFilterTest {
   }
 
   @Test
-  @DisplayName("moving 3 infantry onto one transport loads 2 infantry")
+  @DisplayName("moving 3 infantry onto a transport loads 2 infantry")
   void filterInfantryLoadingOntoTransport() throws Exception {
     final Route route = new Route(germany, sz5);
     final Collection<Unit> units = germanyInfantry();
@@ -173,7 +173,7 @@ public class MovableUnitsFilterTest {
   }
 
   @Test
-  @DisplayName("moving 2 tanks onto one transport loads 1 tank")
+  @DisplayName("moving 2 tanks onto a transport loads 1 tank")
   void filterTankLoadingOntoTransport() throws Exception {
     final Route route = new Route(germany, sz5);
     final Collection<Unit> units = germanyTanks();
@@ -185,7 +185,7 @@ public class MovableUnitsFilterTest {
   }
 
   @Test
-  @DisplayName("moving 1 tank and one infantry onto a transport loads them both")
+  @DisplayName("moving 1 tank and 1 infantry onto a transport loads them both")
   void filterFittingMixedUnitsLoadingOntoTransport() throws Exception {
     final Route route = new Route(germany, sz5);
     final Collection<Unit> units =

--- a/game-core/src/test/java/games/strategy/triplea/util/MovableUnitsFilterTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/util/MovableUnitsFilterTest.java
@@ -59,8 +59,8 @@ public class MovableUnitsFilterTest {
     advanceToStep(bridge, "NonCombatMove");
     final MovableUnitsFilter filter =
         new MovableUnitsFilter(
-            player, route, false, AbstractMoveDelegate.MoveType.DEFAULT, List.of());
-    return filter.filterUnitsThatCanMove(units, Map.of());
+            player, route, false, AbstractMoveDelegate.MoveType.DEFAULT, List.of(), Map.of());
+    return filter.filterUnitsThatCanMove(units);
   }
 
   private Collection<Unit> germanyUnits(final Predicate<Unit> predicate) {


### PR DESCRIPTION
Previously, a move of 3 infantry and 2 tanks to one transport would not result in the algorithm choosing 1 tank and 1 infantry to load - instead, it loaded just one tank.

This is because it sorted the list as {inf, inf, inf, tank, tank} and tried all tail sublists of that list to see what fits.

This change fixes that by just using the mapTransports() algorithm to choose the units that can be loaded and adds unit tests.

Also some more refactoring to make codeclimate happy.

Note: This is an improvement over 1.9 which has the same behavior as current master.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[X] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing

[X] Manual testing done

On Revised, as Germany try to move 3 infantry and 2 tanks onto a single transport that's in sz5. One tank and infantry should be loaded with this change. Before, only a single tank was.
