### PR TITLE
Keep Junit launcher at 1.5.2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,7 +105,7 @@ subprojects {
         jlayerVersion = '1.0.1.4'
         junitJupiterVersion = '5.6.1'
         junitPioneerVersion = '0.5.5'
-        junitPlatformLauncherVersion = '1.6.1'
+        junitPlatformLauncherVersion = '1.5.2' // do not upgrade this to beyond 1.5.2 without testing IDEA test runner.
         mockitoVersion = '3.3.3'
         openFeignVersion = '10.5.1'
         postgresqlVersion = '42.2.11'


### PR DESCRIPTION
With higher versions, IDEA can no longer run tests and
encounters an error:

```
org.junit.platform.commons.JUnitException: TestEngine with ID 'junit-vintage' failed to discover tests
Caused by: org.junit.platform.commons.JUnitException: Failed to parse version of junit:junit: 3.8.2
```


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
Verified this version is the difference between being able to run tests and not.
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

