### PR TITLE
Document ChatHistory and reduce chat cache size from 1000 to 50

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/Chat.java
@@ -35,9 +35,14 @@ public class Chat implements ChatClient {
 
   private final Collection<ChatParticipant> chatters = new HashSet<>();
 
+  /**
+   * ChatHistory is used to copy chat contents from a game staging screen to an actual game once it
+   * has started. For examples, players will chat during the staging screen, click play, then
+   * in-game there is a new chat and we'll copy the history messages to that new chat.
+   */
   @Getter
   private final Collection<ChatMessage> chatHistory =
-      Collections.synchronizedCollection(EvictingQueue.create(1000));
+      Collections.synchronizedCollection(EvictingQueue.create(50));
 
   private final ChatIgnoreList ignoreList = new ChatIgnoreList();
   @Getter private final UserName localUserName;


### PR DESCRIPTION
- It was not very clear how chat history was used, this update adds
  some documentation to describe how 'chatHistory' is used.
- Given that we use chat history to copy recent messages from a staging
  screen to a new game (or vice versa), we do not need the last 1000
  chat messages for this. This update reduces the number of cached
  messages to 50.

