### PR TITLE
Lobby connected games check if new players are banned

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -91,7 +91,7 @@ public class ServerModel extends Observable implements IConnectionChangeListener
 
   private final GameObjectStreamFactory objectStreamFactory = new GameObjectStreamFactory(null);
   private final ServerSetupModel serverSetupModel;
-  private IServerMessenger serverMessenger;
+  private ServerMessenger serverMessenger;
   private Messengers messengers;
   private GameData data;
   private Map<String, String> playersToNodeListing = new HashMap<>();
@@ -422,6 +422,8 @@ public class ServerModel extends Observable implements IConnectionChangeListener
 
         gameToLobbyConnection =
             new GameToLobbyConnection(lobbyUri, gameHostingResponse, errorHandler);
+
+        serverMessenger.setGameToLobbyConnection(gameToLobbyConnection);
 
         gameToLobbyConnection.addMessageListener(
             PlayerBannedMessage.TYPE,

--- a/game-core/src/main/java/games/strategy/net/ServerMessenger.java
+++ b/game-core/src/main/java/games/strategy/net/ServerMessenger.java
@@ -29,6 +29,7 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.extern.java.Log;
 import org.triplea.domain.data.UserName;
+import org.triplea.http.client.web.socket.client.connections.GameToLobbyConnection;
 
 /** A Messenger that can have many clients connected to it. */
 @Log
@@ -54,6 +55,8 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
   private final Map<UserName, String> cachedMacAddresses = new ConcurrentHashMap<>();
   private final Set<String> miniBannedIpAddresses = new ConcurrentSkipListSet<>();
   private final Set<String> miniBannedMacAddresses = new ConcurrentSkipListSet<>();
+
+  @Setter @Nullable private GameToLobbyConnection gameToLobbyConnection;
 
   public ServerMessenger(
       final String name, final int port, final IObjectStreamFactory objectStreamFactory)
@@ -152,7 +155,9 @@ public class ServerMessenger implements IServerMessenger, NioSocketListener {
 
   @Override
   public boolean isPlayerBanned(final String ip, final String mac) {
-    return miniBannedIpAddresses.contains(ip) || miniBannedMacAddresses.contains(mac);
+    return miniBannedIpAddresses.contains(ip)
+        || miniBannedMacAddresses.contains(mac)
+        || (gameToLobbyConnection != null && gameToLobbyConnection.isPlayerBanned(ip));
   }
 
   @Override

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/client/connections/GameToLobbyConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/client/connections/GameToLobbyConnection.java
@@ -6,6 +6,7 @@ import java.util.function.Consumer;
 import lombok.Getter;
 import org.triplea.domain.data.ApiKey;
 import org.triplea.domain.data.LobbyGame;
+import org.triplea.http.client.IpAddressParser;
 import org.triplea.http.client.lobby.HttpLobbyClient;
 import org.triplea.http.client.lobby.game.hosting.GameHostingResponse;
 import org.triplea.http.client.lobby.game.listing.LobbyWatcherClient;
@@ -67,6 +68,12 @@ public class GameToLobbyConnection {
 
   public boolean checkConnectivity(final int localPort) {
     return lobbyClient.getConnectivityCheckClient().checkConnectivity(localPort);
+  }
+
+  public boolean isPlayerBanned(final String ip) {
+    return lobbyClient
+        .getRemoteActionsClient()
+        .checkIfPlayerIsBanned(IpAddressParser.fromString(ip));
   }
 
   public void close() {


### PR DESCRIPTION
After this update lobby games will check with the http-server
if a new player that joins is banned. This update is done
by augmenting the check to the local "mini-ban" to also
check with the server.

Resolves: https://github.com/triplea-game/triplea/issues/6176

<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
- launched a bot on local lobby
- verified could connect to bot directly
- banned myself for 3 minutes
- verified could no longer directly connect to bot
- after ban expired, was able to connect

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

