### PR TITLE
Statistics Panel (4) – TUV, Units & VC charts

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/stats/Statistics.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/Statistics.java
@@ -13,4 +13,5 @@ import lombok.Value;
 @Value
 public class Statistics {
   private final Table<String, Round, Double> productionOfPlayerInRound = HashBasedTable.create();
+  private final Table<String, Round, Double> tuvOfPlayerInRound = HashBasedTable.create();
 }

--- a/game-core/src/main/java/games/strategy/engine/stats/Statistics.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/Statistics.java
@@ -15,4 +15,5 @@ public class Statistics {
   private final Table<String, Round, Double> productionOfPlayerInRound = HashBasedTable.create();
   private final Table<String, Round, Double> tuvOfPlayerInRound = HashBasedTable.create();
   private final Table<String, Round, Double> unitsOfPlayerInRound = HashBasedTable.create();
+  private final Table<String, Round, Double> victoryCitiesOfPlayerInRound = HashBasedTable.create();
 }

--- a/game-core/src/main/java/games/strategy/engine/stats/Statistics.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/Statistics.java
@@ -14,4 +14,5 @@ import lombok.Value;
 public class Statistics {
   private final Table<String, Round, Double> productionOfPlayerInRound = HashBasedTable.create();
   private final Table<String, Round, Double> tuvOfPlayerInRound = HashBasedTable.create();
+  private final Table<String, Round, Double> unitsOfPlayerInRound = HashBasedTable.create();
 }

