### PR TITLE
Fix BC Not At War Bug

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -260,6 +260,11 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
   }
 
+  /**
+   * Used by battle results to get the remaining attackers after the battle is completed. It
+   * includes remaining attackers, retreated attackers, and if attacker won/draw then any owned
+   * units left in the territory.
+   */
   @Override
   public List<Unit> getRemainingAttackingUnits() {
     final List<Unit> remaining = new ArrayList<>(attackingUnitsRetreated);
@@ -276,6 +281,11 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     return remaining;
   }
 
+  /**
+   * Used by battle results to get the remaining defenders after the battle is completed. It
+   * includes remaining defenders, retreated defenders, and if defender won/draw then any owned
+   * units and enemy units of the attacker left in the territory.
+   */
   @Override
   public List<Unit> getRemainingDefendingUnits() {
     final Set<Unit> remaining = new HashSet<>(defendingUnitsRetreated);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -278,14 +278,17 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
 
   @Override
   public List<Unit> getRemainingDefendingUnits() {
-    final List<Unit> remaining = new ArrayList<>(defendingUnitsRetreated);
+    final Set<Unit> remaining = new HashSet<>(defendingUnitsRetreated);
+    remaining.addAll(defendingUnits);
     if (getWhoWon() != WhoWon.ATTACKER || attackingUnits.stream().allMatch(Matches.unitIsAir())) {
       final Collection<Unit> unitsLeftInTerritory = battleSite.getUnits();
       unitsLeftInTerritory.removeAll(killed);
       remaining.addAll(
-          CollectionUtils.getMatches(unitsLeftInTerritory, Matches.enemyUnit(attacker, gameData)));
+          CollectionUtils.getMatches(
+              unitsLeftInTerritory,
+              Matches.unitIsOwnedBy(defender).or(Matches.enemyUnit(attacker, gameData))));
     }
-    return remaining;
+    return new ArrayList<>(remaining);
   }
 
   /**


### PR DESCRIPTION
Addresses bug reported here: https://forums.triplea-game.org/topic/1836/release-2-0-prep-and-testing/3

The battle calc had a bug related to simulating battles where 2 nations aren't actually at war yet that is causing the odd AI behavior. You can actually see this yourself if you simulate a battle in global before 2 nations are at war with say 1 UK ship attacking a large Japanese fleet in the BC and you'll see that it shows a draw with all units destroyed. This is now fixed as it properly consider non-enemy (not at war) remaining defenders.

Tested
- Loading the given save game and the AI making more reasonable moves
- Various scenarios with the BC to ensure proper TUV results