### PR TITLE
Clean up newDelegateBridge() test code.

### DIFF
--- a/game-core/src/test/java/games/strategy/triplea/delegate/AbstractDelegateTestCase.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/AbstractDelegateTestCase.java
@@ -8,7 +8,6 @@ import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.UnitType;
-import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.xml.TestMapGameData;
@@ -105,9 +104,5 @@ public abstract class AbstractDelegateTestCase {
 
   protected static void assertError(final String string) {
     assertNotNull(string, string);
-  }
-
-  protected final IDelegateBridge newDelegateBridge(final PlayerId player) {
-    return MockDelegateBridge.newInstance(gameData, player);
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/AirThatCantLandUtilTest.java
@@ -1,6 +1,7 @@
 package games.strategy.triplea.delegate;
 
 import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
+import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
 import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
 import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -25,10 +26,6 @@ class AirThatCantLandUtilTest {
   private GameData gameData = TestMapGameData.REVISED.getGameData();
   private PlayerId americansPlayer = GameDataTestUtil.americans(gameData);
   private UnitType fighterType = GameDataTestUtil.fighter(gameData);
-
-  private IDelegateBridge newDelegateBridge(final PlayerId player) {
-    return MockDelegateBridge.newInstance(gameData, player);
-  }
 
   private static void fight(final IBattleDelegate battle, final Territory territory) {
     for (final Entry<BattleType, Collection<Territory>> entry :

--- a/game-core/src/test/java/games/strategy/triplea/delegate/BigWorldTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/BigWorldTest.java
@@ -5,6 +5,7 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.british;
 import static games.strategy.triplea.delegate.GameDataTestUtil.moveDelegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
+import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Route;
@@ -24,7 +25,7 @@ class BigWorldTest {
     final Territory sz28 = territory("SZ 28 Eastern Mediterranean", gameData);
     final Territory sz27 = territory("SZ 27 Aegean Sea", gameData);
     final Territory sz29 = territory("SZ 29 Black Sea", gameData);
-    final IDelegateBridge bridge = MockDelegateBridge.newInstance(gameData, british(gameData));
+    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
     advanceToStep(bridge, "CombatMove");
     final MoveDelegate moveDelegate = moveDelegate(gameData);
     moveDelegate.setDelegateBridgeAndPlayer(bridge);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/CasualtySelectorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/CasualtySelectorTest.java
@@ -6,6 +6,7 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.fighter;
 import static games.strategy.triplea.delegate.GameDataTestUtil.makeGameLowLuck;
 import static games.strategy.triplea.delegate.GameDataTestUtil.setSelectAaCasualties;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
+import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
 import static games.strategy.triplea.delegate.MockDelegateBridge.thenGetRandomShouldHaveBeenCalled;
 import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
 import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
@@ -66,7 +67,7 @@ class CasualtySelectorTest {
   @BeforeEach
   void setUp() {
     final GameData data = TestMapGameData.REVISED.getGameData();
-    bridge = MockDelegateBridge.newInstance(data, british(data));
+    bridge = newDelegateBridge(british(data));
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.delegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.bomber;
 import static games.strategy.triplea.delegate.GameDataTestUtil.british;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
+import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
 import static games.strategy.triplea.delegate.MockDelegateBridge.thenGetRandomShouldHaveBeenCalled;
 import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
 import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
@@ -42,10 +43,6 @@ import org.triplea.java.collections.CollectionUtils;
 
 class DiceRollTest {
   private GameData gameData = TestMapGameData.LHTR.getGameData();
-
-  private IDelegateBridge newDelegateBridge(final PlayerId player) {
-    return MockDelegateBridge.newInstance(gameData, player);
-  }
 
   @Test
   void testSimple() {

--- a/game-core/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/LhtrTest.java
@@ -2,6 +2,7 @@ package games.strategy.triplea.delegate;
 
 import static games.strategy.triplea.delegate.GameDataTestUtil.addTo;
 import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
+import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
 import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
 import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -38,10 +39,6 @@ class LhtrTest {
       final IDelegateBridge delegateBridge) {
     verify(delegateBridge.getRemotePlayer(), never()).confirmMoveInFaceOfAa(any());
     verify(delegateBridge.getRemotePlayer(), never()).confirmMoveKamikaze();
-  }
-
-  private IDelegateBridge newDelegateBridge(final PlayerId player) {
-    return MockDelegateBridge.newInstance(gameData, player);
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MockDelegateBridge.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MockDelegateBridge.java
@@ -29,7 +29,8 @@ public final class MockDelegateBridge {
    *
    * @return A mock that can be configured using standard Mockito idioms.
    */
-  public static IDelegateBridge newInstance(final GameData gameData, final PlayerId playerId) {
+  public static IDelegateBridge newDelegateBridge(final PlayerId playerId) {
+    final GameData gameData = playerId.getData();
     final IDelegateBridge delegateBridge = mock(IDelegateBridge.class);
     doAnswer(
             invocation -> {

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -2,6 +2,7 @@ package games.strategy.triplea.delegate;
 
 import static games.strategy.triplea.delegate.GameDataTestUtil.removeFrom;
 import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
+import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
 import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
 import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MustFightBattleTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MustFightBattleTest.java
@@ -6,6 +6,7 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.move;
 import static games.strategy.triplea.delegate.GameDataTestUtil.moveDelegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
+import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
 import static games.strategy.triplea.delegate.MockDelegateBridge.thenGetRandomShouldHaveBeenCalled;
 import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
 import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
@@ -32,7 +33,7 @@ class MustFightBattleTest extends AbstractDelegateTestCase {
     addTo(sz33, GameDataTestUtil.americanCruiser(twwGameData).create(1, usa));
     final Territory sz40 = territory("40 Sea Zone", twwGameData);
     addTo(sz40, GameDataTestUtil.germanMine(twwGameData).create(1, germany));
-    final IDelegateBridge bridge = MockDelegateBridge.newInstance(twwGameData, usa);
+    final IDelegateBridge bridge = newDelegateBridge(usa);
     advanceToStep(bridge, "CombatMove");
     moveDelegate(twwGameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(twwGameData).start();
@@ -59,7 +60,7 @@ class MustFightBattleTest extends AbstractDelegateTestCase {
     celebes.getUnitCollection().clear();
     addTo(celebes, GameDataTestUtil.americanStrategicBomber(twwGameData).create(1, usa));
     addTo(celebes, GameDataTestUtil.germanInfantry(twwGameData).create(1, germany));
-    final IDelegateBridge bridge = MockDelegateBridge.newInstance(twwGameData, germany);
+    final IDelegateBridge bridge = newDelegateBridge(germany);
     battleDelegate(twwGameData).setDelegateBridgeAndPlayer(bridge);
     BattleDelegate.doInitialize(battleDelegate(twwGameData).getBattleTracker(), bridge);
     final IBattle battle =

--- a/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.delegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.load;
 import static games.strategy.triplea.delegate.GameDataTestUtil.move;
 import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
+import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
 import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
 import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/game-core/src/test/java/games/strategy/triplea/delegate/PactOfSteel2Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/PactOfSteel2Test.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea.delegate;
 
+import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -20,10 +21,6 @@ import org.triplea.test.common.TestType;
 @Integration(type = TestType.ACCEPTANCE)
 class PactOfSteel2Test {
   private final GameData gameData = TestMapGameData.PACT_OF_STEEL_2.getGameData();
-
-  private IDelegateBridge newDelegateBridge(final PlayerId player) {
-    return MockDelegateBridge.newInstance(gameData, player);
-  }
 
   @Test
   void testDirectOwnershipTerritories() {

--- a/game-core/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/PlaceDelegateTest.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea.delegate;
 
+import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -35,6 +35,7 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.techDelegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static games.strategy.triplea.delegate.GameDataTestUtil.transport;
 import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
+import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
 import static games.strategy.triplea.delegate.MockDelegateBridge.thenGetRandomShouldHaveBeenCalled;
 import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
 import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
@@ -122,10 +123,6 @@ class RevisedTest {
   private static void givenRemotePlayerWillConfirmMoveInFaceOfAa(
       final IDelegateBridge delegateBridge) {
     when(delegateBridge.getRemotePlayer().confirmMoveInFaceOfAa(any())).thenReturn(true);
-  }
-
-  private IDelegateBridge newDelegateBridge(final PlayerId player) {
-    return MockDelegateBridge.newInstance(gameData, player);
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/triplea/delegate/UnitComparatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/UnitComparatorTest.java
@@ -8,6 +8,7 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.load;
 import static games.strategy.triplea.delegate.GameDataTestUtil.moveDelegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
+import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
@@ -26,7 +27,7 @@ import org.junit.jupiter.api.Test;
 final class UnitComparatorTest {
   private static void startCombatMoveFor(final PlayerId playerId, final GameData gameData) {
     final MoveDelegate moveDelegate = moveDelegate(gameData);
-    final IDelegateBridge bridge = MockDelegateBridge.newInstance(gameData, playerId);
+    final IDelegateBridge bridge = newDelegateBridge(playerId);
     advanceToStep(bridge, "CombatMove");
     moveDelegate.setDelegateBridgeAndPlayer(bridge);
     moveDelegate.start();

--- a/game-core/src/test/java/games/strategy/triplea/delegate/VictoryTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/VictoryTest.java
@@ -1,6 +1,7 @@
 package games.strategy.triplea.delegate;
 
 import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
+import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -56,7 +57,7 @@ class VictoryTest {
     gameData = TestMapGameData.VICTORY_TEST.getGameData();
     italians = GameDataTestUtil.italians(gameData);
     germans = GameDataTestUtil.germans(gameData);
-    testBridge = MockDelegateBridge.newInstance(gameData, italians);
+    testBridge = newDelegateBridge(italians);
     // we need to initialize the original owner
     final InitializationDelegate initDel =
         (InitializationDelegate) gameData.getDelegate("initDelegate");

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -38,6 +38,7 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.techDelegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static games.strategy.triplea.delegate.GameDataTestUtil.transport;
 import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
+import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
 import static games.strategy.triplea.delegate.MockDelegateBridge.thenGetRandomShouldHaveBeenCalled;
 import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
 import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
@@ -133,10 +134,6 @@ class WW2V3Year41Test {
       final IDelegateBridge delegateBridge) {
     verify(delegateBridge.getRemotePlayer(), never())
         .retreatQuery(any(), anyBoolean(), any(), any(), any());
-  }
-
-  private IDelegateBridge newDelegateBridge(final PlayerId player) {
-    return MockDelegateBridge.newInstance(gameData, player);
   }
 
   private static void fight(final BattleDelegate battle, final Territory territory) {

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year42Test.java
@@ -13,6 +13,7 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.removeFrom;
 import static games.strategy.triplea.delegate.GameDataTestUtil.russians;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
+import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -33,10 +34,6 @@ import org.triplea.test.common.TestType;
 @Integration(type = TestType.ACCEPTANCE)
 class WW2V3Year42Test {
   private final GameData gameData = TestMapGameData.WW2V3_1942.getGameData();
-
-  private IDelegateBridge newDelegateBridge(final PlayerId player) {
-    return MockDelegateBridge.newInstance(gameData, player);
-  }
 
   @Test
   void testTransportAttack() {

--- a/game-core/src/test/java/games/strategy/triplea/util/MovableUnitsFilterTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/util/MovableUnitsFilterTest.java
@@ -8,6 +8,7 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.infantry;
 import static games.strategy.triplea.delegate.GameDataTestUtil.russians;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
+import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -25,7 +26,6 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.delegate.AbstractMoveDelegate;
 import games.strategy.triplea.delegate.Matches;
-import games.strategy.triplea.delegate.MockDelegateBridge;
 import games.strategy.triplea.util.MovableUnitsFilter.FilterOperationResult;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.Collection;
@@ -47,10 +47,6 @@ public class MovableUnitsFilterTest {
   final Territory kareliaSsr = territory("Karelia S.S.R.", gameData);
   final UnitType infantryType = infantry(gameData);
   final UnitType armourType = armour(gameData);
-
-  private IDelegateBridge newDelegateBridge(final PlayerId player) {
-    return MockDelegateBridge.newInstance(gameData, player);
-  }
 
   private FilterOperationResult filterUnits(
       final PlayerId player, final Route route, final Collection<Unit> units) {


### PR DESCRIPTION
A lot of tests had smaller helper newDelegateBridge() methods. This change refactors the code to make that method a static method in MockDelegateBridge that is imported statically, removing the need for all those helpers.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[X] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

