### PR TITLE
Add username and password fields to PBF selection screen

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbf/ForumPosterEditor.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbf/ForumPosterEditor.java
@@ -8,6 +8,7 @@ import javax.swing.JCheckBox;
 import javax.swing.JComboBox;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JPasswordField;
 import javax.swing.JTextField;
 import org.triplea.java.ViewModelListener;
 import org.triplea.swing.DocumentListenerBuilder;
@@ -19,6 +20,10 @@ class ForumPosterEditor extends JPanel implements ViewModelListener<ForumPosterE
   private final JButton viewPosts = new JButton("View Forum");
   private final JButton testForum = new JButton("Test Post");
   private final JTextField topicIdField = new JTextField();
+  private final JLabel usernameLabel = new JLabel("Forum Username");
+  private final JTextField usernameField = new JTextField();
+  private final JLabel passwordLabel = new JLabel("Forum Password");
+  private final JPasswordField passwordField = new JPasswordField();
   private final JLabel topicIdLabel = new JLabel("Topic Id:");
   private final JLabel forumLabel = new JLabel("Forums:");
   private final JCheckBox attachSaveGameToSummary = new JCheckBox("Attach save game to summary");
@@ -50,7 +55,16 @@ class ForumPosterEditor extends JPanel implements ViewModelListener<ForumPosterE
             0));
 
     viewModel.getForumSelectionOptions().forEach(forums::addItem);
-    forums.addActionListener(e -> viewModel.setForumSelection((String) forums.getSelectedItem()));
+    forums.addActionListener(
+        e -> {
+          viewModel.setForumSelection((String) forums.getSelectedItem());
+
+          usernameField.setText(viewModel.getForumUsername());
+          passwordField.setText(String.valueOf(viewModel.getForumPassword()));
+          SwingComponents.highlightLabelIfNotValid(viewModel.isForumUsernameValid(), usernameLabel);
+          SwingComponents.highlightLabelIfNotValid(viewModel.isForumPasswordValid(), passwordLabel);
+          testForum.setEnabled(viewModel.isTestForumPostButtonEnabled());
+        });
     forums.setSelectedItem(viewModel.getForumSelection());
     add(
         forums,
@@ -84,7 +98,13 @@ class ForumPosterEditor extends JPanel implements ViewModelListener<ForumPosterE
             0));
 
     DocumentListenerBuilder.attachDocumentListener(
-        topicIdField, () -> viewModel.setTopicId(topicIdField.getText().trim()));
+        topicIdField,
+        () -> {
+          viewModel.setTopicId(topicIdField.getText().trim());
+          SwingComponents.highlightLabelIfNotValid(viewModel.isTopicIdValid(), topicIdLabel);
+          viewPosts.setEnabled(viewModel.isViewForumPostButtonEnabled());
+          testForum.setEnabled(viewModel.isTestForumPostButtonEnabled());
+        });
     add(
         topicIdField,
         new GridBagConstraints(
@@ -116,6 +136,82 @@ class ForumPosterEditor extends JPanel implements ViewModelListener<ForumPosterE
             0,
             0));
     row++;
