### PR TITLE
Statistics Panel (5) – Dynamic resource charts

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/stats/OverTimeStatisticType.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/OverTimeStatisticType.java
@@ -9,7 +9,7 @@ public interface OverTimeStatisticType {
 
   String getAxisLabel();
 
-  @Getter
+  @Getter(onMethod_ = @Override)
   @RequiredArgsConstructor
   enum PredefinedStatistics implements OverTimeStatisticType {
     TUV("TUV", "TUV"),

--- a/game-core/src/main/java/games/strategy/engine/stats/OverTimeStatisticType.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/OverTimeStatisticType.java
@@ -1,0 +1,17 @@
+package games.strategy.engine.stats;
+
+public interface OverTimeStatisticType {
+  String getName();
+
+  enum PredefinedStatistics implements OverTimeStatisticType {
+    TUV,
+    PRODUCTION,
+    UNITS,
+    VC;
+
+    @Override
+    public String getName() {
+      return name();
+    }
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/stats/OverTimeStatisticType.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/OverTimeStatisticType.java
@@ -7,7 +7,7 @@ import lombok.RequiredArgsConstructor;
 public interface OverTimeStatisticType {
   String getName();
 
-  String getXAxisLabel();
+  String getAxisLabel();
 
   @Getter
   @RequiredArgsConstructor
@@ -18,7 +18,7 @@ public interface OverTimeStatisticType {
     VC("VC", "Victory Cities");
 
     private final String name;
-    private final String xAxisLabel;
+    private final String axisLabel;
   }
 
   @RequiredArgsConstructor
@@ -32,7 +32,7 @@ public interface OverTimeStatisticType {
     }
 
     @Override
-    public String getXAxisLabel() {
+    public String getAxisLabel() {
       return String.format("%ss", resource.getName());
     }
   }

--- a/game-core/src/main/java/games/strategy/engine/stats/OverTimeStatisticType.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/OverTimeStatisticType.java
@@ -1,17 +1,39 @@
 package games.strategy.engine.stats;
 
+import games.strategy.engine.data.Resource;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 public interface OverTimeStatisticType {
   String getName();
 
+  String getXAxisLabel();
+
+  @Getter
+  @RequiredArgsConstructor
   enum PredefinedStatistics implements OverTimeStatisticType {
-    TUV,
-    PRODUCTION,
-    UNITS,
-    VC;
+    TUV("TUV", "TUV"),
+    PRODUCTION("Production", "Production from territories"),
+    UNITS("Units", "Units"),
+    VC("VC", "Victory Cities");
+
+    private final String name;
+    private final String xAxisLabel;
+  }
+
+  @RequiredArgsConstructor
+  class ResourceStatistic implements OverTimeStatisticType {
+
+    private final Resource resource;
 
     @Override
     public String getName() {
-      return name();
+      return String.format("%s Overview", resource.getName());
+    }
+
+    @Override
+    public String getXAxisLabel() {
+      return String.format("%ss", resource.getName());
     }
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/stats/ResourceStat.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/ResourceStat.java
@@ -1,0 +1,21 @@
+package games.strategy.engine.stats;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Resource;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class ResourceStat extends AbstractStat {
+  public final Resource resource;
+
+  @Override
+  public String getName() {
+    return resource == null ? "" : resource.getName();
+  }
+
+  @Override
+  public double getValue(final GamePlayer player, final GameData data) {
+    return player.getResources().getQuantity(resource);
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/stats/Statistics.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/Statistics.java
@@ -1,8 +1,9 @@
 package games.strategy.engine.stats;
 
-import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 import games.strategy.engine.history.Round;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.Value;
 
 /**
@@ -12,8 +13,6 @@ import lombok.Value;
  */
 @Value
 public class Statistics {
-  private final Table<String, Round, Double> productionOfPlayerInRound = HashBasedTable.create();
-  private final Table<String, Round, Double> tuvOfPlayerInRound = HashBasedTable.create();
-  private final Table<String, Round, Double> unitsOfPlayerInRound = HashBasedTable.create();
-  private final Table<String, Round, Double> victoryCitiesOfPlayerInRound = HashBasedTable.create();
+  private final Map<OverTimeStatisticType, Table<String, Round, Double>> overTimeStatistics =
+      new HashMap<>();
 }

--- a/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
@@ -21,17 +21,17 @@ import lombok.extern.java.Log;
 @Log
 @RequiredArgsConstructor
 public class StatisticsAggregator {
-  private final Statistics underConstruction = new Statistics();
-  private final GameData game;
   private static final Map<OverTimeStatisticType, IStat> defaultStatisticsMapping =
       Map.of(
           OverTimeStatisticType.PredefinedStatistics.TUV, new TuvStat(),
           OverTimeStatisticType.PredefinedStatistics.PRODUCTION, new ProductionStat(),
           OverTimeStatisticType.PredefinedStatistics.UNITS, new UnitsStat(),
           OverTimeStatisticType.PredefinedStatistics.VC, new VictoryCityStat());
+  private final Statistics underConstruction = new Statistics();
+  private final GameData game;
 
   private static Map<OverTimeStatisticType, IStat> createOverTimeStatisticsMapping(
-      List<Resource> resources) {
+      final List<Resource> resources) {
     final Map<OverTimeStatisticType, IStat> statisticsMapping =
         new HashMap<>(defaultStatisticsMapping);
     resources.forEach(
@@ -52,7 +52,7 @@ public class StatisticsAggregator {
         createOverTimeStatisticsMapping(game.getResourceList().getResources());
     {
       // initialize over time statistics
-      for (OverTimeStatisticType type : overTimeStatisticSources.keySet()) {
+      for (final OverTimeStatisticType type : overTimeStatisticSources.keySet()) {
         underConstruction.getOverTimeStatistics().put(type, HashBasedTable.create());
       }
     }
@@ -66,10 +66,10 @@ public class StatisticsAggregator {
   }
 
   private void collectOverTimeStatisticsForRound(
-      Map<OverTimeStatisticType, IStat> overTimeStatisticSources,
-      List<GamePlayer> players,
-      List<String> alliances,
-      Round round) {
+      final Map<OverTimeStatisticType, IStat> overTimeStatisticSources,
+      final List<GamePlayer> players,
+      final List<String> alliances,
+      final Round round) {
     for (final GamePlayer player : players) {
       overTimeStatisticSources.forEach(
           (type, source) ->

--- a/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
@@ -48,36 +48,43 @@ public class StatisticsAggregator {
   }
 
   private void collectOverTimeStatistics() {
-    final List<GamePlayer> players = game.getPlayerList().getPlayers();
-    final List<String> alliances = new ArrayList<>(game.getAllianceTracker().getAlliances());
-
-    final Map<OverTimeStatisticType, IStat> overTimeStatisticToSource =
+    final Map<OverTimeStatisticType, IStat> overTimeStatisticSources =
         createOverTimeStatisticsMapping(game.getResourceList().getResources());
     {
       // initialize over time statistics
-      for (OverTimeStatisticType type : overTimeStatisticToSource.keySet()) {
+      for (OverTimeStatisticType type : overTimeStatisticSources.keySet()) {
         underConstruction.getOverTimeStatistics().put(type, HashBasedTable.create());
       }
     }
 
+    final List<GamePlayer> players = game.getPlayerList().getPlayers();
+    final List<String> alliances = new ArrayList<>(game.getAllianceTracker().getAlliances());
     for (final Round round : getRounds()) {
       game.getHistory().gotoNode(round);
-      for (final GamePlayer player : players) {
-        overTimeStatisticToSource.forEach(
-            (type, source) ->
-                underConstruction
-                    .getOverTimeStatistics()
-                    .get(type)
-                    .put(player.getName(), round, source.getValue(player, game)));
-      }
-      for (final String alliance : alliances) {
-        overTimeStatisticToSource.forEach(
-            (type, source) ->
-                underConstruction
-                    .getOverTimeStatistics()
-                    .get(type)
-                    .put(alliance, round, source.getValue(alliance, game)));
-      }
+      collectOverTimeStatisticsForRound(overTimeStatisticSources, players, alliances, round);
+    }
+  }
+
+  private void collectOverTimeStatisticsForRound(
+      Map<OverTimeStatisticType, IStat> overTimeStatisticSources,
+      List<GamePlayer> players,
+      List<String> alliances,
+      Round round) {
+    for (final GamePlayer player : players) {
+      overTimeStatisticSources.forEach(
+          (type, source) ->
+              underConstruction
+                  .getOverTimeStatistics()
+                  .get(type)
+                  .put(player.getName(), round, source.getValue(player, game)));
+    }
+    for (final String alliance : alliances) {
+      overTimeStatisticSources.forEach(
+          (type, source) ->
+              underConstruction
+                  .getOverTimeStatistics()
+                  .get(type)
+                  .put(alliance, round, source.getValue(alliance, game)));
     }
   }
 

--- a/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
@@ -46,6 +46,11 @@ public class StatisticsAggregator {
 
   public Statistics aggregate() {
     log.info("Aggregating statistics for game " + game.getGameName());
+    collectOverTimeStatistics();
+    return underConstruction;
+  }
+
+  private void collectOverTimeStatistics() {
     final List<GamePlayer> players = game.getPlayerList().getPlayers();
     final List<String> alliances = new ArrayList<>(game.getAllianceTracker().getAlliances());
 
@@ -77,8 +82,6 @@ public class StatisticsAggregator {
                     .put(alliance, round, source.getValue(alliance, game)));
       }
     }
-
-    return underConstruction;
   }
 
   private List<Round> getRounds() {

--- a/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
@@ -3,10 +3,13 @@ package games.strategy.engine.stats;
 import com.google.common.collect.HashBasedTable;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Resource;
 import games.strategy.engine.history.HistoryNode;
 import games.strategy.engine.history.Round;
+import games.strategy.triplea.ui.AbstractStatPanel;
 import java.util.ArrayList;
 import java.util.Enumeration;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.swing.tree.TreeNode;
@@ -22,12 +25,23 @@ public class StatisticsAggregator {
   private final Statistics underConstruction = new Statistics();
   private final GameData game;
 
-  private static Map<OverTimeStatisticType, IStat> createOverTimeStatisticsMapping() {
-    return Map.of(
-        OverTimeStatisticType.PredefinedStatistics.TUV, new TuvStat(),
-        OverTimeStatisticType.PredefinedStatistics.PRODUCTION, new ProductionStat(),
-        OverTimeStatisticType.PredefinedStatistics.UNITS, new UnitsStat(),
-        OverTimeStatisticType.PredefinedStatistics.VC, new VictoryCityStat());
+  private static final Map<OverTimeStatisticType, IStat> defaultStatisticsMapping =
+      Map.of(
+          OverTimeStatisticType.PredefinedStatistics.TUV, new TuvStat(),
+          OverTimeStatisticType.PredefinedStatistics.PRODUCTION, new ProductionStat(),
+          OverTimeStatisticType.PredefinedStatistics.UNITS, new UnitsStat(),
+          OverTimeStatisticType.PredefinedStatistics.VC, new VictoryCityStat());
+
+  private static Map<OverTimeStatisticType, IStat> createOverTimeStatisticsMapping(
+      List<Resource> resources) {
+    final Map<OverTimeStatisticType, IStat> statisticsMapping =
+        new HashMap<>(defaultStatisticsMapping);
+    resources.forEach(
+        resource ->
+            statisticsMapping.put(
+                new OverTimeStatisticType.ResourceStatistic(resource),
+                new AbstractStatPanel.ResourceStat(resource)));
+    return statisticsMapping;
   }
 
   public Statistics aggregate() {
@@ -36,7 +50,7 @@ public class StatisticsAggregator {
     final List<String> alliances = new ArrayList<>(game.getAllianceTracker().getAlliances());
 
     final Map<OverTimeStatisticType, IStat> overTimeStatisticToSource =
-        createOverTimeStatisticsMapping();
+        createOverTimeStatisticsMapping(game.getResourceList().getResources());
     {
       // initialize over time statistics
       for (OverTimeStatisticType type : overTimeStatisticToSource.keySet()) {

--- a/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/StatisticsAggregator.java
@@ -6,7 +6,6 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Resource;
 import games.strategy.engine.history.HistoryNode;
 import games.strategy.engine.history.Round;
-import games.strategy.triplea.ui.AbstractStatPanel;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -24,7 +23,6 @@ import lombok.extern.java.Log;
 public class StatisticsAggregator {
   private final Statistics underConstruction = new Statistics();
   private final GameData game;
-
   private static final Map<OverTimeStatisticType, IStat> defaultStatisticsMapping =
       Map.of(
           OverTimeStatisticType.PredefinedStatistics.TUV, new TuvStat(),
@@ -39,8 +37,7 @@ public class StatisticsAggregator {
     resources.forEach(
         resource ->
             statisticsMapping.put(
-                new OverTimeStatisticType.ResourceStatistic(resource),
-                new AbstractStatPanel.ResourceStat(resource)));
+                new OverTimeStatisticType.ResourceStatistic(resource), new ResourceStat(resource)));
     return statisticsMapping;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/AbstractStatPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/AbstractStatPanel.java
@@ -43,10 +43,10 @@ public abstract class AbstractStatPanel extends JPanel {
     return players;
   }
 
-  static class ResourceStat extends AbstractStat {
+  public static class ResourceStat extends AbstractStat {
     final Resource resource;
 
-    ResourceStat(final Resource resource) {
+    public ResourceStat(final Resource resource) {
       this.resource = resource;
     }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/AbstractStatPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/AbstractStatPanel.java
@@ -2,8 +2,6 @@ package games.strategy.triplea.ui;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
-import games.strategy.engine.data.Resource;
-import games.strategy.engine.stats.AbstractStat;
 import games.strategy.triplea.util.PlayerOrderComparator;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -41,23 +39,5 @@ public abstract class AbstractStatPanel extends JPanel {
     final List<GamePlayer> players = new ArrayList<>(gameData.getPlayerList().getPlayers());
     players.sort(new PlayerOrderComparator(gameData));
     return players;
-  }
-
-  public static class ResourceStat extends AbstractStat {
-    final Resource resource;
-
-    public ResourceStat(final Resource resource) {
-      this.resource = resource;
-    }
-
-    @Override
-    public String getName() {
-      return resource == null ? "" : resource.getName();
-    }
-
-    @Override
-    public double getValue(final GamePlayer player, final GameData data) {
-      return player.getResources().getQuantity(resource);
-    }
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/EconomyPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EconomyPanel.java
@@ -5,6 +5,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.events.GameDataChangeListener;
+import games.strategy.engine.stats.ResourceStat;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.delegate.AbstractEndTurnDelegate;
 import java.awt.GridLayout;

--- a/game-core/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
@@ -9,6 +9,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.UnitTypeList;
 import games.strategy.engine.stats.AbstractStat;
 import games.strategy.engine.stats.IStat;
+import games.strategy.engine.stats.ResourceStat;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.TechAttachment;

--- a/game-core/src/main/java/games/strategy/triplea/ui/ResourceBar.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ResourceBar.java
@@ -5,6 +5,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.events.GameDataChangeListener;
+import games.strategy.engine.stats.ResourceStat;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.delegate.AbstractEndTurnDelegate;
 import java.awt.GridBagConstraints;

--- a/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -7,6 +7,7 @@ import games.strategy.engine.data.events.GameDataChangeListener;
 import games.strategy.engine.stats.AbstractStat;
 import games.strategy.engine.stats.IStat;
 import games.strategy.engine.stats.ProductionStat;
+import games.strategy.engine.stats.ResourceStat;
 import games.strategy.engine.stats.TuvStat;
 import games.strategy.engine.stats.UnitsStat;
 import games.strategy.engine.stats.VictoryCityStat;

--- a/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
@@ -37,7 +37,7 @@ public class StatisticsDialog extends JPanel {
         .getOverTimeStatistics()
         .forEach(
             (key, value) ->
-                overTimeCharts.add(new OverTimeChart(key.getName(), key.getXAxisLabel(), value)));
+                overTimeCharts.add(new OverTimeChart(key.getName(), key.getAxisLabel(), value)));
 
     final JTabbedPaneBuilder tabbedPane = JTabbedPaneBuilder.builder();
     for (final OverTimeChart chartData : overTimeCharts) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.ui.statistics;
 import com.google.common.collect.Table;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.history.Round;
+import games.strategy.engine.stats.OverTimeStatisticType;
 import games.strategy.engine.stats.Statistics;
 import games.strategy.engine.stats.StatisticsAggregator;
 import java.util.ArrayList;
@@ -37,11 +38,27 @@ public class StatisticsDialog extends JPanel {
             new OverTimeChart(
                 "Production",
                 "Production from territories",
-                statistics.getProductionOfPlayerInRound()),
-            new OverTimeChart("TUV", "TUV", statistics.getTuvOfPlayerInRound()),
-            new OverTimeChart("Units", "Units", statistics.getUnitsOfPlayerInRound()),
+                statistics
+                    .getOverTimeStatistics()
+                    .get(OverTimeStatisticType.PredefinedStatistics.PRODUCTION)),
             new OverTimeChart(
-                "VC", "Victory Cities", statistics.getVictoryCitiesOfPlayerInRound()));
+                "TUV",
+                "TUV",
+                statistics
+                    .getOverTimeStatistics()
+                    .get(OverTimeStatisticType.PredefinedStatistics.TUV)),
+            new OverTimeChart(
+                "Units",
+                "Units",
+                statistics
+                    .getOverTimeStatistics()
+                    .get(OverTimeStatisticType.PredefinedStatistics.UNITS)),
+            new OverTimeChart(
+                "VC",
+                "Victory Cities",
+                statistics
+                    .getOverTimeStatistics()
+                    .get(OverTimeStatisticType.PredefinedStatistics.VC)));
 
     final JTabbedPaneBuilder tabbedPane = JTabbedPaneBuilder.builder();
     for (final OverTimeChart chartData : overTimeCharts) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
@@ -10,8 +10,6 @@ import java.util.List;
 import javax.swing.JPanel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.knowm.xchart.PieChart;
-import org.knowm.xchart.PieChartBuilder;
 import org.knowm.xchart.XChartPanel;
 import org.knowm.xchart.XYChart;
 import org.knowm.xchart.XYChartBuilder;
@@ -46,8 +44,6 @@ public class StatisticsDialog extends JPanel {
                 "VC", "Victory Cities", statistics.getVictoryCitiesOfPlayerInRound()));
 
     final JTabbedPaneBuilder tabbedPane = JTabbedPaneBuilder.builder();
-    tabbedPane.addTab("Lines", createDummyXyGraph(statistics));
-    tabbedPane.addTab("Pie", createDummyPieChart(statistics));
     for (final OverTimeChart chartData : overTimeCharts) {
       tabbedPane.addTab(chartData.getTitle(), createChart(chartData));
     }
@@ -61,32 +57,6 @@ public class StatisticsDialog extends JPanel {
         .getData()
         .rowMap()
         .forEach((key, value) -> chart.addSeries(key, new ArrayList<>(value.values())));
-    return new XChartPanel<>(chart);
-  }
-
-  private JPanel createDummyXyGraph(final Statistics statistics) {
-    final XYChart chart = xyChartDefaults.title("Sample Chart: " + statistics.toString()).build();
-    chart.addSeries("some value1", new double[] {2.0, 0.0, 40.0});
-    chart.addSeries("some value2", new double[] {3.0, 1.0, 41.0});
-    chart.addSeries("some value3", new double[] {4.0, 2.0, 42.0});
-    chart.addSeries("some value4", new double[] {5.0, 3.0, 43.0});
-    chart.addSeries("some value5", new double[] {6.0, 4.0, 44.0});
-    chart.addSeries("some value6", new double[] {7.0, 5.0, 45.0});
-    chart.addSeries("some value7", new double[] {8.0, 6.0, 46.0});
-    return new XChartPanel<>(chart);
-  }
-
-  private JPanel createDummyPieChart(final Statistics statistics) {
-    final PieChart chart =
-        new PieChartBuilder()
-            .theme(Styler.ChartTheme.XChart)
-            .title("Sample Chart: " + statistics.toString())
-            .build();
-    chart.addSeries("Value 1", 27);
-    chart.addSeries("Value 2", 63);
-    chart.addSeries("Value 3", 1);
-    chart.addSeries("Value 4", 9);
-    chart.getStyler().setLegendPosition(Styler.LegendPosition.InsideSE);
     return new XChartPanel<>(chart);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
@@ -3,7 +3,6 @@ package games.strategy.triplea.ui.statistics;
 import com.google.common.collect.Table;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.history.Round;
-import games.strategy.engine.stats.OverTimeStatisticType;
 import games.strategy.engine.stats.Statistics;
 import games.strategy.engine.stats.StatisticsAggregator;
 import java.util.ArrayList;
@@ -33,32 +32,12 @@ public class StatisticsDialog extends JPanel {
   public StatisticsDialog(final GameData game) {
     final Statistics statistics = new StatisticsAggregator(game).aggregate();
 
-    final List<OverTimeChart> overTimeCharts =
-        List.of(
-            new OverTimeChart(
-                "Production",
-                "Production from territories",
-                statistics
-                    .getOverTimeStatistics()
-                    .get(OverTimeStatisticType.PredefinedStatistics.PRODUCTION)),
-            new OverTimeChart(
-                "TUV",
-                "TUV",
-                statistics
-                    .getOverTimeStatistics()
-                    .get(OverTimeStatisticType.PredefinedStatistics.TUV)),
-            new OverTimeChart(
-                "Units",
-                "Units",
-                statistics
-                    .getOverTimeStatistics()
-                    .get(OverTimeStatisticType.PredefinedStatistics.UNITS)),
-            new OverTimeChart(
-                "VC",
-                "Victory Cities",
-                statistics
-                    .getOverTimeStatistics()
-                    .get(OverTimeStatisticType.PredefinedStatistics.VC)));
+    final List<OverTimeChart> overTimeCharts = new ArrayList<>();
+    statistics
+        .getOverTimeStatistics()
+        .forEach(
+            (key, value) ->
+                overTimeCharts.add(new OverTimeChart(key.getName(), key.getXAxisLabel(), value)));
 
     final JTabbedPaneBuilder tabbedPane = JTabbedPaneBuilder.builder();
     for (final OverTimeChart chartData : overTimeCharts) {


### PR DESCRIPTION
This is the fifth pull request in a series (#5866 #5872 #5881 #5890). Subject is the [feature request for a statistics panel](https://forums.triplea-game.org/topic/1660/game-statistics-page/).

This time
 - dummy graphs were deleted
 - graphs were added for dynamic resources of maps (like "PUs", "TechTokens", etc.)

### Notes:
 - I tested the feature with several maps. Sadly it breaks for a few of them while `game.getHistory().gotoNode(round);`. At the end of the PR I've attached some sample stacktraces. But they don't look related to my changes, but rather like bugs in the map. A simple workaround would be a general try catch like
    ```
          try {
            game.getHistory().gotoNode(round);
          } catch (Exception e) {
            /* ? */
          }
    ```
    but I'm not sure if I'm missing something because of that. Any opinions?
 - Since I'm naively creating a chart for all dynamic resources of the map, there might be some charts that seem like noise. An example could be in the G40 screenshot below the "TechTokens" and "SuicideTokens" charts. They are mostly static and maybe not that interesting as [a user on the forums pointed out](https://forums.triplea-game.org/topic/1660/game-statistics-page). 
But I would generally argue against manual filtering. In the end these resources are important for playing the map, so why hide them?
 - `ResourceStat` was moved to own file



## Plan for the next PR
 - Prototype for a non-resource-stat. Some ideas are "Biggest battle in the game" or "Most contested territory".

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Place an X below if applies. Manual testing is a crutch for us,
  we would prefer to rely on automated testing.
-->

[] Manual testing done

<!-- If manually tested, summarize the testing done below this line. -->
Nothing really to test

<!-- If there are UI updates, uncomment and include screenshots below -->
## Screens Shots

Napoleonic Empires:
![scrot_2020-03-15_09-58-43_screenshot](https://user-images.githubusercontent.com/263263/76698965-b4ad0c00-66a8-11ea-9d71-21e549a61510.png)
G40:
![scrot_2020-03-15_09-59-53_screenshot](https://user-images.githubusercontent.com/263263/76698966-b5de3900-66a8-11ea-8d8f-70e81b01f3c5.png)
270BC:
![scrot_2020-03-15_10-12-13_screenshot](https://user-images.githubusercontent.com/263263/76698967-b5de3900-66a8-11ea-839a-810758c76a12.png)
Star Trek Dilithium War (Only from first round because of exception):
![scrot_2020-03-15_10-28-29_screenshot](https://user-images.githubusercontent.com/263263/76698968-b676cf80-66a8-11ea-815e-c0982a228803.png)
Dragon War (Only from first round because of exception):
![scrot_2020-03-15_10-33-04_screenshot](https://user-images.githubusercontent.com/263263/76698969-b70f6600-66a8-11ea-8d91-ec7e0a675ce8.png)

## Stacktraces
Star Trek Dilithium War:
```
März 15, 2020 10:26:14 VORM. org.triplea.game.client.HeadedGameRunner lambda$initializeClientSettingAndLogging$0
SEVERE: Cant remove more than player has of resource: Dilithium. current:0 toRemove: 5
java.lang.IllegalArgumentException: Cant remove more than player has of resource: Dilithium. current:0 toRemove: 5
	at games.strategy.engine.data.ResourceCollection.removeResource(ResourceCollection.java:54)
	at games.strategy.engine.data.changefactory.ChangeResourceChange.perform(ChangeResourceChange.java:43)
	at games.strategy.engine.data.CompositeChange.perform(CompositeChange.java:48)
	at games.strategy.engine.data.CompositeChange.perform(CompositeChange.java:48)
	at games.strategy.engine.data.GameData.performChange(GameData.java:448)
	at games.strategy.engine.history.History.gotoNode(History.java:117)
	at games.strategy.engine.stats.StatisticsAggregator.collectOverTimeStatistics(StatisticsAggregator.java:64)
	at games.strategy.engine.stats.StatisticsAggregator.aggregate(StatisticsAggregator.java:46)
	at games.strategy.triplea.ui.statistics.StatisticsDialog.<init>(StatisticsDialog.java:33)
	at games.strategy.triplea.ui.menubar.GameMenu.lambda$addStatistics$11(GameMenu.java:304)
	at org.triplea.swing.SwingAction$1.actionPerformed(SwingAction.java:60)
	at java.desktop/javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:1967)
	at java.desktop/javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2308)
	at java.desktop/javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:405)
	at java.desktop/javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:262)
	at java.desktop/javax.swing.AbstractButton.doClick(AbstractButton.java:369)
	at java.desktop/javax.swing.plaf.basic.BasicMenuItemUI.doClick(BasicMenuItemUI.java:1020)
	at java.desktop/javax.swing.plaf.basic.BasicMenuItemUI$Handler.mouseReleased(BasicMenuItemUI.java:1064)
	at java.desktop/java.awt.AWTEventMulticaster.mouseReleased(AWTEventMulticaster.java:297)
	at java.desktop/java.awt.Component.processMouseEvent(Component.java:6632)
	at java.desktop/javax.swing.JComponent.processMouseEvent(JComponent.java:3342)
	at java.desktop/java.awt.Component.processEvent(Component.java:6397)
	at java.desktop/java.awt.Container.processEvent(Container.java:2263)
	at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:5008)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2321)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4840)
	at java.desktop/java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4918)
	at java.desktop/java.awt.LightweightDispatcher.processMouseEvent(Container.java:4547)
	at java.desktop/java.awt.LightweightDispatcher.dispatchEvent(Container.java:4488)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2307)
	at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2772)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4840)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:772)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:715)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:95)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:745)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:743)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:742)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
```

Dragon War:
```
März 15, 2020 10:31:56 VORM. org.triplea.game.client.HeadedGameRunner lambda$initializeClientSettingAndLogging$0
SEVERE: Not all units present in:Stormwood.  Trying to remove:[Hvy-Infantry owned by Crowton, Lgt-Infantry owned by Crowton, Spearmen owned by Crowton] present:[Capital-City owned by Crowton, Castle owned by Crowton, Auxiliaries owned by Crowton]
java.lang.IllegalStateException: Not all units present in:Stormwood.  Trying to remove:[Hvy-Infantry owned by Crowton, Lgt-Infantry owned by Crowton, Spearmen owned by Crowton] present:[Capital-City owned by Crowton, Castle owned by Crowton, Auxiliaries owned by Crowton]
	at games.strategy.engine.data.changefactory.RemoveUnits.perform(RemoveUnits.java:44)
	at games.strategy.engine.data.CompositeChange.perform(CompositeChange.java:48)
	at games.strategy.engine.data.CompositeChange.perform(CompositeChange.java:48)
	at games.strategy.engine.data.GameData.performChange(GameData.java:448)
	at games.strategy.engine.history.History.gotoNode(History.java:117)
	at games.strategy.engine.stats.StatisticsAggregator.collectOverTimeStatistics(StatisticsAggregator.java:64)
	at games.strategy.engine.stats.StatisticsAggregator.aggregate(StatisticsAggregator.java:46)
	at games.strategy.triplea.ui.statistics.StatisticsDialog.<init>(StatisticsDialog.java:33)
	at games.strategy.triplea.ui.menubar.GameMenu.lambda$addStatistics$11(GameMenu.java:304)
	at org.triplea.swing.SwingAction$1.actionPerformed(SwingAction.java:60)
	at java.desktop/javax.swing.AbstractButton.fireActionPerformed(AbstractButton.java:1967)
	at java.desktop/javax.swing.AbstractButton$Handler.actionPerformed(AbstractButton.java:2308)
	at java.desktop/javax.swing.DefaultButtonModel.fireActionPerformed(DefaultButtonModel.java:405)
	at java.desktop/javax.swing.DefaultButtonModel.setPressed(DefaultButtonModel.java:262)
	at java.desktop/javax.swing.AbstractButton.doClick(AbstractButton.java:369)
	at java.desktop/javax.swing.plaf.basic.BasicMenuItemUI.doClick(BasicMenuItemUI.java:1020)
	at java.desktop/javax.swing.plaf.basic.BasicMenuItemUI$Handler.mouseReleased(BasicMenuItemUI.java:1064)
	at java.desktop/java.awt.AWTEventMulticaster.mouseReleased(AWTEventMulticaster.java:297)
	at java.desktop/java.awt.Component.processMouseEvent(Component.java:6632)
	at java.desktop/javax.swing.JComponent.processMouseEvent(JComponent.java:3342)
	at java.desktop/java.awt.Component.processEvent(Component.java:6397)
	at java.desktop/java.awt.Container.processEvent(Container.java:2263)
	at java.desktop/java.awt.Component.dispatchEventImpl(Component.java:5008)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2321)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4840)
	at java.desktop/java.awt.LightweightDispatcher.retargetMouseEvent(Container.java:4918)
	at java.desktop/java.awt.LightweightDispatcher.processMouseEvent(Container.java:4547)
	at java.desktop/java.awt.LightweightDispatcher.dispatchEvent(Container.java:4488)
	at java.desktop/java.awt.Container.dispatchEventImpl(Container.java:2307)
	at java.desktop/java.awt.Window.dispatchEventImpl(Window.java:2772)
	at java.desktop/java.awt.Component.dispatchEvent(Component.java:4840)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:772)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:721)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:715)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:95)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:745)
	at java.desktop/java.awt.EventQueue$5.run(EventQueue.java:743)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:85)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:742)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:203)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:124)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:109)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:101)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:90)
```
