### PR TITLE
Make MapData control lifecycle of resource loader and remove close method

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -305,7 +305,8 @@ public class ResourceLoader implements Closeable {
     try {
       return Optional.of(ImageIO.read(url));
     } catch (final IOException e) {
-      throw new IllegalStateException(e);
+      log.log(Level.SEVERE, "Image loading failed: " + imageName, e);
+      return Optional.empty();
     }
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
@@ -56,7 +56,7 @@ public class HeadedUiContext extends AbstractUiContext {
 
   @Override
   protected void internalSetMapDir(final String dir, final GameData data) {
-    if(resourceLoader != null) {
+    if (resourceLoader != null) {
       resourceLoader.close();
     }
     resourceLoader = ResourceLoader.getMapResourceLoader(dir);

--- a/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
@@ -56,6 +56,9 @@ public class HeadedUiContext extends AbstractUiContext {
 
   @Override
   protected void internalSetMapDir(final String dir, final GameData data) {
+    if(resourceLoader != null) {
+      resourceLoader.close();
+    }
     resourceLoader = ResourceLoader.getMapResourceLoader(dir);
     mapData = new MapData(dir);
     // DiceImageFactory needs loader and game data

--- a/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
@@ -173,6 +173,7 @@ public class HeadedUiContext extends AbstractUiContext {
   @Override
   public void shutDown() {
     super.shutDown();
+    resourceLoader.close();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
@@ -57,10 +57,7 @@ public class HeadedUiContext extends AbstractUiContext {
   @Override
   protected void internalSetMapDir(final String dir, final GameData data) {
     resourceLoader = ResourceLoader.getMapResourceLoader(dir);
-    if (mapData != null) {
-      mapData.close();
-    }
-    mapData = new MapData(resourceLoader);
+    mapData = new MapData(dir);
     // DiceImageFactory needs loader and game data
     diceImageFactory = new DiceImageFactory(resourceLoader, data.getDiceSides());
     final double unitScale =
@@ -176,7 +173,6 @@ public class HeadedUiContext extends AbstractUiContext {
   @Override
   public void shutDown() {
     super.shutDown();
-    mapData.close();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -756,11 +756,11 @@ public class MapData {
   }
 
   public Optional<Image> getErrorImage() {
-    return Optional.of(errorImage);
+    return Optional.ofNullable(errorImage);
   }
 
   public Optional<Image> getWarningImage() {
-    return Optional.of(warningImage);
+    return Optional.ofNullable(warningImage);
   }
 
   public Map<String, Image> getTerritoryNameImages() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -140,8 +140,8 @@ public class MapData {
                   + ", the error"
                   + " is that either we did not find the correct path to load. Check the resource "
                   + "loader to make sure the map zip or dir was added. Failing that, the path in "
-                  + "this error message should be available relative to the map folder, or relative "
-                  + "to the root of the map zip");
+                  + "this error message should be available relative to the map folder, or "
+                  + "relative to the root of the map zip");
         }
 
         place.putAll(readPlacementsOneToMany(loader.optionalResource(PLACEMENT_FILE)));

--- a/game-core/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/game-core/src/main/java/tools/image/AutoPlacementFinder.java
@@ -260,56 +260,44 @@ public final class AutoPlacementFinder {
     }
 
     // makes TripleA read all the text data files for the map.
-    try (MapData mapData = new MapData(mapDir)) {
-      textOptionPane.show();
-      textOptionPane.appendNewLine(
-          "Place Dimensions in pixels, being used: " + placeWidth + "x" + placeHeight + "\r\n");
-      textOptionPane.appendNewLine("Calculating, this may take a while...\r\n");
-      final Map<String, List<Point>> placements = new HashMap<>();
-      for (final String name : mapData.getTerritories()) {
-        final Set<Polygon> containedPolygons = mapData.getContainedTerritoryPolygons(name);
-        final List<Point> points =
-            containedPolygons.isEmpty()
-                ? getPlacementsStartingAtMiddle(
-                    mapData.getPolygons(name),
-                    mapData.getBoundingRect(name),
-                    mapData.getCenter(name))
-                : getPlacementsStartingAtTopLeft(
-                    mapData.getPolygons(name),
-                    mapData.getBoundingRect(name),
-                    mapData.getCenter(name),
-                    containedPolygons);
-        placements.put(name, points);
-        textOptionPane.appendNewLine(name + ": " + points.size());
-      }
-      textOptionPane.appendNewLine("\r\nAll Finished!");
-      textOptionPane.countDown();
-      final String fileName =
-          new FileSave("Where To Save place.txt ?", "place.txt", mapFolderLocation).getPathString();
-      if (fileName == null) {
-        textOptionPane.appendNewLine("You chose not to save, Shutting down");
-        textOptionPane.dispose();
-        return;
-      }
-      try (OutputStream os = new FileOutputStream(fileName)) {
-        PointFileReaderWriter.writeOneToMany(os, placements);
-        textOptionPane.appendNewLine("Data written to :" + new File(fileName).getCanonicalPath());
-      } catch (final IOException e) {
-        log.log(Level.SEVERE, "Failed to write points file: " + fileName, e);
-        textOptionPane.dispose();
-        return;
-      }
-      textOptionPane.dispose();
-    } catch (final Exception e) {
-      JOptionPane.showMessageDialog(
-          null,
-          new JLabel(
-              "Could not find map. Make sure it is in finalized location and contains "
-                  + "centers.txt and polygons.txt"));
-      log.severe("Caught Exception.");
-      log.severe("Could be due to some missing text files.");
-      log.log(Level.SEVERE, "Or due to the map folder not being in the right location.", e);
+    MapData mapData = new MapData(mapDir);
+    textOptionPane.show();
+    textOptionPane.appendNewLine(
+        "Place Dimensions in pixels, being used: " + placeWidth + "x" + placeHeight + "\r\n");
+    textOptionPane.appendNewLine("Calculating, this may take a while...\r\n");
+    final Map<String, List<Point>> placements = new HashMap<>();
+    for (final String name : mapData.getTerritories()) {
+      final Set<Polygon> containedPolygons = mapData.getContainedTerritoryPolygons(name);
+      final List<Point> points =
+          containedPolygons.isEmpty()
+              ? getPlacementsStartingAtMiddle(
+                  mapData.getPolygons(name), mapData.getBoundingRect(name), mapData.getCenter(name))
+              : getPlacementsStartingAtTopLeft(
+                  mapData.getPolygons(name),
+                  mapData.getBoundingRect(name),
+                  mapData.getCenter(name),
+                  containedPolygons);
+      placements.put(name, points);
+      textOptionPane.appendNewLine(name + ": " + points.size());
     }
+    textOptionPane.appendNewLine("\r\nAll Finished!");
+    textOptionPane.countDown();
+    final String fileName =
+        new FileSave("Where To Save place.txt ?", "place.txt", mapFolderLocation).getPathString();
+    if (fileName == null) {
+      textOptionPane.appendNewLine("You chose not to save, Shutting down");
+      textOptionPane.dispose();
+      return;
+    }
+    try (OutputStream os = new FileOutputStream(fileName)) {
+      PointFileReaderWriter.writeOneToMany(os, placements);
+      textOptionPane.appendNewLine("Data written to :" + new File(fileName).getCanonicalPath());
+    } catch (final IOException e) {
+      log.log(Level.SEVERE, "Failed to write points file: " + fileName, e);
+      textOptionPane.dispose();
+      return;
+    }
+    textOptionPane.dispose();
   }
 
   /**

--- a/game-core/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/game-core/src/main/java/tools/image/AutoPlacementFinder.java
@@ -259,13 +259,12 @@ public final class AutoPlacementFinder {
       }
     }
 
-    // makes TripleA read all the text data files for the map.
-    MapData mapData = new MapData(mapDir);
     textOptionPane.show();
     textOptionPane.appendNewLine(
         "Place Dimensions in pixels, being used: " + placeWidth + "x" + placeHeight + "\r\n");
     textOptionPane.appendNewLine("Calculating, this may take a while...\r\n");
     final Map<String, List<Point>> placements = new HashMap<>();
+    final MapData mapData = new MapData(mapDir);
     for (final String name : mapData.getTerritories()) {
       final Set<Polygon> containedPolygons = mapData.getContainedTerritoryPolygons(name);
       final List<Point> points =


### PR DESCRIPTION
Updates MapData to always instantiate a resource loader itself and to close
it when construction is done. This ensures that the resource loader is closed
and removes the burden of other classes from having to remember to call
close on map data.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->

## Additional Review Notes

Use this link to hide whitespace changes: https://github.com/triplea-game/triplea/pull/5882/files?utf8=%E2%9C%93&diff=unified&w=1

