### PR TITLE
Update build failure notification to report build stage in comment

### DIFF
--- a/.travis/shared/report-build-status
+++ b/.travis/shared/report-build-status
@@ -22,6 +22,7 @@ readonly BROKEN_BUILD_ISSUE_TITLE="Travis Master Branch Build Failed";
 readonly LATEST_BUILD_LINK="[#$TRAVIS_BUILD_NUMBER]($TRAVIS_BUILD_WEB_URL)"
 readonly BROKEN_BUILD_ISSUE_BODY="Travis master branch build $LATEST_BUILD_LINK failed.\
      Build stage: $BUILD_STAGE"
+readonly BROKEN_BUILD_COMMENT="Build $LATEST_BUILD_LINK failed on stage: $BUILD_STAGE"
 
 readonly API_URL="https://api.github.com/repos/triplea-game/triplea"
 readonly API_AUTH="Authorization: token $GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS"
@@ -101,7 +102,7 @@ function reportBuildFailure() {
   if [ -z "$failedBuildIssue" ]; then
      openNewFailedBuildIssue
   else
-     commentOnIssue "$failedBuildIssue" "Build $LATEST_BUILD_LINK failed"
+     commentOnIssue "$failedBuildIssue" "$BROKEN_BUILD_COMMENT"
   fi
 }
 


### PR DESCRIPTION
If an issue is already open, we leave a comment on the build failed
issue. Missing from this was the build stage (we include the build
stage in the new issue body, but not for dupe reports in comment)


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

