### PR TITLE
Websocket message burn & ban checking

### DIFF
--- a/http-server/src/main/java/org/triplea/http/ServerApplication.java
+++ b/http-server/src/main/java/org/triplea/http/ServerApplication.java
@@ -143,22 +143,6 @@ public class ServerApplication extends Application<AppConfig> {
         .forEach(controller -> environment.jersey().register(controller));
   }
 
-  private static void setupWebSocket(
-      final ServerEndpointConfig websocket,
-      final WebSocketMessagingBus webSocketMessagingBus,
-      final Predicate<Session> sessionBanCheck) {
-
-    // Inject beans into websocket endpoints
-    websocket
-        .getUserProperties()
-        .putAll(
-            Map.of(
-                WebSocketMessagingBus.MESSAGING_BUS_KEY, //
-                webSocketMessagingBus,
-                SessionBannedCheck.BAN_CHECK_KEY,
-                sessionBanCheck));
-  }
-
   private static void enableRequestResponseLogging(final Environment environment) {
     environment
         .jersey()
@@ -206,6 +190,22 @@ public class ServerApplication extends Application<AppConfig> {
 
   private List<Object> exceptionMappers() {
     return ImmutableList.of(new IllegalArgumentMapper());
+  }
+
+  private static void setupWebSocket(
+      final ServerEndpointConfig websocket,
+      final WebSocketMessagingBus webSocketMessagingBus,
+      final Predicate<Session> sessionBanCheck) {
+
+    // Inject beans into websocket endpoints
+    websocket
+        .getUserProperties()
+        .putAll(
+            Map.of(
+                WebSocketMessagingBus.MESSAGING_BUS_KEY, //
+                webSocketMessagingBus,
+                SessionBannedCheck.BAN_CHECK_KEY,
+                sessionBanCheck));
   }
 
   private List<Object> endPointControllers(

--- a/http-server/src/main/java/org/triplea/web/socket/GenericWebSocket.java
+++ b/http-server/src/main/java/org/triplea/web/socket/GenericWebSocket.java
@@ -2,9 +2,22 @@ package org.triplea.web.socket;
 
 import static org.triplea.web.socket.WebSocketMessagingBus.MESSAGING_BUS_KEY;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Ascii;
+import com.google.gson.Gson;
+import com.google.gson.JsonSyntaxException;
+import java.net.InetAddress;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.websocket.CloseReason;
 import javax.websocket.Session;
 import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+import org.triplea.http.client.web.socket.MessageEnvelope;
+import org.triplea.http.client.web.socket.messages.envelopes.ServerErrorMessage;
 
 /**
  * Extracts common code between websocket server methods. Each websocket endpoint is essentially
@@ -12,22 +25,108 @@ import lombok.experimental.UtilityClass;
  * on messages received. In general there should not be many websocket endpoints and they are
  * grouped by the "types" of connections that are created to them (eg: players or games)
  */
+@Slf4j
 @UtilityClass
-public class GenericWebSocket {
-  public static void onOpen(final Session session) {
+class GenericWebSocket {
+  @VisibleForTesting static final int MAX_BAD_MESSAGES = 2;
+
+  private static final Gson GSON = new Gson();
+
+  private static final Cache<InetAddress, AtomicInteger> badMessageCache =
+      Caffeine.newBuilder().expireAfterWrite(Duration.ofSeconds(30)).build();
+
+  static void onOpen(final Session session) {
     ((WebSocketMessagingBus) session.getUserProperties().get(MESSAGING_BUS_KEY)).onOpen(session);
   }
 
-  public static void onMessage(final Session session, final String message) {
-    ((WebSocketMessagingBus) session.getUserProperties().get(MESSAGING_BUS_KEY))
-        .onMessage(session, message);
+  static void onMessage(final Session session, final String message) {
+    onMessage(session, message, badMessageCache, new MessageSender());
   }
 
-  public static void onClose(final Session session, final CloseReason closeReason) {
+  @VisibleForTesting
+  static void onMessage(
+      final Session session,
+      final String message,
+      final Cache<InetAddress, AtomicInteger> badMessageCache,
+      final MessageSender messageSender) {
+
+    readJsonMessage(session, message, badMessageCache, messageSender)
+        .ifPresent(
+            envelope ->
+                ((WebSocketMessagingBus) session.getUserProperties().get(MESSAGING_BUS_KEY))
+                    .onMessage(session, envelope));
+  }
+
+  /**
+   * Checks if session has sent too many bad messages, if so we ignore messages from that session
+   * and return an empty. Otherwise we will convert the message JSON string to a {@code
+   * MessageEnvelope} and return that. If the message is badly formatted, we'll send back an error
+   * message response to the session, increment the bad message count and return an empty.
+   */
+  private static Optional<MessageEnvelope> readJsonMessage(
+      final Session session,
+      final String message,
+      final Cache<InetAddress, AtomicInteger> badMessageCache,
+      final MessageSender messageSender) {
+
+    if (burnMessagesFromThisSession(session, badMessageCache)) {
+      // Burn the message -> no-op
+      // To conserve server resources, we do not even log the message.
+      return Optional.empty();
+    }
+
+    try {
+      return Optional.of(GSON.fromJson(message, MessageEnvelope.class));
+    } catch (final JsonSyntaxException e) {
+      final InetAddress inetAddress = InetExtractor.extract(session.getUserProperties());
+      incrementBadMessageCount(session, badMessageCache);
+      logBadMessage(inetAddress, message);
+      respondWithServerError(messageSender, session);
+      return Optional.empty();
+    }
+  }
+
+  private static boolean burnMessagesFromThisSession(
+      final Session session, final Cache<InetAddress, AtomicInteger> badMessageCache) {
+    final InetAddress inetAddress = InetExtractor.extract(session.getUserProperties());
+
+    final int badMessageCount =
+        Optional.ofNullable(badMessageCache.getIfPresent(inetAddress))
+            .map(AtomicInteger::get)
+            .orElse(0);
+
+    return badMessageCount > MAX_BAD_MESSAGES;
+  }
+
+  private static void incrementBadMessageCount(
+      final Session session, final Cache<InetAddress, AtomicInteger> badMessageCache) {
+    badMessageCache
+        .asMap()
+        .computeIfAbsent(
+            InetExtractor.extract(session.getUserProperties()), inet -> new AtomicInteger(0))
+        .incrementAndGet();
+  }
+
+  private static void logBadMessage(final InetAddress inetAddress, final String message) {
+    log.warn(
+        "Failed to decode JSON string from IP {}, into a MessageEnvelope: {}",
+        inetAddress,
+        Ascii.truncate(message, 500, "..."));
+  }
+
+  private static void respondWithServerError(
+      final MessageSender messageSender, final Session session) {
+    messageSender.accept(
+        session,
+        new ServerErrorMessage("Server is unable to process request, error reading message")
+            .toEnvelope());
+  }
+
+  static void onClose(final Session session, final CloseReason closeReason) {
     ((WebSocketMessagingBus) session.getUserProperties().get(MESSAGING_BUS_KEY)).onClose(session);
   }
 
-  public static void onError(final Session session, final Throwable throwable) {
+  static void onError(final Session session, final Throwable throwable) {
     ((WebSocketMessagingBus) session.getUserProperties().get(MESSAGING_BUS_KEY))
         .onError(session, throwable);
   }

--- a/http-server/src/main/java/org/triplea/web/socket/InetExtractor.java
+++ b/http-server/src/main/java/org/triplea/web/socket/InetExtractor.java
@@ -1,4 +1,4 @@
-package org.triplea.modules.chat;
+package org.triplea.web.socket;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;

--- a/http-server/src/main/java/org/triplea/web/socket/MessageSender.java
+++ b/http-server/src/main/java/org/triplea/web/socket/MessageSender.java
@@ -11,7 +11,7 @@ import org.triplea.java.Interruptibles;
 /** Sends a server message (encoded as a JSON string) to a specific connected websocket sessions. */
 @Slf4j
 class MessageSender implements BiConsumer<Session, MessageEnvelope> {
-  private final Gson gson = new Gson();
+  private static final Gson GSON = new Gson();
 
   @Override
   public void accept(final Session session, final MessageEnvelope message) {
@@ -24,7 +24,7 @@ class MessageSender implements BiConsumer<Session, MessageEnvelope> {
       throws InterruptedException {
     try {
       if (session.isOpen()) {
-        session.getAsyncRemote().sendText(gson.toJson(message)).get();
+        session.getAsyncRemote().sendText(GSON.toJson(message)).get();
       }
     } catch (final ExecutionException e) {
       log.warn("Failed to send message: " + message, e);

--- a/http-server/src/main/java/org/triplea/web/socket/SessionBannedCheck.java
+++ b/http-server/src/main/java/org/triplea/web/socket/SessionBannedCheck.java
@@ -1,0 +1,26 @@
+package org.triplea.web.socket;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.function.Predicate;
+import javax.websocket.Session;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import org.jdbi.v3.core.Jdbi;
+import org.triplea.db.dao.user.ban.UserBanDao;
+
+@AllArgsConstructor(access = AccessLevel.PACKAGE, onConstructor_ = @VisibleForTesting)
+public class SessionBannedCheck implements Predicate<Session> {
+  public static final String BAN_CHECK_KEY = "session.ban.checker";
+
+  private final UserBanDao userBanDao;
+
+  public static SessionBannedCheck build(final Jdbi jdbi) {
+    return new SessionBannedCheck(jdbi.onDemand(UserBanDao.class));
+  }
+
+  @Override
+  public boolean test(final Session session) {
+    final String ip = InetExtractor.extract(session.getUserProperties()).getHostAddress();
+    return userBanDao.isBannedByIp(ip);
+  }
+}

--- a/http-server/src/main/java/org/triplea/web/socket/SessionSet.java
+++ b/http-server/src/main/java/org/triplea/web/socket/SessionSet.java
@@ -10,7 +10,6 @@ import javax.websocket.Session;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.triplea.modules.chat.InetExtractor;
 
 /**
  * Tracks sessions, can be used to listen to IP session ban events and close any matching sessions.

--- a/http-server/src/main/java/org/triplea/web/socket/WebSocketMessagingBus.java
+++ b/http-server/src/main/java/org/triplea/web/socket/WebSocketMessagingBus.java
@@ -1,7 +1,6 @@
 package org.triplea.web.socket;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.gson.Gson;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -25,7 +24,6 @@ import org.triplea.http.client.web.socket.messages.envelopes.ServerErrorMessage;
 @Slf4j
 public class WebSocketMessagingBus {
   public static final String MESSAGING_BUS_KEY = "messaging.bus";
-  private static final Gson GSON = new Gson();
 
   @Nonnull private final MessageBroadcaster messageBroadcaster;
   @Nonnull private final MessageSender messageSender;
@@ -64,9 +62,7 @@ public class WebSocketMessagingBus {
     messageListeners.add(new MessageListener(type, listener));
   }
 
-  void onMessage(final Session session, final String message) {
-    final MessageEnvelope envelope = GSON.fromJson(message, MessageEnvelope.class);
-
+  void onMessage(final Session session, final MessageEnvelope envelope) {
     determineMatchingMessageType(envelope)
         .ifPresent(
             messageType -> {

--- a/http-server/src/test/java/org/triplea/web/socket/GameConnectionWebSocketTest.java
+++ b/http-server/src/test/java/org/triplea/web/socket/GameConnectionWebSocketTest.java
@@ -3,6 +3,7 @@ package org.triplea.web.socket;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.gson.Gson;
 import java.util.Map;
 import javax.websocket.Session;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.http.client.web.socket.messages.envelopes.chat.PlayerStatusUpdateSentMessage;
 
 @ExtendWith(MockitoExtension.class)
 class GameConnectionWebSocketTest {
@@ -21,7 +23,12 @@ class GameConnectionWebSocketTest {
   @BeforeEach
   void setup() {
     when(session.getUserProperties())
-        .thenReturn(Map.of(WebSocketMessagingBus.MESSAGING_BUS_KEY, webSocketMessagingBus));
+        .thenReturn(
+            Map.of(
+                WebSocketMessagingBus.MESSAGING_BUS_KEY,
+                webSocketMessagingBus,
+                InetExtractor.IP_ADDRESS_KEY,
+                "/1.1.1.1:123"));
   }
 
   @Test
@@ -40,9 +47,11 @@ class GameConnectionWebSocketTest {
 
   @Test
   void onMessage() {
-    gameConnectionWebSocket.onMessage(session, "message");
+    final PlayerStatusUpdateSentMessage message = new PlayerStatusUpdateSentMessage("message");
 
-    verify(webSocketMessagingBus).onMessage(session, "message");
+    gameConnectionWebSocket.onMessage(session, new Gson().toJson(message.toEnvelope()));
+
+    verify(webSocketMessagingBus).onMessage(session, message.toEnvelope());
   }
 
   @Test

--- a/http-server/src/test/java/org/triplea/web/socket/GameConnectionWebSocketTest.java
+++ b/http-server/src/test/java/org/triplea/web/socket/GameConnectionWebSocketTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.gson.Gson;
 import java.util.Map;
+import java.util.function.Predicate;
 import javax.websocket.Session;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -22,13 +23,16 @@ class GameConnectionWebSocketTest {
 
   @BeforeEach
   void setup() {
+    final Predicate<Session> banCheck = session -> false;
     when(session.getUserProperties())
         .thenReturn(
             Map.of(
                 WebSocketMessagingBus.MESSAGING_BUS_KEY,
                 webSocketMessagingBus,
                 InetExtractor.IP_ADDRESS_KEY,
-                "/1.1.1.1:123"));
+                "/1.1.1.1:123",
+                SessionBannedCheck.BAN_CHECK_KEY,
+                banCheck));
   }
 
   @Test

--- a/http-server/src/test/java/org/triplea/web/socket/GenericWebSocketTest.java
+++ b/http-server/src/test/java/org/triplea/web/socket/GenericWebSocketTest.java
@@ -1,0 +1,128 @@
+package org.triplea.web.socket;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import com.google.gson.Gson;
+import java.net.InetAddress;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.websocket.Session;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.http.client.IpAddressParser;
+import org.triplea.http.client.web.socket.MessageEnvelope;
+import org.triplea.http.client.web.socket.messages.envelopes.ServerErrorMessage;
+import org.triplea.http.client.web.socket.messages.envelopes.chat.PlayerStatusUpdateSentMessage;
+
+@SuppressWarnings("SameParameterValue")
+@ExtendWith(MockitoExtension.class)
+class GenericWebSocketTest {
+
+  @Mock private Session session;
+
+  @Mock private MessageSender messageSender;
+
+  @Mock private WebSocketMessagingBus webSocketMessagingBus;
+
+  private Cache<InetAddress, AtomicInteger> cache =
+      Caffeine.newBuilder().expireAfterWrite(Duration.ofSeconds(60)).build();
+
+  private ArgumentCaptor<MessageEnvelope> messageCaptor =
+      ArgumentCaptor.forClass(MessageEnvelope.class);
+
+  @Test
+  @DisplayName(
+      "Verify server responds to a bad message with error and increments bad message tracking")
+  void invalidMessageButNotBurned() {
+    givenIpInSession("1.1.1.1");
+
+    GenericWebSocket.onMessage(session, "message", cache, messageSender);
+
+    verify(messageSender).accept(eq(session), messageCaptor.capture());
+    assertThat(
+        "Server should responsd back with an error message, while under the bad message burn limit",
+        messageCaptor.getValue().getMessageTypeId(),
+        is(ServerErrorMessage.TYPE.getMessageTypeId()));
+    assertThat(
+        "Verify cache has been populated and incremented",
+        cache.getIfPresent(IpAddressParser.fromString("1.1.1.1")).get(),
+        is(1));
+  }
+
+  @Test
+  void verifyBadMessageCacheIsIncremented() {
+    givenIpInSession("1.1.1.1");
+    givenIpHasBadMessageCount("1.1.1.1", 1);
+
+    GenericWebSocket.onMessage(session, "message", cache, messageSender);
+
+    assertThat(
+        "Verify cache has been incremented",
+        cache.getIfPresent(IpAddressParser.fromString("1.1.1.1")).get(),
+        is(2));
+  }
+
+  private void givenIpInSession(final String ip) {
+    when(session.getUserProperties())
+        .thenReturn(
+            Map.of(
+                InetExtractor.IP_ADDRESS_KEY,
+                "/" + ip + ":54321",
+                WebSocketMessagingBus.MESSAGING_BUS_KEY,
+                webSocketMessagingBus));
+  }
+
+  @DisplayName("If a session has hit max bad messages, we ignore all messages from that session")
+  @ParameterizedTest
+  @MethodSource
+  void atMaxBadMessagesWillBurnMessages(final String message) {
+    givenIpInSession("1.1.1.1");
+    givenIpHasBadMessageCount("1.1.1.1", GenericWebSocket.MAX_BAD_MESSAGES + 1);
+
+    GenericWebSocket.onMessage(session, message, cache, messageSender);
+
+    verify(webSocketMessagingBus, never()).onMessage(any(), any());
+  }
+
+  @SuppressWarnings("unused")
+  private static List<String> atMaxBadMessagesWillBurnMessages() {
+    return List.of(
+        "invalid json message",
+        new Gson().toJson(new PlayerStatusUpdateSentMessage("valid json").toEnvelope()));
+  }
+
+  private void givenIpHasBadMessageCount(final String ip, final int count) {
+    cache.put(IpAddressParser.fromString(ip), new AtomicInteger(count));
+  }
+
+  @Test
+  @DisplayName("Happy case - Valid messages when under bad message limit are processed")
+  void validMessageUnderLimit() {
+    givenIpInSession("1.1.1.1");
+    givenIpHasBadMessageCount("1.1.1.1", 1);
+    //noinspection ConstantConditions
+    assertThat("Verify test assumptions", 1 < GenericWebSocket.MAX_BAD_MESSAGES, is(true));
+
+    final var messageEnvelope = new PlayerStatusUpdateSentMessage("status").toEnvelope();
+
+    GenericWebSocket.onMessage(session, new Gson().toJson(messageEnvelope), cache, messageSender);
+
+    verify(webSocketMessagingBus).onMessage(session, messageEnvelope);
+  }
+}

--- a/http-server/src/test/java/org/triplea/web/socket/InetExtractorTest.java
+++ b/http-server/src/test/java/org/triplea/web/socket/InetExtractorTest.java
@@ -1,4 +1,4 @@
-package org.triplea.modules.chat;
+package org.triplea.web.socket;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/http-server/src/test/java/org/triplea/web/socket/PlayerConnectionWebSocketTest.java
+++ b/http-server/src/test/java/org/triplea/web/socket/PlayerConnectionWebSocketTest.java
@@ -3,6 +3,7 @@ package org.triplea.web.socket;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.google.gson.Gson;
 import java.util.Map;
 import javax.websocket.Session;
 import org.junit.jupiter.api.BeforeEach;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.http.client.web.socket.messages.envelopes.chat.PlayerStatusUpdateSentMessage;
 
 @ExtendWith(MockitoExtension.class)
 class PlayerConnectionWebSocketTest {
@@ -22,7 +24,12 @@ class PlayerConnectionWebSocketTest {
   @BeforeEach
   void setup() {
     when(session.getUserProperties())
-        .thenReturn(Map.of(WebSocketMessagingBus.MESSAGING_BUS_KEY, webSocketMessagingBus));
+        .thenReturn(
+            Map.of(
+                WebSocketMessagingBus.MESSAGING_BUS_KEY,
+                webSocketMessagingBus,
+                InetExtractor.IP_ADDRESS_KEY,
+                "/1.1.1.1:123"));
   }
 
   @Test
@@ -41,9 +48,11 @@ class PlayerConnectionWebSocketTest {
 
   @Test
   void onMessage() {
-    playerConnectionWebSocket.onMessage(session, "message");
+    final PlayerStatusUpdateSentMessage message = new PlayerStatusUpdateSentMessage("message");
 
-    verify(webSocketMessagingBus).onMessage(session, "message");
+    playerConnectionWebSocket.onMessage(session, new Gson().toJson(message.toEnvelope()));
+
+    verify(webSocketMessagingBus).onMessage(session, message.toEnvelope());
   }
 
   @Test

--- a/http-server/src/test/java/org/triplea/web/socket/PlayerConnectionWebSocketTest.java
+++ b/http-server/src/test/java/org/triplea/web/socket/PlayerConnectionWebSocketTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.when;
 
 import com.google.gson.Gson;
 import java.util.Map;
+import java.util.function.Predicate;
 import javax.websocket.Session;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,13 +24,16 @@ class PlayerConnectionWebSocketTest {
 
   @BeforeEach
   void setup() {
+    final Predicate<Session> banCheck = session -> false;
     when(session.getUserProperties())
         .thenReturn(
             Map.of(
                 WebSocketMessagingBus.MESSAGING_BUS_KEY,
                 webSocketMessagingBus,
                 InetExtractor.IP_ADDRESS_KEY,
-                "/1.1.1.1:123"));
+                "/1.1.1.1:123",
+                SessionBannedCheck.BAN_CHECK_KEY,
+                banCheck));
   }
 
   @Test

--- a/http-server/src/test/java/org/triplea/web/socket/SessionBannedCheckTest.java
+++ b/http-server/src/test/java/org/triplea/web/socket/SessionBannedCheckTest.java
@@ -1,0 +1,44 @@
+package org.triplea.web.socket;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import javax.websocket.Session;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.db.dao.user.ban.UserBanDao;
+
+@ExtendWith(MockitoExtension.class)
+class SessionBannedCheckTest {
+
+  @Mock private UserBanDao userBanDao;
+
+  @InjectMocks private SessionBannedCheck sessionBannedCheck;
+
+  @Mock private Session session;
+
+  @Test
+  void notBanned() {
+    givenSessionIsBanned(false);
+
+    assertThat(sessionBannedCheck.test(session), is(false));
+  }
+
+  @Test
+  void banned() {
+    givenSessionIsBanned(true);
+
+    assertThat(sessionBannedCheck.test(session), is(true));
+  }
+
+  private void givenSessionIsBanned(final boolean isBanned) {
+    when(session.getUserProperties())
+        .thenReturn(Map.of(InetExtractor.IP_ADDRESS_KEY, "/1.1.1.1:555"));
+    when(userBanDao.isBannedByIp("1.1.1.1")).thenReturn(isBanned);
+  }
+}

--- a/http-server/src/test/java/org/triplea/web/socket/SessionSetTest.java
+++ b/http-server/src/test/java/org/triplea/web/socket/SessionSetTest.java
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.http.client.IpAddressParser;
-import org.triplea.modules.chat.InetExtractor;
 
 @ExtendWith(MockitoExtension.class)
 class SessionSetTest {

--- a/http-server/src/test/java/org/triplea/web/socket/WebSocketMessagingBusTest.java
+++ b/http-server/src/test/java/org/triplea/web/socket/WebSocketMessagingBusTest.java
@@ -11,7 +11,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.google.gson.Gson;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.BiConsumer;
@@ -35,8 +34,6 @@ import org.triplea.http.client.web.socket.messages.envelopes.ServerErrorMessage;
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("InnerClassMayBeStatic")
 class WebSocketMessagingBusTest {
-  private static final Gson GSON = new Gson();
-
   private static class StringMessage implements WebSocketMessage {
     private static final MessageType<StringMessage> TYPE = MessageType.of(StringMessage.class);
 
@@ -76,7 +73,7 @@ class WebSocketMessagingBusTest {
 
       // trigger message
       final BooleanMessage message = new BooleanMessage(true);
-      webSocketMessagingBus.onMessage(session, GSON.toJson(message.toEnvelope()));
+      webSocketMessagingBus.onMessage(session, message.toEnvelope());
 
       // capture argument passed to listener
       final ArgumentCaptor<WebSocketMessageContext<BooleanMessage>> argumentCaptor =
@@ -103,7 +100,7 @@ class WebSocketMessagingBusTest {
       webSocketMessagingBus.addListener(BooleanMessage.TYPE, booleanMessageListener);
       webSocketMessagingBus.addListener(StringMessage.TYPE, stringMessageListener);
 
-      webSocketMessagingBus.onMessage(session, GSON.toJson(new BooleanMessage(true).toEnvelope()));
+      webSocketMessagingBus.onMessage(session, new BooleanMessage(true).toEnvelope());
 
       verify(booleanMessageListener).accept(any());
       verify(stringMessageListener, never()).accept(any());
@@ -117,7 +114,7 @@ class WebSocketMessagingBusTest {
       webSocketMessagingBus.addListener(BooleanMessage.TYPE, booleanMessageListener);
       webSocketMessagingBus.addListener(BooleanMessage.TYPE, booleanMessageListenerSecond);
 
-      webSocketMessagingBus.onMessage(session, GSON.toJson(new BooleanMessage(true).toEnvelope()));
+      webSocketMessagingBus.onMessage(session, new BooleanMessage(true).toEnvelope());
 
       verify(booleanMessageListener).accept(any());
       verify(booleanMessageListenerSecond).accept(any());


### PR DESCRIPTION
<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->
## Overview

Hardens websocket endpoints:
1. if we get too many bad messages that can't be parsed from a given IP, then we'll start dropping those messages
2. check if an IP is banned on connect and disconnect if banned.


## Commits

commit 17ee45383ad2c28c40e3062e216cb5798bba6f72

    Burn invalid messages if too many are sent

commit a1db73fb24b5423fdfe1f1af296d6a22fee5d645

    Disconnect banned users connecting via websocket
    
    The banned user http filter is not invoked when players
    connect via websocket. This update adds to the websocket
    onOpen method to check if the connecting IP address is
    banned and if so, disconnects them.


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[x] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing

### Message Burning

- Use wscat to verify the bad message dropping
 
In the screenshot below, notice that the server stops responding to repeated bad messages:
![Screenshot from 2020-04-05 13-55-58](https://user-images.githubusercontent.com/12397753/78511225-d6e9f500-774f-11ea-8d97-38f011462681.png)

For rejected messages, on the server we log:
```
WARN  [2020-04-05 22:14:10,886] org.triplea.web.socket.GenericWebSocket: Failed to decode JSON string from IP /127.0.0.1, into a MessageEnvelope: jkl;
WARN  [2020-04-05 22:14:11,619] org.triplea.web.socket.GenericWebSocket: Failed to decode JSON string from IP /127.0.0.1, into a MessageEnvelope: fdas
WARN  [2020-04-05 22:14:12,147] org.triplea.web.socket.GenericWebSocket: Failed to decode JSON string from IP /127.0.0.1, into a MessageEnvelope: fds
```

### Banned IPs connecting directly to WS

- Again used wscat to verify could not connect when banned:
  - ran 'load_local_data' script to get a moderator user "test:test"
  - banned myself via toolbox after connecting to server
  - verified session was disconnected after connecting with wscat
  - verified that after a 30 second cooldown, server responds with an error message again.
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->

## Additional Review Notes

In both cases we put the checks in `GenericWebSocket`. We shift the responsibility of JSON decoding from the WebsocketMessageBug to GenericWebsocket.

