### PR TITLE
Fix freeze with retreat dialog

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -392,11 +392,7 @@ public class BattleDisplay extends JPanel {
             options,
             cancel);
     // dialog dismissed
-    if (choice == JOptionPane.CLOSED_OPTION) {
-      return false;
-    }
-    // wait
-    if (choice == JOptionPane.CANCEL_OPTION) {
+    if (choice == JOptionPane.CLOSED_OPTION || choice == JOptionPane.CANCEL_OPTION) {
       return false;
     }
     // remain
@@ -457,19 +453,14 @@ public class BattleDisplay extends JPanel {
             options,
             no);
     // dialog dismissed
-    if (choice == JOptionPane.CLOSED_OPTION) {
-      return false;
-    }
-    // wait
-    if (choice == JOptionPane.CANCEL_OPTION) {
+    if (choice == JOptionPane.CLOSED_OPTION || choice == JOptionPane.CANCEL_OPTION) {
       return false;
     }
     // remain
     if (choice == JOptionPane.NO_OPTION) {
       return true;
     }
-    // if you have eliminated the impossible, whatever remains, no matter how improbable,
-    // must be the truth
+
     // retreat
     if (possible.size() == 1) {
       retreatTo.set(possible.iterator().next());

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -392,15 +392,15 @@ public class BattleDisplay extends JPanel {
             options,
             cancel);
     // dialog dismissed
-    if (choice == -1) {
+    if (choice == JOptionPane.CLOSED_OPTION) {
       return false;
     }
     // wait
-    if (choice == 2) {
+    if (choice == JOptionPane.CANCEL_OPTION) {
       return false;
     }
     // remain
-    if (choice == 1) {
+    if (choice == JOptionPane.NO_OPTION) {
       return true;
     }
     // submerge
@@ -457,7 +457,7 @@ public class BattleDisplay extends JPanel {
             options,
             no);
     // dialog dismissed
-    if (choice == -1) {
+    if (choice == JOptionPane.CLOSED_OPTION) {
       return false;
     }
     // wait

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -572,6 +572,7 @@ public class BattleDisplay extends JPanel {
 
                 @Override
                 public void actionPerformed(final ActionEvent e) {
+                  actionButton.setEnabled(false);
                   final String messageText = message + " " + btnText + ".";
                   if (chooser == null || chooserScrollPane == null) {
                     chooser =
@@ -622,6 +623,7 @@ public class BattleDisplay extends JPanel {
                           options,
                           focus);
                   if (option != 0) {
+                    actionButton.setEnabled(true);
                     return;
                   }
                   final List<Unit> killed = chooser.getSelected(false);
@@ -636,10 +638,10 @@ public class BattleDisplay extends JPanel {
                     final CasualtyDetails response = new CasualtyDetails(killed, damaged, false);
                     casualtyDetails.set(response);
                     dicePanel.removeAll();
-                    actionButton.setEnabled(false);
                     actionButton.setAction(nullAction);
                     continueLatch.countDown();
                   }
+                  actionButton.setEnabled(true);
                 }
               });
         });

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -357,44 +357,55 @@ public class BattleDisplay extends JPanel {
         SwingAction.of(
             "Submerge Subs?",
             e -> {
-              final String ok = "Submerge";
-              final String cancel = "Remain";
-              final String wait = "Ask Me Later";
-              final String[] options = {ok, cancel, wait};
-              final int choice =
-                  JOptionPane.showOptionDialog(
-                      BattleDisplay.this,
-                      message,
-                      "Submerge Subs?",
-                      JOptionPane.OK_CANCEL_OPTION,
-                      JOptionPane.PLAIN_MESSAGE,
-                      null,
-                      options,
-                      cancel);
-              // dialog dismissed
-              if (choice == -1) {
-                return;
-              }
-              // wait
-              if (choice == 2) {
-                return;
-              }
-              // remain
-              if (choice == 1) {
+              actionButton.setEnabled(false);
+              if (showSubmergeDialog(message, retreatTo)) {
+                actionButton.setAction(nullAction);
                 latch.countDown();
-                return;
               }
-              // submerge
-              retreatTo.set(battleLocation);
-              latch.countDown();
+              actionButton.setEnabled(true);
             });
-    SwingUtilities.invokeLater(() -> actionButton.setAction(action));
-    SwingUtilities.invokeLater(() -> action.actionPerformed(null));
+    SwingUtilities.invokeLater(
+        () -> {
+          actionButton.setAction(action);
+          action.actionPerformed(null);
+        });
     mapPanel.getUiContext().addShutdownLatch(latch);
     Interruptibles.await(latch);
     mapPanel.getUiContext().removeShutdownLatch(latch);
-    SwingUtilities.invokeLater(() -> actionButton.setAction(nullAction));
     return retreatTo.get();
+  }
+
+  private boolean showSubmergeDialog(
+      final String message, final AtomicReference<Territory> retreatTo) {
+    final String ok = "Submerge";
+    final String cancel = "Remain";
+    final String wait = "Ask Me Later";
+    final String[] options = {ok, cancel, wait};
+    final int choice =
+        JOptionPane.showOptionDialog(
+            BattleDisplay.this,
+            message,
+            "Submerge Subs?",
+            JOptionPane.OK_CANCEL_OPTION,
+            JOptionPane.PLAIN_MESSAGE,
+            null,
+            options,
+            cancel);
+    // dialog dismissed
+    if (choice == -1) {
+      return false;
+    }
+    // wait
+    if (choice == 2) {
+      return false;
+    }
+    // remain
+    if (choice == 1) {
+      return true;
+    }
+    // submerge
+    retreatTo.set(battleLocation);
+    return true;
   }
 
   private Territory getRetreatInternal(final String message, final Collection<Territory> possible) {
@@ -407,67 +418,81 @@ public class BattleDisplay extends JPanel {
         SwingAction.of(
             "Retreat?",
             e -> {
-              final String yes =
-                  possible.size() == 1
-                      ? "Retreat to " + possible.iterator().next().getName()
-                      : "Retreat";
-              final String no = "Remain";
-              final String cancel = "Ask Me Later";
-              final String[] options = {yes, no, cancel};
-              final int choice =
-                  JOptionPane.showOptionDialog(
-                      BattleDisplay.this,
-                      message,
-                      "Retreat?",
-                      JOptionPane.YES_NO_CANCEL_OPTION,
-                      JOptionPane.PLAIN_MESSAGE,
-                      null,
-                      options,
-                      no);
-              // dialog dismissed
-              if (choice == -1) {
-                return;
-              }
-              // wait
-              if (choice == JOptionPane.CANCEL_OPTION) {
-                return;
-              }
-              // remain
-              if (choice == JOptionPane.NO_OPTION) {
+              actionButton.setEnabled(false);
+              if (showRetreatDialog(message, possible, retreatTo)) {
+                actionButton.setAction(nullAction);
                 latch.countDown();
-                return;
               }
-              // if you have eliminated the impossible, whatever remains, no matter how improbable,
-              // must be the truth
-              // retreat
-              if (possible.size() == 1) {
-                retreatTo.set(possible.iterator().next());
-                latch.countDown();
-              } else {
-                final RetreatComponent comp = new RetreatComponent(possible);
-                final int option =
-                    JOptionPane.showConfirmDialog(
-                        BattleDisplay.this,
-                        comp,
-                        message,
-                        JOptionPane.OK_CANCEL_OPTION,
-                        JOptionPane.PLAIN_MESSAGE,
-                        null);
-                if (option == JOptionPane.OK_OPTION) {
-                  if (comp.getSelection() != null) {
-                    retreatTo.set(comp.getSelection());
-                    latch.countDown();
-                  }
-                }
-              }
+              actionButton.setEnabled(true);
             });
-    SwingUtilities.invokeLater(() -> actionButton.setAction(action));
-    SwingUtilities.invokeLater(() -> action.actionPerformed(null));
+    SwingUtilities.invokeLater(
+        () -> {
+          actionButton.setAction(action);
+          action.actionPerformed(null);
+        });
     mapPanel.getUiContext().addShutdownLatch(latch);
     Interruptibles.await(latch);
     mapPanel.getUiContext().removeShutdownLatch(latch);
-    SwingUtilities.invokeLater(() -> actionButton.setAction(nullAction));
+
     return retreatTo.get();
+  }
+
+  private boolean showRetreatDialog(
+      final String message,
+      final Collection<Territory> possible,
+      final AtomicReference<Territory> retreatTo) {
+    final String yes =
+        possible.size() == 1 ? "Retreat to " + possible.iterator().next().getName() : "Retreat";
+    final String no = "Remain";
+    final String cancel = "Ask Me Later";
+    final String[] options = {yes, no, cancel};
+    final int choice =
+        JOptionPane.showOptionDialog(
+            BattleDisplay.this,
+            message,
+            "Retreat?",
+            JOptionPane.YES_NO_CANCEL_OPTION,
+            JOptionPane.PLAIN_MESSAGE,
+            null,
+            options,
+            no);
+    // dialog dismissed
+    if (choice == -1) {
+      return false;
+    }
+    // wait
+    if (choice == JOptionPane.CANCEL_OPTION) {
+      return false;
+    }
+    // remain
+    if (choice == JOptionPane.NO_OPTION) {
+      return true;
+    }
+    // if you have eliminated the impossible, whatever remains, no matter how improbable,
+    // must be the truth
+    // retreat
+    if (possible.size() == 1) {
+      retreatTo.set(possible.iterator().next());
+      return true;
+    }
+
+    final RetreatComponent comp = new RetreatComponent(possible);
+    final int option =
+        JOptionPane.showConfirmDialog(
+            BattleDisplay.this,
+            comp,
+            message,
+            JOptionPane.OK_CANCEL_OPTION,
+            JOptionPane.PLAIN_MESSAGE,
+            null);
+    if (option == JOptionPane.OK_OPTION) {
+      if (comp.getSelection() != null) {
+        retreatTo.set(comp.getSelection());
+        return true;
+      }
+    }
+
+    return false;
   }
 
   private class RetreatComponent extends JPanel {


### PR DESCRIPTION
Fix freeze with retreat dialog. This was caused by the code allowing multiple retreat dialogs to be shown - when clicking the action button multiple times, and the retreat dialog from a previous battle blocking new UI thread code (for the next battle) from running.

Also addresses a similar issue with the select casualties dialog. Previously, you could click the button multiple times to get multiple dialogs shown. When a dialog is still shown when the battle ends, it would also result in a freeze. With this PR, only one dialog can be shown at a time (via making the button disabled while it's shown).

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[X] Code Cleanup or refactor
[] Configuration Change
[X] Problem fix:  https://github.com/triplea-game/triplea/issues/5010
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[X] Manual testing done

Tested that it's not possible to bring up multiple retreat dialogs by clicking the action button multiple times. Also tested that without this change, the problem was reproducible when having multiple retreat dialogs open and ending battle with not all of them having been closed (it would freeze).