### PR TITLE
Statistics Panel (1) – Menu item and dummy dialog

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/stats/Statistics.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/Statistics.java
@@ -5,7 +5,7 @@ import lombok.Data;
 /**
  * Data class class that holds statistics information like "PUs over time per player".
  *
- * Instances are typically created by {@link StatisticsAggregator}.
+ * <p>Instances are typically created by {@link StatisticsAggregator}.
  */
 @Data
 public class Statistics {}

--- a/game-core/src/main/java/games/strategy/engine/stats/Statistics.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/Statistics.java
@@ -1,0 +1,11 @@
+package games.strategy.engine.stats;
+
+import lombok.Data;
+
+/**
+ * Data class class that holds statistics information like "PUs over time per player".
+ *
+ * Instances are typically created by {@link StatisticsAggregator}.
+ */
+@Data
+public class Statistics {}

--- a/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
@@ -1,0 +1,18 @@
+package games.strategy.engine.stats;
+
+import games.strategy.engine.data.GameData;
+import lombok.NonNull;
+import lombok.experimental.UtilityClass;
+import lombok.extern.java.Log;
+
+/**
+ * Analyzes a game's history and aggregates interesting statistics in a {@link Statistics} object.
+ */
+@Log
+@UtilityClass
+public class StatisticsAggregator {
+  public static Statistics aggregate(@NonNull final GameData game) {
+    log.info("Aggregating statistics for game " + game.getGameName());
+    return new Statistics();
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -71,7 +71,9 @@ final class GameMenu extends JMenu {
     addNotificationSettings();
     addShowDiceStats();
     addRollDice();
-    addStatistics();
+    if (ClientSetting.showBetaFeatures.getValueOrThrow()) {
+      addStatistics();
+    }
     addMenuItemWithHotkey(
         SwingAction.of(
             "Battle Calculator",

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -71,6 +71,7 @@ final class GameMenu extends JMenu {
     addNotificationSettings();
     addShowDiceStats();
     addRollDice();
+    addStatistics();
     addMenuItemWithHotkey(
         SwingAction.of(
             "Battle Calculator",
@@ -291,5 +292,14 @@ final class GameMenu extends JMenu {
           }
         });
     add(rollDiceBox);
+  }
+
+  private void addStatistics() {
+    add(
+        SwingAction.of(
+            "Game statistics",
+            e ->
+                JOptionPane.showMessageDialog(
+                    frame, null, "Game statistics", JOptionPane.INFORMATION_MESSAGE)));
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -304,7 +304,7 @@ final class GameMenu extends JMenu {
             e ->
                 JOptionPane.showMessageDialog(
                     frame,
-                    new StatisticsDialog(gameData),
+                    new StatisticsDialog(),
                     "Game statistics",
                     JOptionPane.INFORMATION_MESSAGE)));
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -12,6 +12,7 @@ import games.strategy.triplea.ui.PoliticalStateOverview;
 import games.strategy.triplea.ui.TripleAFrame;
 import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.VerifiedRandomNumbersDialog;
+import games.strategy.triplea.ui.statistics.StatisticsDialog;
 import java.awt.Dimension;
 import java.awt.GridBagLayout;
 import java.awt.Toolkit;
@@ -302,6 +303,9 @@ final class GameMenu extends JMenu {
             "Game statistics",
             e ->
                 JOptionPane.showMessageDialog(
-                    frame, null, "Game statistics", JOptionPane.INFORMATION_MESSAGE)));
+                    frame,
+                    new StatisticsDialog(gameData),
+                    "Game statistics",
+                    JOptionPane.INFORMATION_MESSAGE)));
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -304,7 +304,7 @@ final class GameMenu extends JMenu {
             e ->
                 JOptionPane.showMessageDialog(
                     frame,
-                    new StatisticsDialog(),
+                    new StatisticsDialog(gameData),
                     "Game statistics",
                     JOptionPane.INFORMATION_MESSAGE)));
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
@@ -1,10 +1,10 @@
 package games.strategy.triplea.ui.statistics;
 
-import games.strategy.engine.data.GameData;
-import javax.swing.*;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
 
 public class StatisticsDialog extends JPanel {
-  public StatisticsDialog(GameData gameData) {
+  public StatisticsDialog() {
     this.add(new JLabel("Under construction"));
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
@@ -1,10 +1,15 @@
 package games.strategy.triplea.ui.statistics;
 
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.stats.Statistics;
+import games.strategy.engine.stats.StatisticsAggregator;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 
 public class StatisticsDialog extends JPanel {
-  public StatisticsDialog() {
-    this.add(new JLabel("Under construction"));
+  public StatisticsDialog(final GameData game) {
+    final Statistics statistics = StatisticsAggregator.aggregate(game);
+    // transform statistics object to interesting charts and show them
+    this.add(new JLabel("Under construction: " + statistics.toString()));
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
@@ -1,0 +1,10 @@
+package games.strategy.triplea.ui.statistics;
+
+import games.strategy.engine.data.GameData;
+import javax.swing.*;
+
+public class StatisticsDialog extends JPanel {
+  public StatisticsDialog(GameData gameData) {
+    this.add(new JLabel("Under construction"));
+  }
+}


### PR DESCRIPTION
This is the first pull request in a series. Subject is the [feature request for a statistics panel](https://forums.triplea-game.org/topic/1660/game-statistics-page/).

Here I simply added a new menu entry to the "Game" tab. It is only visible when you have "Show beta features" is active.
When clicked, the menu opens a dialog box with a placeholder text. In future pull requests, this dialog box will hold all charts and statistics.
I also added the basic classes and the `Statistics` data container that is passed between them.

It does not add any useful functionality, nor is it very much code. But I hope this is still a good start.


Plan for the next PR is
 - add charting library
 - show a hard-coded line graph

Then:
 - actual gathering of data

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[x] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us,
  we would prefer to rely on automated testing.
-->

[x] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->
Tested that menu item only visible if betaFeature is active.
Nothing else seems to break.

<!-- If there are UI updates, uncomment and include screenshots below -->
## Screens Shots

![scrot_2020-01-21_23-07-54_screenshot](https://user-images.githubusercontent.com/263263/72847768-82cc8a00-3ca3-11ea-8fea-632d111fc78e.png)
![scrot_2020-01-22_02-20-22_screenshot](https://user-images.githubusercontent.com/263263/72857393-c7651f00-3cbd-11ea-8660-d8b035250de0.png)


## Additional Review Notes

Any feedback is welcome. Specifically I want to know what you think of the package structure. I'm also open for ideas on automated testing.