### PR TITLE
Add tests for server side websocket message listeners

### DIFF
--- a/http-server/src/main/java/org/triplea/modules/chat/event/processing/SlapListener.java
+++ b/http-server/src/main/java/org/triplea/modules/chat/event/processing/SlapListener.java
@@ -23,12 +23,10 @@ public class SlapListener implements Consumer<WebSocketMessageContext<PlayerSlap
       final WebSocketMessageContext<PlayerSlapSentMessage> messageContext,
       final ChatParticipant slapper) {
 
-    messageContext
-        .getMessagingBus()
-        .broadcastMessage(
-            PlayerSlapReceivedMessage.builder()
-                .slappingPlayer(slapper.getUserName().getValue())
-                .slappedPlayer(messageContext.getMessage().getSlappedPlayer())
-                .build());
+    messageContext.broadcastMessage(
+        PlayerSlapReceivedMessage.builder()
+            .slappingPlayer(slapper.getUserName().getValue())
+            .slappedPlayer(messageContext.getMessage().getSlappedPlayer())
+            .build());
   }
 }

--- a/http-server/src/main/java/org/triplea/modules/chat/event/processing/StatusUpdateListener.java
+++ b/http-server/src/main/java/org/triplea/modules/chat/event/processing/StatusUpdateListener.java
@@ -26,10 +26,8 @@ public class StatusUpdateListener
       final WebSocketMessageContext<PlayerStatusUpdateSentMessage> messageContext,
       final ChatParticipant chatParticipant) {
 
-    messageContext
-        .getMessagingBus()
-        .broadcastMessage(
-            new PlayerStatusUpdateReceivedMessage(
-                chatParticipant.getUserName(), messageContext.getMessage().getStatus()));
+    messageContext.broadcastMessage(
+        new PlayerStatusUpdateReceivedMessage(
+            chatParticipant.getUserName(), messageContext.getMessage().getStatus()));
   }
 }

--- a/http-server/src/test/java/org/triplea/modules/chat/event/processing/PlayerConnectedListenerTest.java
+++ b/http-server/src/test/java/org/triplea/modules/chat/event/processing/PlayerConnectedListenerTest.java
@@ -1,0 +1,81 @@
+package org.triplea.modules.chat.event.processing;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import javax.websocket.Session;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.domain.data.ApiKey;
+import org.triplea.domain.data.ChatParticipant;
+import org.triplea.http.client.web.socket.messages.envelopes.chat.ChatterListingMessage;
+import org.triplea.http.client.web.socket.messages.envelopes.chat.ConnectToChatMessage;
+import org.triplea.http.client.web.socket.messages.envelopes.chat.PlayerJoinedMessage;
+import org.triplea.modules.chat.Chatters;
+import org.triplea.web.socket.WebSocketMessageContext;
+
+@ExtendWith(MockitoExtension.class)
+class PlayerConnectedListenerTest {
+
+  private static final ChatParticipant CHAT_PARTICIPANT =
+      ChatParticipant.builder()
+          .userName("user-name")
+          .isModerator(true)
+          .status("status")
+          .playerChatId("123")
+          .build();
+
+  @Mock private Chatters chatters;
+  private PlayerConnectedListener playerConnectedListener;
+
+  @Mock private Session session;
+  @Mock private WebSocketMessageContext<ConnectToChatMessage> context;
+
+  private ArgumentCaptor<ChatterListingMessage> responseCaptor =
+      ArgumentCaptor.forClass(ChatterListingMessage.class);
+  private ArgumentCaptor<PlayerJoinedMessage> broadcastCaptor =
+      ArgumentCaptor.forClass(PlayerJoinedMessage.class);
+
+  @BeforeEach
+  void setup() {
+    playerConnectedListener = new PlayerConnectedListener(chatters);
+  }
+
+  @Test
+  void noOpIfChattersDoesNotAllowPlayerToConnect() {
+    when(context.getMessage()).thenReturn(new ConnectToChatMessage(ApiKey.of("api-key")));
+    when(context.getSenderSession()).thenReturn(session);
+    when(chatters.connectPlayer(any(), any())).thenReturn(Optional.empty());
+
+    playerConnectedListener.accept(context);
+
+    verify(context, never()).sendResponse(any());
+    verify(context, never()).broadcastMessage(any());
+  }
+
+  @Test
+  void playerConnects() {
+    when(context.getMessage()).thenReturn(new ConnectToChatMessage(ApiKey.of("api-key")));
+    when(context.getSenderSession()).thenReturn(session);
+    when(chatters.connectPlayer(any(), any())).thenReturn(Optional.of(CHAT_PARTICIPANT));
+    when(chatters.getChatters()).thenReturn(List.of());
+
+    playerConnectedListener.accept(context);
+
+    verify(context).sendResponse(responseCaptor.capture());
+    assertThat(responseCaptor.getValue().getChatters(), is(List.of()));
+
+    verify(context).broadcastMessage(broadcastCaptor.capture());
+    assertThat(broadcastCaptor.getValue().getChatParticipant(), is(CHAT_PARTICIPANT));
+  }
+}

