### PR TITLE
Default save game name

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -21,6 +21,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.locks.ReadWriteLock;
@@ -58,6 +59,10 @@ import org.triplea.util.Version;
  */
 public class GameData implements Serializable {
   private static final long serialVersionUID = -2612710634080125728L;
+
+  /** When we load a game from a save file, this property will be the name of that file. */
+  private static final String SAVE_GAME_FILE_NAME_PROPERTY = "save.game.file.name";
+
   private transient ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
   private transient volatile boolean forceInSwingEventThread = false;
   private String gameName;
@@ -456,5 +461,13 @@ public class GameData implements Serializable {
     } finally {
       releaseReadLock();
     }
+  }
+
+  public Optional<String> getSaveGameFileName() {
+    return Optional.ofNullable(getProperties().get(SAVE_GAME_FILE_NAME_PROPERTY, null));
+  }
+
+  public void setSaveGameFileName(final String saveGameFileName) {
+    getProperties().set(SAVE_GAME_FILE_NAME_PROPERTY, saveGameFileName);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/network/ui/GetGameSaveClientAction.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/network/ui/GetGameSaveClientAction.java
@@ -1,6 +1,7 @@
 package games.strategy.engine.framework.network.ui;
 
 import games.strategy.engine.framework.startup.mc.IServerStartupRemote;
+import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.triplea.ui.menubar.TripleAMenuBar;
 import java.awt.Component;
 import java.awt.Frame;
@@ -29,7 +30,7 @@ public class GetGameSaveClientAction extends AbstractAction {
   @Override
   public void actionPerformed(final ActionEvent e) {
     final Frame frame = JOptionPane.getFrameForComponent(parent);
-    final File f = TripleAMenuBar.getSaveGameLocation(frame);
+    final File f = SaveGameFileChooser.getSaveGameLocation(frame);
     if (f != null) {
       final byte[] bytes = serverRemote.getSaveGame();
       try (var fileOutputStream = new FileOutputStream(f)) {

--- a/game-core/src/main/java/games/strategy/engine/framework/network/ui/GetGameSaveClientAction.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/network/ui/GetGameSaveClientAction.java
@@ -1,8 +1,8 @@
 package games.strategy.engine.framework.network.ui;
 
+import games.strategy.engine.data.GameData;
 import games.strategy.engine.framework.startup.mc.IServerStartupRemote;
 import games.strategy.engine.framework.ui.SaveGameFileChooser;
-import games.strategy.triplea.ui.menubar.TripleAMenuBar;
 import java.awt.Component;
 import java.awt.Frame;
 import java.awt.event.ActionEvent;
@@ -20,17 +20,22 @@ public class GetGameSaveClientAction extends AbstractAction {
   private static final long serialVersionUID = 1118264715230932068L;
   private final Component parent;
   private final IServerStartupRemote serverRemote;
+  private final GameData gameDataOnStartup;
 
-  public GetGameSaveClientAction(final Component parent, final IServerStartupRemote serverRemote) {
+  public GetGameSaveClientAction(
+      final Component parent,
+      final IServerStartupRemote serverRemote,
+      final GameData gameDataOnStartup) {
     super("Download Gamesave (Save Game)");
     this.parent = JOptionPane.getFrameForComponent(parent);
     this.serverRemote = serverRemote;
+    this.gameDataOnStartup = gameDataOnStartup;
   }
 
   @Override
   public void actionPerformed(final ActionEvent e) {
     final Frame frame = JOptionPane.getFrameForComponent(parent);
-    final File f = SaveGameFileChooser.getSaveGameLocation(frame);
+    final File f = SaveGameFileChooser.getSaveGameLocation(frame, gameDataOnStartup);
     if (f != null) {
       final byte[] bytes = serverRemote.getSaveGame();
       try (var fileOutputStream = new FileOutputStream(f)) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -461,7 +461,7 @@ public class ClientModel implements IMessengerErrorListener {
   }
 
   public Action getHostBotGetGameSaveClientAction(final Component parent) {
-    return new GetGameSaveClientAction(parent, getServerStartup());
+    return new GetGameSaveClientAction(parent, getServerStartup(), gameDataOnStartup);
   }
 
   /** Simple data object for which host we are connecting to and with which name. */

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
@@ -86,6 +86,7 @@ public class GameSelectorModel extends Observable implements GameSelector {
     } else {
       // try to load it as a saved game whatever the extension
       newData = GameDataManager.loadGame(file);
+      newData.setSaveGameFileName(file.getName());
     }
     load(newData, file.getName());
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
@@ -1,10 +1,13 @@
 package games.strategy.engine.framework.ui;
 
+import games.strategy.engine.data.GameData;
 import games.strategy.engine.framework.GameDataFileUtils;
 import games.strategy.triplea.settings.ClientSetting;
 import java.awt.FileDialog;
 import java.awt.Frame;
 import java.io.File;
+import java.time.ZonedDateTime;
+import java.util.StringJoiner;
 import javax.swing.JFileChooser;
 
 /** A file chooser for save games. Defaults to the user's configured save game folder. */
@@ -19,13 +22,14 @@ public final class SaveGameFileChooser extends JFileChooser {
    * @return The file to which the current game should be saved or {@code null} if the user
    *     cancelled the operation.
    */
-  public static File getSaveGameLocation(final Frame frame) {
+  public static File getSaveGameLocation(final Frame frame, final GameData gameData) {
     final FileDialog fileDialog = new FileDialog(frame);
     fileDialog.setMode(FileDialog.SAVE);
     fileDialog.setDirectory(ClientSetting.saveGamesFolderPath.getValueOrThrow().toString());
     fileDialog.setFilenameFilter((dir, name) -> GameDataFileUtils.isCandidateFileName(name));
-    fileDialog.setVisible(true);
+    fileDialog.setFile(getSaveGameName(gameData));
 
+    fileDialog.setVisible(true);
     final String fileName = fileDialog.getFile();
     if (fileName == null) {
       return null;
@@ -34,5 +38,19 @@ public final class SaveGameFileChooser extends JFileChooser {
     // If the user selects a filename that already exists,
     // the AWT Dialog will ask the user for confirmation
     return new File(fileDialog.getDirectory(), GameDataFileUtils.addExtensionIfAbsent(fileName));
+  }
+
+  private static String getSaveGameName(final GameData gameData) {
+    return gameData.getSaveGameFileName().orElse(formatGameName(gameData.getGameName()));
+  }
+
+  private static String formatGameName(final String gameName) {
+    final ZonedDateTime now = ZonedDateTime.now();
+    return new StringJoiner("-")
+        .add(String.valueOf(now.getYear()))
+        .add(String.valueOf(now.getMonthValue()))
+        .add(String.valueOf(now.getDayOfMonth()))
+        .add(gameName.replaceAll(" ", "-") + GameDataFileUtils.getExtension())
+        .toString();
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/SaveGameFileChooser.java
@@ -2,47 +2,37 @@ package games.strategy.engine.framework.ui;
 
 import games.strategy.engine.framework.GameDataFileUtils;
 import games.strategy.triplea.settings.ClientSetting;
+import java.awt.FileDialog;
+import java.awt.Frame;
 import java.io.File;
 import javax.swing.JFileChooser;
-import javax.swing.filechooser.FileFilter;
 
 /** A file chooser for save games. Defaults to the user's configured save game folder. */
 public final class SaveGameFileChooser extends JFileChooser {
   private static final long serialVersionUID = 1548668790891292106L;
 
-  private static SaveGameFileChooser instance;
+  /**
+   * Displays a file chooser dialog for the user to select the file to which the current game should
+   * be saved.
+   *
+   * @param frame The owner of the file chooser dialog; may be {@code null}.
+   * @return The file to which the current game should be saved or {@code null} if the user
+   *     cancelled the operation.
+   */
+  public static File getSaveGameLocation(final Frame frame) {
+    final FileDialog fileDialog = new FileDialog(frame);
+    fileDialog.setMode(FileDialog.SAVE);
+    fileDialog.setDirectory(ClientSetting.saveGamesFolderPath.getValueOrThrow().toString());
+    fileDialog.setFilenameFilter((dir, name) -> GameDataFileUtils.isCandidateFileName(name));
+    fileDialog.setVisible(true);
 
-  private SaveGameFileChooser() {
-    setFileFilter(newGameDataFileFilter());
-    final File saveGamesFolder = ClientSetting.saveGamesFolderPath.getValueOrThrow().toFile();
-    ensureDirectoryExists(saveGamesFolder);
-    setCurrentDirectory(saveGamesFolder);
-  }
-
-  public static SaveGameFileChooser getInstance() {
-    if (instance == null) {
-      instance = new SaveGameFileChooser();
+    final String fileName = fileDialog.getFile();
+    if (fileName == null) {
+      return null;
     }
-    return instance;
-  }
 
-  private static void ensureDirectoryExists(final File f) {
-    if (!f.mkdirs() && !f.exists()) {
-      throw new IllegalStateException("Unable to create save game folder: " + f.getAbsolutePath());
-    }
-  }
-
-  private static FileFilter newGameDataFileFilter() {
-    return new FileFilter() {
-      @Override
-      public boolean accept(final File file) {
-        return file.isDirectory() || GameDataFileUtils.isCandidateFileName(file.getName());
-      }
-
-      @Override
-      public String getDescription() {
-        return "Saved Games, *" + GameDataFileUtils.getExtension();
-      }
-    };
+    // If the user selects a filename that already exists,
+    // the AWT Dialog will ask the user for confirmation
+    return new File(fileDialog.getDirectory(), GameDataFileUtils.addExtensionIfAbsent(fileName));
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -2193,7 +2193,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
                       JOptionPane.INFORMATION_MESSAGE);
                   data.acquireReadLock();
                   try {
-                    final File f = SaveGameFileChooser.getSaveGameLocation(TripleAFrame.this);
+                    final File f = SaveGameFileChooser.getSaveGameLocation(TripleAFrame.this, data);
                     if (f != null) {
                       try (FileOutputStream fileOutputStream = new FileOutputStream(f)) {
                         final GameData datacopy = GameDataUtils.cloneGameData(data, true);

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -32,6 +32,7 @@ import games.strategy.engine.framework.LocalPlayers;
 import games.strategy.engine.framework.ServerGame;
 import games.strategy.engine.framework.startup.ui.InGameLobbyWatcherWrapper;
 import games.strategy.engine.framework.system.SystemProperties;
+import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.engine.history.HistoryNode;
 import games.strategy.engine.history.Round;
 import games.strategy.engine.history.Step;
@@ -2192,7 +2193,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
                       JOptionPane.INFORMATION_MESSAGE);
                   data.acquireReadLock();
                   try {
-                    final File f = TripleAMenuBar.getSaveGameLocation(TripleAFrame.this);
+                    final File f = SaveGameFileChooser.getSaveGameLocation(TripleAFrame.this);
                     if (f != null) {
                       try (FileOutputStream fileOutputStream = new FileOutputStream(f)) {
                         final GameData datacopy = GameDataUtils.cloneGameData(data, true);

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
@@ -5,6 +5,7 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.GameStep;
 import games.strategy.engine.framework.IGame;
 import games.strategy.engine.framework.system.SystemProperties;
+import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.engine.posted.game.pbem.PbemMessagePoster;
 import games.strategy.triplea.delegate.GameStepPropertiesHelper;
 import games.strategy.triplea.ui.MacOsIntegration;
@@ -50,7 +51,7 @@ final class FileMenu extends JMenu {
         .accelerator(KeyCode.S)
         .actionListener(
             () -> {
-              final File f = TripleAMenuBar.getSaveGameLocation(frame);
+              final File f = SaveGameFileChooser.getSaveGameLocation(frame);
               if (f != null) {
                 game.saveGame(f);
                 JOptionPane.showMessageDialog(

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/FileMenu.java
@@ -51,7 +51,7 @@ final class FileMenu extends JMenu {
         .accelerator(KeyCode.S)
         .actionListener(
             () -> {
-              final File f = SaveGameFileChooser.getSaveGameLocation(frame);
+              final File f = SaveGameFileChooser.getSaveGameLocation(frame, gameData);
               if (f != null) {
                 game.saveGame(f);
                 JOptionPane.showMessageDialog(

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/TripleAMenuBar.java
@@ -1,15 +1,10 @@
 package games.strategy.triplea.ui.menubar;
 
-import games.strategy.engine.framework.GameDataFileUtils;
 import games.strategy.engine.framework.startup.ui.InGameLobbyWatcherWrapper;
 import games.strategy.engine.lobby.client.ui.action.EditGameCommentAction;
 import games.strategy.engine.lobby.client.ui.action.RemoveGameFromLobbyAction;
-import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.TripleAFrame;
-import java.awt.FileDialog;
-import java.awt.Frame;
 import java.awt.event.KeyEvent;
-import java.io.File;
 import java.util.Optional;
 import javax.swing.JMenu;
 import javax.swing.JMenuBar;
@@ -45,30 +40,5 @@ public final class TripleAMenuBar extends JMenuBar {
     add(lobby);
     lobby.add(new EditGameCommentAction(watcher, frame));
     lobby.add(new RemoveGameFromLobbyAction(watcher));
-  }
-
-  /**
-   * Displays a file chooser dialog for the user to select the file to which the current game should
-   * be saved.
-   *
-   * @param frame The owner of the file chooser dialog; may be {@code null}.
-   * @return The file to which the current game should be saved or {@code null} if the user
-   *     cancelled the operation.
-   */
-  public static File getSaveGameLocation(final Frame frame) {
-    final FileDialog fileDialog = new FileDialog(frame);
-    fileDialog.setMode(FileDialog.SAVE);
-    fileDialog.setDirectory(ClientSetting.saveGamesFolderPath.getValueOrThrow().toString());
-    fileDialog.setFilenameFilter((dir, name) -> GameDataFileUtils.isCandidateFileName(name));
-    fileDialog.setVisible(true);
-
-    final String fileName = fileDialog.getFile();
-    if (fileName == null) {
-      return null;
-    }
-
-    // If the user selects a filename that already exists,
-    // the AWT Dialog will ask the user for confirmation
-    return new File(fileDialog.getDirectory(), GameDataFileUtils.addExtensionIfAbsent(fileName));
   }
 }


### PR DESCRIPTION
## Commits
commit 9c2b6dbb0114a785bd5d12f2469baded41a1eeff

    Move save-game file chooser logic to SaveGameFileChooser

commit 5bee76ed6a6b6369dc62a0f5e19de7adc0f381be

    Add default save game name
    
    This is done by adding a gameData property that is the save game file name
    that we are loading from. The property is null if we are starting a new game.
    
    In the case wheere we are loading new game, instead of defaulting
    the save game file name to the name of the save game, we instead create
     a default name with this pattern "YYYY-MM-DD-map-name.tsvg"


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  https://github.com/triplea-game/triplea/issues/6105  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
verified:
- default file name is set for new games
- save game file name matches the file name for load games
- verified the two points above hold for both host+client on network games

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->

## Additional Review Notes

- It's technically a new feature that we create a default save game file name for new games, previously we only had a prefilled name for load games
- The 'SaveGameFileChooser' was unused, it was missed as part of a previous removal when we went from FileChooser to FileDialog recently.
