### PR TITLE
Implement transports allowed to retreat when remaining against only transports

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -2138,7 +2138,6 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     queryRetreat(false, RetreatType.PARTIAL_AMPHIB, bridge, possible);
   }
 
-
   private void attackerRetreatStalemate(final IDelegateBridge bridge) {
     attackerRetreat(bridge, true);
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -2138,12 +2138,13 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     queryRetreat(false, RetreatType.PARTIAL_AMPHIB, bridge, possible);
   }
 
-  private void attackerRetreat(final IDelegateBridge bridge) {
-    attackerRetreat(bridge, false);
-  }
 
   private void attackerRetreatStalemate(final IDelegateBridge bridge) {
     attackerRetreat(bridge, true);
+  }
+
+  private void attackerRetreat(final IDelegateBridge bridge) {
+    attackerRetreat(bridge, false);
   }
 
   private void attackerRetreat(


### PR DESCRIPTION
Adds a special rule to stalemate that allows attack the option
to retreat if a naval battle is left down to transport vs transport.

Addresses: https://github.com/triplea-game/triplea/issues/2367

Implements the special case rule:
   "In a sea battle, if both sides have only transports remaining, the
    attacker’s transports can remain in the contested sea zone or
    retreat per the rules in Condition B below, if possible.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix: https://github.com/triplea-game/triplea/issues/2367 <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing

Saved game attach reproduces this scenario. Before patch, in a battle of 1 cruiser + 1 transport vs the same, if the two cruisers both hit then the combat ends. After the patch, the attacker is given the option to retreat with their remaining transport.

[transport-retreat.zip](https://github.com/triplea-game/triplea/files/4310843/transport-retreat.zip)

<!--
  Describe any manual testing performed below. 
-->



<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

