### PR TITLE
Do not double handle map not found exception

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
@@ -78,6 +78,9 @@ public class LocalLauncher extends AbstractLauncher<ServerGame> {
       game.setRandomSource(randomSource);
       gameData.getGameLoader().startGame(game, gamePlayers, launchAction, null);
       return Optional.of(game);
+    } catch (final MapNotFoundException e) {
+      // The throwing method of MapNotFoundException notifies and prompts user to download the map.
+      return Optional.empty();
     } catch (final Exception ex) {
       log.log(Level.SEVERE, "Failed to start game", ex);
       return Optional.empty();


### PR DESCRIPTION
Currently if a map not found exception is raised when loading a game
we both prompt a user if they would like to download the map and
secondly we notify that the game failed to start and provide
an option to upload an error report.

This update removes the latter handling so that when a map is not
found, we simply notify and prompt the user to download the missing
map.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done

- using preferences, set maps folder to any directory not containing maps
- load a map
- observed double or single error prompt handling

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

