### PR TITLE
Fix websocket send race-condition, make send wait and block.

### DIFF
--- a/http-clients/build.gradle
+++ b/http-clients/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'io.github.openfeign:feign-core:10.2.0'
     implementation 'io.github.openfeign:feign-gson:10.2.0'
+    implementation "org.awaitility:awaitility:$awaitilityVersion"
     implementation 'org.java-websocket:Java-WebSocket:1.4.0'
     implementation project(":domain-data")
     implementation project(":java-extras")

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/LobbyChatClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/LobbyChatClient.java
@@ -22,8 +22,7 @@ public class LobbyChatClient
 
   public LobbyChatClient(final URI lobbyUri, final ApiKey apiKey) {
     this(
-        new GenericWebSocketClient(
-            URI.create(lobbyUri + LOBBY_CHAT_WEBSOCKET_PATH), "Failed to connect to chat."),
+        new GenericWebSocketClient(URI.create(lobbyUri + LOBBY_CHAT_WEBSOCKET_PATH)),
         new ChatClientEnvelopeFactory(apiKey));
   }
 

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -9,10 +9,10 @@ import java.util.concurrent.TimeUnit;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import org.awaitility.Awaitility;
+import org.awaitility.core.ConditionTimeoutException;
 import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.handshake.ServerHandshake;
-import org.triplea.java.Interruptibles;
-import org.triplea.java.Interruptibles.Result;
 import org.triplea.java.timer.ScheduledTimer;
 import org.triplea.java.timer.Timers;
 
@@ -28,10 +28,15 @@ import org.triplea.java.timer.Timers;
  * </ul>
  */
 class WebSocketConnection {
-  private static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 5000;
   private final Collection<WebSocketConnectionListener> listeners = new HashSet<>();
+  private final URI serverUri;
 
   private boolean closed = false;
+
+  @Setter(
+      value = AccessLevel.PACKAGE,
+      onMethod_ = {@VisibleForTesting})
+  private int connectTimeoutMillis = 5000;
 
   @Getter(
       value = AccessLevel.PACKAGE,
@@ -44,6 +49,7 @@ class WebSocketConnection {
   private final ScheduledTimer pingSender;
 
   WebSocketConnection(final URI serverUri) {
+    this.serverUri = serverUri;
     client =
         new WebSocketClient(serverUri) {
           @Override
@@ -98,13 +104,13 @@ class WebSocketConnection {
   void connect() {
     Preconditions.checkState(!client.isOpen());
     Preconditions.checkState(!closed);
-    final Result<Boolean> connectionAttempt =
-        Interruptibles.awaitResult(
-            () -> client.connectBlocking(DEFAULT_CONNECT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS));
-    if (!connectionAttempt.completed || !connectionAttempt.result.orElse(false)) {
-      throw new CouldNotConnect(client.getURI());
+    try {
+      client.connect();
+      pingSender.start();
+    } catch (final Exception e) {
+      pingSender.cancel();
+      throw new CouldNotConnect(serverUri);
     }
-    pingSender.start();
   }
 
   /**
@@ -115,7 +121,15 @@ class WebSocketConnection {
    */
   void sendMessage(final String message) {
     Preconditions.checkState(!closed);
-    Preconditions.checkState(client.isOpen());
+    if (!client.isOpen()) {
+      try {
+        Awaitility.await()
+            .atMost(connectTimeoutMillis, TimeUnit.MILLISECONDS)
+            .until(() -> client.isOpen());
+      } catch (final ConditionTimeoutException ignored) {
+        throw new CouldNotConnect(serverUri);
+      }
+    }
     client.send(message);
   }
 

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -125,7 +125,7 @@ class WebSocketConnection {
       try {
         Awaitility.await()
             .atMost(connectTimeoutMillis, TimeUnit.MILLISECONDS)
-            .until(() -> client.isOpen());
+            .until(client::isOpen);
       } catch (final ConditionTimeoutException ignored) {
         throw new CouldNotConnect(serverUri);
       }

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebsocketListener.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebsocketListener.java
@@ -58,11 +58,7 @@ public abstract class WebsocketListener<
    */
   protected WebsocketListener(
       final URI hostUri, final String websocketPath, final ListenersTypeT listeners) {
-    this(
-        new GenericWebSocketClient(
-            URI.create(hostUri + websocketPath),
-            "Failed to connect to " + URI.create(hostUri + websocketPath)),
-        listeners);
+    this(new GenericWebSocketClient(URI.create(hostUri + websocketPath)), listeners);
   }
 
   public void setListeners(final ListenersTypeT listeners) {

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebsocketListenerFactory.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebsocketListenerFactory.java
@@ -43,8 +43,7 @@ public class WebsocketListenerFactory {
       WebsocketListener<MessageTypeT, ListenersTypeT> newListener(
           final URI lobbyUri, final Function<String, MessageTypeT> messageTypeExtraction) {
 
-    final GenericWebSocketClient genericWebSocketClient =
-        new GenericWebSocketClient(lobbyUri, "Unable to connect to: " + lobbyUri);
+    final GenericWebSocketClient genericWebSocketClient = new GenericWebSocketClient(lobbyUri);
 
     return new WebsocketListener<>(genericWebSocketClient) {
       @Override

--- a/http-clients/src/test/java/org/triplea/http/client/web/socket/GenericWebSocketClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/web/socket/GenericWebSocketClientTest.java
@@ -47,8 +47,7 @@ class GenericWebSocketClientTest {
 
   @BeforeEach
   void setup() {
-    genericWebSocketClient =
-        new GenericWebSocketClient(webSocketClient, "test-client connect error message");
+    genericWebSocketClient = new GenericWebSocketClient(webSocketClient);
     genericWebSocketClient.addMessageListener(messageListener);
     genericWebSocketClient.addConnectionLostListener(connectionLostListener);
     genericWebSocketClient.addConnectionClosedListener(connectionClosedListener);


### PR DESCRIPTION
Summary:
- remove single threaded threadpool for websocket connect and send
- make connect be non-blocking
- have send wait for connection to be open (now blocking)

Problem description:
Observed preconditions failures in 'send' for connection closed.
The previous flow relied on single-threaded operations to ensure
we opened a connection and then sent data over an open connection.

This was ordered by queuing operations onto a single-threaded thread
pool. The suspected problem is that (A) the connect thread spawns
a new thread (B) and waits for it to be finished before we spawn
a new thread (C) to do the send. If (C) is spawned before (B), we
hit a race condition and attempt to send befor the websocket connection
is open.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

