### PR TITLE
Fix password too short error message when creating an account

### DIFF
--- a/http-server/src/main/java/org/triplea/server/user/account/create/PasswordValidation.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/create/PasswordValidation.java
@@ -8,12 +8,12 @@ import java.util.function.Function;
 /** We expect password to be sent to server as a hash. Simply check that it is not too short. */
 public class PasswordValidation implements Function<String, Optional<String>> {
   /** Expected MIN_LENGTH is length of a SHA512 hashed string. */
-  @VisibleForTesting static final int MIN_LENGTH = 128;
+  @VisibleForTesting static final int MIN_LENGTH = 5;
 
   @Override
   public Optional<String> apply(final String password) {
     return Strings.nullToEmpty(password).trim().length() < MIN_LENGTH
-        ? Optional.of("Password not encoded properly, too short")
+        ? Optional.of("Password too short")
         : Optional.empty();
   }
 }

--- a/http-server/src/main/java/org/triplea/server/user/account/create/PasswordValidation.java
+++ b/http-server/src/main/java/org/triplea/server/user/account/create/PasswordValidation.java
@@ -7,8 +7,14 @@ import java.util.function.Function;
 
 /** We expect password to be sent to server as a hash. Simply check that it is not too short. */
 public class PasswordValidation implements Function<String, Optional<String>> {
-  /** Expected MIN_LENGTH is length of a SHA512 hashed string. */
-  @VisibleForTesting static final int MIN_LENGTH = 5;
+  // TODO: Md5-Deprecation Set this value to the expected length of a SHA512 hashed string
+  //   When passwords are no longer encoded in md5, and we do not need to upgrade them
+  //   to bcrypt, we can then hash passwords on the client side.
+  /**
+   * Expected MIN_LENGTH is length of the shortest password a user can input on the client-side UI
+   * when creating a new account.
+   */
+  @VisibleForTesting static final int MIN_LENGTH = 3;
 
   @Override
   public Optional<String> apply(final String password) {


### PR DESCRIPTION
Previous password validator assumed we were looking at a hashed value,
now we are looking at a plaintext value. The server validation of
length is still needed as there is no guarantee someone will use
our game-client when creating accounts.

This fix updates password validation on account creation to simply
check that the password is a minimum length.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done
- validated that the larger flow of creating an account works.
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

