### PR TITLE
Ensure JOptionDialog is rendered in swing thread

### DIFF
--- a/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
+++ b/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
@@ -495,7 +495,9 @@ public final class SwingComponents {
 
   public static void showError(
       final Component parentWindow, final String title, final String message) {
-    JOptionPane.showMessageDialog(parentWindow, message, title, JOptionPane.ERROR_MESSAGE);
+    SwingUtilities.invokeLater(
+        () ->
+            JOptionPane.showMessageDialog(parentWindow, message, title, JOptionPane.ERROR_MESSAGE));
   }
 
   /** Displays a pop-up dialog with clickable HTML links. */


### PR DESCRIPTION
Fixes potential error if error dialog is requested outside of the EDT thread.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

