### PR TITLE
Remove caching of travis ~/.gradle folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: xenial
 sudo: false
 language: java
 jdk: openjdk11
-cache: { directories: [ "$HOME/.gradle" , ".gradle" ] }
+cache: { directories: [ ".gradle" ] }
 install: skip
 
 env:


### PR DESCRIPTION
A wrapper jar is still generated despite the gradle cache. If the wrapper
jar is badly downloaded then we wind up with a poisoned cache and see this
error on builds:

> Exception in thread "main" java.lang.RuntimeException: Could not locate the Gradle launcher JAR in Gradle distribution '/home/travis/.gradle/wrapper/dists/gradle-5.6.2-all/9st6wgf78h16so49nn74lgtbb/gradle-5.6.2'.

This update removes travis caching of ~/.gradle


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

