### PR TITLE
Non-blocking websocket send

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/LobbyWatcherThread.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/LobbyWatcherThread.java
@@ -8,6 +8,7 @@ import games.strategy.engine.framework.startup.ui.InGameLobbyWatcherWrapper;
 import games.strategy.engine.framework.startup.ui.LocalServerAvailabilityCheck;
 import games.strategy.net.IServerMessenger;
 import java.net.URI;
+import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -24,10 +25,13 @@ public class LobbyWatcherThread {
   @Nonnull private final WatcherThreadMessaging watcherThreadMessaging;
 
   public void createLobbyWatcher(
-      final URI lobbyUri, final GameHostingResponse gameHostingResponse) {
+      final URI lobbyUri,
+      final GameHostingResponse gameHostingResponse,
+      final Consumer<String> errorHandler) {
 
     final HttpLobbyClient lobbyClient =
-        HttpLobbyClient.newClient(lobbyUri, ApiKey.of(gameHostingResponse.getApiKey()));
+        HttpLobbyClient.newClient(
+            lobbyUri, ApiKey.of(gameHostingResponse.getApiKey()), errorHandler);
 
     InGameLobbyWatcher.newInGameLobbyWatcher(
             serverMessenger,

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/SetupPanelModel.java
@@ -25,6 +25,7 @@ import lombok.Setter;
 import org.triplea.game.startup.ServerSetupModel;
 import org.triplea.http.client.lobby.game.hosting.GameHostingResponse;
 import org.triplea.live.servers.LiveServersFetcher;
+import org.triplea.swing.SwingComponents;
 
 /** This class provides a way to switch between different ISetupPanel displays. */
 @RequiredArgsConstructor
@@ -53,7 +54,12 @@ public class SetupPanelModel implements ServerSetupModel {
    * clients.
    */
   public void showServer() {
-    new ServerModel(gameSelectorModel, this, ui, new HeadedLaunchAction(ui));
+    new ServerModel(
+        gameSelectorModel,
+        this,
+        ui,
+        new HeadedLaunchAction(ui),
+        error -> SwingComponents.showError(null, "Connection problem", error));
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -122,7 +122,9 @@ public class LobbyLogin {
             LobbyClient.builder()
                 .httpLobbyClient(
                     HttpLobbyClient.newClient(
-                        serverProperties.getUri(), ApiKey.of(loginResponse.getApiKey())))
+                        serverProperties.getUri(),
+                        ApiKey.of(loginResponse.getApiKey()),
+                        error -> showError("Connection problem", error)))
                 .anonymousLogin(Strings.nullToEmpty(panel.getPassword()).isEmpty())
                 .passwordChangeRequired(loginResponse.isPasswordChangeRequired())
                 .moderator(loginResponse.isModerator())
@@ -142,7 +144,10 @@ public class LobbyLogin {
   }
 
   private void showError(final String title, final String message) {
-    SwingComponents.showError(parentWindow, title, message);
+    // We use 'null' parentWindow in case there is an async failure connecting to the lobby
+    // server. In the async case, we close the parent window while still connecting, the close
+    // of the parent window will close the child dialog error message as well.
+    SwingComponents.showError(null, title, message);
   }
 
   private Optional<LobbyClient> loginToServer() {
@@ -207,7 +212,9 @@ public class LobbyLogin {
       }
       return Optional.of(
           HttpLobbyClient.newClient(
-              serverProperties.getUri(), ApiKey.of(loginResponse.getApiKey())));
+              serverProperties.getUri(),
+              ApiKey.of(loginResponse.getApiKey()),
+              error -> showError("Connection problem", error)));
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
       return Optional.empty();

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessServerSetupPanelModel.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessServerSetupPanelModel.java
@@ -11,11 +11,13 @@ import games.strategy.engine.framework.startup.mc.ServerModel;
 import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.java.Log;
 import org.triplea.game.startup.ServerSetupModel;
 import org.triplea.http.client.lobby.game.hosting.GameHostingResponse;
 
 /** Setup panel model for headless server. */
 @RequiredArgsConstructor(access = AccessLevel.PACKAGE)
+@Log
 public class HeadlessServerSetupPanelModel implements ServerSetupModel {
 
   private final GameSelectorModel gameSelectorModel;
@@ -23,7 +25,7 @@ public class HeadlessServerSetupPanelModel implements ServerSetupModel {
 
   @Override
   public void showSelectType() {
-    new ServerModel(gameSelectorModel, this, null, new HeadlessLaunchAction());
+    new ServerModel(gameSelectorModel, this, null, new HeadlessLaunchAction(), log::severe);
   }
 
   @Override

--- a/http-clients/build.gradle
+++ b/http-clients/build.gradle
@@ -5,7 +5,6 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.5'
     implementation 'io.github.openfeign:feign-core:10.2.0'
     implementation 'io.github.openfeign:feign-gson:10.2.0'
-    implementation "org.awaitility:awaitility:$awaitilityVersion"
     implementation 'org.java-websocket:Java-WebSocket:1.4.0'
     implementation project(":domain-data")
     implementation project(":java-extras")

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/HttpLobbyClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/HttpLobbyClient.java
@@ -23,18 +23,20 @@ public class HttpLobbyClient {
   private final UserAccountClient userAccountClient;
   private final RemoteActionsClient remoteActionsClient;
 
-  private HttpLobbyClient(final URI lobbyUri, final ApiKey apiKey) {
+  private HttpLobbyClient(
+      final URI lobbyUri, final ApiKey apiKey, final Consumer<String> errorHandler) {
     connectivityCheckClient = ConnectivityCheckClient.newClient(lobbyUri, apiKey);
     gameListingClient = GameListingClient.newClient(lobbyUri, apiKey);
     httpModeratorToolboxClient = HttpModeratorToolboxClient.newClient(lobbyUri, apiKey);
-    lobbyChatClient = LobbyChatClient.newClient(lobbyUri, apiKey);
+    lobbyChatClient = LobbyChatClient.newClient(lobbyUri, apiKey, errorHandler);
     moderatorLobbyClient = ModeratorChatClient.newClient(lobbyUri, apiKey);
     userAccountClient = UserAccountClient.newClient(lobbyUri, apiKey);
     remoteActionsClient = new RemoteActionsClient(lobbyUri, apiKey);
   }
 
-  public static HttpLobbyClient newClient(final URI lobbyUri, final ApiKey apiKey) {
-    return new HttpLobbyClient(lobbyUri, apiKey);
+  public static HttpLobbyClient newClient(
+      final URI lobbyUri, final ApiKey apiKey, final Consumer<String> errorHandler) {
+    return new HttpLobbyClient(lobbyUri, apiKey, errorHandler);
   }
 
   /**

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/LobbyChatClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/LobbyChatClient.java
@@ -20,9 +20,10 @@ public class LobbyChatClient
 
   private final ChatClientEnvelopeFactory outboundMessageFactory;
 
-  public LobbyChatClient(final URI lobbyUri, final ApiKey apiKey) {
+  public LobbyChatClient(
+      final URI lobbyUri, final ApiKey apiKey, final Consumer<String> errorHandler) {
     this(
-        new GenericWebSocketClient(URI.create(lobbyUri + LOBBY_CHAT_WEBSOCKET_PATH)),
+        new GenericWebSocketClient(URI.create(lobbyUri + LOBBY_CHAT_WEBSOCKET_PATH), errorHandler),
         new ChatClientEnvelopeFactory(apiKey));
   }
 
@@ -34,8 +35,9 @@ public class LobbyChatClient
     outboundMessageFactory = clientEventFactory;
   }
 
-  public static LobbyChatClient newClient(final URI lobbyUri, final ApiKey apiKey) {
-    return new LobbyChatClient(lobbyUri, apiKey);
+  public static LobbyChatClient newClient(
+      final URI lobbyUri, final ApiKey apiKey, final Consumer<String> errorHandler) {
+    return new LobbyChatClient(lobbyUri, apiKey, errorHandler);
   }
 
   public void setChatMessageListeners(final ChatMessageListeners chatMessageListeners) {

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/GenericWebSocketClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/GenericWebSocketClient.java
@@ -7,6 +7,8 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.function.Consumer;
+import java.util.logging.Level;
+import lombok.extern.java.Log;
 import org.triplea.http.client.web.socket.messages.ClientMessageEnvelope;
 import org.triplea.http.client.web.socket.messages.ServerMessageEnvelope;
 
@@ -19,6 +21,7 @@ import org.triplea.http.client.web.socket.messages.ServerMessageEnvelope;
  * this class makes sure that all operations are non-blocking, but keep their initial dispatch
  * order.
  */
+@Log
 public class GenericWebSocketClient implements WebSocketConnectionListener {
   private static final Gson gson = new Gson();
 
@@ -38,7 +41,14 @@ public class GenericWebSocketClient implements WebSocketConnectionListener {
       final WebSocketConnection webSocketClient, final Consumer<String> errorHandler) {
     client = webSocketClient;
     client.addListener(this);
-    client.connect(errorHandler);
+    client
+        .connect(errorHandler)
+        .exceptionally(
+            throwable -> {
+              log.log(
+                  Level.SEVERE, "Unexpected exception completing websocket connection", throwable);
+              return false;
+            });
   }
 
   @VisibleForTesting

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/GenericWebSocketClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/GenericWebSocketClient.java
@@ -29,15 +29,16 @@ public class GenericWebSocketClient implements WebSocketConnectionListener {
   /** These are called whenever connection is closed, whether by us or server. */
   private final Collection<Consumer<String>> connectionClosedListeners = new ArrayList<>();
 
-  public GenericWebSocketClient(final URI lobbyUri) {
-    this(new WebSocketConnection(swapHttpsToWssProtocol(lobbyUri)));
+  public GenericWebSocketClient(final URI lobbyUri, final Consumer<String> errorHandler) {
+    this(new WebSocketConnection(swapHttpsToWssProtocol(lobbyUri)), errorHandler);
   }
 
   @VisibleForTesting
-  GenericWebSocketClient(final WebSocketConnection webSocketClient) {
+  GenericWebSocketClient(
+      final WebSocketConnection webSocketClient, final Consumer<String> errorHandler) {
     client = webSocketClient;
     client.addListener(this);
-    client.connect();
+    client.connect(errorHandler);
   }
 
   @VisibleForTesting

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -8,7 +8,6 @@ import java.util.HashSet;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.logging.Level;

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -135,25 +135,19 @@ class WebSocketConnection {
             });
   }
 
-  // Suppression: Ignoring future return values ignores any exceptions thrown by the code
-  // that completes the future. Connect blocking does not throw any exceptions, there are
-  // no exceptions to ignore, we can ignore the future returned by 'submit'.
-  @SuppressWarnings("FutureReturnValueIgnored")
   private CompletableFuture<Boolean> connectAsync() {
     final CompletableFuture<Boolean> completableFuture = new CompletableFuture<>();
     // execute the connection attempt
-    Executors.newSingleThreadExecutor()
-        .submit(
-            () -> {
-              boolean connected;
-              try {
-                connected =
-                    client.connectBlocking(DEFAULT_CONNECT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
-              } catch (final InterruptedException ignored) {
-                connected = false;
-              }
-              return completableFuture.complete(connected);
-            });
+    new Thread(() -> {
+      boolean connected;
+      try {
+        connected =
+            client.connectBlocking(DEFAULT_CONNECT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+      } catch (final InterruptedException ignored) {
+        connected = false;
+      }
+      completableFuture.complete(connected);
+    }).start();
     return completableFuture;
   }
 

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -5,12 +5,15 @@ import com.google.common.base.Preconditions;
 import java.net.URI;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
-import org.awaitility.Awaitility;
-import org.awaitility.core.ConditionTimeoutException;
 import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.handshake.ServerHandshake;
 import org.triplea.java.timer.ScheduledTimer;
@@ -28,15 +31,18 @@ import org.triplea.java.timer.Timers;
  * </ul>
  */
 class WebSocketConnection {
+  @VisibleForTesting static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 5000;
+
   private final Collection<WebSocketConnectionListener> listeners = new HashSet<>();
+  /**
+   * If sending messages before a connection is opened, they will be queued. When the connection is
+   * opened, the queue is flushed and messages will be sent in order.
+   */
+  private final Queue<String> queuedMessages = new ConcurrentLinkedQueue<>();
+
   private final URI serverUri;
 
   private boolean closed = false;
-
-  @Setter(
-      value = AccessLevel.PACKAGE,
-      onMethod_ = {@VisibleForTesting})
-  private int connectTimeoutMillis = 5000;
 
   @Getter(
       value = AccessLevel.PACKAGE,
@@ -46,6 +52,9 @@ class WebSocketConnection {
       onMethod_ = {@VisibleForTesting})
   private WebSocketClient client;
 
+  @Getter(
+      value = AccessLevel.PACKAGE,
+      onMethod_ = {@VisibleForTesting})
   private final ScheduledTimer pingSender;
 
   WebSocketConnection(final URI serverUri) {
@@ -53,7 +62,12 @@ class WebSocketConnection {
     client =
         new WebSocketClient(serverUri) {
           @Override
-          public void onOpen(final ServerHandshake serverHandshake) {}
+          public void onOpen(final ServerHandshake serverHandshake) {
+            synchronized (queuedMessages) {
+              queuedMessages.forEach(this::send);
+              queuedMessages.clear();
+            }
+          }
 
           @Override
           public void onMessage(final String message) {
@@ -95,53 +109,71 @@ class WebSocketConnection {
   }
 
   /**
-   * Initiates a websocket connection. Must be called before {@link #sendMessage(String)}. This
-   * method blocks until the connection has either successfully been established, or the connection
-   * failed.
+   * Initiates a non-blocking websocket connection.
    *
-   * @throws CouldNotConnect If the connection fails
+   * @param errorHandler Invoked if there is a failure to connect.
+   * @throws IllegalStateException Thrown if connection is already open (eg: connect called twice).
+   * @throws IllegalStateException Thrown if connection has been closed (ie: 'close()' was called)
    */
-  void connect() {
+  // Suppression: Ignoring future return values ignores any exceptions thrown by the code
+  // that completes the future. In this case we ignore the returned future from 'whenComplete'
+  // to avoid blocking. We would not expect the ping sender start or error handler to throw
+  // exceptions.
+  @SuppressWarnings("FutureReturnValueIgnored")
+  void connect(final Consumer<String> errorHandler) {
     Preconditions.checkState(!client.isOpen());
     Preconditions.checkState(!closed);
-    try {
-      client.connect();
-      pingSender.start();
-    } catch (final Exception e) {
-      pingSender.cancel();
-      throw new CouldNotConnect(serverUri);
-    }
+
+    connectAsync()
+        .whenComplete(
+            (connected, throwable) -> {
+              if (connected && throwable == null) {
+                pingSender.start();
+              } else {
+                errorHandler.accept("Failed to connect to: " + serverUri);
+              }
+            });
+  }
+
+  // Suppression: Ignoring future return values ignores any exceptions thrown by the code
+  // that completes the future. Connect blocking does not throw any exceptions, there are
+  // no exceptions to ignore, we can ignore the future returned by 'submit'.
+  @SuppressWarnings("FutureReturnValueIgnored")
+  private CompletableFuture<Boolean> connectAsync() {
+    final CompletableFuture<Boolean> completableFuture = new CompletableFuture<>();
+    // execute the connection attempt
+    Executors.newSingleThreadExecutor()
+        .submit(
+            () -> {
+              boolean connected;
+              try {
+                connected =
+                    client.connectBlocking(DEFAULT_CONNECT_TIMEOUT_MILLIS, TimeUnit.MILLISECONDS);
+              } catch (final InterruptedException ignored) {
+                connected = false;
+              }
+              return completableFuture.complete(connected);
+            });
+    return completableFuture;
   }
 
   /**
-   * Sends a message asynchronously.
+   * Sends a message asynchronously. Messages are queued until a connection has been established.
    *
-   * @throws IllegalStateException If the connection hasn't been opened yet. {@link #connect()}
-   *     needs to be called first.
+   * @throws IllegalStateException If the connection has been closed.
    */
   void sendMessage(final String message) {
     Preconditions.checkState(!closed);
-    if (!client.isOpen()) {
-      try {
-        Awaitility.await()
-            .atMost(connectTimeoutMillis, TimeUnit.MILLISECONDS)
-            .until(client::isOpen);
-      } catch (final ConditionTimeoutException ignored) {
-        throw new CouldNotConnect(serverUri);
+
+    // Synchronized to make sure that the connection does not open right after we check it.
+    // If the connection is not yet open, the synchronized block should guarantee that we add
+    // to the queued message queue before we start flushing it.
+    synchronized (queuedMessages) {
+      if (!client.isOpen()) {
+        queuedMessages.add(message);
+      } else {
+        client.send(message);
       }
-    }
-    client.send(message);
-  }
-
-  /** Exception indicating connection to server failed. */
-  @VisibleForTesting
-  static final class CouldNotConnect extends RuntimeException {
-    private static final long serialVersionUID = -5403199291005160495L;
-
-    private static final String ERROR_MESSAGE = "Error, could not connect to server at %s";
-
-    CouldNotConnect(final URI uri) {
-      super(String.format(ERROR_MESSAGE, uri));
     }
   }
 }

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -13,7 +13,6 @@ import java.util.function.Consumer;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.extern.java.Log;
 import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.handshake.ServerHandshake;
 import org.triplea.java.timer.ScheduledTimer;
@@ -30,7 +29,6 @@ import org.triplea.java.timer.Timers;
  *   <li>Issuing periodic keep-alive messages (ping) to keep the websocket connection open
  * </ul>
  */
-@Log
 class WebSocketConnection {
   @VisibleForTesting static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 5000;
 

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import java.util.logging.Level;
@@ -117,11 +118,11 @@ class WebSocketConnection {
    * @throws IllegalStateException Thrown if connection is already open (eg: connect called twice).
    * @throws IllegalStateException Thrown if connection has been closed (ie: 'close()' was called)
    */
-  void connect(final Consumer<String> errorHandler) {
+  CompletableFuture<Boolean> connect(final Consumer<String> errorHandler) {
     Preconditions.checkState(!client.isOpen());
     Preconditions.checkState(!closed);
 
-    connectAsync()
+    return connectAsync()
         .whenComplete(
             (connected, throwable) -> {
               if (connected && throwable == null) {

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -10,7 +10,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import java.util.logging.Level;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
@@ -129,11 +128,6 @@ class WebSocketConnection {
               } else {
                 errorHandler.accept("Failed to connect to: " + serverUri);
               }
-            })
-        .exceptionally(
-            throwable -> {
-              log.log(Level.SEVERE, "Unexpected exception starting socket ping sender", throwable);
-              return false;
             });
   }
 

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebsocketListener.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebsocketListener.java
@@ -1,11 +1,11 @@
 package org.triplea.http.client.web.socket;
 
 import com.google.common.base.Preconditions;
-import java.net.URI;
 import java.util.Optional;
 import java.util.function.Consumer;
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.Setter;
 import org.triplea.http.client.web.socket.messages.ServerMessageEnvelope;
 import org.triplea.http.client.web.socket.messages.WebsocketMessageType;
 
@@ -30,39 +30,11 @@ public abstract class WebsocketListener<
   @Getter(AccessLevel.PROTECTED)
   private final GenericWebSocketClient webSocketClient;
 
-  private ListenersTypeT listeners;
+  @Setter private ListenersTypeT listeners;
 
-  private WebsocketListener(
-      final GenericWebSocketClient genericWebSocketClient, final ListenersTypeT listeners) {
+  protected WebsocketListener(final GenericWebSocketClient genericWebSocketClient) {
     webSocketClient = genericWebSocketClient;
     webSocketClient.addMessageListener(this);
-    this.listeners = listeners;
-  }
-
-  /**
-   * Use this constructor if the listener will also be an outbound message sender. Injecting the
-   * websocket client directly allows for easier testing & mocking.
-   */
-  protected WebsocketListener(final GenericWebSocketClient genericWebSocketClient) {
-    this(genericWebSocketClient, null);
-  }
-
-  /**
-   * Constructs a websocket listener that will be connected and messages will be routed to the
-   * listeners passed in.
-   *
-   * @param hostUri Server host (base) uri.
-   * @param websocketPath Path on the server to the websocket to which we will listen.
-   * @param listeners Listener object that contains listeners for each message type we would expect
-   *     to receive from server.
-   */
-  protected WebsocketListener(
-      final URI hostUri, final String websocketPath, final ListenersTypeT listeners) {
-    this(new GenericWebSocketClient(URI.create(hostUri + websocketPath)), listeners);
-  }
-
-  public void setListeners(final ListenersTypeT listeners) {
-    this.listeners = listeners;
   }
 
   public void close() {

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebsocketListenerFactory.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebsocketListenerFactory.java
@@ -1,6 +1,7 @@
 package org.triplea.http.client.web.socket;
 
 import java.net.URI;
+import java.util.function.Consumer;
 import java.util.function.Function;
 import lombok.experimental.UtilityClass;
 import org.triplea.http.client.web.socket.messages.ServerMessageEnvelope;
@@ -35,10 +36,12 @@ public class WebsocketListenerFactory {
       WebsocketListener<MessageTypeT, ListenersTypeT> newListener(
           final URI serverUri,
           final String path,
-          final Function<String, MessageTypeT> messageTypeExtraction) {
+          final Function<String, MessageTypeT> messageTypeExtraction,
+          final Consumer<String> errorHandler) {
 
     final URI websocketUri = URI.create(serverUri + path);
-    final GenericWebSocketClient genericWebSocketClient = new GenericWebSocketClient(websocketUri);
+    final GenericWebSocketClient genericWebSocketClient =
+        new GenericWebSocketClient(websocketUri, errorHandler);
 
     return new WebsocketListener<>(genericWebSocketClient) {
       @Override

--- a/http-clients/src/test/java/org/triplea/http/client/web/socket/GenericWebSocketClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/web/socket/GenericWebSocketClientTest.java
@@ -47,7 +47,7 @@ class GenericWebSocketClientTest {
 
   @BeforeEach
   void setup() {
-    genericWebSocketClient = new GenericWebSocketClient(webSocketClient);
+    genericWebSocketClient = new GenericWebSocketClient(webSocketClient, errMsg -> {});
     genericWebSocketClient.addMessageListener(messageListener);
     genericWebSocketClient.addConnectionLostListener(connectionLostListener);
     genericWebSocketClient.addConnectionClosedListener(connectionClosedListener);

--- a/http-clients/src/test/java/org/triplea/http/client/web/socket/GenericWebSocketClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/web/socket/GenericWebSocketClientTest.java
@@ -6,9 +6,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import com.google.gson.Gson;
 import java.net.URI;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -47,6 +49,7 @@ class GenericWebSocketClientTest {
 
   @BeforeEach
   void setup() {
+    when(webSocketClient.connect(any())).thenReturn(new CompletableFuture<>());
     genericWebSocketClient = new GenericWebSocketClient(webSocketClient, errMsg -> {});
     genericWebSocketClient.addMessageListener(messageListener);
     genericWebSocketClient.addConnectionLostListener(connectionLostListener);

--- a/http-clients/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
@@ -105,8 +105,9 @@ class WebSocketConnectionTest {
     void connectWillInitiateConnection() throws Exception {
       givenWebSocketConnects(true);
 
-      webSocketConnection.connect(errorHandler);
+      final boolean connected = webSocketConnection.connect(errorHandler).get();
 
+      assertThat(connected, is(true));
       verifyConnectWasCalled();
       verifyPingerIsStarted();
     }
@@ -135,10 +136,9 @@ class WebSocketConnectionTest {
     void connectionFailure() throws Exception {
       givenWebSocketConnects(false);
 
-      webSocketConnection.connect(errorHandler);
+      final boolean connected = webSocketConnection.connect(errorHandler).get();
 
-      // minimal amount of sleep to allow new thread to spawn up and connection attempt to fail.
-      Thread.sleep(50L);
+      assertThat(connected, is(false));
       verifyPingerNotStarted();
       verifyErrorHandlerWasCalled();
     }
@@ -157,10 +157,9 @@ class WebSocketConnectionTest {
     void connectionFailureWithInterruptedException() throws Exception {
       givenConnectionAttemptThrows();
 
-      webSocketConnection.connect(errorHandler);
+      final boolean connected = webSocketConnection.connect(errorHandler).get();
 
-      // minimal amount of sleep to allow new thread to spawn up and connection attempt to fail.
-      Thread.sleep(50L);
+      assertThat(connected, is(false));
       verifyPingerNotStarted();
       verifyErrorHandlerWasCalled();
     }

--- a/http-server/src/test/java/org/triplea/http/server/LobbyChatIntegrationTest.java
+++ b/http-server/src/test/java/org/triplea/http/server/LobbyChatIntegrationTest.java
@@ -87,7 +87,7 @@ class LobbyChatIntegrationTest extends DropwizardTest {
   private LobbyChatClient createModerator() {
     final LobbyChatClient moderator =
         // caution: api-key must match values in database (integration.yml)
-        new LobbyChatClient(localhost, MODERATOR_API_KEY);
+        new LobbyChatClient(localhost, MODERATOR_API_KEY, err -> {});
 
     moderator.setChatMessageListeners(
         ChatMessageListeners.builder()
@@ -107,7 +107,7 @@ class LobbyChatIntegrationTest extends DropwizardTest {
   }
 
   private LobbyChatClient createChatter() {
-    final LobbyChatClient chatter = new LobbyChatClient(localhost, CHATTER_API_KEY);
+    final LobbyChatClient chatter = new LobbyChatClient(localhost, CHATTER_API_KEY, err -> {});
 
     chatter.setChatMessageListeners(
         ChatMessageListeners.builder()

--- a/java-extras/src/main/java/org/triplea/java/timer/ScheduledTimer.java
+++ b/java-extras/src/main/java/org/triplea/java/timer/ScheduledTimer.java
@@ -3,6 +3,7 @@ package org.triplea.java.timer;
 import java.util.Optional;
 import java.util.Timer;
 import java.util.TimerTask;
+import lombok.Getter;
 
 /**
  * Class for creating a class to be executed periodically. Sample usage:
@@ -32,6 +33,7 @@ public class ScheduledTimer {
   private final long periodMillis;
 
   private final Timer timer;
+  @Getter private boolean running;
 
   ScheduledTimer(
       final String threadName,
@@ -45,6 +47,7 @@ public class ScheduledTimer {
   }
 
   public ScheduledTimer start() {
+    running = true;
     timer.scheduleAtFixedRate(
         new TimerTask() {
           @Override
@@ -58,6 +61,7 @@ public class ScheduledTimer {
   }
 
   public void cancel() {
+    running = false;
     timer.cancel();
   }
 }


### PR DESCRIPTION
First, do a blocking connect on a new thread and add a timeout to it. This way
if we fail to connect we will call an error handler to notify the connection
failed. Before, if we never connected, there was never a timeout nor notification.

Second, add a send queue to websocket sender. On send, check if connection is open,
if not open, add the message to send to the send queue. On connection open,
we will flush the send queue. We have a sync block to make sure that
before we check if the connection is open, if we are flushing messages, that
we cannot queue messages. This is to avoid a race condition where after
we check if the connection is open, if it opens then and we then
flush the send queue and clear it, we want to avoid adding any new messages
to the send queue.

Change summary:
- Blocking connect on a new thread with a timeout invokes error handler
- Wire error handler to websocket sender
- Make send non-blocking by using a send queue
- Minor: add lombok getter/setter for test and code cleanup


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done
- connected to a local lobby and verified chat
- disabled local lobby websockets, connected and verified error behavior (pop-up appears, chat does not work)

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes
- please pay extra attention to the two synchronization blocks added on the send queue in WebsocketConnection: 
