### PR TITLE
Prod deploy update

### DIFF
--- a/.travis/stages/deploy/production/run
+++ b/.travis/stages/deploy/production/run
@@ -10,7 +10,6 @@ echo "$ANSIBLE_VAULT_PASSWORD" > "$VAULT_PASSWORD_FILE"
 ansible-vault view --vault-password-file="$VAULT_PASSWORD_FILE" ansible_ssh_key.ed25519 | ssh-add -
 
 ansible-playbook \
-  --vault-password-file "$VAULT_PASSWORD_FILE" \
   -i ansible/inventory/production \
   -t security,admin_user \
  ansible/site.yml

--- a/.travis/stages/deploy/production/run
+++ b/.travis/stages/deploy/production/run
@@ -11,6 +11,6 @@ ansible-vault view --vault-password-file="$VAULT_PASSWORD_FILE" ansible_ssh_key.
 
 ansible-playbook \
   -i ansible/inventory/production \
-  -t security,admin_user \
+  -t admin_user \
  ansible/site.yml
 


### PR DESCRIPTION
<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 
commit 0e5b25bd9d7031d674e4c4b8d4aa8531cc9f8a21

    Prod deployment - only run admin user task.
    
    - Servers on Ubuntu 16.04 are EOL, the repository config is unhealthy
      and standard repositories are no longer even being updated. We are seeing
      an error updating lobby server, avoid this by not bothering to try and
      update OS packages.

commit 80a195e86cd8da6ec8ba1fdc2f83a37f6e059db4

    Remove ansible-vault arg from ansible-playbook command.
    
    - There are no secrets in config that need decryption, hence
    the ansible-vault arg is not needed.



## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

