### PR TITLE
Avoid using JFileChooser in preference for FileDialog

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameFileSelector.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameFileSelector.java
@@ -1,8 +1,6 @@
 package games.strategy.engine.framework.startup.ui.panels.main.game.selector;
 
 import games.strategy.engine.framework.GameDataFileUtils;
-import games.strategy.engine.framework.system.SystemProperties;
-import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.triplea.settings.ClientSetting;
 import java.awt.FileDialog;
 import java.awt.Frame;
@@ -12,7 +10,6 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import javax.swing.JFileChooser;
 import lombok.Builder;
 
 /**
@@ -28,27 +25,15 @@ public final class GameFileSelector {
    * pop-up.
    */
   public Optional<File> selectGameFile(final Frame owner) {
-    // For some strange reason, the only way to get a Mac OS X native-style file dialog
-    // is to use an AWT FileDialog instead of a Swing JDialog
-    if (SystemProperties.isMac()) {
-      final FileDialog fileDialog = new FileDialog(owner);
-      fileDialog.setMode(FileDialog.LOAD);
-      fileDialog.setDirectory(ClientSetting.saveGamesFolderPath.getValueOrThrow().toString());
-      fileDialog.setFilenameFilter((dir, name) -> GameDataFileUtils.isCandidateFileName(name));
-      fileDialog.setVisible(true);
+    final FileDialog fileDialog = new FileDialog(owner);
+    fileDialog.setMode(FileDialog.LOAD);
+    fileDialog.setDirectory(ClientSetting.saveGamesFolderPath.getValueOrThrow().toString());
+    fileDialog.setFilenameFilter((dir, name) -> GameDataFileUtils.isCandidateFileName(name));
+    fileDialog.setVisible(true);
 
-      // FileDialog.getFiles() always returns an array
-      // of 1 or 0 items, because FileDialog.multipleMode is false by default
-      return Arrays.stream(fileDialog.getFiles()).findAny().map(this::mapFileResult);
-    }
-
-    // Non-Mac platforms should use the normal Swing JFileChooser
-    final JFileChooser fileChooser = SaveGameFileChooser.getInstance();
-    final int selectedOption = fileChooser.showOpenDialog(owner);
-    if (selectedOption == JFileChooser.APPROVE_OPTION) {
-      return Optional.of(fileChooser.getSelectedFile()).map(this::mapFileResult);
-    }
-    return Optional.empty();
+    // FileDialog.getFiles() always returns an array
+    // of 1 or 0 items, because FileDialog.multipleMode is false by default
+    return Arrays.stream(fileDialog.getFiles()).findAny().map(this::mapFileResult);
   }
 
   @Nullable

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
@@ -2,8 +2,6 @@ package games.strategy.triplea.ui.menubar;
 
 import games.strategy.engine.framework.GameDataFileUtils;
 import games.strategy.engine.framework.startup.ui.InGameLobbyWatcherWrapper;
-import games.strategy.engine.framework.system.SystemProperties;
-import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.engine.lobby.client.ui.action.EditGameCommentAction;
 import games.strategy.engine.lobby.client.ui.action.RemoveGameFromLobbyAction;
 import games.strategy.triplea.settings.ClientSetting;
@@ -13,10 +11,8 @@ import java.awt.Frame;
 import java.awt.event.KeyEvent;
 import java.io.File;
 import java.util.Optional;
-import javax.swing.JFileChooser;
 import javax.swing.JMenu;
 import javax.swing.JMenuBar;
