### PR TITLE
Cache gradle folder in home folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: xenial
 sudo: false
 language: java
 jdk: openjdk11
-cache: { directories: [ ".gradle" ] }
+cache: { directories: [ ".gradle", "~/.gradle" ] }
 install: skip
 
 env:


### PR DESCRIPTION
Attempt to alleviate the persistent failures we get downloading
gradle dependencies.

