### PR TITLE
Fix Targets Including Dead Units Bug

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/Fire.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/Fire.java
@@ -96,8 +96,7 @@ public class Fire implements IExecutable {
   @Override
   public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
     // add to the stack so we will execute, we want to roll dice, select casualties, then notify in
-    // that order, so push
-    // onto the stack in reverse order
+    // that order, so push onto the stack in reverse order
     final IExecutable rollDice =
         new IExecutable() {
           private static final long serialVersionUID = 7578210876028725797L;
@@ -162,6 +161,8 @@ public class Fire implements IExecutable {
   private void selectCasualties(final IDelegateBridge bridge) {
     final int hitCount = dice.getHits();
     bridge.getDisplayChannelBroadcaster().notifyDice(dice, stepName);
+    // Remove any attackable units that previously died
+    attackableUnits.retainAll(allEnemyUnitsNotIncludingWaitingToDie);
     final int countTransports =
         CollectionUtils.countMatches(
             attackableUnits, Matches.unitIsTransport().and(Matches.unitIsSea()));


### PR DESCRIPTION
Fix #5916. Now that multiple Fire objects are generated with varying targets for the isSuicide improvements, need to ensure to remove any already killed units before selecting casualties since the attackable units might include already killed units.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here --> #5916 
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->
Tested on G40 first turn Germany as that consistently threw the error during the AI's turn as they almost always have a sea battle where you have air that can't target subs fire before the rest.
