### PR TITLE
Update PBEM validation to allow games without setting an email server.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbem/EmailSenderEditor.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbem/EmailSenderEditor.java
@@ -5,7 +5,6 @@ import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.posted.game.pbem.IEmailSender;
-import games.strategy.triplea.settings.ClientSetting;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
@@ -138,7 +137,11 @@ public class EmailSenderEditor extends JPanel {
   }
 
   private void checkFieldsAndNotify() {
-    areFieldsValid();
+    final String toAddressText = toAddress.getText();
+    final boolean addressValid =
+        !toAddressText.isEmpty() && PlayerEmailValidation.isValid(toAddressText);
+    SwingComponents.highlightLabelIfNotValid(addressValid, toLabel);
+    testEmail.setEnabled(addressValid);
     readyCallback.run();
   }
 
@@ -186,27 +189,12 @@ public class EmailSenderEditor extends JPanel {
         .start();
   }
 
-  /** Checks if fields are set, if so enables them and returns true, false otherwise. */
-  public boolean areFieldsValid() {
-    final boolean setupValid =
-        ClientSetting.emailServerHost.isSet()
-            && ClientSetting.emailServerPort.isSet()
-            && ClientSetting.emailServerSecurity.isSet()
-            && ClientSetting.emailUsername.isSet();
-
-    final String toAddressText = toAddress.getText();
-    final boolean addressValid =
-        !toAddressText.isEmpty() && PlayerEmailValidation.isValid(toAddressText);
-    SwingComponents.highlightLabelIfNotValid(addressValid, toLabel);
-    final boolean allValid = setupValid && addressValid;
-    testEmail.setEnabled(allValid);
-    return allValid;
-  }
-
   public void applyToGameProperties(final GameProperties properties) {
-    properties.set(IEmailSender.SUBJECT, subject.getText());
-    properties.set(IEmailSender.RECIPIENTS, toAddress.getText());
-    properties.set(IEmailSender.POST_AFTER_COMBAT, alsoPostAfterCombatMove.isSelected());
+    if (!toAddress.getText().isBlank() && PlayerEmailValidation.isValid(toAddress.getText())) {
+      properties.set(IEmailSender.SUBJECT, subject.getText());
+      properties.set(IEmailSender.RECIPIENTS, toAddress.getText());
+      properties.set(IEmailSender.POST_AFTER_COMBAT, alsoPostAfterCombatMove.isSelected());
+    }
   }
 
   public void populateFromGameProperties(final GameProperties properties) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbem/PbemSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbem/PbemSetupPanel.java
@@ -171,8 +171,7 @@ public class PbemSetupPanel extends SetupPanel implements Observer {
   @Override
   public boolean canGameStart() {
     final boolean diceServerValid = diceServerEditor.areFieldsValid();
-    final boolean emailValid = emailSenderEditor.areFieldsValid();
-    final boolean ready = diceServerValid && emailValid && gameSelectorModel.getGameData() != null;
+    final boolean ready = diceServerValid && gameSelectorModel.getGameData() != null;
     // make sure at least 1 player is enabled
     return ready && playerTypes.stream().anyMatch(PlayerSelectorRow::isPlayerEnabled);
   }
@@ -189,9 +188,7 @@ public class PbemSetupPanel extends SetupPanel implements Observer {
     if (diceServerEditor.areFieldsValid()) {
       diceServerEditor.applyToGameProperties(data.getProperties());
     }
-    if (emailSenderEditor.areFieldsValid()) {
-      emailSenderEditor.applyToGameProperties(data.getProperties());
-    }
+    emailSenderEditor.applyToGameProperties(data.getProperties());
   }
 
   /**


### PR DESCRIPTION
Enables the 'play' button on PBEM game even if email server is not
set. This allows for games with 'verified dice' using a dice server
and manual attachment of save games sent via email manually.

Previously it was required to also set email server settings which
allowed for automatic emails to be sent.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->

## Additional Review Notes

- Working towards resolving: https://github.com/triplea-game/triplea/issues/5856
- Next step (PR) will be to add email setting preferences to the PBEM screen
