### PR TITLE
Avoid unnecessary unit scroller rendering

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -730,7 +730,7 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
     warningImage = getMap().getWarningImage().orElse(null);
     errorImage = getMap().getErrorImage().orElse(null);
 
-    unitScroller = new UnitScroller(getData(), getMap());
+    unitScroller = new UnitScroller(getData(), getMap(), this::isVisible);
   }
 
   // Same as above! Delete this crap after refactoring.

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -80,13 +80,15 @@ public class UnitScroller {
 
   private final Supplier<GamePlayer> currentPlayerSupplier;
   private final Supplier<MovePhase> movePhaseSupplier;
+  private Supplier<Boolean> parentPanelIsVisible;
 
   private final AvatarPanelFactory avatarPanelFactory;
   private final JLabel movesLeftLabel = new JLabel();
   private final JLabel territoryNameLabel = new JLabel();
   private final JPanel selectUnitImagePanel = new JPanel();
 
-  public UnitScroller(final GameData data, final MapPanel mapPanel) {
+  public UnitScroller(
+      final GameData data, final MapPanel mapPanel, final Supplier<Boolean> parentPanelIsVisible) {
     this.gameData = data;
     this.mapPanel = mapPanel;
     this.currentPlayerSupplier = () -> gameData.getSequence().getStep().getPlayerId();
@@ -95,6 +97,7 @@ public class UnitScroller {
             gameData.getSequence().getStep().isNonCombat()
                 ? MovePhase.NON_COMBAT
                 : MovePhase.COMBAT;
+    this.parentPanelIsVisible = parentPanelIsVisible;
     avatarPanelFactory = new AvatarPanelFactory(mapPanel);
 
     gameData.addGameDataEventListener(GameDataEvent.UNIT_MOVED, this::unitMoved);
@@ -102,6 +105,10 @@ public class UnitScroller {
   }
 
   private void unitMoved() {
+    if (!parentPanelIsVisible.get()) {
+      return;
+    }
+
     updateMovesLeftLabel();
     if (lastFocusedTerritory == null) {
       focusCapital();
@@ -142,9 +149,11 @@ public class UnitScroller {
   private void gamePhaseChanged() {
     skippedUnits = new HashSet<>();
     lastFocusedTerritory = null;
-    selectUnitImagePanel.removeAll();
-    selectUnitImagePanel.repaint();
-    focusCapital();
+    if (parentPanelIsVisible.get()) {
+      selectUnitImagePanel.removeAll();
+      selectUnitImagePanel.repaint();
+      focusCapital();
+    }
   }
 
   private void focusCapital() {


### PR DESCRIPTION
If the move panel is not visible, then we do not need to render the unit
scroller and we should avoid any related computation. The unit scroller
is tied into game events, notably phase changes so it can update itself.
Missing from these listeners was the concept to check if the rendering
would have been necessary.

This update wires a supplier function to the unit scroller that can
be used to determine if the parent panel is even visible. If the parent
panel is not visible, then rendering computations are skipped.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  https://github.com/triplea-game/triplea/issues/5875 <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done

- During an all-AI game, so no exceptions and observed no negative consequences from this chagne.

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

