### PR TITLE
Remove rule-book links/buttons in favor of user-guide

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -31,7 +31,6 @@ public class MetaSetupPanel extends SetupPanel {
   private JButton connectToHostedGame;
   private JButton connectToLobby;
   private JButton enginePreferences;
-  private JButton ruleBook;
   private JButton userGuideButton;
 
   private final SetupPanelModel model;
@@ -77,9 +76,7 @@ public class MetaSetupPanel extends SetupPanel {
             + "so long as you know their IP address.</html>");
     enginePreferences = new JButton("Engine Preferences");
     enginePreferences.setToolTipText("<html>Configure certain options related to the engine.");
-    ruleBook = new JButton("Rule Book");
     userGuideButton = new JButton("User Guide & Help");
-    ruleBook.setToolTipText("Download a manual of how to play");
   }
 
   private void layoutComponents() {
@@ -183,20 +180,6 @@ public class MetaSetupPanel extends SetupPanel {
             new Insets(10, 0, 0, 0),
             0,
             0));
-    add(
-        ruleBook,
-        new GridBagConstraints(
-            0,
-            8,
-            1,
-            1,
-            0,
-            0,
-            GridBagConstraints.CENTER,
-            GridBagConstraints.NONE,
-            new Insets(10, 0, 0, 0),
-            0,
-            0));
 
     final JButton mapCreator =
         new JButtonBuilder()
@@ -208,7 +191,7 @@ public class MetaSetupPanel extends SetupPanel {
         mapCreator,
         new GridBagConstraints(
             0,
-            9,
+            8,
             1,
             1,
             0,
@@ -223,7 +206,7 @@ public class MetaSetupPanel extends SetupPanel {
         userGuideButton,
         new GridBagConstraints(
             0,
-            10,
+            9,
             1,
             1,
             0,
@@ -259,12 +242,7 @@ public class MetaSetupPanel extends SetupPanel {
     connectToLobby.addActionListener(e -> model.login());
     enginePreferences.addActionListener(
         e -> ClientSetting.showSettingsWindow(JOptionPane.getFrameForComponent(this)));
-    ruleBook.addActionListener(e -> ruleBook());
     userGuideButton.addActionListener(e -> userGuidePage());
-  }
-
-  private static void ruleBook() {
-    SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.RULE_BOOK);
   }
 
   private static void userGuidePage() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/WebHelpMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/WebHelpMenu.java
@@ -30,12 +30,6 @@ final class WebHelpMenu extends JMenu {
         e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_FORUM));
     add(warClub);
 
-    final JMenuItem ruleBookLink = new JMenuItem("Rule Book");
-    ruleBookLink.setMnemonic(KeyEvent.VK_K);
-    ruleBookLink.addActionListener(
-        e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.RULE_BOOK));
-    add(ruleBookLink);
-
     final JMenuItem donateLink = new JMenuItem("Donate");
     donateLink.setMnemonic(KeyEvent.VK_O);
     donateLink.addActionListener(

--- a/game-headed/src/main/java/org/triplea/game/client/ui/javafx/screens/AboutInformation.java
+++ b/game-headed/src/main/java/org/triplea/game/client/ui/javafx/screens/AboutInformation.java
@@ -32,12 +32,6 @@ public class AboutInformation implements ControlledScreen<ScreenController<FxmlM
     open(UrlConstants.USER_GUIDE);
   }
 
-  @FXML
-  @SuppressWarnings("unused")
-  private void showRuleBook() {
-    open(UrlConstants.RULE_BOOK);
-  }
-
   private void open(final String url) {
     OpenFileUtility.openUrl(
         url, () -> new Alert(Alert.AlertType.INFORMATION, url, ButtonType.CLOSE).show());

--- a/game-headed/src/main/resources/org/triplea/game/client/ui/javafx/fxml/AboutInformation.fxml
+++ b/game-headed/src/main/resources/org/triplea/game/client/ui/javafx/fxml/AboutInformation.fxml
@@ -15,11 +15,6 @@
             <Insets top="10.0" />
          </VBox.margin>
       </Button>
-      <Button mnemonicParsing="false" onAction="#showRuleBook" styleClass="normal-font-size" text="%main.button.rule_book">
-         <VBox.margin>
-            <Insets top="10.0" />
-         </VBox.margin>
-      </Button>
       <Button mnemonicParsing="false" onAction="#back" text="%main.button.back">
          <VBox.margin>
             <Insets top="10.0" />

--- a/game-headed/src/main/resources/org/triplea/game/client/ui/javafx/lang/TripleA_en_US.properties
+++ b/game-headed/src/main/resources/org/triplea/game/client/ui/javafx/lang/TripleA_en_US.properties
@@ -29,7 +29,6 @@ main.button.startPBEM=Play by Email
 main.label.about_title=About
 main.text.about_description=TripleA is an open-source project.\nTODO: Add some description
 main.button.help=Help
-main.button.rule_book=Rule Book
 
 
 settings.button.save=Save Settings


### PR DESCRIPTION
The user-guide page on website has links to the rule book, linking directly
to the rule-book is slightly redundant. Making the situation worse, the rule-book
PDF is becoming deprecated in favor of an HTML version.

This update removes links to the rule-book, everywhere we have a rule-book
link or button, we also had a link to the website 'user-guide' which in turn
has links to the latest rule-book.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[x] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done

Verified (Swing) main screen layout still looked good after removing "rule book" button.

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

