### PR TITLE
Bot deploy fixes & automatically DL missing maps

### DIFF
--- a/infrastructure/ansible/roles/bot/tasks/main.yml
+++ b/infrastructure/ansible/roles/bot/tasks/main.yml
@@ -44,6 +44,10 @@
     - "{{ bot_install_home }}"
     - "{{ bot_maps_folder }}"
 
+- name: download maps on bot server
+  become: true
+  command: "{{ admin_home }}/download-all-maps"
+
 - name: deploy jar file if using latest
   when: using_latest
   become: true

--- a/infrastructure/ansible/roles/bot/tasks/main.yml
+++ b/infrastructure/ansible/roles/bot/tasks/main.yml
@@ -52,7 +52,7 @@
   when: using_latest
   become: true
   copy:
-    src: "triplea-game-headless-{{ version }}-all.jar"
+    src: "triplea-game-headless-{{ version }}.jar"
     dest: "{{ bot_jar }}"
     owner: "{{ bot_user }}"
     group: "{{ bot_user }}"

--- a/infrastructure/ansible/roles/bot/templates/download-all-maps.j2
+++ b/infrastructure/ansible/roles/bot/templates/download-all-maps.j2
@@ -12,7 +12,9 @@ cd {{ bot_maps_folder }}
 for j in 1 2; do
   while read mapRepo; do
     downloadFile="$(echo $mapRepo | sed 's|.*/||')-master.zip"
-    sudo -u {{ bot_user }} wget -O "$downloadFile" "https://github.com/$mapRepo/archive/master.zip"
+    if [ ! -e "$downloadFile" ]; then
+      sudo -u {{ bot_user }} wget -O "$downloadFile" "https://github.com/$mapRepo/archive/master.zip"
+    fi
   done < <(curl --silent "https://api.github.com/orgs/triplea-maps/repos?page=$j&per_page=1000" \
           | grep full_name | sed 's/.*: "//' | sed 's/",$//')
 done


### PR DESCRIPTION
## Fixes:
-  https://github.com/triplea-game/triplea/issues/6040 Pre-Release Bot Server has No Available Games
- https://github.com/triplea-game/triplea/issues/6078 Travis Master Branch Build Failed 

## Commits
commit b21328835375064317ab7c0808820a78ac78866b

    Configure bots to download maps

commit cdcbe3a2f57de685bc7b6530dc493ed0c8a4c872

    Update download map script to only download missing maps.

commit aefd1584c3aef2ca15f864c8fb47271c14855b16 

    Fix bot jar local path, when bulding from source we do not expect to have a "-all.jar" suffix but instead a simple ".jar" suffix


<!-- 
  Commit comment above summarizing the update.  If multiple commits please 
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
--> 


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


## Testing
Ran deployment against prerelease, verified:
 - maps are downloaded to maps folder
 - jar file path looks good




<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


<!-- 
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

