### PR TITLE
Fix 'end turn' hotkey NPE when done out of turn

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/pbem/ForumPosterComponent.java
+++ b/game-core/src/main/java/games/strategy/engine/pbem/ForumPosterComponent.java
@@ -148,6 +148,10 @@ public final class ForumPosterComponent extends JPanel {
     historyLog.requestFocus();
   }
 
+  public boolean canPostTurnSummary() {
+    return forumPosterDelegate != null;
+  }
+
   public boolean getHasPostedTurnSummary() {
     return forumPosterDelegate.getHasPostedTurnSummary();
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/EndTurnPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EndTurnPanel.java
@@ -12,14 +12,16 @@ class EndTurnPanel extends AbstractForumPosterPanel {
 
   @Override
   void performDone() {
-    if (forumPosterComponent.getHasPostedTurnSummary()
-        || JOptionPane.YES_OPTION
-            == JOptionPane.showConfirmDialog(
-                JOptionPane.getFrameForComponent(EndTurnPanel.this),
-                "Are you sure you don't want to post?",
-                "Bypass post",
-                JOptionPane.YES_NO_OPTION)) {
-      release();
+    if (forumPosterComponent.canPostTurnSummary()) {
+      if (forumPosterComponent.getHasPostedTurnSummary()
+          || JOptionPane.YES_OPTION
+              == JOptionPane.showConfirmDialog(
+                  JOptionPane.getFrameForComponent(EndTurnPanel.this),
+                  "Are you sure you don't want to post?",
+                  "Bypass post",
+                  JOptionPane.YES_NO_OPTION)) {
+        release();
+      }
     }
   }
 


### PR DESCRIPTION
Fixes #5809, problem is the end turn panel becomes active
at the end of a turn regardless whether the game is a PBEM
or PBF (end turn panel is used to post turn summaries).
While the panel is active, even though it may not be your
turn or a PBF/PBEM game, the panel still receives events
for the hotkey bound to 'actionPerformed' which typically
finishes the current phase.

A complication to this fix, while the panel is not visible,
swing thinks the done button on that panel is both enabled
and visible.

The fix here checks for a null end turn delegate, if null,
then we no-op when we receive the end-turn action.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  #5809 <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
[x] Manual testing done

- Verified that NPE could no longer be reproduced
- Launched a network game and connected to it locally. Verified that before the fix the problem could be reproduced. Also verified that during each phase, when it is not your turn, 'shift-d' is seemingly a no-op.
 
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes
Most of the changes are whitespace. Use this link to review the diff without white space changes: https://github.com/triplea-game/triplea/pull/5865/files?utf8=%E2%9C%93&diff=unified&w=1
