### PR TITLE
Make Territory.getUnits() return an unmodifiable list. (Reland)

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/UnitCollection.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitCollection.java
@@ -111,7 +111,7 @@ public class UnitCollection extends GameDataComponent implements Collection<Unit
   }
 
   public Collection<Unit> getUnits() {
-    return new ArrayList<>(units);
+    return Collections.unmodifiableList(units);
   }
 
   /** Returns integer map of UnitType. */

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -1652,14 +1652,13 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     if (to == null) {
       return new ArrayList<>();
     }
-    final Collection<Unit> unitsInTo = to.getUnits();
     final Collection<Unit> unitsPlacedAlready = getAlreadyProduced(to);
     if (Matches.territoryIsWater().test(to)) {
       for (final Territory current : getAllProducers(to, player, null, true)) {
         unitsPlacedAlready.addAll(getAlreadyProduced(current));
       }
     }
-    final Collection<Unit> unitsAtStartOfTurnInTo = new ArrayList<>(unitsInTo);
+    final Collection<Unit> unitsAtStartOfTurnInTo = new ArrayList<>(to.getUnits());
     unitsAtStartOfTurnInTo.removeAll(unitsPlacedAlready);
     return unitsAtStartOfTurnInTo;
   }
@@ -1668,7 +1667,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     if (to == null) {
       return new ArrayList<>();
     }
-    final Collection<Unit> unitsInTo = to.getUnits();
+    final Collection<Unit> unitsInTo = new ArrayList<>(to.getUnits());
     final Collection<Unit> unitsAtStartOfStep = unitsAtStartOfStepInTerritory(to);
     unitsInTo.removeAll(unitsAtStartOfStep);
     return unitsInTo;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -295,7 +295,7 @@ public final class AirMovementValidator {
       if (airCanReach.isEmpty()) {
         continue;
       }
-      final Collection<Unit> unitsInLandingSpot = landingSpot.getUnits();
+      final Collection<Unit> unitsInLandingSpot = new ArrayList<>(landingSpot.getUnits());
       unitsInLandingSpot.removeAll(movedCarriersAndTheirFighters.keySet());
       // make sure to remove any units we have already moved, or units that are excluded
       unitsInLandingSpot.removeAll(airNotToConsider);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -268,7 +268,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
   @Override
   public List<Unit> getRemainingAttackingUnits() {
     final List<Unit> remaining = new ArrayList<>(attackingUnitsRetreated);
-    final Collection<Unit> unitsLeftInTerritory = battleSite.getUnits();
+    final Collection<Unit> unitsLeftInTerritory = new ArrayList<>(battleSite.getUnits());
     unitsLeftInTerritory.removeAll(killed);
     remaining.addAll(
         CollectionUtils.getMatches(
@@ -291,7 +291,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final Set<Unit> remaining = new HashSet<>(defendingUnitsRetreated);
     remaining.addAll(defendingUnits);
     if (getWhoWon() != WhoWon.ATTACKER || attackingUnits.stream().allMatch(Matches.unitIsAir())) {
-      final Collection<Unit> unitsLeftInTerritory = battleSite.getUnits();
+      final Collection<Unit> unitsLeftInTerritory = new ArrayList<>(battleSite.getUnits());
       unitsLeftInTerritory.removeAll(killed);
       remaining.addAll(
           CollectionUtils.getMatches(


### PR DESCRIPTION
Make Territory.getUnits() return an unmodifiable list. (Reland)

Previously, it was returning a copy, which was actually quite expensive given how often this was called. On a Domination 1914 game, with all AIs, this took 100 seconds of CPU time (across different threads since it's used in battle sim) over a single round.

A few places that need a copy are updated to do the copy on their side.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix: 
[X] Other:   Optimization

## Testing
Ran ./verify
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

