### PR TITLE
Use abstract object for retreat

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -461,6 +461,11 @@ public class BattleDisplay extends JPanel {
       return RetreatResult.retreatTo(possible.iterator().next());
     }
 
+    return showRetreatOptions(message, possible);
+  }
+
+  private RetreatResult showRetreatOptions(
+      final String message, final Collection<Territory> possible) {
     final RetreatComponent comp = new RetreatComponent(possible);
     final int option =
         JOptionPane.showConfirmDialog(

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -46,6 +46,7 @@ import java.util.Timer;
 import java.util.TimerTask;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
@@ -366,15 +367,16 @@ public class BattleDisplay extends JPanel {
     return retreatTo.get();
   }
 
-  private Action getSubmergeAction(
-      final String message,
+  private Action getPlayerAction(
+      final String title,
+      final Supplier<RetreatResult> showDialog,
       final AtomicReference<Territory> retreatTo,
       final CountDownLatch latch) {
     return SwingAction.of(
-        "Submerge Subs?",
+        title,
         e -> {
           actionButton.setEnabled(false);
-          final RetreatResult retreatResult = showSubmergeDialog(message);
+          final RetreatResult retreatResult = showDialog.get();
           if (retreatResult.isConfirmed()) {
             retreatTo.set(retreatResult.getTarget());
             actionButton.setAction(nullAction);
@@ -382,6 +384,13 @@ public class BattleDisplay extends JPanel {
           }
           actionButton.setEnabled(true);
         });
+  }
+
+  private Action getSubmergeAction(
+      final String message,
+      final AtomicReference<Territory> retreatTo,
+      final CountDownLatch latch) {
+    return getPlayerAction("Submerge Subs?", () -> showSubmergeDialog(message), retreatTo, latch);
   }
 
   private RetreatResult showSubmergeDialog(final String message) {
@@ -416,18 +425,8 @@ public class BattleDisplay extends JPanel {
       final Collection<Territory> possible,
       final AtomicReference<Territory> retreatTo,
       final CountDownLatch latch) {
-    return SwingAction.of(
-        "Retreat?",
-        e -> {
-          actionButton.setEnabled(false);
-          final RetreatResult retreatResult = showRetreatDialog(message, possible);
-          if (retreatResult.isConfirmed()) {
-            retreatTo.set(retreatResult.getTarget());
-            actionButton.setAction(nullAction);
-            latch.countDown();
-          }
-          actionButton.setEnabled(true);
-        });
+    return getPlayerAction(
+        "Retreat?", () -> showRetreatDialog(message, possible), retreatTo, latch);
   }
 
   private RetreatResult showRetreatDialog(

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -355,7 +355,6 @@ public class BattleDisplay extends JPanel {
     if (SwingUtilities.isEventDispatchThread()) {
       throw new IllegalStateException("Should not be called from dispatch thread");
     }
-    final CompletableFuture<Territory> future = new CompletableFuture<>();
     final String title;
     final Supplier<RetreatResult> supplier;
     if (!submerge || possible.size() > 1) {
@@ -365,6 +364,7 @@ public class BattleDisplay extends JPanel {
       title = "Submerge Subs?";
       supplier = () -> showSubmergeDialog(message);
     }
+    final CompletableFuture<Territory> future = new CompletableFuture<>();
     final Action action = getPlayerAction(title, supplier, future);
     SwingUtilities.invokeLater(
         () -> {

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -351,25 +351,31 @@ public class BattleDisplay extends JPanel {
         : getSubmerge(message);
   }
 
+  private Action getSubmergeAction(
+      final String message,
+      final AtomicReference<Territory> retreatTo,
+      final CountDownLatch latch) {
+    return SwingAction.of(
+        "Submerge Subs?",
+        e -> {
+          actionButton.setEnabled(false);
+          final RetreatResult retreatResult = showSubmergeDialog(message);
+          if (retreatResult.isConfirmed()) {
+            retreatTo.set(retreatResult.getTarget());
+            actionButton.setAction(nullAction);
+            latch.countDown();
+          }
+          actionButton.setEnabled(true);
+        });
+  }
+
   private Territory getSubmerge(final String message) {
     if (SwingUtilities.isEventDispatchThread()) {
       throw new IllegalStateException("Should not be called from dispatch thread");
     }
     final AtomicReference<Territory> retreatTo = new AtomicReference<>();
     final CountDownLatch latch = new CountDownLatch(1);
-    final Action action =
-        SwingAction.of(
-            "Submerge Subs?",
-            e -> {
-              actionButton.setEnabled(false);
-              final RetreatResult retreatResult = showSubmergeDialog(message);
-              if (retreatResult.isConfirmed()) {
-                retreatTo.set(retreatResult.getTarget());
-                actionButton.setAction(nullAction);
-                latch.countDown();
-              }
-              actionButton.setEnabled(true);
-            });
+    final Action action = getSubmergeAction(message, retreatTo, latch);
     SwingUtilities.invokeLater(
         () -> {
           actionButton.setAction(action);
@@ -408,25 +414,32 @@ public class BattleDisplay extends JPanel {
     return RetreatResult.retreatTo(battleLocation);
   }
 
+  private Action getRetreatAction(
+      final String message,
+      final Collection<Territory> possible,
+      final AtomicReference<Territory> retreatTo,
+      final CountDownLatch latch) {
+    return SwingAction.of(
+        "Retreat?",
+        e -> {
+          actionButton.setEnabled(false);
+          final RetreatResult retreatResult = showRetreatDialog(message, possible);
+          if (retreatResult.isConfirmed()) {
+            retreatTo.set(retreatResult.getTarget());
+            actionButton.setAction(nullAction);
+            latch.countDown();
+          }
+          actionButton.setEnabled(true);
+        });
+  }
+
   private Territory getRetreatInternal(final String message, final Collection<Territory> possible) {
     if (SwingUtilities.isEventDispatchThread()) {
       throw new IllegalStateException("Should not be called from dispatch thread");
     }
     final AtomicReference<Territory> retreatTo = new AtomicReference<>();
     final CountDownLatch latch = new CountDownLatch(1);
-    final Action action =
-        SwingAction.of(
-            "Retreat?",
-            e -> {
-              actionButton.setEnabled(false);
-              final RetreatResult retreatResult = showRetreatDialog(message, possible);
-              if (retreatResult.isConfirmed()) {
-                retreatTo.set(retreatResult.getTarget());
-                actionButton.setAction(nullAction);
-                latch.countDown();
-              }
-              actionButton.setEnabled(true);
-            });
+    final Action action = getRetreatAction(message, possible, retreatTo, latch);
     SwingUtilities.invokeLater(
         () -> {
           actionButton.setAction(action);


### PR DESCRIPTION
<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 
Follow-up to #5808
Couldn't use optional, because subs already use the current territory with a different meaning, and also couldn't move this object a layer outside to prevent special null meaning magic because I didn't want to break network compatibility for games.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

