### PR TITLE
Thread safe collection utils

### DIFF
--- a/java-extras/src/main/java/org/triplea/java/collections/CollectionUtils.java
+++ b/java-extras/src/main/java/org/triplea/java/collections/CollectionUtils.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static java.util.function.Predicate.not;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterables;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -41,7 +42,7 @@ public final class CollectionUtils {
     checkNotNull(collection);
     checkNotNull(predicate);
 
-    return collection.stream().filter(predicate).collect(Collectors.toList());
+    return ImmutableList.copyOf(collection).stream().filter(predicate).collect(Collectors.toList());
   }
 
   /**

--- a/java-extras/src/main/java/org/triplea/java/collections/CollectionUtils.java
+++ b/java-extras/src/main/java/org/triplea/java/collections/CollectionUtils.java
@@ -107,8 +107,8 @@ public class CollectionUtils {
       final Collection<T> collection1, final Collection<T> collection2) {
     checkNotNull(collection1);
     checkNotNull(collection2);
-    final Collection<T> c1 = ImmutableSet.copyOf(collection1);
-    final Collection<T> c2 = ImmutableSet.copyOf(collection2);
+    final Collection<T> c1 = ImmutableList.copyOf(collection1);
+    final Collection<T> c2 = ImmutableList.copyOf(collection2);
 
     return Iterables.elementsEqual(c1, c2)
         || (c1.size() == c2.size() && c2.containsAll(c1) && c1.containsAll(c2));


### PR DESCRIPTION
<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 
This update makes operations in CollectionUtils immune to concurrent modification exception (essentially thread safe) by iterating over list copies.


commit b5594bafe136a69fd2f3d46a002cfb872500e941 

    Make CollectionUtils consistently threadsafe across all methods (by making immutable collection copies

commit 450974a2e9483c191856a7092056ec4c54c66456

    Iterate over a collection copy to avoid ConcurrentModificationException



## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here --> https://github.com/triplea-game/triplea/issues/5875
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done

Observed two all-AI games and saw no examples of ConcurrentModificationExceptions. Typically the exception could be raised in the first few rounds without this.

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->

## Additional Review Notes
- The first commit is all that is needed to resolve the ConcurrentModificationException.
- The second commit is to make the class consistent about using copies

Couple more notes:
- the list copy is in-memory, so we're dealing with extremely inexpensive operations
- if a list is modified we get an exception, without that we would otherwise have inconsistent results where the output from a method call would depend on timing and modifications to the input. The copy helps ensure that we will always get the same output given a specific input.
