### PR TITLE
Remap unit scroller next/previous unit keys to ',' and '.'

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/MovePanel.java
@@ -1551,10 +1551,10 @@ public class MovePanel extends AbstractMovePanel implements KeyBindingSupplier {
         KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_S),
         unitScrollerAction(unitScroller::sleepCurrentUnits));
     bindings.put(
-        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_N),
+        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_PERIOD),
         unitScrollerAction(unitScroller::centerOnNextMovableUnit));
     bindings.put(
-        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_M),
+        KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_COMMA),
         unitScrollerAction(unitScroller::centerOnPreviousMovableUnit));
     bindings.put(KeyBindingSupplier.fromKeyEventCode(KeyEvent.VK_F), this::highlightMovableUnits);
     bindings.put(

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -56,9 +56,9 @@ public class UnitScroller {
   private static final int HORIZONTAL_BUTTON_GAP = 2;
 
   private static final String PREVIOUS_UNITS_TOOLTIP =
-      "Press 'M' or click to see 'Previous' unmoved units.";
+      "Press ',' or click to see 'Previous' unmoved units.";
   private static final String NEXT_UNITS_TOOLTIP =
-      "Press 'N' or click to see 'Next' unmoved units.";
+      "Press '.' or click to see 'Next' unmoved units.";
   private static final String SLEEP_UNITS_TOOLTIP =
       "Press 'S' or click to 'Sleep' these unmoved units until manually moved or alerted.";
   private static final String SKIP_UNITS_TOOLTIP =


### PR DESCRIPTION
"," and "." are usually labelled with "<" and ">", which makes
scrolling to next and previous make more sense compared to
"n" and "m".


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing

- advanced a single player game to combat phase
- Verified new key mappings worked.

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

