### PR TITLE
Unit Scroller updates

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -22,8 +22,14 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import javax.swing.ImageIcon;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.NoArgsConstructor;
 
 /** A factory for creating unit images. */
+@Builder(toBuilder = true)
+@AllArgsConstructor
+@NoArgsConstructor
 public class UnitImageFactory {
   public static final int DEFAULT_UNIT_ICON_SIZE = 48;
   /**
@@ -48,8 +54,6 @@ public class UnitImageFactory {
   private double scaleFactor;
   private ResourceLoader resourceLoader;
   private MapData mapData;
-
-  public UnitImageFactory() {}
 
   public void setResourceLoader(
       final ResourceLoader loader,

--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -1551,9 +1551,6 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
         KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_S),
         unitScrollerAction(unitScroller::sleepCurrentUnits));
     bindings.put(
-        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_C),
-        unitScrollerAction(unitScroller::centerOnCurrentMovableUnit));
-    bindings.put(
         KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_N),
         unitScrollerAction(unitScroller::centerOnNextMovableUnit));
     bindings.put(

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -15,7 +15,6 @@ import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.triplea.ui.screen.drawable.AbstractDrawable;
 import java.awt.Color;
-import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.Point;

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -196,7 +196,6 @@ public class UnitsDrawer extends AbstractDrawable {
               s,
               x,
               y,
-              MapImage.getPropertyMapFont(),
               MapImage.getPropertyUnitCountColor(),
               MapImage.getPropertyUnitCountOutline());
         }
@@ -215,7 +214,6 @@ public class UnitsDrawer extends AbstractDrawable {
             s,
             x,
             y,
-            MapImage.getPropertyMapFont(),
             MapImage.getPropertyUnitCountColor(),
             MapImage.getPropertyUnitCountOutline());
       }
@@ -255,7 +253,6 @@ public class UnitsDrawer extends AbstractDrawable {
           s,
           x,
           y,
-          MapImage.getPropertyMapFont(),
           MapImage.getPropertyUnitHitDamageColor(),
           MapImage.getPropertyUnitHitDamageOutline());
     }
@@ -273,20 +270,19 @@ public class UnitsDrawer extends AbstractDrawable {
           s,
           x,
           y,
-          MapImage.getPropertyMapFont(),
           MapImage.getPropertyUnitFactoryDamageColor(),
           MapImage.getPropertyUnitFactoryDamageOutline());
     }
   }
 
-  private static void drawOutlinedText(
+  public static void drawOutlinedText(
       final Graphics2D graphics,
       final String s,
       final int x,
       final int y,
-      final Font font,
       final Color textColor,
       final Color outlineColor) {
+    final var font = MapImage.getPropertyMapFont();
     if (font.getSize() > 0) {
       graphics.setRenderingHint(RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON);
       graphics.setFont(font);

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/AvatarPanelFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/AvatarPanelFactory.java
@@ -23,11 +23,6 @@ import org.triplea.swing.jpanel.JPanelBuilder;
  */
 class AvatarPanelFactory {
   /**
-   * Set to be about the maximum height of unit images. Note, unit images can be scaled up and down.
-   */
-  private static final int PANEL_HEIGHT = 70;
-
-  /**
    * Max rendering width is so that the unit scroller image does not stretch too wide. On top of
    * that, once an image has been rendered, the minimum size of the right hand action panels will be
    * equal to the rendering width.
@@ -64,8 +59,9 @@ class AvatarPanelFactory {
         .build();
   }
 
-  private static Image createEmptyUnitStackImage(final int renderingWidth) {
-    return new BufferedImage(renderingWidth, PANEL_HEIGHT, BufferedImage.TYPE_INT_ARGB);
+  private Image createEmptyUnitStackImage(final int renderingWidth) {
+    return new BufferedImage(
+        renderingWidth, unitImageFactory.getUnitImageHeight(), BufferedImage.TYPE_INT_ARGB);
   }
 
   private static Image createUnitStackImage(
@@ -81,7 +77,8 @@ class AvatarPanelFactory {
     final var dimension = unitImageFactory.getImageDimensions(unitsToDraw.get(0).getType(), player);
 
     final var combinedImage =
-        new BufferedImage(renderingWidth, PANEL_HEIGHT, BufferedImage.TYPE_INT_ARGB);
+        new BufferedImage(
+            renderingWidth, unitImageFactory.getUnitImageHeight(), BufferedImage.TYPE_INT_ARGB);
 
     final var graphics = combinedImage.getGraphics();
 
@@ -91,7 +88,7 @@ class AvatarPanelFactory {
             .unitImageHeight(dimension.height)
             .unitImageCount(unitsToDraw.size())
             .renderingWidth(renderingWidth)
-            .renderingHeight(PANEL_HEIGHT)
+            .renderingHeight(unitImageFactory.getUnitImageHeight())
             .build()
             .computeDrawCoordinates();
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/AvatarPanelFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/AvatarPanelFactory.java
@@ -37,7 +37,8 @@ class AvatarPanelFactory {
   private final UnitImageFactory unitImageFactory;
 
   AvatarPanelFactory(final MapPanel mapPanel) {
-    unitImageFactory = mapPanel.getUiContext().getUnitImageFactory();
+    unitImageFactory =
+        mapPanel.getUiContext().getUnitImageFactory().toBuilder().scaleFactor(1.0).build();
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/AvatarPanelFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/AvatarPanelFactory.java
@@ -3,11 +3,16 @@ package games.strategy.triplea.ui.unit.scroller;
 import com.google.common.base.Preconditions;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.image.MapImage;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.ui.panels.map.MapPanel;
+import games.strategy.triplea.ui.screen.UnitsDrawer;
+import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.Point;
 import java.awt.image.BufferedImage;
+import java.util.Collection;
 import java.util.List;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
@@ -28,6 +33,29 @@ class AvatarPanelFactory {
    * equal to the rendering width.
    */
   private static final int MAX_RENDERING_WIDTH = 300;
+
+  /**
+   * Add some extra height to the unit avatar image. This gives us some padding on the top and
+   * bottom of the avatar image and helps the unit count rendering at the bottom of the avatar image
+   * from being cut-off (test this with territories containing multiple subs on NWO).
+   */
+  private static final int EXTRA_DRAW_HEIGHT = 12;
+
+  /**
+   * This value nudges the rendering of units down a bit. If a unit image uses the full image draw
+   * height, the top part can appear cut off or just really close to the maximum upper limit. This
+   * value moves the unit 'down' a bit when rendering it (test this with battleships on NWO).
+   */
+  private static final int UNIT_DRAW_ADDED_VERTICAL_TRANSLATION = 7;
+
+  /**
+   * This value nudges the rendering of the unit count down a bit. Since we shift the rendering of
+   * unit images down, this does not look good for infantry where instead of the unit count being
+   * drawn between their feet, it is drawn squarely between their legs (which looks funny). So we
+   * translate the rendering to be lower by a bit. (test this with territories containing multiple
+   * infantry).
+   */
+  private static final int UNIT_COUNT_ADDED_VERTICAL_TRANSLATION = 4;
 
   private final UnitImageFactory unitImageFactory;
 
@@ -61,7 +89,9 @@ class AvatarPanelFactory {
 
   private Image createEmptyUnitStackImage(final int renderingWidth) {
     return new BufferedImage(
-        renderingWidth, unitImageFactory.getUnitImageHeight(), BufferedImage.TYPE_INT_ARGB);
+        renderingWidth,
+        unitImageFactory.getUnitImageHeight() + EXTRA_DRAW_HEIGHT,
+        BufferedImage.TYPE_INT_ARGB);
   }
 
   private static Image createUnitStackImage(
@@ -78,9 +108,11 @@ class AvatarPanelFactory {
 
     final var combinedImage =
         new BufferedImage(
-            renderingWidth, unitImageFactory.getUnitImageHeight(), BufferedImage.TYPE_INT_ARGB);
+            renderingWidth,
+            unitImageFactory.getUnitImageHeight() + EXTRA_DRAW_HEIGHT,
+            BufferedImage.TYPE_INT_ARGB);
 
-    final var graphics = combinedImage.getGraphics();
+    final Graphics2D graphics = (Graphics2D) combinedImage.getGraphics();
 
     final List<Point> drawLocations =
         AvatarCoordinateCalculator.builder()
@@ -101,8 +133,30 @@ class AvatarPanelFactory {
     for (int i = 0; i < drawLocations.size(); i++) {
       final var imageToDraw = unitImageFactory.getImage(unitsToDraw.get(i));
       final Point drawLocation = drawLocations.get(i);
-      graphics.drawImage(imageToDraw, drawLocation.x, drawLocation.y, null);
+
+      graphics.drawImage(
+          imageToDraw, drawLocation.x, drawLocation.y + UNIT_DRAW_ADDED_VERTICAL_TRANSLATION, null);
+
+      final int unitCount = countUnit(unitsToDraw.get(i).getType(), units);
+      if (unitCount > 1) {
+        UnitsDrawer.drawOutlinedText(
+            graphics,
+            String.valueOf(unitCount),
+            drawLocation.x + unitImageFactory.getUnitCounterOffsetWidth(),
+            drawLocation.y
+                + unitImageFactory.getUnitCounterOffsetHeight()
+                + UNIT_COUNT_ADDED_VERTICAL_TRANSLATION,
+            MapImage.getPropertyUnitCountColor(),
+            MapImage.getPropertyUnitCountOutline());
+      }
     }
     return combinedImage;
+  }
+
+  private static int countUnit(final UnitType unitType, final Collection<Unit> units) {
+    return units.stream() //
+        .map(Unit::getType)
+        .mapToInt(type -> type.equals(unitType) ? 1 : 0)
+        .sum();
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -253,11 +253,11 @@ public class UnitScroller {
             .boxLayoutHorizontal()
             .add(prevUnit)
             .addHorizontalStrut(HORIZONTAL_BUTTON_GAP)
+            .add(wakeAllButton)
+            .addHorizontalStrut(HORIZONTAL_BUTTON_GAP)
             .add(sleepButton)
             .addHorizontalStrut(HORIZONTAL_BUTTON_GAP)
             .add(skipButton)
-            .addHorizontalStrut(HORIZONTAL_BUTTON_GAP)
-            .add(wakeAllButton)
             .addHorizontalStrut(HORIZONTAL_BUTTON_GAP)
             .add(nextUnit)
             .build();

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -60,8 +60,8 @@ public class UnitScroller {
           + "movement left";
   private static final String NEXT_UNITS_TOOLTIP =
       "Press 'n' or click this button to center the screen on the 'next' units with movement left";
-  private static final String STATION_UNITS_TOOLTIP =
-      "Press 's' or click this button to station the current units, they will be automatically "
+  private static final String SLEEP_UNITS_TOOLTIP =
+      "Press 's' or click this button to sleep the current units, they will be automatically "
           + "skipped until you move or wake them.";
   private static final String SKIP_UNITS_TOOLTIP =
       "Press 'space' or click this button to skip the current units and not move them during the "
@@ -232,9 +232,9 @@ public class UnitScroller {
     prevUnit.setAlignmentX(JComponent.CENTER_ALIGNMENT);
     prevUnit.addActionListener(e -> centerOnPreviousMovableUnit());
 
-    final JButton stationButton = new JButton(UnitScrollerIcon.STATION.get());
-    stationButton.setToolTipText(STATION_UNITS_TOOLTIP);
-    stationButton.addActionListener(e -> sleepCurrentUnits());
+    final JButton sleepButton = new JButton(UnitScrollerIcon.SLEEP.get());
+    sleepButton.setToolTipText(SLEEP_UNITS_TOOLTIP);
+    sleepButton.addActionListener(e -> sleepCurrentUnits());
 
     final JButton skipButton = new JButton(UnitScrollerIcon.SKIP.get());
     skipButton.setToolTipText(SKIP_UNITS_TOOLTIP);
@@ -253,7 +253,7 @@ public class UnitScroller {
             .boxLayoutHorizontal()
             .add(prevUnit)
             .addHorizontalStrut(HORIZONTAL_BUTTON_GAP)
-            .add(stationButton)
+            .add(sleepButton)
             .addHorizontalStrut(HORIZONTAL_BUTTON_GAP)
             .add(skipButton)
             .addHorizontalStrut(HORIZONTAL_BUTTON_GAP)

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -56,18 +56,15 @@ public class UnitScroller {
   private static final int HORIZONTAL_BUTTON_GAP = 2;
 
   private static final String PREVIOUS_UNITS_TOOLTIP =
-      "Press 'm' or click this button to center the screen on the 'previous' units with "
-          + "movement left";
+      "Press 'M' or click to see 'Previous' unmoved units.";
   private static final String NEXT_UNITS_TOOLTIP =
-      "Press 'n' or click this button to center the screen on the 'next' units with movement left";
+      "Press 'N' or click to see 'Next' unmoved units.";
   private static final String SLEEP_UNITS_TOOLTIP =
-      "Press 's' or click this button to sleep the current units, they will be automatically "
-          + "skipped until you move or wake them.";
+      "Press 'S' or click to 'Sleep' these unmoved units until manually moved or alerted.";
   private static final String SKIP_UNITS_TOOLTIP =
-      "Press 'space' or click this button to skip the current units and not move them during the "
-          + "current move phase";
+      "Press 'Space' or click to 'Skip' these unmoved units until next move phase.";
   private static final String WAKE_ALL_TOOLTIP =
-      "Press 'w' or click this button to activate all skipped or stationed units";
+      "Press 'W' or click to 'Alert' all skipped and sleeping units on the map.";
 
   private Collection<Unit> skippedUnits = new HashSet<>();
   private final Collection<Unit> sleepingUnits = new HashSet<>();

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -109,7 +109,7 @@ public class UnitScroller {
     if (lastFocusedTerritory == null) {
       focusCapital();
     } else {
-      drawUnitAvatarPane(lastFocusedTerritory, selectUnitImagePanel.getWidth());
+      drawUnitAvatarPane(lastFocusedTerritory);
     }
 
     // remove any moved units from the sleeping units
@@ -161,14 +161,15 @@ public class UnitScroller {
               Optional.ofNullable(lastFocusedTerritory)
                   .ifPresent(
                       t -> {
-                        drawUnitAvatarPane(t, selectUnitImagePanel.getWidth());
+                        drawUnitAvatarPane(t);
                         territoryNameLabel.setText(t.getName());
                       });
             });
   }
 
-  private void drawUnitAvatarPane(final Territory t, final int panelWidth) {
+  private void drawUnitAvatarPane(final Territory t) {
     // use 240 as an approximate default if the containing panel does not yet exist.
+    final int panelWidth = selectUnitImagePanel.getWidth();
     final int renderingWidth = panelWidth == 0 ? 240 : panelWidth;
 
     final GamePlayer player = currentPlayerSupplier.get();
@@ -365,7 +366,7 @@ public class UnitScroller {
       final List<Unit> matchedUnits = getMovableUnits(t);
 
       if (!matchedUnits.isEmpty()) {
-        drawUnitAvatarPane(t, selectUnitImagePanel.getWidth());
+        drawUnitAvatarPane(t);
         newFocusedTerritory = t;
         mapPanel.setUnitHighlight(Set.of(matchedUnits));
         break;

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -64,7 +64,7 @@ public class UnitScroller {
   private static final String SKIP_UNITS_TOOLTIP =
       "Press 'Space' or click to 'Skip' these unmoved units until next move phase.";
   private static final String WAKE_ALL_TOOLTIP =
-      "Press 'W' or click to 'Alert' all skipped and sleeping units on the map.";
+      "Click to 'Alert' all skipped and sleeping units on the map.";
 
   private Collection<Unit> skippedUnits = new HashSet<>();
   private final Collection<Unit> sleepingUnits = new HashSet<>();

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScrollerIcon.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScrollerIcon.java
@@ -28,6 +28,6 @@ class UnitScrollerIcon implements Supplier<Icon> {
   public Icon get() {
     return new ImageIcon(
         ImageLoader.getImage(new File(IMAGE_PATH, imageFile))
-            .getScaledInstance(20, 20, Image.SCALE_SMOOTH));
+            .getScaledInstance(25, 25, Image.SCALE_SMOOTH));
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScrollerIcon.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScrollerIcon.java
@@ -17,7 +17,7 @@ class UnitScrollerIcon implements Supplier<Icon> {
   static final UnitScrollerIcon LEFT_ARROW = new UnitScrollerIcon("left_arrow.png");
   static final UnitScrollerIcon RIGHT_ARROW = new UnitScrollerIcon("right_arrow.png");
   static final UnitScrollerIcon SKIP = new UnitScrollerIcon("skip.png");
-  static final UnitScrollerIcon STATION = new UnitScrollerIcon("station.png");
+  static final UnitScrollerIcon SLEEP = new UnitScrollerIcon("unit_sleep.png");
   static final UnitScrollerIcon WAKE_ALL = new UnitScrollerIcon("wake_all.png");
 
   private static final File IMAGE_PATH = new File(ResourceLoader.RESOURCE_FOLDER, "unit_scroller");

--- a/game-headed/build.gradle
+++ b/game-headed/build.gradle
@@ -42,7 +42,7 @@ clean.doFirst {
 task downloadAssets {
     doLast {
         download {
-            src "https://github.com/triplea-game/assets/releases/download/25/game_headed_assets.zip"
+            src "https://github.com/triplea-game/assets/releases/download/116/game_headed_assets.zip"
             dest "$projectDir/.assets/assets.zip"
             overwrite false
         }


### PR DESCRIPTION
## Summary

Following up with almost all outstanding requests in: https://forums.triplea-game.org/topic/1433
Adding in unit-scroller-tracks-mouse feature from: https://forums.triplea-game.org/topic/1844/

Adds:
- sort order to unit scroller units
- 25% larger unit scroller buttons
- re-orders unit scroller buttons
- improves button tooltips
- unit count to unit scroller avatar images
- territory mouse listener, on territory enter unit scroller changes to that territory
- unit avatar rendering goodness, better vertical height to fit unit image size plus a little padding
- goes back to 'sleep' with moon icon, replaces 'station' terminology with shield icon


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Commit Details

commit a27f42549114a01dca7893c6439efa6df64f1452

    Simplify panel width parameter

commit 21861e3714f7d49f14f901bf9a6cd1b274cbdb12

    UnitScroller follows mouse & remove 'C' to center action.

commit aa7542ea9f8d3c67d2ba83803183460efd2a6860

    Always draw unit scroller avatar units at 100% unit size

commit 2c685da3270b84491d9a33f70337c75006af00e5

    Fit vertical height of unit scroller to unit image height

commit 0a50d3e950e3e81741127ef6982e45a95885b619

    Render unit counts on the unit scroller.

commit 7655bd06548f8b1df105fdae1b735722fde05a8c

    Sort unit scroller units by air/sea/land; then power; then name
    
    From left to right, place:
    - air units
    - sea units
    - land units
    
    Within each category, place stronger attack units
    on the left, then break any ties by sorting by name.
    
    We sort by attack and not defense or a max of the two
    as the unit scroller is viewed during a players combat
    move, the attack power is the operative value during
    that time.

commit 3ba8c8d120c0f768a353418b52aee4465fbed2ea

    Rename 'station' back to 'sleep' and revert back to the sleeping moon icon
    
    The term 'station' was to avoid 'sleep' and seems to no have stuck
    very well. Sleep is a bit more self explanatory even if just marginally so.
    
    Second, the shield icon for station was not a super great mapping to
    the 'station' concept and on initial perception is not as clear as the
    concept of 'sleep'.

commit 94efbead745cdfcd8e62b103eeba416614c8f904

    Update scroller button ordering with "most used to the right"
    
    Set the button order from left to right:
    - previous
    - wake-all
    - sleep
    - skip current
    - next
    
    The thinking per the discussion thread on forums is the buttons
    that are most used should be grouped to the right with least
    used to the left.

commit 78b66bb73ab16a8f89efdf3df56b4c1c867dc515

    Increase scroller button size from 20 to 25

commit 186bcf2a4cf73d52a8aac9ccac4d2bacc79e3c89

    Update unit scroller tooltip text
    
    Essentially shorten and clarify the tooltips.
    Per suggestion in: https://forums.triplea-game.org/post/29322

commit 47635c1b57ae86fbc353d0e9934cfc2a21b720d2

    Update 'wake' tooltip, "W" is no longer the hotkey for it.
    
    Wake-all should not be that commonly used, it does not need a hotkey.
    The hotkey was removed in a previous update, this update corrects
    the tooltip to not say "press w"



## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing

- Tested on NWO and napoleonic wars
  - looked at unit renderings and count, ensured looked good and sort order was good
  - looked at button width, surprisingly they were not cut off on napoleonic wars


<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->

## Screens Shots
![Screenshot from 2020-04-03 20-09-17](https://user-images.githubusercontent.com/12397753/78418016-1ea43b80-75ed-11ea-9a14-caa58f7d5657.png)

![Screenshot from 2020-04-03 20-20-49](https://user-images.githubusercontent.com/12397753/78418017-1f3cd200-75ed-11ea-85ad-263bc22b3990.png)

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->

