### PR TITLE
Log blocking EDT calls

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/message/UnifiedInvocationHandler.java
+++ b/game-core/src/main/java/games/strategy/engine/message/UnifiedInvocationHandler.java
@@ -3,12 +3,16 @@ package games.strategy.engine.message;
 import games.strategy.engine.message.unifiedmessenger.UnifiedMessenger;
 import java.io.Serializable;
 import java.lang.reflect.Method;
+import java.util.logging.Level;
+import javax.swing.SwingUtilities;
+import lombok.extern.java.Log;
 
 /**
  * Invocation handler for the UnifiedMessenger.
  *
  * <p>Handles the invocation for a channel
  */
+@Log
 class UnifiedInvocationHandler extends WrappedInvocationHandler {
   private final UnifiedMessenger messenger;
   private final String endPointName;
@@ -43,6 +47,10 @@ class UnifiedInvocationHandler extends WrappedInvocationHandler {
     if (ignoreResults) {
       messenger.invoke(endPointName, remoteMethodMsg);
       return null;
+    }
+
+    if (SwingUtilities.isEventDispatchThread()) {
+      log.log(Level.INFO, "Blocking Network operation performed from EDT", new Exception());
     }
 
     final RemoteMethodCallResults response = messenger.invokeAndWait(endPointName, remoteMethodMsg);

--- a/game-core/src/main/java/games/strategy/engine/message/UnifiedInvocationHandler.java
+++ b/game-core/src/main/java/games/strategy/engine/message/UnifiedInvocationHandler.java
@@ -50,7 +50,7 @@ class UnifiedInvocationHandler extends WrappedInvocationHandler {
     }
 
     if (SwingUtilities.isEventDispatchThread()) {
-      log.log(Level.INFO, "Blocking Network operation performed from EDT", new Exception());
+      log.log(Level.INFO, "Blocking network operation performed from EDT", new Exception());
     }
 
     final RemoteMethodCallResults response = messenger.invokeAndWait(endPointName, remoteMethodMsg);


### PR DESCRIPTION
<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

Some follow-up to #6104, might help us in the long run.
Note that I haven't really found a good way to make `AbstractMovePanel#undoMove` non-blocking. Using a CompletableFuture will blow things up a bit, but callbacks seem to be weird as well.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[x] Other:   Added a log statement

## Testing
<!--
  Describe any manual testing performed below.
-->
I verified this log statement is run, but doesn't trigger a pop-up window.

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

