### PR TITLE
Fix mkdir NPE and throw error if save folder DNE

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
@@ -27,11 +27,9 @@ public final class SaveGameFileChooser extends JFileChooser {
   }
 
   private static void ensureDirectoryExists(final File f) {
-    if (!f.getParentFile().exists()) {
-      ensureDirectoryExists(f.getParentFile());
-    }
-    if (!f.exists()) {
-      f.mkdir();
+    if (!f.mkdirs() && !f.exists()) {
+      throw new IllegalStateException(
+          "Unable to create save game folder: " + f.getAbsolutePath());
     }
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
@@ -28,8 +28,7 @@ public final class SaveGameFileChooser extends JFileChooser {
 
   private static void ensureDirectoryExists(final File f) {
     if (!f.mkdirs() && !f.exists()) {
-      throw new IllegalStateException(
-          "Unable to create save game folder: " + f.getAbsolutePath());
+      throw new IllegalStateException("Unable to create save game folder: " + f.getAbsolutePath());
     }
   }
 


### PR DESCRIPTION
- If save game folder is set to one that does not exist, then 'f.getParentDir'
  can throw a NPE.
- We previously ensured directory exists and parent directories exist via
  a recursive method call 'ensureDirectoryExists'. This can be replaced
  with a simple 'f.mkdirs()'
- Previously if directory did not exist, we continued with processing,
  if we fail to create directory, then we will now throw an illegal state exception.
  We would normally expect for it to be possible to create the save game folder
  directory.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

