### PR TITLE
Update stalebot labels and reduce close thresholds.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,13 +1,11 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 120
+daysUntilStale: 90 
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 3 
+daysUntilClose: 1 
 # Issues with these labels will never be considered stale
 exemptLabels:
-  - "Release Blocker"
-  - "Impact: Bad Game Rules"
-  - "Impact: Game Crashing"
-  - "Impact: Incorrect UI Behavior"
+  - "Problem"
+  - "Pre-Release Problem"
 # Label to use when marking an issue as stale
 staleLabel: 'Stale'
 
@@ -23,7 +21,7 @@ markComment: >
 closeComment: false
 
 pulls:
-   daysUntilStale: 21 
+   daysUntilStale: 14 
    markComment: >
      This pull request has been automatically marked as stale because it has not had
      recent activity. We are eager to see this work completed, please update and


### PR DESCRIPTION
- Keep open "Problem" and "Pre-Release Problem" labels
  This allows for simpler stale bot rules, we in general
  want to keep open any problem issue.
- Lower PR stale threshold from 21 days to 14
  PRs go stale well before 21 days.
- Lower issue stale threshold from 120 to 90 days
  Non-problem issues are stale after a few months, 4 months
  is a bit overly generous.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

