### PR TITLE
Switch prerelease URL back to 'prerelease'

### DIFF
--- a/infrastructure/ansible/inventory/prerelease
+++ b/infrastructure/ansible/inventory/prerelease
@@ -1,5 +1,5 @@
 [prerelease]
-prerelease2.triplea-game.org
+prerelease.triplea-game.org
 
 [postgresHosts:children]
 prerelease

--- a/servers.yml
+++ b/servers.yml
@@ -1,7 +1,7 @@
 latest: 2.0.16438
 servers:
   - version: "2.0.0"
-    lobby_uri: https://prerelease2.triplea-game.org
+    lobby_uri: https://prerelease.triplea-game.org
     message: |
       Welcome to the TripleA lobby, we are pleased you are here.
 


### PR DESCRIPTION
We had migrated temporarily to avoid letsencrypt weekly encryption limit that
we had triggered during testing.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Describe any manual testing performed below. 
-->



<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

