### PR TITLE
Improve rendering of toast and notify log level change via toast

### DIFF
--- a/game-core/src/main/java/org/triplea/debug/console/window/ConsoleModel.java
+++ b/game-core/src/main/java/org/triplea/debug/console/window/ConsoleModel.java
@@ -12,11 +12,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
-import lombok.extern.java.Log;
 import org.triplea.swing.Toast;
 
 /** View-model for console window. */
-@Log
 @Builder
 class ConsoleModel {
   private final Consumer<String> clipboardAction;

--- a/game-core/src/main/java/org/triplea/debug/console/window/ConsoleModel.java
+++ b/game-core/src/main/java/org/triplea/debug/console/window/ConsoleModel.java
@@ -13,6 +13,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.java.Log;
+import org.triplea.swing.Toast;
 
 /** View-model for console window. */
 @Log
@@ -101,6 +102,6 @@ class ConsoleModel {
   static void setLogLevel(final String selectedLevel) {
     final Level level = LogLevelItem.fromLabel(selectedLevel);
     ClientSetting.loggingVerbosity.setValueAndFlush(level.getName());
-    log.info("Log level set to: " + level);
+    Toast.showToast("Log level set to: " + level.getName());
   }
 }

--- a/swing-lib/src/main/java/org/triplea/swing/Toast.java
+++ b/swing-lib/src/main/java/org/triplea/swing/Toast.java
@@ -18,11 +18,19 @@ import lombok.Builder;
 public class Toast {
 
   @Nonnull private final String message;
-  @Nonnull private final Duration sleepTime;
-  @Nonnull private final JFrame parent;
+  @Builder.Default private final Duration sleepTime = Duration.ofSeconds(1);
+  private final JFrame parent;
 
   private final int windowHeight = 75;
   private final int windowWidth = 400;
+
+  public static void showToast(final JFrame parent, final String message) {
+    builder().parent(parent).message(message).build().showToast();
+  }
+
+  public static void showToast(final String message) {
+    showToast(null, message);
+  }
 
   public void showToast() {
     SwingUtilities.invokeLater(this::showInBackground);
@@ -32,10 +40,8 @@ public class Toast {
     final JWindow window = new JWindow(parent);
 
     window.setLocationRelativeTo(parent);
-    // make the background transparent
     window.setBackground(Color.DARK_GRAY);
 
-    // create a panel
     final JPanel panel =
         new JPanel() {
           @Override
@@ -45,21 +51,11 @@ public class Toast {
 
             // draw the boundary of the toast and fill it
             g.setColor(Color.DARK_GRAY);
-            g.fillRect(10, 10, width + 30, height + 10);
-            // g.setColor(Color.black);
             g.drawRect(10, 10, width + 30, height + 10);
 
             // set the color of text
             g.setColor(new Color(255, 255, 255, 240));
             g.drawString(message, 25, 27);
-            int t = 250;
-
-            // draw the shadow of the toast
-            for (int i = 0; i < 4; i++) {
-              t -= 60;
-              g.setColor(new Color(0, 0, 0, t));
-              g.drawRect(10 - i, 10 - i, width + 30 + i * 2, height + 10 + i * 2);
-            }
           }
         };
 


### PR DESCRIPTION
1. Instead of relying on logging to notify of changed log level use
a toast instead.

2. Improve rendering of toast, a black box surrounding text that does
not fit the overall window does not look very good. This update
removes that black box.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
Play tested:
- launch game
- select preferences > game > console = on
- in console window, select different logging levels.

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

