### PR TITLE
Build update: Handle non-zero exit code when map descriptor files are updated

### DIFF
--- a/.travis/do_release
+++ b/.travis/do_release
@@ -140,9 +140,12 @@ function pushMaps() {
     set -x
     cd website
 
-    git update-index --refresh
-    if ! git diff-index --quiet HEAD --; then
-      git add --all _maps/
+    # Add any new map files now so that 'diff-index' will detect these new files
+    git add --all _maps/
+    # Run 'update-index --refresh' so that we are sure to be comparing against
+    # a latest remote HEAD. A non-zero-exit in either 'git update-index' or
+    # in 'git diff-index' indicates there are changes to commit and push.
+    if ! git update-index --refresh || ! git diff-index --quiet HEAD --; then
       git commit -m "Bot: update map files after game engine build ${TRAVIS_BUILD_NUMBER}"
       git push -fq origin master
     fi


### PR DESCRIPTION
Previously, if there were any modified split map files, then:  `git update-index --refresh` returns a non-zero and the script aborts. This update works around that and ensures we execute the if statement if there are any modified or new files.

<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  ***#5794***  ***#5888*** <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done

- Cloned map repo locally, ran splitter, ran various command combinations and checked exit codes


<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

