### PR TITLE
Fix double "are you sure you do not want to move" dialog

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -1578,16 +1578,18 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
 
   @Override
   protected boolean doneMoveAction() {
-    if (undoableMovesPanel.getCountOfMovesMade() == 0) {
-      final int selectedOption =
-          JOptionPane.showConfirmDialog(
-              JOptionPane.getFrameForComponent(MovePanel.this),
-              "Are you sure you do not want to move?",
-              "End Move",
-              JOptionPane.YES_NO_OPTION);
-      return selectedOption == JOptionPane.YES_OPTION;
+    final boolean performDone =
+        (undoableMovesPanel.getCountOfMovesMade() == 0)
+            && JOptionPane.showConfirmDialog(
+                    JOptionPane.getFrameForComponent(MovePanel.this),
+                    "Are you sure you do not want to move?",
+                    "End Move",
+                    JOptionPane.YES_NO_OPTION)
+                == JOptionPane.YES_OPTION;
+    if (performDone) {
+      unitScrollerPanel.setVisible(false);
     }
-    return true;
+    return performDone;
   }
 
   @Override
@@ -1620,14 +1622,6 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
     }
     if (!highlight.isEmpty()) {
       getMap().setUnitHighlight(highlight);
-    }
-  }
-
-  @Override
-  public void performDone() {
-    if (doneMoveAction()) {
-      super.performDone();
-      unitScrollerPanel.setVisible(false);
     }
   }
 }


### PR DESCRIPTION
We were seeing two prompts of "are you sure you do not want
to move" when ending a move phase.

This is because of a call to "performDone" being done in both
a child class and parent class. This problem was introduced
by adding an override which then set the unit scroller to
invisible if we advanced. The same update inadvertently added
the double logic.

This update fixes that by relying on the parent method call
only and removing the override. The setting of the unit scroller
panel to be invisible is now done in the child class method
override that is invoked by the parent class 'performDone'.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix: https://github.com/triplea-game/triplea/issues/6162 <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing

- verified that double prompt does not appear (simple to repro, start a game, keep clicking done until you get to a move phase and notice the "are you sure you do not want to move" is double prompted after clicking 'yes')

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->

## Additional Review Notes

This is a pretty good example of why inheritance is a bit evil. Notably when you have concrete implementations and override them and then call parent methods that have implementations is where it can really start to go bad...

### Context

The parent method:
```
  @Override
  public void performDone() {
    if (doneMoveAction()) {
      moveMessage = null;
      release();
    }
  }
```

Child class override:
```
  @Override
  public void performDone() {
    if (doneMoveAction()) {
      super.performDone();
      unitScrollerPanel.setVisible(false);
    }
  }
```

Notice there are two calls to `doneMoveAction()`