### PR TITLE
Fix unit scroller NPE.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -103,7 +103,7 @@ public class UnitScroller {
 
   private void unitMoved() {
     updateMovesLeftLabel();
-    if(lastFocusedTerritory == null) {
+    if (lastFocusedTerritory == null) {
       focusCapital();
     } else {
       drawUnitAvatarPane(lastFocusedTerritory);

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -103,7 +103,11 @@ public class UnitScroller {
 
   private void unitMoved() {
     updateMovesLeftLabel();
-    drawUnitAvatarPane(lastFocusedTerritory);
+    if(lastFocusedTerritory == null) {
+      focusCapital();
+    } else {
+      drawUnitAvatarPane(lastFocusedTerritory);
+    }
 
     // remove any moved units from the sleeping units
     sleepingUnits.removeAll(


### PR DESCRIPTION
If a unit move event is fired without a focus on capitol event,
then focus on capitol. This seems to be a problem for maps that
do not automatically focus on capitols on turn transitions,
EG: World At War.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

