### PR TITLE
Remove bot game loading on start-up dead code

### DIFF
--- a/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -50,18 +50,6 @@ public class HeadlessGameServer {
     }
     instance = this;
 
-    final String fileName = System.getProperty(TRIPLEA_GAME, "");
-    if (!fileName.isEmpty()) {
-      try {
-        final File file = new File(fileName);
-        if (file.exists()) {
-          gameSelectorModel.load(file);
-        }
-      } catch (final Exception e) {
-        gameSelectorModel.resetGameDataToNull();
-      }
-    }
-
     Runtime.getRuntime()
         .addShutdownHook(
             new Thread(

--- a/infrastructure/ansible/roles/bot/templates/run_server.j2
+++ b/infrastructure/ansible/roles/bot/templates/run_server.j2
@@ -31,7 +31,6 @@ java -server \
     -Xmx{{ bot_max_memory }} \
     -Djava.awt.headless=true \
     -jar {{ bot_jar }} \
-    -Ptriplea.game= \
     -Ptriplea.port=${BOT_PORT} \
     -Ptriplea.name={{ bot_name }}-${BOT_NUMBER} \
     -Ptriplea.lobby.uri={{ bot_lobby_uri }} \


### PR DESCRIPTION
Bot servers are never initialized with a starting game.
Remove the code that would have loaded a default starting game.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done
- verified code is only executed on startup, not when loading a game, starting a saved game, switching games, or starting a new game.
<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

