### PR TITLE
Fix duplicate player joined message

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/LobbyChatTransmitter.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/LobbyChatTransmitter.java
@@ -45,10 +45,6 @@ public class LobbyChatTransmitter implements ChatTransmitter {
         message -> chatClient.messageReceived(message.getSender(), message.getMessage()));
 
     playerToLobbyConnection.addMessageListener(
-        PlayerJoinedMessage.TYPE,
-        message -> chatClient.participantAdded(message.getChatParticipant()));
-
-    playerToLobbyConnection.addMessageListener(
         ChatEventReceivedMessage.TYPE, message -> chatClient.eventReceived(message.getMessage()));
 
     playerToLobbyConnection.addMessageListener(


### PR DESCRIPTION
Client side, the player joined listener was listed twice.
This caused a duplicate 'player joined' message.
This update fixes that by removing the redundant
player joined listener.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  https://github.com/triplea-game/triplea/issues/6172  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing

Verified locally after the update 'player joined' is listed just once.

(note, we have an automated check that looks for this, it is checking that listener is called at least once, as opposed to exactly once, and hence this scenario was not caught by automated test)
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