+
+    add(
+        usernameLabel,
+        new GridBagConstraints(
+            0,
+            row,
+            1,
+            1,
+            0,
+            0,
+            GridBagConstraints.WEST,
+            GridBagConstraints.NONE,
+            new Insets(0, 0, bottomSpace, labelSpace),
+            0,
+            0));
+
+    DocumentListenerBuilder.attachDocumentListener(
+        usernameField,
+        () -> {
+          viewModel.setForumUsername(usernameField.getText().trim());
+          SwingComponents.highlightLabelIfNotValid(viewModel.isForumUsernameValid(), usernameLabel);
+          testForum.setEnabled(viewModel.isTestForumPostButtonEnabled());
+        });
+    add(
+        usernameField,
+        new GridBagConstraints(
+            1,
+            row,
+            1,
+            1,
+            1.0,
+            0,
+            GridBagConstraints.EAST,
+            GridBagConstraints.HORIZONTAL,
+            new Insets(0, 0, bottomSpace, 0),
+            0,
+            0));
+    row++;
+
+    add(
+        passwordLabel,
+        new GridBagConstraints(
+            0,
+            row,
+            1,
+            1,
+            0,
+            0,
+            GridBagConstraints.WEST,
+            GridBagConstraints.NONE,
+            new Insets(0, 0, bottomSpace, labelSpace),
+            0,
+            0));
+    DocumentListenerBuilder.attachDocumentListener(
+        passwordField,
+        () -> {
+          viewModel.setForumPassword(passwordField.getPassword());
+          SwingComponents.highlightLabelIfNotValid(viewModel.isForumPasswordValid(), passwordLabel);
+          testForum.setEnabled(viewModel.isTestForumPostButtonEnabled());
+        });
+    add(
+        passwordField,
+        new GridBagConstraints(
+            1,
+            row,
+            1,
+            1,
+            1.0,
+            0,
+            GridBagConstraints.EAST,
+            GridBagConstraints.HORIZONTAL,
+            new Insets(0, 0, bottomSpace, 0),
+            0,
+            0));
+    row++;
+
     add(
         new JLabel(""),
         new GridBagConstraints(
@@ -186,15 +282,17 @@ class ForumPosterEditor extends JPanel implements ViewModelListener<ForumPosterE
   @Override
   public void viewModelChanged(final ForumPosterEditorViewModel forumPosterEditorViewModel) {
     forums.setSelectedItem(forumPosterEditorViewModel.getForumSelection());
-    if (!topicIdField.getText().equals(forumPosterEditorViewModel.getTopicId())) {
-      topicIdField.setText(forumPosterEditorViewModel.getTopicId());
-    }
+    topicIdField.setText(forumPosterEditorViewModel.getTopicId());
+    usernameField.setText(forumPosterEditorViewModel.getForumUsername());
+    passwordField.setText(String.valueOf(forumPosterEditorViewModel.getForumPassword()));
     alsoPostAfterCombatMove.setSelected(forumPosterEditorViewModel.isAlsoPostAfterCombatMove());
     attachSaveGameToSummary.setSelected(forumPosterEditorViewModel.isAttachSaveGameToSummary());
-
     SwingComponents.highlightLabelIfNotValid(
         forumPosterEditorViewModel.isTopicIdValid(), topicIdLabel);
-
+    SwingComponents.highlightLabelIfNotValid(
+        forumPosterEditorViewModel.isForumUsernameValid(), usernameLabel);
+    SwingComponents.highlightLabelIfNotValid(
+        forumPosterEditorViewModel.isForumPasswordValid(), passwordLabel);
     viewPosts.setEnabled(forumPosterEditorViewModel.isViewForumPostButtonEnabled());
     testForum.setEnabled(forumPosterEditorViewModel.isTestForumPostButtonEnabled());
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbf/ForumPosterEditorViewModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbf/ForumPosterEditorViewModel.java
@@ -9,6 +9,7 @@ import games.strategy.engine.framework.startup.ui.posted.game.pbf.test.post.Swin
 import games.strategy.engine.framework.startup.ui.posted.game.pbf.test.post.TestPostAction;
 import games.strategy.engine.posted.game.pbf.IForumPoster;
 import games.strategy.engine.posted.game.pbf.NodeBbForumPoster;
+import games.strategy.triplea.settings.ClientSetting;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import lombok.Getter;
@@ -30,13 +31,12 @@ class ForumPosterEditorViewModel {
   private BiConsumer<String, Integer> viewForumPostAction =
       (forumName, topicId) -> NodeBbForumPoster.newInstanceByName(forumName, topicId).viewPosted();
 
-  @Getter private boolean viewForumPostButtonEnabled;
-  @Getter private boolean testForumPostButtonEnabled;
   private String forumSelection;
   @Getter private String topicId = "";
-  @Getter private boolean topicIdValid;
   @Setter @Getter private boolean attachSaveGameToSummary = true;
   @Setter @Getter private boolean alsoPostAfterCombatMove;
+  @Getter private String forumUsername;
+  @Getter private char[] forumPassword;
 
   ForumPosterEditorViewModel(final Runnable readyCallback) {
     this.readyCallback = readyCallback;
@@ -46,6 +46,28 @@ class ForumPosterEditorViewModel {
   ForumPosterEditorViewModel(final Runnable readyCallback, final GameProperties properties) {
     this.readyCallback = readyCallback;
     populateFromGameProperties(properties);
+  }
+
+  void setForumPassword(final char[] password) {
+    final ClientSetting<char[]> passwordSetting =
+        forumSelection.equals(NodeBbForumPoster.TRIPLEA_FORUM_DISPLAY_NAME)
+            ? ClientSetting.tripleaForumPassword
+            : ClientSetting.aaForumPassword;
+
+    passwordSetting.setValueAndFlush(password);
+    forumPassword = password;
+    readyCallback.run();
+  }
+
+  void setForumUsername(final String username) {
+    final ClientSetting<char[]> usernameSetting =
+        forumSelection.equals(NodeBbForumPoster.TRIPLEA_FORUM_DISPLAY_NAME)
+            ? ClientSetting.tripleaForumUsername
+            : ClientSetting.aaForumUsername;
+
+    usernameSetting.setValueAndFlush(username.toCharArray());
+    forumUsername = username;
+    readyCallback.run();
   }
 
   @SuppressWarnings("Guava")
@@ -60,8 +82,14 @@ class ForumPosterEditorViewModel {
         "Forum selection is driven by a drop-down to ensure user can never set it to null, "
             + "if setting to null from a game properties, we default to the first available "
             + "selection entry, forum selection should never be null or empty.");
-    viewForumPostButtonEnabled = areFieldsValid();
-    testForumPostButtonEnabled = areFieldsValid();
+    forumUsername =
+        this.forumSelection.equals(NodeBbForumPoster.TRIPLEA_FORUM_DISPLAY_NAME)
+            ? ClientSetting.tripleaForumUsername.getValue().map(String::valueOf).orElse("")
+            : ClientSetting.aaForumUsername.getValue().map(String::valueOf).orElse("");
+    forumPassword =
+        this.forumSelection.equals(NodeBbForumPoster.TRIPLEA_FORUM_DISPLAY_NAME)
+            ? ClientSetting.tripleaForumPassword.getValue().orElse(new char[] {})
+            : ClientSetting.aaForumPassword.getValue().orElse(new char[] {});
     readyCallback.run();
   }
 
@@ -71,11 +99,11 @@ class ForumPosterEditorViewModel {
   }
 
   synchronized void setTopicId(final String topicId) {
+    if (this.topicId.equals(topicId)) {
+      return;
+    }
+
     this.topicId = topicId;
-    final Integer numericTopicId = Ints.tryParse(topicId);
-    topicIdValid = numericTopicId != null && numericTopicId > 0;
-    viewForumPostButtonEnabled = areFieldsValid();
-    testForumPostButtonEnabled = areFieldsValid();
     readyCallback.run();
   }
 
@@ -86,7 +114,28 @@ class ForumPosterEditorViewModel {
   }
 
   synchronized boolean areFieldsValid() {
-    return topicIdValid;
+    return isTopicIdValid() && isForumUsernameValid() && isForumPasswordValid();
+  }
+
+  boolean isForumPasswordValid() {
+    return forumPassword != null && forumPassword.length > 0;
+  }
+
+  boolean isForumUsernameValid() {
+    return forumUsername != null && !forumUsername.isBlank();
+  }
+
+  boolean isViewForumPostButtonEnabled() {
+    return isTopicIdValid();
+  }
+
+  boolean isTestForumPostButtonEnabled() {
+    return areFieldsValid();
+  }
+
+  boolean isTopicIdValid() {
+    final Integer numericTopicId = Ints.tryParse(topicId);
+    return numericTopicId != null && numericTopicId > 0;
   }
 
   public void populateFromGameProperties(final GameProperties properties) {
@@ -98,7 +147,7 @@ class ForumPosterEditorViewModel {
   }
 
   synchronized void viewForumButtonClicked() {
-    if (areFieldsValid()) {
+    if (isTopicIdValid()) {
       viewForumPostAction.accept(forumSelection, Integer.parseInt(topicId));
     }
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbf/ForumPosterEditorViewModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbf/ForumPosterEditorViewModel.java
@@ -2,7 +2,6 @@ package games.strategy.engine.framework.startup.ui.posted.game.pbf;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Predicates;
 import com.google.common.primitives.Ints;
 import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.engine.framework.startup.ui.posted.game.pbf.test.post.SwingTestPostProgressDisplayFactory;
@@ -12,6 +11,7 @@ import games.strategy.engine.posted.game.pbf.NodeBbForumPoster;
 import games.strategy.triplea.settings.ClientSetting;
 import java.util.Optional;
 import java.util.function.BiConsumer;
+import java.util.function.Predicate;
 import lombok.Getter;
 import lombok.Setter;
 import org.triplea.java.Postconditions;
@@ -70,12 +70,11 @@ class ForumPosterEditorViewModel {
     readyCallback.run();
   }
 
-  @SuppressWarnings("Guava")
   synchronized void setForumSelection(final String forumSelection) {
     // if forumSelect is null or blank, default it to first forum selection option
     this.forumSelection =
         Optional.ofNullable(forumSelection)
-            .filter(Predicates.not(String::isBlank))
+            .filter(Predicate.not(String::isBlank))
             .orElse(getForumSelectionOptions().iterator().next());
     Postconditions.assertState(
         this.forumSelection != null && !this.forumSelection.isBlank(),

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbf/ForumPosterEditorViewModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbf/ForumPosterEditorViewModel.java
@@ -87,8 +87,8 @@ class ForumPosterEditorViewModel {
             : ClientSetting.aaForumUsername.getValue().map(String::valueOf).orElse("");
     forumPassword =
         this.forumSelection.equals(NodeBbForumPoster.TRIPLEA_FORUM_DISPLAY_NAME)
-            ? ClientSetting.tripleaForumPassword.getValue().orElse(new char[] {})
-            : ClientSetting.aaForumPassword.getValue().orElse(new char[] {});
+            ? ClientSetting.tripleaForumPassword.getValue().orElse(new char[0])
+            : ClientSetting.aaForumPassword.getValue().orElse(new char[0]);
     readyCallback.run();
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -283,11 +283,15 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
   private void setEncodedValue(final @Nullable String encodedValue) {
     if (encodedValue == null) {
       getPreferences().remove(name);
+      listeners.forEach(listener -> listener.accept(this));
     } else {
-      getPreferences().put(name, encodedValue);
+      try {
+        getPreferences().put(name, encodedValue);
+        listeners.forEach(listener -> listener.accept(this));
+      } catch (final IllegalArgumentException e) {
+        log.log(Level.SEVERE, "Failed to save value", e);
+      }
     }
-
-    listeners.forEach(listener -> listener.accept(this));
   }
 
   private boolean isDefaultValue(final T value) {


### PR DESCRIPTION
The two fields are required in order to do a test posting or
to start a PBF game. This update places the two required fields
on the same screen where we have the 'play' button.

This update adds similar 'highlight field label red if invalid'
for the username and password field.

Of note, to avoid circular event callbacks between view and
view-model, the view updates its own state after firing an
event on the view-model. For example, the username field
sets the view-model username value, the view then queries
and updates to see if any labels or buttons are updated and
enabled. The view model could invoke the view to update all
fields, this can then trigger another callback though to the
view when fields are updated and action listeners fire to
update the view model which can then again trigger a view
refresh and so-on.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done
Verified:
-  fields are updated when selecting forum option
- play button is enabled/disabled when setting/unsetting fields
- view forum button works for both forum types and is enabled/disabled
- test post button is enabled/disabled as username/password/topic fields are all set/unset


<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
## Screens Shots

### Before
![Screenshot from 2020-02-24 22-50-32](https://user-images.githubusercontent.com/12397753/75222100-4388d180-5758-11ea-9597-78513b44f186.png)

### After
![Screenshot from 2020-02-24 22-49-58](https://user-images.githubusercontent.com/12397753/75222108-471c5880-5758-11ea-82c7-f03e16baa8c8.png)


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

