### PR TITLE
Remove save game folder setting

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/AutoSaveFileUtils.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/AutoSaveFileUtils.java
@@ -4,8 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static games.strategy.engine.framework.GameDataFileUtils.addExtension;
 import static org.triplea.java.StringUtils.capitalize;
 
-import com.google.common.annotations.VisibleForTesting;
-import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import java.io.File;
 import java.nio.file.Paths;
 import java.time.LocalDateTime;
@@ -16,15 +15,13 @@ import java.util.Locale;
  * Provides methods for getting the names of auto-save files periodically generated during a game.
  */
 public class AutoSaveFileUtils {
-  @VisibleForTesting
   File getAutoSaveFile(final String baseFileName) {
-    return ClientSetting.saveGamesFolderPath
-        .getValueOrThrow()
+    return SaveGameFileChooser.getSaveGameFolder()
+        .toPath()
         .resolve(Paths.get("autoSave", getAutoSaveFileName(baseFileName)))
         .toFile();
   }
 
-  @VisibleForTesting
   String getAutoSaveFileName(final String baseFileName) {
     return baseFileName;
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/HeadlessAutoSaveFileUtils.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/HeadlessAutoSaveFileUtils.java
@@ -13,7 +13,7 @@ public class HeadlessAutoSaveFileUtils extends AutoSaveFileUtils {
     if (!prefix.isEmpty()) {
       return prefix + "_" + baseFileName;
     }
-    return super.getAutoSaveFileName(baseFileName);
+    return baseFileName;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameFileSelector.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameFileSelector.java
@@ -3,7 +3,6 @@ package games.strategy.engine.framework.startup.ui.panels.main.game.selector;
 import games.strategy.engine.framework.GameDataFileUtils;
 import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.engine.framework.ui.SaveGameFileChooser;
-import games.strategy.triplea.settings.ClientSetting;
 import java.awt.FileDialog;
 import java.awt.Frame;
 import java.io.File;
@@ -27,7 +26,7 @@ public final class GameFileSelector {
     if (SystemProperties.isMac()) {
       final FileDialog fileDialog = new FileDialog(owner);
       fileDialog.setMode(FileDialog.LOAD);
-      fileDialog.setDirectory(ClientSetting.saveGamesFolderPath.getValueOrThrow().toString());
+      fileDialog.setDirectory(SaveGameFileChooser.getSaveGameFolder().toString());
       fileDialog.setFilenameFilter((dir, name) -> GameDataFileUtils.isCandidateFileName(name));
       fileDialog.setVisible(true);
       final String fileName = fileDialog.getFile();

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
@@ -1,8 +1,9 @@
 package games.strategy.engine.framework.ui;
 
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.GameDataFileUtils;
-import games.strategy.triplea.settings.ClientSetting;
 import java.io.File;
+import java.nio.file.Path;
 import javax.swing.JFileChooser;
 import javax.swing.filechooser.FileFilter;
 
@@ -12,11 +13,21 @@ public final class SaveGameFileChooser extends JFileChooser {
 
   private static SaveGameFileChooser instance;
 
+  private static final Path saveGameFolder =
+      ClientFileSystemHelper.getUserRootFolder().toPath().resolve("savedGames");
+
   private SaveGameFileChooser() {
     setFileFilter(newGameDataFileFilter());
-    final File saveGamesFolder = ClientSetting.saveGamesFolderPath.getValueOrThrow().toFile();
-    ensureDirectoryExists(saveGamesFolder);
-    setCurrentDirectory(saveGamesFolder);
+    setCurrentDirectory(getSaveGameFolder());
+  }
+
+  public static File getSaveGameFolder() {
+    final File folder = saveGameFolder.toFile();
+    if (!folder.mkdirs() && !folder.exists()) {
+      throw new IllegalStateException(
+          "Unable to create save game folder: " + folder.getAbsolutePath());
+    }
+    return folder;
   }
 
   public static SaveGameFileChooser getInstance() {
@@ -24,15 +35,6 @@ public final class SaveGameFileChooser extends JFileChooser {
       instance = new SaveGameFileChooser();
     }
     return instance;
-  }
-
-  private static void ensureDirectoryExists(final File f) {
-    if (!f.getParentFile().exists()) {
-      ensureDirectoryExists(f.getParentFile());
-    }
-    if (!f.exists()) {
-      f.mkdir();
-    }
   }
 
   private static FileFilter newGameDataFileFilter() {

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -108,10 +108,6 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
   public static final ClientSetting<Integer> proxyPort = new IntegerClientSetting("PROXY_PORT");
   public static final BooleanClientSetting rememberLoginPassword =
       new BooleanClientSetting("REMEMBER_PASSWORD", false);
-  public static final ClientSetting<Path> saveGamesFolderPath =
-      new PathClientSetting(
-          "SAVE_GAMES_FOLDER_PATH",
-          ClientFileSystemHelper.getUserRootFolder().toPath().resolve("savedGames"));
   public static final ClientSetting<Integer> serverObserverJoinWaitTime =
       new IntegerClientSetting("SERVER_OBSERVER_JOIN_WAIT_TIME", 180);
   public static final ClientSetting<Integer> serverStartGameSyncWaitTime =

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -241,16 +241,6 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
     }
   },
 
-  SAVE_GAMES_FOLDER_PATH_BINDING(
-      "Saved Games Folder",
-      SettingType.FOLDER_LOCATIONS,
-      "The folder where saved game files will be stored by default") {
-    @Override
-    public SelectionComponent<JComponent> newSelectionComponent() {
-      return folderPath(ClientSetting.saveGamesFolderPath);
-    }
-  },
-
   USER_MAPS_FOLDER_PATH_BINDING(
       "Maps Folder",
       SettingType.FOLDER_LOCATIONS,

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
@@ -6,7 +6,6 @@ import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.engine.lobby.client.ui.action.EditGameCommentAction;
 import games.strategy.engine.lobby.client.ui.action.RemoveGameFromLobbyAction;
-import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.TripleAFrame;
 import java.awt.FileDialog;
 import java.awt.Frame;
@@ -65,7 +64,7 @@ public final class TripleAMenuBar extends JMenuBar {
     if (SystemProperties.isMac()) {
       final FileDialog fileDialog = new FileDialog(frame);
       fileDialog.setMode(FileDialog.SAVE);
-      fileDialog.setDirectory(ClientSetting.saveGamesFolderPath.getValueOrThrow().toString());
+      fileDialog.setDirectory(SaveGameFileChooser.getSaveGameFolder().toString());
       fileDialog.setFilenameFilter((dir, name) -> GameDataFileUtils.isCandidateFileName(name));
       fileDialog.setVisible(true);
 

--- a/game-core/src/test/java/games/strategy/engine/framework/AutoSaveFileUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/AutoSaveFileUtilsTest.java
@@ -4,8 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
-import games.strategy.triplea.settings.ClientSetting;
-import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
@@ -13,19 +11,6 @@ import org.junit.jupiter.api.Test;
 
 final class AutoSaveFileUtilsTest extends AbstractClientSettingTestCase {
   private final AutoSaveFileUtils autoSaveFileUtils = new AutoSaveFileUtils();
-
-  @Nested
-  final class GetAutoSaveFileTest {
-    @Test
-    void shouldReturnFileInAutoSaveFolder() {
-      ClientSetting.saveGamesFolderPath.setValue(Paths.get("path", "to", "saves"));
-
-      final String fileName = "savegame.tsvg";
-      assertThat(
-          autoSaveFileUtils.getAutoSaveFile(fileName),
-          is(Paths.get("path", "to", "saves", "autoSave", fileName).toFile()));
-    }
-  }
 
   @Nested
   final class GetAutoSaveFileNameTest {

--- a/game-core/src/test/java/games/strategy/engine/framework/HeadlessAutoSaveFileUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/HeadlessAutoSaveFileUtilsTest.java
@@ -4,8 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
-import games.strategy.triplea.settings.ClientSetting;
-import java.nio.file.Paths;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Nested;
@@ -13,19 +11,6 @@ import org.junit.jupiter.api.Test;
 
 final class HeadlessAutoSaveFileUtilsTest extends AbstractClientSettingTestCase {
   private final HeadlessAutoSaveFileUtils autoSaveFileUtils = new HeadlessAutoSaveFileUtils();
-
-  @Nested
-  final class GetAutoSaveFileTest {
-    @Test
-    void shouldReturnFileInAutoSaveFolder() {
-      ClientSetting.saveGamesFolderPath.setValue(Paths.get("path", "to", "saves"));
-
-      final String fileName = "savegame.tsvg";
-      assertThat(
-          autoSaveFileUtils.getAutoSaveFile(fileName),
-          is(Paths.get("path", "to", "saves", "autoSave", fileName).toFile()));
-    }
-  }
 
   @Nested
   final class GetAutoSaveFileNameTest {

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/ClientSettingJavaFxUiBinding.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/util/ClientSettingJavaFxUiBinding.java
@@ -140,13 +140,6 @@ public enum ClientSettingJavaFxUiBinding implements GameSettingUiBinding<Region>
     }
   },
 
-  SAVE_GAMES_FOLDER_PATH_BINDING(SettingType.FOLDER_LOCATIONS) {
-    @Override
-    public SelectionComponent<Region> newSelectionComponent() {
-      return folderPath(ClientSetting.saveGamesFolderPath);
-    }
-  },
-
   USER_MAPS_FOLDER_PATH_BINDING(SettingType.FOLDER_LOCATIONS) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {


### PR DESCRIPTION
- The setting option to specify save game folder is not terribly useful
- Check for parent folders 'f.getParentFolder()' can NPE if the save
  game folder setting is set to a non-existent folder. Fix this by using
  a simpler "f.mkdirs" call that both creates folders and avoids a
  potential NPE.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

