### PR TITLE
Hide units to place collapsible panel during placement

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameSequence.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameSequence.java
@@ -11,8 +11,7 @@ import lombok.extern.java.Log;
 public class GameSequence extends GameDataComponent implements Iterable<GameStep> {
   private static final long serialVersionUID = 6354618406598578287L;
 
-  @Getter
-  private final List<GameStep> steps = new ArrayList<>();
+  @Getter private final List<GameStep> steps = new ArrayList<>();
   private int currentIndex;
   private int round = 1;
   private int roundOffset = 0;

--- a/game-core/src/main/java/games/strategy/engine/data/GameSequence.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameSequence.java
@@ -3,6 +3,7 @@ package games.strategy.engine.data;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
+import lombok.Getter;
 import lombok.extern.java.Log;
 
 /** A contiguous sequence of {@link GameStep}s within a single game round. */
@@ -10,6 +11,7 @@ import lombok.extern.java.Log;
 public class GameSequence extends GameDataComponent implements Iterable<GameStep> {
   private static final long serialVersionUID = 6354618406598578287L;
 
+  @Getter
   private final List<GameStep> steps = new ArrayList<>();
   private int currentIndex;
   private int round = 1;

--- a/game-core/src/main/java/games/strategy/engine/data/GameStep.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameStep.java
@@ -166,7 +166,11 @@ public class GameStep extends GameDataComponent {
   }
 
   public static boolean isPurchaseOrBidStep(final String stepName) {
-    return stepName.endsWith("Bid") || stepName.endsWith("Purchase");
+    return stepName.endsWith("Bid") || isPurchase(stepName);
+  }
+
+  public static boolean isPurchase(final String stepName) {
+    return stepName.endsWith("Purchase");
   }
 
   public static boolean isPlaceStep(final String stepName) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -29,14 +29,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Predicate;
 import javax.swing.BorderFactory;
-import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.SwingUtilities;
 import org.triplea.java.collections.CollectionUtils;
-import org.triplea.swing.CollapsiblePanel;
 import org.triplea.swing.SwingComponents;
 
 class PlacePanel extends AbstractMovePanel implements GameDataChangeListener {
@@ -45,7 +43,6 @@ class PlacePanel extends AbstractMovePanel implements GameDataChangeListener {
   private final JLabel leftToPlaceLabel = new JLabel();
   private PlaceData placeData;
 
-  private final CollapsiblePanel detachedCollapsiblePanel;
   private final SimpleUnitPanel unitsToPlacePanel;
 
   private GamePlayer lastPlayer;
@@ -110,16 +107,9 @@ class PlacePanel extends AbstractMovePanel implements GameDataChangeListener {
   PlacePanel(final GameData data, final MapPanel map, final TripleAFrame frame) {
     super(data, map, frame);
     undoableMovesPanel = new UndoablePlacementsPanel(this);
-    unitsToPlacePanel =
-        new SimpleUnitPanel(
-            map.getUiContext(), SimpleUnitPanel.Style.SMALL_ICONS_WRAPPED_WITH_LABEL_WHEN_EMPTY);
-    detachedCollapsiblePanel = new CollapsiblePanel(unitsToPlacePanel, "Units To Place");
+    unitsToPlacePanel = new SimpleUnitPanel(map.getUiContext());
     data.addGameDataEventListener(GameDataEvent.GAME_STEP_CHANGED, this::updateStep);
     leftToPlaceLabel.setText("Units left to place:");
-  }
-
-  public JComponent getDetachedUnitsToPlacePanel() {
-    return detachedCollapsiblePanel;
   }
 
   private void updateStep() {
@@ -164,11 +154,9 @@ class PlacePanel extends AbstractMovePanel implements GameDataChangeListener {
         () -> {
           if (showUnitsToPlace) {
             unitsToPlacePanel.setUnitsFromCategories(unitsToPlace);
-            detachedCollapsiblePanel.setVisible(true);
             unitsToPlacePanel.revalidate();
             unitsToPlacePanel.repaint();
           } else {
-            detachedCollapsiblePanel.setVisible(false);
             unitsToPlacePanel.removeAll();
           }
         });

--- a/game-core/src/main/java/games/strategy/triplea/ui/PlacementUnitsCollapsiblePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PlacementUnitsCollapsiblePanel.java
@@ -1,0 +1,76 @@
+package games.strategy.triplea.ui;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GameDataEvent;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.GameStep;
+import games.strategy.triplea.util.UnitSeparator;
+import javax.swing.SwingUtilities;
+import lombok.Getter;
+import org.triplea.swing.CollapsiblePanel;
+
+class PlacementUnitsCollapsiblePanel {
+  private final SimpleUnitPanel unitsToPlacePanel;
+
+  @Getter private final CollapsiblePanel panel;
+  private final GameData gameData;
+
+  PlacementUnitsCollapsiblePanel(final GameData gameData, final UiContext uiContext) {
+    this.gameData = gameData;
+    unitsToPlacePanel =
+        new SimpleUnitPanel(
+            uiContext, SimpleUnitPanel.Style.SMALL_ICONS_WRAPPED_WITH_LABEL_WHEN_EMPTY);
+    panel = new CollapsiblePanel(unitsToPlacePanel, "");
+    panel.setVisible(false);
+    gameData.addGameDataEventListener(GameDataEvent.GAME_STEP_CHANGED, this::updateStep);
+  }
+
+  private void updateStep() {
+    final GameStep step = gameData.getSequence().getStep();
+
+    SwingUtilities.invokeLater(
+        () -> {
+          if (GameStep.isPlaceStep(step.getName()) || isInitializationStep(step)) {
+            panel.setVisible(false);
+            return;
+          }
+
+          final boolean hasUnitsToPlace = !step.getPlayerId().getUnits().isEmpty();
+
+          if (hasUnitsToPlace || stepIsAfterPurchaseAndBeforePlacement(step)) {
+            panel.setTitle("Units To Place (" + step.getPlayerId().getUnits().size() + ")");
+            unitsToPlacePanel.setUnitsFromCategories(
+                UnitSeparator.categorize(step.getPlayerId().getUnits()));
+            panel.setVisible(true);
+          } else {
+            panel.setVisible(false);
+          }
+        });
+  }
+
+  private static boolean isInitializationStep(final GameStep gameStep) {
+    return gameStep.getPlayerId() == null;
+  }
+
+  private boolean stepIsAfterPurchaseAndBeforePlacement(final GameStep step) {
+    final GamePlayer currentPlayer = step.getPlayerId();
+
+    for (int i = gameData.getSequence().getStepIndex() - 1; i >= 0; i--) {
+      final GameStep previousStep = gameData.getSequence().getStep(i);
+
+      if (isNotPlayersTurn(currentPlayer, previousStep)
+          || GameStep.isPlaceStep(previousStep.getName())) {
+        return false;
+      }
+
+      if (GameStep.isPurchase(previousStep.getName())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean isNotPlayersTurn(final GamePlayer currentPlayer, final GameStep step) {
+    return !currentPlayer.equals(step.getPlayerId());
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
@@ -156,7 +156,6 @@ public class SimpleUnitPanel extends JPanel {
             false);
       }
     }
-    addEmptyLabelIfNeeded();
   }
 
   /**
@@ -188,7 +187,6 @@ public class SimpleUnitPanel extends JPanel {
         }
       }
     }
-    addEmptyLabelIfNeeded();
   }
 
   /**
@@ -206,7 +204,6 @@ public class SimpleUnitPanel extends JPanel {
           category.hasDamageOrBombingUnitDamage(),
           category.getDisabled());
     }
-    addEmptyLabelIfNeeded();
   }
 
   private void addUnits(
@@ -228,11 +225,5 @@ public class SimpleUnitPanel extends JPanel {
           uiContext.getResourceImageFactory().getIcon(unit, style == Style.LARGE_ICONS_COLUMN));
     }
     add(label);
-  }
-
-  private void addEmptyLabelIfNeeded() {
-    if (style == Style.SMALL_ICONS_WRAPPED_WITH_LABEL_WHEN_EMPTY && getComponentCount() == 0) {
-      add(new JLabel("(None)"));
-    }
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -580,8 +580,8 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
     rightHandSidePanel.add(
         new JPanelBuilder()
             .borderLayout()
-            .addNorth(movePanel.getUnitScrollerPanel())
-            .addSouth(new PlacementUnitsCollapsiblePanel(data, uiContext).getPanel())
+            .addNorth(new PlacementUnitsCollapsiblePanel(data, uiContext).getPanel())
+            .addSouth(movePanel.getUnitScrollerPanel())
             .build(),
         BorderLayout.SOUTH);
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -576,13 +576,12 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
 
     final MovePanel movePanel = new MovePanel(data, mapPanel, this);
     actionButtons = new ActionButtons(data, mapPanel, movePanel, this);
-    final PlacePanel placePanel = actionButtons.getPlacePanel();
 
     rightHandSidePanel.add(
         new JPanelBuilder()
             .borderLayout()
             .addNorth(movePanel.getUnitScrollerPanel())
-            .addSouth(placePanel.getDetachedUnitsToPlacePanel())
+            .addSouth(new PlacementUnitsCollapsiblePanel(data, uiContext).getPanel())
             .build(),
         BorderLayout.SOUTH);
 


### PR DESCRIPTION
## Summary
- Changes place panel to be rendered as it was in 1.9
- Updates placement collapsible panel to show placement unit count
- Removes "None" label from collapsible panel when zero units are purchased
- Swaps location of the unit scroller with placements collapsible panel

<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
- play tested on napoleon
  - played through a couple players turns
- play tested on revised
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
## Screens Shots

![Screenshot from 2020-04-07 00-07-38](https://user-images.githubusercontent.com/12397753/78642383-7ea61680-7867-11ea-92b0-09f0460ba232.png)


![Screenshot from 2020-04-07 00-10-44](https://user-images.githubusercontent.com/12397753/78642349-6fbf6400-7867-11ea-953f-373bb3f641c9.png)


<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