-import javax.swing.JOptionPane;
 
 /** The game client menu bar. */
 public final class TripleAMenuBar extends JMenuBar {
@@ -60,60 +56,19 @@ public final class TripleAMenuBar extends JMenuBar {
    *     cancelled the operation.
    */
   public static File getSaveGameLocation(final Frame frame) {
-    // For some strange reason, the only way to get a Mac OS X native-style file dialog
-    // is to use an AWT FileDialog instead of a Swing JDialog
-    if (SystemProperties.isMac()) {
-      final FileDialog fileDialog = new FileDialog(frame);
-      fileDialog.setMode(FileDialog.SAVE);
-      fileDialog.setDirectory(ClientSetting.saveGamesFolderPath.getValueOrThrow().toString());
-      fileDialog.setFilenameFilter((dir, name) -> GameDataFileUtils.isCandidateFileName(name));
-      fileDialog.setVisible(true);
+    final FileDialog fileDialog = new FileDialog(frame);
+    fileDialog.setMode(FileDialog.SAVE);
+    fileDialog.setDirectory(ClientSetting.saveGamesFolderPath.getValueOrThrow().toString());
+    fileDialog.setFilenameFilter((dir, name) -> GameDataFileUtils.isCandidateFileName(name));
+    fileDialog.setVisible(true);
 
-      final String fileName = fileDialog.getFile();
-      if (fileName == null) {
-        return null;
-      }
-
-      // If the user selects a filename that already exists,
-      // the AWT Dialog on Mac OS X will ask the user for confirmation
-      return new File(fileDialog.getDirectory(), GameDataFileUtils.addExtensionIfAbsent(fileName));
-    }
-
-    // Non-Mac platforms should use the normal Swing JFileChooser
-    final JFileChooser fileChooser = SaveGameFileChooser.getInstance();
-    final int selectedOption = fileChooser.showSaveDialog(frame);
-    if (selectedOption != JFileChooser.APPROVE_OPTION) {
+    final String fileName = fileDialog.getFile();
+    if (fileName == null) {
       return null;
     }
-    File f = fileChooser.getSelectedFile();
-    // disallow sub directories to be entered (in the form directory/name) for Windows boxes
-    if (SystemProperties.isWindows()) {
-      final int slashIndex = Math.min(f.getPath().lastIndexOf("\\"), f.getPath().length());
-      final String filePath = f.getPath().substring(0, slashIndex);
-      if (!fileChooser.getCurrentDirectory().toString().equals(filePath)) {
-        JOptionPane.showConfirmDialog(
-            frame,
-            "Sub directories are not allowed in the file name.  Please rename it.",
-            "Cancel?",
-            JOptionPane.DEFAULT_OPTION,
-            JOptionPane.WARNING_MESSAGE);
-        return null;
-      }
-    }
-    f = new File(f.getParent(), GameDataFileUtils.addExtensionIfAbsent(f.getName()));
-    // A small warning so users will not over-write a file
-    if (f.exists()) {
-      final int choice =
-          JOptionPane.showConfirmDialog(
-              frame,
-              "A file by that name already exists. Do you wish to over write it?",
-              "Over-write?",
-              JOptionPane.YES_NO_OPTION,
-              JOptionPane.WARNING_MESSAGE);
-      if (choice != JOptionPane.OK_OPTION) {
-        return null;
-      }
-    }
-    return f;
+
+    // If the user selects a filename that already exists,
+    // the AWT Dialog will ask the user for confirmation
+    return new File(fileDialog.getDirectory(), GameDataFileUtils.addExtensionIfAbsent(fileName));
   }
 }


### PR DESCRIPTION
FileDialog uses a native native file chooser. This has some benefits:
- looks better
- less error prone, removing the option to type a file name means a user
  can't specify a file that does not exist
- removes OS specific code meaning we can test this code once and not
  N times per OS.
- Using native file chooser dialog aligns with JavaFX, in essence
   it's a modernizing approach to avoid JFileChooser



<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
- Verified that the AWT dialog gives a file-overwrite warning

<!--
  Describe any manual testing performed below. 
-->



<!-- If there are UI updates, uncomment and include screenshots below -->
## Screens Shots

### Before
![Screenshot from 2020-03-07 13-38-46](https://user-images.githubusercontent.com/12397753/76153250-4f409600-607e-11ea-818d-9263728d2fc6.png)

### After
![Screenshot from 2020-03-07 13-36-49](https://user-images.githubusercontent.com/12397753/76153254-5667a400-607e-11ea-9fb5-cd6460946224.png)


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes

The only changes in this PR is to delete the OS specific if conditional and delete the 'else' branch that used JFileChooser.


Scope of this update is:
 -  to remove OS specific file dialog selection and always favor FileDialog

Out of scope is removing all usages of JFileChooser or updating FileDialog API usages
 