### PR TITLE
Remove unused method 'getRemoteNode' and 'ToString'

### DIFF
--- a/game-core/src/main/java/games/strategy/net/ClientMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ClientMessenger.java
@@ -237,12 +237,6 @@ public class ClientMessenger implements IClientMessenger, NioSocketListener {
   }
 
   @Override
-  public INode getRemoteNode(final SocketChannel channel) {
-    // we only have one channel
-    return serverNode;
-  }
-
-  @Override
   public void addConnectionChangeListener(final IConnectionChangeListener listener) {}
 
   @Override

--- a/game-core/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ServerMessenger.java
@@ -341,18 +341,4 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
     notifyConnectionsChanged(true, remote);
     log.info("Connection added to:" + remote);
   }
-
-  @Override
-  public INode getRemoteNode(final SocketChannel channel) {
-    return channelToNode.get(channel);
-  }
-
-  @Override
-  public String toString() {
-    return getClass().getSimpleName()
-        + " LocalNode:"
-        + node
-        + " ClientNodes:"
-        + nodeToChannel.keySet();
-  }
 }

--- a/game-core/src/main/java/games/strategy/net/nio/NioSocket.java
+++ b/game-core/src/main/java/games/strategy/net/nio/NioSocket.java
@@ -37,10 +37,6 @@ public class NioSocket implements ErrorReporter {
     return listener.getLocalNode();
   }
 
-  INode getRemoteNode(final SocketChannel channel) {
-    return listener.getRemoteNode(channel);
-  }
-
   /** Stop our threads. This does not close the sockets we are connected to. */
   public void shutDown() {
     writer.shutDown();

--- a/game-core/src/main/java/games/strategy/net/nio/NioSocketListener.java
+++ b/game-core/src/main/java/games/strategy/net/nio/NioSocketListener.java
@@ -18,12 +18,6 @@ public interface NioSocketListener {
   void messageReceived(MessageHeader message, SocketChannel channel);
 
   /**
-   * Get the remote node id for this channel, or null if the remote node id is not yet known. The
-   * node may be unknown if the channel is still quarantined
-   */
-  INode getRemoteNode(SocketChannel channel);
-
-  /**
    * Get the node id for the local machine, or null if the remote node is not yet known. The node
    * must be known by the time we have an unquarantined channel.
    */


### PR DESCRIPTION
 The toString is in place for legacy debugging.

<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done
- hosted a game, with a second instance connected to it locally, disconnected and reconnected.

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

