### PR TITLE
Always null parameter API update

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/ChatPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/ChatPanel.java
@@ -53,9 +53,9 @@ public class ChatPanel extends JPanel implements ChatModel {
         .orElseThrow(() -> new IllegalStateException("Error during Chat Panel creation"));
   }
 
-  public void setChat(final Chat chat) {
-    chatMessagePanel.setChat(chat);
-    chatPlayerPanel.setChat(chat);
+  public void deleteChat() {
+    chatMessagePanel.setChat(null);
+    chatPlayerPanel.setChat(null);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -282,7 +282,7 @@ public class ClientModel implements IMessengerErrorListener {
       messenger.shutDown();
       messenger.removeErrorListener(this);
       objectStreamFactory.setData(null);
-      chatPanel.setChat(null);
+      chatPanel.deleteChat();
       hostIsHeadlessBot = false;
       gameSelectorModel.setIsHostHeadlessBot(false);
       gameSelectorModel.setClientModelForHostBots(null);

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -453,7 +453,7 @@ public class ServerModel extends Observable implements IConnectionChangeListener
             new HeadlessChat(new Chat(new MessengersChatTransmitter(CHAT_NAME, messengers)));
       } else {
         final var chatPanel = ChatPanel.newChatPanel(messengers, CHAT_NAME, ChatSoundProfile.GAME);
-        chatModelCancel = () -> chatPanel.setChat(null);
+        chatModelCancel = chatPanel::deleteChat;
         chatModel = chatPanel;
       }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -772,7 +772,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
     uiContext.shutDown();
     if (chatPanel != null) {
       chatPanel.setPlayerRenderer(null);
-      chatPanel.setChat(null);
+      chatPanel.deleteChat();
     }
     if (historySyncher != null) {
       historySyncher.deactivate();


### PR DESCRIPTION
Instead of accepting a 'chat' parameter that is always null
for 'setChat(Chat)', this update renames that method to 'deleteChat()'
and removes the parameter, inlining the null value. This eliminates
a potentially misleading parameter, parameters should typically
be non-null.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

