### PR TITLE
Rename 'PlayerName' -> 'UserName'

### DIFF
--- a/domain-data/src/main/java/org/triplea/domain/data/UserName.java
+++ b/domain-data/src/main/java/org/triplea/domain/data/UserName.java
@@ -16,16 +16,16 @@ import lombok.Getter;
  */
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
-public class PlayerName implements Serializable {
+public class UserName implements Serializable {
   @VisibleForTesting static final int MAX_LENGTH = 40;
 
   private static final long serialVersionUID = 8356372044000232198L;
   private static final int MIN_LENGTH = 3;
   @Getter private final String value;
 
-  public static PlayerName of(final String name) {
+  public static UserName of(final String name) {
     Preconditions.checkNotNull(name);
-    return new PlayerName(name);
+    return new UserName(name);
   }
 
   @Override

--- a/domain-data/src/test/java/org/triplea/domain/data/UserNameTest.java
+++ b/domain-data/src/test/java/org/triplea/domain/data/UserNameTest.java
@@ -10,7 +10,7 @@ import java.util.List;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
-class PlayerNameTest {
+class UserNameTest {
 
   @SuppressWarnings("unused")
   static List<String> usernameValidationWithInvalidNames() {
@@ -18,7 +18,7 @@ class PlayerNameTest {
         "",
         "a",
         "ab", // still too short
-        Strings.repeat("a", PlayerName.MAX_LENGTH + 1),
+        Strings.repeat("a", UserName.MAX_LENGTH + 1),
         "ab*", // no special characters other than '-' and '_'
         "ab$",
         ".ab",
@@ -39,32 +39,30 @@ class PlayerNameTest {
   void usernameValidationWithInvalidNames(final String invalidName) {
     assertThat(
         "Expected name to have validation error messages: " + invalidName,
-        PlayerName.validate(invalidName),
+        UserName.validate(invalidName),
         notNullValue());
     assertThat(
         "Expected name to be marked as invalid: " + invalidName,
-        PlayerName.isValid(invalidName),
+        UserName.isValid(invalidName),
         is(false));
   }
 
   @SuppressWarnings("unused")
   private static List<String> usernameValidationWithValidNames() {
-    return List.of("abc", Strings.repeat("a", PlayerName.MAX_LENGTH), "a12", "a--");
+    return List.of("abc", Strings.repeat("a", UserName.MAX_LENGTH), "a12", "a--");
   }
 
   @ParameterizedTest
   @MethodSource
   void usernameValidationWithValidNames(final String validName) {
     assertThat(
-        "Expected name to be marked as valid: " + validName,
-        PlayerName.isValid(validName),
-        is(true));
+        "Expected name to be marked as valid: " + validName, UserName.isValid(validName), is(true));
 
     assertThat(
         String.format(
             "Expected name: %s, to have no validation error messages, but had %s",
-            validName, PlayerName.validate(validName)),
-        PlayerName.validate(validName),
+            validName, UserName.validate(validName)),
+        UserName.validate(validName),
         nullValue());
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatClient.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatClient.java
@@ -1,6 +1,6 @@
 package games.strategy.engine.chat;
 
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
 import org.triplea.http.client.lobby.chat.messages.server.ChatMessage;
 import org.triplea.http.client.lobby.chat.messages.server.ChatterList;
@@ -33,14 +33,14 @@ public interface ChatClient {
   void participantAdded(ChatParticipant chatParticipant);
 
   /** A chatter has left chat. */
-  void participantRemoved(PlayerName playerName);
+  void participantRemoved(UserName userName);
 
   /**
    * This method being called indicates the current player has been slapped.
    *
    * @param slapper The player that issued the slap.
    */
-  void slappedBy(PlayerName slapper);
+  void slappedBy(UserName slapper);
 
   /** A message that notifies players that another player has been slapped, eg: "x slapped y". */
   void playerSlapped(String eventMessage);

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatController.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatController.java
@@ -16,7 +16,7 @@ import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 import lombok.extern.java.Log;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
 
 /** Default implementation of {@link IChatController}. */
@@ -28,7 +28,7 @@ public class ChatController implements IChatController {
   private final Predicate<INode> isModerator;
   private final String chatName;
   private final Map<INode, Tag> chatters = new HashMap<>();
-  private final Map<PlayerName, String> chatterStatus = new HashMap<>();
+  private final Map<UserName, String> chatterStatus = new HashMap<>();
 
   private final Object mutex = new Object();
   private final String chatChannel;
@@ -112,7 +112,7 @@ public class ChatController implements IChatController {
       getChatBroadcaster()
           .speakerAdded(
               ChatParticipant.builder()
-                  .playerName(node.getPlayerName())
+                  .userName(node.getPlayerName())
                   .isModerator(tag == Tag.MODERATOR)
                   .build());
 
@@ -121,7 +121,7 @@ public class ChatController implements IChatController {
               entry ->
                   ChatParticipant.builder()
                       .isModerator(entry.getValue() == Tag.MODERATOR)
-                      .playerName(entry.getKey().getPlayerName())
+                      .userName(entry.getKey().getPlayerName())
                       .status(chatterStatus.get(entry.getKey().getPlayerName()))
                       .build())
           .collect(Collectors.toSet());

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatFloodControl.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatFloodControl.java
@@ -2,7 +2,7 @@ package games.strategy.engine.chat;
 
 import java.util.HashMap;
 import java.util.Map;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 
 /**
  * Simple flood control, only allow so many events per window of time. During each rolling time
@@ -15,7 +15,7 @@ class ChatFloodControl {
   static final int WINDOW = ONE_MINUTE;
 
   private final Object lock = new Object();
-  private final Map<PlayerName, Integer> messageCount = new HashMap<>();
+  private final Map<UserName, Integer> messageCount = new HashMap<>();
   private long clearTime;
 
   ChatFloodControl() {
@@ -26,7 +26,7 @@ class ChatFloodControl {
     clearTime = initialClearTime;
   }
 
-  boolean allow(final PlayerName from, final long now) {
+  boolean allow(final UserName from, final long now) {
     synchronized (lock) {
       // reset the window
       if (now > clearTime) {

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatIgnoreList.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatIgnoreList.java
@@ -8,23 +8,23 @@ import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 import java.util.stream.Collectors;
 import lombok.extern.java.Log;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 
 @Log
 class ChatIgnoreList {
   private final Object lock = new Object();
-  private final Set<PlayerName> ignore = new HashSet<>();
+  private final Set<UserName> ignore = new HashSet<>();
 
   ChatIgnoreList() {
     final Preferences prefs = getPrefNode();
     try {
-      ignore.addAll(Arrays.stream(prefs.keys()).map(PlayerName::of).collect(Collectors.toSet()));
+      ignore.addAll(Arrays.stream(prefs.keys()).map(UserName::of).collect(Collectors.toSet()));
     } catch (final BackingStoreException e) {
       log.log(Level.FINE, e.getMessage(), e);
     }
   }
 
-  void add(final PlayerName name) {
+  void add(final UserName name) {
     synchronized (lock) {
       ignore.add(name);
       final Preferences prefs = getPrefNode();
@@ -41,7 +41,7 @@ class ChatIgnoreList {
     return Preferences.userNodeForPackage(ChatIgnoreList.class);
   }
 
-  void remove(final PlayerName name) {
+  void remove(final UserName name) {
     synchronized (lock) {
       ignore.remove(name);
       final Preferences prefs = getPrefNode();
@@ -54,7 +54,7 @@ class ChatIgnoreList {
     }
   }
 
-  boolean shouldIgnore(final PlayerName name) {
+  boolean shouldIgnore(final UserName name) {
     synchronized (lock) {
       return ignore.contains(name);
     }

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatMessageListener.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatMessageListener.java
@@ -1,6 +1,6 @@
 package games.strategy.engine.chat;
 
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.messages.server.ChatMessage;
 
 /** Callback interface for a component that is interested in chat messages. */
@@ -9,7 +9,7 @@ public interface ChatMessageListener {
 
   void messageReceived(ChatMessage chatMessage);
 
-  void slapped(String message, PlayerName from);
+  void slapped(String message, UserName from);
 
   void slap(String message);
 

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatMessagePanel.java
@@ -26,7 +26,7 @@ import javax.swing.text.Document;
 import javax.swing.text.SimpleAttributeSet;
 import javax.swing.text.StyleConstants;
 import lombok.extern.java.Log;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.messages.server.ChatMessage;
 import org.triplea.java.Interruptibles;
 import org.triplea.java.TimeManager;
@@ -231,7 +231,7 @@ public class ChatMessagePanel extends JPanel implements ChatMessageListener {
   }
 
   @Override
-  public void slapped(final String message, final PlayerName from) {
+  public void slapped(final String message, final UserName from) {
     addMessageWithSound(message, from, SoundPath.CLIP_CHAT_SLAP);
   }
 
@@ -240,8 +240,7 @@ public class ChatMessagePanel extends JPanel implements ChatMessageListener {
     addGenericMessage(message);
   }
 
-  private void addMessageWithSound(
-      final String message, final PlayerName from, final String sound) {
+  private void addMessageWithSound(final String message, final UserName from, final String sound) {
     SwingAction.invokeNowOrLater(
         () -> {
           if (from == null || chat == null) {
@@ -249,9 +248,9 @@ public class ChatMessagePanel extends JPanel implements ChatMessageListener {
             return;
           }
           if (!floodControl.allow(from, System.currentTimeMillis())) {
-            if (from.equals(chat.getLocalPlayerName())) {
+            if (from.equals(chat.getLocalUserName())) {
               addChatMessage(
-                  "MESSAGE LIMIT EXCEEDED, TRY AGAIN LATER", PlayerName.of("ADMIN_FLOOD_CONTROL"));
+                  "MESSAGE LIMIT EXCEEDED, TRY AGAIN LATER", UserName.of("ADMIN_FLOOD_CONTROL"));
             }
             return;
           }
@@ -265,7 +264,7 @@ public class ChatMessagePanel extends JPanel implements ChatMessageListener {
         });
   }
 
-  private void addChatMessage(final String originalMessage, final PlayerName from) {
+  private void addChatMessage(final String originalMessage, final UserName from) {
     final String message = Ascii.truncate(originalMessage, 200, "...");
     final String time = "(" + TimeManager.getLocalizedTime() + ")";
     final Document doc = text.getDocument();

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
@@ -26,7 +26,7 @@ import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.ListCellRenderer;
 import javax.swing.UIManager;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
 import org.triplea.http.client.lobby.chat.messages.server.StatusUpdate;
 import org.triplea.swing.SwingAction;
@@ -90,7 +90,7 @@ public class ChatPlayerPanel extends JPanel implements ChatPlayerListener {
   private void setDynamicPreferredSize() {
     int maxNameLength = 0;
     final FontMetrics fontMetrics = this.getFontMetrics(UIManager.getFont("TextField.font"));
-    for (final PlayerName onlinePlayer : chat.getOnlinePlayers()) {
+    for (final UserName onlinePlayer : chat.getOnlinePlayers()) {
       maxNameLength = Math.max(maxNameLength, fontMetrics.stringWidth(onlinePlayer.getValue()));
     }
     int iconCounter = 0;
@@ -121,7 +121,7 @@ public class ChatPlayerPanel extends JPanel implements ChatPlayerListener {
                     setCellRenderer.getListCellRendererComponent(
                         list, getDisplayString(node), index, isSelected, cellHasFocus);
           }
-          if (chat.isIgnored(node.getPlayerName())) {
+          if (chat.isIgnored(node.getUserName())) {
             renderer.setIcon(ignoreIcon);
           }
           return renderer;
@@ -154,21 +154,20 @@ public class ChatPlayerPanel extends JPanel implements ChatPlayerListener {
     actionFactories.add(
         clickedOn -> {
           // you can't slap or ignore yourself
-          if (clickedOn.getPlayerName().equals(chat.getLocalPlayerName())) {
+          if (clickedOn.getUserName().equals(chat.getLocalUserName())) {
             return List.of();
           }
-          final boolean isIgnored = chat.isIgnored(clickedOn.getPlayerName());
+          final boolean isIgnored = chat.isIgnored(clickedOn.getUserName());
           final Action ignore =
               SwingAction.of(
                   isIgnored ? "Stop Ignoring" : "Ignore",
                   e -> {
-                    chat.setIgnored(clickedOn.getPlayerName(), !isIgnored);
+                    chat.setIgnored(clickedOn.getUserName(), !isIgnored);
                     repaint();
                   });
           final Action slap =
               SwingAction.of(
-                  "Slap " + clickedOn.getPlayerName(),
-                  e -> chat.sendSlap(clickedOn.getPlayerName()));
+                  "Slap " + clickedOn.getUserName(), e -> chat.sendSlap(clickedOn.getUserName()));
           return List.of(slap, ignore);
         });
   }
@@ -222,10 +221,10 @@ public class ChatPlayerPanel extends JPanel implements ChatPlayerListener {
     }
 
     final String extra = chatParticipant.isModerator() ? " " + TAG_MODERATOR : "";
-    final String status = Ascii.truncate(chat.getStatus(chatParticipant.getPlayerName()), 25, "");
+    final String status = Ascii.truncate(chat.getStatus(chatParticipant.getUserName()), 25, "");
     final String suffix = status.isEmpty() ? "" : " (" + status + ")";
 
-    return chatParticipant.getPlayerName() + extra + suffix;
+    return chatParticipant.getUserName() + extra + suffix;
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/chat/ChatTransmitter.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatTransmitter.java
@@ -1,7 +1,7 @@
 package games.strategy.engine.chat;
 
 import java.util.Collection;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
 
 /**
@@ -21,10 +21,10 @@ public interface ChatTransmitter {
   void sendMessage(String message);
 
   /** Sends a slap to a target player. */
-  void slap(PlayerName playerName);
+  void slap(UserName userName);
 
   /** Updates the status of current player. */
   void updateStatus(String status);
 
-  PlayerName getLocalPlayerName();
+  UserName getLocalUserName();
 }

--- a/game-core/src/main/java/games/strategy/engine/chat/HeadlessChat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/HeadlessChat.java
@@ -1,7 +1,7 @@
 package games.strategy.engine.chat;
 
 import com.google.common.base.Ascii;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.game.chat.ChatModel;
 import org.triplea.http.client.lobby.chat.messages.server.ChatMessage;
 import org.triplea.java.TimeManager;
@@ -50,7 +50,7 @@ public class HeadlessChat implements ChatMessageListener, ChatModel {
   }
 
   @Override
-  public void slapped(final String message, final PlayerName from) {
+  public void slapped(final String message, final UserName from) {
     messageReceived(new ChatMessage(from, message));
   }
 

--- a/game-core/src/main/java/games/strategy/engine/chat/IChatChannel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/IChatChannel.java
@@ -1,7 +1,7 @@
 package games.strategy.engine.chat;
 
 import games.strategy.engine.message.IChannelSubscriber;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
 
 /**
@@ -14,16 +14,16 @@ public interface IChatChannel extends IChannelSubscriber {
   // we get the sender from MessageContext
   void chatOccurred(String message);
 
-  void slapOccurred(PlayerName playerName);
+  void slapOccurred(UserName userName);
 
   void speakerAdded(ChatParticipant chatParticipant);
 
-  void speakerRemoved(PlayerName playerName);
+  void speakerRemoved(UserName userName);
 
   // purely here to keep connections open and stop NATs and crap from thinking that our connection
   // is closed when it is
   // not.
   void ping();
 
-  void statusChanged(PlayerName playerName, String status);
+  void statusChanged(UserName userName, String status);
 }

--- a/game-core/src/main/java/games/strategy/engine/chat/LobbyChatTransmitter.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/LobbyChatTransmitter.java
@@ -3,7 +3,7 @@ package games.strategy.engine.chat;
 import games.strategy.engine.lobby.client.LobbyClient;
 import java.util.Collection;
 import lombok.extern.java.Log;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.ChatMessageListeners;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
 import org.triplea.http.client.lobby.chat.LobbyChatClient;
@@ -17,10 +17,10 @@ import org.triplea.http.client.lobby.chat.LobbyChatClient;
 @Log
 public class LobbyChatTransmitter implements ChatTransmitter {
   private final LobbyChatClient lobbyChatClient;
-  private final PlayerName localPlayerName;
+  private final UserName localUserName;
 
   public LobbyChatTransmitter(final LobbyClient lobbyClient) {
-    this.localPlayerName = lobbyClient.getPlayerName();
+    this.localUserName = lobbyClient.getUserName();
     this.lobbyChatClient = lobbyClient.getHttpLobbyClient().getLobbyChatClient();
   }
 
@@ -36,7 +36,7 @@ public class LobbyChatTransmitter implements ChatTransmitter {
             .chatEventListener(chatClient::eventReceived)
             .playerSlappedListener(
                 slapEvent -> {
-                  if (slapEvent.getSlapped().equals(localPlayerName)) {
+                  if (slapEvent.getSlapped().equals(localUserName)) {
                     chatClient.slappedBy(slapEvent.getSlapper());
                   } else {
                     chatClient.playerSlapped(
@@ -63,8 +63,8 @@ public class LobbyChatTransmitter implements ChatTransmitter {
   }
 
   @Override
-  public void slap(final PlayerName playerName) {
-    lobbyChatClient.slapPlayer(playerName);
+  public void slap(final UserName userName) {
+    lobbyChatClient.slapPlayer(userName);
   }
 
   @Override
@@ -73,7 +73,7 @@ public class LobbyChatTransmitter implements ChatTransmitter {
   }
 
   @Override
-  public PlayerName getLocalPlayerName() {
-    return localPlayerName;
+  public UserName getLocalUserName() {
+    return localUserName;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/chat/MessengersChatTransmitter.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/MessengersChatTransmitter.java
@@ -4,14 +4,14 @@ import games.strategy.engine.message.MessageContext;
 import games.strategy.engine.message.RemoteName;
 import games.strategy.net.Messengers;
 import java.util.Collection;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
 import org.triplea.http.client.lobby.chat.messages.server.ChatMessage;
 import org.triplea.http.client.lobby.chat.messages.server.StatusUpdate;
 
 /** Chat transmitter that sends and receives messages over Java NIO sockets. */
 public class MessengersChatTransmitter implements ChatTransmitter {
-  private final PlayerName playerName;
+  private final UserName userName;
   private final Messengers messengers;
 
   private IChatChannel chatChannelSubscriber;
@@ -20,7 +20,7 @@ public class MessengersChatTransmitter implements ChatTransmitter {
   private final String chatChannelName;
 
   public MessengersChatTransmitter(final String chatName, final Messengers messengers) {
-    this.playerName = messengers.getLocalNode().getPlayerName();
+    this.userName = messengers.getLocalNode().getPlayerName();
     this.messengers = messengers;
     this.chatName = chatName;
     this.chatChannelName = ChatController.getChatChannelName(chatName);
@@ -40,9 +40,9 @@ public class MessengersChatTransmitter implements ChatTransmitter {
       }
 
       @Override
-      public void slapOccurred(final PlayerName slappedPlayer) {
-        final PlayerName slapper = MessageContext.getSender().getPlayerName();
-        if (slappedPlayer.equals(playerName)) {
+      public void slapOccurred(final UserName slappedPlayer) {
+        final UserName slapper = MessageContext.getSender().getPlayerName();
+        if (slappedPlayer.equals(userName)) {
           chatClient.slappedBy(slapper);
         } else {
           chatClient.playerSlapped(slappedPlayer + " was slapped by " + slapper);
@@ -55,16 +55,16 @@ public class MessengersChatTransmitter implements ChatTransmitter {
       }
 
       @Override
-      public void speakerRemoved(final PlayerName playerName) {
-        chatClient.participantRemoved(playerName);
+      public void speakerRemoved(final UserName userName) {
+        chatClient.participantRemoved(userName);
       }
 
       @Override
       public void ping() {}
 
       @Override
-      public void statusChanged(final PlayerName playerName, final String status) {
-        chatClient.statusUpdated(new StatusUpdate(playerName, status));
+      public void statusChanged(final UserName userName, final String status) {
+        chatClient.statusUpdated(new StatusUpdate(userName, status));
       }
     };
   }
@@ -87,11 +87,11 @@ public class MessengersChatTransmitter implements ChatTransmitter {
   }
 
   @Override
-  public void slap(final PlayerName playerName) {
+  public void slap(final UserName userName) {
     final IChatChannel remote =
         (IChatChannel)
             messengers.getChannelBroadcaster(new RemoteName(chatChannelName, IChatChannel.class));
-    remote.slapOccurred(playerName);
+    remote.slapOccurred(userName);
   }
 
   @Override
@@ -102,7 +102,7 @@ public class MessengersChatTransmitter implements ChatTransmitter {
   }
 
   @Override
-  public PlayerName getLocalPlayerName() {
+  public UserName getLocalUserName() {
     return messengers.getLocalNode().getPlayerName();
   }
 

--- a/game-core/src/main/java/games/strategy/engine/chat/PlayerChatRenderer.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/PlayerChatRenderer.java
@@ -20,7 +20,7 @@ import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JList;
 import javax.swing.SwingConstants;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
 
 /**
@@ -63,26 +63,26 @@ public class PlayerChatRenderer extends DefaultListCellRenderer {
       final boolean cellHasFocus) {
     final ChatParticipant chatParticipant = (ChatParticipant) value;
     final List<Icon> icons =
-        iconMap.getOrDefault(chatParticipant.getPlayerName().getValue(), List.of());
+        iconMap.getOrDefault(chatParticipant.getUserName().getValue(), List.of());
     if (icons.isEmpty()) {
       super.getListCellRendererComponent(
           list,
-          getNodeLabelWithPlayers(chatParticipant.getPlayerName()),
+          getNodeLabelWithPlayers(chatParticipant.getUserName()),
           index,
           isSelected,
           cellHasFocus);
     } else {
       super.getListCellRendererComponent(
-          list, chatParticipant.getPlayerName().getValue(), index, isSelected, cellHasFocus);
+          list, chatParticipant.getUserName().getValue(), index, isSelected, cellHasFocus);
       setHorizontalTextPosition(SwingConstants.LEFT);
       setIcon(new CompositeIcon(icons));
     }
     return this;
   }
 
-  private String getNodeLabelWithPlayers(final PlayerName playerName) {
-    final Set<String> playerNames = playerMap.getOrDefault(playerName.getValue(), Set.of());
-    return playerName
+  private String getNodeLabelWithPlayers(final UserName userName) {
+    final Set<String> playerNames = playerMap.getOrDefault(userName.getValue(), Set.of());
+    return userName
         + (playerNames.isEmpty()
             ? ""
             : playerNames.stream().collect(Collectors.joining(", ", " (", ")")));

--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -32,7 +32,7 @@ import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.game.ApplicationContext;
 import org.triplea.java.Interruptibles;
 import org.triplea.lobby.common.GameDescription;
@@ -189,7 +189,7 @@ public final class GameRunner {
   }
 
   /** Spawns a new process to join a network game. */
-  public static void joinGame(final GameDescription description, final PlayerName playerName) {
+  public static void joinGame(final GameDescription description, final UserName userName) {
     final GameDescription.GameStatus status = description.getStatus();
     if (GameDescription.GameStatus.LAUNCHING == status) {
       return;
@@ -202,7 +202,7 @@ public final class GameRunner {
     commands.add(prefix + TRIPLEA_PORT + "=" + description.getHostedBy().getPort());
     commands.add(
         prefix + TRIPLEA_HOST + "=" + description.getHostedBy().getAddress().getHostAddress());
-    commands.add(prefix + TRIPLEA_NAME + "=" + playerName.getValue());
+    commands.add(prefix + TRIPLEA_NAME + "=" + userName.getValue());
     commands.add(Services.loadAny(ApplicationContext.class).getMainClass().getName());
     ProcessRunnerUtil.exec(commands);
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -62,7 +62,7 @@ import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import lombok.Getter;
 import lombok.extern.java.Log;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.game.chat.ChatModel;
 import org.triplea.game.server.HeadlessGameServer;
 import org.triplea.game.startup.ServerSetupModel;
@@ -351,14 +351,14 @@ public class ServerModel extends Observable implements IConnectionChangeListener
               .password(System.getProperty(SERVER_PASSWORD))
               .build());
     }
-    final PlayerName playerName = PlayerName.of(ClientSetting.playerName.getValueOrThrow());
+    final UserName userName = UserName.of(ClientSetting.playerName.getValueOrThrow());
     final Interruptibles.Result<ServerOptions> optionsResult =
         Interruptibles.awaitResult(
             () ->
                 SwingAction.invokeAndWaitResult(
                     () -> {
                       final ServerOptions options =
-                          new ServerOptions(ui, playerName, GameRunner.PORT, false);
+                          new ServerOptions(ui, userName, GameRunner.PORT, false);
                       options.setLocationRelativeTo(ui);
                       options.setVisible(true);
                       options.dispose();

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ClientSetupPanel.java
@@ -24,7 +24,7 @@ import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.swing.SwingAction;
 
 /** Network client game staging panel, can be used to select sides and chat. */
@@ -69,7 +69,7 @@ public class ClientSetupPanel extends SetupPanel {
       SwingUtilities.invokeLater(
           () ->
               playerRow.update(
-                  Optional.ofNullable(players.get(name)).map(PlayerName::of).orElse(null),
+                  Optional.ofNullable(players.get(name)).map(UserName::of).orElse(null),
                   disableable.contains(name)));
     }
     SwingUtilities.invokeLater(this::layoutComponents);
@@ -205,15 +205,15 @@ public class ClientSetupPanel extends SetupPanel {
       return enabledCheckBox;
     }
 
-    public void update(final PlayerName playerName, final boolean disableable) {
-      if (playerName == null) {
+    public void update(final UserName userName, final boolean disableable) {
+      if (userName == null) {
         playerLabel.setText("-");
         final JButton button = new JButton(takeAction);
         button.setMargin(buttonInsets);
         playerComponent = button;
       } else {
-        playerLabel.setText(playerName.getValue());
-        if (playerName.equals(clientModel.getClientMessenger().getLocalNode().getPlayerName())) {
+        playerLabel.setText(userName.getValue());
+        if (userName.equals(clientModel.getClientMessenger().getLocalNode().getPlayerName())) {
           final JButton button = new JButton(dontTakeAction);
           button.setMargin(buttonInsets);
           playerComponent = button;

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerOptions.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerOptions.java
@@ -15,7 +15,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPasswordField;
 import javax.swing.JTextField;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.swing.IntTextField;
 import org.triplea.swing.SwingAction;
 
@@ -32,7 +32,7 @@ public class ServerOptions extends JDialog {
 
   public ServerOptions(
       final Component owner,
-      final PlayerName defaultName,
+      final UserName defaultName,
       final int defaultPort,
       final boolean showComment) {
     super(owner == null ? null : JOptionPane.getFrameForComponent(owner), "Server options", true);

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/LobbyClient.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/LobbyClient.java
@@ -3,7 +3,7 @@ package games.strategy.engine.lobby.client;
 import javax.annotation.Nonnull;
 import lombok.Builder;
 import lombok.Getter;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.HttpLobbyClient;
 
 /** Provides information about a client connection to a lobby server. */
@@ -11,7 +11,7 @@ import org.triplea.http.client.lobby.HttpLobbyClient;
 @Builder
 public class LobbyClient {
   @Nonnull private final HttpLobbyClient httpLobbyClient;
-  @Nonnull private final PlayerName playerName;
+  @Nonnull private final UserName userName;
   private final boolean anonymousLogin;
   private final boolean moderator;
   private final boolean passwordChangeRequired;

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/CreateAccountPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/CreateAccountPanel.java
@@ -24,7 +24,7 @@ import javax.swing.JPanel;
 import javax.swing.JPasswordField;
 import javax.swing.JTextField;
 import org.triplea.domain.data.PlayerEmailValidation;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.swing.JCheckBoxBuilder;
 import org.triplea.swing.KeyTypeValidator;
 import org.triplea.swing.SwingComponents;
@@ -276,8 +276,8 @@ public final class CreateAccountPanel extends JPanel {
       return Optional.of("Passwords must match");
     } else if (!PlayerEmailValidation.isValid(emailField.getText())) {
       return Optional.of("Email must be valid");
-    } else if (!PlayerName.isValid(usernameField.getText())) {
-      return Optional.ofNullable(PlayerName.validate(usernameField.getText()));
+    } else if (!UserName.isValid(usernameField.getText())) {
+      return Optional.ofNullable(UserName.validate(usernameField.getText()));
     } else if (emailField.getText().isEmpty()) {
       return Optional.of("You must enter an email");
     } else if (passwordField.getPassword().length == 0) {

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/ForgotPasswordPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/ForgotPasswordPanel.java
@@ -17,7 +17,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextField;
 import org.triplea.domain.data.PlayerEmailValidation;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.swing.SwingComponents;
 
 /**
@@ -143,10 +143,10 @@ final class ForgotPasswordPanel extends JPanel {
   }
 
   private void okPressed() {
-    if (!PlayerName.isValid(userNameField.getText())) {
+    if (!UserName.isValid(userNameField.getText())) {
       JOptionPane.showMessageDialog(
           this,
-          PlayerName.validate(userNameField.getText()),
+          UserName.validate(userNameField.getText()),
           "Invalid name",
           JOptionPane.ERROR_MESSAGE);
       return;

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -11,7 +11,7 @@ import java.io.IOException;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import org.triplea.domain.data.ApiKey;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.HttpInteractionException;
 import org.triplea.http.client.SystemIdHeader;
 import org.triplea.http.client.forgot.password.ForgotPasswordClient;
@@ -128,7 +128,7 @@ public class LobbyLogin {
                 .anonymousLogin(Strings.nullToEmpty(panel.getPassword()).isEmpty())
                 .passwordChangeRequired(loginResponse.isPasswordChangeRequired())
                 .moderator(loginResponse.isModerator())
-                .playerName(PlayerName.of(panel.getUserName()))
+                .userName(UserName.of(panel.getUserName()))
                 .build());
       } else {
         showError("Login Failed", loginResponse.getFailReason());
@@ -177,7 +177,7 @@ public class LobbyLogin {
             .map(
                 httpLobbyClient ->
                     LobbyClient.builder()
-                        .playerName(PlayerName.of(createAccountPanel.getUsername()))
+                        .userName(UserName.of(createAccountPanel.getUsername()))
                         .httpLobbyClient(httpLobbyClient)
                         .build());
       case CANCEL:

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LoginPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LoginPanel.java
@@ -20,7 +20,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPasswordField;
 import javax.swing.JTextField;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.JCheckBoxBuilder;
 import org.triplea.swing.SwingComponents;
@@ -222,7 +222,7 @@ final class LoginPanel extends JPanel {
   }
 
   private void logonPressed() {
-    final String validationMessage = PlayerName.validate(username.getText());
+    final String validationMessage = UserName.validate(username.getText());
 
     if (validationMessage != null) {
       JOptionPane.showMessageDialog(

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -122,7 +122,7 @@ public class LobbyFrame extends JFrame {
       return List.of();
     }
 
-    if (clickedOn.getPlayerName().equals(lobbyClient.getPlayerName())) {
+    if (clickedOn.getUserName().equals(lobbyClient.getUserName())) {
       return List.of();
     }
 
@@ -133,7 +133,7 @@ public class LobbyFrame extends JFrame {
             .parent(this)
             .moderatorLobbyClient(moderatorLobbyClient)
             .playerChatId(clickedOn.getPlayerChatId())
-            .playerName(clickedOn.getPlayerName())
+            .userName(clickedOn.getUserName())
             .build()
             .toSwingAction(),
         BanPlayerModeratorAction.builder()

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -178,13 +178,13 @@ class LobbyGamePanel extends JPanel {
     // we sort the table, so get the correct index
     final GameDescription description =
         gameTableModel.get(gameTable.convertRowIndexToModel(selectedIndex));
-    GameRunner.joinGame(description, lobbyClient.getPlayerName());
+    GameRunner.joinGame(description, lobbyClient.getUserName());
   }
 
   private void hostGame(final URI lobbyUri) {
     final ServerOptions options =
         new ServerOptions(
-            JOptionPane.getFrameForComponent(this), lobbyClient.getPlayerName(), 3300, true);
+            JOptionPane.getFrameForComponent(this), lobbyClient.getUserName(), 3300, true);
     options.setLocationRelativeTo(JOptionPane.getFrameForComponent(this));
     options.setNameEditable(false);
     options.setVisible(true);

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/DisconnectPlayerModeratorAction.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/DisconnectPlayerModeratorAction.java
@@ -5,7 +5,7 @@ import javax.swing.Action;
 import javax.swing.JFrame;
 import lombok.Builder;
 import org.triplea.domain.data.PlayerChatId;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.moderator.ModeratorChatClient;
 import org.triplea.swing.SwingAction;
 
@@ -13,14 +13,14 @@ import org.triplea.swing.SwingAction;
 public class DisconnectPlayerModeratorAction {
   @Nonnull private final JFrame parent;
   @Nonnull private final ModeratorChatClient moderatorLobbyClient;
-  @Nonnull private final PlayerName playerName;
+  @Nonnull private final UserName userName;
   @Nonnull private final PlayerChatId playerChatId;
 
   public Action toSwingAction() {
     return SwingAction.of(
-        "Disconnect " + playerName,
+        "Disconnect " + userName,
         e -> {
-          if (new ActionConfirmation(parent).confirm(("Disconnect " + playerName))) {
+          if (new ActionConfirmation(parent).confirm(("Disconnect " + userName))) {
             moderatorLobbyClient.disconnectPlayer(playerChatId);
           }
         });

--- a/game-core/src/main/java/games/strategy/net/INode.java
+++ b/game-core/src/main/java/games/strategy/net/INode.java
@@ -3,7 +3,7 @@ package games.strategy.net;
 import java.io.Serializable;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 
 /**
  * A Node in a network.
@@ -18,8 +18,8 @@ public interface INode extends Serializable, Comparable<INode> {
   /** Returns the display/user name for the node. */
   String getName();
 
-  default PlayerName getPlayerName() {
-    return PlayerName.of(getName());
+  default UserName getPlayerName() {
+    return UserName.of(getName());
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/net/IServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/IServerMessenger.java
@@ -4,7 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Set;
 import javax.annotation.Nullable;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 
 /** A server messenger. Additional methods for accepting new connections. */
 public interface IServerMessenger extends IMessenger {
@@ -32,7 +32,7 @@ public interface IServerMessenger extends IMessenger {
    * Returns the hashed MAC address for the user with the specified name or {@code null} if unknown.
    */
   @Nullable
-  String getPlayerMac(PlayerName name);
+  String getPlayerMac(UserName name);
 
   boolean isPlayerBanned(String ip, String mac);
 

--- a/game-core/src/main/java/games/strategy/net/LocalNoOpMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/LocalNoOpMessenger.java
@@ -4,7 +4,7 @@ import java.io.Serializable;
 import java.net.UnknownHostException;
 import java.util.Set;
 import javax.annotation.Nullable;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 
 /** Implementation of {@link IServerMessenger} for a local game server. */
 public class LocalNoOpMessenger implements IServerMessenger {
@@ -77,7 +77,7 @@ public class LocalNoOpMessenger implements IServerMessenger {
   public void banPlayer(final String ip, final String mac) {}
 
   @Override
-  public @Nullable String getPlayerMac(final PlayerName name) {
+  public @Nullable String getPlayerMac(final UserName name) {
     return null;
   }
 

--- a/game-core/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ServerMessenger.java
@@ -28,7 +28,7 @@ import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.java.Log;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 
 /** A Messenger that can have many clients connected to it. */
 @Log
@@ -51,7 +51,7 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
   // all our nodes
   private final Map<INode, SocketChannel> nodeToChannel = new ConcurrentHashMap<>();
   private final Map<SocketChannel, INode> channelToNode = new ConcurrentHashMap<>();
-  private final Map<PlayerName, String> cachedMacAddresses = new ConcurrentHashMap<>();
+  private final Map<UserName, String> cachedMacAddresses = new ConcurrentHashMap<>();
   private final Set<String> miniBannedIpAddresses = new ConcurrentSkipListSet<>();
   private final Set<String> miniBannedMacAddresses = new ConcurrentSkipListSet<>();
 
@@ -117,7 +117,7 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
   }
 
   @Override
-  public @Nullable String getPlayerMac(final PlayerName name) {
+  public @Nullable String getPlayerMac(final UserName name) {
     return cachedMacAddresses.get(name);
   }
 
@@ -126,8 +126,8 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
    * {@code uniquePlayerName} is the node name and may not be identical to the name of the player
    * associated with the node
    */
-  public void notifyPlayerLogin(final PlayerName uniquePlayerName, final String mac) {
-    cachedMacAddresses.put(uniquePlayerName, mac);
+  public void notifyPlayerLogin(final UserName uniqueUserName, final String mac) {
+    cachedMacAddresses.put(uniqueUserName, mac);
   }
 
   private void notifyPlayerRemoval(final INode node) {

--- a/game-core/src/main/java/games/strategy/net/UserNameAssigner.java
+++ b/game-core/src/main/java/games/strategy/net/UserNameAssigner.java
@@ -4,11 +4,11 @@ import com.google.common.base.Preconditions;
 import java.util.Collection;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 
 /** Utility class that will assign a name to a newly logging in player. */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public final class PlayerNameAssigner {
+public final class UserNameAssigner {
 
   /**
    * Returns a node name, based on the specified node name, that is unique across all nodes. The
@@ -21,7 +21,7 @@ public final class PlayerNameAssigner {
    */
   public static String assignName(
       final String desiredName, final String mac, final Collection<String> loggedInNames) {
-    Preconditions.checkArgument(PlayerName.validate(desiredName) == null);
+    Preconditions.checkArgument(UserName.validate(desiredName) == null);
     Preconditions.checkNotNull(mac);
     Preconditions.checkNotNull(loggedInNames);
 

--- a/game-core/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
+++ b/game-core/src/main/java/games/strategy/net/nio/ServerQuarantineConversation.java
@@ -4,8 +4,8 @@ import games.strategy.net.ILoginValidator;
 import games.strategy.net.INode;
 import games.strategy.net.MessageHeader;
 import games.strategy.net.Node;
-import games.strategy.net.PlayerNameAssigner;
 import games.strategy.net.ServerMessenger;
+import games.strategy.net.UserNameAssigner;
 import java.io.Serializable;
 import java.net.InetSocketAddress;
 import java.nio.channels.SocketChannel;
@@ -15,7 +15,7 @@ import java.util.Optional;
 import java.util.logging.Level;
 import java.util.stream.Collectors;
 import lombok.extern.java.Log;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 
 /** Server-side implementation of {@link QuarantineConversation}. */
 @Log
@@ -97,7 +97,7 @@ public class ServerQuarantineConversation extends QuarantineConversation {
                             remoteName,
                             remoteMac,
                             (InetSocketAddress) channel.socket().getRemoteSocketAddress()))
-                    .orElseGet(() -> PlayerName.validate(remoteName));
+                    .orElseGet(() -> UserName.validate(remoteName));
             if (error != null && !error.equals(CHANGE_PASSWORD)) {
               step = Step.ACK_ERROR;
               send(error);
@@ -114,7 +114,7 @@ public class ServerQuarantineConversation extends QuarantineConversation {
             // address)
             final Collection<String> names =
                 serverMessenger.getNodes().stream().map(INode::getName).collect(Collectors.toSet());
-            remoteName = PlayerNameAssigner.assignName(remoteName, remoteMac, names);
+            remoteName = UserNameAssigner.assignName(remoteName, remoteMac, names);
           }
 
           // send the node its assigned name, our name, an error message that could contain a magic
@@ -130,7 +130,7 @@ public class ServerQuarantineConversation extends QuarantineConversation {
               });
 
           // Login succeeded, so notify the ServerMessenger about the login with the name, mac, etc.
-          serverMessenger.notifyPlayerLogin(PlayerName.of(remoteName), remoteMac);
+          serverMessenger.notifyPlayerLogin(UserName.of(remoteName), remoteMac);
           // We are good
           return Action.UNQUARANTINE;
         case ACK_ERROR:

--- a/game-core/src/test/java/games/strategy/engine/chat/ChatFloodControlTest.java
+++ b/game-core/src/test/java/games/strategy/engine/chat/ChatFloodControlTest.java
@@ -4,7 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 
 class ChatFloodControlTest {
   private static final long INITIAL_CLEAR_TIME = 100;
@@ -12,24 +12,24 @@ class ChatFloodControlTest {
 
   @Test
   void testSimple() {
-    assertTrue(testObj.allow(PlayerName.of("a"), System.currentTimeMillis()));
+    assertTrue(testObj.allow(UserName.of("a"), System.currentTimeMillis()));
   }
 
   @Test
   void testDeny() {
     final long now = 123;
     for (int i = 0; i < ChatFloodControl.EVENTS_PER_WINDOW; i++) {
-      assertTrue(testObj.allow(PlayerName.of("a"), now));
+      assertTrue(testObj.allow(UserName.of("a"), now));
     }
-    assertFalse(testObj.allow(PlayerName.of("a"), now));
+    assertFalse(testObj.allow(UserName.of("a"), now));
   }
 
   @Test
   void throttlingReleasedAfterTimePeriod() {
     final long now = 100;
     for (int i = 0; i < 100; i++) {
-      testObj.allow(PlayerName.of("a"), now);
+      testObj.allow(UserName.of("a"), now);
     }
-    assertTrue(testObj.allow(PlayerName.of("a"), INITIAL_CLEAR_TIME + ChatFloodControl.WINDOW + 1));
+    assertTrue(testObj.allow(UserName.of("a"), INITIAL_CLEAR_TIME + ChatFloodControl.WINDOW + 1));
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/chat/ChatIgnoreListTest.java
+++ b/game-core/src/test/java/games/strategy/engine/chat/ChatIgnoreListTest.java
@@ -8,10 +8,10 @@ import java.util.prefs.Preferences;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 
 class ChatIgnoreListTest {
-  private static final PlayerName PLAYER_NAME = PlayerName.of("test");
+  private static final UserName PLAYER_NAME = UserName.of("test");
 
   @BeforeEach
   void setUp() throws BackingStoreException {

--- a/game-core/src/test/java/games/strategy/engine/chat/ChatIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/chat/ChatIntegrationTest.java
@@ -20,8 +20,8 @@ import java.util.stream.IntStream;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.triplea.domain.data.PlayerName;
 import org.triplea.domain.data.SystemId;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
 import org.triplea.http.client.lobby.chat.messages.server.ChatMessage;
 import org.triplea.test.common.Integration;
@@ -196,7 +196,7 @@ final class ChatIntegrationTest {
     final AtomicReference<String> lastMessageReceived = new AtomicReference<>();
 
     @Override
-    public void slapped(final String message, final PlayerName from) {}
+    public void slapped(final String message, final UserName from) {}
 
     @Override
     public void slap(final String message) {}

--- a/game-core/src/test/java/games/strategy/net/UserNameAssignerTest.java
+++ b/game-core/src/test/java/games/strategy/net/UserNameAssignerTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class PlayerNameAssignerTest {
+class UserNameAssignerTest {
 
   private static final String NAME_1 = "name_one";
   private static final String NAME_2 = "name_two";
@@ -25,22 +25,21 @@ class PlayerNameAssignerTest {
   @Test
   void errorCasesWithNullArguments() {
     assertThrows(
-        NullPointerException.class, () -> PlayerNameAssigner.assignName(NAME_1, null, Set.of()));
+        NullPointerException.class, () -> UserNameAssigner.assignName(NAME_1, null, Set.of()));
 
-    assertThrows(
-        NullPointerException.class, () -> PlayerNameAssigner.assignName(NAME_1, MAC, null));
+    assertThrows(NullPointerException.class, () -> UserNameAssigner.assignName(NAME_1, MAC, null));
   }
 
   @Test
   void assignNameShouldGetAssignedNameWhenNotTaken() {
     assertThat(
         "no nodes to match against, we should get the desired name",
-        PlayerNameAssigner.assignName(NAME_1, MAC, Set.of()),
+        UserNameAssigner.assignName(NAME_1, MAC, Set.of()),
         is(NAME_1));
 
     assertThat(
         "name and address do not match, should get the desired name",
-        PlayerNameAssigner.assignName(NAME_1, MAC, List.of(NAME_2)),
+        UserNameAssigner.assignName(NAME_1, MAC, List.of(NAME_2)),
         is(NAME_1));
   }
 
@@ -48,12 +47,12 @@ class PlayerNameAssignerTest {
   void assignNameWithMatchingNames() {
     assertThat(
         "name match, should be assigned a numeral name",
-        PlayerNameAssigner.assignName(NAME_1, MAC, List.of(NAME_1)),
+        UserNameAssigner.assignName(NAME_1, MAC, List.of(NAME_1)),
         is(NAME_1 + " (1)"));
 
     assertThat(
         "name match, matching against multiple nodes",
-        PlayerNameAssigner.assignName(NAME_1, MAC, List.of(NAME_2, NAME_1)),
+        UserNameAssigner.assignName(NAME_1, MAC, List.of(NAME_2, NAME_1)),
         is(NAME_1 + " (1)"));
   }
 
@@ -65,7 +64,7 @@ class PlayerNameAssignerTest {
   void assignNameMultipleNumerals() {
     assertThat(
         "name match, should get next sequential numeral appended",
-        PlayerNameAssigner.assignName(NAME_1, MAC, List.of(NAME_1, NAME_1 + " (1)")),
+        UserNameAssigner.assignName(NAME_1, MAC, List.of(NAME_1, NAME_1 + " (1)")),
         is(NAME_1 + " (2)"));
   }
 
@@ -77,24 +76,22 @@ class PlayerNameAssignerTest {
   void assignNameShouldFillInMissingNumerals() {
     assertThat(
         "name does not actually match",
-        PlayerNameAssigner.assignName(NAME_1, MAC, List.of(NAME_1 + " (1)")),
+        UserNameAssigner.assignName(NAME_1, MAC, List.of(NAME_1 + " (1)")),
         is(NAME_1));
 
     assertThat(
         "name matches and there is gap in numbering",
-        PlayerNameAssigner.assignName(NAME_1, MAC, List.of(NAME_1, NAME_1 + " (2)")),
+        UserNameAssigner.assignName(NAME_1, MAC, List.of(NAME_1, NAME_1 + " (2)")),
         is(NAME_1 + " (1)"));
 
     assertThat(
         "name matches and there is gap in numbering, ordering should not matter",
-        PlayerNameAssigner.assignName(
-            NAME_1, MAC, List.of(NAME_1 + " (3)", NAME_1 + " (1)", NAME_1)),
+        UserNameAssigner.assignName(NAME_1, MAC, List.of(NAME_1 + " (3)", NAME_1 + " (1)", NAME_1)),
         is(NAME_1 + " (2)"));
 
     assertThat(
         "should get next ascending numeral",
-        PlayerNameAssigner.assignName(
-            NAME_1, MAC, List.of(NAME_1 + " (2)", NAME_1 + " (1)", NAME_1)),
+        UserNameAssigner.assignName(NAME_1, MAC, List.of(NAME_1 + " (2)", NAME_1 + " (1)", NAME_1)),
         is(NAME_1 + " (3)"));
   }
 }

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/ChatMessageListeners.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/ChatMessageListeners.java
@@ -4,7 +4,7 @@ import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import lombok.Builder;
 import lombok.Getter;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.messages.server.ChatMessage;
 import org.triplea.http.client.lobby.chat.messages.server.ChatterList;
 import org.triplea.http.client.lobby.chat.messages.server.PlayerSlapped;
@@ -14,7 +14,7 @@ import org.triplea.http.client.lobby.chat.messages.server.StatusUpdate;
 @Getter
 public class ChatMessageListeners {
   @Nonnull private final Consumer<StatusUpdate> playerStatusListener;
-  @Nonnull private final Consumer<PlayerName> playerLeftListener;
+  @Nonnull private final Consumer<UserName> playerLeftListener;
   @Nonnull private final Consumer<ChatParticipant> playerJoinedListener;
   @Nonnull private final Consumer<PlayerSlapped> playerSlappedListener;
   @Nonnull private final Consumer<ChatMessage> chatMessageListener;

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/ChatParticipant.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/ChatParticipant.java
@@ -10,7 +10,7 @@ import lombok.NonNull;
 import lombok.Setter;
 import lombok.ToString;
 import org.triplea.domain.data.PlayerChatId;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 
 @Builder
 @Getter
@@ -19,7 +19,7 @@ import org.triplea.domain.data.PlayerName;
 public class ChatParticipant implements Serializable {
   private static final long serialVersionUID = 7103177780407531008L;
 
-  @NonNull private final PlayerName playerName;
+  @NonNull private final UserName userName;
   /**
    * Identifier attached to players when joining chat so that front-end can pass values to backend
    * to identify players, specifically useful example for moderator actions.

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/ChatParticipant.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/ChatParticipant.java
@@ -14,7 +14,7 @@ import org.triplea.domain.data.UserName;
 
 @Builder
 @Getter
-@EqualsAndHashCode(of = "playerName")
+@EqualsAndHashCode(of = "userName")
 @ToString
 public class ChatParticipant implements Serializable {
   private static final long serialVersionUID = 7103177780407531008L;

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/LobbyChatClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/LobbyChatClient.java
@@ -6,7 +6,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.function.Consumer;
 import org.triplea.domain.data.ApiKey;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.messages.client.ChatClientEnvelopeFactory;
 import org.triplea.http.client.lobby.chat.messages.server.ChatServerMessageType;
 import org.triplea.http.client.web.socket.GenericWebSocketClient;
@@ -44,8 +44,8 @@ public class LobbyChatClient
     setListeners(chatMessageListeners);
   }
 
-  public void slapPlayer(final PlayerName playerName) {
-    getWebSocketClient().send(outboundMessageFactory.slapMessage(playerName));
+  public void slapPlayer(final UserName userName) {
+    getWebSocketClient().send(outboundMessageFactory.slapMessage(userName));
   }
 
   public void sendChatMessage(final String message) {

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/messages/client/ChatClientEnvelopeFactory.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/messages/client/ChatClientEnvelopeFactory.java
@@ -2,7 +2,7 @@ package org.triplea.http.client.lobby.chat.messages.client;
 
 import lombok.AllArgsConstructor;
 import org.triplea.domain.data.ApiKey;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.web.socket.messages.ClientMessageEnvelope;
 
 /**
@@ -15,7 +15,7 @@ import org.triplea.http.client.web.socket.messages.ClientMessageEnvelope;
 public class ChatClientEnvelopeFactory {
   private final ApiKey apiKey;
 
-  public ClientMessageEnvelope slapMessage(final PlayerName playerToSlap) {
+  public ClientMessageEnvelope slapMessage(final UserName playerToSlap) {
     return packageMessage(ChatClientEnvelopeType.SLAP, playerToSlap.getValue());
   }
 

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/messages/server/ChatMessage.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/messages/server/ChatMessage.java
@@ -6,7 +6,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import lombok.Value;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 
 @Value
 public class ChatMessage {
@@ -14,10 +14,10 @@ public class ChatMessage {
   @VisibleForTesting static final int MAX_LINE_LENGTH = 100;
   @VisibleForTesting static final String ELLIPSES = "..";
 
-  private final PlayerName from;
+  private final UserName from;
   private final String message;
 
-  public ChatMessage(final PlayerName from, final String message) {
+  public ChatMessage(final UserName from, final String message) {
     this.from = Preconditions.checkNotNull(from);
     this.message =
         Joiner.on("\n")

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/messages/server/ChatServerEnvelopeFactory.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/messages/server/ChatServerEnvelopeFactory.java
@@ -2,7 +2,7 @@ package org.triplea.http.client.lobby.chat.messages.server;
 
 import java.util.List;
 import lombok.experimental.UtilityClass;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
 import org.triplea.http.client.web.socket.messages.ServerMessageEnvelope;
 
@@ -24,7 +24,7 @@ public class ChatServerEnvelopeFactory {
         ChatServerMessageType.PLAYER_JOINED.toString(), chatParticipant);
   }
 
-  public ServerMessageEnvelope newPlayerLeft(final PlayerName playerLeft) {
+  public ServerMessageEnvelope newPlayerLeft(final UserName playerLeft) {
     return ServerMessageEnvelope.packageMessage(
         ChatServerMessageType.PLAYER_LEFT.toString(), playerLeft);
   }

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/messages/server/ChatServerMessageType.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/messages/server/ChatServerMessageType.java
@@ -4,7 +4,7 @@ import static org.triplea.http.client.web.socket.messages.MessageTypeListenerBin
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.ChatMessageListeners;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
 import org.triplea.http.client.web.socket.messages.MessageTypeListenerBinding;
@@ -18,7 +18,7 @@ public enum ChatServerMessageType implements WebsocketMessageType<ChatMessageLis
   CHAT_EVENT(newBinding(String.class, ChatMessageListeners::getChatEventListener)),
   CHAT_MESSAGE(newBinding(ChatMessage.class, ChatMessageListeners::getChatMessageListener)),
   PLAYER_JOINED(newBinding(ChatParticipant.class, ChatMessageListeners::getPlayerJoinedListener)),
-  PLAYER_LEFT(newBinding(PlayerName.class, ChatMessageListeners::getPlayerLeftListener)),
+  PLAYER_LEFT(newBinding(UserName.class, ChatMessageListeners::getPlayerLeftListener)),
   PLAYER_LISTING(newBinding(ChatterList.class, ChatMessageListeners::getConnectedListener)),
   PLAYER_SLAPPED(newBinding(PlayerSlapped.class, ChatMessageListeners::getPlayerSlappedListener)),
   SERVER_ERROR(newBinding(String.class, ChatMessageListeners::getServerErrorListener)),

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/messages/server/PlayerSlapped.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/messages/server/PlayerSlapped.java
@@ -3,12 +3,12 @@ package org.triplea.http.client.lobby.chat.messages.server;
 import javax.annotation.Nonnull;
 import lombok.Builder;
 import lombok.Value;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 
 /** Payload indicating someone slapped another other player (that was not the local player). */
 @Builder
 @Value
 public class PlayerSlapped {
-  @Nonnull private final PlayerName slapper;
-  @Nonnull private final PlayerName slapped;
+  @Nonnull private final UserName slapper;
+  @Nonnull private final UserName slapped;
 }

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/chat/messages/server/StatusUpdate.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/chat/messages/server/StatusUpdate.java
@@ -1,10 +1,10 @@
 package org.triplea.http.client.lobby.chat.messages.server;
 
 import lombok.Value;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 
 @Value
 public class StatusUpdate {
-  private final PlayerName playerName;
+  private final UserName userName;
   private final String status;
 }

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/chat/LobbyChatClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/chat/LobbyChatClientTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.domain.data.PlayerChatId;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.messages.client.ChatClientEnvelopeFactory;
 import org.triplea.http.client.lobby.chat.messages.server.ChatMessage;
 import org.triplea.http.client.lobby.chat.messages.server.ChatServerEnvelopeFactory;
@@ -28,19 +28,19 @@ import org.triplea.http.client.web.socket.messages.ClientMessageEnvelope;
 @ExtendWith(MockitoExtension.class)
 class LobbyChatClientTest {
 
-  private static final PlayerName PLAYER_NAME = PlayerName.of("player_name");
+  private static final UserName PLAYER_NAME = UserName.of("player_name");
   private static final String MESSAGE = "message";
   private static final String STATUS = "status";
 
   private static final ChatterList chatters = new ChatterList(List.of());
   private static final ChatParticipant CHAT_PARTICIPANT =
       ChatParticipant.builder()
-          .playerName(PlayerName.of("player-name"))
+          .userName(UserName.of("player-name"))
           .playerChatId(PlayerChatId.newId())
           .build();
   private static final StatusUpdate STATUS_UPDATE = new StatusUpdate(PLAYER_NAME, "");
   private static final PlayerSlapped PLAYER_SLAPPED =
-      PlayerSlapped.builder().slapper(PLAYER_NAME).slapped(PlayerName.of("slapped")).build();
+      PlayerSlapped.builder().slapper(PLAYER_NAME).slapped(UserName.of("slapped")).build();
   private static final ChatMessage CHAT_MESSAGE = new ChatMessage(PLAYER_NAME, "message");
 
   @Mock private GenericWebSocketClient webSocketClient;
@@ -49,7 +49,7 @@ class LobbyChatClientTest {
 
   @Mock private ClientMessageEnvelope clientEnvelope;
   @Mock private Consumer<StatusUpdate> playerStatusListener;
-  @Mock private Consumer<PlayerName> playerLeftListener;
+  @Mock private Consumer<UserName> playerLeftListener;
   @Mock private Consumer<ChatParticipant> playerJoinedListener;
   @Mock private Consumer<PlayerSlapped> playerSlappedListener;
   @Mock private Consumer<ChatMessage> chatMessageListener;

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/chat/messages/server/ChatMessageTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/chat/messages/server/ChatMessageTest.java
@@ -8,7 +8,7 @@ import static org.hamcrest.core.StringEndsWith.endsWith;
 import com.google.common.base.Strings;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 
 class ChatMessageTest {
 
@@ -74,6 +74,6 @@ class ChatMessageTest {
   }
 
   private static String chatMessage(final String inputMessage) {
-    return new ChatMessage(PlayerName.of("player-name"), inputMessage).getMessage();
+    return new ChatMessage(UserName.of("player-name"), inputMessage).getMessage();
   }
 }

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/chat/messages/server/ChatServerEnvelopeFactoryTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/chat/messages/server/ChatServerEnvelopeFactoryTest.java
@@ -6,7 +6,7 @@ import static org.hamcrest.core.IsNull.notNullValue;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
 import org.triplea.http.client.web.socket.messages.ServerMessageEnvelope;
 
@@ -14,14 +14,14 @@ class ChatServerEnvelopeFactoryTest {
   private static final String STATUS = "status";
   private static final String MESSAGE = "message";
 
-  private static final PlayerName PLAYER_NAME = PlayerName.of("player");
+  private static final UserName PLAYER_NAME = UserName.of("player");
   private static final ChatParticipant CHAT_PARTICIPANT =
-      ChatParticipant.builder().playerName(PLAYER_NAME).isModerator(true).build();
+      ChatParticipant.builder().userName(PLAYER_NAME).isModerator(true).build();
 
   private static final StatusUpdate STATUS_UPDATE = new StatusUpdate(PLAYER_NAME, STATUS);
   private static final ChatMessage CHAT_MESSAGE = new ChatMessage(PLAYER_NAME, MESSAGE);
   private static final PlayerSlapped PLAYER_SLAPPED =
-      PlayerSlapped.builder().slapper(PLAYER_NAME).slapped(PlayerName.of("slapped")).build();
+      PlayerSlapped.builder().slapper(PLAYER_NAME).slapped(UserName.of("slapped")).build();
   private static final ChatterList PLAYER_LISTING = new ChatterList(List.of(CHAT_PARTICIPANT));
 
   @Test
@@ -51,7 +51,7 @@ class ChatServerEnvelopeFactoryTest {
 
     assertThat(
         serverEventEnvelope.getMessageType(), is(ChatServerMessageType.PLAYER_LEFT.toString()));
-    assertThat(serverEventEnvelope.getPayload(PlayerName.class), is(PLAYER_NAME));
+    assertThat(serverEventEnvelope.getPayload(UserName.class), is(PLAYER_NAME));
   }
 
   @Test

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/chat/messages/server/ChatServerMessageTypeTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/chat/messages/server/ChatServerMessageTypeTest.java
@@ -20,25 +20,25 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.domain.data.PlayerChatId;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.ChatMessageListeners;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
 
 @ExtendWith(MockitoExtension.class)
 class ChatServerMessageTypeTest {
   private static final StatusUpdate STATUS_UPDATE =
-      new StatusUpdate(PlayerName.of("player"), "value");
+      new StatusUpdate(UserName.of("player"), "value");
   private static final ChatMessage CHAT_MESSAGE_DATA =
-      new ChatMessage(PlayerName.of("player"), "message");
+      new ChatMessage(UserName.of("player"), "message");
   private static final PlayerSlapped PLAYER_SLAPPED_DATA =
       PlayerSlapped.builder()
-          .slapped(PlayerName.of("slapped"))
-          .slapper(PlayerName.of("slapper"))
+          .slapped(UserName.of("slapped"))
+          .slapper(UserName.of("slapper"))
           .build();
-  private static final PlayerName PLAYER_LEFT_DATA = PlayerName.of("player");
+  private static final UserName PLAYER_LEFT_DATA = UserName.of("player");
   private static final ChatParticipant PLAYER_JOINED_DATA =
       ChatParticipant.builder()
-          .playerName(PlayerName.of("player-name"))
+          .userName(UserName.of("player-name"))
           .playerChatId(PlayerChatId.newId())
           .build();
 
@@ -47,7 +47,7 @@ class ChatServerMessageTypeTest {
   @Mock private Consumer<StatusUpdate> playerStatusListener;
   @Mock private Consumer<ChatMessage> chatMessageListener;
   @Mock private Consumer<PlayerSlapped> playerSlappedListener;
-  @Mock private Consumer<PlayerName> playerLeftListener;
+  @Mock private Consumer<UserName> playerLeftListener;
   @Mock private Consumer<ChatParticipant> playerJoinedListener;
   @Mock private Consumer<ChatterList> connectedListener;
 

--- a/http-server/src/main/java/org/triplea/lobby/server/db/dao/api/key/GamePlayerLookup.java
+++ b/http-server/src/main/java/org/triplea/lobby/server/db/dao/api/key/GamePlayerLookup.java
@@ -5,8 +5,8 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.jdbi.v3.core.mapper.RowMapper;
-import org.triplea.domain.data.PlayerName;
 import org.triplea.domain.data.SystemId;
+import org.triplea.domain.data.UserName;
 
 @Getter
 @Builder
@@ -16,14 +16,14 @@ public class GamePlayerLookup {
   static final String SYSTEM_ID_COLUMN = "system_id";
   static final String IP_COLUMN = "ip";
 
-  @Nonnull private final PlayerName playerName;
+  @Nonnull private final UserName userName;
   @Nonnull private final SystemId systemId;
   @Nonnull private final String ip;
 
   public static RowMapper<GamePlayerLookup> buildResultMapper() {
     return (rs, ctx) ->
         GamePlayerLookup.builder()
-            .playerName(PlayerName.of(rs.getString(PLAYER_NAME_COLUMN)))
+            .userName(UserName.of(rs.getString(PLAYER_NAME_COLUMN)))
             .systemId(SystemId.of(rs.getString(SYSTEM_ID_COLUMN)))
             .ip(rs.getString(IP_COLUMN))
             .build();

--- a/http-server/src/main/java/org/triplea/lobby/server/db/dao/api/key/LobbyApiKeyDaoWrapper.java
+++ b/http-server/src/main/java/org/triplea/lobby/server/db/dao/api/key/LobbyApiKeyDaoWrapper.java
@@ -13,8 +13,8 @@ import lombok.AllArgsConstructor;
 import org.jdbi.v3.core.Jdbi;
 import org.triplea.domain.data.ApiKey;
 import org.triplea.domain.data.PlayerChatId;
-import org.triplea.domain.data.PlayerName;
 import org.triplea.domain.data.SystemId;
+import org.triplea.domain.data.UserName;
 import org.triplea.java.Postconditions;
 import org.triplea.lobby.server.db.dao.UserJdbiDao;
 import org.triplea.lobby.server.db.dao.UserRoleDao;
@@ -67,23 +67,23 @@ public class LobbyApiKeyDaoWrapper {
 
   /** Creates (and stores in DB) a new API key for registered or anonymous users. */
   public ApiKey newKey(
-      final PlayerName playerName,
+      final UserName userName,
       final InetAddress ip,
       final SystemId systemId,
       final PlayerChatId playerChatId) {
-    Preconditions.checkNotNull(playerName);
+    Preconditions.checkNotNull(userName);
     Preconditions.checkNotNull(ip);
 
     final ApiKey key = keyMaker.get();
 
     userJdbiDao
-        .lookupUserIdAndRoleIdByUserName(playerName.getValue())
+        .lookupUserIdAndRoleIdByUserName(userName.getValue())
         .ifPresentOrElse(
             userRoleLookup -> {
               // insert key for registered user
               insertKey(
                   userRoleLookup.getUserId(),
-                  playerName.getValue(),
+                  userName.getValue(),
                   key,
                   ip,
                   systemId,
@@ -94,13 +94,7 @@ public class LobbyApiKeyDaoWrapper {
               // insert key for anonymous user
               final int anonymousUserRoleId = userRoleDao.lookupRoleId(UserRole.ANONYMOUS);
               insertKey(
-                  null,
-                  playerName.getValue(),
-                  key,
-                  ip,
-                  systemId,
-                  playerChatId,
-                  anonymousUserRoleId);
+                  null, userName.getValue(), key, ip, systemId, playerChatId, anonymousUserRoleId);
             });
     return key;
   }

--- a/http-server/src/main/java/org/triplea/server/lobby/chat/ChatParticipantAdapter.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/chat/ChatParticipantAdapter.java
@@ -2,7 +2,7 @@ package org.triplea.server.lobby.chat;
 
 import java.util.function.Function;
 import org.triplea.domain.data.PlayerChatId;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
 import org.triplea.lobby.server.db.dao.api.key.UserWithRoleRecord;
 import org.triplea.lobby.server.db.data.UserRole;
@@ -11,7 +11,7 @@ public class ChatParticipantAdapter implements Function<UserWithRoleRecord, Chat
   @Override
   public ChatParticipant apply(final UserWithRoleRecord userWithRoleRecord) {
     return ChatParticipant.builder()
-        .playerName(PlayerName.of(userWithRoleRecord.getUsername()))
+        .userName(UserName.of(userWithRoleRecord.getUsername()))
         .isModerator(
             userWithRoleRecord.getRole().equals(UserRole.ADMIN)
                 || userWithRoleRecord.getRole().equals(UserRole.MODERATOR))

--- a/http-server/src/main/java/org/triplea/server/lobby/chat/event/processing/ChatEventProcessor.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/chat/event/processing/ChatEventProcessor.java
@@ -5,7 +5,7 @@ import java.util.List;
 import java.util.Optional;
 import javax.websocket.Session;
 import lombok.AllArgsConstructor;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
 import org.triplea.http.client.lobby.chat.messages.client.ChatClientEnvelopeType;
 import org.triplea.http.client.lobby.chat.messages.server.ChatMessage;
@@ -72,24 +72,24 @@ public class ChatEventProcessor {
 
   private ServerResponse playerSlappedMessage(
       final ChatParticipant sender, final ClientMessageEnvelope clientMessageEnvelope) {
-    final PlayerName slapped = PlayerName.of(clientMessageEnvelope.getPayload());
+    final UserName slapped = UserName.of(clientMessageEnvelope.getPayload());
     return ServerResponse.broadcast(
         ChatServerEnvelopeFactory.newSlap(
-            PlayerSlapped.builder().slapper(sender.getPlayerName()).slapped(slapped).build()));
+            PlayerSlapped.builder().slapper(sender.getUserName()).slapped(slapped).build()));
   }
 
   private ServerResponse chatMessage(
       final ChatParticipant sender, final ClientMessageEnvelope clientMessageEnvelope) {
     return ServerResponse.broadcast(
         ChatServerEnvelopeFactory.newChatMessage(
-            new ChatMessage(sender.getPlayerName(), clientMessageEnvelope.getPayload())));
+            new ChatMessage(sender.getUserName(), clientMessageEnvelope.getPayload())));
   }
 
   private ServerResponse statusUpdateMessage(
       final ChatParticipant sender, final ClientMessageEnvelope clientMessageEnvelope) {
     return ServerResponse.broadcast(
         ChatServerEnvelopeFactory.newStatusUpdate(
-            new StatusUpdate(sender.getPlayerName(), clientMessageEnvelope.getPayload())));
+            new StatusUpdate(sender.getUserName(), clientMessageEnvelope.getPayload())));
   }
 
   public Optional<ServerMessageEnvelope> disconnect(final Session session) {

--- a/http-server/src/main/java/org/triplea/server/lobby/chat/event/processing/Chatters.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/chat/event/processing/Chatters.java
@@ -15,7 +15,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
 
 @Slf4j
@@ -32,10 +32,10 @@ public class Chatters {
   @Getter(value = AccessLevel.PACKAGE, onMethod_ = @VisibleForTesting)
   private final Map<String, ChatterSession> participants = new HashMap<>();
 
-  Optional<PlayerName> removeSession(final Session session) {
+  Optional<UserName> removeSession(final Session session) {
     return Optional.ofNullable(participants.remove(session.getId()))
         .map(ChatterSession::getChatParticipant)
-        .map(ChatParticipant::getPlayerName);
+        .map(ChatParticipant::getUserName);
   }
 
   void put(final Session session, final ChatParticipant chatter) {
@@ -48,11 +48,11 @@ public class Chatters {
         .collect(Collectors.toSet());
   }
 
-  public boolean hasPlayer(final PlayerName playerName) {
+  public boolean hasPlayer(final UserName userName) {
     return participants.values().stream()
         .map(ChatterSession::getChatParticipant)
-        .map(ChatParticipant::getPlayerName)
-        .anyMatch(playerName::equals);
+        .map(ChatParticipant::getUserName)
+        .anyMatch(userName::equals);
   }
 
   public Collection<Session> fetchOpenSessions() {
@@ -68,16 +68,15 @@ public class Chatters {
    * Disconnects all sessions belonging to a given player identified by name. A disconnected session
    * is closed, the closure will trigger a notification on the client of the disconnected player.
    *
-   * @param playerName The name of the player whose sessions will be disconnected.
+   * @param userName The name of the player whose sessions will be disconnected.
    * @param disconnectMessage Message that will be displayed to the disconnected player.
    */
-  public void disconnectPlayerSessions(
-      final PlayerName playerName, final String disconnectMessage) {
+  public void disconnectPlayerSessions(final UserName userName, final String disconnectMessage) {
     final Set<Session> sessions =
         participants.values().stream()
             .filter(
                 chatterSession ->
-                    chatterSession.getChatParticipant().getPlayerName().equals(playerName))
+                    chatterSession.getChatParticipant().getUserName().equals(userName))
             .map(ChatterSession::getSession)
             .collect(Collectors.toSet());
 

--- a/http-server/src/main/java/org/triplea/server/lobby/chat/moderation/ModeratorActionPersistence.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/chat/moderation/ModeratorActionPersistence.java
@@ -23,7 +23,7 @@ class ModeratorActionPersistence {
       final BanPlayerRequest banPlayerRequest) {
     userBanDao.addBan(
         UUID.randomUUID().toString(),
-        gamePlayerLookup.getPlayerName().getValue(),
+        gamePlayerLookup.getUserName().getValue(),
         gamePlayerLookup.getSystemId().getValue(),
         gamePlayerLookup.getIp(),
         banPlayerRequest.getBanMinutes());
@@ -32,7 +32,7 @@ class ModeratorActionPersistence {
             .moderatorUserId(moderatorId)
             .actionName(AuditAction.BAN_USER)
             .actionTarget(
-                gamePlayerLookup.getPlayerName().getValue()
+                gamePlayerLookup.getUserName().getValue()
                     + " "
                     + BanDurationFormatter.formatBanMinutes(banPlayerRequest.getBanMinutes()))
             .build());
@@ -43,7 +43,7 @@ class ModeratorActionPersistence {
         ModeratorAuditHistoryDao.AuditArgs.builder()
             .moderatorUserId(moderatorId)
             .actionName(AuditAction.DISCONNECT_USER)
-            .actionTarget(gamePlayerLookup.getPlayerName().getValue())
+            .actionTarget(gamePlayerLookup.getUserName().getValue())
             .build());
   }
 }

--- a/http-server/src/main/java/org/triplea/server/lobby/chat/moderation/ModeratorChatService.java
+++ b/http-server/src/main/java/org/triplea/server/lobby/chat/moderation/ModeratorChatService.java
@@ -3,7 +3,7 @@ package org.triplea.server.lobby.chat.moderation;
 import javax.annotation.Nonnull;
 import lombok.Builder;
 import org.triplea.domain.data.PlayerChatId;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.IpAddressParser;
 import org.triplea.http.client.lobby.chat.messages.server.ChatServerEnvelopeFactory;
 import org.triplea.http.client.lobby.moderator.BanDurationFormatter;
@@ -35,11 +35,11 @@ class ModeratorChatService {
     lookupUpPlayer(PlayerChatId.of(banPlayerRequest.getPlayerChatId()));
 
     chatters.disconnectPlayerSessions(
-        gamePlayerLookup.getPlayerName(), playerBannedMessage(banPlayerRequest));
+        gamePlayerLookup.getUserName(), playerBannedMessage(banPlayerRequest));
     messageBroadcaster.accept(
         chatters.fetchOpenSessions(),
         ChatServerEnvelopeFactory.newEventMessage(
-            playerBannedNotification(gamePlayerLookup.getPlayerName(), banPlayerRequest)));
+            playerBannedNotification(gamePlayerLookup.getUserName(), banPlayerRequest)));
 
     remoteActionsEventQueue.addPlayerBannedEvent(
         IpAddressParser.fromString(gamePlayerLookup.getIp()));
@@ -60,10 +60,10 @@ class ModeratorChatService {
   }
 
   private static String playerBannedNotification(
-      final PlayerName bannedPlayerName, final BanPlayerRequest banPlayerRequest) {
+      final UserName bannedUserName, final BanPlayerRequest banPlayerRequest) {
     return String.format(
         "%s violated lobby rules and was banned for %s",
-        bannedPlayerName, BanDurationFormatter.formatBanMinutes(banPlayerRequest.getBanMinutes()));
+        bannedUserName, BanDurationFormatter.formatBanMinutes(banPlayerRequest.getBanMinutes()));
   }
 
   /**
@@ -72,12 +72,11 @@ class ModeratorChatService {
    */
   void disconnectPlayer(final int moderatorId, final PlayerChatId playerChatId) {
     final GamePlayerLookup gamePlayerLookup = lookupUpPlayer(playerChatId);
-    chatters.disconnectPlayerSessions(
-        gamePlayerLookup.getPlayerName(), "Disconnected by moderator");
+    chatters.disconnectPlayerSessions(gamePlayerLookup.getUserName(), "Disconnected by moderator");
     messageBroadcaster.accept(
         chatters.fetchOpenSessions(),
         ChatServerEnvelopeFactory.newEventMessage(
-            gamePlayerLookup.getPlayerName() + " was disconnected by moderator"));
+            gamePlayerLookup.getUserName() + " was disconnected by moderator"));
     moderatorActionPersistence.recordPlayerDisconnect(moderatorId, gamePlayerLookup);
   }
 }

--- a/http-server/src/main/java/org/triplea/server/moderator/toolbox/banned/users/UserBanService.java
+++ b/http-server/src/main/java/org/triplea/server/moderator/toolbox/banned/users/UserBanService.java
@@ -5,7 +5,7 @@ import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import lombok.Builder;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.IpAddressParser;
 import org.triplea.http.client.lobby.moderator.toolbox.banned.user.UserBanData;
 import org.triplea.http.client.lobby.moderator.toolbox.banned.user.UserBanParams;
@@ -76,7 +76,7 @@ public class UserBanService {
     }
 
     chatters.disconnectPlayerSessions(
-        PlayerName.of(banUserParams.getUsername()),
+        UserName.of(banUserParams.getUsername()),
         "You have been banned for " + banUserParams.getHoursToBan() + " hours");
 
     remoteActionsEventQueue.addPlayerBannedEvent(IpAddressParser.fromString(banUserParams.getIp()));

--- a/http-server/src/main/java/org/triplea/server/user/account/create/CreateAccountControllerFactory.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/create/CreateAccountControllerFactory.java
@@ -3,7 +3,7 @@ package org.triplea.server.user.account.create;
 import java.util.Optional;
 import lombok.experimental.UtilityClass;
 import org.jdbi.v3.core.Jdbi;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.lobby.server.db.dao.BadWordsDao;
 import org.triplea.lobby.server.db.dao.UserJdbiDao;
 import org.triplea.server.user.account.NameValidation;
@@ -27,7 +27,7 @@ public class CreateAccountControllerFactory {
                             NameValidation.builder()
                                 .userJdbiDao(jdbi.onDemand(UserJdbiDao.class))
                                 .syntaxValidation(
-                                    name -> Optional.ofNullable(PlayerName.validate(name)))
+                                    name -> Optional.ofNullable(UserName.validate(name)))
                                 .badWordsDao(jdbi.onDemand(BadWordsDao.class))
                                 .build())
                         .emailValidator(new EmailValidation())

--- a/http-server/src/main/java/org/triplea/server/user/account/login/AccessLogUpdater.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/login/AccessLogUpdater.java
@@ -16,11 +16,11 @@ class AccessLogUpdater implements Consumer<LoginRecord> {
     final int updateCount =
         loginRecord.isRegistered()
             ? accessLogDao.insertRegisteredUserRecord(
-                loginRecord.getPlayerName().getValue(),
+                loginRecord.getUserName().getValue(),
                 loginRecord.getIp(),
                 loginRecord.getSystemId().getValue())
             : accessLogDao.insertAnonymousUserRecord(
-                loginRecord.getPlayerName().getValue(),
+                loginRecord.getUserName().getValue(),
                 loginRecord.getIp(),
                 loginRecord.getSystemId().getValue());
 

--- a/http-server/src/main/java/org/triplea/server/user/account/login/ApiKeyGenerator.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/login/ApiKeyGenerator.java
@@ -18,7 +18,7 @@ class ApiKeyGenerator implements Function<LoginRecord, ApiKey> {
   public ApiKey apply(final LoginRecord loginRecord) {
     try {
       return apiKeyDaoWrapper.newKey(
-          loginRecord.getPlayerName(),
+          loginRecord.getUserName(),
           InetAddress.getByName(loginRecord.getIp()),
           loginRecord.getSystemId(),
           loginRecord.getPlayerChatId());

--- a/http-server/src/main/java/org/triplea/server/user/account/login/LoginModule.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/login/LoginModule.java
@@ -9,8 +9,8 @@ import javax.annotation.Nonnull;
 import lombok.Builder;
 import org.triplea.domain.data.ApiKey;
 import org.triplea.domain.data.PlayerChatId;
-import org.triplea.domain.data.PlayerName;
 import org.triplea.domain.data.SystemId;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.login.LobbyLoginResponse;
 import org.triplea.http.client.lobby.login.LoginRequest;
 import org.triplea.lobby.server.db.dao.UserJdbiDao;
@@ -20,7 +20,7 @@ import org.triplea.lobby.server.db.data.UserRole;
 class LoginModule {
   @Nonnull private Predicate<LoginRequest> registeredLogin;
   @Nonnull private Predicate<LoginRequest> tempPasswordLogin;
-  @Nonnull private Function<PlayerName, Optional<String>> anonymousLogin;
+  @Nonnull private Function<UserName, Optional<String>> anonymousLogin;
   @Nonnull private Consumer<LoginRecord> accessLogUpdater;
   @Nonnull private final Function<LoginRecord, ApiKey> apiKeyGenerator;
   @Nonnull private final UserJdbiDao userJdbiDao;
@@ -34,7 +34,7 @@ class LoginModule {
     }
 
     final SystemId playerSystemId = SystemId.of(systemId);
-    final String nameValidation = PlayerName.validate(loginRequest.getName());
+    final String nameValidation = UserName.validate(loginRequest.getName());
     if (nameValidation != null) {
       return LobbyLoginResponse.builder().failReason("Invalid name: " + nameValidation).build();
     }
@@ -64,7 +64,7 @@ class LoginModule {
           .build();
     } else { // anonymous login
       final Optional<String> errorMessage =
-          anonymousLogin.apply(PlayerName.of(loginRequest.getName()));
+          anonymousLogin.apply(UserName.of(loginRequest.getName()));
       if (errorMessage.isPresent()) {
         return LobbyLoginResponse.builder().failReason(errorMessage.get()).build();
       } else {
@@ -102,7 +102,7 @@ class LoginModule {
       final boolean isRegistered) {
     final var loginRecord =
         LoginRecord.builder()
-            .playerName(PlayerName.of(loginRequest.getName()))
+            .userName(UserName.of(loginRequest.getName()))
             .systemId(systemId)
             .playerChatId(playerchatId)
             .ip(ip)

--- a/http-server/src/main/java/org/triplea/server/user/account/login/LoginRecord.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/login/LoginRecord.java
@@ -4,13 +4,13 @@ import javax.annotation.Nonnull;
 import lombok.Builder;
 import lombok.Value;
 import org.triplea.domain.data.PlayerChatId;
-import org.triplea.domain.data.PlayerName;
 import org.triplea.domain.data.SystemId;
+import org.triplea.domain.data.UserName;
 
 @Builder
 @Value
 public class LoginRecord {
-  @Nonnull private final PlayerName playerName;
+  @Nonnull private final UserName userName;
   @Nonnull private String ip;
   @Nonnull private final SystemId systemId;
   @Nonnull private final PlayerChatId playerChatId;

--- a/http-server/src/main/java/org/triplea/server/user/account/login/authorizer/anonymous/AnonymousLogin.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/login/authorizer/anonymous/AnonymousLogin.java
@@ -6,12 +6,12 @@ import java.util.function.Function;
 import javax.annotation.Nonnull;
 import lombok.Builder;
 import lombok.NonNull;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.lobby.server.db.dao.UserJdbiDao;
 import org.triplea.server.lobby.chat.event.processing.Chatters;
 
 @Builder
-class AnonymousLogin implements Function<PlayerName, Optional<String>> {
+class AnonymousLogin implements Function<UserName, Optional<String>> {
   @NonNull private final Chatters chatters;
   @Nonnull private final UserJdbiDao userJdbiDao;
 
@@ -19,10 +19,10 @@ class AnonymousLogin implements Function<PlayerName, Optional<String>> {
   // TODO: Project#12 banned username check
 
   @Override
-  public Optional<String> apply(final PlayerName playerName) {
-    Preconditions.checkNotNull(playerName);
-    return (!chatters.hasPlayer(playerName)
-            && userJdbiDao.lookupUserIdByName(playerName.getValue()).isEmpty())
+  public Optional<String> apply(final UserName userName) {
+    Preconditions.checkNotNull(userName);
+    return (!chatters.hasPlayer(userName)
+            && userJdbiDao.lookupUserIdByName(userName.getValue()).isEmpty())
         ? Optional.empty()
         : Optional.of("Name is already in use, please choose another");
   }

--- a/http-server/src/main/java/org/triplea/server/user/account/login/authorizer/anonymous/AnonymousLoginFactory.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/login/authorizer/anonymous/AnonymousLoginFactory.java
@@ -4,14 +4,14 @@ import java.util.Optional;
 import java.util.function.Function;
 import lombok.experimental.UtilityClass;
 import org.jdbi.v3.core.Jdbi;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.lobby.server.db.dao.UserJdbiDao;
 import org.triplea.server.lobby.chat.event.processing.Chatters;
 
 @UtilityClass
 public class AnonymousLoginFactory {
 
-  public static Function<PlayerName, Optional<String>> build(
+  public static Function<UserName, Optional<String>> build(
       final Jdbi jdbi, final Chatters chatters) {
     return AnonymousLogin.builder()
         .chatters(chatters)

--- a/http-server/src/main/java/org/triplea/server/user/account/login/authorizer/legacy/LegacyPasswordCheck.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/login/authorizer/legacy/LegacyPasswordCheck.java
@@ -3,18 +3,18 @@ package org.triplea.server.user.account.login.authorizer.legacy;
 import java.util.function.BiPredicate;
 import lombok.Builder;
 import lombok.NonNull;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.lobby.server.db.dao.UserJdbiDao;
 
 @Builder
-public class LegacyPasswordCheck implements BiPredicate<PlayerName, String> {
+public class LegacyPasswordCheck implements BiPredicate<UserName, String> {
 
   @NonNull private final UserJdbiDao userJdbiDao;
 
   @Override
-  public boolean test(final PlayerName playerName, final String plainTextPassword) {
+  public boolean test(final UserName userName, final String plainTextPassword) {
     return userJdbiDao
-        .getLegacyPassword(playerName.getValue())
+        .getLegacyPassword(userName.getValue())
         .map(
             legacyDbPassword -> {
               final String salt = Md5Crypt.getSalt(legacyDbPassword);

--- a/http-server/src/main/java/org/triplea/server/user/account/login/authorizer/legacy/LegacyPasswordUpdate.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/login/authorizer/legacy/LegacyPasswordUpdate.java
@@ -6,29 +6,29 @@ import java.util.function.BiConsumer;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
 import lombok.Builder;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.java.Postconditions;
 import org.triplea.lobby.server.db.dao.UserJdbiDao;
 
 // TODO: Md5-Deprecation - This class can be removed when MD5 is removed
 @Builder
-public class LegacyPasswordUpdate implements BiConsumer<PlayerName, String> {
+public class LegacyPasswordUpdate implements BiConsumer<UserName, String> {
 
   @Nonnull private final UserJdbiDao userJdbiDao;
   @Nonnull private final Function<String, String> passwordBcrypter;
 
   @Override
-  public void accept(final PlayerName playerName, final String password) {
+  public void accept(final UserName userName, final String password) {
     Preconditions.checkNotNull(Strings.emptyToNull(password));
-    Preconditions.checkNotNull(playerName);
+    Preconditions.checkNotNull(userName);
 
     final int id =
         userJdbiDao
-            .lookupUserIdByName(playerName.getValue())
-            .orElseThrow(() -> new IllegalArgumentException("No user id found for: " + playerName));
+            .lookupUserIdByName(userName.getValue())
+            .orElseThrow(() -> new IllegalArgumentException("No user id found for: " + userName));
     Postconditions.assertState(id > 0);
 
     final int updateCount = userJdbiDao.updatePassword(id, passwordBcrypter.apply(password));
-    Postconditions.assertState(updateCount == 1, "Password update failed: " + playerName);
+    Postconditions.assertState(updateCount == 1, "Password update failed: " + userName);
   }
 }

--- a/http-server/src/main/java/org/triplea/server/user/account/login/authorizer/registered/PasswordCheck.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/login/authorizer/registered/PasswordCheck.java
@@ -5,20 +5,20 @@ import com.google.common.base.Strings;
 import java.util.function.BiPredicate;
 import javax.annotation.Nonnull;
 import lombok.Builder;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.lobby.server.db.dao.UserJdbiDao;
 
 @Builder
-public class PasswordCheck implements BiPredicate<PlayerName, String> {
+public class PasswordCheck implements BiPredicate<UserName, String> {
 
   @Nonnull private final UserJdbiDao userJdbiDao;
   @Nonnull private final BiPredicate<String, String> passwordVerifier;
 
   @Override
-  public boolean test(final PlayerName playerName, final String password) {
+  public boolean test(final UserName userName, final String password) {
     Preconditions.checkNotNull(Strings.emptyToNull(password));
     return userJdbiDao
-        .getPassword(playerName.getValue())
+        .getPassword(userName.getValue())
         .map(dbPassword -> passwordVerifier.test(password, dbPassword))
         .orElse(false);
   }

--- a/http-server/src/main/java/org/triplea/server/user/account/login/authorizer/registered/RegisteredLogin.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/login/authorizer/registered/RegisteredLogin.java
@@ -6,15 +6,15 @@ import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
 import lombok.Builder;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.login.LoginRequest;
 
 @Builder
 public class RegisteredLogin implements Predicate<LoginRequest> {
 
-  @Nonnull private final BiPredicate<PlayerName, String> passwordCheck;
-  @Nonnull private final BiPredicate<PlayerName, String> legacyPasswordCheck;
-  @Nonnull private final BiConsumer<PlayerName, String> legacyPasswordUpdater;
+  @Nonnull private final BiPredicate<UserName, String> passwordCheck;
+  @Nonnull private final BiPredicate<UserName, String> legacyPasswordCheck;
+  @Nonnull private final BiConsumer<UserName, String> legacyPasswordUpdater;
 
   @Override
   public boolean test(final LoginRequest loginRequest) {
@@ -22,7 +22,7 @@ public class RegisteredLogin implements Predicate<LoginRequest> {
     Preconditions.checkNotNull(loginRequest.getName());
     Preconditions.checkNotNull(loginRequest.getPassword());
 
-    final var playerName = PlayerName.of(loginRequest.getName());
+    final var playerName = UserName.of(loginRequest.getName());
 
     if (passwordCheck.test(playerName, loginRequest.getPassword())) {
       return true;

--- a/http-server/src/test/java/org/triplea/http/server/LobbyChatIntegrationTest.java
+++ b/http-server/src/test/java/org/triplea/http/server/LobbyChatIntegrationTest.java
@@ -14,7 +14,7 @@ import org.awaitility.Awaitility;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.triplea.domain.data.ApiKey;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.ChatMessageListeners;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
 import org.triplea.http.client.lobby.chat.LobbyChatClient;
@@ -60,16 +60,16 @@ class LobbyChatIntegrationTest extends DropwizardTest {
   private static final ApiKey MODERATOR_API_KEY = ApiKey.of("MODERATOR");
   private static final ApiKey CHATTER_API_KEY = ApiKey.of("PLAYER");
 
-  private static final PlayerName MODERATOR_NAME = PlayerName.of("mod");
+  private static final UserName MODERATOR_NAME = UserName.of("mod");
   private static final ChatParticipant MODERATOR =
-      ChatParticipant.builder().playerName(MODERATOR_NAME).isModerator(true).status("").build();
+      ChatParticipant.builder().userName(MODERATOR_NAME).isModerator(true).status("").build();
 
-  private static final PlayerName CHATTER_NAME = PlayerName.of("chatter");
+  private static final UserName CHATTER_NAME = UserName.of("chatter");
   private static final ChatParticipant CHATTER =
-      ChatParticipant.builder().playerName(CHATTER_NAME).isModerator(false).status("").build();
+      ChatParticipant.builder().userName(CHATTER_NAME).isModerator(false).status("").build();
 
   private List<StatusUpdate> modPlayerStatusEvents = new ArrayList<>();
-  private List<PlayerName> modPlayerLeftEvents = new ArrayList<>();
+  private List<UserName> modPlayerLeftEvents = new ArrayList<>();
   private List<ChatParticipant> modPlayerJoinedEvents = new ArrayList<>();
   private List<PlayerSlapped> modPlayerSlappedEvents = new ArrayList<>();
   private List<ChatMessage> modMessageEvents = new ArrayList<>();
@@ -77,7 +77,7 @@ class LobbyChatIntegrationTest extends DropwizardTest {
   private LobbyChatClient moderator;
 
   private List<StatusUpdate> chatterPlayerStatusEvents = new ArrayList<>();
-  private List<PlayerName> chatterPlayerLeftEvents = new ArrayList<>();
+  private List<UserName> chatterPlayerLeftEvents = new ArrayList<>();
   private List<ChatParticipant> chatterPlayerJoinedEvents = new ArrayList<>();
   private List<PlayerSlapped> chatterPlayerSlappedEvents = new ArrayList<>();
   private List<ChatMessage> chatterMessageEvents = new ArrayList<>();
@@ -158,12 +158,7 @@ class LobbyChatIntegrationTest extends DropwizardTest {
     // moderator is notified that chatter has joined
     assertThat(
         modPlayerJoinedEvents.get(1),
-        is(
-            ChatParticipant.builder()
-                .playerName(CHATTER_NAME)
-                .isModerator(true)
-                .status("")
-                .build()));
+        is(ChatParticipant.builder().userName(CHATTER_NAME).isModerator(true).status("").build()));
     // moderator should *not* receive a connected event when chatter joins
     assertThat(modConnectedEvents, hasSize(1));
   }

--- a/http-server/src/test/java/org/triplea/lobby/server/db/dao/api/key/GamePlayerLookupTest.java
+++ b/http-server/src/test/java/org/triplea/lobby/server/db/dao/api/key/GamePlayerLookupTest.java
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.triplea.domain.data.PlayerName;
 import org.triplea.domain.data.SystemId;
+import org.triplea.domain.data.UserName;
 
 @ExtendWith(MockitoExtension.class)
 class GamePlayerLookupTest {
@@ -27,7 +27,7 @@ class GamePlayerLookupTest {
 
     final GamePlayerLookup result = GamePlayerLookup.buildResultMapper().map(resultSet, null);
 
-    assertThat(result.getPlayerName(), is(PlayerName.of(PLAYER_NAME)));
+    assertThat(result.getUserName(), is(UserName.of(PLAYER_NAME)));
     assertThat(result.getSystemId(), is(SystemId.of(SYSTEM_ID)));
     assertThat(result.getIp(), is(IP));
   }

--- a/http-server/src/test/java/org/triplea/lobby/server/db/dao/api/key/LobbyApiKeyDaoTest.java
+++ b/http-server/src/test/java/org/triplea/lobby/server/db/dao/api/key/LobbyApiKeyDaoTest.java
@@ -9,8 +9,8 @@ import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
-import org.triplea.domain.data.PlayerName;
 import org.triplea.domain.data.SystemId;
+import org.triplea.domain.data.UserName;
 import org.triplea.lobby.server.db.dao.DaoTest;
 import org.triplea.lobby.server.db.data.UserRole;
 
@@ -92,7 +92,7 @@ class LobbyApiKeyDaoTest extends DaoTest {
         playerIdLookup,
         isPresentAndIs(
             GamePlayerLookup.builder()
-                .playerName(PlayerName.of("registered-user"))
+                .userName(UserName.of("registered-user"))
                 .systemId(SystemId.of("system-id0"))
                 .ip("127.0.0.1")
                 .build()));

--- a/http-server/src/test/java/org/triplea/lobby/server/db/dao/api/key/LobbyApiKeyDaoWrapperTest.java
+++ b/http-server/src/test/java/org/triplea/lobby/server/db/dao/api/key/LobbyApiKeyDaoWrapperTest.java
@@ -21,8 +21,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.domain.data.ApiKey;
 import org.triplea.domain.data.PlayerChatId;
-import org.triplea.domain.data.PlayerName;
 import org.triplea.domain.data.SystemId;
+import org.triplea.domain.data.UserName;
 import org.triplea.lobby.server.db.dao.UserJdbiDao;
 import org.triplea.lobby.server.db.dao.UserRoleDao;
 import org.triplea.lobby.server.db.data.UserRole;
@@ -33,12 +33,12 @@ class LobbyApiKeyDaoWrapperTest {
 
   private static final ApiKey API_KEY = ApiKey.of("api-key");
   private static final String HASHED_KEY = "Dead, rainy shores proud swashbuckler";
-  private static final PlayerName PLAYER_NAME = PlayerName.of("The_captain");
+  private static final UserName PLAYER_NAME = UserName.of("The_captain");
   private static final PlayerChatId PLAYER_CHAT_ID = PlayerChatId.of("player-chat-id");
   private static final SystemId SYSTEM_ID = SystemId.of("system-id");
   private static final int ANONYMOUS_ROLE_ID = 123;
   private static final GamePlayerLookup PLAYER_ID_LOOKUP =
-      GamePlayerLookup.builder().playerName(PLAYER_NAME).systemId(SYSTEM_ID).ip("ip").build();
+      GamePlayerLookup.builder().userName(PLAYER_NAME).systemId(SYSTEM_ID).ip("ip").build();
 
   private static final UserRoleLookup USER_ROLE_LOOKUP =
       UserRoleLookup.builder().userId(10).userRoleId(20).build();

--- a/http-server/src/test/java/org/triplea/server/lobby/chat/ChatParticipantAdapterTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/chat/ChatParticipantAdapterTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.triplea.domain.data.PlayerChatId;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
 import org.triplea.lobby.server.db.dao.api.key.UserWithRoleRecord;
 import org.triplea.lobby.server.db.data.UserRole;
@@ -44,11 +44,7 @@ class ChatParticipantAdapterTest {
 
     assertThat(
         result,
-        is(
-            ChatParticipant.builder()
-                .isModerator(true)
-                .playerName(PlayerName.of(USERNAME))
-                .build()));
+        is(ChatParticipant.builder().isModerator(true).userName(UserName.of(USERNAME)).build()));
   }
 
   private UserWithRoleRecord givenUserRecordWithRole(final String userRole) {
@@ -69,10 +65,6 @@ class ChatParticipantAdapterTest {
 
     assertThat(
         result,
-        is(
-            ChatParticipant.builder()
-                .isModerator(true)
-                .playerName(PlayerName.of(USERNAME))
-                .build()));
+        is(ChatParticipant.builder().isModerator(true).userName(UserName.of(USERNAME)).build()));
   }
 }

--- a/http-server/src/test/java/org/triplea/server/lobby/chat/event/processing/ChatEventProcessorTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/chat/event/processing/ChatEventProcessorTest.java
@@ -19,7 +19,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.domain.data.ApiKey;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
 import org.triplea.http.client.lobby.chat.messages.client.ChatClientEnvelopeFactory;
 import org.triplea.http.client.lobby.chat.messages.server.ChatMessage;
@@ -38,13 +38,13 @@ class ChatEventProcessorTest {
   private static final String MESSAGE = "chat-message";
   private static final String STATUS = "status";
 
-  private static final PlayerName PLAYER_NAME_0 = PlayerName.of("playerName");
+  private static final UserName PLAYER_NAME_0 = UserName.of("playerName");
   private static final ChatParticipant CHAT_PARTICIPANT_0 =
-      ChatParticipant.builder().playerName(PLAYER_NAME_0).isModerator(true).build();
+      ChatParticipant.builder().userName(PLAYER_NAME_0).isModerator(true).build();
 
-  private static final PlayerName PLAYER_NAME_1 = PlayerName.of("playerName");
+  private static final UserName PLAYER_NAME_1 = UserName.of("playerName");
   private static final ChatParticipant CHAT_PARTICIPANT_1 =
-      ChatParticipant.builder().playerName(PLAYER_NAME_1).isModerator(true).build();
+      ChatParticipant.builder().userName(PLAYER_NAME_1).isModerator(true).build();
 
   private final ChatEventProcessor chatEventProcessor = new ChatEventProcessor(new Chatters());
 
@@ -124,7 +124,7 @@ class ChatEventProcessorTest {
               ServerResponse.broadcast(
                   ChatServerEnvelopeFactory.newSlap(
                       PlayerSlapped.builder()
-                          .slapper(CHAT_PARTICIPANT_0.getPlayerName())
+                          .slapper(CHAT_PARTICIPANT_0.getUserName())
                           .slapped(PLAYER_NAME_1)
                           .build()))));
     }
@@ -141,7 +141,7 @@ class ChatEventProcessorTest {
           is(
               ServerResponse.broadcast(
                   ChatServerEnvelopeFactory.newChatMessage(
-                      new ChatMessage(CHAT_PARTICIPANT_0.getPlayerName(), MESSAGE)))));
+                      new ChatMessage(CHAT_PARTICIPANT_0.getUserName(), MESSAGE)))));
     }
 
     @Test
@@ -156,7 +156,7 @@ class ChatEventProcessorTest {
           is(
               ServerResponse.broadcast(
                   ChatServerEnvelopeFactory.newStatusUpdate(
-                      new StatusUpdate(CHAT_PARTICIPANT_0.getPlayerName(), STATUS)))));
+                      new StatusUpdate(CHAT_PARTICIPANT_0.getUserName(), STATUS)))));
     }
 
     @Test

--- a/http-server/src/test/java/org/triplea/server/lobby/chat/event/processing/ChattersTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/chat/event/processing/ChattersTest.java
@@ -26,7 +26,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.domain.data.PlayerChatId;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.chat.ChatParticipant;
 import org.triplea.server.lobby.chat.event.processing.Chatters.ChatterSession;
 
@@ -35,9 +35,9 @@ import org.triplea.server.lobby.chat.event.processing.Chatters.ChatterSession;
 class ChattersTest {
 
   private static final ChatParticipant CHAT_PARTICIPANT =
-      ChatParticipant.builder().playerName(PlayerName.of("player-name")).build();
+      ChatParticipant.builder().userName(UserName.of("player-name")).build();
   private static final ChatParticipant CHAT_PARTICIPANT_2 =
-      ChatParticipant.builder().playerName(PlayerName.of("player-name2")).build();
+      ChatParticipant.builder().userName(UserName.of("player-name2")).build();
   private static final String ID = "id";
 
   private final Chatters chatters = new Chatters();
@@ -50,7 +50,7 @@ class ChattersTest {
     when(session.getId()).thenReturn(ID);
     chatters.put(session, CHAT_PARTICIPANT);
 
-    assertThat(chatters.removeSession(session), isPresentAndIs(CHAT_PARTICIPANT.getPlayerName()));
+    assertThat(chatters.removeSession(session), isPresentAndIs(CHAT_PARTICIPANT.getUserName()));
 
     assertThat(
         "Second remove should be empty, session is already removed.",
@@ -83,22 +83,22 @@ class ChattersTest {
   @Test
   void hasPlayer() {
     // no chatters added yet
-    assertThat(chatters.hasPlayer(CHAT_PARTICIPANT.getPlayerName()), is(false));
-    assertThat(chatters.hasPlayer(CHAT_PARTICIPANT_2.getPlayerName()), is(false));
+    assertThat(chatters.hasPlayer(CHAT_PARTICIPANT.getUserName()), is(false));
+    assertThat(chatters.hasPlayer(CHAT_PARTICIPANT_2.getUserName()), is(false));
 
     when(session.getId()).thenReturn(ID);
     chatters.put(session, CHAT_PARTICIPANT);
 
     // one chatter is added
-    assertThat(chatters.hasPlayer(CHAT_PARTICIPANT.getPlayerName()), is(true));
-    assertThat(chatters.hasPlayer(CHAT_PARTICIPANT_2.getPlayerName()), is(false));
+    assertThat(chatters.hasPlayer(CHAT_PARTICIPANT.getUserName()), is(true));
+    assertThat(chatters.hasPlayer(CHAT_PARTICIPANT_2.getUserName()), is(false));
 
     when(session2.getId()).thenReturn("id2");
     chatters.put(session2, CHAT_PARTICIPANT_2);
 
     // two chatters added, both should exist
-    assertThat(chatters.hasPlayer(CHAT_PARTICIPANT.getPlayerName()), is(true));
-    assertThat(chatters.hasPlayer(CHAT_PARTICIPANT_2.getPlayerName()), is(true));
+    assertThat(chatters.hasPlayer(CHAT_PARTICIPANT.getUserName()), is(true));
+    assertThat(chatters.hasPlayer(CHAT_PARTICIPANT_2.getUserName()), is(true));
   }
 
   @Nested
@@ -132,7 +132,7 @@ class ChattersTest {
   class DisconnectPlayerSessions {
     @Test
     void noOpIfPlayerNotConnected() {
-      chatters.disconnectPlayerSessions(CHAT_PARTICIPANT.getPlayerName(), "disconnect message");
+      chatters.disconnectPlayerSessions(CHAT_PARTICIPANT.getUserName(), "disconnect message");
     }
 
     @Test
@@ -140,7 +140,7 @@ class ChattersTest {
       when(session.getId()).thenReturn(ID);
       chatters.put(session, CHAT_PARTICIPANT);
 
-      chatters.disconnectPlayerSessions(CHAT_PARTICIPANT.getPlayerName(), "disconnect message");
+      chatters.disconnectPlayerSessions(CHAT_PARTICIPANT.getUserName(), "disconnect message");
 
       verify(session).close(any(CloseReason.class));
     }
@@ -152,10 +152,10 @@ class ChattersTest {
       final ChatParticipant participant2 = givenChatParticipant(session2);
       assertThat(
           "verify test data assumption",
-          participant1.getPlayerName(),
-          is(participant2.getPlayerName()));
+          participant1.getUserName(),
+          is(participant2.getUserName()));
 
-      chatters.disconnectPlayerSessions(participant1.getPlayerName(), "disconnect message");
+      chatters.disconnectPlayerSessions(participant1.getUserName(), "disconnect message");
 
       verify(session).close(any(CloseReason.class));
       verify(session2).close(any(CloseReason.class));
@@ -165,7 +165,7 @@ class ChattersTest {
       final var chatParticipant =
           ChatParticipant.builder()
               .playerChatId(PlayerChatId.newId())
-              .playerName(PlayerName.of("player-name"))
+              .userName(UserName.of("player-name"))
               .build();
 
       when(chatterSession.getId()).thenReturn(UUID.randomUUID().toString());

--- a/http-server/src/test/java/org/triplea/server/lobby/chat/moderation/ModeratorActionPersistenceTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/chat/moderation/ModeratorActionPersistenceTest.java
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.triplea.domain.data.PlayerName;
 import org.triplea.domain.data.SystemId;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.moderator.BanPlayerRequest;
 import org.triplea.lobby.server.db.dao.ModeratorAuditHistoryDao;
 import org.triplea.lobby.server.db.dao.ModeratorAuditHistoryDao.AuditAction;
@@ -24,7 +24,7 @@ class ModeratorActionPersistenceTest {
   private static final GamePlayerLookup PLAYER_ID_LOOKUP =
       GamePlayerLookup.builder()
           .systemId(SystemId.of("system-id"))
-          .playerName(PlayerName.of("player-name"))
+          .userName(UserName.of("player-name"))
           .ip("ip")
           .build();
   private static final BanPlayerRequest BAN_PLAYER_REQUEST =
@@ -42,7 +42,7 @@ class ModeratorActionPersistenceTest {
     verify(userBanDao)
         .addBan(
             anyString(),
-            eq(PLAYER_ID_LOOKUP.getPlayerName().getValue()),
+            eq(PLAYER_ID_LOOKUP.getUserName().getValue()),
             eq(PLAYER_ID_LOOKUP.getSystemId().getValue()),
             eq(PLAYER_ID_LOOKUP.getIp()),
             eq(BAN_PLAYER_REQUEST.getBanMinutes()));
@@ -65,7 +65,7 @@ class ModeratorActionPersistenceTest {
             ModeratorAuditHistoryDao.AuditArgs.builder()
                 .moderatorUserId(MODERATOR_ID)
                 .actionName(AuditAction.DISCONNECT_USER)
-                .actionTarget(PLAYER_ID_LOOKUP.getPlayerName().getValue())
+                .actionTarget(PLAYER_ID_LOOKUP.getUserName().getValue())
                 .build());
   }
 }

--- a/http-server/src/test/java/org/triplea/server/lobby/chat/moderation/ModeratorChatServiceTest.java
+++ b/http-server/src/test/java/org/triplea/server/lobby/chat/moderation/ModeratorChatServiceTest.java
@@ -24,8 +24,8 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.domain.data.PlayerChatId;
-import org.triplea.domain.data.PlayerName;
 import org.triplea.domain.data.SystemId;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.IpAddressParser;
 import org.triplea.http.client.lobby.chat.messages.server.ChatServerMessageType;
 import org.triplea.http.client.lobby.moderator.BanDurationFormatter;
@@ -48,7 +48,7 @@ class ModeratorChatServiceTest {
   private static final GamePlayerLookup PLAYER_ID_LOOKUP =
       GamePlayerLookup.builder()
           .ip("99.99.99.99")
-          .playerName(PlayerName.of("player-name"))
+          .userName(UserName.of("player-name"))
           .systemId(SystemId.of("system-id"))
           .build();
 
@@ -109,7 +109,7 @@ class ModeratorChatServiceTest {
       final ArgumentCaptor<String> disconnectMessageCaptor = ArgumentCaptor.forClass(String.class);
       verify(chatters)
           .disconnectPlayerSessions(
-              eq(PLAYER_ID_LOOKUP.getPlayerName()), disconnectMessageCaptor.capture());
+              eq(PLAYER_ID_LOOKUP.getUserName()), disconnectMessageCaptor.capture());
       assertThat(
           "Make sure ban message has the word 'banned'",
           disconnectMessageCaptor.getValue().toLowerCase(),
@@ -137,7 +137,7 @@ class ModeratorChatServiceTest {
       assertThat(
           "Make sure ban event message contains the banned players name",
           serverMessageCaptor.getValue().getPayload(String.class),
-          containsString(PLAYER_ID_LOOKUP.getPlayerName().getValue()));
+          containsString(PLAYER_ID_LOOKUP.getUserName().getValue()));
       assertThat(
           "Make sure ban event message contains the word ban",
           serverMessageCaptor.getValue().getPayload(String.class).toLowerCase(),
@@ -186,7 +186,7 @@ class ModeratorChatServiceTest {
       final ArgumentCaptor<String> disconnectMessageCaptor = ArgumentCaptor.forClass(String.class);
       verify(chatters)
           .disconnectPlayerSessions(
-              eq(PLAYER_ID_LOOKUP.getPlayerName()), disconnectMessageCaptor.capture());
+              eq(PLAYER_ID_LOOKUP.getUserName()), disconnectMessageCaptor.capture());
       assertThat(
           "Disconnect message should contain the word 'disconnect'",
           disconnectMessageCaptor.getValue().toLowerCase(),
@@ -208,7 +208,7 @@ class ModeratorChatServiceTest {
       assertThat(
           "Disconnect message contains player name",
           eventMessageCaptor.getValue().getPayload(String.class),
-          containsString(PLAYER_ID_LOOKUP.getPlayerName().getValue()));
+          containsString(PLAYER_ID_LOOKUP.getUserName().getValue()));
     }
 
     private void verifyDisconnectIsRecorded() {

--- a/http-server/src/test/java/org/triplea/server/moderator/toolbox/banned/users/UserBanServiceTest.java
+++ b/http-server/src/test/java/org/triplea/server/moderator/toolbox/banned/users/UserBanServiceTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.IpAddressParser;
 import org.triplea.http.client.lobby.moderator.toolbox.banned.user.UserBanData;
 import org.triplea.http.client.lobby.moderator.toolbox.banned.user.UserBanParams;
@@ -162,7 +162,7 @@ class UserBanServiceTest {
                   .build());
 
       verify(chatters)
-          .disconnectPlayerSessions(eq(PlayerName.of(USER_BAN_PARAMS.getUsername())), any());
+          .disconnectPlayerSessions(eq(UserName.of(USER_BAN_PARAMS.getUsername())), any());
       verify(playerBanEvents)
           .addPlayerBannedEvent(IpAddressParser.fromString(USER_BAN_PARAMS.getIp()));
     }

--- a/http-server/src/test/java/org/triplea/server/user/account/login/AccessLogUpdaterTest.java
+++ b/http-server/src/test/java/org/triplea/server/user/account/login/AccessLogUpdaterTest.java
@@ -10,8 +10,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.domain.data.PlayerChatId;
-import org.triplea.domain.data.PlayerName;
 import org.triplea.domain.data.SystemId;
+import org.triplea.domain.data.UserName;
 import org.triplea.lobby.server.db.dao.access.log.AccessLogDao;
 
 @ExtendWith(MockitoExtension.class)
@@ -23,7 +23,7 @@ class AccessLogUpdaterTest {
           .systemId(SystemId.of("system-id"))
           .playerChatId(PlayerChatId.newId())
           .ip("ip")
-          .playerName(PlayerName.of("player-name"))
+          .userName(UserName.of("player-name"))
           .build();
 
   private static final LoginRecord ANONYMOUS_LOGIN_RECORD =
@@ -32,7 +32,7 @@ class AccessLogUpdaterTest {
           .systemId(SystemId.of("system-id"))
           .playerChatId(PlayerChatId.newId())
           .ip("ip")
-          .playerName(PlayerName.of("player-name"))
+          .userName(UserName.of("player-name"))
           .build();
 
   @Mock private AccessLogDao accessLogDao;
@@ -52,7 +52,7 @@ class AccessLogUpdaterTest {
 
     verify(accessLogDao)
         .insertRegisteredUserRecord(
-            REGISTEREDLOGIN_RECORD.getPlayerName().getValue(),
+            REGISTEREDLOGIN_RECORD.getUserName().getValue(),
             REGISTEREDLOGIN_RECORD.getIp(),
             REGISTEREDLOGIN_RECORD.getSystemId().getValue());
   }
@@ -65,7 +65,7 @@ class AccessLogUpdaterTest {
 
     verify(accessLogDao)
         .insertAnonymousUserRecord(
-            ANONYMOUS_LOGIN_RECORD.getPlayerName().getValue(),
+            ANONYMOUS_LOGIN_RECORD.getUserName().getValue(),
             ANONYMOUS_LOGIN_RECORD.getIp(),
             ANONYMOUS_LOGIN_RECORD.getSystemId().getValue());
   }

--- a/http-server/src/test/java/org/triplea/server/user/account/login/LoginModuleTest.java
+++ b/http-server/src/test/java/org/triplea/server/user/account/login/LoginModuleTest.java
@@ -26,8 +26,8 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.domain.data.ApiKey;
-import org.triplea.domain.data.PlayerName;
 import org.triplea.domain.data.SystemId;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.login.LobbyLoginResponse;
 import org.triplea.http.client.lobby.login.LoginRequest;
 import org.triplea.lobby.server.db.dao.UserJdbiDao;
@@ -49,7 +49,7 @@ class LoginModuleTest {
 
   @Mock private Predicate<LoginRequest> registeredLogin;
   @Mock private Predicate<LoginRequest> tempPasswordLogin;
-  @Mock private Function<PlayerName, Optional<String>> anonymousLogin;
+  @Mock private Function<UserName, Optional<String>> anonymousLogin;
   @Mock private Function<LoginRecord, ApiKey> apiKeyGenerator;
   @Mock private Consumer<LoginRecord> accessLogUpdater;
   @Mock private UserJdbiDao userJdbiDao;
@@ -102,7 +102,7 @@ class LoginModuleTest {
   class AnonymousLogin {
     @Test
     void loginRejected() {
-      when(anonymousLogin.apply(PlayerName.of(ANONYMOUS_LOGIN_REQUEST.getName())))
+      when(anonymousLogin.apply(UserName.of(ANONYMOUS_LOGIN_REQUEST.getName())))
           .thenReturn(Optional.of("error"));
 
       final LobbyLoginResponse result =
@@ -116,7 +116,7 @@ class LoginModuleTest {
 
     @Test
     void loginSuccess() {
-      when(anonymousLogin.apply(PlayerName.of(ANONYMOUS_LOGIN_REQUEST.getName())))
+      when(anonymousLogin.apply(UserName.of(ANONYMOUS_LOGIN_REQUEST.getName())))
           .thenReturn(Optional.empty());
       when(apiKeyGenerator.apply(any())).thenReturn(API_KEY);
 

--- a/http-server/src/test/java/org/triplea/server/user/account/login/authorizer/anonymous/AnonymousLoginTest.java
+++ b/http-server/src/test/java/org/triplea/server/user/account/login/authorizer/anonymous/AnonymousLoginTest.java
@@ -11,13 +11,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.lobby.server.db.dao.UserJdbiDao;
 import org.triplea.server.lobby.chat.event.processing.Chatters;
 
 @ExtendWith(MockitoExtension.class)
 class AnonymousLoginTest {
-  private static final PlayerName PLAYER_NAME = PlayerName.of("Player");
+  private static final UserName PLAYER_NAME = UserName.of("Player");
 
   @Mock private UserJdbiDao userJdbiDao;
   @Mock private Chatters chatters;

--- a/http-server/src/test/java/org/triplea/server/user/account/login/authorizer/legacy/LegacyPasswordCheckTest.java
+++ b/http-server/src/test/java/org/triplea/server/user/account/login/authorizer/legacy/LegacyPasswordCheckTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.lobby.server.db.dao.UserJdbiDao;
 
 @ExtendWith(MockitoExtension.class)
@@ -19,7 +19,7 @@ class LegacyPasswordCheckTest {
   private static final String DB_LEGACY_PASSWORD = "$1$GTV9OtVd$WKt1JeqIasr4GlAJylq2A/";
   private static final String PLAINTEXT_PASSWORD = "legacy";
 
-  private static final PlayerName PLAYER_NAME = PlayerName.of("user");
+  private static final UserName PLAYER_NAME = UserName.of("user");
 
   @Mock private UserJdbiDao userJdbiDao;
 

--- a/http-server/src/test/java/org/triplea/server/user/account/login/authorizer/legacy/LegacyPasswordUpdateTest.java
+++ b/http-server/src/test/java/org/triplea/server/user/account/login/authorizer/legacy/LegacyPasswordUpdateTest.java
@@ -10,12 +10,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.lobby.server.db.dao.UserJdbiDao;
 
 @ExtendWith(MockitoExtension.class)
 class LegacyPasswordUpdateTest {
-  private static final PlayerName PLAYER_NAME = PlayerName.of("player-name");
+  private static final UserName PLAYER_NAME = UserName.of("player-name");
   private static final int USER_ID = 100;
 
   private static final String PASSWORD = "password";

--- a/http-server/src/test/java/org/triplea/server/user/account/login/authorizer/registered/PasswordCheckTest.java
+++ b/http-server/src/test/java/org/triplea/server/user/account/login/authorizer/registered/PasswordCheckTest.java
@@ -11,12 +11,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.lobby.server.db.dao.UserJdbiDao;
 
 @ExtendWith(MockitoExtension.class)
 class PasswordCheckTest {
-  private static final PlayerName PLAYER_NAME = PlayerName.of("player-name");
+  private static final UserName PLAYER_NAME = UserName.of("player-name");
   private static final String PASSWORD = "plaintext-pass";
   private static final String DB_PASSWORD = "db-pass";
 

--- a/http-server/src/test/java/org/triplea/server/user/account/login/authorizer/registered/RegisteredLoginTest.java
+++ b/http-server/src/test/java/org/triplea/server/user/account/login/authorizer/registered/RegisteredLoginTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.triplea.domain.data.PlayerName;
+import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.login.LoginRequest;
 
 @ExtendWith(MockitoExtension.class)
@@ -23,9 +23,9 @@ class RegisteredLoginTest {
   private static final LoginRequest LOGIN_REQUEST =
       LoginRequest.builder().name("name").password("password").build();
 
-  @Mock private BiPredicate<PlayerName, String> passwordCheck;
-  @Mock private BiPredicate<PlayerName, String> legacyPasswordCheck;
-  @Mock private BiConsumer<PlayerName, String> legacyPasswordUpdater;
+  @Mock private BiPredicate<UserName, String> passwordCheck;
+  @Mock private BiPredicate<UserName, String> legacyPasswordCheck;
+  @Mock private BiConsumer<UserName, String> legacyPasswordUpdater;
 
   private RegisteredLogin registeredLogin;
 
@@ -50,19 +50,19 @@ class RegisteredLoginTest {
   @Test
   void legacyPasswordMatches() {
     when(legacyPasswordCheck.test(
-            PlayerName.of(LOGIN_REQUEST.getName()), LOGIN_REQUEST.getPassword()))
+            UserName.of(LOGIN_REQUEST.getName()), LOGIN_REQUEST.getPassword()))
         .thenReturn(true);
 
     final boolean result = registeredLogin.test(LOGIN_REQUEST);
 
     assertThat(result, is(true));
     verify(legacyPasswordUpdater)
-        .accept(PlayerName.of(LOGIN_REQUEST.getName()), LOGIN_REQUEST.getPassword());
+        .accept(UserName.of(LOGIN_REQUEST.getName()), LOGIN_REQUEST.getPassword());
   }
 
   @Test
   void passwordMatches() {
-    when(passwordCheck.test(PlayerName.of(LOGIN_REQUEST.getName()), LOGIN_REQUEST.getPassword()))
+    when(passwordCheck.test(UserName.of(LOGIN_REQUEST.getName()), LOGIN_REQUEST.getPassword()))
         .thenReturn(true);
 
     final boolean result = registeredLogin.test(LOGIN_REQUEST);


### PR DESCRIPTION
Completes: https://github.com/triplea-game/triplea/issues/5427

Username matches the DB terminology and helps disambiguate a player name for the other variants of players.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 
