### PR TITLE
Add ansible role to deploy postfix (email sender)

### DIFF
--- a/infrastructure/ansible/roles/postfix/tasks/main.yml
+++ b/infrastructure/ansible/roles/postfix/tasks/main.yml
@@ -1,0 +1,28 @@
+- name: Install postfix
+  become: true
+  apt:
+    state: present
+    name: postfix
+
+- name: Deploy postfix config
+  become: true
+  template:
+    src: main.cf.j2
+    dest: /etc/postfix/main.cf
+    owner: root
+    group: root
+    mode: "0644"
+  register: postfix_config
+
+- name: Restart postfix if config changes
+  become: true
+  when: postfix_config.changed
+  systemd:
+    name: postfix
+    state: restarted
+
+- name: Ensure postfix is started
+  become: true
+  systemd:
+    name: postfix
+    state: started

--- a/infrastructure/ansible/roles/postfix/templates/main.cf.j2
+++ b/infrastructure/ansible/roles/postfix/templates/main.cf.j2
@@ -1,0 +1,52 @@
+# See /usr/share/postfix/main.cf.dist for a commented, more complete version
+
+
+# Debian specific:  Specifying a file name will cause the first
+# line of that file to be used as the name.  The Debian default
+# is /etc/mailname.
+#myorigin = /etc/mailname
+
+smtpd_banner = $myhostname ESMTP $mail_name (Ubuntu)
+biff = no
+
+# appending .domain is the MUA's job.
+append_dot_mydomain = no
+
+# Uncomment the next line to generate "delayed mail" warnings
+#delay_warning_time = 4h
+
+readme_directory = no
+
+# See http://www.postfix.org/COMPATIBILITY_README.html -- default to 2 on
+# fresh installs.
+compatibility_level = 2
+
+# TLS parameters
+smtpd_tls_cert_file=/etc/letsencrypt/live/{{ inventory_hostname }}/fullchain.pem
+smtpd_tls_key_file=/etc/letsencrypt/live/{{ inventory_hostname }}/privkey.pem
+smtp_tls_security_level=encrypt
+smtp_tls_mandatory_ciphers=high
+smtpd_use_tls=yes
+smtpd_tls_session_cache_database = btree:${data_directory}/smtpd_scache
+smtp_tls_session_cache_database = btree:${data_directory}/smtp_scache
+smtpd_tls_ciphers = high
+smtp_tls_ciphers = high
+smtpd_tls_protocols = !SSLv2, !SSLv3
+smtp_tls_protocols = !SSLv2, !SSLv3
+
+# See /usr/share/doc/postfix/TLS_README.gz in the postfix-doc package for
+# information on enabling SSL in the smtp client.
+
+smtpd_relay_restrictions = permit_mynetworks permit_sasl_authenticated defer_unauth_destination
+myhostname = triplea-game.org
+alias_maps = hash:/etc/aliases
+alias_database = hash:/etc/aliases
+myorigin = /etc/mailname
+mydestination = triplea-game.org, localhost
+relayhost = 
+mynetworks = 127.0.0.0/8 [::ffff:127.0.0.0]/104 [::1]/128
+mailbox_command = procmail -a "$EXTENSION"
+mailbox_size_limit = 0
+recipient_delimiter = +
+inet_interfaces = all
+inet_protocols = all

--- a/infrastructure/ansible/site.yml
+++ b/infrastructure/ansible/site.yml
@@ -45,6 +45,8 @@
       tags: [ http_server ]
     - role: nginx
       tags: [ nginx ]
+    - role: postfix
+      tags: [ postfix ]
 
 - hosts: letsEncrypt
   gather_facts: no


### PR DESCRIPTION
<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix: https://github.com/triplea-game/triplea/issues/6115 <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing

- verified forgot password email could be sent 
- created deployment script
- deployed to prerelease, verified diff that was created
- verified forgot password email could still be sent
  - email uses TLS
  - gmail reported email sender could be verified

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
