### PR TITLE
Remove 'show map only'

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -240,57 +240,50 @@ public final class BattlePanel extends ActionPanel {
             cleanUpBattleWindow();
             currentBattleDisplayed = null;
           }
-          if (!getMap().getUiContext().getShowMapOnly()) {
-            battleDisplay =
-                new BattleDisplay(
-                    getData(),
-                    location,
-                    attacker,
-                    defender,
-                    attackingUnits,
-                    defendingUnits,
-                    killedUnits,
-                    attackingWaitingToDie,
-                    defendingWaitingToDie,
-                    BattlePanel.this.getMap(),
-                    isAmphibious,
-                    battleType,
-                    amphibiousLandAttackers);
-            battleFrame.setTitle(
-                attacker.getName()
-                    + " attacks "
-                    + defender.getName()
-                    + " in "
-                    + location.getName());
-            battleFrame.getContentPane().removeAll();
-            battleFrame.getContentPane().add(battleDisplay);
-            battleFrame.setMinimumSize(new Dimension(800, 600));
-            battleFrame.setLocationRelativeTo(JOptionPane.getFrameForComponent(BattlePanel.this));
-            PbemDiceRoller.setFocusWindow(battleFrame);
-            boolean foundHumanInBattle = false;
-            for (final Player gamePlayer :
-                getMap().getUiContext().getLocalPlayers().getLocalPlayers()) {
-              if ((gamePlayer.getGamePlayer().equals(attacker)
-                      && gamePlayer instanceof TripleAPlayer)
-                  || (gamePlayer.getGamePlayer().equals(defender)
-                      && gamePlayer instanceof TripleAPlayer)) {
-                foundHumanInBattle = true;
-                break;
-              }
+          battleDisplay =
+              new BattleDisplay(
+                  getData(),
+                  location,
+                  attacker,
+                  defender,
+                  attackingUnits,
+                  defendingUnits,
+                  killedUnits,
+                  attackingWaitingToDie,
+                  defendingWaitingToDie,
+                  BattlePanel.this.getMap(),
+                  isAmphibious,
+                  battleType,
+                  amphibiousLandAttackers);
+          battleFrame.setTitle(
+              attacker.getName() + " attacks " + defender.getName() + " in " + location.getName());
+          battleFrame.getContentPane().removeAll();
+          battleFrame.getContentPane().add(battleDisplay);
+          battleFrame.setMinimumSize(new Dimension(800, 600));
+          battleFrame.setLocationRelativeTo(JOptionPane.getFrameForComponent(BattlePanel.this));
+          PbemDiceRoller.setFocusWindow(battleFrame);
+          boolean foundHumanInBattle = false;
+          for (final Player gamePlayer :
+              getMap().getUiContext().getLocalPlayers().getLocalPlayers()) {
+            if ((gamePlayer.getGamePlayer().equals(attacker) && gamePlayer instanceof TripleAPlayer)
+                || (gamePlayer.getGamePlayer().equals(defender)
+                    && gamePlayer instanceof TripleAPlayer)) {
+              foundHumanInBattle = true;
+              break;
             }
-            if (ClientSetting.showBattlesWhenObserving.getValueOrThrow() || foundHumanInBattle) {
-              battleFrame.setAlwaysOnTop(true);
-              battleFrame.setVisible(true);
-              battleFrame.validate();
-              battleFrame.invalidate();
-              battleFrame.repaint();
-            } else {
-              battleFrame.setVisible(false);
-            }
-            battleFrame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
-            currentBattleDisplayed = battleId;
-            SwingUtilities.invokeLater(battleFrame::toFront);
           }
+          if (ClientSetting.showBattlesWhenObserving.getValueOrThrow() || foundHumanInBattle) {
+            battleFrame.setAlwaysOnTop(true);
+            battleFrame.setVisible(true);
+            battleFrame.validate();
+            battleFrame.invalidate();
+            battleFrame.repaint();
+          } else {
+            battleFrame.setVisible(false);
+          }
+          battleFrame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
+          currentBattleDisplayed = battleId;
+          SwingUtilities.invokeLater(battleFrame::toFront);
         });
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
@@ -46,7 +46,6 @@ public class HeadedUiContext extends AbstractUiContext {
   private final PuImageFactory puImageFactory = new PuImageFactory();
   private boolean drawUnits = true;
   private boolean drawTerritoryEffects = false;
-  private boolean drawMapOnly = false;
 
   @Getter(onMethod_ = {@Override})
   private Cursor cursor = Cursor.getDefaultCursor();
@@ -198,16 +197,6 @@ public class HeadedUiContext extends AbstractUiContext {
   @Override
   public boolean getShowTerritoryEffects() {
     return drawTerritoryEffects;
-  }
-
-  @Override
-  public boolean getShowMapOnly() {
-    return drawMapOnly;
-  }
-
-  @Override
-  public void setShowMapOnly(final boolean showMapOnly) {
-    drawMapOnly = showMapOnly;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/ui/HeadlessUiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/HeadlessUiContext.java
@@ -111,13 +111,5 @@ public class HeadlessUiContext extends AbstractUiContext {
   }
 
   @Override
-  public boolean getShowMapOnly() {
-    return false;
-  }
-
-  @Override
-  public void setShowMapOnly(final boolean showMapOnly) {}
-
-  @Override
   public void setUnitScaleFactor(final double scaleFactor) {}
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -2324,7 +2324,7 @@ public final class TripleAFrame extends JFrame implements KeyBindingSupplier, Qu
   private void setWidgetActivation() {
     SwingAction.invokeNowOrLater(
         () -> {
-          showHistoryAction.setEnabled(!(inHistory.get()));
+          showHistoryAction.setEnabled(!inHistory.get());
           showGameAction.setEnabled(!inGame.get());
           if (editModeButtonModel != null) {
             editModeButtonModel.setEnabled(editDelegate != null);

--- a/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -121,10 +121,6 @@ public interface UiContext {
 
   boolean getShowTerritoryEffects();
 
-  boolean getShowMapOnly();
-
-  void setShowMapOnly(boolean showMapOnly);
-
   boolean getShowEndOfTurnReport();
 
   void setShowEndOfTurnReport(boolean value);

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -64,7 +64,6 @@ final class GameMenu extends JMenu {
     addSeparator();
     addMenuItemWithHotkey(frame.getShowGameAction(), KeyEvent.VK_G);
     addMenuItemWithHotkey(frame.getShowHistoryAction(), KeyEvent.VK_H);
-    add(frame.getShowMapOnlyAction()).setMnemonic(KeyEvent.VK_M);
     addSeparator();
     addGameOptionsMenu();
     addShowVerifiedDice();


### PR DESCRIPTION
Removal reasons:
- Feature is very buggy and will be difficult to fix.
- Feature had a poor UX, was not clear when it was enabled and even could be used.
- Feature is largely a copy/paste of show-history, not clear it was a good idea to add
  beyond it was 'easy' to add.
- Feature is arguably unnecessary, can be replicated by minimizing the left and right
  side-bars

Resolves bug #5860


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[x] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done
- observed an AI vs AI game and watched for errors.

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->

## Additional Review Notes

Some significant whitespace changes, use this link to review with whitespace change ignored: https://github.com/triplea-game/triplea/pull/5876/files?utf8=%E2%9C%93&diff=unified&w=1

