### PR TITLE
Further increase heap size of install4j task from 3G to 4G

### DIFF
--- a/.travis/stages/deploy/installers/do-release
+++ b/.travis/stages/deploy/installers/do-release
@@ -29,7 +29,7 @@ function installInstall4j() {
 }
 
 function buildReleaseArtifacts() {
-  JAVA_OPTS=-Xmx3G ./gradlew \
+  JAVA_OPTS=-Xmx4G ./gradlew \
       --no-daemon \
       --parallel \
       -Pinstall4jHomeDir="$INSTALL4J_HOME" \


### PR DESCRIPTION
Still seeing examples of:
"install4j: compilation failed. Reason: java.lang.OutOfMemoryError: Java heap space" (https://travis-ci.org/triplea-game/triplea/jobs/650941855)

Going from 2G to 3G helped avoid the above problem considering, now moving to 4G.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

