### PR TITLE
Update infrastructure to be able to deloy 1.9 bots

### DIFF
--- a/.travis/stages/deploy/production/run
+++ b/.travis/stages/deploy/production/run
@@ -11,6 +11,5 @@ ansible-vault view --vault-password-file="$VAULT_PASSWORD_FILE" ansible_ssh_key.
 
 ansible-playbook \
   -i ansible/inventory/production \
-  -t admin_user \
- ansible/site.yml
+  ansible/site.yml
 

--- a/infrastructure/Vagrantfile
+++ b/infrastructure/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/bionic64"
+  config.vm.box = "bento/ubuntu-19.04"
 
   config.vm.define "vagrantHost" do |vagrantHost|
     vagrantHost.vm.network "forwarded_port", guest: 22, host: 2010, host_ip: "127.0.0.1", id: "ssh"

--- a/infrastructure/ansible/group_vars/all.yml
+++ b/infrastructure/ansible/group_vars/all.yml
@@ -9,3 +9,5 @@ lobby_db_name: lobby_db
 lobby_db_user: lobby_user
 version: "{{ lookup('env', 'VERSION') }}"
 
+admin_user: "admin"
+admin_home: "/home/{{ admin_user }}"

--- a/infrastructure/ansible/group_vars/prerelease.yml
+++ b/infrastructure/ansible/group_vars/prerelease.yml
@@ -1,2 +1,3 @@
 lobby_uri: "https://prerelease.triplea-game.org"
-
+using_latest: true
+bot_numbers: ["01", "02"]

--- a/infrastructure/ansible/group_vars/production.yml
+++ b/infrastructure/ansible/group_vars/production.yml
@@ -1,1 +1,20 @@
 lobby_uri: "https://production.triplea-game.org"
+version: "1.9.0.0.12226"
+using_latest: false
+java_version: "openjdk-8-jdk-headless"
+
+bot_run_args:
+  triplea.game: ""
+  triplea.lobby.game.comments: "automated_host"
+  triplea.lobby.game.hostedBy: "Bot{{ bot_prefix }}${BOT_NUMBER}_{{ bot_name }}"
+  triplea.lobby.game.reconnection: "172800"
+  triplea.lobby.game.supportEmail: "do-not-send@triplea-game.org"
+  triplea.lobby.game.supportPassword: ""
+  triplea.lobby.host: "lobby.triplea-game.org"
+  triplea.lobby.port: "3304"
+  triplea.lobby.uri: "{{ bot_lobby_uri }}"
+  triplea.map.folder: "{{ bot_maps_folder }}"
+  triplea.name: "Bot{{ bot_prefix }}${BOT_NUMBER}_{{ bot_name }}"
+  triplea.port: "${BOT_PORT}"
+  triplea.server.password: ""
+  triplea.server: "true"

--- a/infrastructure/ansible/group_vars/vagrant.yml
+++ b/infrastructure/ansible/group_vars/vagrant.yml
@@ -6,3 +6,18 @@ lobby_uri: "http://localhost:8080"
 lobby_db_password: "vagrant-db-password"
 nginx_ssl_certificate: "/vagrant/.vagrant/{{ lookup('env','CRT_FILE') }}"
 
+bot_numbers: ["01", "02"]
+bot_run_args:
+  triplea.game: ""
+  triplea.lobby.game.comments: "automated_host"
+  triplea.lobby.game.hostedBy: "{{ bot_name }}-${BOT_NUMBER}"
+  triplea.lobby.game.supportEmail: "do-not-send@triplea-game.org"
+  triplea.lobby.game.supportPassword: ""
+  triplea.lobby.host: "localhost"
+  triplea.lobby.port: "3304"
+  triplea.map.folder: "$MAPS_FOLDER"
+  triplea.name: "{{ bot_name }}-${BOT_NUMBER}"
+  triplea.port: "${BOT_PORT}"
+  triplea.server: true
+  triplea.server.password: ""
+  triplea.lobby.game.reconnection: "172800"

--- a/infrastructure/ansible/inventory/production
+++ b/infrastructure/ansible/inventory/production
@@ -1,14 +1,13 @@
 [postgresHosts]
-lobby.triplea-game.org
 
 [dropwizardHosts]
-lobby.triplea-game.org
 
 [botHosts]
