### PR TITLE
Use doubles over BigDecimal

### DIFF
--- a/game-core/src/test/java/games/strategy/engine/data/RouteFinderTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/RouteFinderTest.java
@@ -9,7 +9,6 @@ import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -145,11 +144,10 @@ class RouteFinderTest {
     final RouteFinder routeFinder =
         Mockito.spy(new RouteFinder(map, t -> true, new ArrayList<>(), player));
     doAnswer(
-            invocation -> {
-              return territoriesWithIncreasedCost.contains(invocation.getArgument(0))
-                  ? new BigDecimal(5)
-                  : BigDecimal.ONE;
-            })
+            invocation ->
+                territoriesWithIncreasedCost.contains(invocation.<Territory>getArgument(0))
+                    ? 5D
+                    : 1D)
         .when(routeFinder)
         .getMaxMovementCost(any());
     return routeFinder;


### PR DESCRIPTION
<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 
Just stumbled over this a week ago, it's super weird having to deal with BigDecimals here, not really necessary at this point, rounding errors are ok, so we save some overhead.

@ron-murhammer Do you know why BigDecimals are being used everywhere?
I assume that the type is being used for currencies, and somehow managed to spread all over the codebase?

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

