### PR TITLE
Add 2.0 to 1.9 draw_mode 'enum not found' compatibility hack

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -26,6 +26,8 @@ import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
+import java.util.prefs.BackingStoreException;
+import java.util.prefs.Preferences;
 import javax.swing.AbstractAction;
 import javax.swing.AbstractButton;
 import javax.swing.Action;
@@ -435,6 +437,19 @@ final class ViewMenu extends JMenu {
   }
 
   private void addFlagDisplayModeMenu() {
+    // 2.0 to 1.9 compatibility hack. Can be removed when all players that have played a 2.0
+    // prelease have launched a game containing this patch. When going from 2.0 to 1.9,
+    // 1.9 will crash due to an enum value not found error when loading 'DRAW_MODE'
+    final Preferences prefs = Preferences.userNodeForPackage(getClass());
+    if (prefs.get("DRAW_MODE", null) != null) {
+      prefs.remove("DRAW_MODE");
+      try {
+        prefs.flush();
+      } catch (final BackingStoreException ignored) {
+        // ignore
+      }
+    }
+
     final JMenu flagDisplayMenu = new JMenu();
     flagDisplayMenu.setMnemonic(KeyEvent.VK_N);
     flagDisplayMenu.setText("Flag Display Mode");


### PR DESCRIPTION
The problem being addressed is specifically when loading a 2.0 game,
then loading a 1.9 game will crash.

This update addresses that problem where a 1.9 game tries to load an
enum from a setting key that was set in later versions to a value that
is not contained in the 1.9 enum. This patch clears out the preferences
key which allows 1.9 to behave properly.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix: https://github.com/triplea-game/triplea/issues/5835
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done
Was seeing the crash in 1.9 on game start, after starting a 2.0 game with this patch added, was able to go back and start a 1.9 game again.

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

