### PR TITLE
Fix focus lost when typing on PBEM screen.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanelBuilder.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanelBuilder.java
@@ -52,8 +52,8 @@ public class MainPanelBuilder {
                 .map(SetupModel::getChatModel)
                 .orElse(null),
             setupPanelModel::showSelectType);
-    setupPanelModel.setPanelChangeListener(mainPanel);
-    gameSelectorModel.addObserver(mainPanel);
+    setupPanelModel.setPanelChangeListener(setupPanel -> mainPanel.setSetupPanel(setupPanel));
+    gameSelectorModel.addObserver((observable, arg) -> mainPanel.updatePlayButtonState());
     return mainPanel;
   }
 }


### PR DESCRIPTION
This was caused by MainPanel having two types of observers and a bug introduced in 895115c that caused the wrong one to be called.

This change changes reverts that error and renames the two mechanisms to disambiguate them - one is about setting a new set up panel and the other is about updating the button to start the game.

Also cleans up a use of Observable.

<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[X] Code Cleanup or refactor
[] Configuration Change
[X] Problem fix:  https://github.com/triplea-game/triplea/issues/5638
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[X] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

