### PR TITLE
Add 'set -x' to build scripts

### DIFF
--- a/.travis/shared/report-build-status
+++ b/.travis/shared/report-build-status
@@ -12,7 +12,7 @@ if [ -z "$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS" ]; then
   exit 1
 fi
 
-set -eu
+set -eux
 
 # Should be one of {SUCCESS|FAILURE}
 RESULT=${1-}

--- a/.travis/shared/set-version-number
+++ b/.travis/shared/set-version-number
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eEu
+set -eEux
 
 ## Overwrites the version property file to contain a version number that
 ## has the current build number in it. This script then prints (returns)

--- a/.travis/shared/setup-database
+++ b/.travis/shared/setup-database
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eu
+set -eux
 
 echo "create database lobby_db" | psql -h localhost -U postgres -d postgres
 echo "create user lobby_user with password 'postgres'" | psql -h localhost -U postgres -d postgres

--- a/.travis/stages/deploy/ansible-deploy-to-prerelease/run
+++ b/.travis/stages/deploy/ansible-deploy-to-prerelease/run
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eEu
+set -eEux
 
 version=$(.travis/shared/set-version-number)
 

--- a/.travis/stages/deploy/installers/run
+++ b/.travis/stages/deploy/installers/run
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eEu
+set -eEux
 
 .travis/shared/set-version-number
 

--- a/.travis/stages/deploy/production/run
+++ b/.travis/stages/deploy/production/run
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eEu
+set -eEux
 
 eval "$(ssh-agent -s)"
 cd infrastructure || exit 1

--- a/.travis/stages/deploy/update-maps-on-website/run
+++ b/.travis/stages/deploy/update-maps-on-website/run
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eEu
+set -eEux
 
 
 ## Live update maps list on website, read the maps in 'triplea_maps.yaml' and 

--- a/.travis/stages/verify/check-links-and-yaml-syntax/run
+++ b/.travis/stages/verify/check-links-and-yaml-syntax/run
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eEu
+set -eEux
 
 script_dir=$(dirname "$0")
 "$script_dir/check-links"

--- a/.travis/stages/verify/checkstyle/run
+++ b/.travis/stages/verify/checkstyle/run
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eEu
+set -eEux
 
 ./gradlew --parallel checkstyleMain checkstyleTest 
 

--- a/.travis/stages/verify/code-convention-checks/run
+++ b/.travis/stages/verify/code-convention-checks/run
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eEu
+set -eEux
 
 ## shellcheck all shell scripts
 find .travis/ -type f -print0 | xargs --null grep -lE "^#\!/bin/bash$" | xargs shellcheck

--- a/.travis/stages/verify/find-unused-or-unmatched-tests/run
+++ b/.travis/stages/verify/find-unused-or-unmatched-tests/run
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eEu
+set -eEux
 
 script_dir=$(dirname "$0")
 "$script_dir/find-unused-dbunit-datasets"

--- a/.travis/stages/verify/integration-testing/run
+++ b/.travis/stages/verify/integration-testing/run
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eEu
+set -eEux
 
 .travis/shared/setup-database
 

--- a/.travis/stages/verify/java-formatting/run
+++ b/.travis/stages/verify/java-formatting/run
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eEu
+set -eEux
 
 ./gradlew --parallel spotlessCheck
 

--- a/.travis/stages/verify/pmd-verification/run
+++ b/.travis/stages/verify/pmd-verification/run
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eEu
+set -eEux
 
 ./gradlew --parallel pmdMain pmdTest
 

--- a/.travis/stages/verify/unit-testing/run
+++ b/.travis/stages/verify/unit-testing/run
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -eEu
+set -eEux
 
 # Run Tests
 ./gradlew --parallel test 


### PR DESCRIPTION
The 'x' provides output of the commands being run. We typically do
not look at build output, when we do, the extra debug information
to know what the build was doing could be useful.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

