### PR TITLE
Fix transposed time units when banning from toolbox

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/BanDuration.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/BanDuration.java
@@ -4,12 +4,17 @@ import com.google.common.base.Preconditions;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
-final class BanDuration {
+public final class BanDuration {
   private final Integer duration;
   private final BanTimeUnit timeUnit;
 
-  long toMinutes() {
+  public long toMinutes() {
     Preconditions.checkNotNull(duration);
     return timeUnit.toMinutes(duration);
+  }
+
+  @Override
+  public String toString() {
+    return duration + " " + timeUnit;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/BanDurationDialog.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/BanDurationDialog.java
@@ -19,13 +19,18 @@ public final class BanDurationDialog extends JDialog {
   static final int MAX_DURATION = 10_000_000;
   private static final long serialVersionUID = 1367343948352548021L;
 
+  private static final String TITLE = "Select Timespan";
+  private static final String MESSAGE =
+      "Please consult other admins before banning longer than 1 day. \n"
+          + "And please remember to report this ban.";
+
   private final JSpinner durationSpinner =
       new JSpinner(new SpinnerNumberModel(1, 1, MAX_DURATION, 1));
   private final JComboBox<BanTimeUnit> timeUnitComboBox = new JComboBox<>(BanTimeUnit.values());
   private Result result = Result.CANCEL;
 
-  private BanDurationDialog(final Frame owner, final String title, final String message) {
-    super(owner, title, true);
+  private BanDurationDialog(final Frame owner) {
+    super(owner, TITLE, true);
 
     add(
         new JPanelBuilder()
@@ -34,7 +39,7 @@ public final class BanDurationDialog extends JDialog {
             .add(
                 new JPanelBuilder()
                     .boxLayoutHorizontal()
-                    .add(JLabelBuilder.builder().text(message).build())
+                    .add(JLabelBuilder.builder().text(MESSAGE).build())
                     .addHorizontalGlue()
                     .build())
             .addVerticalStrut(10)
@@ -105,16 +110,10 @@ public final class BanDurationDialog extends JDialog {
    * Prompts the user to enter a timespan. If the operation is not cancelled, the action Consumer is
    * run. Not that the Date passed to the consumer can be null if the user chose forever.
    */
-  public static void prompt(
-      final Frame owner,
-      final String title,
-      final String message,
-      final Consumer<BanDuration> action) {
+  public static void prompt(final Frame owner, final Consumer<BanDuration> action) {
     checkNotNull(owner);
-    checkNotNull(title);
-    checkNotNull(message);
     checkNotNull(action);
 
-    new BanDurationDialog(owner, title, message).open().ifPresent(action);
+    new BanDurationDialog(owner).open().ifPresent(action);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/BanPlayerModeratorAction.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/BanPlayerModeratorAction.java
@@ -21,9 +21,6 @@ public class BanPlayerModeratorAction {
         e ->
             BanDurationDialog.prompt(
                 parent,
-                "Select Timespan",
-                "Please consult other admins before banning longer than 1 day. \n"
-                    + "And please remember to report this ban.",
                 timespan ->
                     // do confirmation
                     playerToLobbyConnection.banPlayer(

--- a/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/access/log/AccessLogTabActions.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/access/log/AccessLogTabActions.java
@@ -1,46 +1,23 @@
 package games.strategy.engine.lobby.moderator.toolbox.tabs.access.log;
 
-import com.google.common.collect.ImmutableMap;
+import games.strategy.engine.lobby.client.ui.action.BanDuration;
+import games.strategy.engine.lobby.client.ui.action.BanDurationDialog;
 import games.strategy.engine.lobby.moderator.toolbox.MessagePopup;
 import games.strategy.engine.lobby.moderator.toolbox.tabs.Pager;
-import java.awt.Component;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 import java.util.function.BiConsumer;
 import javax.annotation.Nonnull;
-import javax.swing.AbstractButton;
-import javax.swing.Box;
-import javax.swing.ButtonGroup;
 import javax.swing.JButton;
-import javax.swing.JDialog;
 import javax.swing.JFrame;
-import javax.swing.JLabel;
-import javax.swing.JOptionPane;
-import javax.swing.JPanel;
-import javax.swing.JRadioButton;
 import javax.swing.JTable;
 import javax.swing.table.DefaultTableModel;
 import lombok.Builder;
 import org.triplea.http.client.lobby.moderator.toolbox.banned.user.UserBanParams;
-import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.JTableBuilder;
 import org.triplea.swing.SwingComponents;
-import org.triplea.swing.jpanel.JPanelBuilder;
 
 class AccessLogTabActions {
   private static final int PAGE_SIZE = 50;
-
-  private static final String ONE_HOUR = "1 Hour";
-  private static final String ONE_DAY = "1 Day";
-  private static final String ONE_WEEK = "1 Week";
-  private static final String THREE_WEEKS = "3 Weeks";
-
-  private static final ImmutableMap<String, Integer> TIME_DURATION_MAP =
-      ImmutableMap.of(
-          ONE_HOUR, 1,
-          ONE_DAY, (int) TimeUnit.DAYS.toHours(1),
-          ONE_WEEK, (int) TimeUnit.DAYS.toHours(7),
-          THREE_WEEKS, (int) TimeUnit.DAYS.toHours(21));
 
   private final JFrame parentFrame;
 
@@ -85,12 +62,17 @@ class AccessLogTabActions {
 
   BiConsumer<Integer, DefaultTableModel> banUser() {
     return (rowNumber, tableModel) ->
-        promptForBanDuration(
-            BanData.builder()
-                .username(String.valueOf(tableModel.getValueAt(rowNumber, 1)))
-                .ip(String.valueOf(tableModel.getValueAt(rowNumber, 2)))
-                .hashedMac(String.valueOf(tableModel.getValueAt(rowNumber, 3)))
-                .build());
+        BanDurationDialog.prompt(
+            parentFrame,
+            duration -> {
+              confirmBan(
+                  duration,
+                  BanData.builder()
+                      .username(String.valueOf(tableModel.getValueAt(rowNumber, 1)))
+                      .ip(String.valueOf(tableModel.getValueAt(rowNumber, 2)))
+                      .hashedMac(String.valueOf(tableModel.getValueAt(rowNumber, 3)))
+                      .build());
+            });
   }
 
   @Builder
@@ -100,98 +82,20 @@ class AccessLogTabActions {
     @Nonnull private final String hashedMac;
   }
 
-  private void promptForBanDuration(final BanData banData) {
-    final JDialog dialog =
-        new JDialog(JOptionPane.getFrameForComponent(parentFrame), "Ban " + banData.username, true);
-    dialog
-        .getContentPane()
-        .add(
-            new JPanelBuilder()
-                .borderLayout()
-                .addNorth(new JLabel("How long to ban?"))
-                .addCenter(banDurationPanel(dialog, banData))
-                .build());
-    SwingComponents.addEscapeKeyListener(dialog, dialog::dispose);
-    dialog.pack();
-    dialog.setLocationRelativeTo(parentFrame);
-    dialog.setVisible(true);
-    dialog.dispose();
-  }
-
-  private Component banDurationPanel(final JDialog dialog, final BanData banData) {
-    final JRadioButton oneHour = new JRadioButton("1 Hour");
-    oneHour.setSelected(true);
-    final JRadioButton oneDay = new JRadioButton("1 Day");
-    final JRadioButton oneWeek = new JRadioButton("1 Week");
-    final JRadioButton threeWeeks = new JRadioButton("3 Weeks");
-
-    final ButtonGroup group = new ButtonGroup();
-    group.add(oneHour);
-    group.add(oneDay);
-    group.add(oneWeek);
-    group.add(threeWeeks);
-
-    final JPanel radioPanel =
-        new JPanelBuilder()
-            .boxLayoutVertical()
-            .add(oneHour)
-            .add(oneDay)
-            .add(oneWeek)
-            .add(threeWeeks)
-            .build();
-
-    return new JPanelBuilder()
-        .borderLayout()
-        .addCenter(radioPanel)
-        .addSouth(
-            new JPanelBuilder()
-                .flowLayout()
-                .add(Box.createHorizontalStrut(10))
-                .add(new JButtonBuilder().title("Cancel").actionListener(dialog::dispose).build())
-                .add(Box.createHorizontalStrut(25))
-                .add(
-                    new JButtonBuilder()
-                        .title("Submit")
-                        .actionListener(
-                            () -> {
-                              dialog.dispose();
-                              final String selectedDuration =
-                                  getSelection(List.of(oneHour, oneDay, oneWeek, threeWeeks));
-                              confirmBan(selectedDuration, banData);
-                            })
-                        .build())
-                .build())
-        .build();
-  }
-
-  private String getSelection(final List<JRadioButton> radioButtons) {
-    return radioButtons.stream()
-        .filter(AbstractButton::isSelected)
-        .findFirst()
-        .map(AbstractButton::getText)
-        // .map(TIME_DURATION_MAP::get)
-        .orElseThrow(
-            () ->
-                new IllegalStateException(
-                    "Expected to find a selected button, programming error."));
-  }
-
-  private void confirmBan(final String banDurationText, final BanData banData) {
-
+  private void confirmBan(final BanDuration banDuration, final BanData banData) {
     SwingComponents.promptUser(
         "Confirm Ban",
-        "Are you sure you want to ban: " + banData.username + " for " + banDurationText,
+        "Are you sure you want to ban: " + banData.username + " for " + banDuration,
         () -> {
           accessLogTabModel.banUser(
               UserBanParams.builder()
                   .username(banData.username)
                   .ip(banData.ip)
                   .systemId(banData.hashedMac)
-                  .minutesToBan(TIME_DURATION_MAP.get(banDurationText))
+                  .minutesToBan(banDuration.toMinutes())
                   .build());
 
-          MessagePopup.showMessage(
-              parentFrame, banData.username + " banned for " + banDurationText);
+          MessagePopup.showMessage(parentFrame, banData.username + " banned for " + banDuration);
         });
   }
 }


### PR DESCRIPTION
The time unit from toolbox ban was transposed and was being sent
as minutes instead of as hours or days.

The fix here is two-fold, one we consolidate a duplicate ban
duration prompt to re-use the ban duration prompt available
when right-clicking player names. Using this ban prompt
we can then send the proper minute time value for ban durations.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix: https://github.com/triplea-game/triplea/issues/6126  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
- play tested, verified in audit log that the correct time value shows up
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

