### PR TITLE
Scale correctly when dragging map

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
@@ -56,11 +56,6 @@ public class HeadedUiContext extends AbstractUiContext {
   }
 
   @Override
-  public void setScale(final double scale) {
-    super.setScale(scale);
-  }
-
-  @Override
   protected void internalSetMapDir(final String dir, final GameData data) {
     resourceLoader = ResourceLoader.getMapResourceLoader(dir);
     if (mapData != null) {

--- a/game-core/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
+++ b/game-core/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
@@ -185,10 +185,10 @@ public class ImageScrollerLargeView extends JComponent {
                 insideCount = 0;
               }
               // compute the amount to move
-              final int dx = (dragScrollingLastX - x);
-              final int dy = (dragScrollingLastY - y);
+              final int dx = (int) Math.round((dragScrollingLastX - x) / scale);
+              final int dy = (int) Math.round((dragScrollingLastY - y) / scale);
               // move left and right and test for wrap
-              final int newX = (ImageScrollerLargeView.this.model.getX() + dx);
+              final int newX = ImageScrollerLargeView.this.model.getX() + dx;
               // move up and down and test for edges
               final int newY = ImageScrollerLargeView.this.model.getY() + dy;
               // update the map


### PR DESCRIPTION
<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 
Previously dragging the map around whilst holding the mouse wheel (button 3) or the right mouse button (button 2) when zoomed out did only move the map by the same amount it moved when zoomed to 100%.
This felt extremely weird, so I change that.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

