### PR TITLE
Clear lobby_user table explicitly in test data to avoid FK removal error

### DIFF
--- a/http-server/src/test/resources/datasets/lobby_api_key/delete_old_keys_before.yml
+++ b/http-server/src/test/resources/datasets/lobby_api_key/delete_old_keys_before.yml
@@ -1,3 +1,5 @@
+lobby_user:
+
 user_role:
   - id: 1
     name: ANONYMOUS


### PR DESCRIPTION
In theory the 'clean-before' flag should be dropping data before new data is inserted.
This is not consistent currently, this update removes data from 'lobby_user' table
to avoid FK error when new data is deleted and then re-inserted into 'user_role'


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
<!--
  Describe any manual testing performed below. 
-->



<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

