### PR TITLE
Fix opcode mismatch

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
@@ -55,4 +55,8 @@ public interface IAbstractPlaceDelegate extends IAbstractMoveDelegate<UndoablePl
    */
   @RemoteActionCode(9)
   Collection<Territory> getTerritoriesWhereAirCantLand();
+
+  @RemoteActionCode(17)
+  @Override
+  String undoMove(int moveIndex);
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
@@ -19,6 +19,7 @@ public interface IAbstractPlaceDelegate extends IAbstractMoveDelegate<UndoablePl
   @RemoteActionCode(13)
   String placeUnits(Collection<Unit> units, Territory at, BidMode bidMode);
 
+  /** Convenience method for testing. Never called over the network. */
   default String placeUnits(final Collection<Unit> units, final Territory at) {
     return placeUnits(units, at, BidMode.NOT_BID);
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/remote/IAbstractPlaceDelegate.java
@@ -19,7 +19,6 @@ public interface IAbstractPlaceDelegate extends IAbstractMoveDelegate<UndoablePl
   @RemoteActionCode(13)
   String placeUnits(Collection<Unit> units, Territory at, BidMode bidMode);
 
-  @RemoteActionCode(12)
   default String placeUnits(final Collection<Unit> units, final Territory at) {
     return placeUnits(units, at, BidMode.NOT_BID);
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/remote/IMoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/remote/IMoveDelegate.java
@@ -4,8 +4,10 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.MoveDescription;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.message.RemoteActionCode;
+import games.strategy.engine.posted.game.pbem.PbemMessagePoster;
 import games.strategy.triplea.delegate.UndoableMove;
 import java.util.Collection;
+import java.util.List;
 
 /** Remote interface for MoveDelegate. */
 public interface IMoveDelegate
@@ -38,4 +40,20 @@ public interface IMoveDelegate
    */
   @RemoteActionCode(10)
   Collection<Territory> getTerritoriesWhereUnitsCantFight();
+
+  @RemoteActionCode(17)
+  @Override
+  void setHasPostedTurnSummary(boolean hasPostedTurnSummary);
+
+  @RemoteActionCode(14)
+  @Override
+  boolean postTurnSummary(PbemMessagePoster poster, String title);
+
+  @RemoteActionCode(19)
+  @Override
+  String undoMove(int moveIndex);
+
+  @RemoteActionCode(5)
+  @Override
+  List<UndoableMove> getMovesMade();
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/remote/IPurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/remote/IPurchaseDelegate.java
@@ -21,4 +21,8 @@ public interface IPurchaseDelegate extends IAbstractForumPosterDelegate {
   /** Returns an error code, or null if all is good. */
   @RemoteActionCode(11)
   String purchaseRepair(Map<Unit, IntegerMap<RepairRule>> productionRules);
+
+  @RemoteActionCode(14)
+  @Override
+  void setHasPostedTurnSummary(boolean hasPostedTurnSummary);
 }


### PR DESCRIPTION
<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->
Fix for #6104 and potentially other issues.
There is one thing that could potentially (in theory) still be an issue, but at this point it's highly unlikely it actually exists:
Interfaces that inherit their methods from `IRemote` and `IDelegate` don't specify an op-code for the methods defined in `IDelegate` and subinterfaces, just the ones specified in subinterfaces of `IRemote`. This decision was intentional and up until this point it does ot seem like delegate-only methods are ever invoked over the network, the client side would report this issue already.


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  #6104
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->
I verified #6104 could no longer be reproduced.

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