--- a/http-server/src/test/java/org/triplea/modules/chat/event/processing/PlayerLeftListenerTest.java
+++ b/http-server/src/test/java/org/triplea/modules/chat/event/processing/PlayerLeftListenerTest.java
@@ -1,0 +1,54 @@
+package org.triplea.modules.chat.event.processing;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import javax.websocket.Session;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.domain.data.UserName;
+import org.triplea.http.client.web.socket.messages.envelopes.chat.PlayerLeftMessage;
+import org.triplea.modules.chat.Chatters;
+import org.triplea.web.socket.WebSocketMessagingBus;
+
+@ExtendWith(MockitoExtension.class)
+class PlayerLeftListenerTest {
+  @Mock private Chatters chatters;
+  @InjectMocks private PlayerLeftListener playerLeftListener;
+
+  @Mock private Session session;
+  @Mock private WebSocketMessagingBus webSocketMessagingBus;
+
+  private ArgumentCaptor<PlayerLeftMessage> messageCaptor =
+      ArgumentCaptor.forClass(PlayerLeftMessage.class);
+
+  @Test
+  void noopIfChattersSessionDoesNotExist() {
+    when(chatters.playerLeft(session)).thenReturn(Optional.empty());
+
+    playerLeftListener.accept(webSocketMessagingBus, session);
+
+    verify(webSocketMessagingBus, never()).broadcastMessage(any());
+  }
+
+  @Test
+  @DisplayName("If a player is in the chatter session, then we do relay their message")
+  void ifPlayerSessionDoesExistThenRelayTheirMessage() {
+    when(chatters.playerLeft(session)).thenReturn(Optional.of(UserName.of("user-name")));
+
+    playerLeftListener.accept(webSocketMessagingBus, session);
+
+    verify(webSocketMessagingBus).broadcastMessage(messageCaptor.capture());
+    assertThat(messageCaptor.getValue().getUserName(), is(UserName.of("user-name")));
+  }
+}

--- a/http-server/src/test/java/org/triplea/modules/chat/event/processing/SlapListenerTest.java
+++ b/http-server/src/test/java/org/triplea/modules/chat/event/processing/SlapListenerTest.java
@@ -1,0 +1,70 @@
+package org.triplea.modules.chat.event.processing;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import javax.websocket.Session;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.domain.data.ChatParticipant;
+import org.triplea.domain.data.UserName;
+import org.triplea.http.client.web.socket.messages.envelopes.chat.PlayerSlapReceivedMessage;
+import org.triplea.http.client.web.socket.messages.envelopes.chat.PlayerSlapSentMessage;
+import org.triplea.modules.chat.Chatters;
+import org.triplea.web.socket.WebSocketMessageContext;
+
+@ExtendWith(MockitoExtension.class)
+class SlapListenerTest {
+  @Mock private Chatters chatters;
+  @InjectMocks private SlapListener slapListener;
+
+  @Mock private Session session;
+  @Mock private WebSocketMessageContext<PlayerSlapSentMessage> messageContext;
+
+  private ArgumentCaptor<PlayerSlapReceivedMessage> messageCaptor =
+      ArgumentCaptor.forClass(PlayerSlapReceivedMessage.class);
+
+  @Test
+  void noopIfChattersSessionDoesNotExist() {
+    when(messageContext.getSenderSession()).thenReturn(session);
+    when(chatters.lookupPlayerBySession(session)).thenReturn(Optional.empty());
+
+    slapListener.accept(messageContext);
+
+    verify(messageContext, never()).broadcastMessage(any());
+  }
+
+  @Test
+  @DisplayName("If a player is in the chatter session, then we do relay their message")
+  void ifPlayerSessionDoesExistThenRelayTheirMessage() {
+    when(messageContext.getSenderSession()).thenReturn(session);
+    when(messageContext.getMessage())
+        .thenReturn(new PlayerSlapSentMessage(UserName.of("slapped-player")));
+    givenChatterSession(session, ChatParticipant.builder().userName("user-name").build());
+
+    slapListener.accept(messageContext);
+
+    verify(messageContext).broadcastMessage(messageCaptor.capture());
+    verifyMessageContents(messageCaptor.getValue());
+  }
+
+  private void givenChatterSession(final Session session, final ChatParticipant chatParticipant) {
+    when(chatters.lookupPlayerBySession(session)) //
+        .thenReturn(Optional.of(chatParticipant));
+  }
+
+  private static void verifyMessageContents(final PlayerSlapReceivedMessage chatReceivedMessage) {
+    assertThat(chatReceivedMessage.getSlappedPlayer(), is(UserName.of("slapped-player")));
+    assertThat(chatReceivedMessage.getSlappingPlayer(), is(UserName.of("user-name")));
+  }
+}

