### PR TITLE
Report build script failure script fix, report master branch failures only

### DIFF
--- a/.travis/shared/report-build-status
+++ b/.travis/shared/report-build-status
@@ -5,10 +5,9 @@
 # On failure, this script will check for an open "build broken" issue and will create one
 # if there is not one already open.
 
-
-if [ -z "$GITHUB_PERSONAL_ACCESS_TOKEN_FOR_TRAVIS" ]; then
-  echo "Aborting issue creation, access token not set. Assuming this is not a 'master' branch build."
-  echo "If the current branch is not 'master', this is fine, otherwise this is a configuration bug."
+if [ "$TRAVIS_PULL_REQUEST" != "false" ] || [ "$TRAVIS_BRANCH" != "master" ]; then
+  # If this is a PR, or a branch build, then just exit and maintain the error code
+  # exit flag - do not create a build fail issue.
   exit 1
 fi
 

--- a/.travis/shared/report-build-status
+++ b/.travis/shared/report-build-status
@@ -5,6 +5,12 @@
 # On failure, this script will check for an open "build broken" issue and will create one
 # if there is not one already open.
 
+
+## Make sure we are building master branch.
+## PRs will have their pull request number set in 'TRAVIS_PULL_REQUEST', otherwise
+## they are false.
+## TRAVIS_BRANCH will be set to 'master' for PR builds, but for branch builds it
+## it will be set to the name of the branch being built.
 if [ "$TRAVIS_PULL_REQUEST" != "false" ] || [ "$TRAVIS_BRANCH" != "master" ]; then
   # If this is a PR, or a branch build, then just exit and maintain the error code
   # exit flag - do not create a build fail issue.


### PR DESCRIPTION
This update makes the check for if we are building a non-master branch
more robust and avoids false-positive "master branch build failed" reports.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done
Push a PR branch and a standard branch with injected failures to watch for reports of build failure.

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes

Should resolve the false-positives reported in: https://github.com/triplea-game/triplea/issues/5964#issuecomment-589924374

