### PR TITLE
Replace static constructor method with static import

### DIFF
--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/messages/server/ChatServerMessageType.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/messages/server/ChatServerMessageType.java
@@ -1,5 +1,7 @@
 package org.triplea.http.client.lobby.chat.messages.server;
 
+import static org.triplea.http.client.web.socket.messages.MessageTypeListenerBinding.newBinding;
+
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import org.triplea.domain.data.PlayerName;
@@ -11,27 +13,17 @@ import org.triplea.http.client.web.socket.messages.WebsocketMessageType;
 /** Chat message types that a server can send over websocket to client. */
 @Getter(onMethod_ = @Override)
 @AllArgsConstructor
+@SuppressWarnings("ImmutableEnumChecker")
 public enum ChatServerMessageType implements WebsocketMessageType<ChatMessageListeners> {
-  CHAT_EVENT(
-      MessageTypeListenerBinding.of(String.class, ChatMessageListeners::getChatEventListener)),
-  CHAT_MESSAGE(
-      MessageTypeListenerBinding.of(
-          ChatMessage.class, ChatMessageListeners::getChatMessageListener)),
-  PLAYER_JOINED(
-      MessageTypeListenerBinding.of(
-          ChatParticipant.class, ChatMessageListeners::getPlayerJoinedListener)),
-  PLAYER_LEFT(
-      MessageTypeListenerBinding.of(PlayerName.class, ChatMessageListeners::getPlayerLeftListener)),
-  PLAYER_LISTING(
-      MessageTypeListenerBinding.of(ChatterList.class, ChatMessageListeners::getConnectedListener)),
-  PLAYER_SLAPPED(
-      MessageTypeListenerBinding.of(
-          PlayerSlapped.class, ChatMessageListeners::getPlayerSlappedListener)),
-  SERVER_ERROR(
-      MessageTypeListenerBinding.of(String.class, ChatMessageListeners::getServerErrorListener)),
-  STATUS_CHANGED(
-      MessageTypeListenerBinding.of(
-          StatusUpdate.class, ChatMessageListeners::getPlayerStatusListener));
+  CHAT_EVENT(newBinding(String.class, ChatMessageListeners::getChatEventListener)),
+  CHAT_MESSAGE(newBinding(ChatMessage.class, ChatMessageListeners::getChatMessageListener)),
+  PLAYER_JOINED(newBinding(ChatParticipant.class, ChatMessageListeners::getPlayerJoinedListener)),
+  PLAYER_LEFT(newBinding(PlayerName.class, ChatMessageListeners::getPlayerLeftListener)),
+  PLAYER_LISTING(newBinding(ChatterList.class, ChatMessageListeners::getConnectedListener)),
+  PLAYER_SLAPPED(newBinding(PlayerSlapped.class, ChatMessageListeners::getPlayerSlappedListener)),
+  SERVER_ERROR(newBinding(String.class, ChatMessageListeners::getServerErrorListener)),
+  STATUS_CHANGED(newBinding(StatusUpdate.class, ChatMessageListeners::getPlayerStatusListener)),
+  ;
 
   private final MessageTypeListenerBinding<ChatMessageListeners, ?> messageTypeListenerBinding;
 }

--- a/http-clients/src/main/java/org/triplea/http/client/remote/actions/messages/server/ServerRemoteActionMessageType.java
+++ b/http-clients/src/main/java/org/triplea/http/client/remote/actions/messages/server/ServerRemoteActionMessageType.java
@@ -1,5 +1,7 @@
 package org.triplea.http.client.remote.actions.messages.server;
 
+import static org.triplea.http.client.web.socket.messages.MessageTypeListenerBinding.newBinding;
+
 import java.net.InetAddress;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -10,14 +12,14 @@ import org.triplea.http.client.web.socket.messages.WebsocketMessageType;
 /** Types of messages that can be sent from server to client indicating a 'remote action' */
 @Getter(onMethod_ = @Override)
 @AllArgsConstructor
