### PR TITLE
AI add buying zero move units

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/Constants.java
+++ b/game-core/src/main/java/games/strategy/triplea/Constants.java
@@ -248,6 +248,7 @@ public interface Constants {
   String PROPERTY_FALSE = "false";
 
   String CONSTRUCTION_TYPE_FACTORY = "factory";
+  String CONSTRUCTION_TYPE_STRUCTURE = "structure";
 
   static String getIncomePercentageFor(final GamePlayer gamePlayer) {
     return gamePlayer.getName() + " Income Percentage";

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -2569,8 +2569,6 @@ class ProPurchaseAi {
                 ppt.getTerritory(),
                 purchaseTerritory.getTerritory(),
                 isBid)) {
-
-          // Place max number of units
           final List<Unit> constructions =
               CollectionUtils.getMatches(unitsToPlace, Matches.unitIsConstruction());
           unitsToPlace.removeAll(constructions);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -23,6 +23,7 @@ import games.strategy.triplea.ai.pro.util.ProBattleUtils;
 import games.strategy.triplea.ai.pro.util.ProMatches;
 import games.strategy.triplea.ai.pro.util.ProOddsCalculator;
 import games.strategy.triplea.ai.pro.util.ProPurchaseUtils;
+import games.strategy.triplea.ai.pro.util.ProPurchaseValidationUtils;
 import games.strategy.triplea.ai.pro.util.ProTerritoryValueUtils;
 import games.strategy.triplea.ai.pro.util.ProTransportUtils;
 import games.strategy.triplea.ai.pro.util.ProUtils;
@@ -730,7 +731,7 @@ class ProPurchaseAi {
             new ArrayList<>(defensePurchaseOptions);
         allDefensePurchaseOptions.addAll(zeroMoveDefensePurchaseOptions);
         final List<ProPurchaseOption> purchaseOptionsForTerritory =
-            ProPurchaseUtils.findPurchaseOptionsForTerritory(
+            ProPurchaseValidationUtils.findPurchaseOptionsForTerritory(
                 proData,
                 player,
                 allDefensePurchaseOptions,
@@ -743,7 +744,7 @@ class ProPurchaseAi {
         while (true) {
 
           // Select purchase option
-          ProPurchaseUtils.removeInvalidPurchaseOptions(
+          ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
               player,
               startOfTurnData,
               purchaseOptionsForTerritory,
@@ -959,9 +960,9 @@ class ProPurchaseAi {
 
       // Remove options that cost too much PUs or production
       final List<ProPurchaseOption> purchaseOptionsForTerritory =
-          ProPurchaseUtils.findPurchaseOptionsForTerritory(
+          ProPurchaseValidationUtils.findPurchaseOptionsForTerritory(
               proData, player, specialPurchaseOptions, t, isBid);
-      ProPurchaseUtils.removeInvalidPurchaseOptions(
+      ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
           player,
           startOfTurnData,
           purchaseOptionsForTerritory,
@@ -1046,13 +1047,13 @@ class ProPurchaseAi {
 
       // Determine most cost efficient units that can be produced in this territory
       final List<ProPurchaseOption> landFodderOptions =
-          ProPurchaseUtils.findPurchaseOptionsForTerritory(
+          ProPurchaseValidationUtils.findPurchaseOptionsForTerritory(
               proData, player, purchaseOptions.getLandFodderOptions(), t, isBid);
       final List<ProPurchaseOption> landAttackOptions =
-          ProPurchaseUtils.findPurchaseOptionsForTerritory(
+          ProPurchaseValidationUtils.findPurchaseOptionsForTerritory(
               proData, player, purchaseOptions.getLandAttackOptions(), t, isBid);
       final List<ProPurchaseOption> landDefenseOptions =
-          ProPurchaseUtils.findPurchaseOptionsForTerritory(
+          ProPurchaseValidationUtils.findPurchaseOptionsForTerritory(
               proData, player, purchaseOptions.getLandDefenseOptions(), t, isBid);
 
       // Determine enemy distance and locally owned units
@@ -1079,7 +1080,7 @@ class ProPurchaseAi {
       for (final Iterator<Unit> it = unplacedUnits.iterator(); it.hasNext(); ) {
         final Unit u = it.next();
         if (remainingUnitProduction > 0
-            && ProPurchaseUtils.canUnitsBePlaced(proData, List.of(u), player, t, isBid)) {
+            && ProPurchaseValidationUtils.canUnitsBePlaced(proData, List.of(u), player, t, isBid)) {
           remainingUnitProduction--;
           unitsToPlace.add(u);
           it.remove();
@@ -1094,7 +1095,7 @@ class ProPurchaseAi {
       while (true) {
 
         // Remove options that cost too much PUs or production
-        ProPurchaseUtils.removeInvalidPurchaseOptions(
+        ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
             player,
             startOfTurnData,
             landFodderOptions,
@@ -1102,7 +1103,7 @@ class ProPurchaseAi {
             remainingUnitProduction,
             unitsToPlace,
             purchaseTerritories);
-        ProPurchaseUtils.removeInvalidPurchaseOptions(
+        ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
             player,
             startOfTurnData,
             landAttackOptions,
@@ -1110,7 +1111,7 @@ class ProPurchaseAi {
             remainingUnitProduction,
             unitsToPlace,
             purchaseTerritories);
-        ProPurchaseUtils.removeInvalidPurchaseOptions(
+        ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
             player,
             startOfTurnData,
             landDefenseOptions,
@@ -1336,10 +1337,10 @@ class ProPurchaseAi {
 
       // Determine units that can be produced in this territory
       final List<ProPurchaseOption> purchaseOptionsForTerritory =
-          ProPurchaseUtils.findPurchaseOptionsForTerritory(
+          ProPurchaseValidationUtils.findPurchaseOptionsForTerritory(
               proData, player, purchaseOptions.getFactoryOptions(), maxTerritory, isBid);
       resourceTracker.removeTempPurchase(maxPlacedOption);
-      ProPurchaseUtils.removeInvalidPurchaseOptions(
+      ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
           player,
           startOfTurnData,
           purchaseOptionsForTerritory,
@@ -1560,7 +1561,7 @@ class ProPurchaseAi {
 
           // Determine sea and transport units that can be produced in this territory
           final List<ProPurchaseOption> seaPurchaseOptionsForTerritory =
-              ProPurchaseUtils.findPurchaseOptionsForTerritory(
+              ProPurchaseValidationUtils.findPurchaseOptionsForTerritory(
                   proData,
                   player,
                   purchaseOptions.getSeaDefenseOptions(),
@@ -1580,7 +1581,7 @@ class ProPurchaseAi {
             }
 
             // Select purchase option
-            ProPurchaseUtils.removeInvalidPurchaseOptions(
+            ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
                 player,
                 startOfTurnData,
                 seaPurchaseOptionsForTerritory,
@@ -1788,7 +1789,7 @@ class ProPurchaseAi {
 
         // Determine sea and transport units that can be produced in this territory
         final List<ProPurchaseOption> seaPurchaseOptionsForTerritory =
-            ProPurchaseUtils.findPurchaseOptionsForTerritory(
+            ProPurchaseValidationUtils.findPurchaseOptionsForTerritory(
                 proData,
                 player,
                 purchaseOptions.getSeaDefenseOptions(),
@@ -1805,7 +1806,7 @@ class ProPurchaseAi {
           }
 
           // Select purchase option
-          ProPurchaseUtils.removeInvalidPurchaseOptions(
+          ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
               player,
               startOfTurnData,
               seaPurchaseOptionsForTerritory,
@@ -1906,10 +1907,10 @@ class ProPurchaseAi {
 
         // Determine sea and transport units that can be produced in this territory
         final List<ProPurchaseOption> seaTransportPurchaseOptionsForTerritory =
-            ProPurchaseUtils.findPurchaseOptionsForTerritory(
+            ProPurchaseValidationUtils.findPurchaseOptionsForTerritory(
                 proData, player, purchaseOptions.getSeaTransportOptions(), t, landTerritory, isBid);
         final List<ProPurchaseOption> amphibPurchaseOptionsForTerritory =
-            ProPurchaseUtils.findPurchaseOptionsForTerritory(
+            ProPurchaseValidationUtils.findPurchaseOptionsForTerritory(
                 proData, player, purchaseOptions.getLandOptions(), landTerritory, isBid);
 
         // Find transports that need loaded and units to ignore that are already paired up
@@ -1988,7 +1989,7 @@ class ProPurchaseAi {
             while (transportCapacity > 0) {
 
               // Select amphib purchase option and add units
-              ProPurchaseUtils.removeInvalidPurchaseOptions(
+              ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
                   player,
                   startOfTurnData,
                   amphibPurchaseOptionsForTerritory,
@@ -2024,7 +2025,7 @@ class ProPurchaseAi {
           } else {
 
             // Select purchase option
-            ProPurchaseUtils.removeInvalidPurchaseOptions(
+            ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
                 player,
                 startOfTurnData,
                 seaTransportPurchaseOptionsForTerritory,
@@ -2122,7 +2123,7 @@ class ProPurchaseAi {
       final List<ProPurchaseOption> airAndLandPurchaseOptions = new ArrayList<>(airPurchaseOptions);
       airAndLandPurchaseOptions.addAll(landPurchaseOptions);
       final List<ProPurchaseOption> purchaseOptionsForTerritory =
-          ProPurchaseUtils.findPurchaseOptionsForTerritory(
+          ProPurchaseValidationUtils.findPurchaseOptionsForTerritory(
               proData, player, airAndLandPurchaseOptions, t, isBid);
 
       // Purchase long range attack units for any remaining production
@@ -2130,7 +2131,7 @@ class ProPurchaseAi {
       while (true) {
 
         // Remove options that cost too much PUs or production
-        ProPurchaseUtils.removeInvalidPurchaseOptions(
+        ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
             player,
             startOfTurnData,
             purchaseOptionsForTerritory,
@@ -2190,7 +2191,7 @@ class ProPurchaseAi {
       final List<ProPurchaseOption> airAndLandPurchaseOptions = new ArrayList<>(airPurchaseOptions);
       airAndLandPurchaseOptions.addAll(landPurchaseOptions);
       final List<ProPurchaseOption> purchaseOptionsForTerritory =
-          ProPurchaseUtils.findPurchaseOptionsForTerritory(
+          ProPurchaseValidationUtils.findPurchaseOptionsForTerritory(
               proData, player, airAndLandPurchaseOptions, t, isBid);
 
       // Purchase defense units for any remaining production
@@ -2198,7 +2199,7 @@ class ProPurchaseAi {
       while (true) {
 
         // Select purchase option
-        ProPurchaseUtils.removeInvalidPurchaseOptions(
+        ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
             player,
             startOfTurnData,
             purchaseOptionsForTerritory,
@@ -2267,7 +2268,7 @@ class ProPurchaseAi {
           new ArrayList<>(purchaseOptions.getAirOptions());
       airAndLandPurchaseOptions.addAll(purchaseOptions.getLandOptions());
       final List<ProPurchaseOption> purchaseOptionsForTerritory =
-          ProPurchaseUtils.findPurchaseOptionsForTerritory(
+          ProPurchaseValidationUtils.findPurchaseOptionsForTerritory(
               proData, player, airAndLandPurchaseOptions, t, isBid);
 
       // Purchase long range attack units for any remaining production
@@ -2293,7 +2294,7 @@ class ProPurchaseAi {
 
         // Remove options that cost too much PUs or production
         resourceTracker.removeTempPurchase(minPurchaseOption);
-        ProPurchaseUtils.removeInvalidPurchaseOptions(
+        ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
             player,
             startOfTurnData,
             purchaseOptionsForTerritory,
@@ -2561,7 +2562,7 @@ class ProPurchaseAi {
         // If place territory is equal to the current place territory and has remaining production
         if (placeTerritory.equals(ppt)
             && purchaseTerritory.getRemainingUnitProduction() > 0
-            && ProPurchaseUtils.canUnitsBePlaced(
+            && ProPurchaseValidationUtils.canUnitsBePlaced(
                 proData,
                 unitsToPlace,
                 player,

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
@@ -258,7 +258,7 @@ public class ProPurchaseOption {
 
   private double calculateLandDistanceFactor(final int enemyDistance) {
     if (movement <= 0) {
-      return 0.1;
+      return 0.1; // Set 0 move units to an order of magnitude less than 1 move units
     }
     final double distance = Math.max(0, enemyDistance - 1.5);
     final int moveValue = isLandTransport ? (movement + 1) : movement;

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
@@ -27,13 +27,14 @@ import org.triplea.java.collections.IntegerMap;
 public class ProPurchaseOption {
 
   @Getter private final ProductionRule productionRule;
-
   @Getter private final UnitType unitType;
   private final GamePlayer player;
-
   @Getter private final int cost;
-
   @Getter private final IntegerMap<Resource> costs;
+  @Getter private final boolean isConstruction;
+  @Getter private final String constructionType;
+  @Getter private final int constructionTypePerTurn;
+  @Getter private final int maxConstructionType;
   @Getter private final int movement;
   @Getter private final int quantity;
   @Getter private int hitPoints;
@@ -71,6 +72,10 @@ public class ProPurchaseOption {
     final Resource pus = data.getResourceList().getResource(Constants.PUS);
     cost = productionRule.getCosts().getInt(pus);
     costs = productionRule.getCosts();
+    isConstruction = unitAttachment.getIsConstruction();
+    constructionType = unitAttachment.getConstructionType();
+    constructionTypePerTurn = unitAttachment.getConstructionsPerTerrPerTypePerTurn();
+    maxConstructionType = unitAttachment.getMaxConstructionsPerTypePerTerr();
     movement = unitAttachment.getMovement(player);
     quantity = productionRule.getResults().totalValues();
     final boolean isInfra = unitAttachment.getIsInfrastructure();
@@ -170,7 +175,7 @@ public class ProPurchaseOption {
         0.25, 0.25, supportAttackFactor, supportDefenseFactor, distanceFactor, data);
   }
 
-  public double getAttackEfficiency2(
+  public double getAttackEfficiency(
       final int enemyDistance,
       final GameData data,
       final List<Unit> ownedLocalUnits,
@@ -184,7 +189,7 @@ public class ProPurchaseOption {
         1.25, 0.75, supportAttackFactor, supportDefenseFactor, distanceFactor, data);
   }
 
-  public double getDefenseEfficiency2(
+  public double getDefenseEfficiency(
       final int enemyDistance,
       final GameData data,
       final List<Unit> ownedLocalUnits,
@@ -252,6 +257,9 @@ public class ProPurchaseOption {
   }
 
   private double calculateLandDistanceFactor(final int enemyDistance) {
+    if (movement <= 0) {
+      return 0.1;
+    }
     final double distance = Math.max(0, enemyDistance - 1.5);
     final int moveValue = isLandTransport ? (movement + 1) : movement;
     // 1, 2, 2.5, 2.75, etc

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOptionMap.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOptionMap.java
@@ -23,6 +23,7 @@ public class ProPurchaseOptionMap {
   private final List<ProPurchaseOption> landFodderOptions;
   private final List<ProPurchaseOption> landAttackOptions;
   private final List<ProPurchaseOption> landDefenseOptions;
+  private final List<ProPurchaseOption> landZeroMoveOptions;
   private final List<ProPurchaseOption> airOptions;
   private final List<ProPurchaseOption> seaDefenseOptions;
   private final List<ProPurchaseOption> seaTransportOptions;
@@ -40,6 +41,7 @@ public class ProPurchaseOptionMap {
     landFodderOptions = new ArrayList<>();
     landAttackOptions = new ArrayList<>();
     landDefenseOptions = new ArrayList<>();
+    landZeroMoveOptions = new ArrayList<>();
     airOptions = new ArrayList<>();
     seaDefenseOptions = new ArrayList<>();
     seaTransportOptions = new ArrayList<>();
@@ -64,9 +66,7 @@ public class ProPurchaseOptionMap {
       final UnitType unitType = (UnitType) resourceOrUnit;
 
       // Add rule to appropriate purchase option list
-      if ((UnitAttachment.get(unitType).getMovement(player) <= 0
-              && !UnitAttachment.get(unitType).getCanProduceUnits())
-          || Matches.unitTypeConsumesUnitsOnCreation().test(unitType)
+      if (Matches.unitTypeConsumesUnitsOnCreation().test(unitType)
           || UnitAttachment.get(unitType).getIsSuicide()
           || UnitAttachment.get(unitType).getIsSuicideOnHit()) {
         final ProPurchaseOption ppo = new ProPurchaseOption(rule, unitType, player, data);
@@ -77,6 +77,11 @@ public class ProPurchaseOptionMap {
         final ProPurchaseOption ppo = new ProPurchaseOption(rule, unitType, player, data);
         factoryOptions.add(ppo);
         ProLogger.debug("Factory: " + ppo);
+      } else if (UnitAttachment.get(unitType).getMovement(player) <= 0
+          && Matches.unitTypeIsLand().test(unitType)) {
+        final ProPurchaseOption ppo = new ProPurchaseOption(rule, unitType, player, data);
+        landZeroMoveOptions.add(ppo);
+        ProLogger.debug("Zero Move Land: " + ppo);
       } else if (Matches.unitTypeIsLand().test(unitType)) {
         final ProPurchaseOption ppo = new ProPurchaseOption(rule, unitType, player, data);
         if (!Matches.unitTypeIsInfrastructure().test(unitType)) {
@@ -127,6 +132,7 @@ public class ProPurchaseOptionMap {
     logOptions(landFodderOptions, "Land Fodder Options: ");
     logOptions(landAttackOptions, "Land Attack Options: ");
     logOptions(landDefenseOptions, "Land Defense Options: ");
+    logOptions(landZeroMoveOptions, "Land Zero Move Options: ");
     logOptions(airOptions, "Air Options: ");
     logOptions(seaDefenseOptions, "Sea Defense Options: ");
     logOptions(seaTransportOptions, "Sea Transport Options: ");
@@ -140,6 +146,7 @@ public class ProPurchaseOptionMap {
   public List<ProPurchaseOption> getAllOptions() {
     final Set<ProPurchaseOption> allOptions = new HashSet<>();
     allOptions.addAll(getLandOptions());
+    allOptions.addAll(landZeroMoveOptions);
     allOptions.addAll(airOptions);
     allOptions.addAll(getSeaOptions());
     allOptions.addAll(aaOptions);
@@ -175,6 +182,10 @@ public class ProPurchaseOptionMap {
 
   public List<ProPurchaseOption> getLandDefenseOptions() {
     return landDefenseOptions;
+  }
+
+  public List<ProPurchaseOption> getLandZeroMoveOptions() {
+    return landZeroMoveOptions;
   }
 
   public List<ProPurchaseOption> getAirOptions() {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOptionMap.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOptionMap.java
@@ -6,6 +6,7 @@ import games.strategy.engine.data.NamedAttachable;
 import games.strategy.engine.data.ProductionFrontier;
 import games.strategy.engine.data.ProductionRule;
 import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.Properties;
 import games.strategy.triplea.ai.pro.logging.ProLogger;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
@@ -67,8 +68,8 @@ public class ProPurchaseOptionMap {
 
       // Add rule to appropriate purchase option list
       if (Matches.unitTypeConsumesUnitsOnCreation().test(unitType)
-          || UnitAttachment.get(unitType).getIsSuicide()
-          || UnitAttachment.get(unitType).getIsSuicideOnHit()) {
+          || UnitAttachment.get(unitType).getIsSuicideOnHit()
+          || canUnitTypeSuicide(unitType, player, data)) {
         final ProPurchaseOption ppo = new ProPurchaseOption(rule, unitType, player, data);
         specialOptions.add(ppo);
         ProLogger.debug("Special: " + ppo);
@@ -141,6 +142,13 @@ public class ProPurchaseOptionMap {
     logOptions(aaOptions, "AA Options: ");
     logOptions(factoryOptions, "Factory Options: ");
     logOptions(specialOptions, "Special Options: ");
+  }
+
+  private boolean canUnitTypeSuicide(
+      final UnitType unitType, final GamePlayer player, final GameData data) {
+    return UnitAttachment.get(unitType).getIsSuicide()
+        && (UnitAttachment.get(unitType).getMovement(player) > 0
+            || !Properties.getDefendingSuicideAndMunitionUnitsDoNotFire(data));
   }
 
   public List<ProPurchaseOption> getAllOptions() {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseTerritory.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseTerritory.java
@@ -66,7 +66,7 @@ public class ProPurchaseTerritory {
     int remainingUnitProduction = unitProduction;
     for (final ProPlaceTerritory ppt : canPlaceTerritories) {
       remainingUnitProduction -=
-          CollectionUtils.countMatches(ppt.getPlaceUnits(), Matches.unitIsConstruction().negate());
+          CollectionUtils.countMatches(ppt.getPlaceUnits(), Matches.unitIsNotConstruction());
     }
     return remainingUnitProduction;
   }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseTerritory.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseTerritory.java
@@ -11,6 +11,7 @@ import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.triplea.java.collections.CollectionUtils;
 
 /** The result of an AI purchase analysis for a single territory. */
 @ToString
@@ -64,7 +65,8 @@ public class ProPurchaseTerritory {
   public int getRemainingUnitProduction() {
     int remainingUnitProduction = unitProduction;
     for (final ProPlaceTerritory ppt : canPlaceTerritories) {
-      remainingUnitProduction -= ppt.getPlaceUnits().size();
+      remainingUnitProduction -=
+          CollectionUtils.countMatches(ppt.getPlaceUnits(), Matches.unitIsConstruction().negate());
     }
     return remainingUnitProduction;
   }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
@@ -99,10 +99,12 @@ public final class ProBattleUtils {
       final Collection<Unit> attackingUnits,
       final Collection<Unit> defendingUnits) {
 
-    if (attackingUnits.stream().allMatch(Matches.unitIsInfrastructure())) {
+    if (attackingUnits.stream().allMatch(Matches.unitIsInfrastructure())
+        || estimatePower(proData, t, attackingUnits, defendingUnits, true) <= 0) {
       return 0;
     }
-    if (defendingUnits.stream().allMatch(Matches.unitIsInfrastructure())) {
+    if (defendingUnits.stream().allMatch(Matches.unitIsInfrastructure())
+        || estimatePower(proData, t, defendingUnits, attackingUnits, false) <= 0) {
       return 99999;
     }
     final double attackerStrength =

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
@@ -31,12 +31,13 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.function.Predicate;
+import lombok.experimental.UtilityClass;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 
 /** Pro AI purchase utilities. */
+@UtilityClass
 public final class ProPurchaseUtils {
-  private ProPurchaseUtils() {}
 
   /**
    * Randomly selects one of the specified purchase options of the specified type.

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
@@ -473,31 +473,11 @@ public final class ProPurchaseUtils {
       final GamePlayer player,
       final List<ProPurchaseOption> zeroMoveDefensePurchaseOptions) {
     final IntegerMap<String> constructionTypesPerTurn = new IntegerMap<>();
-    //    final boolean wasFactoryThereAtStart =
-    //        ProMatches.territoryHasFactoryAndIsNotConqueredOwnedLand(player,
-    // data).test(territory);
-    //    int production = 0;
-    //    final TerritoryAttachment terrAttachment = TerritoryAttachment.get(territory);
-    //    if (terrAttachment != null) {
-    //      production = terrAttachment.getProduction();
-    //    }
     for (final ProPurchaseOption ppo : zeroMoveDefensePurchaseOptions) {
       final UnitAttachment ua = UnitAttachment.get(ppo.getUnitType());
       if (ua.getIsConstruction()) {
         final String constructionType = ua.getConstructionType();
         final int constructionTypePerTurn = ua.getConstructionsPerTerrPerTypePerTurn();
-        //        if (!constructionType.equals(Constants.CONSTRUCTION_TYPE_FACTORY)
-        //            && !constructionType.endsWith("structure")) {
-        //          if (Properties.getUnlimitedConstructions(data)) {
-        //            constructionTypePerTurn = Integer.MAX_VALUE;
-        //          } else if (wasFactoryThereAtStart &&
-        // Properties.getMoreConstructionsWithFactory(data)) {
-        //            constructionTypePerTurn = Math.max(constructionTypePerTurn, production);
-        //          } else if (!wasFactoryThereAtStart
-        //              && Properties.getMoreConstructionsWithoutFactory(data)) {
-        //            constructionTypePerTurn = Math.max(constructionTypePerTurn, production);
-        //          }
-        //        }
         constructionTypesPerTurn.put(constructionType, constructionTypePerTurn);
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
@@ -8,20 +8,15 @@ import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
-import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Constants;
-import games.strategy.triplea.Properties;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.ai.pro.ProData;
 import games.strategy.triplea.ai.pro.data.ProPlaceTerritory;
 import games.strategy.triplea.ai.pro.data.ProPurchaseOption;
 import games.strategy.triplea.ai.pro.data.ProPurchaseTerritory;
-import games.strategy.triplea.ai.pro.data.ProResourceTracker;
 import games.strategy.triplea.ai.pro.logging.ProLogger;
-import games.strategy.triplea.ai.pro.simulate.ProDummyDelegateBridge;
 import games.strategy.triplea.attachments.RulesAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
-import games.strategy.triplea.delegate.AbstractPlaceDelegate;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.OriginalOwnerTracker;
 import games.strategy.triplea.delegate.TransportTracker;
@@ -30,7 +25,6 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -43,251 +37,6 @@ import org.triplea.java.collections.IntegerMap;
 /** Pro AI purchase utilities. */
 public final class ProPurchaseUtils {
   private ProPurchaseUtils() {}
-
-  public static List<ProPurchaseOption> findPurchaseOptionsForTerritory(
-      final ProData proData,
-      final GamePlayer player,
-      final List<ProPurchaseOption> purchaseOptions,
-      final Territory t,
-      final boolean isBid) {
-    return findPurchaseOptionsForTerritory(proData, player, purchaseOptions, t, t, isBid);
-  }
-
-  public static List<ProPurchaseOption> findPurchaseOptionsForTerritory(
-      final ProData proData,
-      final GamePlayer player,
-      final List<ProPurchaseOption> purchaseOptions,
-      final Territory t,
-      final Territory factoryTerritory,
-      final boolean isBid) {
-    final List<ProPurchaseOption> result = new ArrayList<>();
-    for (final ProPurchaseOption ppo : purchaseOptions) {
-      if (canTerritoryUsePurchaseOption(proData, player, ppo, t, factoryTerritory, isBid)) {
-        result.add(ppo);
-      }
-    }
-    return result;
-  }
-
-  private static boolean canTerritoryUsePurchaseOption(
-      final ProData proData,
-      final GamePlayer player,
-      final ProPurchaseOption ppo,
-      final Territory t,
-      final Territory factoryTerritory,
-      final boolean isBid) {
-    if (ppo == null) {
-      return false;
-    }
-    final List<Unit> units = ppo.getUnitType().create(ppo.getQuantity(), player, true);
-    return canUnitsBePlaced(proData, units, player, t, factoryTerritory, isBid);
-  }
-
-  public static boolean canUnitsBePlaced(
-      final ProData proData,
-      final List<Unit> units,
-      final GamePlayer player,
-      final Territory t,
-      final boolean isBid) {
-    return canUnitsBePlaced(proData, units, player, t, t, isBid);
-  }
-
-  /** Check if units can be placed in given territory by specified factory. */
-  public static boolean canUnitsBePlaced(
-      final ProData proData,
-      final List<Unit> units,
-      final GamePlayer player,
-      final Territory t,
-      final Territory factoryTerritory,
-      final boolean isBid) {
-    final GameData data = player.getData();
-    AbstractPlaceDelegate placeDelegate = (AbstractPlaceDelegate) data.getDelegate("place");
-    if (isBid) {
-      placeDelegate = (AbstractPlaceDelegate) data.getDelegate("placeBid");
-    } else if (!t.equals(factoryTerritory)
-        && !units.stream()
-            .allMatch(
-                Matches.unitWhichRequiresUnitsHasRequiredUnitsInList(
-                    placeDelegate.unitsAtStartOfStepInTerritory(factoryTerritory)))) {
-      return false;
-    }
-    final IDelegateBridge bridge = new ProDummyDelegateBridge(proData.getProAi(), player, data);
-    placeDelegate.setDelegateBridgeAndPlayer(bridge);
-    return isPlacingFightersOnNewCarriers(t, units)
-        ? placeDelegate.canUnitsBePlaced(
-                t, CollectionUtils.getMatches(units, Matches.unitIsNotAir()), player)
-            == null
-        : placeDelegate.canUnitsBePlaced(t, units, player) == null;
-  }
-
-  private static boolean isPlacingFightersOnNewCarriers(final Territory t, final List<Unit> units) {
-    return t.isWater()
-        && Properties.getProduceFightersOnCarriers(t.getData())
-        && units.stream().anyMatch(Matches.unitIsAir())
-        && units.stream().anyMatch(Matches.unitIsCarrier());
-  }
-
-  public static void removeInvalidPurchaseOptions(
-      final GamePlayer player,
-      final GameData data,
-      final List<ProPurchaseOption> purchaseOptions,
-      final ProResourceTracker resourceTracker,
-      final int remainingUnitProduction,
-      final List<Unit> unitsToPlace,
-      final Map<Territory, ProPurchaseTerritory> purchaseTerritories) {
-    ProPurchaseUtils.removeInvalidPurchaseOptions(
-        player,
-        data,
-        purchaseOptions,
-        resourceTracker,
-        remainingUnitProduction,
-        unitsToPlace,
-        purchaseTerritories,
-        0,
-        null);
-  }
-
-  /** Removes any invalid purchase options from {@code purchaseOptions}. */
-  public static void removeInvalidPurchaseOptions(
-      final GamePlayer player,
-      final GameData data,
-      final List<ProPurchaseOption> purchaseOptions,
-      final ProResourceTracker resourceTracker,
-      final int remainingUnitProduction,
-      final List<Unit> unitsToPlace,
-      final Map<Territory, ProPurchaseTerritory> purchaseTerritories,
-      final int remainingConstructions,
-      final Territory territory) {
-
-    for (final Iterator<ProPurchaseOption> it = purchaseOptions.iterator(); it.hasNext(); ) {
-      final ProPurchaseOption purchaseOption = it.next();
-      if (!hasEnoughResourcesAndProduction(
-              purchaseOption, resourceTracker, remainingUnitProduction, remainingConstructions)
-          || hasReachedMaxUnitBuiltPerPlayer(
-              purchaseOption, player, data, unitsToPlace, purchaseTerritories)
-          || hasReachedConstructionLimits(
-              purchaseOption, data, unitsToPlace, purchaseTerritories, territory)) {
-        it.remove();
-      }
-    }
-  }
-
-  private static boolean hasEnoughResourcesAndProduction(
-      final ProPurchaseOption purchaseOption,
-      final ProResourceTracker resourceTracker,
-      final int remainingUnitProduction,
-      final int remainingConstructions) {
-    return resourceTracker.hasEnough(purchaseOption)
-        && purchaseOption.getQuantity()
-            <= (purchaseOption.isConstruction() ? remainingConstructions : remainingUnitProduction);
-  }
-
-  private static boolean hasReachedMaxUnitBuiltPerPlayer(
-      final ProPurchaseOption purchaseOption,
-      final GamePlayer player,
-      final GameData data,
-      final List<Unit> unitsToPlace,
-      final Map<Territory, ProPurchaseTerritory> purchaseTerritories) {
-
-    // Check max unit limits (-1 is unlimited)
-    final int maxBuilt = purchaseOption.getMaxBuiltPerPlayer();
-    final UnitType type = purchaseOption.getUnitType();
-    if (maxBuilt == 0) {
-      return true;
-    } else if (maxBuilt > 0) {
-
-      // Find number of unit type that are already built and about to be placed
-      final Predicate<Unit> unitTypeOwnedBy =
-          Matches.unitIsOfType(type).and(Matches.unitIsOwnedBy(player));
-      int currentlyBuilt = CollectionUtils.countMatches(unitsToPlace, unitTypeOwnedBy);
-      final List<Territory> allTerritories = data.getMap().getTerritories();
-      for (final Territory t : allTerritories) {
-        currentlyBuilt += t.getUnitCollection().countMatches(unitTypeOwnedBy);
-      }
-      for (final ProPurchaseTerritory t : purchaseTerritories.values()) {
-        for (final ProPlaceTerritory placeTerritory : t.getCanPlaceTerritories()) {
-          currentlyBuilt +=
-              CollectionUtils.countMatches(placeTerritory.getPlaceUnits(), unitTypeOwnedBy);
-        }
-      }
-      final int allowedBuild = maxBuilt - currentlyBuilt;
-      if (allowedBuild - purchaseOption.getQuantity() < 0) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private static boolean hasReachedConstructionLimits(
-      final ProPurchaseOption purchaseOption,
-      final GameData data,
-      final List<Unit> unitsToPlace,
-      final Map<Territory, ProPurchaseTerritory> purchaseTerritories,
-      final Territory territory) {
-
-    if (purchaseOption.isConstruction() && territory != null) {
-
-      final int numConstructionTypeToPlace =
-          findNumberOfConstructionTypeToPlace(
-              purchaseOption, unitsToPlace, purchaseTerritories, territory);
-      if (numConstructionTypeToPlace >= purchaseOption.getConstructionTypePerTurn()) {
-        return true;
-      }
-
-      final int maxConstructionType =
-          findMaxConstructionTypeAllowed(purchaseOption, data, territory);
-      final int numExistingConstructionType =
-          CollectionUtils.countMatches(
-              territory.getUnits(), Matches.unitIsOfType(purchaseOption.getUnitType()));
-      if ((numConstructionTypeToPlace + numExistingConstructionType) >= maxConstructionType) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  private static int findNumberOfConstructionTypeToPlace(
-      final ProPurchaseOption purchaseOption,
-      final List<Unit> unitsToPlace,
-      final Map<Territory, ProPurchaseTerritory> purchaseTerritories,
-      final Territory territory) {
-
-    int numConstructionTypeToPlace =
-        CollectionUtils.countMatches(
-            unitsToPlace, Matches.unitIsOfType(purchaseOption.getUnitType()));
-    for (final ProPurchaseTerritory t : purchaseTerritories.values()) {
-      for (final ProPlaceTerritory placeTerritory : t.getCanPlaceTerritories()) {
-        if (placeTerritory.getTerritory().equals(territory)) {
-          numConstructionTypeToPlace +=
-              CollectionUtils.countMatches(
-                  placeTerritory.getPlaceUnits(),
-                  Matches.unitIsOfType(purchaseOption.getUnitType()));
-        }
-      }
-    }
-    return numConstructionTypeToPlace;
-  }
-
-  private static int findMaxConstructionTypeAllowed(
-      final ProPurchaseOption purchaseOption, final GameData data, final Territory territory) {
-
-    int maxConstructionType = purchaseOption.getMaxConstructionType();
-    final String constructionType = purchaseOption.getConstructionType();
-    if (!constructionType.equals(Constants.CONSTRUCTION_TYPE_FACTORY)
-        && !constructionType.endsWith("structure")) {
-      if (Properties.getUnlimitedConstructions(data)) {
-        maxConstructionType = Integer.MAX_VALUE;
-      } else if (Properties.getMoreConstructionsWithFactory(data)) {
-        int production = 0;
-        final TerritoryAttachment terrAttachment = TerritoryAttachment.get(territory);
-        if (terrAttachment != null) {
-          production = terrAttachment.getProduction();
-        }
-        maxConstructionType = Math.max(maxConstructionType, production);
-      }
-    }
-    return maxConstructionType;
-  }
 
   /**
    * Randomly selects one of the specified purchase options of the specified type.
@@ -342,7 +91,7 @@ public final class ProPurchaseUtils {
     final Resource pus = data.getResourceList().getResource(Constants.PUS);
     final int pusRemaining = player.getResources().getQuantity(pus);
     final List<ProPurchaseOption> purchaseOptionsForTerritory =
-        findPurchaseOptionsForTerritory(proData, player, landPurchaseOptions, t, false);
+        ProPurchaseValidationUtils.findPurchaseOptionsForTerritory(proData, player, landPurchaseOptions, t, false);
     ProPurchaseOption bestDefenseOption = null;
     double maxDefenseEfficiency = 0;
     for (final ProPurchaseOption ppo : purchaseOptionsForTerritory) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
@@ -21,7 +21,6 @@ import games.strategy.triplea.ai.pro.logging.ProLogger;
 import games.strategy.triplea.ai.pro.simulate.ProDummyDelegateBridge;
 import games.strategy.triplea.attachments.RulesAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.AbstractPlaceDelegate;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.OriginalOwnerTracker;
@@ -474,11 +473,8 @@ public final class ProPurchaseUtils {
       final List<ProPurchaseOption> zeroMoveDefensePurchaseOptions) {
     final IntegerMap<String> constructionTypesPerTurn = new IntegerMap<>();
     for (final ProPurchaseOption ppo : zeroMoveDefensePurchaseOptions) {
-      final UnitAttachment ua = UnitAttachment.get(ppo.getUnitType());
-      if (ua.getIsConstruction()) {
-        final String constructionType = ua.getConstructionType();
-        final int constructionTypePerTurn = ua.getConstructionsPerTerrPerTypePerTurn();
-        constructionTypesPerTurn.put(constructionType, constructionTypePerTurn);
+      if (ppo.isConstruction()) {
+        constructionTypesPerTurn.put(ppo.getConstructionType(), ppo.getConstructionTypePerTurn());
       }
     }
     return constructionTypesPerTurn.totalValues();

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
@@ -91,7 +91,8 @@ public final class ProPurchaseUtils {
     final Resource pus = data.getResourceList().getResource(Constants.PUS);
     final int pusRemaining = player.getResources().getQuantity(pus);
     final List<ProPurchaseOption> purchaseOptionsForTerritory =
-        ProPurchaseValidationUtils.findPurchaseOptionsForTerritory(proData, player, landPurchaseOptions, t, false);
+        ProPurchaseValidationUtils.findPurchaseOptionsForTerritory(
+            proData, player, landPurchaseOptions, t, false);
     ProPurchaseOption bestDefenseOption = null;
     double maxDefenseEfficiency = 0;
     for (final ProPurchaseOption ppo : purchaseOptionsForTerritory) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseValidationUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseValidationUtils.java
@@ -1,0 +1,279 @@
+package games.strategy.triplea.ai.pro.util;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.Constants;
+import games.strategy.triplea.Properties;
+import games.strategy.triplea.ai.pro.ProData;
+import games.strategy.triplea.ai.pro.data.ProPlaceTerritory;
+import games.strategy.triplea.ai.pro.data.ProPurchaseOption;
+import games.strategy.triplea.ai.pro.data.ProPurchaseTerritory;
+import games.strategy.triplea.ai.pro.data.ProResourceTracker;
+import games.strategy.triplea.ai.pro.simulate.ProDummyDelegateBridge;
+import games.strategy.triplea.attachments.TerritoryAttachment;
+import games.strategy.triplea.delegate.AbstractPlaceDelegate;
+import games.strategy.triplea.delegate.Matches;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import org.triplea.java.collections.CollectionUtils;
+
+/** Pro AI purchase utilities. */
+public final class ProPurchaseValidationUtils {
+  private ProPurchaseValidationUtils() {}
+
+  public static List<ProPurchaseOption> findPurchaseOptionsForTerritory(
+      final ProData proData,
+      final GamePlayer player,
+      final List<ProPurchaseOption> purchaseOptions,
+      final Territory t,
+      final boolean isBid) {
+    return ProPurchaseValidationUtils.findPurchaseOptionsForTerritory(
+        proData, player, purchaseOptions, t, t, isBid);
+  }
+
+  public static List<ProPurchaseOption> findPurchaseOptionsForTerritory(
+      final ProData proData,
+      final GamePlayer player,
+      final List<ProPurchaseOption> purchaseOptions,
+      final Territory t,
+      final Territory factoryTerritory,
+      final boolean isBid) {
+    final List<ProPurchaseOption> result = new ArrayList<>();
+    for (final ProPurchaseOption ppo : purchaseOptions) {
+      if (ProPurchaseValidationUtils.canTerritoryUsePurchaseOption(
+          proData, player, ppo, t, factoryTerritory, isBid)) {
+        result.add(ppo);
+      }
+    }
+    return result;
+  }
+
+  private static boolean canTerritoryUsePurchaseOption(
+      final ProData proData,
+      final GamePlayer player,
+      final ProPurchaseOption ppo,
+      final Territory t,
+      final Territory factoryTerritory,
+      final boolean isBid) {
+    if (ppo == null) {
+      return false;
+    }
+    final List<Unit> units = ppo.getUnitType().create(ppo.getQuantity(), player, true);
+    return ProPurchaseValidationUtils.canUnitsBePlaced(
+        proData, units, player, t, factoryTerritory, isBid);
+  }
+
+  public static boolean canUnitsBePlaced(
+      final ProData proData,
+      final List<Unit> units,
+      final GamePlayer player,
+      final Territory t,
+      final boolean isBid) {
+    return ProPurchaseValidationUtils.canUnitsBePlaced(proData, units, player, t, t, isBid);
+  }
+
+  /** Check if units can be placed in given territory by specified factory. */
+  public static boolean canUnitsBePlaced(
+      final ProData proData,
+      final List<Unit> units,
+      final GamePlayer player,
+      final Territory t,
+      final Territory factoryTerritory,
+      final boolean isBid) {
+    final GameData data = player.getData();
+    AbstractPlaceDelegate placeDelegate = (AbstractPlaceDelegate) data.getDelegate("place");
+    if (isBid) {
+      placeDelegate = (AbstractPlaceDelegate) data.getDelegate("placeBid");
+    } else if (!t.equals(factoryTerritory)
+        && !units.stream()
+            .allMatch(
+                Matches.unitWhichRequiresUnitsHasRequiredUnitsInList(
+                    placeDelegate.unitsAtStartOfStepInTerritory(factoryTerritory)))) {
+      return false;
+    }
+    final IDelegateBridge bridge = new ProDummyDelegateBridge(proData.getProAi(), player, data);
+    placeDelegate.setDelegateBridgeAndPlayer(bridge);
+    return isPlacingFightersOnNewCarriers(t, units)
+        ? placeDelegate.canUnitsBePlaced(
+                t, CollectionUtils.getMatches(units, Matches.unitIsNotAir()), player)
+            == null
+        : placeDelegate.canUnitsBePlaced(t, units, player) == null;
+  }
+
+  private static boolean isPlacingFightersOnNewCarriers(final Territory t, final List<Unit> units) {
+    return t.isWater()
+        && Properties.getProduceFightersOnCarriers(t.getData())
+        && units.stream().anyMatch(Matches.unitIsAir())
+        && units.stream().anyMatch(Matches.unitIsCarrier());
+  }
+
+  public static void removeInvalidPurchaseOptions(
+      final GamePlayer player,
+      final GameData data,
+      final List<ProPurchaseOption> purchaseOptions,
+      final ProResourceTracker resourceTracker,
+      final int remainingUnitProduction,
+      final List<Unit> unitsToPlace,
+      final Map<Territory, ProPurchaseTerritory> purchaseTerritories) {
+    ProPurchaseValidationUtils.removeInvalidPurchaseOptions(
+        player,
+        data,
+        purchaseOptions,
+        resourceTracker,
+        remainingUnitProduction,
+        unitsToPlace,
+        purchaseTerritories,
+        0,
+        null);
+  }
+
+  /** Removes any invalid purchase options from {@code purchaseOptions}. */
+  public static void removeInvalidPurchaseOptions(
+      final GamePlayer player,
+      final GameData data,
+      final List<ProPurchaseOption> purchaseOptions,
+      final ProResourceTracker resourceTracker,
+      final int remainingUnitProduction,
+      final List<Unit> unitsToPlace,
+      final Map<Territory, ProPurchaseTerritory> purchaseTerritories,
+      final int remainingConstructions,
+      final Territory territory) {
+
+    for (final Iterator<ProPurchaseOption> it = purchaseOptions.iterator(); it.hasNext(); ) {
+      final ProPurchaseOption purchaseOption = it.next();
+      if (!hasEnoughResourcesAndProduction(
+              purchaseOption, resourceTracker, remainingUnitProduction, remainingConstructions)
+          || hasReachedMaxUnitBuiltPerPlayer(
+              purchaseOption, player, data, unitsToPlace, purchaseTerritories)
+          || hasReachedConstructionLimits(
+              purchaseOption, data, unitsToPlace, purchaseTerritories, territory)) {
+        it.remove();
+      }
+    }
+  }
+
+  private static boolean hasEnoughResourcesAndProduction(
+      final ProPurchaseOption purchaseOption,
+      final ProResourceTracker resourceTracker,
+      final int remainingUnitProduction,
+      final int remainingConstructions) {
+    return resourceTracker.hasEnough(purchaseOption)
+        && purchaseOption.getQuantity()
+            <= (purchaseOption.isConstruction() ? remainingConstructions : remainingUnitProduction);
+  }
+
+  private static boolean hasReachedMaxUnitBuiltPerPlayer(
+      final ProPurchaseOption purchaseOption,
+      final GamePlayer player,
+      final GameData data,
+      final List<Unit> unitsToPlace,
+      final Map<Territory, ProPurchaseTerritory> purchaseTerritories) {
+
+    // Check max unit limits (-1 is unlimited)
+    final int maxBuilt = purchaseOption.getMaxBuiltPerPlayer();
+    final UnitType type = purchaseOption.getUnitType();
+    if (maxBuilt == 0) {
+      return true;
+    } else if (maxBuilt > 0) {
+
+      // Find number of unit type that are already built and about to be placed
+      final Predicate<Unit> unitTypeOwnedBy =
+          Matches.unitIsOfType(type).and(Matches.unitIsOwnedBy(player));
+      int currentlyBuilt = CollectionUtils.countMatches(unitsToPlace, unitTypeOwnedBy);
+      final List<Territory> allTerritories = data.getMap().getTerritories();
+      for (final Territory t : allTerritories) {
+        currentlyBuilt += t.getUnitCollection().countMatches(unitTypeOwnedBy);
+      }
+      for (final ProPurchaseTerritory t : purchaseTerritories.values()) {
+        for (final ProPlaceTerritory placeTerritory : t.getCanPlaceTerritories()) {
+          currentlyBuilt +=
+              CollectionUtils.countMatches(placeTerritory.getPlaceUnits(), unitTypeOwnedBy);
+        }
+      }
+      final int allowedBuild = maxBuilt - currentlyBuilt;
+      if (allowedBuild - purchaseOption.getQuantity() < 0) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean hasReachedConstructionLimits(
+      final ProPurchaseOption purchaseOption,
+      final GameData data,
+      final List<Unit> unitsToPlace,
+      final Map<Territory, ProPurchaseTerritory> purchaseTerritories,
+      final Territory territory) {
+
+    if (purchaseOption.isConstruction() && territory != null) {
+
+      final int numConstructionTypeToPlace =
+          ProPurchaseValidationUtils.findNumberOfConstructionTypeToPlace(
+              purchaseOption, unitsToPlace, purchaseTerritories, territory);
+      if (numConstructionTypeToPlace >= purchaseOption.getConstructionTypePerTurn()) {
+        return true;
+      }
+
+      final int maxConstructionType =
+          ProPurchaseValidationUtils.findMaxConstructionTypeAllowed(
+              purchaseOption, data, territory);
+      final int numExistingConstructionType =
+          CollectionUtils.countMatches(
+              territory.getUnits(), Matches.unitIsOfType(purchaseOption.getUnitType()));
+      if ((numConstructionTypeToPlace + numExistingConstructionType) >= maxConstructionType) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static int findNumberOfConstructionTypeToPlace(
+      final ProPurchaseOption purchaseOption,
+      final List<Unit> unitsToPlace,
+      final Map<Territory, ProPurchaseTerritory> purchaseTerritories,
+      final Territory territory) {
+
+    int numConstructionTypeToPlace =
+        CollectionUtils.countMatches(
+            unitsToPlace, Matches.unitIsOfType(purchaseOption.getUnitType()));
+    for (final ProPurchaseTerritory t : purchaseTerritories.values()) {
+      for (final ProPlaceTerritory placeTerritory : t.getCanPlaceTerritories()) {
+        if (placeTerritory.getTerritory().equals(territory)) {
+          numConstructionTypeToPlace +=
+              CollectionUtils.countMatches(
+                  placeTerritory.getPlaceUnits(),
+                  Matches.unitIsOfType(purchaseOption.getUnitType()));
+        }
+      }
+    }
+    return numConstructionTypeToPlace;
+  }
+
+  private static int findMaxConstructionTypeAllowed(
+      final ProPurchaseOption purchaseOption, final GameData data, final Territory territory) {
+
+    int maxConstructionType = purchaseOption.getMaxConstructionType();
+    final String constructionType = purchaseOption.getConstructionType();
+    if (!constructionType.equals(Constants.CONSTRUCTION_TYPE_FACTORY)
+        && !constructionType.endsWith(Constants.CONSTRUCTION_TYPE_STRUCTURE)) {
+      if (Properties.getUnlimitedConstructions(data)) {
+        maxConstructionType = Integer.MAX_VALUE;
+      } else if (Properties.getMoreConstructionsWithFactory(data)) {
+        int production = 0;
+        final TerritoryAttachment terrAttachment = TerritoryAttachment.get(territory);
+        if (terrAttachment != null) {
+          production = terrAttachment.getProduction();
+        }
+        maxConstructionType = Math.max(maxConstructionType, production);
+      }
+    }
+    return maxConstructionType;
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseValidationUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseValidationUtils.java
@@ -22,11 +22,15 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
+import lombok.experimental.UtilityClass;
 import org.triplea.java.collections.CollectionUtils;
 
-/** Pro AI purchase utilities. */
+/**
+ * Pro AI utility methods for finding purchase options and validating which ones a territory can
+ * use.
+ */
+@UtilityClass
 public final class ProPurchaseValidationUtils {
-  private ProPurchaseValidationUtils() {}
 
   public static List<ProPurchaseOption> findPurchaseOptionsForTerritory(
       final ProData proData,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -1439,7 +1439,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
         int unitMax = unitMapMaxType.getInt(constructionType);
         if (wasFactoryThereAtStart
             && !constructionType.equals(Constants.CONSTRUCTION_TYPE_FACTORY)
-            && !constructionType.endsWith("structure")) {
+            && !constructionType.endsWith(Constants.CONSTRUCTION_TYPE_STRUCTURE)) {
           unitMax =
               Math.max(
                   Math.max(unitMax, (moreWithFactory ? toProduction : 0)),
@@ -1447,7 +1447,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
         }
         if (!wasFactoryThereAtStart
             && !constructionType.equals(Constants.CONSTRUCTION_TYPE_FACTORY)
-            && !constructionType.endsWith("structure")) {
+            && !constructionType.endsWith(Constants.CONSTRUCTION_TYPE_STRUCTURE)) {
           unitMax =
               Math.max(
                   Math.max(unitMax, (moreWithoutFactory ? toProduction : 0)),


### PR DESCRIPTION
Address forum requests: https://forums.triplea-game.org/topic/1707/simple-trigger-help/20

Add AI support to purchase 0 move and/or construction units which are generally used as static defenses. These are fairly important in some maps.

## Testing

[x] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->
Ran several all AI games on NWO, NML, and revised to ensure there are no issues and the AI appropriately considers buying bunkers in NWO and trenches in NML.
