### PR TITLE
Fix error dialog not appearing

### DIFF
--- a/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
+++ b/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
@@ -19,6 +19,7 @@ import java.util.logging.Level;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 import lombok.extern.java.Log;
+import org.triplea.debug.ErrorMessage;
 import org.triplea.debug.LoggerManager;
 import org.triplea.java.Interruptibles;
 import org.triplea.swing.SwingAction;
@@ -86,7 +87,7 @@ public final class HeadedGameRunner {
     initializeLookAndFeel();
 
     initializeDesktopIntegrations(args);
-
+    SwingUtilities.invokeLater(ErrorMessage::initialize);
     GameRunner.start();
   }
 }


### PR DESCRIPTION
Adds a missing initialize call. When we split JavaFX launcher, the initialize
call was migrated to the JavaFx runner, but missing from the swing client.

With this update we'll see an error report dialog again on severe logging or
uncaught exceptiions


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes

- inject an exception and severe logged to verify the error message shows
