### PR TITLE
Fix adding moderator shows as removing a moderator in audit log

### DIFF
--- a/http-server/src/main/java/org/triplea/db/dao/ModeratorAuditHistoryDao.java
+++ b/http-server/src/main/java/org/triplea/db/dao/ModeratorAuditHistoryDao.java
@@ -30,6 +30,7 @@ public interface ModeratorAuditHistoryDao {
     REMOVE_BAD_WORD,
     BAN_USER,
     REMOVE_USER_BAN,
+    ADD_MODERATOR,
     REMOVE_MODERATOR,
     ADD_SUPER_MOD,
     DISCONNECT_USER,

--- a/http-server/src/main/java/org/triplea/modules/moderation/moderators/ModeratorsService.java
+++ b/http-server/src/main/java/org/triplea/modules/moderation/moderators/ModeratorsService.java
@@ -52,7 +52,7 @@ class ModeratorsService {
     moderatorAuditHistoryDao.addAuditRecord(
         ModeratorAuditHistoryDao.AuditArgs.builder()
             .moderatorUserId(moderatorIdRequesting)
-            .actionName(ModeratorAuditHistoryDao.AuditAction.REMOVE_MODERATOR)
+            .actionName(ModeratorAuditHistoryDao.AuditAction.ADD_MODERATOR)
             .actionTarget(username)
             .build());
     log.info(username + " was promoted to moderator");

--- a/http-server/src/test/java/org/triplea/modules/moderation/moderators/ModeratorsServiceTest.java
+++ b/http-server/src/test/java/org/triplea/modules/moderation/moderators/ModeratorsServiceTest.java
@@ -61,7 +61,7 @@ class ModeratorsServiceTest {
           .addAuditRecord(
               ModeratorAuditHistoryDao.AuditArgs.builder()
                   .moderatorUserId(MODERATOR_ID)
-                  .actionName(ModeratorAuditHistoryDao.AuditAction.REMOVE_MODERATOR)
+                  .actionName(ModeratorAuditHistoryDao.AuditAction.ADD_MODERATOR)
                   .actionTarget(USERNAME)
                   .build());
     }


### PR DESCRIPTION
Simplify flips a "remove moderator" audit action to "add moderator"


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  Example B of https://github.com/triplea-game/triplea/issues/6126<!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

