### PR TITLE
Install4j memory boost

### DIFF
--- a/.travis/do_release
+++ b/.travis/do_release
@@ -33,14 +33,11 @@ function installInstall4j() {
 }
 
 function buildReleaseArtifacts() {
-  (
-     ./gradlew \
-           --no-daemon \
-           --parallel \
-           -Pinstall4jHomeDir="$INSTALL4J_HOME" release  2> errors \
-        && echo "INSTALL4J finished with $(wc -l errors)"
-  ) || 
-  (echo "INSTALL4J FAILED" && tail -500 errors)
+  ./gradlew \
+      --no-daemon \
+      --parallel \
+      -Pinstall4jHomeDir="$INSTALL4J_HOME" \
+      release
 }
 
 #

--- a/.travis/do_release
+++ b/.travis/do_release
@@ -33,7 +33,7 @@ function installInstall4j() {
 }
 
 function buildReleaseArtifacts() {
-  ./gradlew \
+  JAVA_OPTS=-Xmx3G ./gradlew \
       --no-daemon \
       --parallel \
       -Pinstall4jHomeDir="$INSTALL4J_HOME" \


### PR DESCRIPTION
<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 
## Updates


#### Remove output install4j buffering
4e38ac4

Error messages are being printed currently from install4j (perhaps they
are being printed now to stdout instead of stderr). This update
removes functionality to cache error messages to a temporary
file for the purpose of suppressing those error messages. It was previously
important as the error message volume was sufficient to run out of
console buffer on travis resulting in truncated messages.

#### Increase install4j task max heap size to 3G from 2G
e16b69f

Addresses OOM problem (exhausted heap space) while
building install4j installers.




## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[x] Problem fix: ***#5794*** - Binaries missing in pre-releases <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done

- Pushed a branch without any changes and just the install4j task to travis, verified was able to reproduce the OOM. 
- Pushed a second branch with java-opts flag and heap of 3G, verified was able to get a successful build on 2 successive runs.

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

