### PR TITLE
Update DocumentListenerBuilder to have a buffering callback API

### DIFF
--- a/swing-lib/src/main/java/org/triplea/swing/DocumentListenerBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/DocumentListenerBuilder.java
@@ -1,17 +1,84 @@
 package org.triplea.swing;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.swing.event.DocumentEvent;
 import javax.swing.event.DocumentListener;
 import javax.swing.text.JTextComponent;
+import lombok.RequiredArgsConstructor;
 
 /**
- * Helper to create a 'DocumentListener', which is a way to listen to text events on text fields and
- * text areas. An action listener on text fields only fires on a keypressed 'enter' event and a key
- * listener does not fire when text is copy-pasted into the field. The document listener should
- * reliably trigger when text is changed.
+ * Helper to create a 'DocumentListener' that will fire callback events on keypressed events.
+ * Callbacks are not fired on copy/paste (insert) events.
+ *
+ * <p>This helper will buffer callbacks and waits a short duration after the last event before
+ * firing a single callback.
+ *
+ * <p>Document action listeners typically only fire when a user has pressed enter, this document
+ * listener should reliably fire whenever text is changed (apart from copy/paste events).
+ *
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * new DocumentListenerBuilder(() -> callbackRunnable)
+ *    .attachTo(textField1, textField2)
+ * }</pre>
  */
+@RequiredArgsConstructor
 public final class DocumentListenerBuilder {
-  private DocumentListenerBuilder() {}
+
+  private final AtomicReference<Timer> callListenerAction = new AtomicReference<>();
+  private final Runnable listener;
+
+  public void attachTo(final JTextComponent textComponent, final JTextComponent... components) {
+    attachListener(textComponent);
+    List.of(components).forEach(this::attachListener);
+  }
+
+  private void attachListener(final JTextComponent textComponent) {
+    textComponent
+        .getDocument()
+        .addDocumentListener(
+            new DocumentListener() {
+              @Override
+              public void insertUpdate(final DocumentEvent e) {
+                scheduleCallback();
+              }
+
+              @Override
+              public void removeUpdate(final DocumentEvent e) {
+                scheduleCallback();
+              }
+
+              @Override
+              public void changedUpdate(final DocumentEvent e) {
+                scheduleCallback();
+              }
+            });
+  }
+
+  private void scheduleCallback() {
+    // set new timer and cancel old one if present
+    final var newTimer = createNewTimer();
+    final var oldTimer = callListenerAction.getAndSet(newTimer);
+    Optional.ofNullable(oldTimer).ifPresent(Timer::cancel);
+  }
+
+  private Timer createNewTimer() {
+    final Timer timer = new Timer();
+    timer.schedule(
+        new TimerTask() {
+          @Override
+          public void run() {
+            listener.run();
+          }
+        },
+        100);
+    return timer;
+  }
 
   /**
    * Attaches a given (add/remove/changed) text change action to a {@code JTextComponent}.


### PR DESCRIPTION
Forward looking change to add functionality to DocumentListenerBuilder
that will buffer text listener callbackss.

The text update callback will be scheduled to be executed only after
an initial delay after the first text update event. But, if another
text update comes along, the previously scheduled callback is canceled
and a new one with delay is scheduled.

This allows for essentially (more or less) one callback to be done
after a user is done typing text rather than rapid firing many callback
events.

Usages of the previous non-buffered API will be replaced with the new API
in upcoming PRs


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Testing
- As part of other changes, demo'd the update and verified how many callbacks were done and observed UI responsiveness. Without the buffer, initial text updates usually first 3-5 events and then many events as you type. With the buffer, you still get multiple events but it's not nearly as many and text input is less laggy.

<!--
  Describe any manual testing performed below. 
-->



<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

