### PR TITLE
Fix account creation retry loop

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -198,7 +198,7 @@ public class LobbyLogin {
                           panel.getUsername(), panel.getEmail(), panel.getPassword()));
       if (!createAccountResponse.isSuccess()) {
         showError("Account Creation Failed", createAccountResponse.getErrorMessage());
-        return createAccount(panel);
+        return Optional.empty();
       }
 
       final LobbyLoginResponse loginResponse =


### PR DESCRIPTION
Account creation was written to have a recursive call for a prompt-create-retry
loop. On modification later, this loop became broken and is now just a hard
retry loop until server locks the user out for too many retries.

This update fixes this situation by aborting account creation if there is
an error rather than executing another retry to server. It is not
fully ideal as any user input from the account creation screen is lost
and the user must re-enter the create account flow from scratch.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

