### PR TITLE
Adjust `@Nullable` annotations

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/DefaultMapSelectionListener.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/DefaultMapSelectionListener.java
@@ -8,7 +8,7 @@ class DefaultMapSelectionListener implements MapSelectionListener {
   public void territorySelected(final Territory territory, final MouseDetails me) {}
 
   @Override
-  public void mouseEntered(final Territory territory) {}
+  public void mouseEntered(final @Nullable Territory territory) {}
 
   @Override
   public void mouseMoved(final @Nullable Territory territory, final MouseDetails me) {}

--- a/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -229,9 +229,6 @@ class EditPanel extends ActionPanel {
       new DefaultMapSelectionListener() {
         @Override
         public void territorySelected(final Territory territory, final MouseDetails md) {
-          if (territory == null) {
-            return;
-          }
           if (currentAction == changeTerritoryOwnerAction) {
             final TerritoryAttachment ta = TerritoryAttachment.get(territory);
             if (ta == null) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapPanel.java
@@ -206,7 +206,7 @@ public class MapPanel extends ImageScrollerLargeView {
             final double scaledMouseY = e.getY() / scale;
             final double x = normalizeX(scaledMouseX + getXOffset());
             final double y = normalizeY(scaledMouseY + getYOffset());
-            final Territory terr = getTerritory(x, y);
+            final @Nullable Territory terr = getTerritory(x, y);
             if (terr != null) {
               notifyTerritorySelected(terr, md);
             }
@@ -506,6 +506,7 @@ public class MapPanel extends ImageScrollerLargeView {
     }
   }
 
+  @Nullable
   private Territory getTerritory(final double x, final double y) {
     final String name = uiContext.getMapData().getTerritoryAt(normalizeX(x), normalizeY(y));
     if (name == null) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/MapSelectionListener.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MapSelectionListener.java
@@ -7,7 +7,7 @@ interface MapSelectionListener {
   void territorySelected(Territory territory, MouseDetails md);
 
   /** The mouse has entered the given territory, null if the mouse is in no territory. */
-  void mouseEntered(Territory territory);
+  void mouseEntered(@Nullable Territory territory);
 
   void mouseMoved(@Nullable Territory territory, MouseDetails md);
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
@@ -82,9 +82,6 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
       new DefaultMapSelectionListener() {
         @Override
         public void territorySelected(final Territory territory, final MouseDetails md) {
-          if (territory == null) {
-            return;
-          }
           if (currentAction == selectTerritoryAction) {
             if (!territoryChoices.contains(territory)) {
               EventThreadJOptionPane.showMessageDialog(

--- a/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -104,7 +104,7 @@ class TerritoryDetailPanel extends AbstractStatPanel {
     territoryChanged(null);
   }
 
-  private void territoryChanged(final Territory territory) {
+  private void territoryChanged(final @Nullable Territory territory) {
     currentTerritory = territory;
     if (territory == null) {
       setElementsVisible(false);


### PR DESCRIPTION
<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 
I noticed that the `@Nullable` annotations are applied a bit inconsistent for the `MapSelectionListener` interface.

This PR fixes this inconsistency and removes redundant null checks, I verified that the only values ever supplied are non-null there.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

