### PR TITLE
Improve unit support tooltip

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -694,7 +694,7 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer {
   public boolean confirmMoveInFaceOfAa(final Collection<Territory> aaFiringTerritories) {
     final String question =
         "Your units will be fired on in: "
-            + MyFormatter.defaultNamedToTextList(aaFiringTerritories, " and ", false)
+            + MyFormatter.defaultNamedToTextList(aaFiringTerritories)
             + ".  Do you still want to move?";
     return ui.getOk(question);
   }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -3267,9 +3267,9 @@ public class UnitAttachment extends DefaultAttachment {
                 + (support.getAllied() && support.getEnemy()
                     ? " Allied & Enemy "
                     : (support.getAllied() ? " Allied " : " Enemy "))
-                + (support.getUnitType().size() > 4
+                + (support.getUnitType().size() > 25
                     ? "Units"
-                    : MyFormatter.defaultNamedToTextList(support.getUnitType(), "/", false));
+                    : MyFormatter.defaultNamedToTextList(support.getUnitType()));
         tuples.add(Tuple.of(key, text));
       }
     }
@@ -3557,7 +3557,12 @@ public class UnitAttachment extends DefaultAttachment {
     for (final Tuple<String, String> tuple : tuples) {
       result.append(tuple.getFirst());
       if (!tuple.getSecond().isEmpty()) {
-        result.append(": <b>").append(tuple.getSecond()).append("</b>");
+        result
+            .append(": <b>")
+            .append(
+                MyFormatter.addHtmlBreaksAndIndents(
+                    tuple.getSecond(), 100 - tuple.getFirst().length(), 100))
+            .append("</b>");
       }
       result.append("<br />");
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -303,9 +303,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
       // end round delegate)
       final String title =
           "Victory Achieved"
-              + (winners.isEmpty()
-                  ? ""
-                  : " by " + MyFormatter.defaultNamedToTextList(winners, ", ", false));
+              + (winners.isEmpty() ? "" : " by " + MyFormatter.defaultNamedToTextList(winners));
       // we send the bridge, because we can call this method from outside this delegate, which
       // means our local copy of playerBridge could be null.
       bridge

--- a/game-core/src/main/java/games/strategy/triplea/formatter/MyFormatter.java
+++ b/game-core/src/main/java/games/strategy/triplea/formatter/MyFormatter.java
@@ -409,6 +409,16 @@ public class MyFormatter {
     return buf.toString().replaceFirst(separator, "");
   }
 
+  /**
+   * Adds HTML line breaks and indentation to a string so it wraps for things like long tooltips.
+   *
+   * <pre>
+   * string part 1
+   *           string part 2
+   *           ...
+   *           string part X
+   * </pre>
+   */
   public static String addHtmlBreaksAndIndents(
       final String target, final int firstLineMaxLength, final int maxLength) {
     final StringBuilder sb = new StringBuilder();

--- a/game-core/src/main/java/games/strategy/triplea/formatter/MyFormatter.java
+++ b/game-core/src/main/java/games/strategy/triplea/formatter/MyFormatter.java
@@ -10,6 +10,7 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.delegate.Die;
 import games.strategy.triplea.util.UnitOwner;
+import java.text.BreakIterator;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -406,5 +407,29 @@ public class MyFormatter {
       }
     }
     return buf.toString().replaceFirst(separator, "");
+  }
+
+  public static String addHtmlBreaksAndIndents(
+      final String target, final int firstLineMaxLength, final int maxLength) {
+    final StringBuilder sb = new StringBuilder();
+    final BreakIterator breakIterator = BreakIterator.getLineInstance();
+    breakIterator.setText(target);
+    int start = breakIterator.first();
+    int end = breakIterator.next();
+    int lineLength = 0;
+    int currentMaxLength = firstLineMaxLength;
+    while (end != BreakIterator.DONE) {
+      final String word = target.substring(start, end);
+      lineLength = lineLength + word.length();
+      if (lineLength >= currentMaxLength) {
+        sb.append("<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;");
+        lineLength = word.length() + 5; // Add 5 for the indent
+        currentMaxLength = maxLength;
+      }
+      sb.append(word);
+      start = end;
+      end = breakIterator.next();
+    }
+    return sb.toString();
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/formatter/MyFormatterTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/formatter/MyFormatterTest.java
@@ -66,5 +66,35 @@ final class MyFormatterTest {
 
       assertThat(MyFormatter.unitsToText(units), is("2 unitTypes owned by the playerId"));
     }
+
+    @Test
+    void addHtmlBreaksAndIndentsWithEmptyString() {
+      assertThat(MyFormatter.addHtmlBreaksAndIndents("", 80, 100), is(""));
+    }
+
+    @Test
+    void addHtmlBreaksAndIndentsWithNoBreak() {
+      final String target = "unitType, unitType";
+      assertThat(MyFormatter.addHtmlBreaksAndIndents(target, 80, 100), is(target));
+    }
+
+    @Test
+    void addHtmlBreaksAndIndentsWithBreak() {
+      final String target =
+          "unitType, unitType, unitType, unitType, unitType, unitType, unitType, unitType, unitType, unitType, unitType, unitType";
+      final String result =
+          "unitType, unitType, unitType, unitType, unitType, unitType, unitType, "
+              + "<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unitType, unitType, unitType, unitType, unitType";
+      assertThat(MyFormatter.addHtmlBreaksAndIndents(target, 80, 100), is(result));
+    }
+
+    @Test
+    void addHtmlBreaksAndIndentsWithVeryLongWord() {
+      final String target =
+          "aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongUnitType";
+      final String result =
+          "<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongUnitType";
+      assertThat(MyFormatter.addHtmlBreaksAndIndents(target, 80, 100), is(result));
+    }
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/formatter/MyFormatterTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/formatter/MyFormatterTest.java
@@ -81,19 +81,24 @@ final class MyFormatterTest {
     @Test
     void addHtmlBreaksAndIndentsWithBreak() {
       final String target =
-          "unitType, unitType, unitType, unitType, unitType, unitType, unitType, unitType, unitType, unitType, unitType, unitType";
+          "unitType, unitType, unitType, unitType, unitType, unitType, unitType, "
+              + "unitType, unitType, unitType, unitType, unitType";
       final String result =
           "unitType, unitType, unitType, unitType, unitType, unitType, unitType, "
-              + "<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;unitType, unitType, unitType, unitType, unitType";
+              + "<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;"
+              + "unitType, unitType, unitType, unitType, unitType";
       assertThat(MyFormatter.addHtmlBreaksAndIndents(target, 80, 100), is(result));
     }
 
     @Test
     void addHtmlBreaksAndIndentsWithVeryLongWord() {
       final String target =
-          "aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongUnitType";
+          "aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVery"
+              + "VeryLongUnitType";
       final String result =
-          "<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;aVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryLongUnitType";
+          "<br />&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;aVery"
+              + "VeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVeryVery"
+              + "VeryLongUnitType";
       assertThat(MyFormatter.addHtmlBreaksAndIndents(target, 80, 100), is(result));
     }
   }


### PR DESCRIPTION
Address feature request: https://forums.triplea-game.org/topic/1741/tooltip-info-gets-worse-by-the-unit-feature-request

100 max character width, 10 space indent for new lines, and 25 limit to number of unit types. 

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[x] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->
Manually tested several maps including dragon war and TWW to see unit help and unit tooltip for support.

<!-- If there are UI updates, uncomment and include screenshots below -->
## Screens Shots
![image](https://user-images.githubusercontent.com/1427689/72857786-4f2e3780-3c84-11ea-9d1d-328d3c00970f.png)
![image](https://user-images.githubusercontent.com/1427689/72857800-55bcaf00-3c84-11ea-82c3-c2f9cbc58dd2.png)
![image](https://user-images.githubusercontent.com/1427689/72857804-58b79f80-3c84-11ea-8e0f-97a2a97d235c.png)

