### PR TITLE
Update Unit Scroller - Single Row of Buttons

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -4,7 +4,6 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.MoveDescription;
 import games.strategy.engine.data.Unit;
-import games.strategy.engine.framework.LocalPlayers;
 import games.strategy.engine.player.IPlayerBridge;
 import games.strategy.triplea.delegate.UndoableMove;
 import games.strategy.triplea.delegate.remote.IAbstractMoveDelegate;
@@ -59,7 +58,7 @@ abstract class AbstractMovePanel extends ActionPanel {
     }
   }
 
-  abstract Component getUnitScrollerPanel(LocalPlayers localPlayers);
+  abstract Component getUnitScrollerPanel();
 
   /*
    * sub-classes method for done handling
@@ -239,7 +238,6 @@ abstract class AbstractMovePanel extends ActionPanel {
         () -> {
           removeAll();
           add(movedUnitsPanel(gamePlayer, actionLabel));
-          add(getUnitScrollerPanel(frame.getLocalPlayers()));
           refresh.run();
         });
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -8,7 +8,6 @@ import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
-import games.strategy.engine.framework.LocalPlayers;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.TechAttachment;
@@ -56,6 +55,8 @@ import javax.annotation.Nullable;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.KeyStroke;
+import javax.swing.SwingUtilities;
+import lombok.Getter;
 import lombok.Setter;
 import org.triplea.java.ObjectUtils;
 import org.triplea.java.PredicateBuilder;
@@ -100,6 +101,9 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
   private String displayText = "Combat Move";
   private MoveType moveType = MoveType.DEFAULT;
   private final UnitScroller unitScroller;
+
+  @Getter(onMethod_ = @Override)
+  private final Component unitScrollerPanel;
 
   private final UnitSelectionListener unitSelectionListener =
       new UnitSelectionListener() {
@@ -731,6 +735,8 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
     errorImage = getMap().getErrorImage().orElse(null);
 
     unitScroller = new UnitScroller(getData(), getMap(), this::isVisible);
+    unitScrollerPanel = unitScroller.build();
+    unitScrollerPanel.setVisible(false);
   }
 
   // Same as above! Delete this crap after refactoring.
@@ -1494,6 +1500,7 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
     updateRouteAndMouseShadowUnits(null);
     forced = null;
     getMap().showMouseCursor();
+    unitScrollerPanel.setVisible(false);
   }
 
   @Override
@@ -1521,6 +1528,7 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
   @Override
   public final void display(final GamePlayer gamePlayer) {
     super.display(gamePlayer, displayText);
+    SwingUtilities.invokeLater(() -> unitScrollerPanel.setVisible(true));
   }
 
   @Override
@@ -1619,7 +1627,10 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
   }
 
   @Override
-  Component getUnitScrollerPanel(final LocalPlayers localPlayers) {
-    return unitScroller.build(localPlayers, this::highlightMovableUnits);
+  public void performDone() {
+    if (doneMoveAction()) {
+      super.performDone();
+      unitScrollerPanel.setVisible(false);
+    }
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -8,7 +8,6 @@ import games.strategy.engine.data.GameStep;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.events.GameDataChangeListener;
-import games.strategy.engine.framework.LocalPlayers;
 import games.strategy.engine.player.IPlayerBridge;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.PlayerAttachment;
@@ -187,7 +186,7 @@ class PlacePanel extends AbstractMovePanel implements GameDataChangeListener {
   }
 
   @Override
-  Component getUnitScrollerPanel(final LocalPlayers localPlayers) {
+  Component getUnitScrollerPanel() {
     return new JPanel();
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -160,6 +160,7 @@ import org.triplea.swing.EventThreadJOptionPane;
 import org.triplea.swing.JFrameBuilder;
 import org.triplea.swing.SwingAction;
 import org.triplea.swing.SwingComponents;
+import org.triplea.swing.jpanel.JPanelBuilder;
 import org.triplea.thread.ThreadPool;
 import org.triplea.util.ExitStatus;
 import org.triplea.util.LocalizeHtml;
@@ -575,7 +576,14 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
     final MovePanel movePanel = new MovePanel(data, mapPanel, this);
     actionButtons = new ActionButtons(data, mapPanel, movePanel, this);
     final PlacePanel placePanel = actionButtons.getPlacePanel();
-    rightHandSidePanel.add(placePanel.getDetachedUnitsToPlacePanel(), BorderLayout.SOUTH);
+
+    rightHandSidePanel.add(
+        new JPanelBuilder()
+            .borderLayout()
+            .addNorth(movePanel.getUnitScrollerPanel())
+            .addSouth(placePanel.getDetachedUnitsToPlacePanel())
+            .build(),
+        BorderLayout.SOUTH);
 
     addKeyBindings(movePanel, actionButtons);
     SwingUtilities.invokeLater(() -> mapPanel.addKeyListener(getArrowKeyListener()));

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/AvatarPanelFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/AvatarPanelFactory.java
@@ -3,10 +3,8 @@ package games.strategy.triplea.ui.unit.scroller;
 import com.google.common.base.Preconditions;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Unit;
-import games.strategy.triplea.image.FlagIconImageFactory;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.ui.panels.map.MapPanel;
-import games.strategy.triplea.util.UnitCategory;
 import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.awt.image.ImageObserver;
@@ -33,29 +31,21 @@ class AvatarPanelFactory {
   private static final int WIDTH_OFFSET = 12;
 
   private final UnitImageFactory unitImageFactory;
-  private final FlagIconImageFactory flagIconImageFactory;
 
   AvatarPanelFactory(final MapPanel mapPanel) {
     unitImageFactory = mapPanel.getUiContext().getUnitImageFactory();
-    flagIconImageFactory = mapPanel.getUiContext().getFlagImageFactory();
   }
 
   JPanel buildPanel(final List<Unit> units, final GamePlayer currentPlayer) {
-    final Icon unitIcon;
-    final Icon flagIcon;
-    if (units.isEmpty()) {
-      unitIcon = new ImageIcon(createEmptyUnitStackImage());
-      flagIcon = new ImageIcon(createEmptyUnitStackImage());
-    } else {
-      final Unit firstUnit = units.iterator().next();
-      final UnitCategory unitCategory = new UnitCategory(firstUnit.getType(), currentPlayer);
-      unitIcon = new ImageIcon(createUnitStackImage(unitImageFactory, currentPlayer, units));
-      flagIcon = new ImageIcon(flagIconImageFactory.getSmallFlag(unitCategory.getOwner()));
-    }
+    final Icon unitIcon =
+        units.isEmpty()
+            ? new ImageIcon(createEmptyUnitStackImage())
+            : new ImageIcon(createUnitStackImage(unitImageFactory, currentPlayer, units));
 
-    final JLabel unitImage = new JLabel(unitIcon, SwingConstants.CENTER);
-    final JLabel unitCount = new JLabel("x" + units.size(), flagIcon, SwingConstants.CENTER);
-    return new JPanelBuilder().borderLayout().addCenter(unitImage).addSouth(unitCount).build();
+    return new JPanelBuilder() //
+        .borderLayout()
+        .addCenter(new JLabel(unitIcon, SwingConstants.CENTER))
+        .build();
   }
 
   private static Image createEmptyUnitStackImage() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScrollerIcon.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScrollerIcon.java
@@ -2,6 +2,7 @@ package games.strategy.triplea.ui.unit.scroller;
 
 import games.strategy.triplea.ResourceLoader;
 import games.strategy.triplea.image.ImageLoader;
+import java.awt.Image;
 import java.io.File;
 import java.util.function.Supplier;
 import javax.swing.Icon;
@@ -12,9 +13,6 @@ import lombok.AllArgsConstructor;
 /** Class to handle icon paths and getting references to Icon images. */
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 class UnitScrollerIcon implements Supplier<Icon> {
-
-  static final UnitScrollerIcon CENTER_ON_UNIT = new UnitScrollerIcon("center.png");
-  static final UnitScrollerIcon UNIT_HIGHLIGHT = new UnitScrollerIcon("highlight.png");
 
   static final UnitScrollerIcon LEFT_ARROW = new UnitScrollerIcon("left_arrow.png");
   static final UnitScrollerIcon RIGHT_ARROW = new UnitScrollerIcon("right_arrow.png");
@@ -28,6 +26,8 @@ class UnitScrollerIcon implements Supplier<Icon> {
 
   @Override
   public Icon get() {
-    return new ImageIcon(ImageLoader.getImage(new File(IMAGE_PATH, imageFile)));
+    return new ImageIcon(
+        ImageLoader.getImage(new File(IMAGE_PATH, imageFile))
+            .getScaledInstance(20, 20, Image.SCALE_SMOOTH));
   }
 }

--- a/swing-lib/src/main/java/org/triplea/swing/CollapsiblePanel.java
+++ b/swing-lib/src/main/java/org/triplea/swing/CollapsiblePanel.java
@@ -4,6 +4,7 @@ import games.strategy.engine.framework.system.SystemProperties;
 import java.awt.BorderLayout;
 import javax.swing.JButton;
 import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
 
 /**
  * A panel that can be collapsed and expanded via a button at the top of it.
@@ -14,9 +15,14 @@ import javax.swing.JPanel;
 public class CollapsiblePanel extends JPanel {
   private static final long serialVersionUID = 1L;
 
-  private final String title;
+  private static final String COLLAPSED_INDICATOR = " ►";
+  private static final String EXPANDED_INDICATOR = " ▼";
+
   private final JPanel content;
   private final JButton toggleButton;
+
+  private String title;
+  private String currentToggleIndicator = EXPANDED_INDICATOR;
 
   public CollapsiblePanel(final JPanel content, final String title) {
     super();
@@ -41,19 +47,22 @@ public class CollapsiblePanel extends JPanel {
     expand();
   }
 
-  public boolean isExpanded() {
-    return content.isVisible();
-  }
-
   public void collapse() {
-    toggleButton.setText(title + " ►");
+    currentToggleIndicator = COLLAPSED_INDICATOR;
+    toggleButton.setText(title + currentToggleIndicator);
     content.setVisible(false);
     revalidate();
   }
 
   public void expand() {
-    toggleButton.setText(title + " ▼");
+    currentToggleIndicator = EXPANDED_INDICATOR;
+    toggleButton.setText(title + currentToggleIndicator);
     content.setVisible(true);
     revalidate();
+  }
+
+  public void setTitle(final String title) {
+    this.title = title;
+    SwingUtilities.invokeLater(() -> toggleButton.setText(title + currentToggleIndicator));
   }
 }

--- a/swing-lib/src/main/java/org/triplea/swing/JLabelBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/JLabelBuilder.java
@@ -1,7 +1,7 @@
 package org.triplea.swing;
 
-import com.google.common.base.Preconditions;
 import java.awt.Dimension;
+import java.awt.Font;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.swing.Icon;
@@ -30,8 +30,9 @@ public class JLabelBuilder {
   private String toolTip;
   private Border border;
   private Integer borderSize;
+  private int biggerFont;
 
-  private JLabelBuilder() {}
+  public JLabelBuilder() {}
 
   public static JLabelBuilder builder() {
     return new JLabelBuilder();
@@ -41,9 +42,7 @@ public class JLabelBuilder {
    * Constructs a Swing JLabel using current builder values. Values that must be set: text or icon
    */
   public JLabel build() {
-    Preconditions.checkState(text != null || icon != null);
-
-    final JLabel label = new JLabel(text);
+    final JLabel label = text == null ? new JLabel() : new JLabel(text);
 
     Optional.ofNullable(icon).ifPresent(label::setIcon);
 
@@ -54,6 +53,8 @@ public class JLabelBuilder {
             align -> {
               if (align == Alignment.LEFT) {
                 label.setAlignmentX(JComponent.LEFT_ALIGNMENT);
+              } else if (align == Alignment.CENTER) {
+                label.setAlignmentX(JComponent.CENTER_ALIGNMENT);
               }
             });
 
@@ -66,6 +67,13 @@ public class JLabelBuilder {
     Optional.ofNullable(borderSize)
         .ifPresent(size -> label.setBorder(new EmptyBorder(size, size, size, size)));
 
+    if (biggerFont > 0) {
+      label.setFont(
+          new Font(
+              label.getFont().getName(),
+              label.getFont().getStyle(),
+              label.getFont().getSize() + biggerFont));
+    }
     return label;
   }
 
@@ -81,6 +89,11 @@ public class JLabelBuilder {
 
   public JLabelBuilder leftAlign() {
     alignment = Alignment.LEFT;
+    return this;
+  }
+
+  public JLabelBuilder centerAlign() {
+    alignment = Alignment.CENTER;
     return this;
   }
 
@@ -113,7 +126,14 @@ public class JLabelBuilder {
     return this;
   }
 
+  /** Increases button text size by a default amount. */
+  public JLabelBuilder biggerFont() {
+    biggerFont = 4;
+    return this;
+  }
+
   private enum Alignment {
-    LEFT
+    LEFT,
+    CENTER
   }
 }

--- a/swing-lib/src/test/java/org/triplea/swing/JLabelBuilderTest.java
+++ b/swing-lib/src/test/java/org/triplea/swing/JLabelBuilderTest.java
@@ -1,7 +1,6 @@
 package org.triplea.swing;
 
 import static org.hamcrest.core.Is.is;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import javax.swing.JComponent;
 import javax.swing.JLabel;
@@ -28,11 +27,6 @@ class JLabelBuilderTest {
     final int value = 42;
     final JLabel label = JLabelBuilder.builder().text("value").iconTextGap(value).build();
     MatcherAssert.assertThat(label.getIconTextGap(), is(value));
-  }
-
-  @Test
-  void textOrIconIsRequired() {
-    assertThrows(IllegalStateException.class, JLabelBuilder.builder()::build);
   }
 
   @Test


### PR DESCRIPTION
Changes to the unit scroller:
- Put buttons on same row
- Scaled/shrank button images to 20x20
- Removed the unit flag and unit count
- Removed the unit highlight button and center on units button
- Decreased button horizontal gap spacing (now 2 pixels apart rather than 15)
- Fixed up layout so the component does not stretch to fill half of the vertical space of the action tab
- Put the component behind a collapse button, clicking the collapse button shows/hides the component
- Unit scroller is now always visible during combat and non-combat moves
- Made the territory text larger
- Moved the "units left to move count" to be part of the label for "Units To Move (#)"
- Moved the territory label to be below the units rather than above

Fixes:
- The check for if the scroller was visible skipped the computation of selecting
  the current players capitol. This meant the unit scroller was not pre-filled
  with a territory or units. An empty unit scroller is only really expected
  when all units have moved. The problem was introduced in another fix to avoid
  unnecessary computation when the unit scroller is not visible anyways. There
  are a number of other fixes that make that not as much of a problem. For now
  it is necessary to do computation in the unit scroller when it is not visible
  so that when it does become visible, the data in the unit scroller would be
  current.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

- Ran through a few turn phases to be sure that the unit scroller appeared and disappeared at expected times. 
- Exercised the unit scroller buttons, next/previous etc.. and verified behavior when unit movement was exhausted. 
- Verified that on a new player turn the players capitol is the 'current selected' territory and has units. 
- Verified that the units to move count updates/resets.


<!-- If there are UI updates, uncomment and include screenshots below -->
## Screens Shots

### Before

This is an example of the 'bug' that was fixed, on initial render there is no current selection.

![Screenshot from 2020-03-31 00-40-46](https://user-images.githubusercontent.com/12397753/78000858-c10ca800-72e9-11ea-99a0-3bdda6a86297.png)


![Screenshot from 2020-03-31 00-40-59](https://user-images.githubusercontent.com/12397753/78000861-c1a53e80-72e9-11ea-9b62-4fc0bd2b2bb4.png)

### After
![Screenshot from 2020-03-31 00-35-49](https://user-images.githubusercontent.com/12397753/78000876-c7028900-72e9-11ea-9fe5-74ab81441497.png)
![Screenshot from 2020-03-31 00-18-40](https://user-images.githubusercontent.com/12397753/78000975-eac5cf00-72e9-11ea-8deb-d978d42efa6a.png)

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->

## Additional Review Notes

Forums feature thread: https://forums.triplea-game.org/topic/1433/screen-centering-cycling-around-map-ui-idea
