### PR TITLE
Fix Install4j warning

### DIFF
--- a/game-headed/build.install4j
+++ b/game-headed/build.install4j
@@ -2,7 +2,7 @@
 <install4j version="8.0.4" transformSequenceNumber="8">
   <directoryPresets config=".triplea-root" />
   <application name="TripleA" applicationId="5251-3669-9623-1649" mediaDir="build/releases" mediaFilePattern="${compiler:sys.fullName}_${compiler:sys.version}_${compiler:sys.platform}" compression="9" lzmaCompression="true" pack200Compression="true" createChecksums="false" shortName="TripleA" publisher="TripleA Developer Team" publisherWeb="http://triplea-game.org" version="${compiler:sys.version}" allPathsRelative="true" autoSave="true" convertDotsToUnderscores="false" macVolumeId="af9346379363d40e" javaMinVersion="11" jdkMode="jdk">
-    <jreBundles jdkProviderId="JBR" release="11.0.6-b722.15" />
+    <jreBundles jdkProviderId="AdoptOpenJDK" release="openjdk11/jdk-11.0.6+10" />
   </application>
   <files>
     <mountPoints>

--- a/game-headed/build.install4j
+++ b/game-headed/build.install4j
@@ -8,13 +8,11 @@
     <mountPoints>
       <mountPoint id="28" location="assets" />
       <mountPoint id="23" location="bin" />
-      <mountPoint id="27" location="dice_servers" />
       <mountPoint id="22" />
     </mountPoints>
     <entries>
       <dirEntry mountPoint="28" file="assets" subDirectory="assets" />
       <dirEntry mountPoint="23" file="build/libs" />
-      <dirEntry mountPoint="27" file="dice_servers" subDirectory="dice_servers" />
       <fileEntry mountPoint="22" file=".triplea-root" />
     </entries>
   </files>


### PR DESCRIPTION
<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 

For some reason the JBR can't be downloaded right now, switching to adoptopenjdk for now:

> install4j: compilation failed. Reason: java.net.SocketTimeoutException: Read timed out

Also removes the entry for the now no longer existing dice_server directory.

Self merging to get the build working again.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

