### PR TITLE
Split GameListing controller into LobbyWatcherController

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/LobbyWatcherThread.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/LobbyWatcherThread.java
@@ -14,7 +14,7 @@ import lombok.Getter;
 import org.triplea.domain.data.ApiKey;
 import org.triplea.http.client.lobby.HttpLobbyClient;
 import org.triplea.http.client.lobby.game.hosting.GameHostingResponse;
-import org.triplea.http.client.lobby.game.listing.GameListingClient;
+import org.triplea.http.client.lobby.game.listing.LobbyWatcherClient;
 
 @AllArgsConstructor
 public class LobbyWatcherThread {
@@ -32,7 +32,7 @@ public class LobbyWatcherThread {
     InGameLobbyWatcher.newInGameLobbyWatcher(
             serverMessenger,
             gameHostingResponse,
-            GameListingClient.newClient(lobbyUri, ApiKey.of(gameHostingResponse.getApiKey())),
+            LobbyWatcherClient.newClient(lobbyUri, ApiKey.of(gameHostingResponse.getApiKey())),
             watcherThreadMessaging::connectionLostReporter,
             watcherThreadMessaging::connectionReEstablishedReporter,
             lobbyWatcher.getInGameLobbyWatcher())

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -19,7 +19,7 @@ import javax.annotation.Nullable;
 import lombok.extern.java.Log;
 import org.triplea.game.server.HeadlessGameServer;
 import org.triplea.http.client.lobby.game.hosting.GameHostingResponse;
-import org.triplea.http.client.lobby.game.listing.GameListingClient;
+import org.triplea.http.client.lobby.game.listing.LobbyWatcherClient;
 import org.triplea.java.timer.ScheduledTimer;
 import org.triplea.java.timer.Timers;
 import org.triplea.lobby.common.GameDescription;
@@ -40,7 +40,7 @@ public class InGameLobbyWatcher {
   private final IConnectionChangeListener connectionChangeListener;
   private final boolean humanPlayer;
 
-  private final GameListingClient gameListingClient;
+  private final LobbyWatcherClient gameListingClient;
 
   private final IServerMessenger serverMessenger;
 
@@ -49,7 +49,7 @@ public class InGameLobbyWatcher {
   private InGameLobbyWatcher(
       final IServerMessenger serverMessenger,
       final GameHostingResponse gameHostingResponse,
-      final GameListingClient gameListingClient,
+      final LobbyWatcherClient gameListingClient,
       final Consumer<String> errorReporter,
       final Consumer<String> reconnectionReporter,
       @Nullable final InGameLobbyWatcher oldWatcher) {
@@ -66,7 +66,7 @@ public class InGameLobbyWatcher {
   private InGameLobbyWatcher(
       final IServerMessenger serverMessenger,
       final GameHostingResponse gameHostingResponse,
-      final GameListingClient gameListingClient,
+      final LobbyWatcherClient gameListingClient,
       final Consumer<String> errorReporter,
       final Consumer<String> reconnectionReporter,
       @Nullable final GameDescription oldGameDescription,
@@ -121,7 +121,7 @@ public class InGameLobbyWatcher {
     // message is lost or missed, we have time to send another one before reaching the cut-off time.
     keepAliveTimer =
         Timers.fixedRateTimer("lobby-watcher-keep-alive")
-            .period((GameListingClient.KEEP_ALIVE_SECONDS / 2L) - 1, TimeUnit.SECONDS)
+            .period((LobbyWatcherClient.KEEP_ALIVE_SECONDS / 2L) - 1, TimeUnit.SECONDS)
             .task(
                 LobbyWatcherKeepAliveTask.builder()
                     .gameId(gameId)
@@ -162,7 +162,7 @@ public class InGameLobbyWatcher {
   public static Optional<InGameLobbyWatcher> newInGameLobbyWatcher(
       final IServerMessenger serverMessenger,
       final GameHostingResponse gameHostingResponse,
-      final GameListingClient gameListingClient,
+      final LobbyWatcherClient gameListingClient,
       final Consumer<String> errorReporter,
       final Consumer<String> reconnectionReporter,
       final InGameLobbyWatcher oldWatcher) {

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/game/listing/GameListingClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/game/listing/GameListingClient.java
@@ -2,55 +2,29 @@ package org.triplea.http.client.lobby.game.listing;
 
 import java.net.URI;
 import java.util.List;
-import lombok.AllArgsConstructor;
+import javax.annotation.Nonnull;
+import lombok.Builder;
 import org.triplea.domain.data.ApiKey;
 import org.triplea.http.client.AuthenticationHeaders;
 import org.triplea.http.client.HttpClient;
 
-/**
- * Http client for interacting with lobby game listing. Can be used to post, remove, boot, fetch and
- * update games.
- */
-@AllArgsConstructor
+@Builder
 public class GameListingClient {
-  public static final int KEEP_ALIVE_SECONDS = 10;
-
-  public static final String BOOT_GAME_PATH = "/lobby/games/boot-game";
   public static final String FETCH_GAMES_PATH = "/lobby/games/fetch-games";
-  public static final String KEEP_ALIVE_PATH = "/lobby/games/keep-alive";
-  public static final String POST_GAME_PATH = "/lobby/games/post-game";
-  public static final String UPDATE_GAME_PATH = "/lobby/games/update-game";
-  public static final String REMOVE_GAME_PATH = "/lobby/games/remove-game";
+  public static final String BOOT_GAME_PATH = "/lobby/games/boot-game";
 
-  private final AuthenticationHeaders authenticationHeaders;
-  private final GameListingFeignClient gameListingFeignClient;
+  @Nonnull private final AuthenticationHeaders authenticationHeaders;
+  @Nonnull private final GameListingFeignClient gameListingFeignClient;
 
   public static GameListingClient newClient(final URI serverUri, final ApiKey apiKey) {
-    return new GameListingClient(
-        new AuthenticationHeaders(apiKey),
-        new HttpClient<>(GameListingFeignClient.class, serverUri).get());
+    return GameListingClient.builder()
+        .authenticationHeaders(new AuthenticationHeaders(apiKey))
+        .gameListingFeignClient(new HttpClient<>(GameListingFeignClient.class, serverUri).get())
+        .build();
   }
 
   public List<LobbyGameListing> fetchGameListing() {
     return gameListingFeignClient.fetchGameListing(authenticationHeaders.createHeaders());
-  }
-
-  public String postGame(final LobbyGame lobbyGame) {
-    return gameListingFeignClient.postGame(authenticationHeaders.createHeaders(), lobbyGame);
-  }
-
-  public void updateGame(final String gameId, final LobbyGame lobbyGame) {
-    gameListingFeignClient.updateGame(
-        authenticationHeaders.createHeaders(),
-        UpdateGameRequest.builder().gameId(gameId).gameData(lobbyGame).build());
-  }
-
-  public boolean sendKeepAlive(final String gameId) {
-    return gameListingFeignClient.sendKeepAlive(authenticationHeaders.createHeaders(), gameId);
-  }
-
-  public void removeGame(final String gameId) {
-    gameListingFeignClient.removeGame(authenticationHeaders.createHeaders(), gameId);
   }
 
   public void bootGame(final String gameId) {

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/game/listing/GameListingFeignClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/game/listing/GameListingFeignClient.java
@@ -12,18 +12,6 @@ interface GameListingFeignClient {
   @RequestLine("GET " + GameListingClient.FETCH_GAMES_PATH)
   List<LobbyGameListing> fetchGameListing(@HeaderMap Map<String, Object> headers);
 
-  @RequestLine("POST " + GameListingClient.POST_GAME_PATH)
-  String postGame(@HeaderMap Map<String, Object> headers, LobbyGame lobbyGame);
-
-  @RequestLine("POST " + GameListingClient.UPDATE_GAME_PATH)
-  void updateGame(@HeaderMap Map<String, Object> headers, UpdateGameRequest updateGameRequest);
-
-  @RequestLine("POST " + GameListingClient.REMOVE_GAME_PATH)
-  void removeGame(@HeaderMap Map<String, Object> headers, String gameId);
-
-  @RequestLine("POST " + GameListingClient.KEEP_ALIVE_PATH)
-  boolean sendKeepAlive(@HeaderMap Map<String, Object> headers, String gameId);
-
   @RequestLine("POST " + GameListingClient.BOOT_GAME_PATH)
   void bootGame(@HeaderMap Map<String, Object> headers, String gameId);
 }

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/game/listing/LobbyWatcherClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/game/listing/LobbyWatcherClient.java
@@ -1,0 +1,48 @@
+package org.triplea.http.client.lobby.game.listing;
+
+import java.net.URI;
+import lombok.AllArgsConstructor;
+import org.triplea.domain.data.ApiKey;
+import org.triplea.http.client.AuthenticationHeaders;
+import org.triplea.http.client.HttpClient;
+
+/**
+ * Http client for interacting with lobby game listing. Can be used to post, remove, boot, fetch and
+ * update games.
+ */
+@AllArgsConstructor
+public class LobbyWatcherClient {
+  public static final int KEEP_ALIVE_SECONDS = 20;
+
+  public static final String KEEP_ALIVE_PATH = "/lobby/games/keep-alive";
+  public static final String POST_GAME_PATH = "/lobby/games/post-game";
+  public static final String UPDATE_GAME_PATH = "/lobby/games/update-game";
+  public static final String REMOVE_GAME_PATH = "/lobby/games/remove-game";
+
+  private final AuthenticationHeaders authenticationHeaders;
+  private final LobbyWatcherFeignClient gameListingFeignClient;
+
+  public static LobbyWatcherClient newClient(final URI serverUri, final ApiKey apiKey) {
+    return new LobbyWatcherClient(
+        new AuthenticationHeaders(apiKey),
+        new HttpClient<>(LobbyWatcherFeignClient.class, serverUri).get());
+  }
+
+  public String postGame(final LobbyGame lobbyGame) {
+    return gameListingFeignClient.postGame(authenticationHeaders.createHeaders(), lobbyGame);
+  }
+
+  public void updateGame(final String gameId, final LobbyGame lobbyGame) {
+    gameListingFeignClient.updateGame(
+        authenticationHeaders.createHeaders(),
+        UpdateGameRequest.builder().gameId(gameId).gameData(lobbyGame).build());
+  }
+
+  public boolean sendKeepAlive(final String gameId) {
+    return gameListingFeignClient.sendKeepAlive(authenticationHeaders.createHeaders(), gameId);
+  }
+
+  public void removeGame(final String gameId) {
+    gameListingFeignClient.removeGame(authenticationHeaders.createHeaders(), gameId);
+  }
+}

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/game/listing/LobbyWatcherFeignClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/game/listing/LobbyWatcherFeignClient.java
@@ -1,0 +1,22 @@
+package org.triplea.http.client.lobby.game.listing;
+
+import feign.HeaderMap;
+import feign.Headers;
+import feign.RequestLine;
+import java.util.Map;
+import org.triplea.http.client.HttpConstants;
+
+@Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
+interface LobbyWatcherFeignClient {
+  @RequestLine("POST " + LobbyWatcherClient.POST_GAME_PATH)
+  String postGame(@HeaderMap Map<String, Object> headers, LobbyGame lobbyGame);
+
+  @RequestLine("POST " + LobbyWatcherClient.UPDATE_GAME_PATH)
+  void updateGame(@HeaderMap Map<String, Object> headers, UpdateGameRequest updateGameRequest);
+
+  @RequestLine("POST " + LobbyWatcherClient.REMOVE_GAME_PATH)
+  void removeGame(@HeaderMap Map<String, Object> headers, String gameId);
+
+  @RequestLine("POST " + LobbyWatcherClient.KEEP_ALIVE_PATH)
+  boolean sendKeepAlive(@HeaderMap Map<String, Object> headers, String gameId);
+}

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/game/listing/GameListingClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/game/listing/GameListingClientTest.java
@@ -1,7 +1,6 @@
 package org.triplea.http.client.lobby.game.listing;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -44,57 +43,6 @@ class GameListingClientTest extends WireMockTest {
 
     assertThat(results, hasSize(1));
     assertThat(results.get(0), is(LOBBY_GAME_LISTING));
-  }
-
-  @Test
-  void postGame(@WiremockResolver.Wiremock final WireMockServer server) {
-    server.stubFor(
-        post(GameListingClient.POST_GAME_PATH)
-            .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
-            .withRequestBody(equalToJson(toJson(LOBBY_GAME)))
-            .willReturn(WireMock.aResponse().withStatus(200).withBody(GAME_ID)));
-
-    final String gameId = newClient(server).postGame(LOBBY_GAME);
-
-    assertThat(gameId, is(GAME_ID));
-  }
-
-  @Test
-  void updateGame(@WiremockResolver.Wiremock final WireMockServer server) {
-    server.stubFor(
-        post(GameListingClient.UPDATE_GAME_PATH)
-            .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
-            .withRequestBody(
-                equalToJson(
-                    toJson(
-                        UpdateGameRequest.builder().gameId(GAME_ID).gameData(LOBBY_GAME).build())))
-            .willReturn(WireMock.aResponse().withStatus(200)));
-
-    newClient(server).updateGame(GAME_ID, LOBBY_GAME);
-  }
-
-  @Test
-  void sendKeepAlive(@WiremockResolver.Wiremock final WireMockServer server) {
-    server.stubFor(
-        post(GameListingClient.KEEP_ALIVE_PATH)
-            .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
-            .withRequestBody(equalTo(GAME_ID))
-            .willReturn(WireMock.aResponse().withStatus(200).withBody("true")));
-
-    final boolean result = newClient(server).sendKeepAlive(GAME_ID);
-
-    assertThat(result, is(true));
-  }
-
-  @Test
-  void removeGame(@WiremockResolver.Wiremock final WireMockServer server) {
-    server.stubFor(
-        post(GameListingClient.REMOVE_GAME_PATH)
-            .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
-            .withRequestBody(equalTo(GAME_ID))
-            .willReturn(WireMock.aResponse().withStatus(200)));
-
-    newClient(server).removeGame(GAME_ID);
   }
 
   @Test

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/game/listing/LobbyWatcherClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/game/listing/LobbyWatcherClientTest.java
@@ -1,0 +1,78 @@
+package org.triplea.http.client.lobby.game.listing;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.triplea.http.client.HttpClientTesting.EXPECTED_API_KEY;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import org.junit.jupiter.api.Test;
+import org.triplea.http.client.AuthenticationHeaders;
+import org.triplea.http.client.TestData;
+import org.triplea.http.client.WireMockTest;
+import ru.lanwen.wiremock.ext.WiremockResolver;
+
+class LobbyWatcherClientTest extends WireMockTest {
+
+  private static final String GAME_ID = "gameId";
+
+  private static final LobbyGame LOBBY_GAME = TestData.LOBBY_GAME;
+
+  private static LobbyWatcherClient newClient(final WireMockServer wireMockServer) {
+    return newClient(wireMockServer, LobbyWatcherClient::newClient);
+  }
+
+  @Test
+  void postGame(@WiremockResolver.Wiremock final WireMockServer server) {
+    server.stubFor(
+        post(LobbyWatcherClient.POST_GAME_PATH)
+            .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
+            .withRequestBody(equalToJson(toJson(LOBBY_GAME)))
+            .willReturn(WireMock.aResponse().withStatus(200).withBody(GAME_ID)));
+
+    final String gameId = newClient(server).postGame(LOBBY_GAME);
+
+    assertThat(gameId, is(GAME_ID));
+  }
+
+  @Test
+  void updateGame(@WiremockResolver.Wiremock final WireMockServer server) {
+    server.stubFor(
+        post(LobbyWatcherClient.UPDATE_GAME_PATH)
+            .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
+            .withRequestBody(
+                equalToJson(
+                    toJson(
+                        UpdateGameRequest.builder().gameId(GAME_ID).gameData(LOBBY_GAME).build())))
+            .willReturn(WireMock.aResponse().withStatus(200)));
+
+    newClient(server).updateGame(GAME_ID, LOBBY_GAME);
+  }
+
+  @Test
+  void sendKeepAlive(@WiremockResolver.Wiremock final WireMockServer server) {
+    server.stubFor(
+        post(LobbyWatcherClient.KEEP_ALIVE_PATH)
+            .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
+            .withRequestBody(equalTo(GAME_ID))
+            .willReturn(WireMock.aResponse().withStatus(200).withBody("true")));
+
+    final boolean result = newClient(server).sendKeepAlive(GAME_ID);
+
+    assertThat(result, is(true));
+  }
+
+  @Test
+  void removeGame(@WiremockResolver.Wiremock final WireMockServer server) {
+    server.stubFor(
+        post(LobbyWatcherClient.REMOVE_GAME_PATH)
+            .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
+            .withRequestBody(equalTo(GAME_ID))
+            .willReturn(WireMock.aResponse().withStatus(200)));
+
+    newClient(server).removeGame(GAME_ID);
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/http/ServerApplication.java
+++ b/http-server/src/main/java/org/triplea/server/http/ServerApplication.java
@@ -43,6 +43,8 @@ import org.triplea.server.lobby.chat.moderation.ModeratorChatControllerFactory;
 import org.triplea.server.lobby.game.ConnectivityControllerFactory;
 import org.triplea.server.lobby.game.hosting.GameHostingControllerFactory;
 import org.triplea.server.lobby.game.listing.GameListingControllerFactory;
+import org.triplea.server.lobby.game.listing.GameListingFactory;
+import org.triplea.server.lobby.game.listing.LobbyWatcherControllerFactory;
 import org.triplea.server.moderator.toolbox.access.log.AccessLogControllerFactory;
 import org.triplea.server.moderator.toolbox.audit.history.ModeratorAuditHistoryControllerFactory;
 import org.triplea.server.moderator.toolbox.bad.words.BadWordControllerFactory;
@@ -193,6 +195,8 @@ public class ServerApplication extends Application<AppConfig> {
       final Jdbi jdbi,
       final Chatters chatters,
       final RemoteActionsEventQueue remoteActionsEventQueue) {
+    final var gameListing = GameListingFactory.buildGameListing(jdbi);
+
     return ImmutableList.of(
         AccessLogControllerFactory.buildController(jdbi),
         BadWordControllerFactory.buildController(jdbi),
@@ -200,7 +204,8 @@ public class ServerApplication extends Application<AppConfig> {
         CreateAccountControllerFactory.buildController(jdbi),
         ForgotPasswordControllerFactory.buildController(appConfig, jdbi),
         GameHostingControllerFactory.buildController(jdbi),
-        GameListingControllerFactory.buildController(jdbi),
+        GameListingControllerFactory.buildController(gameListing),
+        LobbyWatcherControllerFactory.buildController(gameListing),
         LoginControllerFactory.buildController(jdbi, chatters),
         ModeratorChatControllerFactory.buildController(jdbi, chatters, remoteActionsEventQueue),
         UsernameBanControllerFactory.buildController(appConfig, jdbi),

--- a/http-server/src/main/java/org/triplea/server/lobby/game/listing/GameListingController.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/game/listing/GameListingController.java
@@ -16,9 +16,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import org.triplea.http.client.lobby.game.listing.GameListingClient;
-import org.triplea.http.client.lobby.game.listing.LobbyGame;
 import org.triplea.http.client.lobby.game.listing.LobbyGameListing;
-import org.triplea.http.client.lobby.game.listing.UpdateGameRequest;
 import org.triplea.lobby.server.db.data.UserRole;
 import org.triplea.server.access.AuthenticatedUser;
 import org.triplea.server.http.HttpController;
@@ -33,47 +31,6 @@ public class GameListingController extends HttpController {
 
   private final GameListing gameListing;
 
-  /**
-   * Adds a game to the lobby listing. Responds with the gameId assigned to the new game. If we see
-   * duplicate posts, the same gameId will be returned.
-   */
-  @RateLimited(
-      keys = {KeyPart.IP},
-      rates = {@Rate(limit = 20, duration = 4, timeUnit = TimeUnit.MINUTES)})
-  @POST
-  @Path(GameListingClient.POST_GAME_PATH)
-  public String postGame(
-      @Auth final AuthenticatedUser authenticatedUser, final LobbyGame lobbyGame) {
-    // TODO: Project#12 Combine availability check with gameListing.postGame
-    return gameListing.postGame(authenticatedUser.getApiKey(), lobbyGame);
-  }
-
-  /** Explicit remove of a game from the lobby. */
-  @RateLimited(
-      keys = {KeyPart.IP},
-      rates = {@Rate(limit = 5, duration = 1, timeUnit = TimeUnit.SECONDS)})
-  @POST
-  @Path(GameListingClient.REMOVE_GAME_PATH)
-  public Response removeGame(@Auth final AuthenticatedUser authenticatedUser, final String gameId) {
-    gameListing.removeGame(authenticatedUser.getApiKey(), gameId);
-    return Response.ok().build();
-  }
-
-  /**
-   * "Alive" endpoint to periodically invoked after a game has been posted to indicate the client is
-   * still hosting and is alive. If the endpoint is not invoked within a cutoff time then the game
-   * with the corresponding gameId will be unlisted. The return value indicates if the game has been
-   * kept alive, or false indicates the game was already removed and the client should re-post.
-   */
-  @RateLimited(
-      keys = {KeyPart.IP},
-      rates = {@Rate(limit = 5, duration = 1, timeUnit = TimeUnit.SECONDS)})
-  @POST
-  @Path(GameListingClient.KEEP_ALIVE_PATH)
-  public boolean keepAlive(@Auth final AuthenticatedUser authenticatedUser, final String gameId) {
-    return gameListing.keepAlive(authenticatedUser.getApiKey(), gameId);
-  }
-
   /** Returns a listing of the current games. */
   @RateLimited(
       keys = {KeyPart.IP},
@@ -83,21 +40,6 @@ public class GameListingController extends HttpController {
   @RolesAllowed(UserRole.ANONYMOUS)
   public Collection<LobbyGameListing> fetchGames() {
     return gameListing.getGames();
-  }
-
-  /** Replaces an existing game with new game data details. */
-  @RateLimited(
-      keys = {KeyPart.IP},
-      rates = {@Rate(limit = 10, duration = 1, timeUnit = TimeUnit.SECONDS)})
-  @POST
-  @Path(GameListingClient.UPDATE_GAME_PATH)
-  public Response updateGame(
-      @Auth final AuthenticatedUser authenticatedUser, final UpdateGameRequest updateGameRequest) {
-    gameListing.updateGame(
-        authenticatedUser.getApiKey(),
-        updateGameRequest.getGameId(),
-        updateGameRequest.getGameData());
-    return Response.ok().build();
   }
 
   /** Moderator action to remove a game. */

--- a/http-server/src/main/java/org/triplea/server/lobby/game/listing/GameListingControllerFactory.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/game/listing/GameListingControllerFactory.java
@@ -1,26 +1,10 @@
 package org.triplea.server.lobby.game.listing;
 
-import com.google.common.cache.CacheBuilder;
-import java.util.concurrent.TimeUnit;
-import lombok.AccessLevel;
-import lombok.NoArgsConstructor;
-import org.jdbi.v3.core.Jdbi;
-import org.triplea.http.client.lobby.game.listing.GameListingClient;
-import org.triplea.lobby.server.db.dao.ModeratorAuditHistoryDao;
+import lombok.experimental.UtilityClass;
 
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@UtilityClass
 public final class GameListingControllerFactory {
-
-  public static GameListingController buildController(final Jdbi jdbi) {
-    return GameListingController.builder()
-        .gameListing(
-            GameListing.builder()
-                .auditHistoryDao(jdbi.onDemand(ModeratorAuditHistoryDao.class))
-                .games(
-                    CacheBuilder.newBuilder()
-                        .expireAfterWrite(GameListingClient.KEEP_ALIVE_SECONDS, TimeUnit.SECONDS)
-                        .build())
-                .build())
-        .build();
+  public static GameListingController buildController(final GameListing gameListing) {
+    return GameListingController.builder().gameListing(gameListing).build();
   }
 }

--- a/http-server/src/main/java/org/triplea/server/lobby/game/listing/GameListingFactory.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/game/listing/GameListingFactory.java
@@ -1,0 +1,21 @@
+package org.triplea.server.lobby.game.listing;
+
+import com.google.common.cache.CacheBuilder;
+import java.util.concurrent.TimeUnit;
+import lombok.experimental.UtilityClass;
+import org.jdbi.v3.core.Jdbi;
+import org.triplea.http.client.lobby.game.listing.LobbyWatcherClient;
+import org.triplea.lobby.server.db.dao.ModeratorAuditHistoryDao;
+
+@UtilityClass
+public final class GameListingFactory {
+  public static GameListing buildGameListing(final Jdbi jdbi) {
+    return GameListing.builder()
+        .auditHistoryDao(jdbi.onDemand(ModeratorAuditHistoryDao.class))
+        .games(
+            CacheBuilder.newBuilder()
+                .expireAfterWrite(LobbyWatcherClient.KEEP_ALIVE_SECONDS, TimeUnit.SECONDS)
+                .build())
+        .build();
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/lobby/game/listing/LobbyWatcherController.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/game/listing/LobbyWatcherController.java
@@ -1,0 +1,87 @@
+package org.triplea.server.lobby.game.listing;
+
+import com.google.common.annotations.VisibleForTesting;
+import es.moki.ratelimij.dropwizard.annotation.Rate;
+import es.moki.ratelimij.dropwizard.annotation.RateLimited;
+import es.moki.ratelimij.dropwizard.filter.KeyPart;
+import io.dropwizard.auth.Auth;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.core.Response;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import org.triplea.http.client.lobby.game.listing.LobbyGame;
+import org.triplea.http.client.lobby.game.listing.LobbyWatcherClient;
+import org.triplea.http.client.lobby.game.listing.UpdateGameRequest;
+import org.triplea.lobby.server.db.data.UserRole;
+import org.triplea.server.access.AuthenticatedUser;
+import org.triplea.server.http.HttpController;
+
+/** Controller with endpoints for posting, getting and removing games. */
+@Builder
+@AllArgsConstructor(
+    access = AccessLevel.PACKAGE,
+    onConstructor_ = {@VisibleForTesting})
+@RolesAllowed(UserRole.HOST)
+public class LobbyWatcherController extends HttpController {
+
+  private final GameListing gameListing;
+
+  /**
+   * Adds a game to the lobby listing. Responds with the gameId assigned to the new game. If we see
+   * duplicate posts, the same gameId will be returned.
+   */
+  @RateLimited(
+      keys = {KeyPart.IP},
+      rates = {@Rate(limit = 20, duration = 4, timeUnit = TimeUnit.MINUTES)})
+  @POST
+  @Path(LobbyWatcherClient.POST_GAME_PATH)
+  public String postGame(
+      @Auth final AuthenticatedUser authenticatedUser, final LobbyGame lobbyGame) {
+    return gameListing.postGame(authenticatedUser.getApiKey(), lobbyGame);
+  }
+
+  /** Explicit remove of a game from the lobby. */
+  @RateLimited(
+      keys = {KeyPart.IP},
+      rates = {@Rate(limit = 5, duration = 1, timeUnit = TimeUnit.SECONDS)})
+  @POST
+  @Path(LobbyWatcherClient.REMOVE_GAME_PATH)
+  public Response removeGame(@Auth final AuthenticatedUser authenticatedUser, final String gameId) {
+    gameListing.removeGame(authenticatedUser.getApiKey(), gameId);
+    return Response.ok().build();
+  }
+
+  /**
+   * "Alive" endpoint to periodically invoked after a game has been posted to indicate the client is
+   * still hosting and is alive. If the endpoint is not invoked within a cutoff time then the game
+   * with the corresponding gameId will be unlisted. The return value indicates if the game has been
+   * kept alive, or false indicates the game was already removed and the client should re-post.
+   */
+  @RateLimited(
+      keys = {KeyPart.IP},
+      rates = {@Rate(limit = 5, duration = 1, timeUnit = TimeUnit.SECONDS)})
+  @POST
+  @Path(LobbyWatcherClient.KEEP_ALIVE_PATH)
+  public boolean keepAlive(@Auth final AuthenticatedUser authenticatedUser, final String gameId) {
+    return gameListing.keepAlive(authenticatedUser.getApiKey(), gameId);
+  }
+
+  /** Replaces an existing game with new game data details. */
+  @RateLimited(
+      keys = {KeyPart.IP},
+      rates = {@Rate(limit = 10, duration = 1, timeUnit = TimeUnit.SECONDS)})
+  @POST
+  @Path(LobbyWatcherClient.UPDATE_GAME_PATH)
+  public Response updateGame(
+      @Auth final AuthenticatedUser authenticatedUser, final UpdateGameRequest updateGameRequest) {
+    gameListing.updateGame(
+        authenticatedUser.getApiKey(),
+        updateGameRequest.getGameId(),
+        updateGameRequest.getGameData());
+    return Response.ok().build();
+  }
+}

--- a/http-server/src/main/java/org/triplea/server/lobby/game/listing/LobbyWatcherControllerFactory.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/game/listing/LobbyWatcherControllerFactory.java
@@ -1,0 +1,11 @@
+package org.triplea.server.lobby.game.listing;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class LobbyWatcherControllerFactory {
+  public static LobbyWatcherController buildController(final GameListing gameListing) {
+    return LobbyWatcherController.builder().gameListing(gameListing).build();
+  }
+}

--- a/http-server/src/test/java/org/triplea/server/lobby/game/listing/GameListingControllerTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/game/listing/GameListingControllerTest.java
@@ -1,11 +1,9 @@
 package org.triplea.server.lobby.game.listing;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.core.Is.is;
-
 import org.junit.jupiter.api.Test;
 import org.triplea.http.client.lobby.game.listing.GameListingClient;
 import org.triplea.http.client.lobby.game.listing.LobbyGame;
+import org.triplea.http.client.lobby.game.listing.LobbyWatcherClient;
 import org.triplea.server.TestData;
 import org.triplea.server.http.AllowedUserRole;
 import org.triplea.server.http.ProtectedEndpointTest;
@@ -14,44 +12,24 @@ class GameListingControllerTest extends ProtectedEndpointTest<GameListingClient>
 
   private static final LobbyGame LOBBY_GAME = TestData.LOBBY_GAME;
 
+  private final LobbyWatcherClient lobbyWatcherClient;
+
   GameListingControllerTest() {
     super(AllowedUserRole.HOST, GameListingClient::newClient);
-  }
-
-  @Test
-  void postGame() {
-    verifyEndpoint(client -> client.postGame(LOBBY_GAME));
-  }
-
-  @Test
-  void removeGame() {
-    final String gameId = verifyEndpointReturningObject(client -> client.postGame(LOBBY_GAME));
-    verifyEndpoint(client -> client.removeGame(gameId));
-  }
-
-  @Test
-  void keepAlive() {
-    final String gameId = verifyEndpointReturningObject(client -> client.postGame(LOBBY_GAME));
-    final boolean result = verifyEndpointReturningObject(client -> client.sendKeepAlive(gameId));
-    assertThat(result, is(true));
+    lobbyWatcherClient =
+        LobbyWatcherClient.newClient(localhost, AllowedUserRole.HOST.getAllowedKey());
   }
 
   @Test
   void fetchGames() {
-    verifyEndpoint(client -> client.postGame(LOBBY_GAME));
+    lobbyWatcherClient.postGame(LOBBY_GAME);
     verifyEndpointReturningCollection(
         AllowedUserRole.ANONYMOUS, GameListingClient::fetchGameListing);
   }
 
   @Test
-  void updateGame() {
-    final String gameId = verifyEndpointReturningObject(client -> client.postGame(LOBBY_GAME));
-    verifyEndpoint(client -> client.updateGame(gameId, LOBBY_GAME));
-  }
-
-  @Test
   void bootGame() {
-    final String gameId = verifyEndpointReturningObject(client -> client.postGame(LOBBY_GAME));
+    final String gameId = lobbyWatcherClient.postGame(LOBBY_GAME);
     verifyEndpoint(AllowedUserRole.MODERATOR, client -> client.bootGame(gameId));
   }
 }

--- a/http-server/src/test/java/org/triplea/server/lobby/game/listing/LobbyWatcherControllerTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/game/listing/LobbyWatcherControllerTest.java
@@ -1,0 +1,44 @@
+package org.triplea.server.lobby.game.listing;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import org.junit.jupiter.api.Test;
+import org.triplea.http.client.lobby.game.listing.LobbyGame;
+import org.triplea.http.client.lobby.game.listing.LobbyWatcherClient;
+import org.triplea.server.TestData;
+import org.triplea.server.http.AllowedUserRole;
+import org.triplea.server.http.ProtectedEndpointTest;
+
+class LobbyWatcherControllerTest extends ProtectedEndpointTest<LobbyWatcherClient> {
+
+  private static final LobbyGame LOBBY_GAME = TestData.LOBBY_GAME;
+
+  LobbyWatcherControllerTest() {
+    super(AllowedUserRole.HOST, LobbyWatcherClient::newClient);
+  }
+
+  @Test
+  void postGame() {
+    verifyEndpoint(client -> client.postGame(LOBBY_GAME));
+  }
+
+  @Test
+  void removeGame() {
+    final String gameId = verifyEndpointReturningObject(client -> client.postGame(LOBBY_GAME));
+    verifyEndpoint(client -> client.removeGame(gameId));
+  }
+
+  @Test
+  void keepAlive() {
+    final String gameId = verifyEndpointReturningObject(client -> client.postGame(LOBBY_GAME));
+    final boolean result = verifyEndpointReturningObject(client -> client.sendKeepAlive(gameId));
+    assertThat(result, is(true));
+  }
+
+  @Test
+  void updateGame() {
+    final String gameId = verifyEndpointReturningObject(client -> client.postGame(LOBBY_GAME));
+    verifyEndpoint(client -> client.updateGame(gameId, LOBBY_GAME));
+  }
+}


### PR DESCRIPTION
- Splits the GameListingClient into two, helps comply with interface
segregation principle. The game update actions: post, update, remove,
are only done by lobby watcher, while fetch games and boot game are
done by a player from the lobby the two sets of interfaces are used
in a mutually exclusive way)


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes

- No code changes, just splits controller and respective clients into two.