-bot01.triplea-game.org
-bot02.triplea-game.org
-bot03.triplea-game.org
-bot04.triplea-game.org
+bot05.triplea-game.org  bot_prefix=1  bot_name=Dallas
+bot06.triplea-game.org  bot_prefix=7  bot_name=London
+bot07.triplea-game.org  bot_prefix=8  bot_name=California
+bot08.triplea-game.org  bot_prefix=9  bot_name=NewJersey
+bot09.triplea-game.org  bot_prefix=2  bot_name=Toronto
 
 [forums]
 forums.triplea-game.org
@@ -23,5 +22,4 @@ forums
 production
 
 [letsEncrypt:children]
-dropwizardHosts
 

--- a/infrastructure/ansible/roles/admin_user/defaults/main.yml
+++ b/infrastructure/ansible/roles/admin_user/defaults/main.yml
@@ -1,1 +1,0 @@
-admin_user: admin

--- a/infrastructure/ansible/roles/admin_user/tasks/main.yml
+++ b/infrastructure/ansible/roles/admin_user/tasks/main.yml
@@ -25,7 +25,7 @@
 - name: create ssh directory
   become: true
   file:
-    path: "/home/{{ admin_user }}/.ssh/"
+    path: "{{ admin_home }}/.ssh/"
     state: directory
     mode: "700"
     owner: "{{ admin_user }}"
@@ -35,7 +35,7 @@
   become: true
   copy:
     src: authorized_keys
-    dest: "/home/{{ admin_user }}/.ssh/authorized_keys"
+    dest: "{{ admin_home }}/.ssh/authorized_keys"
     mode: "600"
     owner: "{{ admin_user }}"
     group: "{{ admin_user }}"

--- a/infrastructure/ansible/roles/bot/defaults/main.yml
+++ b/infrastructure/ansible/roles/bot/defaults/main.yml
@@ -1,19 +1,45 @@
 bot_user: "bot"
-
 bot_folder: "/home/{{ bot_user }}"
 
-bot_jar: "triplea-game-headless-{{ version }}.jar"
+# The location where we will install the bot binaries
+bot_install_home: "{{ bot_folder }}/{{ version }}"
 
+# The location of the jar executable that we will run to launch the bot server.
+bot_jar: "{{ bot_install_home }}/triplea-game-headless-{{ version }}.jar"
+
+# A folder where the bot server will find maps.
 bot_maps_folder: "{{ bot_folder }}/maps"
 
+# The URI of the lobby that the bot would connect to.
 bot_lobby_uri: "{{ lobby_uri }}"
 
 bot_max_memory: "168m"
 
-bot_name: "BotServer"
+# Each bot number matches a bot instance that will be deployed and started.
+# 7 bots is standard for the 2GB RAM, $10/month linodes that we typically use.
+bot_numbers: ["01", "02", "03", "04", "05", "06", "07"]
 
-bot_ports:
-  - 4001
-  - 4002
-  - 4003
-  - 4004
+# Bot prefix we expect to be overriden in inventory.
+# We deploy bots to multiple server, to keep the host numbers unique, there is a prefix.
+# The bot prefix should be unique across all bot hosts.
+# EG: with bot_prefix = 1, and bot_number=01, the bot number in the bot name will be '101'.
+bot_prefix: ""
+
+# Using latest flag indicates we should use assets that are built locally. False indicates we
+# will download assets for a target version.
+using_latest: true
+
+# Download URL for grabbing bot artifacts, not used if using_latest is false.
+zip_download: "https://github.com/triplea-game/triplea/releases/download/{{ version }}/triplea-game-headless-{{ version }}.zip"
+
+# Name of the bot server, this will typically be overriden in inventory. The final name of the bot host is
+# concatenation of the "Bot" the "bot name", and the "bot number" with prefix.
+bot_name: "Server"
+
+# Arguments when running bot servers. Each of the key value pairs will be added as a '-p{key}={value}' argument
+# passed to the JVM when running the bot.
+bot_run_args:
+  triplea.port: "${BOT_PORT}"
+  triplea.name: "Bot{{ bot_prefix }}${BOT_NUMBER}_{{ bot_name }}"
+  triplea.lobby.uri: "{{ bot_lobby_uri }}"
+  triplea.map.folder: "{{ bot_maps_folder }}"

--- a/infrastructure/ansible/roles/bot/tasks/main.yml
+++ b/infrastructure/ansible/roles/bot/tasks/main.yml
@@ -1,3 +1,17 @@
+- name: allow ports
+  become: true
+  ufw:
+    rule: allow
+    port: "40{{ item }}"
+    proto: tcp
+  with_items: "{{ bot_numbers }}"
+
+- name: apt install unzip
+  become: true
+  apt:
+    name: unzip
+    state: present
+
 - name: create service user to run the app
   become: true
   user:
