### PR TITLE
Remove redundant game data params.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -247,7 +247,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
         player == null
             ? neighborFilter
             : neighborFilter.and(
-                t -> MoveValidator.canAnyUnitsPassCanal(territory, t, units, player, getData())));
+                t -> MoveValidator.canAnyUnitsPassCanal(territory, t, units, player)));
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -2515,8 +2515,7 @@ class ProNonCombatMoveAi {
                       u,
                       player);
           final MoveValidationResult mvr =
-              MoveValidator.validateMove(
-                  new MoveDescription(List.of(u), r), player, true, null, data);
+              MoveValidator.validateMove(new MoveDescription(List.of(u), r), player, true, null);
           if (!mvr.isMoveValid()) {
             continue;
           }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
@@ -433,7 +433,7 @@ final class ProTechAi {
           }
           if (sea) {
             final Route r = new Route(neighbor, current);
-            if (MoveValidator.validateCanal(r, null, player, data) != null) {
+            if (MoveValidator.validateCanal(r, null, player) != null) {
               continue;
             }
           }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -1166,8 +1166,7 @@ public class ProTerritoryManager {
               if (MoveValidator.validateCanal(
                       new Route(currentTerritory, possibleNeighborTerritory),
                       List.of(myTransportUnit),
-                      player,
-                      data)
+                      player)
                   == null) {
                 nextTerritories.add(possibleNeighborTerritory);
               }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -1163,11 +1163,8 @@ public class ProTerritoryManager {
                         currentTerritory,
                         ProMatches.territoryCanMoveSeaUnitsThrough(player, data, isCombatMove));
             for (final Territory possibleNeighborTerritory : possibleNeighborTerritories) {
-              if (MoveValidator.validateCanal(
-                      new Route(currentTerritory, possibleNeighborTerritory),
-                      List.of(myTransportUnit),
-                      player)
-                  == null) {
+              final Route route = new Route(currentTerritory, possibleNeighborTerritory);
+              if (MoveValidator.validateCanal(route, List.of(myTransportUnit), player) == null) {
                 nextTerritories.add(possibleNeighborTerritory);
               }
             }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -232,9 +232,8 @@ public final class ProMoveUtils {
             int maxDistanceFromEnd =
                 Integer.MIN_VALUE; // Used to move to farthest away loading territory first
             for (final Territory neighbor : neighbors) {
-              if (MoveValidator.validateCanal(
-                      new Route(transportTerritory, neighbor), List.of(transport), player)
-                  != null) {
+              final Route route = new Route(transportTerritory, neighbor);
+              if (MoveValidator.validateCanal(route, List.of(transport), player) != null) {
                 continue;
               }
               int distanceFromUnloadTerritory = 0;

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -233,7 +233,7 @@ public final class ProMoveUtils {
                 Integer.MIN_VALUE; // Used to move to farthest away loading territory first
             for (final Territory neighbor : neighbors) {
               if (MoveValidator.validateCanal(
-                      new Route(transportTerritory, neighbor), List.of(transport), player, data)
+                      new Route(transportTerritory, neighbor), List.of(transport), player)
                   != null) {
                 continue;
               }

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -317,7 +317,7 @@ public class WeakAi extends AbstractAi {
     final Predicate<Territory> routeCond =
         Matches.territoryIsWater()
             .and(Matches.territoryHasEnemyUnits(player, data).negate())
-            .and(Matches.territoryHasNonAllowedCanal(player, null, data).negate());
+            .and(Matches.territoryHasNonAllowedCanal(player, null).negate());
     Route r = data.getMap().getRoute(start, destination, routeCond);
     if (r == null || r.hasNoSteps() || !routeCond.test(destination)) {
       return null;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
@@ -124,12 +124,11 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
       final MoveDescription move,
       final PlayerId player,
       final boolean isNonCombat,
-      final List<UndoableMove> undoableMoves,
-      final GameData data) {
+      final List<UndoableMove> undoableMoves) {
     if (moveType == MoveType.SPECIAL) {
-      return SpecialMoveDelegate.validateMove(move.getUnits(), move.getRoute(), player, data);
+      return SpecialMoveDelegate.validateMove(move.getUnits(), move.getRoute(), player);
     }
-    return MoveValidator.validateMove(move, player, isNonCombat, undoableMoves, data);
+    return MoveValidator.validateMove(move, player, isNonCombat, undoableMoves);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -39,11 +39,11 @@ public final class AirMovementValidator {
   // carriers. these would be air units that have already been moved this turn, and therefore would
   // need pickup.
   static MoveValidationResult validateAirCanLand(
-      final GameData data,
       final Collection<Unit> units,
       final Route route,
       final PlayerId player,
       final MoveValidationResult result) {
+    final GameData data = player.getData();
     // First check if we even need to check
     if (getEditMode(data) // Edit Mode, no need to check
         || units.stream().noneMatch(Matches.unitIsAir()) // No Airunits, nothing to check

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -1431,7 +1431,7 @@ public class DiceRoll implements Externalizable {
       if (rolls <= 0 || strength <= 0) {
         continue;
       }
-      if (rolls > 1 && (lhtrBombers || ua.getChooseBestRoll())) {
+      if (rolxtestRoll())) {
         int smallestDieIndex = 0;
         int smallestDie = data.getDiceSides();
         for (int i = 0; i < rolls; i++) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -1431,7 +1431,7 @@ public class DiceRoll implements Externalizable {
       if (rolls <= 0 || strength <= 0) {
         continue;
       }
-      if (rolxtestRoll())) {
+      if (rolls > 1 && (lhtrBombers || ua.getChooseBestRoll())) {
         int smallestDieIndex = 0;
         int smallestDie = data.getDiceSides();
         for (int i = 0; i < rolls; i++) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1515,8 +1515,8 @@ public final class Matches {
 
   // TODO: Eventually remove as only used by AI and doesn't handle canals very well
   public static Predicate<Territory> territoryHasNonAllowedCanal(
-      final PlayerId player, final Collection<Unit> unitsMoving, final GameData data) {
-    return t -> MoveValidator.validateCanal(new Route(t), unitsMoving, player, data) != null;
+      final PlayerId player, final Collection<Unit> unitsMoving) {
+    return t -> MoveValidator.validateCanal(new Route(t), unitsMoving, player) != null;
   }
 
   public static Predicate<Territory> territoryIsBlockedSea(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -621,7 +621,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     final PlayerId player = getUnitsOwner(move.getUnits());
     final MoveValidationResult result =
         MoveValidator.validateMove(
-            move, player, GameStepPropertiesHelper.isNonCombatMove(data, false), movesToUndo, data);
+            move, player, GameStepPropertiesHelper.isNonCombatMove(data, false), movesToUndo);
     final StringBuilder errorMsg = new StringBuilder(100);
     final int numProblems = result.getTotalWarningCount() - (result.hasError() ? 0 : 1);
     final String numErrorsMsg =

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -1124,8 +1124,7 @@ public class MoveValidator {
     // neutrals we will overfly in the first place
     final GameData data = player.getData();
     final Collection<Territory> neutrals = MoveDelegate.getEmptyNeutral(route);
-    final int pus =
-        (player.isNull()) ? 0 : player.getResources().getQuantity(Constants.PUS);
+    final int pus = player.isNull() ? 0 : player.getResources().getQuantity(Constants.PUS);
     if (pus < getNeutralCharge(data, neutrals.size())) {
       return result.setErrorReturnResult(TOO_POOR_TO_VIOLATE_NEUTRALITY);
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -1125,7 +1125,7 @@ public class MoveValidator {
     final GameData data = player.getData();
     final Collection<Territory> neutrals = MoveDelegate.getEmptyNeutral(route);
     final int pus =
-        (player == null || player.isNull()) ? 0 : player.getResources().getQuantity(Constants.PUS);
+        (player.isNull()) ? 0 : player.getResources().getQuantity(Constants.PUS);
     if (pus < getNeutralCharge(data, neutrals.size())) {
       return result.setErrorReturnResult(TOO_POOR_TO_VIOLATE_NEUTRALITY);
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveValidator.java
@@ -74,8 +74,7 @@ public class MoveValidator {
       final MoveDescription move,
       final PlayerId player,
       final boolean isNonCombat,
-      final List<UndoableMove> undoableMoves,
-      final GameData data) {
+      final List<UndoableMove> undoableMoves) {
     final Collection<Unit> units = move.getUnits();
     final Route route = move.getRoute();
     final Map<Unit, Unit> unitsToTransports = move.getUnitsToTransports();
@@ -84,48 +83,47 @@ public class MoveValidator {
     if (route.hasNoSteps()) {
       return result;
     }
-    if (validateFirst(data, units, route, player, result).getError() != null) {
+    if (validateFirst(units, route, player, result).getError() != null) {
       return result;
     }
     if (isNonCombat) {
-      if (validateNonCombat(data, units, route, player, result).getError() != null) {
+      if (validateNonCombat(units, route, player, result).getError() != null) {
         return result;
       }
     } else {
-      if (validateCombat(data, units, route, player, result).getError() != null) {
+      if (validateCombat(units, route, player, result).getError() != null) {
         return result;
       }
     }
-    if (validateNonEnemyUnitsOnPath(data, units, route, player, result).getError() != null) {
+    if (validateNonEnemyUnitsOnPath(units, route, player, result).getError() != null) {
       return result;
     }
-    if (validateBasic(data, units, route, player, unitsToTransports, newDependents, result)
-            .getError()
+    if (validateBasic(units, route, player, unitsToTransports, newDependents, result).getError()
         != null) {
       return result;
     }
-    if (AirMovementValidator.validateAirCanLand(data, units, route, player, result).getError()
-        != null) {
+    if (AirMovementValidator.validateAirCanLand(units, route, player, result).getError() != null) {
       return result;
     }
     if (validateTransport(
-                isNonCombat, data, undoableMoves, units, route, player, unitsToTransports, result)
+                isNonCombat, undoableMoves, units, route, player, unitsToTransports, result)
             .getError()
         != null) {
       return result;
     }
-    if (validateParatroops(isNonCombat, data, units, route, player, result).getError() != null) {
+    if (validateParatroops(isNonCombat, units, route, player, result).getError() != null) {
       return result;
     }
-    if (validateCanal(data, units, route, player, newDependents, result).getError() != null) {
+    if (validateCanal(units, route, player, newDependents, result).getError() != null) {
       return result;
     }
-    if (validateFuel(data, units, route, player, result).getError() != null) {
+    if (validateFuel(units, route, player, result).getError() != null) {
       return result;
     }
 
     // Don't let the user move out of a battle zone, the exception is air units and unloading units
     // into a battle zone
+    final GameData data = player.getData();
     if (AbstractMoveDelegate.getBattleTracker(data).hasPendingBattle(route.getStart(), false)
         && units.stream().anyMatch(Matches.unitIsNotAir())) {
       // if the units did not move into the territory, then they can move out this will happen if
@@ -157,11 +155,11 @@ public class MoveValidator {
   }
 
   static MoveValidationResult validateFirst(
-      final GameData data,
       final Collection<Unit> units,
       final Route route,
       final PlayerId player,
       final MoveValidationResult result) {
+    final GameData data = player.getData();
     if (!units.isEmpty() && !getEditMode(data)) {
       final Collection<Unit> matches =
           CollectionUtils.getMatches(
@@ -187,7 +185,7 @@ public class MoveValidator {
       result.setError("Invalid route:" + route);
       return result;
     }
-    if (validateMovementRestrictedByTerritory(data, route, player, result).getError() != null) {
+    if (validateMovementRestrictedByTerritory(route, player, result).getError() != null) {
       return result;
     }
     // cannot enter territories owned by a player to which we are neutral towards
@@ -236,11 +234,11 @@ public class MoveValidator {
   }
 
   static MoveValidationResult validateFuel(
-      final GameData data,
       final Collection<Unit> units,
       final Route route,
       final PlayerId player,
       final MoveValidationResult result) {
+    final GameData data = player.getData();
     if (getEditMode(data)) {
       return result;
     }
@@ -256,17 +254,17 @@ public class MoveValidator {
   }
 
   private static MoveValidationResult validateCanal(
-      final GameData data,
       final Collection<Unit> units,
       final Route route,
       final PlayerId player,
       final Map<Unit, Collection<Unit>> newDependents,
       final MoveValidationResult result) {
+    final GameData data = player.getData();
     if (getEditMode(data)) {
       return result;
     }
     // TODO: merge validateCanal here and provide granular unit warnings
-    return result.setErrorReturnResult(validateCanal(route, units, newDependents, player, data));
+    return result.setErrorReturnResult(validateCanal(route, units, newDependents, player));
   }
 
   /**
@@ -275,17 +273,16 @@ public class MoveValidator {
    * @param units (Can be null. If null we will assume all units would be stopped by the canal.)
    */
   public static String validateCanal(
-      final Route route, final Collection<Unit> units, final PlayerId player, final GameData data) {
-    return validateCanal(route, units, new HashMap<>(), player, data);
+      final Route route, final Collection<Unit> units, final PlayerId player) {
+    return validateCanal(route, units, new HashMap<>(), player);
   }
 
   private static String validateCanal(
       final Route route,
       final Collection<Unit> units,
       final Map<Unit, Collection<Unit>> newDependents,
-      final PlayerId player,
-      final GameData data) {
-
+      final PlayerId player) {
+    final GameData data = player.getData();
     // Check each unit 1 by 1 to see if they can move through necessary canals on route
     String result = null;
     final Set<Unit> unitsThatFailCanal = new HashSet<>();
@@ -300,7 +297,7 @@ public class MoveValidator {
           if (!CanalAttachment.isCanalOnRoute(canalAttachment.getCanalName(), route)) {
             continue; // Only check canals that are on the route
           }
-          failureMessage = canPassThroughCanal(canalAttachment, unit, player, data);
+          failureMessage = canPassThroughCanal(canalAttachment, unit, player);
           final boolean canPass = failureMessage.isEmpty();
           if ((!Properties.getControlAllCanalsBetweenTerritoriesToPass(data) && canPass)
               || (Properties.getControlAllCanalsBetweenTerritoriesToPass(data) && !canPass)) {
@@ -333,23 +330,22 @@ public class MoveValidator {
                     unitsThatFailCanal.contains(unit)
                         || !Matches.unitHasEnoughMovementForRoute(route).test(unit))
             .collect(Collectors.toSet());
-    return checkLandTransports(data, player, potentialLandTransports, unitsToLandTransport)
-            .isEmpty()
+    return checkLandTransports(player, potentialLandTransports, unitsToLandTransport).isEmpty()
         ? null
         : result;
   }
 
   /**
-   * Simplified version of {@link #validateCanal(Route, Collection, PlayerId, GameData)
-   * validateCanal} used for route finding to check neighboring territories and avoid validating
-   * every unit. Performance of this method is critical.
+   * Simplified version of {@link #validateCanal(Route, Collection, PlayerId) validateCanal} used
+   * for route finding to check neighboring territories and avoid validating every unit. Performance
+   * of this method is critical.
    */
   public static boolean canAnyUnitsPassCanal(
       final Territory start,
       final Territory end,
       final Collection<Unit> units,
-      final PlayerId player,
-      final GameData data) {
+      final PlayerId player) {
+    final GameData data = player.getData();
     boolean canPass = true;
     final Route route = new Route(start, end);
     for (final CanalAttachment canalAttachment : CanalAttachment.get(start)) {
@@ -358,8 +354,7 @@ public class MoveValidator {
       }
       final Collection<Unit> unitsWithoutDependents =
           findNonDependentUnits(units, route, new HashMap<>());
-      canPass =
-          canAnyPassThroughCanal(canalAttachment, unitsWithoutDependents, player, data).isEmpty();
+      canPass = canAnyPassThroughCanal(canalAttachment, unitsWithoutDependents, player).isEmpty();
       if ((!Properties.getControlAllCanalsBetweenTerritoriesToPass(data) && canPass)
           || (Properties.getControlAllCanalsBetweenTerritoriesToPass(data) && !canPass)) {
         break; // If need to control any canal and can pass OR need to control all canals and can't
@@ -370,11 +365,11 @@ public class MoveValidator {
   }
 
   private static MoveValidationResult validateCombat(
-      final GameData data,
       final Collection<Unit> units,
       final Route route,
       final PlayerId player,
       final MoveValidationResult result) {
+    final GameData data = player.getData();
     if (getEditMode(data)) {
       return result;
     }
@@ -506,7 +501,7 @@ public class MoveValidator {
       }
     }
     // make sure no conquered territories on route
-    if (MoveValidator.hasConqueredNonBlitzedNonWaterOnRoute(route, data)) {
+    if (hasConqueredNonBlitzedNonWaterOnRoute(route, data)) {
       // unless we are all air or we are in non combat OR the route is water (was a bug in convoy
       // zone movement)
       if (units.isEmpty() || !units.stream().allMatch(Matches.unitIsAir())) {
@@ -538,11 +533,11 @@ public class MoveValidator {
   }
 
   private static MoveValidationResult validateNonCombat(
-      final GameData data,
       final Collection<Unit> units,
       final Route route,
       final PlayerId player,
       final MoveValidationResult result) {
+    final GameData data = player.getData();
     if (getEditMode(data)) {
       return result;
     }
@@ -569,7 +564,7 @@ public class MoveValidator {
     // Subs can't move under destroyers
     if (!units.isEmpty()
         && units.stream().allMatch(Matches.unitCanMoveThroughEnemies())
-        && MoveValidator.enemyDestroyerOnPath(route, player, data)) {
+        && enemyDestroyerOnPath(route, player)) {
       return result.setErrorReturnResult("Cannot move submarines under destroyers");
     }
     // Can't advance to battle unless only ignored units on route, only air units to sea, or only
@@ -577,7 +572,7 @@ public class MoveValidator {
     // territories with enemy units during NCM
     if (end.getUnitCollection()
             .anyMatch(Matches.enemyUnit(player, data).and(Matches.unitIsSubmerged().negate()))
-        && !onlyIgnoredUnitsOnPath(route, player, data, false)
+        && !onlyIgnoredUnitsOnPath(route, player, false)
         && !(end.isWater() && units.stream().allMatch(Matches.unitIsAir()))
         && !(Properties.getSubsCanEndNonCombatMoveWithEnemies(data)
             && units.stream().allMatch(Matches.unitCanMoveThroughEnemies()))) {
@@ -619,10 +614,8 @@ public class MoveValidator {
 
   // Added to handle restriction of movement to listed territories
   static MoveValidationResult validateMovementRestrictedByTerritory(
-      final GameData data,
-      final Route route,
-      final PlayerId player,
-      final MoveValidationResult result) {
+      final Route route, final PlayerId player, final MoveValidationResult result) {
+    final GameData data = player.getData();
     if (getEditMode(data)) {
       return result;
     }
@@ -654,16 +647,16 @@ public class MoveValidator {
   }
 
   private static MoveValidationResult validateNonEnemyUnitsOnPath(
-      final GameData data,
       final Collection<Unit> units,
       final Route route,
       final PlayerId player,
       final MoveValidationResult result) {
+    final GameData data = player.getData();
     if (getEditMode(data)) {
       return result;
     }
     // check to see no enemy units on path
-    if (MoveValidator.noEnemyUnitsOnPathMiddleSteps(route, player, data)) {
+    if (noEnemyUnitsOnPathMiddleSteps(route, player)) {
       return result;
     }
     // if we are all air, then its ok
@@ -675,11 +668,11 @@ public class MoveValidator {
         CollectionUtils.getMatches(units, Matches.unitIsBeingTransported().negate());
     if (!matches.isEmpty() && matches.stream().allMatch(Matches.unitCanMoveThroughEnemies())) {
       // this is ok unless there are destroyer on the path
-      return MoveValidator.enemyDestroyerOnPath(route, player, data)
+      return enemyDestroyerOnPath(route, player)
           ? result.setErrorReturnResult("Cannot move submarines under destroyers")
           : result;
     }
-    if (onlyIgnoredUnitsOnPath(route, player, data, true)) {
+    if (onlyIgnoredUnitsOnPath(route, player, true)) {
       return result;
     }
     // omit paratroops
@@ -690,13 +683,13 @@ public class MoveValidator {
   }
 
   private static MoveValidationResult validateBasic(
-      final GameData data,
       final Collection<Unit> units,
       final Route route,
       final PlayerId player,
       final Map<Unit, Unit> unitToTransport,
       final Map<Unit, Collection<Unit>> newDependents,
       final MoveValidationResult result) {
+    final GameData data = player.getData();
     final boolean isEditMode = getEditMode(data);
     // make sure transports in the destination
     if (!route.getEnd().getUnitCollection().containsAll(unitToTransport.values())
@@ -732,7 +725,7 @@ public class MoveValidator {
           unitsWithoutDependents.stream()
               .filter(unit -> !Matches.unitHasEnoughMovementForRoute(route).test(unit))
               .collect(Collectors.toSet());
-      checkLandTransports(data, player, unitsWithEnoughMovement, unitsWithoutEnoughMovement)
+      checkLandTransports(player, unitsWithEnoughMovement, unitsWithoutEnoughMovement)
           .forEach(unit -> result.addDisallowedUnit("Not all units have enough movement", unit));
 
       // Can only move owned units except transported units or allied air on carriers
@@ -780,7 +773,7 @@ public class MoveValidator {
 
     // make sure that no non sea non transportable no carriable units end at sea
     if (route.getEnd().isWater()) {
-      for (final Unit unit : MoveValidator.getUnitsThatCantGoOnWater(units)) {
+      for (final Unit unit : getUnitsThatCantGoOnWater(units)) {
         result.addDisallowedUnit("Not all units can end at water", unit);
       }
     }
@@ -842,7 +835,7 @@ public class MoveValidator {
     if (!isEditMode && route.anyMatch(Matches.territoryIsImpassable())) {
       return result.setErrorReturnResult(CANT_MOVE_THROUGH_IMPASSABLE);
     }
-    if (canCrossNeutralTerritory(data, route, player, result).getError() != null) {
+    if (canCrossNeutralTerritory(route, player, result).getError() != null) {
       return result;
     }
     if (isNeutralsImpassable(data)
@@ -859,7 +852,7 @@ public class MoveValidator {
       final Map<Unit, Collection<Unit>> newDependents) {
     Collection<Unit> unitsWithoutDependents = new ArrayList<>(units);
     if (route.getStart().isWater()) {
-      unitsWithoutDependents = MoveValidator.getNonLand(units);
+      unitsWithoutDependents = getNonLand(units);
     }
     final Map<Unit, Collection<Unit>> dependentsMap =
         getDependents(CollectionUtils.getMatches(units, Matches.unitCanTransport()));
@@ -877,10 +870,10 @@ public class MoveValidator {
    * using capacity and cost
    */
   private static Set<Unit> checkLandTransports(
-      final GameData data,
       final PlayerId player,
       final Collection<Unit> possibleLandTransports,
       final Set<Unit> unitsToLandTransport) {
+    final GameData data = player.getData();
     final Set<Unit> disallowedUnits = new HashSet<>();
     data.acquireReadLock();
     try {
@@ -951,11 +944,10 @@ public class MoveValidator {
    * Checks that there are no enemy units on the route except possibly at the end. Submerged enemy
    * units are not considered as they don't affect movement. AA and factory dont count as enemy.
    */
-  static boolean noEnemyUnitsOnPathMiddleSteps(
-      final Route route, final PlayerId player, final GameData data) {
+  static boolean noEnemyUnitsOnPathMiddleSteps(final Route route, final PlayerId player) {
     final Predicate<Unit> alliedOrNonCombat =
         Matches.unitIsInfrastructure()
-            .or(Matches.enemyUnit(player, data).negate())
+            .or(Matches.enemyUnit(player, player.getData()).negate())
             .or(Matches.unitIsSubmerged());
     // Submerged units do not interfere with movement
     return route.getMiddleSteps().stream()
@@ -967,7 +959,8 @@ public class MoveValidator {
    * factory dont count as enemy.
    */
   static boolean onlyIgnoredUnitsOnPath(
-      final Route route, final PlayerId player, final GameData data, final boolean ignoreRouteEnd) {
+      final Route route, final PlayerId player, final boolean ignoreRouteEnd) {
+    final GameData data = player.getData();
     final Predicate<Unit> transportOnly =
         Matches.unitIsInfrastructure()
             .or(Matches.unitIsTransportButNotCombatTransport())
@@ -1005,8 +998,9 @@ public class MoveValidator {
     return validMove;
   }
 
-  private static boolean enemyDestroyerOnPath(
-      final Route route, final PlayerId player, final GameData data) {
+  private static boolean enemyDestroyerOnPath(final Route route, final PlayerId player) {
+    final GameData data = player.getData();
+
     final Predicate<Unit> enemyDestroyer =
         Matches.unitIsDestroyer().and(Matches.enemyUnit(player, data));
     return route.getMiddleSteps().stream()
@@ -1126,11 +1120,9 @@ public class MoveValidator {
   // can't cross neutral
   // territories in WW2V2.
   private static MoveValidationResult canCrossNeutralTerritory(
-      final GameData data,
-      final Route route,
-      final PlayerId player,
-      final MoveValidationResult result) {
+      final Route route, final PlayerId player, final MoveValidationResult result) {
     // neutrals we will overfly in the first place
+    final GameData data = player.getData();
     final Collection<Territory> neutrals = MoveDelegate.getEmptyNeutral(route);
     final int pus =
         (player == null || player.isNull()) ? 0 : player.getResources().getQuantity(Constants.PUS);
@@ -1152,13 +1144,13 @@ public class MoveValidator {
 
   private static MoveValidationResult validateTransport(
       final boolean isNonCombat,
-      final GameData data,
       final List<UndoableMove> undoableMoves,
       final Collection<Unit> units,
       final Route route,
       final PlayerId player,
       final Map<Unit, Unit> unitsToTransports,
       final MoveValidationResult result) {
+    final GameData data = player.getData();
     final boolean isEditMode = getEditMode(data);
     if (!units.isEmpty() && units.stream().allMatch(Matches.unitIsAir())) {
       return result;
@@ -1316,7 +1308,7 @@ public class MoveValidator {
       if (!Properties.getUnitsCanLoadInHostileSeaZones(data)
           && route.getEnd().getUnitCollection().anyMatch(enemyNonSubmerged)
           && nonParatroopersPresent(player, landAndAir)
-          && !onlyIgnoredUnitsOnPath(route, player, data, false)
+          && !onlyIgnoredUnitsOnPath(route, player, false)
           && !AbstractMoveDelegate.getBattleTracker(data)
               .didAllThesePlayersJustGoToWarThisTurn(player, route.getEnd().getUnits(), data)) {
         return result.setErrorReturnResult("Cannot load when enemy sea units are present");
@@ -1450,7 +1442,6 @@ public class MoveValidator {
 
   private static MoveValidationResult validateParatroops(
       final boolean nonCombat,
-      final GameData data,
       final Collection<Unit> units,
       final Route route,
       final PlayerId player,
@@ -1462,6 +1453,7 @@ public class MoveValidator {
         || units.stream().noneMatch(Matches.unitIsAirTransport())) {
       return result;
     }
+    final GameData data = player.getData();
     if (nonCombat && !isAirTransportableCanMoveDuringNonCombat(data)) {
       return result.setErrorReturnResult("Paratroops may not move during NonCombat");
     }
@@ -1519,29 +1511,24 @@ public class MoveValidator {
   }
 
   private static Optional<String> canPassThroughCanal(
-      final CanalAttachment canalAttachment,
-      final Unit unit,
-      final PlayerId player,
-      final GameData data) {
+      final CanalAttachment canalAttachment, final Unit unit, final PlayerId player) {
     if (unit != null && Matches.unitIsOfTypes(canalAttachment.getExcludedUnits()).test(unit)) {
       return Optional.empty();
     }
-    return checkCanalStepAndOwnership(canalAttachment, player, data);
+    return checkCanalStepAndOwnership(canalAttachment, player);
   }
 
   private static Optional<String> canAnyPassThroughCanal(
-      final CanalAttachment canalAttachment,
-      final Collection<Unit> units,
-      final PlayerId player,
-      final GameData data) {
+      final CanalAttachment canalAttachment, final Collection<Unit> units, final PlayerId player) {
     if (units.stream().anyMatch(Matches.unitIsOfTypes(canalAttachment.getExcludedUnits()))) {
       return Optional.empty();
     }
-    return checkCanalStepAndOwnership(canalAttachment, player, data);
+    return checkCanalStepAndOwnership(canalAttachment, player);
   }
 
   private static Optional<String> checkCanalStepAndOwnership(
-      final CanalAttachment canalAttachment, final PlayerId player, final GameData data) {
+      final CanalAttachment canalAttachment, final PlayerId player) {
+    final GameData data = player.getData();
     if (canalAttachment.getCanNotMoveThroughDuringCombatMove()
         && GameStepPropertiesHelper.isCombatMove(data, true)) {
       return Optional.of(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -235,7 +235,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
     // TODO: This checks for ignored sub/trns and skips the set of the attackers to 0 movement left
     // If attacker stops in an occupied territory, movement stops (battle is optional)
-    if (MoveValidator.onlyIgnoredUnitsOnPath(route, attacker, gameData, false)) {
+    if (MoveValidator.onlyIgnoredUnitsOnPath(route, attacker, false)) {
       return change;
     }
     change.add(ChangeFactory.markNoMovementChange(nonAir));
@@ -1140,7 +1140,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final Predicate<Territory> canalMatch =
         t -> {
           final Route r = new Route(battleSite, t);
-          return MoveValidator.validateCanal(r, unitsToRetreat, defender, gameData) == null;
+          return MoveValidator.validateCanal(r, unitsToRetreat, defender) == null;
         };
     final Predicate<Territory> match =
         Matches.territoryIsWater()

--- a/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -102,7 +102,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
     // player.
     final PlayerId player = getUnitsOwner(units);
     // here we have our own new validation method....
-    final MoveValidationResult result = validateMove(units, route, player, data);
+    final MoveValidationResult result = validateMove(units, route, player);
     final StringBuilder errorMsg = new StringBuilder(100);
     final int numProblems = result.getTotalWarningCount() - (result.hasError() ? 0 : 1);
     final String numErrorsMsg =
@@ -171,18 +171,18 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
   }
 
   static MoveValidationResult validateMove(
-      final Collection<Unit> units, final Route route, final PlayerId player, final GameData data) {
+      final Collection<Unit> units, final Route route, final PlayerId player) {
     final MoveValidationResult result = new MoveValidationResult();
     if (route.hasNoSteps()) {
       return result;
     }
-    if (MoveValidator.validateFirst(data, units, route, player, result).getError() != null) {
+    if (MoveValidator.validateFirst(units, route, player, result).getError() != null) {
       return result;
     }
-    if (MoveValidator.validateFuel(data, units, route, player, result).getError() != null) {
+    if (MoveValidator.validateFuel(units, route, player, result).getError() != null) {
       return result;
     }
-    final boolean isEditMode = getEditMode(data);
+    final boolean isEditMode = getEditMode(player.getData());
     if (!isEditMode) {
       // make sure all units are at least friendly
       for (final Unit unit :
@@ -190,18 +190,18 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
         result.addDisallowedUnit("Can only move owned units", unit);
       }
     }
-    if (validateAirborneMovements(data, units, route, player, result).getError() != null) {
+    if (validateAirborneMovements(units, route, player, result).getError() != null) {
       return result;
     }
     return result;
   }
 
   private static MoveValidationResult validateAirborneMovements(
-      final GameData data,
       final Collection<Unit> units,
       final Route route,
       final PlayerId player,
       final MoveValidationResult result) {
+    final GameData data = player.getData();
     if (!TechAbilityAttachment.getAllowAirborneForces(player, data)) {
       return result.setErrorReturnResult("Do Not Have Airborne Tech");
     }

--- a/game-core/src/main/java/games/strategy/triplea/util/MovableUnitsFilter.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/MovableUnitsFilter.java
@@ -209,8 +209,7 @@ public final class MovableUnitsFilter {
               : TransportUtils.mapTransports(route, units, transportsToLoad);
       final MoveDescription move =
           new MoveDescription(unitsWithDependents, route, unitsToTransports, dependentUnits);
-      result =
-          AbstractMoveDelegate.validateMove(moveType, move, player, nonCombat, undoableMoves, data);
+      result = AbstractMoveDelegate.validateMove(moveType, move, player, nonCombat, undoableMoves);
     } finally {
       data.releaseReadLock();
     }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
@@ -116,46 +116,35 @@ class MoveValidatorTest extends AbstractDelegateTestCase {
     final Route r = new Route(berlin, easternGermany);
     List<Unit> toMove = berlin.getUnitCollection().getMatches(Matches.unitCanMove());
     MoveValidationResult results =
-        MoveValidator.validateMove(
-            new MoveDescription(toMove, r), germans, false, null, twwGameData);
+        MoveValidator.validateMove(new MoveDescription(toMove, r), germans, false, null);
     assertTrue(results.isMoveValid());
 
     // Add germanTrain to units which fails since it requires germainRail
     addTo(berlin, GameDataTestUtil.germanTrain(twwGameData).create(1, germans));
     toMove = berlin.getUnitCollection().getMatches(Matches.unitCanMove());
-    results =
-        MoveValidator.validateMove(
-            new MoveDescription(toMove, r), germans, false, null, twwGameData);
+    results = MoveValidator.validateMove(new MoveDescription(toMove, r), germans, false, null);
     assertFalse(results.isMoveValid());
 
     // Add germanRail to only destination so it fails
     final Collection<Unit> germanRail = GameDataTestUtil.germanRail(twwGameData).create(1, germans);
     addTo(easternGermany, germanRail);
-    results =
-        MoveValidator.validateMove(
-            new MoveDescription(toMove, r), germans, false, null, twwGameData);
+    results = MoveValidator.validateMove(new MoveDescription(toMove, r), germans, false, null);
     assertFalse(results.isMoveValid());
 
     // Add germanRail to start so move succeeds
     addTo(berlin, GameDataTestUtil.germanRail(twwGameData).create(1, germans));
-    results =
-        MoveValidator.validateMove(
-            new MoveDescription(toMove, r), germans, false, null, twwGameData);
+    results = MoveValidator.validateMove(new MoveDescription(toMove, r), germans, false, null);
     assertTrue(results.isMoveValid());
 
     // Remove germanRail from destination so move fails
     GameDataTestUtil.removeFrom(easternGermany, germanRail);
-    results =
-        MoveValidator.validateMove(
-            new MoveDescription(toMove, r), germans, false, null, twwGameData);
+    results = MoveValidator.validateMove(new MoveDescription(toMove, r), germans, false, null);
     assertFalse(results.isMoveValid());
 
     // Add allied owned germanRail to destination so move succeeds
     final PlayerId japan = GameDataTestUtil.japan(twwGameData);
     addTo(easternGermany, GameDataTestUtil.germanRail(twwGameData).create(1, japan));
-    results =
-        MoveValidator.validateMove(
-            new MoveDescription(toMove, r), germans, false, null, twwGameData);
+    results = MoveValidator.validateMove(new MoveDescription(toMove, r), germans, false, null);
     assertTrue(results.isMoveValid());
   }
 
@@ -174,42 +163,42 @@ class MoveValidatorTest extends AbstractDelegateTestCase {
     addTo(berlin, GameDataTestUtil.truck(twwGameData).create(1, germans));
     MoveValidationResult results =
         MoveValidator.validateMove(
-            new MoveDescription(berlin.getUnitCollection(), r), germans, true, null, twwGameData);
+            new MoveDescription(berlin.getUnitCollection(), r), germans, true, null);
     assertTrue(results.isMoveValid());
 
     // Add an infantry for truck to transport
     addTo(berlin, GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
     results =
         MoveValidator.validateMove(
-            new MoveDescription(berlin.getUnitCollection(), r), germans, true, null, twwGameData);
+            new MoveDescription(berlin.getUnitCollection(), r), germans, true, null);
     assertTrue(results.isMoveValid());
 
     // Add an infantry and the truck can't transport both
     addTo(berlin, GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
     results =
         MoveValidator.validateMove(
-            new MoveDescription(berlin.getUnitCollection(), r), germans, true, null, twwGameData);
+            new MoveDescription(berlin.getUnitCollection(), r), germans, true, null);
     assertFalse(results.isMoveValid());
 
     // Add a large truck (has capacity for 2 infantry) to transport second infantry
     addTo(berlin, GameDataTestUtil.largeTruck(twwGameData).create(1, germans));
     results =
         MoveValidator.validateMove(
-            new MoveDescription(berlin.getUnitCollection(), r), germans, true, null, twwGameData);
+            new MoveDescription(berlin.getUnitCollection(), r), germans, true, null);
     assertTrue(results.isMoveValid());
 
     // Add an infantry that the large truck can also transport
     addTo(berlin, GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
     results =
         MoveValidator.validateMove(
-            new MoveDescription(berlin.getUnitCollection(), r), germans, true, null, twwGameData);
+            new MoveDescription(berlin.getUnitCollection(), r), germans, true, null);
     assertTrue(results.isMoveValid());
 
     // Add an infantry that can't be transported
     addTo(berlin, GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
     results =
         MoveValidator.validateMove(
-            new MoveDescription(berlin.getUnitCollection(), r), germans, true, null, twwGameData);
+            new MoveDescription(berlin.getUnitCollection(), r), germans, true, null);
     assertFalse(results.isMoveValid());
   }
 
@@ -232,8 +221,7 @@ class MoveValidatorTest extends AbstractDelegateTestCase {
             new MoveDescription(northernGermany.getUnitCollection(), r, unitsToTransports),
             germans,
             false,
-            null,
-            twwGameData);
+            null);
     assertTrue(results.isMoveValid());
 
     // Add USA ship to transport sea zone
@@ -246,8 +234,7 @@ class MoveValidatorTest extends AbstractDelegateTestCase {
             new MoveDescription(northernGermany.getUnitCollection(), r, unitsToTransports),
             germans,
             false,
-            null,
-            twwGameData);
+            null);
     assertFalse(results.isMoveValid());
 
     // Set 'Units Can Load In Hostile Sea Zones' to true
@@ -259,8 +246,7 @@ class MoveValidatorTest extends AbstractDelegateTestCase {
             new MoveDescription(northernGermany.getUnitCollection(), r, unitsToTransports),
             germans,
             false,
-            null,
-            twwGameData);
+            null);
     assertTrue(results.isMoveValid());
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -1420,8 +1420,7 @@ class WW2V3Year41Test {
         france.getUnitCollection().getMatches(Matches.unitIsAirTransportable());
     assertFalse(paratroopers.isEmpty());
     final MoveValidationResult results =
-        MoveValidator.validateMove(
-            new MoveDescription(paratroopers, r), germans, false, null, gameData);
+        MoveValidator.validateMove(new MoveDescription(paratroopers, r), germans, false, null);
     assertFalse(results.isMoveValid());
   }
 
@@ -1442,7 +1441,7 @@ class WW2V3Year41Test {
     toMove.addAll(germany.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()));
     assertEquals(2, toMove.size());
     final MoveValidationResult results =
-        MoveValidator.validateMove(new MoveDescription(toMove, r), germans, false, null, gameData);
+        MoveValidator.validateMove(new MoveDescription(toMove, r), germans, false, null);
     assertFalse(results.isMoveValid());
   }
 
@@ -1463,7 +1462,7 @@ class WW2V3Year41Test {
     toMove.addAll(germany.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()));
     assertEquals(2, toMove.size());
     final MoveValidationResult results =
-        MoveValidator.validateMove(new MoveDescription(toMove, r), germans, false, null, gameData);
+        MoveValidator.validateMove(new MoveDescription(toMove, r), germans, false, null);
     assertFalse(results.isMoveValid());
   }
 


### PR DESCRIPTION
Remove redundant game data params.

This PR removes GameData params on methods related to move validation. These params are unnecessary since all these methods take a PlayerId param from which the data can be retrieved. This simplifies the code and removes an error prone case where an inconsistent player/data is passed (which can happen in tests).

Note: More code can be similarly cleaned up, but this change is already large, so want to limit it here for now.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[X] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

