### PR TITLE
Fix quit dialog not appearing on Mac when dismissed.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -131,7 +131,7 @@ public class LobbyFrame extends JFrame {
             .toSwingAction());
   }
 
-  public void shutdown() {
+  public boolean shutdown() {
     setVisible(false);
     dispose();
     new Thread(
@@ -140,5 +140,6 @@ public class LobbyFrame extends JFrame {
               GameRunner.exitGameIfFinished();
             })
         .start();
+    return true;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -11,6 +11,7 @@ import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.lobby.client.LobbyClient;
 import games.strategy.engine.lobby.client.ui.action.BanPlayerModeratorAction;
 import games.strategy.engine.lobby.client.ui.action.DisconnectPlayerModeratorAction;
+import games.strategy.triplea.ui.QuitHandler;
 import games.strategy.triplea.ui.menubar.LobbyMenu;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
@@ -28,7 +29,7 @@ import org.triplea.swing.JFrameBuilder;
 import org.triplea.swing.SwingComponents;
 
 /** The top-level frame window for the lobby client UI. */
-public class LobbyFrame extends JFrame {
+public class LobbyFrame extends JFrame implements QuitHandler {
   private static final long serialVersionUID = -388371674076362572L;
 
   @Getter private final LobbyClient lobbyClient;
@@ -131,6 +132,7 @@ public class LobbyFrame extends JFrame {
             .toSwingAction());
   }
 
+  @Override
   public boolean shutdown() {
     setVisible(false);
     dispose();

--- a/game-core/src/main/java/games/strategy/triplea/ui/MacOsIntegration.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MacOsIntegration.java
@@ -5,7 +5,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.awt.Desktop;
 import java.io.File;
 import java.net.URI;
-import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 
 /** Utility class to add macOS integration. */
@@ -41,12 +40,12 @@ public final class MacOsIntegration {
   }
 
   /** Sets the specified quit handler to the application. */
-  public static void setQuitHandler(final BooleanSupplier handler) {
+  public static void setQuitHandler(final QuitHandler handler) {
     checkNotNull(handler);
     Desktop.getDesktop()
         .setQuitHandler(
             (quitEvent, quitResponse) -> {
-              if (handler.getAsBoolean()) {
+              if (handler.shutdown()) {
                 quitResponse.performQuit();
               } else {
                 quitResponse.cancelQuit();

--- a/game-core/src/main/java/games/strategy/triplea/ui/MacOsIntegration.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MacOsIntegration.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.awt.Desktop;
 import java.io.File;
 import java.net.URI;
+import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 
 /** Utility class to add macOS integration. */
@@ -40,8 +41,16 @@ public final class MacOsIntegration {
   }
 
   /** Sets the specified quit handler to the application. */
-  public static void setQuitHandler(final Runnable handler) {
+  public static void setQuitHandler(final BooleanSupplier handler) {
     checkNotNull(handler);
-    Desktop.getDesktop().setQuitHandler((quitEvent, quitResponse) -> handler.run());
+    Desktop.getDesktop()
+        .setQuitHandler(
+            (quitEvent, quitResponse) -> {
+              if (handler.getAsBoolean()) {
+                quitResponse.performQuit();
+              } else {
+                quitResponse.cancelQuit();
+              }
+            });
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/QuitHandler.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/QuitHandler.java
@@ -1,0 +1,10 @@
+package games.strategy.triplea.ui;
+
+public interface QuitHandler {
+  /**
+   * Performs the quit operation, potentially prompting the user for confirmation.
+   *
+   * @return If false, the quit operation was canceled.
+   */
+  boolean shutdown();
+}

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -170,7 +170,7 @@ import org.triplea.util.Tuple;
 
 /** Main frame for the triple a game. */
 @Log
-public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
+public final class TripleAFrame extends JFrame implements KeyBindingSupplier, QuitHandler {
   private static final long serialVersionUID = 7640069668264418976L;
 
   private final LocalPlayers localPlayers;
@@ -836,6 +836,7 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
    * If the frame is visible, prompts the user if they wish to exit the application. If they answer
    * yes or the frame is not visible, the game will be stopped, and the process will be terminated.
    */
+  @Override
   public boolean shutdown() {
     if (isVisible()) {
       final int selectedOption =

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -836,7 +836,7 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
    * If the frame is visible, prompts the user if they wish to exit the application. If they answer
    * yes or the frame is not visible, the game will be stopped, and the process will be terminated.
    */
-  public void shutdown() {
+  public boolean shutdown() {
     if (isVisible()) {
       final int selectedOption =
           EventThreadJOptionPane.showConfirmDialog(
@@ -846,12 +846,13 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier {
               JOptionPane.YES_NO_OPTION,
               getUiContext().getCountDownLatchHandler());
       if (selectedOption != JOptionPane.OK_OPTION) {
-        return;
+        return false;
       }
     }
 
     stopGame();
     ExitStatus.SUCCESS.exit();
+    return true;
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
@@ -112,7 +112,7 @@ final class FileMenu extends JMenu {
     // Mac OS X automatically creates a Quit menu item under the TripleA menu,
     // so all we need to do is register that menu item with triplea's shutdown mechanism
     if (isMac) {
-      MacOsIntegration.setQuitHandler(() -> frame.shutdown());
+      MacOsIntegration.setQuitHandler(frame);
     } else { // On non-Mac operating systems, we need to manually create an Exit menu item
       final JMenuItem menuFileExit =
           new JMenuItem(SwingAction.of("Exit Program", e -> frame.shutdown()));

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
@@ -112,7 +112,7 @@ final class FileMenu extends JMenu {
     // Mac OS X automatically creates a Quit menu item under the TripleA menu,
     // so all we need to do is register that menu item with triplea's shutdown mechanism
     if (isMac) {
-      MacOsIntegration.setQuitHandler(frame::shutdown);
+      MacOsIntegration.setQuitHandler(() -> frame.shutdown());
     } else { // On non-Mac operating systems, we need to manually create an Exit menu item
       final JMenuItem menuFileExit =
           new JMenuItem(SwingAction.of("Exit Program", e -> frame.shutdown()));

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -26,7 +26,7 @@ public final class LobbyMenu extends JMenuBar {
     if (!SystemProperties.isMac()) {
       add(new JMenuBuilder("File", 'F').addMenuItem("Exit", 'X', lobbyFrame::shutdown).build());
     } else {
-      MacOsIntegration.setQuitHandler(lobbyFrame::shutdown);
+      MacOsIntegration.setQuitHandler(() -> lobbyFrame.shutdown());
     }
 
     if (!lobbyFrame.getLobbyClient().isAnonymousLogin()) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -26,7 +26,7 @@ public final class LobbyMenu extends JMenuBar {
     if (!SystemProperties.isMac()) {
       add(new JMenuBuilder("File", 'F').addMenuItem("Exit", 'X', lobbyFrame::shutdown).build());
     } else {
-      MacOsIntegration.setQuitHandler(() -> lobbyFrame.shutdown());
+      MacOsIntegration.setQuitHandler(lobbyFrame);
     }
 
     if (!lobbyFrame.getLobbyClient().isAnonymousLogin()) {


### PR DESCRIPTION
Fix quit dialog not appearing on Mac when dismissed.
We were not calling quitResponse.cancelQuit() when quit was canceled, which was needed.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[X] Problem fix:  https://github.com/triplea-game/triplea/issues/4525
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[X] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

