### PR TITLE
Replace various size checks with isEmpty

### DIFF
--- a/.travis/check-custom-style
+++ b/.travis/check-custom-style
@@ -141,10 +141,13 @@ function noTabsInSql() {
 }
 
 function useEmptyOverSizeEqualsZero() {
-  title "Avoid size() == 0, use isEmpty() instead"
+  title "Avoid using size() to check for empty or not empty"
+  example "size() == 0 -> isEmpty(), size() > 0 -> !isEmpty()"
   local found=0
   while read -r file; do
-    grep --color=auto -H "size() == 0" "$file" && status=1 && found=1
+    grep --color=auto -EH \
+        "size\(\) == 0|size\(\) < 1|size\(\) <= 0|size\(\) > 0|size\(\) != 0|size\(\) >= 1" "$file" \
+      && status=1 && found=1
   done <<< "$(cat "$javaFiles")"
 
   displayResult "$found"

--- a/game-core/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameParser.java
@@ -821,7 +821,7 @@ public final class GameParser {
   }
 
   private void parseRelationInitialize(final List<Element> relations) throws GameParseException {
-    if (relations.size() > 0) {
+    if (!relations.isEmpty()) {
       final RelationshipTracker tracker = data.getRelationshipTracker();
       for (final Element current : relations) {
         final PlayerId p1 = getPlayerId(current, "player1", true);

--- a/game-core/src/main/java/games/strategy/engine/data/Route.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Route.java
@@ -155,7 +155,7 @@ public class Route implements Serializable, Iterable<Territory> {
 
   public BigDecimal getMovementCostIgnoreEnd(final Unit unit) {
     final List<Territory> territories =
-        steps.size() > 0 ? steps.subList(0, steps.size() - 1) : steps;
+        !steps.isEmpty() ? steps.subList(0, steps.size() - 1) : steps;
     return findMovementCost(unit, territories);
   }
 

--- a/game-core/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
+++ b/game-core/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
@@ -99,7 +99,7 @@ public class GameDataExporter {
   private static String playertechs(final GameData data) {
     final StringBuilder returnValue = new StringBuilder();
     for (final PlayerId player : data.getPlayerList()) {
-      if (player.getTechnologyFrontierList().getFrontiers().size() > 0) {
+      if (!player.getTechnologyFrontierList().getFrontiers().isEmpty()) {
         returnValue
             .append("        <playerTech player=\"")
             .append(player.getName())
@@ -128,7 +128,7 @@ public class GameDataExporter {
 
   private static String technologies(final GameData data) {
     final StringBuilder returnValue = new StringBuilder();
-    if (data.getTechnologyFrontier().getTechs().size() > 0) {
+    if (!data.getTechnologyFrontier().getTechs().isEmpty()) {
       returnValue.append("        <technologies>\n");
       for (final TechAdvance tech : data.getTechnologyFrontier().getTechs()) {
         String name = tech.getName();

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -406,7 +406,7 @@ public class DownloadMapsWindow extends JFrame {
 
     final JLabel mapSizeLabel = new JLabel(" ");
 
-    if (maps.size() > 0) {
+    if (!maps.isEmpty()) {
       final DefaultListModel<String> model = new DefaultListModel<>();
       maps.stream().map(DownloadFileDescription::getMapName).forEach(model::addElement);
 
@@ -434,7 +434,7 @@ public class DownloadMapsWindow extends JFrame {
 
   private static DownloadFileDescription determineCurrentMapSelection(
       final List<DownloadFileDescription> maps, final Optional<String> mapToSelect) {
-    checkArgument(maps.size() > 0);
+    checkArgument(!maps.isEmpty());
     if (mapToSelect.isPresent()) {
       final Optional<DownloadFileDescription> potentialMap =
           maps.stream().filter(m -> m.getMapName().equalsIgnoreCase(mapToSelect.get())).findFirst();

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/GameSelectorModel.java
@@ -213,7 +213,7 @@ public class GameSelectorModel extends Observable {
     final GameChooserModel model = new GameChooserModel();
     GameChooserEntry selectedGame = model.findByName(userPreferredDefaultGameName).orElse(null);
 
-    if (selectedGame == null && model.size() > 0) {
+    if (selectedGame == null && !model.isEmpty()) {
       selectedGame = model.get(0);
     }
     if (selectedGame == null) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -290,7 +290,7 @@ public final class GameSelectorPanel extends JPanel implements Observer {
           if (canChangeHostBotGameData
               || (canSelectGameData
                   && model.getGameData() != null
-                  && model.getGameData().getProperties().getEditableProperties().size() > 0)) {
+                  && !model.getGameData().getProperties().getEditableProperties().isEmpty())) {
             gameOptions.setEnabled(true);
           } else {
             gameOptions.setEnabled(false);

--- a/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -758,7 +758,7 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer {
       return null;
     }
     final IntegerMap<Resource> resourcesAndAttackValues = pa.getSuicideAttackResources();
-    if (resourcesAndAttackValues.size() <= 0) {
+    if (resourcesAndAttackValues.isEmpty()) {
       return null;
     }
     final IntegerMap<Resource> playerResourceCollection = id.getResources().getResourcesCopy();
@@ -769,7 +769,7 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer {
         attackTokens.put(possible, amount);
       }
     }
-    if (attackTokens.size() <= 0) {
+    if (attackTokens.isEmpty()) {
       return null;
     }
     final Map<Territory, Map<Unit, IntegerMap<Resource>>> kamikazeSuicideAttacks = new HashMap<>();

--- a/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -417,7 +417,7 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer {
         for (final Territory t : data.getMap().getTerritories()) {
           damagedUnits.addAll(CollectionUtils.getMatches(t.getUnits(), myDamaged));
         }
-        if (damagedUnits.size() > 0) {
+        if (!damagedUnits.isEmpty()) {
           final Map<Unit, IntegerMap<RepairRule>> repair =
               ui.getRepair(id, bid, GameStepPropertiesHelper.getRepairPlayers(data, id));
           if (repair != null) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
@@ -127,7 +127,7 @@ public abstract class AbstractAi extends AbstractBasePlayer {
           "Select Casualties showing different numbers for number of hits to take vs total "
               + "size of default casualty selections");
     }
-    if (defaultCasualties.getKilled().size() <= 0) {
+    if (defaultCasualties.getKilled().isEmpty()) {
       return new CasualtyDetails(defaultCasualties, false);
     }
     final CasualtyDetails myCasualties = new CasualtyDetails(false);
@@ -268,7 +268,7 @@ public abstract class AbstractAi extends AbstractBasePlayer {
       return null;
     }
     final IntegerMap<Resource> resourcesAndAttackValues = pa.getSuicideAttackResources();
-    if (resourcesAndAttackValues.size() <= 0) {
+    if (resourcesAndAttackValues.isEmpty()) {
       return null;
     }
     final IntegerMap<Resource> playerResourceCollection = id.getResources().getResourcesCopy();
@@ -279,19 +279,19 @@ public abstract class AbstractAi extends AbstractBasePlayer {
         attackTokens.put(possible, amount);
       }
     }
-    if (attackTokens.size() <= 0) {
+    if (attackTokens.isEmpty()) {
       return null;
     }
     final Map<Territory, Map<Unit, IntegerMap<Resource>>> kamikazeSuicideAttacks = new HashMap<>();
     for (final Entry<Territory, Collection<Unit>> entry : possibleUnitsToAttack.entrySet()) {
-      if (attackTokens.size() <= 0) {
+      if (attackTokens.isEmpty()) {
         continue;
       }
       final Territory t = entry.getKey();
       final List<Unit> targets = new ArrayList<>(entry.getValue());
       Collections.shuffle(targets);
       for (final Unit u : targets) {
-        if (attackTokens.size() <= 0) {
+        if (attackTokens.isEmpty()) {
           continue;
         }
         final IntegerMap<Resource> resourceMap = new IntegerMap<>();

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProAi.java
@@ -373,7 +373,7 @@ public class ProAi extends AbstractAi {
           "Select Casualties showing different numbers for number of hits to take vs total "
               + "size of default casualty selections");
     }
-    if (defaultCasualties.getKilled().size() <= 0) {
+    if (defaultCasualties.getKilled().isEmpty()) {
       return new CasualtyDetails(defaultCasualties, false);
     }
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -1247,7 +1247,7 @@ public class ProCombatMoveAi {
       }
 
       // Add units with attack options to map
-      if (canAttackTerritories.size() >= 1) {
+      if (!canAttackTerritories.isEmpty()) {
         unitAttackOptions.put(unit, canAttackTerritories);
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
@@ -330,7 +330,7 @@ public final class ProPurchaseUtils {
     final TerritoryAttachment ta = TerritoryAttachment.get(territory);
     final boolean originalFactory = (ta != null && ta.getOriginalFactory());
     final boolean playerIsOriginalOwner =
-        factoryUnits.size() > 0 && player.equals(getOriginalFactoryOwner(territory, player));
+        !factoryUnits.isEmpty() && player.equals(getOriginalFactoryOwner(territory, player));
     final RulesAttachment ra = player.getRulesAttachment();
     if (originalFactory && playerIsOriginalOwner) {
       if (ra != null && ra.getMaxPlacePerTerritory() != -1) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -186,7 +186,7 @@ public class WeakAi extends AbstractAi {
           }
         }
       }
-      if (units.size() > 0) {
+      if (!units.isEmpty()) {
         final Route route = new Route(capitol, neighbor);
         moves.add(new MoveDescription(units, route, transportMap, Map.of()));
       }
@@ -679,7 +679,7 @@ public class WeakAi extends AbstractAi {
               units = Utils.getUnitsUpToStrength(remainingStrengthNeeded, units);
             }
             remainingStrengthNeeded -= AiUtils.strength(units, true, false);
-            if (units.size() > 0) {
+            if (!units.isEmpty()) {
               unitsAlreadyMoved.addAll(units);
               moves.add(new MoveDescription(units, new Route(owned, enemy)));
             }
@@ -1070,7 +1070,7 @@ public class WeakAi extends AbstractAi {
     }
     final List<Unit> seaUnits =
         new ArrayList<>(player.getUnitCollection().getMatches(Matches.unitIsSea()));
-    if (seaUnits.size() > 0) {
+    if (!seaUnits.isEmpty()) {
       final Route amphibRoute = getAmphibRoute(player, data);
       Territory seaPlaceAt = null;
       if (amphibRoute != null) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -638,7 +638,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     final List<PlayerId> players = getPlayers();
     final GameData data = delegateBridge.getData();
     // check meta conditions (conditions which hold other conditions)
-    if (conditions.size() > 0) {
+    if (!conditions.isEmpty()) {
       final Map<ICondition, Boolean> actualTestedConditions =
           Optional.ofNullable(testedConditions)
               .orElseGet(
@@ -835,7 +835,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       objectiveMet = checkTechs(playerAttachedTo, data);
     }
     // check for relationships
-    if (objectiveMet && relationship.size() > 0) {
+    if (objectiveMet && !relationship.isEmpty()) {
       objectiveMet = checkRelationships();
     }
     // check for battle stats
@@ -1013,7 +1013,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
         default:
           return false;
       }
-      if (allUnits.size() > 0) {
+      if (!allUnits.isEmpty()) {
         if (!useSpecific) {
           numberMet += 1;
           if (numberMet >= numberNeeded) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -90,7 +90,7 @@ public class TerritoryAttachment extends DefaultAttachment {
         }
         if (player.equals(whoseCapital)) {
           if (player.equals(current.getOwner())) {
-            if (data.getMap().getNeighbors(current).size() > 0) {
+            if (!data.getMap().getNeighbors(current).isEmpty()) {
               return current;
             }
             noNeighborCapitals.add(current);

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -3238,7 +3238,7 @@ public class UnitAttachment extends DefaultAttachment {
             Matches.unitSupportAttachmentCanBeUsedByPlayer(player));
     if (supports.size() > 3) {
       tuples.add(Tuple.of("Can Provide Support to Units", ""));
-    } else if (supports.size() > 0) {
+    } else if (!supports.isEmpty()) {
       final boolean moreThanOneSupportType = UnitSupportAttachment.get(getData()).size() > 1;
       for (final UnitSupportAttachment support : supports) {
         if (support.getUnitType() == null || support.getUnitType().isEmpty()) {
@@ -3457,7 +3457,7 @@ public class UnitAttachment extends DefaultAttachment {
     }
 
     if (getRequiresUnits() != null
-        && getRequiresUnits().size() > 0
+        && !getRequiresUnits().isEmpty()
         && Properties.getUnitPlacementRestrictions(getData())) {
       final List<String> totalUnitsListed = new ArrayList<>();
       for (final String[] list : getRequiresUnits()) {
@@ -3566,7 +3566,7 @@ public class UnitAttachment extends DefaultAttachment {
 
   private static <T extends DefaultNamed> void addIntegerMapDescription(
       final String key, final IntegerMap<T> integerMap, final List<Tuple<String, String>> tuples) {
-    if (integerMap != null && integerMap.size() > 0) {
+    if (integerMap != null && !integerMap.isEmpty()) {
       final StringBuilder sb = new StringBuilder();
       if (integerMap.size() > 4) {
         sb.append(integerMap.totalValues());

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -1189,7 +1189,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     final boolean unitPlacementPerTerritoryRestricted = isUnitPlacementPerTerritoryRestricted();
     final boolean originalFactory = (ta != null && ta.getOriginalFactory());
     final boolean playerIsOriginalOwner =
-        factoryUnits.size() > 0 && this.player.equals(getOriginalFactoryOwner(producer));
+        !factoryUnits.isEmpty() && this.player.equals(getOriginalFactoryOwner(producer));
     final RulesAttachment ra =
         (RulesAttachment) player.getAttachment(Constants.RULES_ATTACHMENT_NAME);
     final Collection<Unit> alreadyProducedUnits = getAlreadyProduced(producer);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -1174,7 +1174,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
             ? CollectionUtils.getMatches(
                 units, unitWhichRequiresUnitsHasRequiredUnits(producer, true))
             : new ArrayList<>(units));
-    if (unitsCanBePlacedByThisProducer.size() <= 0) {
+    if (unitsCanBePlacedByThisProducer.isEmpty()) {
       return 0;
     }
     // if its an original factory then unlimited production

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
@@ -37,7 +37,7 @@ public class AirThatCantLandUtil {
     for (final Territory current : data.getMap().getTerritories()) {
       final Predicate<Unit> ownedAir = Matches.unitIsAir().and(Matches.unitIsOwnedBy(player));
       final Collection<Unit> air = current.getUnitCollection().getMatches(ownedAir);
-      if (air.size() != 0 && !AirMovementValidator.canLand(air, current, player, data)) {
+      if (!air.isEmpty() && !AirMovementValidator.canLand(air, current, player, data)) {
         cantLand.add(current);
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -1350,7 +1350,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       }
       // See if the player has any attack tokens
       final IntegerMap<Resource> resourcesAndAttackValues = pa.getSuicideAttackResources();
-      if (resourcesAndAttackValues.size() <= 0) {
+      if (resourcesAndAttackValues.isEmpty()) {
         continue;
       }
       final IntegerMap<Resource> playerResourceCollection =
@@ -1362,7 +1362,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
           attackTokens.put(possible, amount);
         }
       }
-      if (attackTokens.size() <= 0) {
+      if (attackTokens.isEmpty()) {
         continue;
       }
       // now let the enemy decide if they will do attacks

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BattleDelegate.java
@@ -1122,7 +1122,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       }
       if (isWW2v2orIsSurvivingAirMoveToLand) {
         Territory territory;
-        while (canLandHere.size() > 1 && defendingAir.size() > 0) {
+        while (canLandHere.size() > 1 && !defendingAir.isEmpty()) {
           territory =
               getRemotePlayer(defender)
                   .selectTerritoryForAirToLand(
@@ -1153,7 +1153,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
           canLandHere.remove(territory);
         }
         // Land in the last remaining territory
-        if (canLandHere.size() > 0 && defendingAir.size() > 0) {
+        if (!canLandHere.isEmpty() && !defendingAir.isEmpty()) {
           territory = canLandHere.iterator().next();
           if (territory.isWater()) {
             landPlanesOnCarriers(
@@ -1169,7 +1169,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             continue;
           }
         }
-      } else if (canLandHere.size() > 0) {
+      } else if (!canLandHere.isEmpty()) {
         // now defending air has what cant stay, is there a place we can go?
         // check for an island in this sea zone
         for (final Territory currentTerritory : canLandHere) {
@@ -1179,7 +1179,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
           }
         }
       }
-      if (defendingAir.size() > 0) {
+      if (!defendingAir.isEmpty()) {
         // no where to go, they must die
         bridge
             .getHistoryWriter()
@@ -1405,7 +1405,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
           final Unit unitUnderFire = unitEntry.getKey();
           final IntegerMap<Resource> numberOfAttacks = unitEntry.getValue();
           if (numberOfAttacks != null
-              && numberOfAttacks.size() > 0
+              && !numberOfAttacks.isEmpty()
               && numberOfAttacks.totalValues() > 0) {
             fireKamikazeSuicideAttacks(
                 unitUnderFire, numberOfAttacks, resourcesAndAttackValues, currentEnemy, location);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/CasualtySelector.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/CasualtySelector.java
@@ -325,7 +325,7 @@ public class CasualtySelector {
       for (final List<Unit> group : airSplit.getFirst()) {
         tempPossibleHitUnits.add(group.get(0));
       }
-      if (airSplit.getSecond().size() > 0) {
+      if (!airSplit.getSecond().isEmpty()) {
         // if we have a remainder group, we need to add some of them into the mix
         // but we have to do so randomly
         final List<Unit> remainders = new ArrayList<>(airSplit.getSecond());
@@ -802,7 +802,7 @@ public class CasualtySelector {
       if (amphibTypes.contains(unit.getType())) { // add a unit from the collection
         final List<Unit> oneAmphibUnit =
             CollectionUtils.getNMatches(allAmphibUnits, 1, Matches.unitIsOfType(unit.getType()));
-        if (oneAmphibUnit.size() > 0) {
+        if (!oneAmphibUnit.isEmpty()) {
           final Unit amphibUnit = oneAmphibUnit.iterator().next();
           killed.remove(unit);
           killed.add(amphibUnit);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/FinishedBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/FinishedBattle.java
@@ -128,7 +128,7 @@ public class FinishedBattle extends AbstractBattle {
       final Collection<Unit> units, final IDelegateBridge bridge, final boolean withdrawn) {
     final Collection<Unit> lost = getDependentUnits(units);
     lost.addAll(CollectionUtils.intersection(units, attackingUnits));
-    if (lost.size() != 0) {
+    if (!lost.isEmpty()) {
       attackingUnits.removeAll(lost);
       if (attackingUnits.isEmpty()) {
         final IntegerMap<UnitType> costs = TuvUtils.getCostsForTuv(attacker, gameData);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -879,7 +879,7 @@ public final class Matches {
   }
 
   public static Predicate<Territory> territoryHasWaterNeighbor(final GameData data) {
-    return t -> data.getMap().getNeighbors(t, territoryIsWater()).size() > 0;
+    return t -> !data.getMap().getNeighbors(t, territoryIsWater()).isEmpty();
   }
 
   public static Predicate<Territory> territoryIsOwnedAndHasOwnedUnitMatching(
@@ -1637,7 +1637,7 @@ public final class Matches {
     return unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
       return ua != null
-          && ua.getGivesMovement().size() > 0
+          && !ua.getGivesMovement().isEmpty()
           && unitIsBeingTransported().negate().test(unit);
     };
   }
@@ -1689,7 +1689,7 @@ public final class Matches {
   static Predicate<Unit> unitCreatesUnits() {
     return unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      return ua != null && ua.getCreatesUnitsList() != null && ua.getCreatesUnitsList().size() > 0;
+      return ua != null && ua.getCreatesUnitsList() != null && !ua.getCreatesUnitsList().isEmpty();
     };
   }
 
@@ -1698,21 +1698,21 @@ public final class Matches {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
       return ua != null
           && ua.getCreatesResourcesList() != null
-          && ua.getCreatesResourcesList().size() > 0;
+          && !ua.getCreatesResourcesList().isEmpty();
     };
   }
 
   public static Predicate<UnitType> unitTypeConsumesUnitsOnCreation() {
     return unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit);
-      return ua != null && ua.getConsumesUnits() != null && ua.getConsumesUnits().size() > 0;
+      return ua != null && ua.getConsumesUnits() != null && !ua.getConsumesUnits().isEmpty();
     };
   }
 
   static Predicate<Unit> unitConsumesUnitsOnCreation() {
     return unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      return ua != null && ua.getConsumesUnits() != null && ua.getConsumesUnits().size() > 0;
+      return ua != null && ua.getConsumesUnits() != null && !ua.getConsumesUnits().isEmpty();
     };
   }
 
@@ -1751,7 +1751,7 @@ public final class Matches {
   public static Predicate<Unit> unitRequiresUnitsOnCreation() {
     return unit -> {
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      return ua != null && ua.getRequiresUnits() != null && ua.getRequiresUnits().size() > 0;
+      return ua != null && ua.getRequiresUnits() != null && !ua.getRequiresUnits().isEmpty();
     };
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -645,7 +645,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     // confirm kamikaze moves, and remove them from unresolved units
     if (getKamikazeAir || move.getUnits().stream().anyMatch(Matches.unitIsKamikaze())) {
       kamikazeUnits = result.getUnresolvedUnits(MoveValidator.NOT_ALL_AIR_UNITS_CAN_LAND);
-      if (kamikazeUnits.size() > 0 && bridge.getRemotePlayer().confirmMoveKamikaze()) {
+      if (!kamikazeUnits.isEmpty() && bridge.getRemotePlayer().confirmMoveKamikaze()) {
         for (final Unit unit : kamikazeUnits) {
           if (getKamikazeAir || Matches.unitIsKamikaze().test(unit)) {
             result.removeUnresolvedUnit(MoveValidator.NOT_ALL_AIR_UNITS_CAN_LAND, unit);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -167,7 +167,7 @@ public class MovePerformer implements Serializable {
             change.add(Route.getFuelChanges(units, route, id, data));
 
             markTransportsMovement(arrived, transporting, route);
-            if (route.anyMatch(mustFightThrough) && arrived.size() != 0) {
+            if (route.anyMatch(mustFightThrough) && !arrived.isEmpty()) {
               boolean ignoreBattle = false;
               // could it be a bombing raid
               final Collection<Unit> enemyUnits =
@@ -365,7 +365,7 @@ public class MovePerformer implements Serializable {
     // if neutrals were taken over mark land units with 0 movement
     // if entered a non blitzed conquered territory, mark with 0 movement
     if (GameStepPropertiesHelper.isCombatMove(data)
-        && (MoveDelegate.getEmptyNeutral(route).size() != 0 || hasConqueredNonBlitzed(route))) {
+        && (!MoveDelegate.getEmptyNeutral(route).isEmpty() || hasConqueredNonBlitzed(route))) {
       for (final Unit unit : CollectionUtils.getMatches(units, Matches.unitIsLand())) {
         change.add(ChangeFactory.markNoMovementChange(Set.of(unit)));
       }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MustFightBattle.java
@@ -134,7 +134,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     attackingUnits = new ArrayList<>(attacking);
     bombardingUnits = new ArrayList<>(bombarding);
     amphibiousLandAttackers = new ArrayList<>(amphibious);
-    isAmphibious = amphibiousLandAttackers.size() > 0;
+    isAmphibious = !amphibiousLandAttackers.isEmpty();
     this.defender = defender;
     this.territoryEffects = territoryEffects;
   }
@@ -691,7 +691,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       }
     }
     // write attacking units to history
-    if (attackingUnits.size() > 0) {
+    if (!attackingUnits.isEmpty()) {
       bridge.getHistoryWriter().addChildToEvent(transcriptText.toString(), allAttackingUnits);
     }
     // find all defending players (unsorted)
@@ -723,7 +723,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       allDefendingUnits.addAll(defendingUnits);
     }
     // write defending units to history
-    if (defendingUnits.size() > 0) {
+    if (!defendingUnits.isEmpty()) {
       bridge.getHistoryWriter().addChildToEvent(transcriptBuilder.toString(), allDefendingUnits);
     }
   }
@@ -953,14 +953,14 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (offensiveAa == null) {
       updateOffensiveAaUnits();
     }
-    return offensiveAa.size() > 0;
+    return !offensiveAa.isEmpty();
   }
 
   private boolean canFireDefendingAa() {
     if (defendingAa == null) {
       updateDefendingAaUnits();
     }
-    return defendingAa.size() > 0;
+    return !defendingAa.isEmpty();
   }
 
   private boolean defenderSubsFireFirst() {
@@ -1350,7 +1350,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       bridge.addChange(change);
     }
     final boolean canReturnFire = Properties.getNavalBombardCasualtiesReturnFire(gameData);
-    if (bombard.size() > 0 && attacked.size() > 0) {
+    if (!bombard.isEmpty() && !attacked.isEmpty()) {
       if (!headless) {
         bridge
             .getSoundChannelBroadcaster()
@@ -1854,7 +1854,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
       final Collection<Unit> enemyUnits =
           CollectionUtils.getMatches(battleSite.getUnits(), enemyUnitsMatch);
       // If there are attackers set their movement to 0 and kill the transports
-      if (enemyUnits.size() > 0) {
+      if (!enemyUnits.isEmpty()) {
         final Change change =
             ChangeFactory.markNoMovementChange(
                 CollectionUtils.getMatches(enemyUnits, Matches.unitIsSea()));

--- a/game-core/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/NonFightingBattle.java
@@ -141,7 +141,7 @@ public class NonFightingBattle extends DependentBattle {
     Collection<Unit> lost = new ArrayList<>(getDependentUnits(units));
     lost.addAll(CollectionUtils.intersection(units, attackingUnits));
     lost = CollectionUtils.getMatches(lost, Matches.unitIsInTerritory(battleSite));
-    if (lost.size() != 0) {
+    if (!lost.isEmpty()) {
       final String transcriptText =
           MyFormatter.unitsToText(lost) + " lost in " + battleSite.getName();
       bridge.getHistoryWriter().addChildToEvent(transcriptText, lost);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/StrategicBombingRaidBattle.java
@@ -207,7 +207,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     aaTypes = UnitAttachment.getAllOfTypeAas(defendingAa);
     // reverse since stacks are in reverse order
     Collections.reverse(aaTypes);
-    final boolean hasAa = defendingAa.size() > 0;
+    final boolean hasAa = !defendingAa.isEmpty();
     steps = new ArrayList<>();
     if (hasAa) {
       for (final String typeAa : UnitAttachment.getAllOfTypeAas(defendingAa)) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
@@ -36,7 +36,7 @@ public class TechActivationDelegate extends BaseTripleADelegate {
     final Map<PlayerId, Collection<TechAdvance>> techMap =
         DelegateFinder.techDelegate(data).getAdvances();
     final Collection<TechAdvance> advances = techMap.get(player);
-    if ((advances != null) && (advances.size() > 0)) {
+    if ((advances != null) && (!advances.isEmpty())) {
       // Start event
       bridge
           .getHistoryWriter()

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
@@ -36,7 +36,7 @@ public class TechActivationDelegate extends BaseTripleADelegate {
     final Map<PlayerId, Collection<TechAdvance>> techMap =
         DelegateFinder.techDelegate(data).getAdvances();
     final Collection<TechAdvance> advances = techMap.get(player);
-    if ((advances != null) && (!advances.isEmpty())) {
+    if (advances != null && !advances.isEmpty()) {
       // Start event
       bridge
           .getHistoryWriter()

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -291,7 +291,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
       }
     }
     final String transcriptText = player.getName() + " discover " + text;
-    if (advances.size() > 0) {
+    if (!advances.isEmpty()) {
       bridge.getHistoryWriter().startEvent(transcriptText);
       // play a sound
       bridge

--- a/game-core/src/main/java/games/strategy/triplea/delegate/data/MoveValidationResult.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/data/MoveValidationResult.java
@@ -107,7 +107,7 @@ public class MoveValidationResult implements Serializable, Comparable<MoveValida
   }
 
   public boolean hasDisallowedUnits() {
-    return disallowedUnitWarnings.size() > 0;
+    return !disallowedUnitWarnings.isEmpty();
   }
 
   public int getDisallowedUnitCount() {
@@ -115,7 +115,7 @@ public class MoveValidationResult implements Serializable, Comparable<MoveValida
   }
 
   public boolean hasUnresolvedUnits() {
-    return unresolvedUnitWarnings.size() > 0;
+    return !unresolvedUnitWarnings.isEmpty();
   }
 
   public int getUnresolvedUnitCount() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -573,7 +573,7 @@ public final class BattlePanel extends ActionPanel {
       }
       list = new JList<>(SwingComponents.newListModel(listElements));
       list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-      if (listElements.size() >= 1) {
+      if (!listElements.isEmpty()) {
         list.setSelectedIndex(0);
       }
       final JScrollPane scroll = new JScrollPane(list);

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -699,7 +699,7 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
                         || unitsThatCanMoveOnRoute.stream().allMatch(Matches.unitIsAir()))) {
                   final Collection<Unit> airUnits =
                       CollectionUtils.getMatches(selectedUnits, Matches.unitIsAir());
-                  if (airUnits.size() > 0) {
+                  if (!airUnits.isEmpty()) {
                     route = getRoute(getFirstSelectedTerritory(), territory, airUnits);
                     updateUnitsThatCanMoveOnRoute(airUnits, route);
                   }
@@ -885,7 +885,7 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
               }
             }
             // Repeat until there are no units left or no changes occur
-          } while (availableUnits.size() > 0 && hasChanged);
+          } while (!availableUnits.isEmpty() && hasChanged);
 
           // If we haven't seen all of the transports (and removed them) then there are extra
           // transports that don't fit

--- a/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -304,7 +304,7 @@ class PlacePanel extends AbstractMovePanel implements GameDataChangeListener {
 
   @Override
   protected boolean doneMoveAction() {
-    if (getCurrentPlayer().getUnitCollection().size() > 0) {
+    if (!getCurrentPlayer().getUnitCollection().isEmpty()) {
       final int option =
           JOptionPane.showConfirmDialog(
               getTopLevelAncestor(),

--- a/game-core/src/main/java/games/strategy/triplea/ui/TabbedProductionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TabbedProductionPanel.java
@@ -81,7 +81,7 @@ class TabbedProductionPanel extends ProductionPanel {
     final List<Tuple<String, List<Rule>>> ruleLists = getRuleLists(properties);
     calculateRowsAndColumns(properties, largestList(ruleLists));
     for (final Tuple<String, List<Rule>> ruleList : ruleLists) {
-      if (ruleList.getSecond().size() > 0) {
+      if (!ruleList.getSecond().isEmpty()) {
         tabs.addTab(ruleList.getFirst(), new JScrollPane(getRulesPanel(ruleList.getSecond())));
       }
     }
@@ -190,7 +190,7 @@ class TabbedProductionPanel extends ProductionPanel {
         rulesCopy.remove(rule);
       }
     }
-    if (rulesCopy.size() > 0) {
+    if (!rulesCopy.isEmpty()) {
       throw new IllegalStateException(
           "production_tabs: must include all player production rules/units");
     }

--- a/swing-lib/src/main/java/org/triplea/swing/JComboBoxBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/JComboBoxBuilder.java
@@ -41,7 +41,7 @@ public final class JComboBoxBuilder<E> {
 
   /** Builds the swing component. */
   public JComboBox<E> build() {
-    Preconditions.checkState(items.size() > 0);
+    Preconditions.checkState(!items.isEmpty());
 
     @SuppressWarnings("unchecked")
     final E[] array = (E[]) Array.newInstance(itemType, items.size());


### PR DESCRIPTION
Several commits to replace variations of 'isEmpty()' checks that use the 'size()' methods
<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

