### PR TITLE
Remove redundant (bot-game) user action list

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.framework.startup.ui;
 
 import games.strategy.engine.chat.ChatPanel;
-import games.strategy.engine.framework.HeadlessAutoSaveType;
 import games.strategy.engine.framework.startup.launcher.ILauncher;
 import games.strategy.engine.framework.startup.mc.ClientModel;
 import games.strategy.engine.framework.startup.mc.IRemoteModelListener;
@@ -23,7 +22,6 @@ import javax.swing.JButton;
 import javax.swing.JCheckBox;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
-import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import org.triplea.domain.data.PlayerName;
@@ -246,41 +244,7 @@ public class ClientSetupPanel extends SetupPanel {
 
   @Override
   public List<Action> getUserActions() {
-    if (clientModel == null) {
-      return new ArrayList<>();
-    }
-    final boolean isServerHeadless = clientModel.getIsServerHeadlessCached();
-    if (!isServerHeadless) {
-      return new ArrayList<>();
-    }
-    final List<Action> actions = new ArrayList<>();
-    actions.add(clientModel.getHostBotSetMapClientAction(this));
-    actions.add(clientModel.getHostBotChangeGameOptionsClientAction(this));
-    actions.add(
-        clientModel.getHostBotChangeGameToSaveGameClientAction(
-            JOptionPane.getFrameForComponent(this)));
-    actions.add(
-        clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.DEFAULT));
-    actions.add(
-        clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.ODD_ROUND));
-    actions.add(
-        clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.EVEN_ROUND));
-    actions.add(
-        clientModel.getHostBotChangeToAutosaveClientAction(this, HeadlessAutoSaveType.END_TURN));
-    actions.add(
-        clientModel.getHostBotChangeToAutosaveClientAction(
-            this, HeadlessAutoSaveType.BEFORE_BATTLE));
-    actions.add(
-        clientModel.getHostBotChangeToAutosaveClientAction(
-            this, HeadlessAutoSaveType.AFTER_BATTLE));
-    actions.add(
-        clientModel.getHostBotChangeToAutosaveClientAction(
-            this, HeadlessAutoSaveType.AFTER_COMBAT_MOVE));
-    actions.add(
-        clientModel.getHostBotChangeToAutosaveClientAction(
-            this, HeadlessAutoSaveType.AFTER_NON_COMBAT_MOVE));
-    actions.add(clientModel.getHostBotGetGameSaveClientAction(this));
-    return actions;
+    return List.of();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/LocalSetupPanel.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Observable;
 import java.util.Observer;
 import java.util.Optional;
+import javax.swing.Action;
 import org.triplea.game.startup.SetupModel;
 import org.triplea.swing.SwingAction;
 
