### PR TITLE
Statistics Panel (3) – Production chart

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/stats/ProductionStat.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/ProductionStat.java
@@ -1,0 +1,29 @@
+package games.strategy.engine.stats;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.triplea.Properties;
+import games.strategy.triplea.attachments.TerritoryAttachment;
+import games.strategy.triplea.delegate.Matches;
+
+public class ProductionStat extends AbstractStat {
+  @Override
+  public String getName() {
+    return "Production";
+  }
+
+  @Override
+  public double getValue(final GamePlayer player, final GameData data) {
+    final int production =
+        data.getMap().getTerritories().stream()
+            .filter(place -> place.getOwner().equals(player))
+            .filter(Matches.territoryCanCollectIncomeFrom(player, data))
+            .mapToInt(TerritoryAttachment::getProduction)
+            .sum();
+    /*
+     * Match will Check if terr is a Land Convoy Route and check ownership
+     * of neighboring Sea Zone, or if contested
+     */
+    return (double) production * Properties.getPuMultiplier(data);
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/stats/Statistics.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/Statistics.java
@@ -1,11 +1,16 @@
 package games.strategy.engine.stats;
 
-import lombok.Data;
+import com.google.common.collect.HashBasedTable;
+import com.google.common.collect.Table;
+import games.strategy.engine.history.Round;
+import lombok.Value;
 
 /**
  * Data class class that holds statistics information like "PUs over time per player".
  *
  * <p>Instances are typically created by {@link StatisticsAggregator}.
  */
-@Data
-public class Statistics {}
+@Value
+public class Statistics {
+  private final Table<String, Round, Double> productionOfPlayerInRound = HashBasedTable.create();
+}

--- a/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
@@ -1,6 +1,13 @@
 package games.strategy.engine.stats;
 
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.history.HistoryNode;
+import games.strategy.engine.history.Round;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import javax.swing.tree.TreeNode;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
 import lombok.extern.java.Log;
@@ -11,8 +18,42 @@ import lombok.extern.java.Log;
 @Log
 @UtilityClass
 public class StatisticsAggregator {
+  private static IStat productionStat = new ProductionStat();
+
   public static Statistics aggregate(@NonNull final GameData game) {
     log.info("Aggregating statistics for game " + game.getGameName());
-    return new Statistics();
+    final Statistics underConstruction = new Statistics();
+
+    final List<GamePlayer> players = game.getPlayerList().getPlayers();
+    final List<String> alliances = new ArrayList<>(game.getAllianceTracker().getAlliances());
+
+    for (final Round round : getRounds(game)) {
+      game.getHistory().gotoNode(round);
+      for (final GamePlayer player : players) {
+        underConstruction
+            .getProductionOfPlayerInRound()
+            .put(player.getName(), round, productionStat.getValue(player, game));
+      }
+      for (final String alliance : alliances) {
+        underConstruction
+            .getProductionOfPlayerInRound()
+            .put(alliance, round, productionStat.getValue(alliance, game));
+      }
+    }
+
+    return underConstruction;
+  }
+
+  private static List<Round> getRounds(final GameData gameData) {
+    final List<Round> rounds = new ArrayList<>();
+    final HistoryNode root = (HistoryNode) gameData.getHistory().getRoot();
+    final Enumeration<TreeNode> rootChildren = root.children();
+    while (rootChildren.hasMoreElements()) {
+      final TreeNode child = rootChildren.nextElement();
+      if (child instanceof Round) {
+        rounds.add((Round) child);
+      }
+    }
+    return rounds;
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -9,8 +9,8 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.events.GameDataChangeListener;
 import games.strategy.engine.stats.AbstractStat;
 import games.strategy.engine.stats.IStat;
+import games.strategy.engine.stats.ProductionStat;
 import games.strategy.triplea.Constants;
-import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.Matches;
@@ -409,28 +409,6 @@ class StatPanel extends AbstractStatPanel {
       gameData = data;
       gameData.addDataChangeListener(this);
       isDirty = true;
-    }
-  }
-
-  static class ProductionStat extends AbstractStat {
-    @Override
-    public String getName() {
-      return "Production";
-    }
-
-    @Override
-    public double getValue(final GamePlayer player, final GameData data) {
-      final int production =
-          data.getMap().getTerritories().stream()
-              .filter(place -> place.getOwner().equals(player))
-              .filter(Matches.territoryCanCollectIncomeFrom(player, data))
-              .mapToInt(TerritoryAttachment::getProduction)
-              .sum();
-      /*
-       * Match will Check if terr is a Land Convoy Route and check ownership
-       * of neighboring Sea Zone, or if contested
-       */
-      return (double) production * Properties.getPuMultiplier(data);
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.ui.statistics;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.stats.Statistics;
 import games.strategy.engine.stats.StatisticsAggregator;
+import java.util.ArrayList;
 import javax.swing.JPanel;
 import org.knowm.xchart.PieChart;
 import org.knowm.xchart.PieChartBuilder;
@@ -13,20 +14,29 @@ import org.knowm.xchart.style.Styler;
 import org.triplea.swing.JTabbedPaneBuilder;
 
 public class StatisticsDialog extends JPanel {
+
+  private XYChartBuilder xyChartDefaults = new XYChartBuilder().theme(Styler.ChartTheme.Matlab);
+
   public StatisticsDialog(final GameData game) {
     final Statistics statistics = StatisticsAggregator.aggregate(game);
     final JTabbedPaneBuilder tabbedPane = JTabbedPaneBuilder.builder();
     tabbedPane.addTab("Lines", createDummyXyGraph(statistics));
     tabbedPane.addTab("Pie", createDummyPieChart(statistics));
+    tabbedPane.addTab("Production", createProductionChart(statistics));
     this.add(tabbedPane.build());
   }
 
+  private JPanel createProductionChart(final Statistics statistics) {
+    final XYChart chart = xyChartDefaults.title("Production").build();
+    statistics
+        .getProductionOfPlayerInRound()
+        .rowMap()
+        .forEach((key, value) -> chart.addSeries(key, new ArrayList<>(value.values())));
+    return new XChartPanel<>(chart);
+  }
+
   private JPanel createDummyXyGraph(final Statistics statistics) {
-    final XYChart chart =
-        new XYChartBuilder()
-            .theme(Styler.ChartTheme.Matlab)
-            .title("Sample Chart: " + statistics.toString())
-            .build();
+    final XYChart chart = xyChartDefaults.title("Sample Chart: " + statistics.toString()).build();
     chart.addSeries("some value1", new double[] {2.0, 0.0, 40.0});
     chart.addSeries("some value2", new double[] {3.0, 1.0, 41.0});
     chart.addSeries("some value3", new double[] {4.0, 2.0, 42.0});

--- a/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
@@ -15,7 +15,8 @@ import org.triplea.swing.JTabbedPaneBuilder;
 
 public class StatisticsDialog extends JPanel {
 
-  private XYChartBuilder xyChartDefaults = new XYChartBuilder().theme(Styler.ChartTheme.Matlab);
+  private final XYChartBuilder xyChartDefaults =
+      new XYChartBuilder().theme(Styler.ChartTheme.Matlab).xAxisTitle("#Rounds");
 
   public StatisticsDialog(final GameData game) {
     final Statistics statistics = StatisticsAggregator.aggregate(game);
@@ -27,7 +28,8 @@ public class StatisticsDialog extends JPanel {
   }
 
   private JPanel createProductionChart(final Statistics statistics) {
-    final XYChart chart = xyChartDefaults.title("Production").build();
+    final XYChart chart =
+        xyChartDefaults.title("Production").yAxisTitle("Production from territories").build();
     statistics
         .getProductionOfPlayerInRound()
         .rowMap()


### PR DESCRIPTION
This is the third pull request in a series (#5866 #5872). Subject is the [feature request for a statistics panel](https://forums.triplea-game.org/topic/1660/game-statistics-page/).

This time, I added the first actual statistics graph. An overview over production values per player over the game rounds.

### Note:
I am reusing the `IStat` implementation `ProductionStat` that was already used in `StatPanel` for getting the actual values. I moved this class from `ui` to `engine.stats` package, where it fits better imho.
I plan to do the same with all the other `IStat` implementations that are still in `StatPanel` when I'm adding these to the statistics aggregations.

Slowly I come to the realm where automated tests can make sense. Can you link me to some examples on how to nicely create/mock `GameData` objects?

Plan for the next PR is
 - create graphs for more statistics from the `StatPanel` class


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[x] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us,
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->
Nothing really to test

<!-- If there are UI updates, uncomment and include screenshots below -->
## Screens Shots

![scrot_2020-01-25_16-55-55_screenshot](https://user-images.githubusercontent.com/263263/73123860-f9fc6980-3f94-11ea-8c85-03b5393113fb.png)


