### PR TITLE
WebSocketConnection concurrency updates

### DIFF
--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -3,6 +3,7 @@ package org.triplea.http.client.web.socket;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.net.URI;
+import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -37,13 +38,13 @@ class WebSocketConnection {
    * If sending messages before a connection is opened, they will be queued. When the connection is
    * opened, the queue is flushed and messages will be sent in order.
    */
-  private final Queue<String> queuedMessages = new LinkedList<>();
+  private final Queue<String> queuedMessages = new ArrayDeque<>();
 
   /**
    * State variable to track open connection, this value is set and checked under the same
    * synchronization lock.
    */
-  private volatile boolean connectionIsOpen = false;
+  private boolean connectionIsOpen = false;
 
   private final URI serverUri;
 

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -6,7 +6,6 @@ import java.net.URI;
 import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.HashSet;
-import java.util.LinkedList;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -5,9 +5,9 @@ import com.google.common.base.Preconditions;
 import java.net.URI;
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.Queue;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import lombok.AccessLevel;
@@ -37,7 +37,13 @@ class WebSocketConnection {
    * If sending messages before a connection is opened, they will be queued. When the connection is
    * opened, the queue is flushed and messages will be sent in order.
    */
-  private final Queue<String> queuedMessages = new ConcurrentLinkedQueue<>();
+  private final Queue<String> queuedMessages = new LinkedList<>();
+
+  /**
+   * State variable to track open connection, this value is set and checked under the same
+   * synchronization lock.
+   */
+  private volatile boolean connectionIsOpen = false;
 
   private final URI serverUri;
 
@@ -63,6 +69,7 @@ class WebSocketConnection {
           @Override
           public void onOpen(final ServerHandshake serverHandshake) {
             synchronized (queuedMessages) {
+              connectionIsOpen = true;
               queuedMessages.forEach(this::send);
               queuedMessages.clear();
             }
@@ -159,7 +166,7 @@ class WebSocketConnection {
     // If the connection is not yet open, the synchronized block should guarantee that we add
     // to the queued message queue before we start flushing it.
     synchronized (queuedMessages) {
-      if (!client.isOpen()) {
+      if (!connectionIsOpen) {
         queuedMessages.add(message);
       } else {
         client.send(message);

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -43,6 +43,9 @@ class WebSocketConnection {
    * State variable to track open connection, this value is set and checked under the same
    * synchronization lock.
    */
+  @Setter(
+      value = AccessLevel.PACKAGE,
+      onMethod_ = {@VisibleForTesting})
   private boolean connectionIsOpen = false;
 
   private final URI serverUri;

--- a/http-clients/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
@@ -183,22 +183,16 @@ class WebSocketConnectionTest {
     @Test
     @DisplayName("Send will send messages if connection is open")
     void sendMessage() {
-      givenWebSocketIsOpen(true);
+      webSocketConnection.setConnectionIsOpen(true);
 
       webSocketConnection.sendMessage(MESSAGE);
 
       verify(webSocketClient).send(MESSAGE);
     }
 
-    private void givenWebSocketIsOpen(final boolean isOpen) {
-      when(webSocketClient.isOpen()).thenReturn(isOpen);
-    }
-
     @Test
     @DisplayName("Send will queue messages if connection is not open")
     void sendMessageWillQueueMessagesIfConnectionIsNotOpen() {
-      givenWebSocketIsOpen(false);
-
       webSocketConnection.sendMessage(MESSAGE);
 
       verify(webSocketClient, never()).send(anyString());


### PR DESCRIPTION
- Use non-concurrent linked list implementation, since it is accessed under a lock, access
  is effectively single-threaded and we can use a non-concurrent linked list implementatoin.
- Use boolean tracking variable for connection is open check. State of variable is changed
  only under synchronization. This is to avoid potential race conditions between the point
  when the websocket state is marked as open and when 'onOpen' is called. Under such a
  a condition, messages could be sent out of order.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

