### PR TITLE
Specify error prone version in http server, avoid version conflict

### DIFF
--- a/http-server/build.gradle
+++ b/http-server/build.gradle
@@ -20,6 +20,8 @@ configurations {
 }
 
 dependencies {
+    errorprone "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
+
     implementation "com.liveperson:dropwizard-websockets:$dropwizardWebsocketsVersion"
     implementation "com.sun.mail:jakarta.mail:$jakartaMailVersion"
     implementation "com.sun.xml.bind:jaxb-core:$jaxbCoreVersion"


### PR DESCRIPTION
Error prone pulls in an older version of caffeine that conflicts
with the version we need. This problem is fixed in 'java-extras',
but if gradle dependencies are evaluated from http-server then
we can still pick in this older version.

This update applies the same fix we did for 'java-extras' and we
explicitly specify the caffeine version to use in error prone
which prevents the wrong version from being used in test-implementation.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