@@ -26,6 +27,11 @@ public class LocalSetupPanel extends SetupPanel implements Observer {
 
   private void setupListeners() {
     gameSelectorModel.addObserver(this);
+  }
+
+  @Override
+  public List<Action> getUserActions() {
+    return List.of();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -8,7 +8,9 @@ import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
+import java.util.List;
 import java.util.Optional;
+import javax.swing.Action;
 import javax.swing.JButton;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -272,6 +274,11 @@ public class MetaSetupPanel extends SetupPanel {
   @Override
   public boolean canGameStart() {
     return false;
+  }
+
+  @Override
+  public List<Action> getUserActions() {
+    return List.of();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PbemSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PbemSetupPanel.java
@@ -23,6 +23,7 @@ import java.util.Map;
 import java.util.Observable;
 import java.util.Observer;
 import java.util.Optional;
+import javax.swing.Action;
 import javax.swing.JButton;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
@@ -141,6 +142,11 @@ public class PbemSetupPanel extends SetupPanel implements Observer {
             0,
             0));
     layoutPlayerComponents(localPlayerPanel, playerTypes, gameSelectorModel.getGameData());
+  }
+
+  @Override
+  public List<Action> getUserActions() {
+    return List.of();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.framework.startup.ui;
 
+import com.google.common.collect.ImmutableList;
 import games.strategy.engine.data.PlayerId;
 import games.strategy.engine.framework.network.ui.BanPlayerAction;
 import games.strategy.engine.framework.network.ui.BootPlayerAction;
@@ -488,7 +489,7 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
               actions.add(new EditGameCommentAction(watcher, ServerSetupPanel.this));
               actions.add(new RemoveGameFromLobbyAction(watcher));
             });
-    return actions;
+    return ImmutableList.copyOf(actions);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/SetupPanel.java
@@ -5,7 +5,6 @@ import games.strategy.engine.data.PlayerId;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -46,9 +45,7 @@ public abstract class SetupPanel extends JPanel implements SetupModel {
     return null;
   }
 
-  public List<Action> getUserActions() {
-    return new ArrayList<>();
-  }
+  public abstract List<Action> getUserActions();
 
   void layoutPlayerComponents(
       final JPanel panel, final List<PlayerSelectorRow> playerRows, final GameData data) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
@@ -141,8 +141,9 @@ public class MainPanel extends JPanel implements Observer, Consumer<SetupPanel> 
       final JPanel cancelPanel = new JPanel();
       cancelPanel.setBorder(new EmptyBorder(10, 0, 10, 10));
       cancelPanel.setLayout(new FlowLayout(FlowLayout.RIGHT));
-      if (!gameSetupPanel.getUserActions().isEmpty()) {
-        createUserActionMenu(gameSetupPanel, cancelPanel);
+      final List<Action> actions = gameSetupPanel.getUserActions();
+      if (!actions.isEmpty()) {
+        createUserActionMenu(gameSetupPanel, cancelPanel, actions);
       }
       cancelPanel.add(cancelButton);
       gameSetupPanelHolder.add(cancelPanel, BorderLayout.SOUTH);
@@ -162,13 +163,12 @@ public class MainPanel extends JPanel implements Observer, Consumer<SetupPanel> 
   }
 
   private static void createUserActionMenu(
-      final SetupPanel gameSetupPanel, final JPanel cancelPanel) {
+      final SetupPanel gameSetupPanel, final JPanel cancelPanel, final List<Action> actions) {
     // if we need this for something other than network, add a way to set it
     final JButton button = new JButton("Network...");
     button.addActionListener(
         e -> {
           final JPopupMenu menu = new JPopupMenu();
-          final List<Action> actions = gameSetupPanel.getUserActions();
           for (final Action a : actions) {
             menu.add(a);
           }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
@@ -143,7 +143,7 @@ public class MainPanel extends JPanel implements Observer, Consumer<SetupPanel> 
       cancelPanel.setLayout(new FlowLayout(FlowLayout.RIGHT));
       final List<Action> actions = gameSetupPanel.getUserActions();
       if (!actions.isEmpty()) {
-        createUserActionMenu(gameSetupPanel, cancelPanel, actions);
+        createUserActionMenu(cancelPanel, actions);
       }
       cancelPanel.add(cancelButton);
       gameSetupPanelHolder.add(cancelPanel, BorderLayout.SOUTH);
@@ -162,8 +162,7 @@ public class MainPanel extends JPanel implements Observer, Consumer<SetupPanel> 
     revalidate();
   }
 
-  private static void createUserActionMenu(
-      final SetupPanel gameSetupPanel, final JPanel cancelPanel, final List<Action> actions) {
+  private static void createUserActionMenu(final JPanel cancelPanel, final List<Action> actions) {
     // if we need this for something other than network, add a way to set it
     final JButton button = new JButton("Network...");
     button.addActionListener(


### PR DESCRIPTION
Action list in the network button is redundant to existing controls on
the same screen. The menu options also paraphrase or alias the existing
controls (which is not great for consistency).


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[x] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done
- After this update, the 'network' button is no longer visible on bot game staging screens.
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
## Screens Shots

This screenshot marks where the redundant controls are (I'm not able to get a screenshot with menus open):
![Screenshot from 2019-12-26 19-48-24](https://user-images.githubusercontent.com/12397753/71500225-e2588680-2818-11ea-8b03-2521107575d3.png)



<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