+@SuppressWarnings("ImmutableEnumChecker")
 public enum ServerRemoteActionMessageType implements WebsocketMessageType<RemoteActionListeners> {
   /** Requests that the server receiving this message to disconnect and shutdown. */
-  SHUTDOWN(MessageTypeListenerBinding.of(String.class, RemoteActionListeners::getShutdownListener)),
+  SHUTDOWN(newBinding(String.class, RemoteActionListeners::getShutdownListener)),
 
   /** Indicates a player has been banned and they should be disconnected if present. */
-  PLAYER_BANNED(
-      MessageTypeListenerBinding.of(
-          InetAddress.class, RemoteActionListeners::getBannedPlayerListener));
+  PLAYER_BANNED(newBinding(InetAddress.class, RemoteActionListeners::getBannedPlayerListener)),
+  ;
 
   private final MessageTypeListenerBinding<RemoteActionListeners, ?> messageTypeListenerBinding;
 }

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/messages/MessageTypeListenerBinding.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/messages/MessageTypeListenerBinding.java
@@ -1,25 +1,34 @@
 package org.triplea.http.client.web.socket.messages;
 
-import com.google.errorprone.annotations.Immutable;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import lombok.Value;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
 
-@Value(staticConstructor = "of")
-@Immutable
-// The function passed as second param isn't
-// guaranteed to be immutable, but we are
-// going to trust the future-devs to use
-// stateless lambdas.
-@SuppressWarnings("Immutable")
-public class MessageTypeListenerBinding<T, X> {
+/**
+ * Binds a datatype with a listener in an event listener container class. The listener within the
+ * container class is then enforced to consume the same datatype.
+ *
+ * @param <ListenersTypeT> The listener container class type.
+ * @param <MessageTypeT> The datatype we expect a given listener within the listener container to
+ *     consume.
+ */
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public class MessageTypeListenerBinding<ListenersTypeT, MessageTypeT> {
 
-  private final Class<X> classType;
-  private final Function<T, Consumer<X>> listenerMethod;
+  private final Class<MessageTypeT> classType;
+  private final Function<ListenersTypeT, Consumer<MessageTypeT>> listenerMethod;
 
-  public void sendPayloadToListener(
-      final ServerMessageEnvelope serverMessageEnvelope, final T listener) {
-    final X payload = serverMessageEnvelope.getPayload(getClassType());
+  public static <L, M> MessageTypeListenerBinding<L, M> newBinding(
+      final Class<M> classType, final Function<L, Consumer<M>> listenerMethod) {
+    return new MessageTypeListenerBinding<>(classType, listenerMethod);
+  }
+
+  void sendPayloadToListener(
+      final ServerMessageEnvelope serverMessageEnvelope, final ListenersTypeT listener) {
+    final MessageTypeT payload = serverMessageEnvelope.getPayload(getClassType());
     getListenerMethod().apply(listener).accept(payload);
   }
 }

--- a/http-clients/src/test/java/org/triplea/http/client/web/socket/messages/WebsocketMessageTypeTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/web/socket/messages/WebsocketMessageTypeTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.triplea.http.client.web.socket.messages.MessageTypeListenerBinding.newBinding;
 
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
@@ -26,9 +27,9 @@ class WebsocketMessageTypeTest {
 
   @Getter(onMethod_ = @Override)
   @AllArgsConstructor
+  @SuppressWarnings("ImmutableEnumChecker")
   private enum ExampleMessageType implements WebsocketMessageType<ExampleMessageListeners> {
-    MESSAGE_TYPE(
-        MessageTypeListenerBinding.of(Integer.class, ExampleMessageListeners::getListener));
+    MESSAGE_TYPE(newBinding(Integer.class, ExampleMessageListeners::getListener));
 
     private final MessageTypeListenerBinding<ExampleMessageListeners, ?> messageTypeListenerBinding;
   }


### PR DESCRIPTION
- Rename static constructor method 'of' to 'newBinding', then use static import
- Use @AllArgsConstructor+@Getter to replace @Value annotation and use a boilerplate
  static constructor. Using '@Value' with the updated static constructor name causes
  a lombok conflict and the project fails to compile.
- Update enum values to end with a comma
- Replace '@Immutable' and '@Suppresswarning' and comment with a suppresswarning
  on enums.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

