### PR TITLE
Remove throws on flag rendering and default to 'NONE'

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -137,37 +137,39 @@ public class UnitsDrawer extends AbstractDrawable {
 
     final UnitFlagDrawMode drawMode =
         ClientSetting.unitFlagDrawMode.getValue().orElse(UnitFlagDrawMode.NONE);
-    if (drawMode == UnitFlagDrawMode.LARGE_FLAG) {
-      // If unit is not in the "excluded list" it will get drawn
-      if (maxRange != 0) {
-        final Image flag = uiContext.getFlagImageFactory().getFlag(owner);
-        final int xoffset = img.get().getWidth(null) / 2 - flag.getWidth(null) / 2;
-        final int yoffset = img.get().getHeight(null) / 2 - flag.getHeight(null) / 4 - 5;
-        graphics.drawImage(
-            flag,
-            (placementPoint.x - bounds.x) + xoffset,
-            (placementPoint.y - bounds.y) + yoffset,
-            null);
+    if (img.isPresent()) {
+      if (drawMode == UnitFlagDrawMode.LARGE_FLAG) {
+        // If unit is not in the "excluded list" it will get drawn
+        if (maxRange != 0) {
+          final Image flag = uiContext.getFlagImageFactory().getFlag(owner);
+          final int xoffset = img.get().getWidth(null) / 2 - flag.getWidth(null) / 2;
+          final int yoffset = img.get().getHeight(null) / 2 - flag.getHeight(null) / 4 - 5;
+          graphics.drawImage(
+              flag,
+              (placementPoint.x - bounds.x) + xoffset,
+              (placementPoint.y - bounds.y) + yoffset,
+              null);
+        }
+        drawUnit(graphics, img.get(), bounds, data);
+      } else if (drawMode == UnitFlagDrawMode.SMALL_FLAG) {
+        drawUnit(graphics, img.get(), bounds, data);
+        // If unit is not in the "excluded list" it will get drawn
+        if (maxRange != 0) {
+          final Image flag = uiContext.getFlagImageFactory().getSmallFlag(owner);
+          final int xoffset = img.get().getWidth(null) - flag.getWidth(null);
+          final int yoffset = img.get().getHeight(null) - flag.getHeight(null);
+          // This Method draws the Flag in the lower right corner of the unit image. Since the
+          // position is the upper
+          // left corner we have to move the picture up by the height and left by the width.
+          graphics.drawImage(
+              flag,
+              (placementPoint.x - bounds.x) + xoffset,
+              (placementPoint.y - bounds.y) + yoffset,
+              null);
+        }
+      } else {
+        drawUnit(graphics, img.get(), bounds, data);
       }
-      drawUnit(graphics, img.get(), bounds, data);
-    } else if (drawMode == UnitFlagDrawMode.SMALL_FLAG) {
-      drawUnit(graphics, img.get(), bounds, data);
-      // If unit is not in the "excluded list" it will get drawn
-      if (maxRange != 0) {
-        final Image flag = uiContext.getFlagImageFactory().getSmallFlag(owner);
-        final int xoffset = img.get().getWidth(null) - flag.getWidth(null);
-        final int yoffset = img.get().getHeight(null) - flag.getHeight(null);
-        // This Method draws the Flag in the lower right corner of the unit image. Since the
-        // position is the upper
-        // left corner we have to move the picture up by the height and left by the width.
-        graphics.drawImage(
-            flag,
-            (placementPoint.x - bounds.x) + xoffset,
-            (placementPoint.y - bounds.y) + yoffset,
-            null);
-      }
-    } else {
-      img.ifPresent(image -> drawUnit(graphics, image, bounds, data));
     }
 
     // more then 1 unit of this category

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -133,44 +133,38 @@ public class UnitsDrawer extends AbstractDrawable {
               + territoryName);
     }
 
-    if (img.isPresent()
-        && ClientSetting.unitFlagDrawMode.getValueOrThrow() != UnitFlagDrawMode.NONE) {
-      final int maxRange = new TripleAUnit(type, owner, data).getMaxMovementAllowed();
-      switch (ClientSetting.unitFlagDrawMode.getValueOrThrow()) {
-        case LARGE_FLAG:
-          // If unit is not in the "excluded list" it will get drawn
-          if (maxRange != 0) {
-            final Image flag = uiContext.getFlagImageFactory().getFlag(owner);
-            final int xoffset = img.get().getWidth(null) / 2 - flag.getWidth(null) / 2;
-            final int yoffset = img.get().getHeight(null) / 2 - flag.getHeight(null) / 4 - 5;
-            graphics.drawImage(
-                flag,
-                (placementPoint.x - bounds.x) + xoffset,
-                (placementPoint.y - bounds.y) + yoffset,
-                null);
-          }
-          drawUnit(graphics, img.get(), bounds, data);
-          break;
-        case SMALL_FLAG:
-          drawUnit(graphics, img.get(), bounds, data);
-          // If unit is not in the "excluded list" it will get drawn
-          if (maxRange != 0) {
-            final Image flag = uiContext.getFlagImageFactory().getSmallFlag(owner);
-            final int xoffset = img.get().getWidth(null) - flag.getWidth(null);
-            final int yoffset = img.get().getHeight(null) - flag.getHeight(null);
-            // This Method draws the Flag in the lower right corner of the unit image. Since the
-            // position is the upper
-            // left corner we have to move the picture up by the height and left by the width.
-            graphics.drawImage(
-                flag,
-                (placementPoint.x - bounds.x) + xoffset,
-                (placementPoint.y - bounds.y) + yoffset,
-                null);
-          }
-          break;
-        default:
-          throw new AssertionError(
-              "unknown unit flag draw mode: " + ClientSetting.unitFlagDrawMode.getValueOrThrow());
+    final int maxRange = new TripleAUnit(type, owner, data).getMaxMovementAllowed();
+
+    final UnitFlagDrawMode drawMode =
+        ClientSetting.unitFlagDrawMode.getValue().orElse(UnitFlagDrawMode.NONE);
+    if (drawMode == UnitFlagDrawMode.LARGE_FLAG) {
+      // If unit is not in the "excluded list" it will get drawn
+      if (maxRange != 0) {
+        final Image flag = uiContext.getFlagImageFactory().getFlag(owner);
+        final int xoffset = img.get().getWidth(null) / 2 - flag.getWidth(null) / 2;
+        final int yoffset = img.get().getHeight(null) / 2 - flag.getHeight(null) / 4 - 5;
+        graphics.drawImage(
+            flag,
+            (placementPoint.x - bounds.x) + xoffset,
+            (placementPoint.y - bounds.y) + yoffset,
+            null);
+      }
+      drawUnit(graphics, img.get(), bounds, data);
+    } else if (drawMode == UnitFlagDrawMode.SMALL_FLAG) {
+      drawUnit(graphics, img.get(), bounds, data);
+      // If unit is not in the "excluded list" it will get drawn
+      if (maxRange != 0) {
+        final Image flag = uiContext.getFlagImageFactory().getSmallFlag(owner);
+        final int xoffset = img.get().getWidth(null) - flag.getWidth(null);
+        final int yoffset = img.get().getHeight(null) - flag.getHeight(null);
+        // This Method draws the Flag in the lower right corner of the unit image. Since the
+        // position is the upper
+        // left corner we have to move the picture up by the height and left by the width.
+        graphics.drawImage(
+            flag,
+            (placementPoint.x - bounds.x) + xoffset,
+            (placementPoint.y - bounds.y) + yoffset,
+            null);
       }
     } else {
       img.ifPresent(image -> drawUnit(graphics, image, bounds, data));


### PR DESCRIPTION
- Replace case statement for flag rendering with if/else
- Default to flag rendering of 'NONE', if flag rendering is
 otherwise not 'small' or 'large', we will default to NONE

This avoids potential error condition if we change the flag rendering
name or somehow have no flag rendering stored in ClientSettings.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes

Updates here are mostly whitespace changes, just a few lines are changed.
Use this link to review without white space changes: https://github.com/triplea-game/triplea/pull/5849/files?utf8=%E2%9C%93&diff=unified&w=1