### PR TITLE
Add config to restart http_server (spitfire) if changed

### DIFF
--- a/infrastructure/ansible/roles/http_server/tasks/main.yml
+++ b/infrastructure/ansible/roles/http_server/tasks/main.yml
@@ -7,6 +7,7 @@
 
 - name: deploy jar file
   become: true
+  register: deploy_jar_file
   copy:
     src: "{{ http_server_jar }}"
     dest: "{{ http_server_home_folder }}/{{ http_server_jar }}"
@@ -24,6 +25,7 @@
 
 - name: deploy server config file
   become: true
+  register: deploy_config_file
   template:
     src: configuration.yml.j2
     dest: "{{ http_server_home_folder}}/configuration.yml"
@@ -44,8 +46,17 @@
     daemon_reload: yes
 
 - name: enable and start service
+  when: (deploy_jar_file.changed == false) and (deploy_config_file.changed == false)
   become: true
   service:
     name: http_server
     state: started
+    enabled: yes
+
+- name: restart service if new jar file deployed
+  when: (deploy_jar_file.changed) or (deploy_config_file.changed)
+  become: true
+  service:
+    name: http_server
+    state: restarted
     enabled: yes


### PR DESCRIPTION
Addresses: #5681 (Unable to Join Lobby)

We were running a stale version and had changed the server-client
data format causing errors on connection. Restarting the server
to pick up the latest version fixed the problem. The previous
deployment configuration did not restart the service, with this
update if we change the http-server jar file or server config
then we'll restart the service.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done

Tested with:
```
cd infrastructure
vagrant up
./run_ansible_vagrant -t http_server
```

Then altered http_server code, ran a gradle clean, and re-ran the above verifying the 'changed' code above was triggered.

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

