### PR TITLE
Fix nullable accelerator to be uninitialized

### DIFF
--- a/swing-lib/src/main/java/org/triplea/swing/JMenuItemBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/JMenuItemBuilder.java
@@ -23,11 +23,12 @@ public class JMenuItemBuilder {
   private final String title;
   private final KeyCode mnemonic;
   private Runnable actionListener;
-  private int acceleratorKey;
+  private Integer acceleratorKey;
   private boolean selected;
 
   public JMenuItemBuilder(final String title, final KeyCode mnemonic) {
     ArgChecker.checkNotEmpty(title);
+    Preconditions.checkNotNull(mnemonic);
     this.title = title;
     this.mnemonic = mnemonic;
   }


### PR DESCRIPTION
(1) Fixes menu accelerator used in a 'if not null' block, but
the value is a primitive and is never null. Hence, if an
accelerator is not specified, it was incorrectly defaulted
to zero rather than being a no-op. This fix updates
an 'int' field then to be an 'Integer' field.

(2) Add a parameter guide to fail early if we get a null
mnemonic, the value is expected to be non-null.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix: https://github.com/triplea-game/triplea/issues/6130  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->

## Screens Shots

### Before

![Screenshot from 2020-04-03 17-21-23](https://user-images.githubusercontent.com/12397753/78418548-05ea5480-75f2-11ea-8d17-e7d628a6f1bf.png)


### After
![Screenshot from 2020-04-12 12-06-59](https://user-images.githubusercontent.com/12397753/79077390-27180880-7cb6-11ea-8bca-a05675327c88.png)

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

