### PR TITLE
Suppress some false positive sonarcloud warnings related to Optional

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -156,14 +156,14 @@ public class UnitImageFactory {
     final Optional<URL> imageLocation = getBaseImageUrl(baseImageName, id);
     Image image = null;
     if (imageLocation.isPresent()) {
-      image = Toolkit.getDefaultToolkit().getImage(getBaseImageUrl(baseImageName, id).get());
+      image = Toolkit.getDefaultToolkit().getImage(imageLocation.get());
       Util.ensureImageLoaded(image);
       if (needToTransformImage(id, type, mapData)) {
         image = convertToBufferedImage(image);
-        if (mapData.getUnitColor(id.getName()).isPresent()) {
-          final Color color = mapData.getUnitColor(id.getName()).get();
+        final Optional<Color> unitColor = mapData.getUnitColor(id.getName());
+        if (unitColor.isPresent()) {
           final int brightness = mapData.getUnitBrightness(id.getName());
-          ImageTransformer.colorize(color, brightness, (BufferedImage) image);
+          ImageTransformer.colorize(unitColor.get(), brightness, (BufferedImage) image);
         }
         if (mapData.shouldFlipUnit(id.getName())) {
           image = ImageTransformer.flipHorizontally((BufferedImage) image);

--- a/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.settings;
 
-import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
@@ -41,7 +40,7 @@ public interface GameSetting<T> {
    * default value.
    */
   default T getValueOrThrow() {
-    return getValue().orElseThrow(() -> new NoSuchElementException());
+    return getValue().orElseThrow();
   }
 
   /** Resets the setting to its default value or empty if it has no default value. */

--- a/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea.settings;
 
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
@@ -40,7 +41,7 @@ public interface GameSetting<T> {
    * default value.
    */
   default T getValueOrThrow() {
-    return getValue().get();
+    return getValue().orElseThrow(() -> new NoSuchElementException());
   }
 
   /** Resets the setting to its default value or empty if it has no default value. */


### PR DESCRIPTION
Fixes 3 warnings related to use of Optional identified here:

https://sonarcloud.io/project/issues?id=triplea-game-sonar&open=AW6pgYgSgYcRdnXYRPab&resolved=false&types=BUG

These are all false positives - but this change should suppress them and make the code clearer that it's correct.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[X] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

