### PR TITLE
Reset value on failure

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -350,7 +350,7 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
       return decodeValue(encodedValue);
     } catch (final ValueEncodingException e) {
       log.log(
-          Level.WARNING,
+          Level.INFO,
           String.format(
               "Failed to decode encoded value: '%s' in client setting '%s'", encodedValue, name),
           e);

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -354,6 +354,7 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
           String.format(
               "Failed to decode encoded value: '%s' in client setting '%s'", encodedValue, name),
           e);
+      resetValue();
       return getDefaultValue().orElse(null);
     }
   }


### PR DESCRIPTION
<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 
For some reason I managed to mess up the encoded credentials on my machine, so I was repeatedly getting exception dialogs whenever I was opening the engine preferences dialog or was actually using the properties.
Adding this one line made the errors go away on my machine, but I'm not sure if it's desireable to have the value auto-reset if something goes wrong 🤷‍♂ 
So I'll leave it up to you to decide if this change is actually useful

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us, 
  we would prefer to rely on automated testing.
-->

[x] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

