### PR TITLE
Fix inverted boolean return when disconnecting chatters

### DIFF
--- a/http-server/src/main/java/org/triplea/modules/chat/Chatters.java
+++ b/http-server/src/main/java/org/triplea/modules/chat/Chatters.java
@@ -114,6 +114,6 @@ public class Chatters {
                 e);
           }
         });
-    return sessions.isEmpty();
+    return !sessions.isEmpty();
   }
 }

--- a/http-server/src/test/java/org/triplea/modules/chat/ChattersTest.java
+++ b/http-server/src/test/java/org/triplea/modules/chat/ChattersTest.java
@@ -168,7 +168,9 @@ class ChattersTest {
   class DisconnectPlayerSessions {
     @Test
     void noOpIfPlayerNotConnected() {
-      chatters.disconnectPlayerSessions(CHAT_PARTICIPANT.getUserName(), "disconnect message");
+      final boolean result =
+          chatters.disconnectPlayerSessions(CHAT_PARTICIPANT.getUserName(), "disconnect message");
+      assertThat(result, is(false));
     }
 
     @Test
@@ -177,7 +179,9 @@ class ChattersTest {
       when(session.getId()).thenReturn("100");
       chatters.connectPlayer(API_KEY, session);
 
-      chatters.disconnectPlayerSessions(CHAT_PARTICIPANT.getUserName(), "disconnect message");
+      final boolean result =
+          chatters.disconnectPlayerSessions(CHAT_PARTICIPANT.getUserName(), "disconnect message");
+      assertThat(result, is(true));
 
       verify(session).close(any(CloseReason.class));
     }
@@ -194,7 +198,9 @@ class ChattersTest {
       chatters.connectPlayer(API_KEY, session);
       chatters.connectPlayer(API_KEY_2, session2);
 
-      chatters.disconnectPlayerSessions(CHAT_PARTICIPANT.getUserName(), "disconnect message");
+      final boolean result =
+          chatters.disconnectPlayerSessions(CHAT_PARTICIPANT.getUserName(), "disconnect message");
+      assertThat(result, is(true));
 
       verify(session).close(any(CloseReason.class));
       verify(session2).close(any(CloseReason.class));


### PR DESCRIPTION
Disconnect chatters should return true when a chatter
is disconnected. The return value was inverted.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

