### PR TITLE
Fix console window not appearing

### DIFF
--- a/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
+++ b/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
@@ -21,6 +21,7 @@ import javax.swing.SwingUtilities;
 import lombok.extern.java.Log;
 import org.triplea.debug.ErrorMessage;
 import org.triplea.debug.LoggerManager;
+import org.triplea.debug.console.window.ConsoleConfiguration;
 import org.triplea.java.Interruptibles;
 import org.triplea.swing.SwingAction;
 
@@ -87,6 +88,7 @@ public final class HeadedGameRunner {
     initializeLookAndFeel();
 
     initializeDesktopIntegrations(args);
+    SwingUtilities.invokeLater(ConsoleConfiguration::initialize);
     SwingUtilities.invokeLater(ErrorMessage::initialize);
     GameRunner.start();
   }


### PR DESCRIPTION
When splitting headed runners between javafx and swing, the console window initializer
did not make into the swing headed game runner.

This update fixes the console window not appearing when toggled from preferences
by adding the missing initializion of console window.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix: https://github.com/triplea-game/triplea/issues/6211 <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->
