### PR TITLE
Fix rocketHelper NPE if game is loaded from an in-battle save

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -113,6 +113,11 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     }
     battleTracker.fightAirRaidsAndStrategicBombing(bridge);
     if (needToFireRockets) {
+      // If we are loading a save-game created during battle and after the 'needToCreateRockets'
+      // phase, rocketHelper can be null here.
+      if (rocketHelper == null) {
+        rocketHelper = RocketsFireHelper.setUpRockets(bridge);
+      }
       rocketHelper.fireRockets(bridge);
       needToFireRockets = false;
     }


### PR DESCRIPTION
While investigating another problem, noticed that if we de-serialize
from a save-game that is saved after 'needToCreate' rockets phase,
that rocketHelper is not initialized from the de-serialized save
and we can run into a NPE.

The impact of this NPE seemed to be secondary, a 'game staging' screen
opened up but the main game and battle still continued.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Describe any manual testing performed below. 
-->
- created a strategic bombing battle
- started the battle
- saved game immediately after AA fires
- closed the game
- loaded the save game
- progressed through the combat and noted that before this fix we got a NPE and the 'game staging' screen opened, the fix we get neither a NPE and the 'game staging screen' does not open.

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes
This is a save-game that repro's the NPE: [repro.zip](https://github.com/triplea-game/triplea/files/4297115/repro.zip)

- Launch the save game and you should see the NPE after advancing the in-progress combat.


NPE was discovered while investigating: "UI Freeze Problem vs AI https://github.com/triplea-game/triplea/issues/5216"

