### PR TITLE
Unify to one factory method for websocket listener

### DIFF
--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebsocketListenerFactory.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebsocketListenerFactory.java
@@ -9,15 +9,6 @@ import org.triplea.http.client.web.socket.messages.WebsocketMessageType;
 @UtilityClass
 public class WebsocketListenerFactory {
 
-  /** Convenience method when host URI and path are given as separate parameters. */
-  public static <MessageTypeT extends WebsocketMessageType<ListenersTypeT>, ListenersTypeT>
-      WebsocketListener<MessageTypeT, ListenersTypeT> newListener(
-          final URI lobbyUri,
-          final String path,
-          final Function<String, MessageTypeT> messageTypeExtraction) {
-    return newListener(URI.create(lobbyUri + path), messageTypeExtraction);
-  }
-
   /**
    * Constructs a fully wired WebsocketListener that routes websocket messages, based on type, to a
    * specific websocket event listener. A WebsocketListener is more specifically an object that
@@ -33,7 +24,8 @@ public class WebsocketListenerFactory {
    * WebsocketListenerFactory.newListener(uri, MessageType::valueOf);
    * }</pre>
    *
-   * @param lobbyUri Fully qualified URI of the webosocket that will send us messages.
+   * @param serverUri URI of the server hosting the websocket endpoint.
+   * @param path Path on the remote server to the websocket endpoint.
    * @param messageTypeExtraction Function to extract
    * @param <MessageTypeT> Enumerated message types that can be sent from server.
    * @param <ListenersTypeT> Listeners class that contains the set of listeners that will handle the
@@ -41,9 +33,12 @@ public class WebsocketListenerFactory {
    */
   public static <MessageTypeT extends WebsocketMessageType<ListenersTypeT>, ListenersTypeT>
       WebsocketListener<MessageTypeT, ListenersTypeT> newListener(
-          final URI lobbyUri, final Function<String, MessageTypeT> messageTypeExtraction) {
+          final URI serverUri,
+          final String path,
+          final Function<String, MessageTypeT> messageTypeExtraction) {
 
-    final GenericWebSocketClient genericWebSocketClient = new GenericWebSocketClient(lobbyUri);
+    final URI websocketUri = URI.create(serverUri + path);
+    final GenericWebSocketClient genericWebSocketClient = new GenericWebSocketClient(websocketUri);
 
     return new WebsocketListener<>(genericWebSocketClient) {
       @Override


### PR DESCRIPTION
Looks like all clients currents and planned for short term will
use the same factory method with 'host-uri, path, messageTypeExtraction'


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

