### PR TITLE
Optimize findMaxLandMassSize() which can take 10% of AI time.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/util/BreadthFirstSearch.java
+++ b/game-core/src/main/java/games/strategy/engine/data/util/BreadthFirstSearch.java
@@ -63,12 +63,11 @@ public class BreadthFirstSearch {
     int currentDistance = 0;
     Territory lastTerritoryAtCurrentDistance = territoriesToCheck.peekLast();
     while (!territoriesToCheck.isEmpty()) {
-      final Territory node = territoriesToCheck.removeFirst();
-      visitNeighbors(node);
+      final Territory territory = checkNextTerritory();
 
       // If we just processed the last territory at the current distance, increment the distance
       // and set the territory at which we need to update it again to be the last one added.
-      if (ObjectUtils.referenceEquals(node, lastTerritoryAtCurrentDistance)) {
+      if (ObjectUtils.referenceEquals(territory, lastTerritoryAtCurrentDistance)) {
         currentDistance++;
         if (!shouldContinueSearch(currentDistance)) {
           return;
@@ -78,7 +77,8 @@ public class BreadthFirstSearch {
     }
   }
 
-  private void visitNeighbors(final Territory territory) {
+  private Territory checkNextTerritory() {
+    final Territory territory = territoriesToCheck.removeFirst();
     // Note: We don't pass cond to getNeighbors() because that implementation is much slower.
     for (final Territory neighbor : map.getNeighbors(territory)) {
       if (cond.test(neighbor) && visited.add(neighbor)) {
@@ -86,5 +86,6 @@ public class BreadthFirstSearch {
         visit(neighbor);
       }
     }
+    return territory;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/util/BreadthFirstSearch.java
+++ b/game-core/src/main/java/games/strategy/engine/data/util/BreadthFirstSearch.java
@@ -1,0 +1,86 @@
+package games.strategy.engine.data.util;
+
+import games.strategy.engine.data.GameMap;
+import games.strategy.engine.data.Territory;
+import games.strategy.triplea.delegate.Matches;
+import java.util.ArrayDeque;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import lombok.Getter;
+import org.triplea.java.ObjectUtils;
+
+/**
+ * Implements Breadth First Search (BFS) to traverse / find territories. Since the search criteria
+ * varies depending on the use case, the class is designed to be sub-classed, with methods visit()
+ * and shouldContinueSearch() that can be overridden to customize the behavior.
+ */
+public class BreadthFirstSearch {
+  private final GameMap map;
+  @Getter private final Set<Territory> visited;
+  private final ArrayDeque<Territory> territoriesToCheck;
+  private final Predicate<Territory> cond;
+
+  public BreadthFirstSearch(final Territory startTerritory, final Predicate<Territory> cond) {
+    this.map = startTerritory.getData().getMap();
+    this.visited = new HashSet<Territory>(List.of(startTerritory));
+    this.territoriesToCheck = new ArrayDeque<Territory>(List.of(startTerritory));
+    this.cond = cond;
+  }
+
+  public BreadthFirstSearch(final Territory startTerritory) {
+    this(startTerritory, Matches.always());
+  }
+
+  /**
+   * Called when a new territory is encountered. Can be overridden to provide custom search
+   * behavior.
+   *
+   * @param territory The new territory.
+   */
+  public void visit(final Territory territory) {}
+
+  /**
+   * Called after all territories within the specified distance have been searched. Can be
+   * overridden to terminate the search.
+   *
+   * @param distanceSearched The current distance searched
+   * @return Whether the search should continue.
+   */
+  public boolean shouldContinueSearch(final int distanceSearched) {
+    return true;
+  }
+
+  /**
+   * Performs the search. It will end when either all territories have been visited or
+   * shouldContinueSearch() returns false.
+   */
+  public void search() {
+    // Since we process territories in order of distance, we can keep track of the last territory
+    // at the current distance that's in the territoriesToCheck queue. When we encounter it, we
+    // increment the distance and update lastTerritoryAtCurrentDistance.
+    int currentDistance = 0;
+    Territory lastTerritoryAtCurrentDistance = territoriesToCheck.peekLast();
+    while (!territoriesToCheck.isEmpty()) {
+      final Territory node = territoriesToCheck.removeFirst();
+      // Note: We don't pass cond to getNeighbors() because that implementation is much slower.
+      for (final Territory neighbor : map.getNeighbors(node)) {
+        if (cond.test(neighbor) && visited.add(neighbor)) {
+          territoriesToCheck.add(neighbor);
+          visit(neighbor);
+        }
+      }
+
+      // If we just processed the last territory at the current distance, increment the distance
+      // and set the territory at which we need to update it again to be the last one added.
+      if (ObjectUtils.referenceEquals(node, lastTerritoryAtCurrentDistance)) {
+        currentDistance++;
+        if (!shouldContinueSearch(currentDistance)) {
+          return;
+        }
+        lastTerritoryAtCurrentDistance = territoriesToCheck.peekLast();
+      }
+    }
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/data/util/BreadthFirstSearch.java
+++ b/game-core/src/main/java/games/strategy/engine/data/util/BreadthFirstSearch.java
@@ -12,14 +12,13 @@ import org.triplea.java.ObjectUtils;
 
 /**
  * Implements Breadth First Search (BFS) to traverse / find territories. Since the search criteria
- * varies depending on the use case, the class is designed to be sub-classed, with methods visit()
- * and shouldContinueSearch() that can be overridden to customize the behavior.
+ * varies depending on the use case, the class is designed to take a Visitor object with methods
+ * visit() and shouldContinueSearch() for customizing the behavior.
  */
-public class BreadthFirstSearch {
+public final class BreadthFirstSearch {
   public abstract static class Visitor {
     /**
-     * Called when a new territory is encountered. Can be overridden to provide custom search
-     * behavior.
+     * Called when a new territory is encountered.
      *
      * @param territory The new territory.
      */
@@ -40,13 +39,19 @@ public class BreadthFirstSearch {
   private final GameMap map;
   private final Set<Territory> visited;
   private final ArrayDeque<Territory> territoriesToCheck;
-  private final Predicate<Territory> cond;
+  private final Predicate<Territory> neighborCondition;
 
-  public BreadthFirstSearch(final Territory startTerritory, final Predicate<Territory> cond) {
+  /**
+   * @param startTerritory The territory from where to start the search.
+   * @param neighborCondition Condition that neighboring territories must match to be considered
+   *     neighbors.
+   */
+  public BreadthFirstSearch(
+      final Territory startTerritory, final Predicate<Territory> neighborCondition) {
     this.map = startTerritory.getData().getMap();
     this.visited = new HashSet<>(List.of(startTerritory));
     this.territoriesToCheck = new ArrayDeque<>(List.of(startTerritory));
-    this.cond = cond;
+    this.neighborCondition = neighborCondition;
   }
 
   public BreadthFirstSearch(final Territory startTerritory) {
@@ -82,9 +87,9 @@ public class BreadthFirstSearch {
 
   private Territory checkNextTerritory(final Visitor visitor) {
     final Territory territory = territoriesToCheck.removeFirst();
-    // Note: We don't pass cond to getNeighbors() because that implementation is much slower.
+    // Note: The condition isn't passed to getNeighbors() because that implementation is very slow.
     for (final Territory neighbor : map.getNeighbors(territory)) {
-      if (cond.test(neighbor) && visited.add(neighbor)) {
+      if (neighborCondition.test(neighbor) && visited.add(neighbor)) {
         territoriesToCheck.add(neighbor);
         visitor.visit(neighbor);
       }

--- a/game-core/src/main/java/games/strategy/engine/data/util/BreadthFirstSearch.java
+++ b/game-core/src/main/java/games/strategy/engine/data/util/BreadthFirstSearch.java
@@ -64,13 +64,7 @@ public class BreadthFirstSearch {
     Territory lastTerritoryAtCurrentDistance = territoriesToCheck.peekLast();
     while (!territoriesToCheck.isEmpty()) {
       final Territory node = territoriesToCheck.removeFirst();
-      // Note: We don't pass cond to getNeighbors() because that implementation is much slower.
-      for (final Territory neighbor : map.getNeighbors(node)) {
-        if (cond.test(neighbor) && visited.add(neighbor)) {
-          territoriesToCheck.add(neighbor);
-          visit(neighbor);
-        }
-      }
+      visitNeighbors(node);
 
       // If we just processed the last territory at the current distance, increment the distance
       // and set the territory at which we need to update it again to be the last one added.
@@ -80,6 +74,16 @@ public class BreadthFirstSearch {
           return;
         }
         lastTerritoryAtCurrentDistance = territoriesToCheck.peekLast();
+      }
+    }
+  }
+
+  private void visitNeighbors(final Territory territory) {
+    // Note: We don't pass cond to getNeighbors() because that implementation is much slower.
+    for (final Territory neighbor : map.getNeighbors(territory)) {
+      if (cond.test(neighbor) && visited.add(neighbor)) {
+        territoriesToCheck.add(neighbor);
+        visit(neighbor);
       }
     }
   }

--- a/game-core/src/main/java/games/strategy/engine/data/util/BreadthFirstSearch.java
+++ b/game-core/src/main/java/games/strategy/engine/data/util/BreadthFirstSearch.java
@@ -23,7 +23,7 @@ public class BreadthFirstSearch {
      *
      * @param territory The new territory.
      */
-    public abstract void visit(final Territory territory);
+    public abstract void visit(Territory territory);
 
     /**
      * Called after all territories within the specified distance have been searched. Can be

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -1,14 +1,13 @@
 package games.strategy.triplea.ai.pro.util;
 
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.GameMap;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.util.BreadthFirstSearch;
 import games.strategy.triplea.ai.pro.ProData;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.Matches;
-import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -17,7 +16,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import org.triplea.java.ObjectUtils;
+import java.util.function.Predicate;
 import org.triplea.java.collections.CollectionUtils;
 
 /** Pro AI battle utilities. */
@@ -178,18 +177,30 @@ public final class ProTerritoryValueUtils {
   }
 
   private static int findMaxLandMassSize(final GamePlayer player) {
-    int maxLandMassSize = 1;
     final GameData data = player.getData();
+    final Predicate<Territory> cond = ProMatches.territoryCanPotentiallyMoveLandUnits(player, data);
+    class LandMassFinder extends BreadthFirstSearch {
+      int landMassSize = 0;
+
+      LandMassFinder(final Territory startTerritory) {
+        super(startTerritory, cond);
+      }
+
+      @Override
+      public void visit(final Territory territory) {
+        landMassSize++;
+      }
+    }
+
+    int maxLandMassSize = 1;
+    final var fullVisited = new HashSet<Territory>();
     for (final Territory t : data.getMap().getTerritories()) {
-      if (!t.isWater()) {
-        final int landMassSize =
-            1
-                + data.getMap()
-                    .getNeighbors(
-                        t, 6, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data))
-                    .size();
-        if (landMassSize > maxLandMassSize) {
-          maxLandMassSize = landMassSize;
+      if (!t.isWater() && !fullVisited.contains(t)) {
+        final LandMassFinder finder = new LandMassFinder(t);
+        finder.search();
+        fullVisited.addAll(finder.getVisited());
+        if (finder.landMassSize > maxLandMassSize) {
+          maxLandMassSize = finder.landMassSize;
         }
       }
     }
@@ -448,39 +459,26 @@ public final class ProTerritoryValueUtils {
    */
   protected static Collection<Territory> findNearbyEnemyCapitalsAndFactories(
       final Territory startTerritory, final Set<Territory> enemyCapitalsAndFactories) {
-    final GameMap map = startTerritory.getData().getMap();
-    // Use breadth first search to traverse territories, keeping track of which have already been
-    // visited and which territories from the target list have  been found.
     final var found = new HashSet<Territory>();
-    final var visited = new HashSet<Territory>(List.of(startTerritory));
-    final var territoriesToCheck = new ArrayDeque<Territory>(List.of(startTerritory));
-
-    // Since we process territories in order of distance, we can keep track of the last territory
-    // at the current distance that's in the territoriesToCheck queue. When we encounter it, we
-    // increment the distance and update lastTerritoryAtCurrentDistance.
-    int distance = 0;
-    Territory lastTerritoryAtCurrentDistance = startTerritory;
-    while (!territoriesToCheck.isEmpty()) {
-      final Territory node = territoriesToCheck.removeFirst();
-      for (final Territory neighbor : map.getNeighbors(node)) {
-        if (visited.add(neighbor)) {
-          territoriesToCheck.add(neighbor);
-          if (enemyCapitalsAndFactories.contains(neighbor)) {
-            found.add(neighbor);
+    final BreadthFirstSearch bfs =
+        new BreadthFirstSearch(startTerritory) {
+          @Override
+          public void visit(final Territory territory) {
+            if (enemyCapitalsAndFactories.contains(territory)) {
+              found.add(territory);
+            }
           }
-        }
-      }
 
-      // If we just processed the last territory at the current distance, increment the distance
-      // and set the territory at which we need to update it again to be the last one added.
-      if (ObjectUtils.referenceEquals(node, lastTerritoryAtCurrentDistance)) {
-        distance++;
-        if (distance >= MIN_FACTORY_CHECK_DISTANCE && !found.isEmpty()) {
-          break;
-        }
-        lastTerritoryAtCurrentDistance = territoriesToCheck.peekLast();
-      }
-    }
+          @Override
+          public boolean shouldContinueSearch(final int distanceSearched) {
+            if (distanceSearched >= MIN_FACTORY_CHECK_DISTANCE && !found.isEmpty()) {
+              return false;
+            }
+            return true;
+          }
+        };
+
+    bfs.search();
     return found;
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -176,7 +176,7 @@ public final class ProTerritoryValueUtils {
     return territoryValueMap;
   }
 
-  private static int findMaxLandMassSize(final GamePlayer player) {
+  protected static int findMaxLandMassSize(final GamePlayer player) {
     final GameData data = player.getData();
     final Predicate<Territory> cond = ProMatches.territoryCanPotentiallyMoveLandUnits(player, data);
     class LandMassFinder extends BreadthFirstSearch {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -469,10 +469,7 @@ public final class ProTerritoryValueUtils {
 
               @Override
               public boolean shouldContinueSearch(final int distanceSearched) {
-                if (distanceSearched >= MIN_FACTORY_CHECK_DISTANCE && !found.isEmpty()) {
-                  return false;
-                }
-                return true;
+                return distanceSearched < MIN_FACTORY_CHECK_DISTANCE || found.isEmpty();
               }
             });
     return found;

--- a/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtilsTest.java
@@ -37,7 +37,7 @@ public class ProTerritoryValueUtilsTest {
   }
 
   @Test
-  @DisplayName("only targets within distance the min distance are found")
+  @DisplayName("only targets within the min distance are found")
   void testFindNearbyEnemyCapitalsAndFactoriesSomeWithinDistance9() {
     final var toFind = Set.of(swUsa, england, northJapan, moscow);
     final Collection<Territory> result =
@@ -66,12 +66,30 @@ public class ProTerritoryValueUtilsTest {
   }
 
   @Test
-  @DisplayName("checks the computation of the max land mass size")
-  void testFindMaxLandMassSize() {
+  @DisplayName("checks the computation of the max land mass size on big world")
+  void testFindMaxLandMassSizeBigWorld() {
     // The result should be the same for each player since territoryCanPotentiallyMoveLandUnits()
     // should be the same for all players.
     for (final GamePlayer player : gameData.getPlayerList().getPlayers()) {
       assertThat(ProTerritoryValueUtils.findMaxLandMassSize(player), is(89));
+    }
+  }
+
+  @Test
+  @DisplayName("checks the computation of the max land mass size on revised")
+  void testFindMaxLandSizeRevised() {
+    final GameData gameData = TestMapGameData.REVISED.getGameData();
+    for (final GamePlayer player : gameData.getPlayerList().getPlayers()) {
+      assertThat(ProTerritoryValueUtils.findMaxLandMassSize(player), is(37));
+    }
+  }
+
+  @Test
+  @DisplayName("checks the computation of the max land mass size on minimap (single continent)")
+  void testFindMaxLandSizeMinimap() {
+    final GameData gameData = TestMapGameData.MINIMAP.getGameData();
+    for (final GamePlayer player : gameData.getPlayerList().getPlayers()) {
+      assertThat(ProTerritoryValueUtils.findMaxLandMassSize(player), is(14));
     }
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtilsTest.java
@@ -3,8 +3,10 @@ package games.strategy.triplea.ai.pro.util;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
 
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.Collection;
@@ -61,5 +63,15 @@ public class ProTerritoryValueUtilsTest {
             + ") of newSouthWales:",
         result,
         containsInAnyOrder(northJapan));
+  }
+
+  @Test
+  @DisplayName("checks the computation of the max land mass size")
+  void testFindMaxLandMassSize() {
+    // The result should be the same for each player since territoryCanPotentiallyMoveLandUnits()
+    // should be the same for all players.
+    for (final GamePlayer player : gameData.getPlayerList().getPlayers()) {
+      assertThat(ProTerritoryValueUtils.findMaxLandMassSize(player), is(89));
+    }
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
+++ b/game-core/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
@@ -38,7 +38,9 @@ public enum TestMapGameData {
 
   GAME_EXAMPLE("GameExample.xml"),
 
-  TWW("Total_World_War_Dec1941.xml");
+  TWW("Total_World_War_Dec1941.xml"),
+
+  MINIMAP("minimap.xml");
 
   private final String fileName;
 

--- a/game-core/src/test/resources/minimap.xml
+++ b/game-core/src/test/resources/minimap.xml
@@ -521,10 +521,7 @@
         <!-- Map Name: also used for map utils when asked -->
         <property name="mapName" value="minimap" editable="false"/>
         <property name="notes">
-            <value><![CDATA[
-
-		        	A simple two player game.
-	        	]]></value>
+            <value><![CDATA[A simple two player game.]]></value>
         </property>
     </propertyList>
 </game>

--- a/game-core/src/test/resources/minimap.xml
+++ b/game-core/src/test/resources/minimap.xml
@@ -1,0 +1,530 @@
+<?xml version="1.0"?>
+<!DOCTYPE game SYSTEM "game.dtd">
+<game>
+    <info name="Minimap" version="1.2"/>
+    <loader javaClass="games.strategy.triplea.TripleA"/>
+    <triplea minimumVersion="1.5"/>
+    <map>
+        <!-- Territory Definitions -->
+        <territory name="red capitol"/>
+        <territory name="red north 1"/>
+        <territory name="red north 2"/>
+        <territory name="red middle 1"/>
+        <territory name="red middle 2"/>
+        <territory name="red south 1"/>
+        <territory name="red south 2"/>
+        <territory name="blue capitol"/>
+        <territory name="blue north 1"/>
+        <territory name="blue north 2"/>
+        <territory name="blue middle 1"/>
+        <territory name="blue middle 2"/>
+        <territory name="blue south 1"/>
+        <territory name="blue south 2"/>
+        <territory name="neutral territory 1"/>
+        <territory name="neutral territory 2"/>
+        <territory name="sea zone 1" water="true"/>
+        <territory name="sea zone 2" water="true"/>
+        <territory name="sea zone 3" water="true"/>
+        <territory name="sea zone 4" water="true"/>
+        <!-- Territory Connections -->
+        <connection t1="red capitol" t2="red north 1"/>
+        <connection t1="red capitol" t2="red middle 1"/>
+        <connection t1="red capitol" t2="red south 1"/>
+        <connection t1="red north 1" t2="red north 2"/>
+        <connection t1="red north 1" t2="sea zone 1"/>
+        <connection t1="red north 1" t2="red middle 1"/>
+        <connection t1="red north 2" t2="sea zone 1"/>
+        <connection t1="red north 2" t2="blue north 2"/>
+        <connection t1="blue north 2" t2="blue north 1"/>
+        <connection t1="blue north 2" t2="sea zone 2"/>
+        <connection t1="blue north 1" t2="sea zone 2"/>
+        <connection t1="blue north 1" t2="blue capitol"/>
+        <connection t1="red middle 1" t2="red middle 2"/>
+        <connection t1="red middle 1" t2="red south 1"/>
+        <connection t1="red middle 1" t2="sea zone 1"/>
+        <connection t1="red middle 1" t2="sea zone 3"/>
+        <connection t1="red middle 2" t2="sea zone 1"/>
+        <connection t1="red middle 2" t2="sea zone 3"/>
+        <connection t1="red middle 2" t2="blue middle 2"/>
+        <connection t1="blue middle 2" t2="blue middle 1"/>
+        <connection t1="blue middle 2" t2="sea zone 2"/>
+        <connection t1="blue middle 2" t2="sea zone 4"/>
+        <connection t1="blue middle 1" t2="sea zone 2"/>
+        <connection t1="blue middle 1" t2="sea zone 4"/>
+        <connection t1="blue middle 1" t2="blue north 1"/>
+        <connection t1="blue middle 1" t2="blue south 1"/>
+        <connection t1="blue middle 1" t2="blue capitol"/>
+        <connection t1="red south 1" t2="red south 2"/>
+        <connection t1="red south 1" t2="sea zone 3"/>
+        <connection t1="red south 2" t2="blue south 2"/>
+        <connection t1="red south 2" t2="sea zone 3"/>
+        <connection t1="blue south 2" t2="blue south 1"/>
+        <connection t1="blue south 2" t2="sea zone 4"/>
+        <connection t1="blue south 1" t2="blue capitol"/>
+        <connection t1="blue south 1" t2="sea zone 4"/>
+        <connection t1="sea zone 1" t2="sea zone 2"/>
+        <connection t1="sea zone 3" t2="sea zone 4"/>
+        <connection t1="neutral territory 1" t2="red capitol"/>
+        <connection t1="neutral territory 1" t2="red north 1"/>
+        <connection t1="neutral territory 1" t2="red north 2"/>
+        <connection t1="neutral territory 1" t2="red south 1"/>
+        <connection t1="neutral territory 1" t2="red south 2"/>
+        <connection t1="neutral territory 2" t2="blue capitol"/>
+        <connection t1="neutral territory 2" t2="blue north 1"/>
+        <connection t1="neutral territory 2" t2="blue north 2"/>
+        <connection t1="neutral territory 2" t2="blue south 1"/>
+        <connection t1="neutral territory 2" t2="blue south 2"/>
+    </map>
+    <resourceList>
+        <resource name="PUs"/>
+    </resourceList>
+    <playerList>
+        <!-- In turn order -->
+        <player name="Russians" optional="false"/>
+        <player name="Italians" optional="false"/>
+        <!-- Axis Alliances -->
+        <alliance player="Italians" alliance="Italians"/>
+        <!-- Allies Alliances -->
+        <alliance player="Russians" alliance="Russians"/>
+    </playerList>
+    <unitList>
+        <unit name="infantry"/>
+        <unit name="armour"/>
+        <unit name="fighter"/>
+        <unit name="bomber"/>
+        <unit name="transport"/>
+        <unit name="battleship"/>
+        <unit name="carrier"/>
+        <unit name="submarine"/>
+        <unit name="factory"/>
+        <unit name="aaGun"/>
+        <unit name="artillery"/>
+        <unit name="destroyer"/>
+    </unitList>
+    <gamePlay>
+        <delegate name="initDelegate" javaClass="games.strategy.triplea.delegate.InitializationDelegate" display="Initializing Delegates"/>
+        <delegate name="tech" javaClass="games.strategy.triplea.delegate.TechnologyDelegate" display="Research Technology"/>
+        <delegate name="tech_activation" javaClass="games.strategy.triplea.delegate.TechActivationDelegate" display="Activate Technology"/>
+        <delegate name="battle" javaClass="games.strategy.triplea.delegate.BattleDelegate" display="Combat"/>
+        <delegate name="move" javaClass="games.strategy.triplea.delegate.MoveDelegate" display="Combat Move"/>
+        <delegate name="place" javaClass="games.strategy.triplea.delegate.PlaceDelegate" display="Place Units"/>
+        <delegate name="purchase" javaClass="games.strategy.triplea.delegate.PurchaseDelegate" display="Purchase Units"/>
+        <delegate name="endTurn" javaClass="games.strategy.triplea.delegate.EndTurnDelegate" display="Turn Complete"/>
+        <delegate name="endRound" javaClass="games.strategy.triplea.delegate.EndRoundDelegate" display="Round Complete"/>
+        <delegate name="placeBid" javaClass="games.strategy.triplea.delegate.BidPlaceDelegate" display="Bid Placement"/>
+        <delegate name="bid" javaClass="games.strategy.triplea.delegate.BidPurchaseDelegate" display="Bid Purchase"/>
+        <sequence>
+            <step name="gameInitDelegate" delegate="initDelegate" maxRunCount="1"/>
+            <!-- Bidding Phase -->
+            <step name="russianBid" delegate="bid" player="Russians" maxRunCount="1"/>
+            <step name="russianBidPlace" delegate="placeBid" player="Russians" maxRunCount="1"/>
+            <step name="italianBid" delegate="bid" player="Italians" maxRunCount="1"/>
+            <step name="italianBidPlace" delegate="placeBid" player="Italians" maxRunCount="1"/>
+            <!-- Russians Game Sequence -->
+            <step name="russianPurchase" delegate="purchase" player="Russians"/>
+            <step name="russianCombatMove" delegate="move" player="Russians"/>
+            <step name="russianBattle" delegate="battle" player="Russians"/>
+            <step name="russianNonCombatMove" delegate="move" player="Russians" display="Non Combat Move"/>
+            <step name="russianPlace" delegate="place" player="Russians"/>
+            <step name="russianEndTurn" delegate="endTurn" player="Russians"/>
+            <!-- Italians Game Sequence -->
+            <step name="italianPurchase" delegate="purchase" player="Italians"/>
+            <step name="italianCombatMove" delegate="move" player="Italians"/>
+            <step name="italianBattle" delegate="battle" player="Italians"/>
+            <step name="italianNonCombatMove" delegate="move" player="Italians" display="Non Combat Move"/>
+            <step name="italianPlace" delegate="place" player="Italians"/>
+            <step name="italianEndTurn" delegate="endTurn" player="Italians"/>
+            <step name="endRoundStep" delegate="endRound"/>
+        </sequence>
+    </gamePlay>
+    <production>
+        <!-- Unit Production Cost -->
+        <productionRule name="buyInfantry">
+            <cost resource="PUs" quantity="3"/>
+            <result resourceOrUnit="infantry" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyArtillery">
+            <cost resource="PUs" quantity="4"/>
+            <result resourceOrUnit="artillery" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyArmour">
+            <cost resource="PUs" quantity="5"/>
+            <result resourceOrUnit="armour" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyFighter">
+            <cost resource="PUs" quantity="10"/>
+            <result resourceOrUnit="fighter" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyBomber">
+            <cost resource="PUs" quantity="15"/>
+            <result resourceOrUnit="bomber" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyTransport">
+            <cost resource="PUs" quantity="8"/>
+            <result resourceOrUnit="transport" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyCarrier">
+            <cost resource="PUs" quantity="16"/>
+            <result resourceOrUnit="carrier" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyDestroyer">
+            <cost resource="PUs" quantity="12"/>
+            <result resourceOrUnit="destroyer" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyBattleship">
+            <cost resource="PUs" quantity="24"/>
+            <result resourceOrUnit="battleship" quantity="1"/>
+        </productionRule>
+        <productionRule name="buySubmarine">
+            <cost resource="PUs" quantity="8"/>
+            <result resourceOrUnit="submarine" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyFactory">
+            <cost resource="PUs" quantity="15"/>
+            <result resourceOrUnit="factory" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyAAGun">
+            <cost resource="PUs" quantity="5"/>
+            <result resourceOrUnit="aaGun" quantity="1"/>
+        </productionRule>
+        <!-- Advanced Industrial Production -->
+        <productionRule name="buyInfantryIndustrialTechnology">
+            <cost resource="PUs" quantity="2"/>
+            <result resourceOrUnit="infantry" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyArtilleryIndustrialTechnology">
+            <cost resource="PUs" quantity="3"/>
+            <result resourceOrUnit="artillery" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyArmourIndustrialTechnology">
+            <cost resource="PUs" quantity="4"/>
+            <result resourceOrUnit="armour" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyFighterIndustrialTechnology">
+            <cost resource="PUs" quantity="9"/>
+            <result resourceOrUnit="fighter" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyBomberIndustrialTechnology">
+            <cost resource="PUs" quantity="14"/>
+            <result resourceOrUnit="bomber" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyTransportIndustrialTechnology">
+            <cost resource="PUs" quantity="7"/>
+            <result resourceOrUnit="transport" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyCarrierIndustrialTechnology">
+            <cost resource="PUs" quantity="15"/>
+            <result resourceOrUnit="carrier" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyDestroyerIndustrialTechnology">
+            <cost resource="PUs" quantity="11"/>
+            <result resourceOrUnit="destroyer" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyBattleshipIndustrialTechnology">
+            <cost resource="PUs" quantity="23"/>
+            <result resourceOrUnit="battleship" quantity="1"/>
+        </productionRule>
+        <productionRule name="buySubmarineIndustrialTechnology">
+            <cost resource="PUs" quantity="7"/>
+            <result resourceOrUnit="submarine" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyFactoryIndustrialTechnology">
+            <cost resource="PUs" quantity="14"/>
+            <result resourceOrUnit="factory" quantity="1"/>
+        </productionRule>
+        <productionRule name="buyAAGunIndustrialTechnology">
+            <cost resource="PUs" quantity="4"/>
+            <result resourceOrUnit="aaGun" quantity="1"/>
+        </productionRule>
+        <productionFrontier name="production">
+            <frontierRules name="buyInfantry"/>
+            <frontierRules name="buyArtillery"/>
+            <frontierRules name="buyArmour"/>
+            <frontierRules name="buyFighter"/>
+            <frontierRules name="buyBomber"/>
+            <frontierRules name="buyAAGun"/>
+        </productionFrontier>
+        <productionFrontier name="productionIndustrialTechnology">
+            <frontierRules name="buyInfantryIndustrialTechnology"/>
+            <frontierRules name="buyArtilleryIndustrialTechnology"/>
+            <frontierRules name="buyArmourIndustrialTechnology"/>
+            <frontierRules name="buyFighterIndustrialTechnology"/>
+            <frontierRules name="buyBomberIndustrialTechnology"/>
+            <frontierRules name="buyAAGunIndustrialTechnology"/>
+        </productionFrontier>
+        <playerProduction player="Italians" frontier="production"/>
+        <playerProduction player="Russians" frontier="production"/>
+    </production>
+    <attachmentList>
+        <attachment name="techAttachment" attachTo="Italians" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
+            <option name="heavyBomber" value="false"/>
+            <option name="jetPower" value="false"/>
+            <option name="industrialTechnology" value="false"/>
+            <option name="superSub" value="false"/>
+            <option name="rocket" value="false"/>
+            <option name="longRangeAir" value="false"/>
+        </attachment>
+        <attachment name="techAttachment" attachTo="Russians" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player">
+            <option name="heavyBomber" value="false"/>
+            <option name="jetPower" value="false"/>
+            <option name="industrialTechnology" value="false"/>
+            <option name="superSub" value="false"/>
+            <option name="rocket" value="false"/>
+            <option name="longRangeAir" value="false"/>
+        </attachment>
+        <attachment name="unitAttachment" attachTo="infantry" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+            <option name="movement" value="1"/>
+            <option name="transportCost" value="2"/>
+            <option name="attack" value="1"/>
+            <option name="defense" value="2"/>
+            <option name="artillerySupportable" value="true"/>
+            <option name="isInfantry" value="true"/>
+        </attachment>
+        <attachment name="unitAttachment" attachTo="artillery" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+            <option name="movement" value="1"/>
+            <option name="transportCost" value="3"/>
+            <option name="attack" value="2"/>
+            <option name="defense" value="2"/>
+            <option name="artillery" value="true"/>
+        </attachment>
+        <attachment name="unitAttachment" attachTo="armour" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+            <option name="movement" value="2"/>
+            <option name="transportCost" value="3"/>
+            <option name="canBlitz" value="true"/>
+            <option name="attack" value="3"/>
+            <option name="defense" value="3"/>
+        </attachment>
+        <attachment name="unitAttachment" attachTo="fighter" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+            <option name="movement" value="4"/>
+            <option name="carrierCost" value="1"/>
+            <option name="isAir" value="true"/>
+            <option name="attack" value="3"/>
+            <option name="defense" value="4"/>
+        </attachment>
+        <attachment name="unitAttachment" attachTo="bomber" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+            <option name="movement" value="6"/>
+            <option name="isAir" value="true"/>
+            <option name="attack" value="4"/>
+            <option name="defense" value="1"/>
+            <option name="isStrategicBomber" value="true"/>
+        </attachment>
+        <attachment name="unitAttachment" attachTo="transport" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+            <option name="movement" value="2"/>
+            <option name="isSea" value="true"/>
+            <option name="transportCapacity" value="5"/>
+            <option name="attack" value="0"/>
+            <option name="defense" value="1"/>
+        </attachment>
+        <attachment name="unitAttachment" attachTo="battleship" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+            <option name="movement" value="2"/>
+            <option name="isSea" value="true"/>
+            <option name="attack" value="4"/>
+            <option name="defense" value="4"/>
+            <option name="canBombard" value="true"/>
+            <option name="hitPoints" value="1"/>
+        </attachment>
+        <attachment name="unitAttachment" attachTo="destroyer" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+            <option name="movement" value="2"/>
+            <option name="isSea" value="true"/>
+            <option name="attack" value="3"/>
+            <option name="defense" value="3"/>
+            <option name="isDestroyer" value="true"/>
+        </attachment>
+        <attachment name="unitAttachment" attachTo="carrier" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+            <option name="carrierCapacity" value="2"/>
+            <option name="movement" value="2"/>
+            <option name="isSea" value="true"/>
+            <option name="attack" value="1"/>
+            <option name="defense" value="3"/>
+        </attachment>
+        <attachment name="unitAttachment" attachTo="submarine" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+            <option name="isSub" value="true"/>
+            <option name="movement" value="2"/>
+            <option name="isSea" value="true"/>
+            <option name="attack" value="2"/>
+            <option name="defense" value="2"/>
+        </attachment>
+        <attachment name="unitAttachment" attachTo="factory" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+            <option name="isFactory" value="true"/>
+        </attachment>
+        <attachment name="unitAttachment" attachTo="aaGun" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType">
+            <option name="isAA" value="true"/>
+            <option name="transportCost" value="3"/>
+            <option name="movement" value="1"/>
+        </attachment>
+        <attachment name="territoryAttachment" attachTo="neutral territory 1" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+            <option name="production" value="0"/>
+            <option name="isImpassable" value="true"/>
+        </attachment>
+        <attachment name="territoryAttachment" attachTo="neutral territory 2" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+            <option name="production" value="0"/>
+            <option name="isImpassable" value="true"/>
+        </attachment>
+        <attachment name="territoryAttachment" attachTo="red capitol" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+            <option name="production" value="10"/>
+            <option name="capital" value="Russians"/>
+            <option name="victoryCity" value="1"/>
+        </attachment>
+        <attachment name="territoryAttachment" attachTo="blue capitol" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+            <option name="production" value="10"/>
+            <option name="capital" value="Italians"/>
+            <option name="victoryCity" value="1"/>
+        </attachment>
+        <attachment name="territoryAttachment" attachTo="red north 1" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+            <option name="production" value="5"/>
+        </attachment>
+        <attachment name="territoryAttachment" attachTo="red north 2" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+            <option name="production" value="2"/>
+        </attachment>
+        <attachment name="territoryAttachment" attachTo="red middle 1" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+            <option name="production" value="5"/>
+        </attachment>
+        <attachment name="territoryAttachment" attachTo="red middle 2" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+            <option name="production" value="2"/>
+        </attachment>
+        <attachment name="territoryAttachment" attachTo="red south 1" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+            <option name="production" value="5"/>
+        </attachment>
+        <attachment name="territoryAttachment" attachTo="red south 2" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+            <option name="production" value="2"/>
+        </attachment>
+        <attachment name="territoryAttachment" attachTo="blue north 1" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+            <option name="production" value="5"/>
+        </attachment>
+        <attachment name="territoryAttachment" attachTo="blue north 2" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+            <option name="production" value="2"/>
+        </attachment>
+        <attachment name="territoryAttachment" attachTo="blue middle 1" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+            <option name="production" value="5"/>
+        </attachment>
+        <attachment name="territoryAttachment" attachTo="blue middle 2" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+            <option name="production" value="2"/>
+        </attachment>
+        <attachment name="territoryAttachment" attachTo="blue south 1" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+            <option name="production" value="5"/>
+        </attachment>
+        <attachment name="territoryAttachment" attachTo="blue south 2" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory">
+            <option name="production" value="2"/>
+        </attachment>
+    </attachmentList>
+    <initialize>
+        <ownerInitialize>
+            <!-- italian Owned Territories -->
+            <territoryOwner territory="blue capitol" owner="Italians"/>
+            <territoryOwner territory="blue north 1" owner="Italians"/>
+            <territoryOwner territory="blue north 2" owner="Italians"/>
+            <territoryOwner territory="blue middle 1" owner="Italians"/>
+            <territoryOwner territory="blue middle 2" owner="Italians"/>
+            <territoryOwner territory="blue south 1" owner="Italians"/>
+            <territoryOwner territory="blue south 2" owner="Italians"/>
+            <!-- Russian Owned Territories -->
+            <territoryOwner territory="red capitol" owner="Russians"/>
+            <territoryOwner territory="red north 1" owner="Russians"/>
+            <territoryOwner territory="red north 2" owner="Russians"/>
+            <territoryOwner territory="red middle 1" owner="Russians"/>
+            <territoryOwner territory="red middle 2" owner="Russians"/>
+            <territoryOwner territory="red south 1" owner="Russians"/>
+            <territoryOwner territory="red south 2" owner="Russians"/>
+        </ownerInitialize>
+        <unitInitialize>
+            <!-- Russian Unit Placements -->
+            <unitPlacement unitType="factory" territory="red capitol" quantity="1" owner="Russians"/>
+            <unitPlacement unitType="infantry" territory="red capitol" quantity="7" owner="Russians"/>
+            <unitPlacement unitType="artillery" territory="red capitol" quantity="3" owner="Russians"/>
+            <unitPlacement unitType="armour" territory="red capitol" quantity="3" owner="Russians"/>
+            <unitPlacement unitType="fighter" territory="red capitol" quantity="2" owner="Russians"/>
+            <unitPlacement unitType="bomber" territory="red capitol" quantity="1" owner="Russians"/>
+            <unitPlacement unitType="aaGun" territory="red capitol" quantity="1" owner="Russians"/>
+            <unitPlacement unitType="infantry" territory="red north 2" quantity="2" owner="Russians"/>
+            <unitPlacement unitType="infantry" territory="red middle 2" quantity="2" owner="Russians"/>
+            <unitPlacement unitType="infantry" territory="red south 2" quantity="2" owner="Russians"/>
+            <unitPlacement unitType="infantry" territory="red north 1" quantity="2" owner="Russians"/>
+            <unitPlacement unitType="artillery" territory="red north 1" quantity="1" owner="Russians"/>
+            <unitPlacement unitType="infantry" territory="red middle 1" quantity="2" owner="Russians"/>
+            <unitPlacement unitType="artillery" territory="red middle 1" quantity="1" owner="Russians"/>
+            <unitPlacement unitType="infantry" territory="red south 1" quantity="2" owner="Russians"/>
+            <unitPlacement unitType="artillery" territory="red south 1" quantity="1" owner="Russians"/>
+            <!-- italian Unit Placements -->
+            <unitPlacement unitType="factory" territory="blue capitol" quantity="1" owner="Italians"/>
+            <unitPlacement unitType="infantry" territory="blue capitol" quantity="7" owner="Italians"/>
+            <unitPlacement unitType="artillery" territory="blue capitol" quantity="3" owner="Italians"/>
+            <unitPlacement unitType="armour" territory="blue capitol" quantity="3" owner="Italians"/>
+            <unitPlacement unitType="fighter" territory="blue capitol" quantity="2" owner="Italians"/>
+            <unitPlacement unitType="bomber" territory="blue capitol" quantity="1" owner="Italians"/>
+            <unitPlacement unitType="aaGun" territory="blue capitol" quantity="1" owner="Italians"/>
+            <unitPlacement unitType="infantry" territory="blue north 2" quantity="2" owner="Italians"/>
+            <unitPlacement unitType="infantry" territory="blue middle 2" quantity="2" owner="Italians"/>
+            <unitPlacement unitType="infantry" territory="blue south 2" quantity="2" owner="Italians"/>
+            <unitPlacement unitType="infantry" territory="blue north 1" quantity="2" owner="Italians"/>
+            <unitPlacement unitType="artillery" territory="blue north 1" quantity="1" owner="Italians"/>
+            <unitPlacement unitType="infantry" territory="blue middle 1" quantity="2" owner="Italians"/>
+            <unitPlacement unitType="artillery" territory="blue middle 1" quantity="1" owner="Italians"/>
+            <unitPlacement unitType="infantry" territory="blue south 1" quantity="2" owner="Italians"/>
+            <unitPlacement unitType="artillery" territory="blue south 1" quantity="1" owner="Italians"/>
+        </unitInitialize>
+        <resourceInitialize>
+            <resourceGiven player="Russians" resource="PUs" quantity="24"/>
+            <resourceGiven player="Italians" resource="PUs" quantity="44"/>
+        </resourceInitialize>
+    </initialize>
+    <propertyList>
+        <!-- Bids -->
+        <property name="Russians bid" value="0" editable="true">
+            <number min="0" max="1000"/>
+        </property>
+        <property name="Italians bid" value="0" editable="true">
+            <number min="0" max="1000"/>
+        </property>
+        <property name="Total Victory" value="true" editable="true">
+            <boolean/>
+        </property>
+        <property name="Russians Total Victory VCs" value="2" editable="false">
+            <number min="2" max="2"/>
+        </property>
+        <property name="Italians Total Victory VCs" value="2" editable="false">
+            <number min="2" max="2"/>
+        </property>
+        <!-- Low Luck -->
+        <property name="Low Luck" value="false" editable="true">
+            <boolean/>
+        </property>
+        <property name="Low Luck for AntiAircraft" value="false" editable="true">
+            <boolean/>
+        </property>
+        <property name="Low Luck for Technology" value="false" editable="false">
+            <boolean/>
+        </property>
+        <property name="Low Luck for Bombing and Territory Damage" value="false" editable="true">
+            <boolean/>
+        </property>
+        <property name="Heavy Bomber Dice Rolls" value="2" editable="false">
+            <number min="2" max="10"/>
+        </property>
+        <property name="Always on AA" value="true" editable="true">
+            <boolean/>
+        </property>
+        <property name="Territory Turn Limit" value="true" editable="true">
+            <boolean/>
+        </property>
+        <property name="Tech Development" value="false" editable="false">
+            <boolean/>
+        </property>
+        <!-- Use WW2V2 Rules -->
+        <property name="WW2V2" value="true" editable="false">
+            <boolean/>
+        </property>
+        <property name="Allied Air Dependents" value="true" editable="false">
+            <boolean/>
+        </property>
+        <property name="neutralCharge" value="9999999"/>
+        <property name="maxFactoriesPerTerritory" value="1"/>
+        <!-- Map Name: also used for map utils when asked -->
+        <property name="mapName" value="minimap" editable="false"/>
+        <property name="notes">
+            <value><![CDATA[
+
+		        	A simple two player game.
+	        	]]></value>
+        </property>
+    </propertyList>
+</game>


### PR DESCRIPTION
Optimize findMaxLandMassSize() which can take 10% of AI time.
    
This change optimizes findMaxLandMassSize() by reducing the amount of work needed to do. The main difference is we now keep track of land territories already processed so that we don't need to start new searches from them.
    
This creates a new BreadthFirstSearch class that takes out the BFS implementation I implemented earlier for finding capitals, so that it can be re-used here.
    
It also fixes a correctness issue with finding the max land size - the previous search would only search up to a distance of 6. The new implementation does not have this limitation.
    
On Domination 1914 map, which has a lot of territories, this saves about 50 seconds of CPU time over a round of an all-AI game.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[X] Other: Optimization

## Testing
Tested manually on a game of Domination 1914 and profiled the game.
