### PR TITLE
Tile locking update

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -677,15 +677,15 @@ public class MapPanel extends ImageScrollerLargeView {
     final Rectangle2D.Double mainBounds =
         new Rectangle2D.Double(x, y, getScaledWidth(), getScaledHeight());
     drawTiles(g2d, images, data, mainBounds, undrawnTiles);
-    if (routeDescription != null && mouseShadowImage != null && routeDescription.getEnd() != null) {
-      final AffineTransform t = new AffineTransform();
-      t.translate(
-          normalizeX(routeDescription.getEnd().getX() - getXOffset()),
-          normalizeY(routeDescription.getEnd().getY() - getYOffset()));
-      t.translate(mouseShadowImage.getWidth() / -2.0, mouseShadowImage.getHeight() / -2.0);
-      g2d.drawImage(mouseShadowImage, t, this);
-    }
     if (routeDescription != null) {
+      if (mouseShadowImage != null && routeDescription.getEnd() != null) {
+        final AffineTransform t = new AffineTransform();
+        t.translate(
+            normalizeX(routeDescription.getEnd().getX() - getXOffset()),
+            normalizeY(routeDescription.getEnd().getY() - getYOffset()));
+        t.translate(mouseShadowImage.getWidth() / -2.0, mouseShadowImage.getHeight() / -2.0);
+        g2d.drawImage(mouseShadowImage, t, this);
+      }
       routeDrawer.drawRoute(
           g2d,
           routeDescription,
@@ -776,7 +776,7 @@ public class MapPanel extends ImageScrollerLargeView {
               getScaledHeight() + (2.0 * preDrawMargin));
       final List<Tile> tileList = tileManager.getTiles(extendedBounds);
       for (final Tile tile : tileList) {
-        if (tile.isDirty()) {
+        if (tile.needsRedraw()) {
           undrawnTiles.add(tile);
         }
       }
@@ -794,7 +794,7 @@ public class MapPanel extends ImageScrollerLargeView {
       tile.acquireLock();
       try {
         final Image img;
-        if (tile.isDirty()) {
+        if (tile.needsRedraw()) {
           // take what we can get to avoid screen flicker
           undrawn.add(tile);
           img = tile.getRawImage();

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
@@ -48,9 +48,9 @@ public class Tile {
 
   /** Returns the image representing this tile, re-rendering it first if the tile is dirty. */
   public Image getImage(final GameData data, final MapData mapData) {
-    acquireLock();
-    try {
-      if (isDirty) {
+    if (isDirty) {
+      acquireLock();
+      try {
         isDrawing = true;
         final Graphics2D g = (Graphics2D) image.getGraphics();
         g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
@@ -64,11 +64,11 @@ public class Tile {
         draw(g, data, mapData);
         g.dispose();
         isDrawing = false;
+      } finally {
+        releaseLock();
       }
-      return image;
-    } finally {
-      releaseLock();
     }
+    return image;
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
@@ -21,7 +21,8 @@ import org.triplea.thread.LockUtil;
 
 /** Responsible for rendering a single map tile. */
 public class Tile {
-  private boolean isDirty = true;
+  private volatile boolean isDirty = true;
+  private volatile boolean isDrawing = false;
 
   private final Image image;
   private final Rectangle bounds;
@@ -33,13 +34,8 @@ public class Tile {
     image = Util.newImage((int) bounds.getWidth(), (int) bounds.getHeight(), true);
   }
 
-  public boolean isDirty() {
-    acquireLock();
-    try {
-      return isDirty;
-    } finally {
-      releaseLock();
-    }
+  public boolean needsRedraw() {
+    return isDirty && !isDrawing;
   }
 
   public void acquireLock() {
@@ -55,6 +51,7 @@ public class Tile {
     acquireLock();
     try {
       if (isDirty) {
+        isDrawing = true;
         final Graphics2D g = (Graphics2D) image.getGraphics();
         g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
         g.setRenderingHint(
@@ -66,6 +63,7 @@ public class Tile {
             RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON);
         draw(g, data, mapData);
         g.dispose();
+        isDrawing = false;
       }
       return image;
     } finally {
@@ -79,7 +77,12 @@ public class Tile {
    * @return the image we currently have.
    */
   public Image getRawImage() {
-    return image;
+    acquireLock();
+    try {
+      return image;
+    } finally {
+      releaseLock();
+    }
   }
 
   private void draw(final Graphics2D g, final GameData data, final MapData mapData) {


### PR DESCRIPTION
<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 
I realized that the engine did lock the UI Thread every time isDirty was called, which wastes a lot of time.
Instead the if check was changed to somewhat hide the inner logic and only lock when necessary.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

