### PR TITLE
Change bcrypt dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -75,6 +75,7 @@ subprojects {
 
     ext {
         awaitilityVersion = '4.0.2'
+        bcryptVersion = '0.9.0'
         commonsCliVersion = '1.4'
         commonsCodecVersion = '1.14'
         commonsIoVersion = '2.6'
@@ -95,7 +96,6 @@ subprojects {
         jaxbApiVersion = '2.3.1'
         jaxbCoreVersion = '2.3.0.1'
         jaxbImplVersion = '2.3.2'
-        bcryptVersion = '0.9.0'
         jdbiVersion = '3.12.0'
         jlayerVersion = '1.0.1.4'
         junitJupiterVersion = '5.5.2'

--- a/build.gradle
+++ b/build.gradle
@@ -95,7 +95,7 @@ subprojects {
         jaxbApiVersion = '2.3.1'
         jaxbCoreVersion = '2.3.0.1'
         jaxbImplVersion = '2.3.2'
-        jbcryptVersion = '0.4'
+        bcryptVersion = '0.9.0'
         jdbiVersion = '3.12.0'
         jlayerVersion = '1.0.1.4'
         junitJupiterVersion = '5.5.2'

--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -1,5 +1,3 @@
-import org.apache.tools.ant.filters.ReplaceTokens
-
 description = 'TripleA core library containing code shared between headed and headless versions'
 
 ext {

--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -14,7 +14,6 @@ dependencies {
     implementation "org.apache.commons:commons-math3:$commonsMathVersion"
     implementation "org.apache.httpcomponents:httpclient:$apacheHttpComponentsVersion"
     implementation "org.apache.httpcomponents:httpmime:$apacheHttpComponentsVersion"
-    implementation "at.favre.lib:bcrypt:$bcryptVersion"
     implementation "org.snakeyaml:snakeyaml-engine:$snakeYamlVersion"
     implementation project(":domain-data")
     implementation project(":http-clients")

--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -14,7 +14,7 @@ dependencies {
     implementation "org.apache.commons:commons-math3:$commonsMathVersion"
     implementation "org.apache.httpcomponents:httpclient:$apacheHttpComponentsVersion"
     implementation "org.apache.httpcomponents:httpmime:$apacheHttpComponentsVersion"
-    implementation "org.mindrot:jbcrypt:$jbcryptVersion"
+    implementation "at.favre.lib:bcrypt:$bcryptVersion"
     implementation "org.snakeyaml:snakeyaml-engine:$snakeYamlVersion"
     implementation project(":domain-data")
     implementation project(":http-clients")

--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation "javax.xml.bind:jaxb-api:$jaxbApiVersion"
     implementation "org.jdbi:jdbi3-core:$jdbiVersion"
     implementation "org.jdbi:jdbi3-sqlobject:$jdbiVersion"
-    implementation "org.mindrot:jbcrypt:$jbcryptVersion"
+    implementation "at.favre.lib:bcrypt:$bcryptVersion"
     implementation project(':domain-data')
     implementation project(':http-clients')
     implementation project(':java-extras')

--- a/http-server/src/main/java/org/triplea/server/forgot/password/TempPasswordPersistence.java
+++ b/http-server/src/main/java/org/triplea/server/forgot/password/TempPasswordPersistence.java
@@ -1,12 +1,12 @@
 package org.triplea.server.forgot.password;
 
+import at.favre.lib.crypto.bcrypt.BCrypt;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import org.jdbi.v3.core.Jdbi;
-import org.mindrot.jbcrypt.BCrypt;
 import org.triplea.http.client.forgot.password.ForgotPasswordRequest;
 import org.triplea.java.Sha512Hasher;
 import org.triplea.lobby.server.db.dao.TempPasswordDao;
@@ -27,7 +27,7 @@ class TempPasswordPersistence {
     return new TempPasswordPersistence(
         jdbi.onDemand(TempPasswordDao.class),
         Sha512Hasher::hashPasswordWithSalt,
-        hashedPass -> BCrypt.hashpw(hashedPass, BCrypt.gensalt()));
+        hashedPass -> BCrypt.withDefaults().hashToString(10, hashedPass.toCharArray()));
   }
 
   boolean storeTempPassword(

--- a/http-server/src/main/java/org/triplea/server/forgot/password/TempPasswordPersistence.java
+++ b/http-server/src/main/java/org/triplea/server/forgot/password/TempPasswordPersistence.java
@@ -1,6 +1,7 @@
 package org.triplea.server.forgot.password;
 
 import at.favre.lib.crypto.bcrypt.BCrypt;
+import at.favre.lib.crypto.bcrypt.LongPasswordStrategies;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
@@ -27,7 +28,8 @@ class TempPasswordPersistence {
     return new TempPasswordPersistence(
         jdbi.onDemand(TempPasswordDao.class),
         Sha512Hasher::hashPasswordWithSalt,
-        hashedPass -> BCrypt.withDefaults().hashToString(10, hashedPass.toCharArray()));
+        hashedPass ->
+            BCrypt.with(LongPasswordStrategies.none()).hashToString(10, hashedPass.toCharArray()));
   }
 
   boolean storeTempPassword(

--- a/http-server/src/main/java/org/triplea/server/forgot/password/TempPasswordPersistence.java
+++ b/http-server/src/main/java/org/triplea/server/forgot/password/TempPasswordPersistence.java
@@ -1,7 +1,5 @@
 package org.triplea.server.forgot.password;
 
-import at.favre.lib.crypto.bcrypt.BCrypt;
-import at.favre.lib.crypto.bcrypt.LongPasswordStrategies;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
@@ -11,6 +9,7 @@ import org.jdbi.v3.core.Jdbi;
 import org.triplea.http.client.forgot.password.ForgotPasswordRequest;
 import org.triplea.java.Sha512Hasher;
 import org.triplea.lobby.server.db.dao.TempPasswordDao;
+import org.triplea.server.user.account.PasswordBCrypter;
 
 /**
  * Stores a user temporary password in database. When we generate a new temporary password, all
@@ -28,8 +27,7 @@ class TempPasswordPersistence {
     return new TempPasswordPersistence(
         jdbi.onDemand(TempPasswordDao.class),
         Sha512Hasher::hashPasswordWithSalt,
-        hashedPass ->
-            BCrypt.with(LongPasswordStrategies.none()).hashToString(10, hashedPass.toCharArray()));
+        PasswordBCrypter::hashPassword);
   }
 
   boolean storeTempPassword(

--- a/http-server/src/main/java/org/triplea/server/user/account/PasswordBCrypter.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/PasswordBCrypter.java
@@ -1,6 +1,7 @@
 package org.triplea.server.user.account;
 
 import at.favre.lib.crypto.bcrypt.BCrypt;
+import at.favre.lib.crypto.bcrypt.LongPasswordStrategies;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.io.BaseEncoding;
@@ -18,7 +19,7 @@ public class PasswordBCrypter implements Function<String, String> {
   public String apply(final String password) {
     // TODO: Md5-Deprecation remove hashing here, move to client-side
     final String hashed = hashPasswordWithSalt(password);
-    return BCrypt.withDefaults().hashToString(10, hashed.toCharArray());
+    return BCrypt.with(LongPasswordStrategies.none()).hashToString(10, hashed.toCharArray());
   }
 
   @VisibleForTesting

--- a/http-server/src/main/java/org/triplea/server/user/account/PasswordBCrypter.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/PasswordBCrypter.java
@@ -19,10 +19,45 @@ public class PasswordBCrypter implements Function<String, String> {
   public String apply(final String password) {
     // TODO: Md5-Deprecation remove hashing here, move to client-side
     final String hashed = hashPasswordWithSalt(password);
-    return BCrypt.with(LongPasswordStrategies.none()).hashToString(10, hashed.toCharArray());
+    return hashPassword(hashed);
   }
 
-  @VisibleForTesting
+  /**
+   * This is a helper method designed to simplify the bcrypt API and hide some of the constants
+   * involved. This method generates a hash with 10 rounds. This number is arbitrary and might
+   * increase at a later time.
+   *
+   * @param password The string to apply the bcrypt algorithm to.
+   * @return A hashed password using a randomly generated bcrypt salt.
+   */
+  public static String hashPassword(final String password) {
+    return BCrypt.with(LongPasswordStrategies.none()).hashToString(10, password.toCharArray());
+  }
+
+  /**
+   * Checks of the provided password does match the existing hash. NOTE: Any passwords longer than
+   * 72 bytes (UTF-8) will result in the same hash as the version trimmed to 72 bytes.
+   *
+   * @param password The password to check.
+   * @param hash The hash to verify the password against.
+   * @return True if the password matches the hash, false otherwise.
+   */
+  public static boolean verifyHash(final String password, final String hash) {
+    return BCrypt.verifyer(null, LongPasswordStrategies.none())
+        .verify(password.toCharArray(), hash.toCharArray())
+        .verified;
+  }
+
+  /**
+   * Legacy security precaution. When the lobby still relied on plain TCP sockets, a pseudo-security
+   * for passwords was implemented to prevent them from leaking out into the internet. This
+   * algorithm was vulnerable to a MITM-attack, so in order to keep the user safe in case they
+   * re-used their TripleA password anywhere else, we took the password, prepended a fixed String
+   * provided by {@link #PSEUDO_SALT}, and SHA-512 hashed the whole thing before sending it over the
+   * network. This way an attacker would have to explicitly pre-calculate hashes for TripleA
+   * exclusively in order to brute-force the original password, which hopefully made the thing
+   * annoying enough for most people to try.
+   */
   public static String hashPasswordWithSalt(final String password) {
     Preconditions.checkNotNull(password);
     return sha512(PSEUDO_SALT + password);

--- a/http-server/src/main/java/org/triplea/server/user/account/PasswordBCrypter.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/PasswordBCrypter.java
@@ -1,5 +1,6 @@
 package org.triplea.server.user.account;
 
+import at.favre.lib.crypto.bcrypt.BCrypt;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.io.BaseEncoding;
@@ -7,7 +8,6 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.function.Function;
-import org.mindrot.jbcrypt.BCrypt;
 
 public class PasswordBCrypter implements Function<String, String> {
   // TODO: Md5-Deprecation This value needs to be kept in sync with Sha512Hasher
@@ -18,7 +18,7 @@ public class PasswordBCrypter implements Function<String, String> {
   public String apply(final String password) {
     // TODO: Md5-Deprecation remove hashing here, move to client-side
     final String hashed = hashPasswordWithSalt(password);
-    return BCrypt.hashpw(hashed, BCrypt.gensalt());
+    return BCrypt.withDefaults().hashToString(10, hashed.toCharArray());
   }
 
   @VisibleForTesting

--- a/http-server/src/main/java/org/triplea/server/user/account/login/authorizer/BCryptHashVerifier.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/login/authorizer/BCryptHashVerifier.java
@@ -10,7 +10,7 @@ public class BCryptHashVerifier implements BiPredicate<String, String> {
   public boolean test(final String password, final String databaseBcrypted) {
     // TODO: Md5-Deprecation Move SHA512 hashing to client side
     final String hashedPassword = PasswordBCrypter.hashPasswordWithSalt(password);
-    return BCrypt.verifyer(BCrypt.Version.VERSION_2A, LongPasswordStrategies.none())
+    return BCrypt.verifyer(null, LongPasswordStrategies.none())
         .verify(hashedPassword.toCharArray(), databaseBcrypted.toCharArray())
         .verified;
   }

--- a/http-server/src/main/java/org/triplea/server/user/account/login/authorizer/BCryptHashVerifier.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/login/authorizer/BCryptHashVerifier.java
@@ -1,7 +1,5 @@
 package org.triplea.server.user.account.login.authorizer;
 
-import at.favre.lib.crypto.bcrypt.BCrypt;
-import at.favre.lib.crypto.bcrypt.LongPasswordStrategies;
 import java.util.function.BiPredicate;
 import org.triplea.server.user.account.PasswordBCrypter;
 
@@ -10,8 +8,6 @@ public class BCryptHashVerifier implements BiPredicate<String, String> {
   public boolean test(final String password, final String databaseBcrypted) {
     // TODO: Md5-Deprecation Move SHA512 hashing to client side
     final String hashedPassword = PasswordBCrypter.hashPasswordWithSalt(password);
-    return BCrypt.verifyer(null, LongPasswordStrategies.none())
-        .verify(hashedPassword.toCharArray(), databaseBcrypted.toCharArray())
-        .verified;
+    return PasswordBCrypter.verifyHash(hashedPassword, databaseBcrypted);
   }
 }

--- a/http-server/src/main/java/org/triplea/server/user/account/login/authorizer/BCryptHashVerifier.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/login/authorizer/BCryptHashVerifier.java
@@ -1,7 +1,7 @@
 package org.triplea.server.user.account.login.authorizer;
 
+import at.favre.lib.crypto.bcrypt.BCrypt;
 import java.util.function.BiPredicate;
-import org.mindrot.jbcrypt.BCrypt;
 import org.triplea.server.user.account.PasswordBCrypter;
 
 public class BCryptHashVerifier implements BiPredicate<String, String> {
@@ -9,6 +9,8 @@ public class BCryptHashVerifier implements BiPredicate<String, String> {
   public boolean test(final String password, final String databaseBcrypted) {
     // TODO: Md5-Deprecation Move SHA512 hashing to client side
     final String hashedPassword = PasswordBCrypter.hashPasswordWithSalt(password);
-    return BCrypt.checkpw(hashedPassword, databaseBcrypted);
+    return BCrypt.verifyer()
+        .verify(hashedPassword.toCharArray(), databaseBcrypted.toCharArray())
+        .verified;
   }
 }

--- a/http-server/src/main/java/org/triplea/server/user/account/login/authorizer/BCryptHashVerifier.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/login/authorizer/BCryptHashVerifier.java
@@ -1,6 +1,7 @@
 package org.triplea.server.user.account.login.authorizer;
 
 import at.favre.lib.crypto.bcrypt.BCrypt;
+import at.favre.lib.crypto.bcrypt.LongPasswordStrategies;
 import java.util.function.BiPredicate;
 import org.triplea.server.user.account.PasswordBCrypter;
 
@@ -9,7 +10,7 @@ public class BCryptHashVerifier implements BiPredicate<String, String> {
   public boolean test(final String password, final String databaseBcrypted) {
     // TODO: Md5-Deprecation Move SHA512 hashing to client side
     final String hashedPassword = PasswordBCrypter.hashPasswordWithSalt(password);
-    return BCrypt.verifyer()
+    return BCrypt.verifyer(BCrypt.Version.VERSION_2A, LongPasswordStrategies.none())
         .verify(hashedPassword.toCharArray(), databaseBcrypted.toCharArray())
         .verified;
   }

--- a/http-server/src/test/java/org/triplea/server/user/account/PasswordBCrypterTest.java
+++ b/http-server/src/test/java/org/triplea/server/user/account/PasswordBCrypterTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.StringStartsWith.startsWith;
 
 import at.favre.lib.crypto.bcrypt.BCrypt;
+import at.favre.lib.crypto.bcrypt.LongPasswordStrategies;
 import org.junit.jupiter.api.Test;
 
 class PasswordBCrypterTest {
@@ -27,7 +28,7 @@ class PasswordBCrypterTest {
     final String crypted = new PasswordBCrypter().apply("password");
 
     final boolean result =
-        BCrypt.verifyer()
+        BCrypt.verifyer(BCrypt.Version.VERSION_2A, LongPasswordStrategies.none())
             .verify(
                 PasswordBCrypter.hashPasswordWithSalt("password").toCharArray(),
                 crypted.toCharArray())

--- a/http-server/src/test/java/org/triplea/server/user/account/PasswordBCrypterTest.java
+++ b/http-server/src/test/java/org/triplea/server/user/account/PasswordBCrypterTest.java
@@ -5,8 +5,8 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.StringStartsWith.startsWith;
 
+import at.favre.lib.crypto.bcrypt.BCrypt;
 import org.junit.jupiter.api.Test;
-import org.mindrot.jbcrypt.BCrypt;
 
 class PasswordBCrypterTest {
 
@@ -27,7 +27,11 @@ class PasswordBCrypterTest {
     final String crypted = new PasswordBCrypter().apply("password");
 
     final boolean result =
-        BCrypt.checkpw(PasswordBCrypter.hashPasswordWithSalt("password"), crypted);
+        BCrypt.verifyer()
+            .verify(
+                PasswordBCrypter.hashPasswordWithSalt("password").toCharArray(),
+                crypted.toCharArray())
+            .verified;
 
     assertThat(
         "Verify BCrypt to match a plaintext password against a crypted password", result, is(true));

--- a/http-server/src/test/java/org/triplea/server/user/account/PasswordBCrypterTest.java
+++ b/http-server/src/test/java/org/triplea/server/user/account/PasswordBCrypterTest.java
@@ -5,8 +5,6 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.StringStartsWith.startsWith;
 
-import at.favre.lib.crypto.bcrypt.BCrypt;
-import at.favre.lib.crypto.bcrypt.LongPasswordStrategies;
 import org.junit.jupiter.api.Test;
 
 class PasswordBCrypterTest {
@@ -28,11 +26,7 @@ class PasswordBCrypterTest {
     final String crypted = new PasswordBCrypter().apply("password");
 
     final boolean result =
-        BCrypt.verifyer(null, LongPasswordStrategies.none())
-            .verify(
-                PasswordBCrypter.hashPasswordWithSalt("password").toCharArray(),
-                crypted.toCharArray())
-            .verified;
+        PasswordBCrypter.verifyHash(PasswordBCrypter.hashPasswordWithSalt("password"), crypted);
 
     assertThat(
         "Verify BCrypt to match a plaintext password against a crypted password", result, is(true));

--- a/http-server/src/test/java/org/triplea/server/user/account/PasswordBCrypterTest.java
+++ b/http-server/src/test/java/org/triplea/server/user/account/PasswordBCrypterTest.java
@@ -28,7 +28,7 @@ class PasswordBCrypterTest {
     final String crypted = new PasswordBCrypter().apply("password");
 
     final boolean result =
-        BCrypt.verifyer(BCrypt.Version.VERSION_2A, LongPasswordStrategies.none())
+        BCrypt.verifyer(null, LongPasswordStrategies.none())
             .verify(
                 PasswordBCrypter.hashPasswordWithSalt("password").toCharArray(),
                 crypted.toCharArray())


### PR DESCRIPTION
<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 
Follow-up to #5804
It looks like our jbcrypt library is no longer actively maintained.
That's why I decided to migrate to a what seems to be modern variant of the library https://github.com/patrickfav/bcrypt with good documentation and a modern approach to this task.
I'm about 99% sure that I chose the correct "default settings", we should consider increasing the amount of rounds (currently 10), or moving to a new hashing algorithm like argon2 when we're already at it anyways. See https://medium.com/@mpreziuso/password-hashing-pbkdf2-scrypt-bcrypt-and-argon2-e25aaf41598e



## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