--- a/http-server/src/test/java/org/triplea/modules/chat/event/processing/StatusUpdateListenerTest.java
+++ b/http-server/src/test/java/org/triplea/modules/chat/event/processing/StatusUpdateListenerTest.java
@@ -1,0 +1,70 @@
+package org.triplea.modules.chat.event.processing;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import javax.websocket.Session;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.domain.data.ChatParticipant;
+import org.triplea.domain.data.UserName;
+import org.triplea.http.client.web.socket.messages.envelopes.chat.PlayerStatusUpdateReceivedMessage;
+import org.triplea.http.client.web.socket.messages.envelopes.chat.PlayerStatusUpdateSentMessage;
+import org.triplea.modules.chat.Chatters;
+import org.triplea.web.socket.WebSocketMessageContext;
+
+@ExtendWith(MockitoExtension.class)
+class StatusUpdateListenerTest {
+  @Mock private Chatters chatters;
+  @InjectMocks private StatusUpdateListener statusUpdateListener;
+
+  @Mock private Session session;
+  @Mock private WebSocketMessageContext<PlayerStatusUpdateSentMessage> messageContext;
+
+  private ArgumentCaptor<PlayerStatusUpdateReceivedMessage> messageCaptor =
+      ArgumentCaptor.forClass(PlayerStatusUpdateReceivedMessage.class);
+
+  @Test
+  void noopIfChattersSessionDoesNotExist() {
+    when(messageContext.getSenderSession()).thenReturn(session);
+    when(chatters.lookupPlayerBySession(session)).thenReturn(Optional.empty());
+
+    statusUpdateListener.accept(messageContext);
+
+    verify(messageContext, never()).broadcastMessage(any());
+  }
+
+  @Test
+  @DisplayName("If a player is in the chatter session, then we do relay their message")
+  void ifPlayerSessionDoesExistThenRelayTheirMessage() {
+    when(messageContext.getSenderSession()).thenReturn(session);
+    when(messageContext.getMessage()).thenReturn(new PlayerStatusUpdateSentMessage("status"));
+    givenChatterSession(session, ChatParticipant.builder().userName("user-name").build());
+
+    statusUpdateListener.accept(messageContext);
+
+    verify(messageContext).broadcastMessage(messageCaptor.capture());
+    verifyMessageContents(messageCaptor.getValue());
+  }
+
+  private void givenChatterSession(final Session session, final ChatParticipant chatParticipant) {
+    when(chatters.lookupPlayerBySession(session)) //
+        .thenReturn(Optional.of(chatParticipant));
+  }
+
+  private static void verifyMessageContents(
+      final PlayerStatusUpdateReceivedMessage chatReceivedMessage) {
+    assertThat(chatReceivedMessage.getStatus(), is("status"));
+    assertThat(chatReceivedMessage.getUserName(), is(UserName.of("user-name")));
+  }
+}


### PR DESCRIPTION
Adds test coverage to server side websocket message listeners.

<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[x] Other:  add tests <!-- Please specify -->