--- a/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
@@ -19,6 +19,7 @@ import lombok.extern.java.Log;
 @UtilityClass
 public class StatisticsAggregator {
   private static IStat productionStat = new ProductionStat();
+  private static IStat tuvStat = new TuvStat();
 
   public static Statistics aggregate(@NonNull final GameData game) {
     log.info("Aggregating statistics for game " + game.getGameName());
@@ -33,11 +34,17 @@ public class StatisticsAggregator {
         underConstruction
             .getProductionOfPlayerInRound()
             .put(player.getName(), round, productionStat.getValue(player, game));
+        underConstruction
+            .getTuvOfPlayerInRound()
+            .put(player.getName(), round, tuvStat.getValue(player, game));
       }
       for (final String alliance : alliances) {
         underConstruction
             .getProductionOfPlayerInRound()
             .put(alliance, round, productionStat.getValue(alliance, game));
+        underConstruction
+            .getTuvOfPlayerInRound()
+            .put(alliance, round, tuvStat.getValue(alliance, game));
       }
     }
 

--- a/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
@@ -20,6 +20,7 @@ import lombok.extern.java.Log;
 public class StatisticsAggregator {
   private static IStat productionStat = new ProductionStat();
   private static IStat tuvStat = new TuvStat();
+  private static IStat unitsStat = new UnitsStat();
 
   public static Statistics aggregate(@NonNull final GameData game) {
     log.info("Aggregating statistics for game " + game.getGameName());
@@ -37,6 +38,9 @@ public class StatisticsAggregator {
         underConstruction
             .getTuvOfPlayerInRound()
             .put(player.getName(), round, tuvStat.getValue(player, game));
+        underConstruction
+            .getUnitsOfPlayerInRound()
+            .put(player.getName(), round, unitsStat.getValue(player, game));
       }
       for (final String alliance : alliances) {
         underConstruction
@@ -45,6 +49,9 @@ public class StatisticsAggregator {
         underConstruction
             .getTuvOfPlayerInRound()
             .put(alliance, round, tuvStat.getValue(alliance, game));
+        underConstruction
+            .getUnitsOfPlayerInRound()
+            .put(alliance, round, unitsStat.getValue(alliance, game));
       }
     }
 

--- a/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
@@ -21,6 +21,7 @@ public class StatisticsAggregator {
   private static IStat productionStat = new ProductionStat();
   private static IStat tuvStat = new TuvStat();
   private static IStat unitsStat = new UnitsStat();
+  private static IStat victoryCityStat = new VictoryCityStat();
 
   public static Statistics aggregate(@NonNull final GameData game) {
     log.info("Aggregating statistics for game " + game.getGameName());
@@ -41,6 +42,9 @@ public class StatisticsAggregator {
         underConstruction
             .getUnitsOfPlayerInRound()
             .put(player.getName(), round, unitsStat.getValue(player, game));
+        underConstruction
+            .getVictoryCitiesOfPlayerInRound()
+            .put(player.getName(), round, victoryCityStat.getValue(player, game));
       }
       for (final String alliance : alliances) {
         underConstruction
@@ -52,6 +56,9 @@ public class StatisticsAggregator {
         underConstruction
             .getUnitsOfPlayerInRound()
             .put(alliance, round, unitsStat.getValue(alliance, game));
+        underConstruction
+            .getVictoryCitiesOfPlayerInRound()
+            .put(alliance, round, victoryCityStat.getValue(alliance, game));
       }
     }
 

--- a/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
@@ -8,66 +8,74 @@ import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import javax.swing.tree.TreeNode;
-import lombok.NonNull;
-import lombok.experimental.UtilityClass;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.java.Log;
 
 /**
  * Analyzes a game's history and aggregates interesting statistics in a {@link Statistics} object.
  */
 @Log
-@UtilityClass
+@RequiredArgsConstructor
 public class StatisticsAggregator {
   private static IStat productionStat = new ProductionStat();
   private static IStat tuvStat = new TuvStat();
   private static IStat unitsStat = new UnitsStat();
   private static IStat victoryCityStat = new VictoryCityStat();
 
-  public static Statistics aggregate(@NonNull final GameData game) {
-    log.info("Aggregating statistics for game " + game.getGameName());
-    final Statistics underConstruction = new Statistics();
+  private final Statistics underConstruction = new Statistics();
+  private final GameData game;
 
+  public Statistics aggregate() {
+    log.info("Aggregating statistics for game " + game.getGameName());
     final List<GamePlayer> players = game.getPlayerList().getPlayers();
     final List<String> alliances = new ArrayList<>(game.getAllianceTracker().getAlliances());
 
-    for (final Round round : getRounds(game)) {
+    for (final Round round : getRounds()) {
       game.getHistory().gotoNode(round);
       for (final GamePlayer player : players) {
-        underConstruction
-            .getProductionOfPlayerInRound()
-            .put(player.getName(), round, productionStat.getValue(player, game));
-        underConstruction
-            .getTuvOfPlayerInRound()
-            .put(player.getName(), round, tuvStat.getValue(player, game));
-        underConstruction
-            .getUnitsOfPlayerInRound()
-            .put(player.getName(), round, unitsStat.getValue(player, game));
-        underConstruction
-            .getVictoryCitiesOfPlayerInRound()
-            .put(player.getName(), round, victoryCityStat.getValue(player, game));
+        processRoundOfPlayer(round, player);
       }
       for (final String alliance : alliances) {
-        underConstruction
-            .getProductionOfPlayerInRound()
-            .put(alliance, round, productionStat.getValue(alliance, game));
-        underConstruction
-            .getTuvOfPlayerInRound()
-            .put(alliance, round, tuvStat.getValue(alliance, game));
-        underConstruction
-            .getUnitsOfPlayerInRound()
-            .put(alliance, round, unitsStat.getValue(alliance, game));
-        underConstruction
-            .getVictoryCitiesOfPlayerInRound()
-            .put(alliance, round, victoryCityStat.getValue(alliance, game));
+        processRoundOfAlliance(round, alliance);
       }
     }
 
     return underConstruction;
   }
 
-  private static List<Round> getRounds(final GameData gameData) {
+  private void processRoundOfAlliance(final Round round, final String alliance) {
+    underConstruction
+        .getProductionOfPlayerInRound()
+        .put(alliance, round, productionStat.getValue(alliance, game));
+    underConstruction
+        .getTuvOfPlayerInRound()
+        .put(alliance, round, tuvStat.getValue(alliance, game));
+    underConstruction
+        .getUnitsOfPlayerInRound()
+        .put(alliance, round, unitsStat.getValue(alliance, game));
+    underConstruction
+        .getVictoryCitiesOfPlayerInRound()
+        .put(alliance, round, victoryCityStat.getValue(alliance, game));
+  }
+
+  private void processRoundOfPlayer(final Round round, final GamePlayer player) {
+    underConstruction
+        .getProductionOfPlayerInRound()
+        .put(player.getName(), round, productionStat.getValue(player, game));
+    underConstruction
+        .getTuvOfPlayerInRound()
+        .put(player.getName(), round, tuvStat.getValue(player, game));
+    underConstruction
+        .getUnitsOfPlayerInRound()
+        .put(player.getName(), round, unitsStat.getValue(player, game));
+    underConstruction
+        .getVictoryCitiesOfPlayerInRound()
+        .put(player.getName(), round, victoryCityStat.getValue(player, game));
+  }
+
+  private List<Round> getRounds() {
     final List<Round> rounds = new ArrayList<>();
-    final HistoryNode root = (HistoryNode) gameData.getHistory().getRoot();
+    final HistoryNode root = (HistoryNode) game.getHistory().getRoot();
     final Enumeration<TreeNode> rootChildren = root.children();
     while (rootChildren.hasMoreElements()) {
       final TreeNode child = rootChildren.nextElement();

--- a/game-core/src/main/java/games/strategy/engine/stats/TuvStat.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/TuvStat.java
@@ -1,0 +1,29 @@
+package games.strategy.engine.stats;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.delegate.Matches;
+import games.strategy.triplea.util.TuvUtils;
+import java.util.function.Predicate;
+import org.triplea.java.collections.IntegerMap;
+
+public class TuvStat extends AbstractStat {
+  @Override
+  public String getName() {
+    return "TUV";
+  }
+
+  @Override
+  public double getValue(final GamePlayer player, final GameData data) {
+    final IntegerMap<UnitType> costs = TuvUtils.getCostsForTuv(player, data);
+    final Predicate<Unit> unitIsOwnedBy = Matches.unitIsOwnedBy(player);
+    return data.getMap().getTerritories().stream()
+        .map(Territory::getUnitCollection)
+        .map(units -> units.getMatches(unitIsOwnedBy))
+        .mapToInt(owned -> TuvUtils.getTuv(owned, costs))
+        .sum();
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/stats/UnitsStat.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/UnitsStat.java
@@ -1,0 +1,25 @@
+package games.strategy.engine.stats;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.triplea.delegate.Matches;
+import java.util.function.Predicate;
+
+public class UnitsStat extends AbstractStat {
+  @Override
+  public String getName() {
+    return "Units";
+  }
+
+  @Override
+  public double getValue(final GamePlayer player, final GameData data) {
+    final Predicate<Unit> ownedBy = Matches.unitIsOwnedBy(player);
+    // sum the total match count
+    return data.getMap().getTerritories().stream()
+        .map(Territory::getUnitCollection)
+        .mapToInt(units -> units.countMatches(ownedBy))
+        .sum();
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/stats/VictoryCityStat.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/VictoryCityStat.java
@@ -1,0 +1,24 @@
+package games.strategy.engine.stats;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.triplea.attachments.TerritoryAttachment;
+import java.util.Objects;
+
+public class VictoryCityStat extends AbstractStat {
+  @Override
+  public String getName() {
+    return "VC";
+  }
+
+  @Override
+  public double getValue(final GamePlayer player, final GameData data) {
+    // return sum of victory cities
+    return data.getMap().getTerritories().stream()
+        .filter(place -> place.getOwner().equals(player))
+        .map(TerritoryAttachment::get)
+        .filter(Objects::nonNull)
+        .mapToInt(TerritoryAttachment::getVictoryCity)
+        .sum();
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -5,18 +5,17 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
-import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.events.GameDataChangeListener;
 import games.strategy.engine.stats.AbstractStat;
 import games.strategy.engine.stats.IStat;
 import games.strategy.engine.stats.ProductionStat;
+import games.strategy.engine.stats.TuvStat;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TechAdvance;
 import games.strategy.triplea.delegate.TechTracker;
-import games.strategy.triplea.util.TuvUtils;
 import java.awt.Component;
 import java.awt.GridLayout;
 import java.awt.Image;
@@ -38,7 +37,6 @@ import javax.swing.SwingUtilities;
 import javax.swing.table.AbstractTableModel;
 import javax.swing.table.TableCellRenderer;
 import javax.swing.table.TableColumn;
-import org.triplea.java.collections.IntegerMap;
 
 class StatPanel extends AbstractStatPanel {
   private static final long serialVersionUID = 4340684166664492498L;
@@ -431,24 +429,6 @@ class StatPanel extends AbstractStatPanel {
       return data.getMap().getTerritories().stream()
           .map(Territory::getUnitCollection)
           .mapToInt(units -> units.countMatches(ownedBy))
-          .sum();
-    }
-  }
-
-  static class TuvStat extends AbstractStat {
-    @Override
-    public String getName() {
-      return "TUV";
-    }
-
-    @Override
-    public double getValue(final GamePlayer player, final GameData data) {
-      final IntegerMap<UnitType> costs = TuvUtils.getCostsForTuv(player, data);
-      final Predicate<Unit> unitIsOwnedBy = Matches.unitIsOwnedBy(player);
-      return data.getMap().getTerritories().stream()
-          .map(Territory::getUnitCollection)
-          .map(units -> units.getMatches(unitIsOwnedBy))
-          .mapToInt(owned -> TuvUtils.getTuv(owned, costs))
           .sum();
     }
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -9,9 +9,9 @@ import games.strategy.engine.stats.IStat;
 import games.strategy.engine.stats.ProductionStat;
 import games.strategy.engine.stats.TuvStat;
 import games.strategy.engine.stats.UnitsStat;
+import games.strategy.engine.stats.VictoryCityStat;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.PlayerAttachment;
-import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TechAdvance;
 import games.strategy.triplea.delegate.TechTracker;
@@ -24,7 +24,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import javax.swing.ImageIcon;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
@@ -411,24 +410,6 @@ class StatPanel extends AbstractStatPanel {
   class PuStat extends ResourceStat {
     PuStat() {
       super(getResourcePUs(gameData));
-    }
-  }
-
-  static class VictoryCityStat extends AbstractStat {
-    @Override
-    public String getName() {
-      return "VC";
-    }
-
-    @Override
-    public double getValue(final GamePlayer player, final GameData data) {
-      // return sum of victory cities
-      return data.getMap().getTerritories().stream()
-          .filter(place -> place.getOwner().equals(player))
-          .map(TerritoryAttachment::get)
-          .filter(Objects::nonNull)
-          .mapToInt(TerritoryAttachment::getVictoryCity)
-          .sum();
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -3,13 +3,12 @@ package games.strategy.triplea.ui;
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
-import games.strategy.engine.data.Territory;
-import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.events.GameDataChangeListener;
 import games.strategy.engine.stats.AbstractStat;
 import games.strategy.engine.stats.IStat;
 import games.strategy.engine.stats.ProductionStat;
 import games.strategy.engine.stats.TuvStat;
+import games.strategy.engine.stats.UnitsStat;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
@@ -26,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.function.Predicate;
 import javax.swing.ImageIcon;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
@@ -413,23 +411,6 @@ class StatPanel extends AbstractStatPanel {
   class PuStat extends ResourceStat {
     PuStat() {
       super(getResourcePUs(gameData));
-    }
-  }
-
-  static class UnitsStat extends AbstractStat {
-    @Override
-    public String getName() {
-      return "Units";
-    }
-
-    @Override
-    public double getValue(final GamePlayer player, final GameData data) {
-      final Predicate<Unit> ownedBy = Matches.unitIsOwnedBy(player);
-      // sum the total match count
-      return data.getMap().getTerritories().stream()
-          .map(Territory::getUnitCollection)
-          .mapToInt(units -> units.countMatches(ownedBy))
-          .sum();
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
@@ -24,6 +24,7 @@ public class StatisticsDialog extends JPanel {
     tabbedPane.addTab("Lines", createDummyXyGraph(statistics));
     tabbedPane.addTab("Pie", createDummyPieChart(statistics));
     tabbedPane.addTab("Production", createProductionChart(statistics));
+    tabbedPane.addTab("TUV", createTuvChart(statistics));
     this.add(tabbedPane.build());
   }
 
@@ -32,6 +33,15 @@ public class StatisticsDialog extends JPanel {
         xyChartDefaults.title("Production").yAxisTitle("Production from territories").build();
     statistics
         .getProductionOfPlayerInRound()
+        .rowMap()
+        .forEach((key, value) -> chart.addSeries(key, new ArrayList<>(value.values())));
+    return new XChartPanel<>(chart);
+  }
+
+  private JPanel createTuvChart(final Statistics statistics) {
+    final XYChart chart = xyChartDefaults.title("TUV").yAxisTitle("TUV").build();
+    statistics
+        .getTuvOfPlayerInRound()
         .rowMap()
         .forEach((key, value) -> chart.addSeries(key, new ArrayList<>(value.values())));
     return new XChartPanel<>(chart);

--- a/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
@@ -25,6 +25,7 @@ public class StatisticsDialog extends JPanel {
     tabbedPane.addTab("Pie", createDummyPieChart(statistics));
     tabbedPane.addTab("Production", createProductionChart(statistics));
     tabbedPane.addTab("TUV", createTuvChart(statistics));
+    tabbedPane.addTab("Units", createUnitsChart(statistics));
     this.add(tabbedPane.build());
   }
 
@@ -42,6 +43,15 @@ public class StatisticsDialog extends JPanel {
     final XYChart chart = xyChartDefaults.title("TUV").yAxisTitle("TUV").build();
     statistics
         .getTuvOfPlayerInRound()
+        .rowMap()
+        .forEach((key, value) -> chart.addSeries(key, new ArrayList<>(value.values())));
+    return new XChartPanel<>(chart);
+  }
+
+  private JPanel createUnitsChart(final Statistics statistics) {
+    final XYChart chart = xyChartDefaults.title("Units").yAxisTitle("TUV").build();
+    statistics
+        .getUnitsOfPlayerInRound()
         .rowMap()
         .forEach((key, value) -> chart.addSeries(key, new ArrayList<>(value.values())));
     return new XChartPanel<>(chart);

--- a/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
@@ -41,7 +41,9 @@ public class StatisticsDialog extends JPanel {
                 "Production from territories",
                 statistics.getProductionOfPlayerInRound()),
             new OverTimeChart("TUV", "TUV", statistics.getTuvOfPlayerInRound()),
-            new OverTimeChart("Units", "Units", statistics.getUnitsOfPlayerInRound()));
+            new OverTimeChart("Units", "Units", statistics.getUnitsOfPlayerInRound()),
+            new OverTimeChart(
+                "VC", "Victory Cities", statistics.getVictoryCitiesOfPlayerInRound()));
 
     final JTabbedPaneBuilder tabbedPane = JTabbedPaneBuilder.builder();
     tabbedPane.addTab("Lines", createDummyXyGraph(statistics));

--- a/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
@@ -32,7 +32,7 @@ public class StatisticsDialog extends JPanel {
       new XYChartBuilder().theme(Styler.ChartTheme.Matlab).xAxisTitle("#Rounds");
 
   public StatisticsDialog(final GameData game) {
-    final Statistics statistics = StatisticsAggregator.aggregate(game);
+    final Statistics statistics = new StatisticsAggregator(game).aggregate();
 
     final List<OverTimeChart> overTimeCharts =
         List.of(


### PR DESCRIPTION
This is the fourth pull request in a series (#5866 #5872 #5881). Subject is the [feature request for a statistics panel](https://forums.triplea-game.org/topic/1660/game-statistics-page/).

This time, I added charts for TUV, number of units and victory cities.

As started in the last pull-request, I moved all statistics to their own file in the `engine.stats` package.
This accounts for a big chunk of the changed lines.


Plan for the next PR is
 - create graphs for dynamic resources of maps
 - delete dummy charts

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[x] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us,
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->
Nothing really to test

<!-- If there are UI updates, uncomment and include screenshots below -->
## Screens Shots


![scrot_2020-01-29_20-28-00_screenshot](https://user-images.githubusercontent.com/263263/73390181-e1ae8680-42d5-11ea-938e-ac41d887d42d.png)
