### PR TITLE
Move getting current units call inside invokeLater to avoid error

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -159,16 +159,15 @@ public class UnitScroller {
   }
 
   private void drawUnitAvatarPane(final Territory t) {
-    final List<Unit> matchedUnits =
-        UnitScrollerModel.getMoveableUnits(
-            t, movePhaseSupplier.get(), currentPlayerSupplier.get(), getAllSkippedUnits());
-
     SwingUtilities.invokeLater(
         () -> {
           selectUnitImagePanel.removeAll();
           if (currentPlayerSupplier.get() != null) {
+            final List<Unit> moveableUnits =
+                UnitScrollerModel.getMoveableUnits(
+                    t, movePhaseSupplier.get(), currentPlayerSupplier.get(), getAllSkippedUnits());
             selectUnitImagePanel.add(
-                avatarPanelFactory.buildPanel(matchedUnits, currentPlayerSupplier.get()));
+                avatarPanelFactory.buildPanel(moveableUnits, currentPlayerSupplier.get()));
           }
           selectUnitImagePanel.revalidate();
           selectUnitImagePanel.repaint();


### PR DESCRIPTION
Fixes #5840 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->
Re-tested running an all Fast AI NWO games and don't see the error on Russia's first turn anymore.
