### PR TITLE
Simplify: Convert ResourceLocationTracker.getMapPrefix to be a static method

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -36,7 +36,7 @@ public class ResourceLoader implements Closeable {
   public static final String RESOURCE_FOLDER = "assets";
 
   private final URLClassLoader loader;
-  private final ResourceLocationTracker resourceLocationTracker;
+  private final String mapPrefix;
   @Getter private final String mapName;
 
   private ResourceLoader(final String mapName, final String[] paths) {
@@ -55,7 +55,7 @@ public class ResourceLoader implements Closeable {
         throw new IllegalStateException(e);
       }
     }
-    resourceLocationTracker = new ResourceLocationTracker(mapName, urls);
+    mapPrefix = ResourceLocationTracker.getMapPrefix(mapName, urls);
     // Note: URLClassLoader does not always respect the ordering of the search URLs
     // To solve this we will get all matching paths and then filter by what matched
     // the assets folder.
@@ -226,7 +226,7 @@ public class ResourceLoader implements Closeable {
    *     resource. Do not use '\' or File.separator)
    */
   public @Nullable URL getResource(final String inputPath) {
-    final String path = resourceLocationTracker.getMapPrefix() + inputPath;
+    final String path = mapPrefix + inputPath;
     return findResource(path).or(() -> findResource(inputPath)).orElse(null);
   }
 
@@ -239,8 +239,8 @@ public class ResourceLoader implements Closeable {
    * @param inputPath2 Same as inputPath but this takes second priority when loading
    */
   public @Nullable URL getResource(final String inputPath, final String inputPath2) {
-    final String path = resourceLocationTracker.getMapPrefix() + inputPath;
-    final String path2 = resourceLocationTracker.getMapPrefix() + inputPath2;
+    final String path = mapPrefix + inputPath;
+    final String path2 = mapPrefix + inputPath2;
     return findResource(path)
         .or(() -> findResource(path2))
         .or(() -> findResource(inputPath))

--- a/game-core/src/main/java/games/strategy/triplea/ResourceLocationTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLocationTracker.java
@@ -2,11 +2,13 @@ package games.strategy.triplea;
 
 import java.net.URL;
 import java.util.Arrays;
+import lombok.experimental.UtilityClass;
 
 /**
  * Utility class containing the logic for whether or not to create a special resource loading path
  * prefix.
  */
+@UtilityClass
 class ResourceLocationTracker {
 
   /**
@@ -17,10 +19,14 @@ class ResourceLocationTracker {
 
   static final String MASTER_ZIP_IDENTIFYING_SUFFIX = "-master.zip";
 
-  private final String mapPrefix;
-
   /**
-   * Initializes a new instance of the ResourceLocationTracker class.
+   * * Will return an empty string unless a special prefix is needed, in which case that prefix is *
+   * constructed based on the map name. * *
+   *
+   * <p>The 'mapPrefix' is the path within a map zip file where we will then find any map contents.
+   * * For example, if the map prefix is "map", then when we expand the map zip, we would expect *
+   * "/map" to be the first folder we see, and we would expect things like "/map/game" and *
+   * "/map/polygons.txt" to exist.
    *
    * @param mapName Used to construct any special resource loading path prefixes, used as needed
    *     depending upon which resources are in the path
@@ -28,7 +34,7 @@ class ResourceLocationTracker {
    *     if the map is being loaded from a zip or a directory, and if zip, if it matches any
    *     particular naming.
    */
-  ResourceLocationTracker(final String mapName, final URL[] resourcePaths) {
+  static String getMapPrefix(final String mapName, final URL[] resourcePaths) {
     final boolean isUsingMasterZip =
         Arrays.stream(resourcePaths)
             .map(Object::toString)
@@ -36,23 +42,10 @@ class ResourceLocationTracker {
 
     // map skins will have the full path name as their map name.
     if (mapName.endsWith("-master.zip")) {
-      mapPrefix =
-          mapName.substring(0, mapName.length() - "-master.zip".length()) + MASTER_ZIP_MAGIC_PREFIX;
+      return mapName.substring(0, mapName.length() - "-master.zip".length())
+          + MASTER_ZIP_MAGIC_PREFIX;
     } else {
-      mapPrefix = isUsingMasterZip ? mapName + MASTER_ZIP_MAGIC_PREFIX : "";
+      return isUsingMasterZip ? mapName + MASTER_ZIP_MAGIC_PREFIX : "";
     }
-  }
-
-  /**
-   * Will return an empty string unless a special prefix is needed, in which case that prefix is
-   * constructed based on the map name.
-   *
-   * <p>The 'mapPrefix' is the path within a map zip file where we will then find any map contents.
-   * For example, if the map prefix is "map", then when we expand the map zip, we would expect
-   * "/map" to be the first folder we see, and we would expect things like "/map/game" and
-   * "/map/polygons.txt" to exist.
-   */
-  String getMapPrefix() {
-    return mapPrefix;
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/ResourceLocationTrackerTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ResourceLocationTrackerTest.java
@@ -9,28 +9,26 @@ import org.junit.jupiter.api.Test;
 class ResourceLocationTrackerTest {
   @Test
   void defaultEmptyMapPrefix() {
-    final ResourceLocationTracker testObj = new ResourceLocationTracker("", new URL[0]);
-    assertThat(testObj.getMapPrefix(), is(""));
+    assertThat(ResourceLocationTracker.getMapPrefix("", new URL[0]), is(""));
   }
 
   @Test
   void defaultEmptyMapPrefixWithMoreInterestingTestData() throws Exception {
-    final ResourceLocationTracker testObj =
-        new ResourceLocationTracker(
-            "", new URL[] {new URL("file://localhost"), new URL("file://oldFormat.zip")});
-    assertThat(testObj.getMapPrefix(), is(""));
+    assertThat(
+        ResourceLocationTracker.getMapPrefix(
+            "", new URL[] {new URL("file://localhost"), new URL("file://oldFormat.zip")}),
+        is(""));
   }
 
   @Test
   void masterZipsGetSpecialPrefixBasedOnTheMapName() throws Exception {
     final String fakeMapName = "fakeMapName";
-    final ResourceLocationTracker testObj =
-        new ResourceLocationTracker(
+    assertThat(
+        ResourceLocationTracker.getMapPrefix(
             fakeMapName,
             new URL[] {
               new URL("file://pretend" + ResourceLocationTracker.MASTER_ZIP_IDENTIFYING_SUFFIX)
-            });
-    assertThat(
-        testObj.getMapPrefix(), is(fakeMapName + ResourceLocationTracker.MASTER_ZIP_MAGIC_PREFIX));
+            }),
+        is(fakeMapName + ResourceLocationTracker.MASTER_ZIP_MAGIC_PREFIX));
   }
 }


### PR DESCRIPTION


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