@@ -5,20 +19,77 @@
     create_home: yes
     system: yes
 
-- name: deploy jar file
+- name: deploy scripts to admin home
+  become: true
+  template:
+    src: "{{ item }}.j2"
+    dest: "{{ admin_home }}/{{ item }}"
+    owner: "{{ admin_user }}"
+    group: "{{ admin_user }}"
+    mode: "0755"
+  with_items:
+    - start-all
+    - stop-all
+    - download-all-maps
+
+- name: create maps folder
+  become: true
+  file:
+    state: directory
+    path: "{{ item }}"
+    mode: "0755"
+    owner: "{{ bot_user }}"
+    group: "{{ bot_user }}"
+  with_items:
+    - "{{ bot_install_home }}"
+    - "{{ bot_maps_folder }}"
+
+- name: deploy jar file if using latest
+  when: using_latest
   become: true
   copy:
-    src: "{{ bot_jar }}"
-    dest: "{{ bot_folder }}/{{ bot_jar }}"
+    src: "triplea-game-headless-{{ version }}-all.jar"
+    dest: "{{ bot_jar }}"
     owner: "{{ bot_user }}"
     group: "{{ bot_user }}"
 
-- name: install systemd service script
+- name: create triplea-root touch file
   become: true
-  template:
-    src: bot.service.j2
-    dest: /lib/systemd/system/bot@.service
-    mode: "644"
+  file:
+    state: touch
+    path: "{{ bot_install_home }}/.triplea-root"
+    mode: "0644"
+    owner: "{{ bot_user }}"
+    group: "{{ bot_user }}"
+
+- name: download zip file if not using latest
+  when: not using_latest
+  become: true
+  get_url:
+    url: "{{ zip_download }}"
+    dest: "{{ bot_install_home }}/triplea-game-headless-{{ version }}.zip"
+    owner: "{{ bot_user }}"
+    group: "{{ bot_user }}"
+
+- name: extract zip file if not using latest
+  when: not using_latest
+  become: true
+  unarchive:
+    remote_src: yes
+    src: "{{ bot_install_home }}/triplea-game-headless-{{ version }}.zip"
+    dest: "{{ bot_install_home }}/"
+    owner: "{{ bot_user }}"
+    group: "{{ bot_user }}"
+
+- name: move jar file to expected location if not using latest
+  when: not using_latest
+  become: true
+  copy:
+    remote_src: true
+    src: "{{ bot_install_home }}/bin/triplea-game-headless-{{ version }}-all.jar"
+    dest: "{{ bot_jar }}"
+    owner: "{{ bot_user }}"
+    group: "{{ bot_user }}"
 
 - name: deploy run_server script
   become: true
@@ -29,29 +100,32 @@
     owner: "{{ bot_user }}"
     group: "{{ bot_user }}"
 
-- name: allow ports
+- name: install systemd service script
   become: true
-  ufw:
-    rule: allow
-    port: "{{ item }}"
-    proto: tcp
-  with_items: "{{ bot_ports }}"
+  template:
+    src: bot.service.j2
+    dest: /lib/systemd/system/bot@.service
+    mode: "644"
 
 - name: reload systemd
   become: true
   systemd:
     daemon_reload: yes
 
-- name: enable and start bot01
+- name: restart bots if deploying latest
+  when: using_latest
   become: true
   service:
-    name: "bot@01"
-    state: started
+    name: "bot@{{ item }}"
+    state: restarted
     enabled: yes
+  with_items: "{{ bot_numbers }}"
 
-- name: enable and start bot02
+- name: enable and ensure bots are started
+  when: not using_latest
   become: true
   service:
-    name: "bot@02"
+    name: "bot@{{ item }}"
     state: started
     enabled: yes
+  with_items: "{{ bot_numbers }}"

--- a/infrastructure/ansible/roles/bot/templates/download-all-maps.j2
+++ b/infrastructure/ansible/roles/bot/templates/download-all-maps.j2
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+## note:
+##  -  it appears that it takes some time for a repo to show up in an orgs repo list
+##  -  the curl call below is rate limited, not intended for repeated invocations
+
+# Usage:
+# - Simply execute this script without any arguments
+
+sudo -u {{ bot_user }} mkdir -p {{ bot_maps_folder }}
+cd {{ bot_maps_folder }}
+for j in 1 2; do
+  while read mapRepo; do
+    downloadFile="$(echo $mapRepo | sed 's|.*/||')-master.zip"
+    sudo -u {{ bot_user }} wget -O "$downloadFile" "https://github.com/$mapRepo/archive/master.zip"
+  done < <(curl --silent "https://api.github.com/orgs/triplea-maps/repos?page=$j&per_page=1000" \
+          | grep full_name | sed 's/.*: "//' | sed 's/",$//')
+done

