### PR TITLE
Remove websocket dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,7 +110,6 @@ subprojects {
         openFeignVersion = '10.5.1'
         postgresqlVersion = '42.2.11'
         rateLimitjVersion = '0.6.0'
-        slf4jSimpleVersion = '1.7.28'
         snakeYamlVersion = '2.1'
         sonatypeGoodiesPrefsVersion = '2.3.1'
         substanceVersion = '2.5.1'

--- a/http-clients/build.gradle
+++ b/http-clients/build.gradle
@@ -4,7 +4,6 @@ dependencies {
     implementation "com.google.code.gson:gson:$gsonVersion"
     implementation "io.github.openfeign:feign-core:$feignCoreVersion"
     implementation "io.github.openfeign:feign-gson:$feignGsonVersion"
-    implementation "org.java-websocket:Java-WebSocket:$javaWebsocketVersion"
     implementation project(":domain-data")
     implementation project(":java-extras")
     testImplementation "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonDataTypeVersion"

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/GenericWebSocketClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/GenericWebSocketClient.java
@@ -57,7 +57,7 @@ public class GenericWebSocketClient implements WebSocketConnectionListener {
             throwable -> {
               log.log(
                   Level.SEVERE, "Unexpected exception completing websocket connection", throwable);
-              return false;
+              return null;
             });
   }
 
@@ -95,7 +95,7 @@ public class GenericWebSocketClient implements WebSocketConnectionListener {
   }
 
   @Override
-  public void handleError(final Exception exception) {
-    log.log(Level.SEVERE, "Websocket error", exception);
+  public void handleError(final Throwable error) {
+    log.log(Level.SEVERE, "Websocket error", error);
   }
 }

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/GenericWebSocketClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/GenericWebSocketClient.java
@@ -51,14 +51,7 @@ public class GenericWebSocketClient implements WebSocketConnectionListener {
 
   public void registerListenerAndConnect(final Consumer<ServerMessageEnvelope> messageListener) {
     this.messageListener = messageListener;
-    client
-        .connect(this, errorHandler)
-        .exceptionally(
-            throwable -> {
-              log.log(
-                  Level.SEVERE, "Unexpected exception completing websocket connection", throwable);
-              return null;
-            });
+    client.connect(this, errorHandler);
   }
 
   /**

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/GenericWebSocketClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/GenericWebSocketClient.java
@@ -32,7 +32,7 @@ public class GenericWebSocketClient implements WebSocketConnectionListener {
   private Consumer<ServerMessageEnvelope> messageListener;
 
   public GenericWebSocketClient(final URI lobbyUri, final Consumer<String> errorHandler) {
-    this(new WebSocketConnection(swapHttpsToWssProtocol(lobbyUri)), errorHandler);
+    this(new WebSocketConnection(swapHttpToWsProtocol(lobbyUri)), errorHandler);
   }
 
   @VisibleForTesting
@@ -43,9 +43,9 @@ public class GenericWebSocketClient implements WebSocketConnectionListener {
   }
 
   @VisibleForTesting
-  static URI swapHttpsToWssProtocol(final URI uri) {
-    return uri.getScheme().equals("https")
-        ? URI.create(uri.toString().replace("https", "wss"))
+  static URI swapHttpToWsProtocol(final URI uri) {
+    return uri.getScheme().matches("^https?$")
+        ? URI.create(uri.toString().replaceFirst("^http", "ws"))
         : uri;
   }
 

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -157,6 +157,8 @@ class WebSocketConnection {
    * @param errorHandler Invoked if there is a failure to connect.
    * @throws IllegalStateException Thrown if connection is already open (eg: connect called twice).
    * @throws IllegalStateException Thrown if connection has been closed (ie: 'close()' was called)
+   * @return A {@link CompletableFuture} behaving like the {@link CompletableFuture} returned by
+   *     {@link WebSocket.Builder#buildAsync(URI, Listener)} in case of an error.
    */
   CompletableFuture<WebSocket> connect(
       final WebSocketConnectionListener listener, final Consumer<String> errorHandler) {

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -71,7 +71,7 @@ class WebSocketConnection {
   @Getter(
       value = AccessLevel.PACKAGE,
       onMethod_ = {@VisibleForTesting})
-  private final WebSocket.Listener webSocketListener = new WebSocketListener();
+  private final WebSocket.Listener internalListener = new InternalWebSocketListener();
 
   @Getter(
       value = AccessLevel.PACKAGE,
@@ -138,7 +138,7 @@ class WebSocketConnection {
     return httpClient
         .newWebSocketBuilder()
         .connectTimeout(Duration.ofMillis(DEFAULT_CONNECT_TIMEOUT_MILLIS))
-        .buildAsync(serverUri, webSocketListener);
+        .buildAsync(serverUri, internalListener);
   }
 
   /**
@@ -172,7 +172,7 @@ class WebSocketConnection {
   }
 
   @VisibleForTesting
-  class WebSocketListener implements Listener {
+  class InternalWebSocketListener implements Listener {
     private final StringBuilder textAccumulator = new StringBuilder();
 
     @Override

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -106,9 +106,6 @@ class WebSocketConnection {
         @Override
         public CompletionStage<?> onClose(
             final WebSocket webSocket, final int statusCode, final String reason) {
-          if (!reason.equals(CLIENT_DISCONNECT_MESSAGE)) {
-            log.severe("Connection to server closed: " + reason);
-          }
           pingSender.cancel();
           listener.connectionClosed(reason);
           return null;

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -97,7 +97,7 @@ class WebSocketConnection {
   /** Does an async close of the current websocket connection. */
   void close() {
     closed = true;
-    if (!client.isOutputClosed()) {
+    if (client != null && !client.isOutputClosed()) {
       client
           .sendClose(WebSocket.NORMAL_CLOSURE, CLIENT_DISCONNECT_MESSAGE)
           .exceptionally(logWebSocketError(Level.INFO, "Failed to close"));

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -7,7 +7,6 @@ import java.net.http.HttpClient;
 import java.net.http.WebSocket;
 import java.net.http.WebSocket.Listener;
 import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.Queue;
@@ -132,7 +131,7 @@ class WebSocketConnection {
                 () -> {
                   if (!client.isOutputClosed()) {
                     client
-                        .sendPing(ByteBuffer.wrap("Ping".getBytes(StandardCharsets.UTF_8)))
+                        .sendPing(ByteBuffer.allocate(0))
                         .exceptionally(logWebSocketError("Failed to send ping."));
                   }
                 });

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -97,6 +97,8 @@ class WebSocketConnection {
   /** Does an async close of the current websocket connection. */
   void close() {
     closed = true;
+    // Client can be null if the connection hasn't completely opened yet.
+    // This null check prevents a potential NPE, which should rarely ever occur.
     if (client != null && !client.isOutputClosed()) {
       client
           .sendClose(WebSocket.NORMAL_CLOSURE, CLIENT_DISCONNECT_MESSAGE)

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnectionListener.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnectionListener.java
@@ -6,5 +6,5 @@ interface WebSocketConnectionListener {
 
   void connectionClosed(String reason);
 
-  void handleError(Exception exception);
+  void handleError(Throwable error);
 }

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebsocketListenerFactory.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebsocketListenerFactory.java
@@ -40,7 +40,7 @@ public class WebsocketListenerFactory {
           final Consumer<String> errorHandler,
           final ListenersTypeT listeners) {
 
-    final URI websocketUri = URI.create(serverUri.toString().replaceFirst("^http", "ws") + path);
+    final URI websocketUri = URI.create(serverUri + path);
     final GenericWebSocketClient genericWebSocketClient =
         new GenericWebSocketClient(websocketUri, errorHandler);
 

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebsocketListenerFactory.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebsocketListenerFactory.java
@@ -40,7 +40,7 @@ public class WebsocketListenerFactory {
           final Consumer<String> errorHandler,
           final ListenersTypeT listeners) {
 
-    final URI websocketUri = URI.create(serverUri + path);
+    final URI websocketUri = URI.create(serverUri.toString().replaceFirst("^http", "ws") + path);
     final GenericWebSocketClient genericWebSocketClient =
         new GenericWebSocketClient(websocketUri, errorHandler);
 

--- a/http-clients/src/test/java/org/triplea/http/client/web/socket/GenericWebSocketClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/web/socket/GenericWebSocketClientTest.java
@@ -101,16 +101,16 @@ class GenericWebSocketClientTest {
     @DisplayName("Verify 'https' protocol when present is swapped to 'wss'")
     void swapHttpsProtocol() {
       final URI inputUri = URI.create("https://uri.com");
-      final URI updated = GenericWebSocketClient.swapHttpsToWssProtocol(inputUri);
+      final URI updated = GenericWebSocketClient.swapHttpToWsProtocol(inputUri);
       assertThat(updated, is(URI.create("wss://uri.com")));
     }
 
     @Test
-    @DisplayName("Verify swap is a no-op with 'http' protocol")
+    @DisplayName("Verify 'http' protocol when present is swapped to 'ws'")
     void swapHttpProtocol() {
       final URI inputUri = URI.create("http://uri.com");
-      final URI updated = GenericWebSocketClient.swapHttpsToWssProtocol(inputUri);
-      assertThat(updated, is(inputUri));
+      final URI updated = GenericWebSocketClient.swapHttpToWsProtocol(inputUri);
+      assertThat(updated, is("ws://uri.com"));
     }
   }
 }

--- a/http-clients/src/test/java/org/triplea/http/client/web/socket/GenericWebSocketClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/web/socket/GenericWebSocketClientTest.java
@@ -110,7 +110,7 @@ class GenericWebSocketClientTest {
     void swapHttpProtocol() {
       final URI inputUri = URI.create("http://uri.com");
       final URI updated = GenericWebSocketClient.swapHttpToWsProtocol(inputUri);
-      assertThat(updated, is("ws://uri.com"));
+      assertThat(updated, is(URI.create("ws://uri.com")));
     }
   }
 }

--- a/http-clients/src/test/java/org/triplea/http/client/web/socket/GenericWebSocketClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/web/socket/GenericWebSocketClientTest.java
@@ -2,15 +2,12 @@ package org.triplea.http.client.web.socket;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 import com.google.gson.Gson;
 import java.net.URI;
-import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -48,7 +45,6 @@ class GenericWebSocketClientTest {
 
   @BeforeEach
   void setup() {
-    when(webSocketClient.connect(any(), any())).thenReturn(new CompletableFuture<>());
     genericWebSocketClient = new GenericWebSocketClient(webSocketClient, errMsg -> {});
     genericWebSocketClient.registerListenerAndConnect(messageListener);
     genericWebSocketClient.addConnectionClosedListener(connectionClosedListener);

--- a/http-clients/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
@@ -66,7 +66,6 @@ class WebSocketConnectionTest {
       listener.onText(mock(WebSocket.class), "2", false);
       listener.onText(mock(WebSocket.class), "3", true);
 
-
       verify(webSocketConnectionListener).messageReceived("123");
     }
 
@@ -78,7 +77,6 @@ class WebSocketConnectionTest {
       listener.onText(mock(WebSocket.class), "3", true);
       listener.onText(mock(WebSocket.class), "4", false);
       listener.onText(mock(WebSocket.class), "5", true);
-
 
       verify(webSocketConnectionListener).messageReceived("123");
       verify(webSocketConnectionListener).messageReceived("45");

--- a/http-clients/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
@@ -8,6 +8,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -212,8 +213,7 @@ class WebSocketConnectionTest {
       requiresCloseAction();
       webSocketConnection.close();
 
-      verify(webSocket)
-          .sendClose(WebSocket.NORMAL_CLOSURE, WebSocketConnection.CLIENT_DISCONNECT_MESSAGE);
+      verify(webSocket).sendClose(eq(WebSocket.NORMAL_CLOSURE), any());
       assertThat(webSocketConnection.getPingSender().isRunning(), is(false));
     }
 

--- a/http-clients/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
@@ -1,6 +1,7 @@
 package org.triplea.http.client.web.socket;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -12,6 +13,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.WebSocket;
@@ -183,9 +185,13 @@ class WebSocketConnectionTest {
     @Test
     @DisplayName("Verify connect failing invokes error handler and pinger is not running")
     void connectionFailure() {
-      assertThrows(
-          ExecutionException.class,
-          () -> webSocketConnection.connect(webSocketConnectionListener, errorHandler).get());
+      // ExecutionException is thrown by Future#get when the future fails with an exception.
+      final Exception exception =
+          assertThrows(
+              ExecutionException.class,
+              () -> webSocketConnection.connect(webSocketConnectionListener, errorHandler).get());
+
+      assertThat(exception.getCause(), is(instanceOf(IOException.class)));
 
       verifyPingerNotStarted();
       verifyErrorHandlerWasCalled();

--- a/http-clients/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
@@ -1,9 +1,7 @@
 package org.triplea.http.client.web.socket;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -14,13 +12,11 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.WebSocket;
 import java.time.Duration;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -148,10 +144,8 @@ class WebSocketConnectionTest {
     void connectWillInitiateConnection() throws Exception {
       final HttpClient httpClient = mockHttpClient();
       webSocketConnection.setHttpClient(httpClient);
-      final WebSocket webSocket =
-          webSocketConnection.connect(webSocketConnectionListener, errorHandler).get();
+      webSocketConnection.connectInternal(webSocketConnectionListener, errorHandler).get();
 
-      assertThat(webSocket, is(this.webSocket));
       verify(httpClient.newWebSocketBuilder())
           .connectTimeout(Duration.ofMillis(WebSocketConnection.DEFAULT_CONNECT_TIMEOUT_MILLIS));
       verifyPingerIsStarted();
@@ -180,14 +174,8 @@ class WebSocketConnectionTest {
 
     @Test
     @DisplayName("Verify connect failing invokes error handler and pinger is not running")
-    void connectionFailure() {
-      // ExecutionException is thrown by Future#get when the future fails with an exception.
-      final Exception exception =
-          assertThrows(
-              ExecutionException.class,
-              () -> webSocketConnection.connect(webSocketConnectionListener, errorHandler).get());
-
-      assertThat(exception.getCause(), is(instanceOf(IOException.class)));
+    void connectionFailure() throws Exception {
+      webSocketConnection.connectInternal(webSocketConnectionListener, errorHandler).get();
 
       verifyPingerNotStarted();
       verifyErrorHandlerWasCalled();

--- a/http-clients/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
@@ -153,10 +153,10 @@ class WebSocketConnectionTest {
     void connectWillInitiateConnection() throws Exception {
       final HttpClient httpClient = mockHttpClient();
       webSocketConnection.setHttpClient(httpClient);
-      final WebSocket connected =
+      final WebSocket webSocket =
           webSocketConnection.connect(webSocketConnectionListener, errorHandler).get();
 
-      assertThat(connected, is(webSocket));
+      assertThat(webSocket, is(this.webSocket));
       verify(httpClient.newWebSocketBuilder())
           .connectTimeout(Duration.ofMillis(WebSocketConnection.DEFAULT_CONNECT_TIMEOUT_MILLIS));
       verifyPingerIsStarted();

--- a/http-clients/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
@@ -40,11 +40,13 @@ class WebSocketConnectionTest {
   class WebSocketClientCallbacks {
     @Mock private WebSocketConnectionListener webSocketConnectionListener;
     private WebSocketConnection webSocketConnection;
+    private WebSocket.Listener listener;
 
     @BeforeEach
     void setup() {
       webSocketConnection = new WebSocketConnection(INVALID_URI);
       webSocketConnection.connect(webSocketConnectionListener, err -> {});
+      listener = webSocketConnection.getWebSocketListener();
     }
 
     @AfterEach
@@ -54,13 +56,12 @@ class WebSocketConnectionTest {
 
     @Test
     void onMessage() {
-      webSocketConnection.getWebSocketListener().onText(mock(WebSocket.class), MESSAGE, true);
+      listener.onText(mock(WebSocket.class), MESSAGE, true);
       verify(webSocketConnectionListener).messageReceived(MESSAGE);
     }
 
     @Test
     void verifyListenerAccumulatesMessagesUntilLast() {
-      final WebSocket.Listener listener = webSocketConnection.getWebSocketListener();
       listener.onText(mock(WebSocket.class), "1", false);
       listener.onText(mock(WebSocket.class), "2", false);
       listener.onText(mock(WebSocket.class), "3", true);
@@ -70,7 +71,6 @@ class WebSocketConnectionTest {
 
     @Test
     void verifyListenerClearsMessageCorrectly() {
-      final WebSocket.Listener listener = webSocketConnection.getWebSocketListener();
       listener.onText(mock(WebSocket.class), "1", false);
       listener.onText(mock(WebSocket.class), "2", false);
       listener.onText(mock(WebSocket.class), "3", true);
@@ -83,13 +83,13 @@ class WebSocketConnectionTest {
 
     @Test
     void onClose() {
-      webSocketConnection.getWebSocketListener().onClose(mock(WebSocket.class), 0, REASON);
+      listener.onClose(mock(WebSocket.class), 0, REASON);
       verify(webSocketConnectionListener).connectionClosed(REASON);
     }
 
     @Test
     void onError() {
-      webSocketConnection.getWebSocketListener().onError(mock(WebSocket.class), exception);
+      listener.onError(mock(WebSocket.class), exception);
       verify(webSocketConnectionListener).handleError(exception);
     }
 
@@ -102,7 +102,7 @@ class WebSocketConnectionTest {
       verify(mockedWebSocket, never()).sendText(any(), anyBoolean());
 
       // onOpen should trigger message send
-      webSocketConnection.getWebSocketListener().onOpen(mockedWebSocket);
+      listener.onOpen(mockedWebSocket);
 
       verify(mockedWebSocket).sendText(any(), anyBoolean());
     }

--- a/http-clients/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
@@ -46,7 +46,7 @@ class WebSocketConnectionTest {
     void setup() {
       webSocketConnection = new WebSocketConnection(INVALID_URI);
       webSocketConnection.connect(webSocketConnectionListener, err -> {});
-      listener = webSocketConnection.getWebSocketListener();
+      listener = webSocketConnection.getInternalListener();
     }
 
     @AfterEach
@@ -194,7 +194,7 @@ class WebSocketConnectionTest {
     @Test
     @DisplayName("Close will close the underlying socket and stops the pinger")
     void close() {
-      webSocketConnection.getWebSocketListener().onOpen(webSocket);
+      webSocketConnection.getInternalListener().onOpen(webSocket);
       when(webSocket.sendClose(anyInt(), any()))
           .thenReturn(CompletableFuture.completedFuture(null));
       webSocketConnection.close();
@@ -207,7 +207,7 @@ class WebSocketConnectionTest {
     @DisplayName("Send will send messages if connection is open")
     void sendMessage() {
       requiresSendTextAction();
-      webSocketConnection.getWebSocketListener().onOpen(webSocket);
+      webSocketConnection.getInternalListener().onOpen(webSocket);
       webSocketConnection.setConnectionIsOpen(true);
 
       webSocketConnection.sendMessage(MESSAGE);

--- a/http-clients/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
@@ -138,11 +138,6 @@ class WebSocketConnectionTest {
           .thenReturn(CompletableFuture.completedFuture(null));
     }
 
-    private void requiresCloseAction() {
-      when(webSocket.sendClose(anyInt(), any()))
-          .thenReturn(CompletableFuture.completedFuture(null));
-    }
-
     @AfterEach
     void tearDown() {
       webSocketConnection.getPingSender().cancel();
@@ -210,7 +205,8 @@ class WebSocketConnectionTest {
     @DisplayName("Close will close the underlying socket and stops the pinger")
     void close() {
       webSocketConnection.getWebSocketListener().onOpen(webSocket);
-      requiresCloseAction();
+      when(webSocket.sendClose(anyInt(), any()))
+          .thenReturn(CompletableFuture.completedFuture(null));
       webSocketConnection.close();
 
       verify(webSocket).sendClose(eq(WebSocket.NORMAL_CLOSURE), any());


### PR DESCRIPTION
<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 

When looking at #6027 it seems like the Java-WebSocket dependency introduced the SLF4J dependency according to gradle (`gradle game-headless:dependencies`).

So I decided to use the default JDK API for websockets instead. It works slightly different with some gotchas and more fine grained control, but I verified it actually works.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  #6027 (Haven't actually verified that, but it no longer has the dependency)
[] Other:   <!-- Please specify -->


## Testing
<!--
  Describe any manual testing performed below. 
-->

I verified I could join the lobby and send some chat messages (it uses the same code)

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

