### PR TITLE
Add a nginx rewrite rule for remote actions websocket

### DIFF
--- a/infrastructure/ansible/roles/nginx/templates/etc_nginx_sites_enabled_default.j2
+++ b/infrastructure/ansible/roles/nginx/templates/etc_nginx_sites_enabled_default.j2
@@ -60,4 +60,11 @@ server {
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
     }
+    
+    location /remote/actions/ws {
+      proxy_pass http://localhost:8080;
+      proxy_http_version 1.1;
+      proxy_set_header Upgrade $http_upgrade;
+      proxy_set_header Connection "upgrade";
+    }
 }


### PR DESCRIPTION
Without this rule, nginx does not know where to send upgraded
SSL websocket traffic and connections to the remote actions
websocket endpoint then fail. This update adds that rule and
thereby avoids the connection error.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Describe any manual testing performed below. 
-->



<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

