### PR TITLE
Change text of saving map snapshot to 'gameboard picture'

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/export/ScreenshotExporter.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/export/ScreenshotExporter.java
@@ -63,7 +63,7 @@ public final class ScreenshotExporter {
     final CompletableFuture<?> future =
         SwingComponents.runWithProgressBar(
                 frame,
-                "Saving map snapshot...",
+                "Saving picture of the gameboard...",
                 () -> {
                   save(gameData, node, file);
                   return null;
@@ -75,14 +75,14 @@ public final class ScreenshotExporter {
                           if (e == null) {
                             JOptionPane.showMessageDialog(
                                 frame,
-                                "Map Snapshot Saved",
-                                "Map Snapshot Saved",
+                                "Saved to: " + file.getAbsolutePath(),
+                                "Gameboard Picture Saved",
                                 JOptionPane.INFORMATION_MESSAGE);
                           } else {
                             JOptionPane.showMessageDialog(
                                 frame,
                                 e.getMessage(),
-                                "Error Saving Map Snapshot",
+                                "Error Saving Gameboard Picture",
                                 JOptionPane.ERROR_MESSAGE);
                           }
                         }));


### PR DESCRIPTION
Follows up on: https://github.com/triplea-game/triplea/pull/5770
Addresses: https://github.com/triplea-game/triplea/issues/5483

Previously we renamed the menu 'map snapshot' to 'gameboard picture',
this update changes the dialog terminology and secondly makes
the success dialog more useful and states where the save file
is located.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Describe any manual testing performed below. 
-->



<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

