### PR TITLE
Add validation text to change password form

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/ChangePasswordPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/ChangePasswordPanel.java
@@ -3,6 +3,7 @@ package games.strategy.engine.lobby.client.login;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.ui.Util;
 import java.awt.BorderLayout;
+import java.awt.Color;
 import java.awt.GridBagLayout;
 import java.awt.Window;
 import java.util.Arrays;
@@ -21,6 +22,7 @@ import org.triplea.http.client.web.socket.client.connections.PlayerToLobbyConnec
 import org.triplea.swing.DocumentListenerBuilder;
 import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.JCheckBoxBuilder;
+import org.triplea.swing.JLabelBuilder;
 import org.triplea.swing.SwingComponents;
 import org.triplea.swing.jpanel.FlowLayoutBuilder;
 import org.triplea.swing.jpanel.GridBagConstraintsAnchor;
@@ -39,6 +41,7 @@ public final class ChangePasswordPanel extends JPanel {
   private final JButton okButton = new JButton("OK");
   private final JCheckBox rememberPassword =
       new JCheckBoxBuilder("Remember Password").bind(ClientSetting.rememberLoginPassword).build();
+  private final JLabel validationLabel = new JLabelBuilder().foregroundColor(Color.RED).build();
 
   public enum AllowCancelMode {
     SHOW_CANCEL_BUTTON,
@@ -92,6 +95,14 @@ public final class ChangePasswordPanel extends JPanel {
             .insets(5, 5, 0, 0)
             .build());
 
+    main.add(
+        validationLabel,
+        new GridBagConstraintsBuilder(0, 3)
+            .anchor(GridBagConstraintsAnchor.WEST)
+            .fill(GridBagConstraintsFill.HORIZONTAL)
+            .insets(5, 5, 0, 0)
+            .build());
+
     final JPanel buttons =
         new JPanelBuilder()
             .border(BorderFactory.createEmptyBorder(10, 5, 10, 5))
@@ -117,7 +128,8 @@ public final class ChangePasswordPanel extends JPanel {
 
     SwingComponents.addEnterKeyListener(this, this::close);
 
-    new DocumentListenerBuilder(() -> okButton.setEnabled(validatePasswords()))
+    new DocumentListenerBuilder(
+            () -> okButton.setEnabled(validatePasswordsAndUpdateValidationText()))
         .attachTo(passwordField, passwordConfirmField);
   }
 
@@ -127,9 +139,17 @@ public final class ChangePasswordPanel extends JPanel {
     }
   }
 
-  private boolean validatePasswords() {
-    return Arrays.equals(passwordField.getPassword(), passwordConfirmField.getPassword())
-        && passwordField.getPassword().length > 4;
+  private boolean validatePasswordsAndUpdateValidationText() {
+    if (!Arrays.equals(passwordField.getPassword(), passwordConfirmField.getPassword())) {
+      validationLabel.setText("Passwords must match");
+      return false;
+    } else if (passwordField.getPassword().length <= 4) {
+      validationLabel.setText("Password is too short");
+      return false;
+    } else {
+      validationLabel.setText("");
+      return true;
+    }
   }
 
   /**
@@ -147,7 +167,7 @@ public final class ChangePasswordPanel extends JPanel {
     dialog.setVisible(true);
     dialog.dispose();
     dialog = null;
-    if (!validatePasswords()) {
+    if (!validatePasswordsAndUpdateValidationText()) {
       return Optional.empty();
     }
 

--- a/swing-lib/src/main/java/org/triplea/swing/JLabelBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/JLabelBuilder.java
@@ -1,5 +1,6 @@
 package org.triplea.swing;
 
+import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Font;
 import java.util.Optional;
@@ -31,6 +32,7 @@ public class JLabelBuilder {
   private Border border;
   private Integer borderSize;
   private int biggerFont;
+  private Color foregroundColor;
 
   public JLabelBuilder() {}
 
@@ -66,6 +68,8 @@ public class JLabelBuilder {
 
     Optional.ofNullable(borderSize)
         .ifPresent(size -> label.setBorder(new EmptyBorder(size, size, size, size)));
+
+    Optional.ofNullable(foregroundColor).ifPresent(label::setForeground);
 
     if (biggerFont > 0) {
       label.setFont(
@@ -129,6 +133,11 @@ public class JLabelBuilder {
   /** Increases button text size by a default amount. */
   public JLabelBuilder biggerFont() {
     biggerFont = 4;
+    return this;
+  }
+
+  public JLabelBuilder foregroundColor(final Color foregroundColor) {
+    this.foregroundColor = foregroundColor;
     return this;
   }
 


### PR DESCRIPTION
This update adds validation message to the 'change password' form.
Notably before there was no messaging of what was wrong with the
passwords such that the 'okay' button was not enabled. This update
adds validation text that prints in red when password and password
confirm do not match or is too short (which should explain why
okay button is not enabled).


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  https://github.com/triplea-game/triplea/issues/6168 <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing

- run "load sample data"
- launch local spitfire server
- launch headed-game runner
- join to local game (available via test menu in preference, "local server")
- login with "test:test"
- on lobby window select "account > change password"
- can demo/repro whether validation text appears

(of note, the change password dialog is the same we show after a user uses 'forgot password' feature).

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
## Screens Shots

![Screenshot from 2020-04-10 21-59-45](https://user-images.githubusercontent.com/12397753/79035857-20cf4280-7b77-11ea-9fe4-c41d431ba55b.png)
![Screenshot from 2020-04-10 21-59-53](https://user-images.githubusercontent.com/12397753/79035858-2167d900-7b77-11ea-88a6-b539d87ada7c.png)
![Screenshot from 2020-04-10 22-00-00](https://user-images.githubusercontent.com/12397753/79035859-2167d900-7b77-11ea-9fde-e98d103b4012.png)

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

