### PR TITLE
Remove toggle arrow from collapsible menu

### DIFF
--- a/swing-lib/src/main/java/org/triplea/swing/CollapsiblePanel.java
+++ b/swing-lib/src/main/java/org/triplea/swing/CollapsiblePanel.java
@@ -15,20 +15,13 @@ import javax.swing.SwingUtilities;
 public class CollapsiblePanel extends JPanel {
   private static final long serialVersionUID = 1L;
 
-  private static final String COLLAPSED_INDICATOR = " ►";
-  private static final String EXPANDED_INDICATOR = " ▼";
-
   private final JPanel content;
   private final JButton toggleButton;
 
-  private String title;
-  private String currentToggleIndicator = EXPANDED_INDICATOR;
-
   public CollapsiblePanel(final JPanel content, final String title) {
     super();
-    this.title = title;
     this.content = content;
-    this.toggleButton = new JButton();
+    this.toggleButton = new JButton(title);
     // We want the button to have square edges. On Mac, there's a special property for that.
     if (SystemProperties.isMac()) {
       toggleButton.putClientProperty("JButton.buttonType", "gradient");
@@ -48,21 +41,16 @@ public class CollapsiblePanel extends JPanel {
   }
 
   public void collapse() {
-    currentToggleIndicator = COLLAPSED_INDICATOR;
-    toggleButton.setText(title + currentToggleIndicator);
     content.setVisible(false);
     revalidate();
   }
 
   public void expand() {
-    currentToggleIndicator = EXPANDED_INDICATOR;
-    toggleButton.setText(title + currentToggleIndicator);
     content.setVisible(true);
     revalidate();
   }
 
   public void setTitle(final String title) {
-    this.title = title;
-    SwingUtilities.invokeLater(() -> toggleButton.setText(title + currentToggleIndicator));
+    SwingUtilities.invokeLater(() -> toggleButton.setText(title));
   }
 }


### PR DESCRIPTION
The toggle arrow is defined by a unicode character, unfortunately
not all fonts have that unicode character mapped. In those cases
the toggle arrow will display as a square.

This update removes the toggle arrow. We could consider adding a
transparent GIF to represent the arrow, though we run into a number
of troubles:
- sizing
- foreground color contrasting against the background
- getting the arrow to look nice and be anti-aliased

Given that a user can visually tell when the collapsible menu
is expanded or collapsed, and learning that it is toggled by clicking
the menu button, it's not ideal but we can perhpas live without
the toggle arrows for now.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


<!-- If there are UI updates, uncomment and include screenshots below -->
## Screens Shots

### Before
![Screenshot from 2020-04-12 13-10-25](https://user-images.githubusercontent.com/12397753/79078707-02745e80-7cbf-11ea-8942-7481985fad9d.png)


### After
![Screenshot from 2020-04-12 13-04-48](https://user-images.githubusercontent.com/12397753/79078681-c3460d80-7cbe-11ea-84b4-78e93dbff1aa.png)

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

