### PR TITLE
Update stale thresholds, auto-comment @ 30 and auto-close @ 60 days

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,7 +1,7 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 70 
+daysUntilStale: 30
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 0
+daysUntilClose: 30
 # Issues with these labels will never be considered stale
 exemptLabels:
   - "Problem"
@@ -12,7 +12,7 @@ staleLabel: 'Stale'
 markComment: >
   This issue has been automatically marked as stale because it has not
   had recent activity. If there is something that can be done to resolve
-  this issue, please add a comment indicating what would be and this will
+  this issue, please add a comment indicating what that would be and this issue will
   be re-opened. If there are multiple items that can be completed independently,
   we encourage you to use the "reference in new issue" option next to any
   outstanding comment so that we may divide and conquer.


### PR DESCRIPTION
- 30 days to mark, this essentially auto-comments the issue
- 30 days to close stale issues (0 days never closed stale issues rather than immediately closing them).

The idea with the new threshold is that issues will be auto-commented sooner encouraging for the issue to remain actionable, and if another 30 days pass and an issue is still stale then it is closed.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Describe any manual testing performed below. 
-->



<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