--- a/infrastructure/ansible/roles/bot/templates/run_server.j2
+++ b/infrastructure/ansible/roles/bot/templates/run_server.j2
@@ -31,7 +31,7 @@ java -server \
     -Xmx{{ bot_max_memory }} \
     -Djava.awt.headless=true \
     -jar {{ bot_jar }} \
-    -Ptriplea.port=${BOT_PORT} \
-    -Ptriplea.name={{ bot_name }}-${BOT_NUMBER} \
-    -Ptriplea.lobby.uri={{ bot_lobby_uri }} \
-    -Ptriplea.map.folder={{ bot_maps_folder }}
+{% for key,value in bot_run_args.items()|sort(attribute='1') %}
+  -P{{ key }}={{ value }} \
+{% endfor %}
+

--- a/infrastructure/ansible/roles/bot/templates/start-all.j2
+++ b/infrastructure/ansible/roles/bot/templates/start-all.j2
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+{% for item in bot_numbers %}
+sudo service bot@{{ item }} start
+{% endfor %}

--- a/infrastructure/ansible/roles/bot/templates/stop-all.j2
+++ b/infrastructure/ansible/roles/bot/templates/stop-all.j2
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+{% for item in bot_numbers %}
+sudo service bot@{{ item }} stop
+{% endfor %}

--- a/infrastructure/ansible/roles/java/defaults/main.yml
+++ b/infrastructure/ansible/roles/java/defaults/main.yml
@@ -1,0 +1,1 @@
+java_version: "openjdk-11-jre-headless"

--- a/infrastructure/ansible/roles/java/tasks/main.yml
+++ b/infrastructure/ansible/roles/java/tasks/main.yml
@@ -1,5 +1,6 @@
-- name: install openjdk-11-jre
+- name: install java
   become: true
   apt:
     state: present
-    name: openjdk-11-jre-headless
+    update_cache: true
+    name: "{{ java_version }}"

--- a/infrastructure/ansible/site.yml
+++ b/infrastructure/ansible/site.yml
@@ -15,7 +15,7 @@
         - nginx
         - http_server
     - name: admin_user
-      tags: [ admin_user ]
+      tags: [ admin_user, bots ]
     - name: firewall
       tags: [ firewall ]
     - name: security
@@ -66,6 +66,7 @@
   serial: 100%
   tags: bots
   roles:
+    - admin_user
+    - firewall
     - java
-    - role: bot
-      tags: [ bot ]
+    - bot


### PR DESCRIPTION
- Update production inventory to reflect servers that are fully managed by ansible
  deployments. We can deploy admin keys as a one-off by hand to other servers
  as needed. Otherwise now we will have bot updates take effect after merges.
- Update production overrides to reflect 1.9 servers. When creating a 2.0 production,
  we will probably want to create as second production inventory file to keep
  the server configurations different.
- Parameterize the bot args and define one set of args for 1.9 in production.yml
  group_vars, an override that applies to servers only in production.yml. Otherwise
  the default vars are appropriate for 2.0 servers.
- Add an important 'using_latest' parameter to allow bot servers to either
  use a latest 'jar' file build or when 'using_latest' is false to download
  a target jar file version. This parameter allows for deployments of arbitrary
  versions. To support this, we override and fix the version value in production.
- Use version 1.9.0.0.12226 for production bots, the latest stable jar build (13066)
  has an inadvertent AWT (headed) dependency and fails on startup.


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Describe any manual testing performed below. 
-->



<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->

## Additional Review Notes
- Mostly checking in code that was used to launch the latest new 1.9 bot servers
- Review focusing on consistency and any clarity names/text is welcome
- The 'download-all-maps' script is based on the 'clone-all-maps' script located in maps repo: https://github.com/triplea-maps/admin_scripts/blob/master/bin/clone_all.sh
- I plan to follow-up with another PR with documentation on how to set up linodes for bot servers and which commands to run to get the servers configured and running. As is, if we add a bot server to the production inventory, it will be launched, will have admin scripts (and will have no maps on it, but only need to SSH to it and run the 'download-all-maps' script).

