### PR TITLE
Remove travis_terminate command from build script

### DIFF
--- a/.travis/stages/deploy/ansible-deploy-to-prerelease/run
+++ b/.travis/stages/deploy/ansible-deploy-to-prerelease/run
@@ -9,6 +9,5 @@ eval "$(ssh-agent -s)"
 cd infrastructure
 ./build_deployment_artifacts
 echo "$ANSIBLE_VAULT_PASSWORD" > vault_password
-./run_deployment "$version" -i ansible/inventory/prerelease || travis_terminate 1
-
+./run_deployment "$version" -i ansible/inventory/prerelease 
 


### PR DESCRIPTION
- travis_terminate is used to terminate travis build if any commands in a scripted
list fail (othewrise, even with a non-zero exit code, travis continues execution).
- This update removes a 'travis_terminate' which seemingly is not in scope from
within a scripted script:

```
.travis/stages/deploy/ansible-deploy-to-prerelease/run: line 12: travis_terminate: command not found
```

Given that we now only have a single command per script block, if the block exits with
a non-zero exit code, the build should be marked as failed anyways, negating the need
for a 'travis_terminate'
