### PR TITLE
Statistics Panel (2) – XChart library

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -109,6 +109,7 @@ subprojects {
         snakeYamlVersion = '2.0'
         sonatypeGoodiesPrefsVersion = '2.3.1'
         substanceVersion = '2.5.1'
+        xchartVersion = '3.6.1'
     }
 
     repositories {

--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -14,6 +14,7 @@ dependencies {
     implementation "org.apache.commons:commons-math3:$commonsMathVersion"
     implementation "org.apache.httpcomponents:httpclient:$apacheHttpComponentsVersion"
     implementation "org.apache.httpcomponents:httpmime:$apacheHttpComponentsVersion"
+    implementation "org.knowm.xchart:xchart:$xchartVersion"
     implementation "org.snakeyaml:snakeyaml-engine:$snakeYamlVersion"
     implementation project(":domain-data")
     implementation project(":http-clients")

--- a/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
@@ -3,38 +3,42 @@ package games.strategy.triplea.ui.statistics;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.stats.Statistics;
 import games.strategy.engine.stats.StatisticsAggregator;
-import javax.swing.*;
-import org.knowm.xchart.*;
+import javax.swing.JPanel;
+import org.knowm.xchart.PieChart;
+import org.knowm.xchart.PieChartBuilder;
+import org.knowm.xchart.XChartPanel;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYChartBuilder;
 import org.knowm.xchart.style.Styler;
 import org.triplea.swing.JTabbedPaneBuilder;
 
 public class StatisticsDialog extends JPanel {
   public StatisticsDialog(final GameData game) {
     final Statistics statistics = StatisticsAggregator.aggregate(game);
-    JTabbedPaneBuilder tabbedPane = JTabbedPaneBuilder.builder();
-    tabbedPane.addTab("Lines", createDummyXYGraph(statistics));
+    final JTabbedPaneBuilder tabbedPane = JTabbedPaneBuilder.builder();
+    tabbedPane.addTab("Lines", createDummyXyGraph(statistics));
     tabbedPane.addTab("Pie", createDummyPieChart(statistics));
     this.add(tabbedPane.build());
   }
 
-  private JPanel createDummyXYGraph(Statistics statistics) {
-    XYChart sample_chart =
+  private JPanel createDummyXyGraph(final Statistics statistics) {
+    final XYChart chart =
         new XYChartBuilder()
             .theme(Styler.ChartTheme.Matlab)
             .title("Sample Chart: " + statistics.toString())
             .build();
-    sample_chart.addSeries("some value1", new double[] {2.0, 0.0, 40.0});
-    sample_chart.addSeries("some value2", new double[] {3.0, 1.0, 41.0});
-    sample_chart.addSeries("some value3", new double[] {4.0, 2.0, 42.0});
-    sample_chart.addSeries("some value4", new double[] {5.0, 3.0, 43.0});
-    sample_chart.addSeries("some value5", new double[] {6.0, 4.0, 44.0});
-    sample_chart.addSeries("some value6", new double[] {7.0, 5.0, 45.0});
-    sample_chart.addSeries("some value7", new double[] {8.0, 6.0, 46.0});
-    return new XChartPanel<>(sample_chart);
+    chart.addSeries("some value1", new double[] {2.0, 0.0, 40.0});
+    chart.addSeries("some value2", new double[] {3.0, 1.0, 41.0});
+    chart.addSeries("some value3", new double[] {4.0, 2.0, 42.0});
+    chart.addSeries("some value4", new double[] {5.0, 3.0, 43.0});
+    chart.addSeries("some value5", new double[] {6.0, 4.0, 44.0});
+    chart.addSeries("some value6", new double[] {7.0, 5.0, 45.0});
+    chart.addSeries("some value7", new double[] {8.0, 6.0, 46.0});
+    return new XChartPanel<>(chart);
   }
 
-  private JPanel createDummyPieChart(Statistics statistics) {
-    PieChart chart =
+  private JPanel createDummyPieChart(final Statistics statistics) {
+    final PieChart chart =
         new PieChartBuilder()
             .theme(Styler.ChartTheme.XChart)
             .title("Sample Chart: " + statistics.toString())

--- a/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
@@ -43,6 +43,7 @@ public class StatisticsDialog extends JPanel {
     chart.addSeries("Value 2", 63);
     chart.addSeries("Value 3", 1);
     chart.addSeries("Value 4", 9);
+    chart.getStyler().setLegendPosition(Styler.LegendPosition.InsideSE);
     return new XChartPanel<>(chart);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
@@ -4,19 +4,21 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.stats.Statistics;
 import games.strategy.engine.stats.StatisticsAggregator;
 import javax.swing.*;
-import org.knowm.xchart.XChartPanel;
-import org.knowm.xchart.XYChart;
-import org.knowm.xchart.XYChartBuilder;
+import org.knowm.xchart.*;
 import org.knowm.xchart.style.Styler;
+import org.triplea.swing.JTabbedPaneBuilder;
 
 public class StatisticsDialog extends JPanel {
   public StatisticsDialog(final GameData game) {
     final Statistics statistics = StatisticsAggregator.aggregate(game);
     // transform statistics object to interesting charts and show them
-    this.add(createDummyGraph(statistics));
+    JTabbedPaneBuilder tabbedPane = JTabbedPaneBuilder.builder();
+    tabbedPane.addTab("Lines", createDummyXYGraph(statistics));
+    tabbedPane.addTab("Pie", createDummyPieChart(statistics));
+    this.add(tabbedPane.build());
   }
 
-  private JPanel createDummyGraph(Statistics statistics) {
+  private JPanel createDummyXYGraph(Statistics statistics) {
     XYChart sample_chart =
         new XYChartBuilder()
             .theme(Styler.ChartTheme.Matlab)
@@ -30,5 +32,18 @@ public class StatisticsDialog extends JPanel {
     sample_chart.addSeries("some value6", new double[] {7.0, 5.0, 45.0});
     sample_chart.addSeries("some value7", new double[] {8.0, 6.0, 46.0});
     return new XChartPanel<>(sample_chart);
+  }
+
+  private JPanel createDummyPieChart(Statistics statistics) {
+    PieChart chart =
+        new PieChartBuilder()
+            .theme(Styler.ChartTheme.XChart)
+            .title("Sample Chart: " + statistics.toString())
+            .build();
+    chart.addSeries("Value 1", 27);
+    chart.addSeries("Value 2", 63);
+    chart.addSeries("Value 3", 1);
+    chart.addSeries("Value 4", 9);
+    return new XChartPanel<>(chart);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
@@ -3,13 +3,32 @@ package games.strategy.triplea.ui.statistics;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.stats.Statistics;
 import games.strategy.engine.stats.StatisticsAggregator;
-import javax.swing.JLabel;
-import javax.swing.JPanel;
+import javax.swing.*;
+import org.knowm.xchart.XChartPanel;
+import org.knowm.xchart.XYChart;
+import org.knowm.xchart.XYChartBuilder;
+import org.knowm.xchart.style.Styler;
 
 public class StatisticsDialog extends JPanel {
   public StatisticsDialog(final GameData game) {
     final Statistics statistics = StatisticsAggregator.aggregate(game);
     // transform statistics object to interesting charts and show them
-    this.add(new JLabel("Under construction: " + statistics.toString()));
+    this.add(createDummyGraph(statistics));
+  }
+
+  private JPanel createDummyGraph(Statistics statistics) {
+    XYChart sample_chart =
+        new XYChartBuilder()
+            .theme(Styler.ChartTheme.Matlab)
+            .title("Sample Chart: " + statistics.toString())
+            .build();
+    sample_chart.addSeries("some value1", new double[] {2.0, 0.0, 40.0});
+    sample_chart.addSeries("some value2", new double[] {3.0, 1.0, 41.0});
+    sample_chart.addSeries("some value3", new double[] {4.0, 2.0, 42.0});
+    sample_chart.addSeries("some value4", new double[] {5.0, 3.0, 43.0});
+    sample_chart.addSeries("some value5", new double[] {6.0, 4.0, 44.0});
+    sample_chart.addSeries("some value6", new double[] {7.0, 5.0, 45.0});
+    sample_chart.addSeries("some value7", new double[] {8.0, 6.0, 46.0});
+    return new XChartPanel<>(sample_chart);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
@@ -11,7 +11,6 @@ import org.triplea.swing.JTabbedPaneBuilder;
 public class StatisticsDialog extends JPanel {
   public StatisticsDialog(final GameData game) {
     final Statistics statistics = StatisticsAggregator.aggregate(game);
-    // transform statistics object to interesting charts and show them
     JTabbedPaneBuilder tabbedPane = JTabbedPaneBuilder.builder();
     tabbedPane.addTab("Lines", createDummyXYGraph(statistics));
     tabbedPane.addTab("Pie", createDummyPieChart(statistics));


### PR DESCRIPTION
This is the second pull request in a series (#5866). Subject is the [feature request for a statistics panel](https://forums.triplea-game.org/topic/1660/game-statistics-page/).

This time I added a dependency to the [XChart library](https://github.com/knowm/XChart) and a tabbed dialog with two hardcoded sample charts in order to see how the real ones later might look.

Are you fine with this as a dependency?

Plan for the next PR is
 - aggregate first data
 - show real graphs


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[x] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us,
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->
Nothing really to test

<!-- If there are UI updates, uncomment and include screenshots below -->
## Screens Shots

![scrot_2020-01-23_21-27-35_screenshot](https://user-images.githubusercontent.com/263263/73021740-702f8d80-3e28-11ea-85c6-4668f6ecdb60.png)
![scrot_2020-01-23_21-27-47_screenshot](https://user-images.githubusercontent.com/263263/73021741-70c82400-3e28-11ea-8caf-816a7feec398.png)



