### PR TITLE
Adds a check to conditionally display expanded/collapses arrows

### DIFF
--- a/swing-lib/src/main/java/org/triplea/swing/CollapsiblePanel.java
+++ b/swing-lib/src/main/java/org/triplea/swing/CollapsiblePanel.java
@@ -15,14 +15,19 @@ import javax.swing.SwingUtilities;
 public class CollapsiblePanel extends JPanel {
   private static final long serialVersionUID = 1L;
 
-  private static final String COLLAPSED_INDICATOR = " ►";
-  private static final String EXPANDED_INDICATOR = " ▼";
+  private static final char COLLAPSED_INDICATOR = '►';
+  private static final String COLLAPSED_TEXT =
+      SwingComponents.canDisplayCharacter(COLLAPSED_INDICATOR) ? " " + COLLAPSED_INDICATOR : "";
+
+  private static final char EXPANDED_INDICATOR = '▼';
+  private static final String EXPANDED_TEXT =
+      SwingComponents.canDisplayCharacter(EXPANDED_INDICATOR) ? " " + EXPANDED_INDICATOR : "";
 
   private final JPanel content;
   private final JButton toggleButton;
 
   private String title;
-  private String currentToggleIndicator = EXPANDED_INDICATOR;
+  private String currentToggleIndicator = EXPANDED_TEXT;
 
   public CollapsiblePanel(final JPanel content, final String title) {
     super();
@@ -33,6 +38,7 @@ public class CollapsiblePanel extends JPanel {
     if (SystemProperties.isMac()) {
       toggleButton.putClientProperty("JButton.buttonType", "gradient");
     }
+
     toggleButton.addActionListener(
         e -> {
           if (content.isVisible()) {
@@ -48,14 +54,14 @@ public class CollapsiblePanel extends JPanel {
   }
 
   public void collapse() {
-    currentToggleIndicator = COLLAPSED_INDICATOR;
+    currentToggleIndicator = COLLAPSED_TEXT;
     toggleButton.setText(title + currentToggleIndicator);
     content.setVisible(false);
     revalidate();
   }
 
   public void expand() {
-    currentToggleIndicator = EXPANDED_INDICATOR;
+    currentToggleIndicator = EXPANDED_TEXT;
     toggleButton.setText(title + currentToggleIndicator);
     content.setVisible(true);
     revalidate();

--- a/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
+++ b/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
@@ -562,4 +562,12 @@ public final class SwingComponents {
 
     private final int optionPaneFlag;
   }
+
+  /**
+   * Checks if the current font can display a given character. Not all fonts can display all unicode
+   * characters. EG: not all fonts can display '►'.
+   */
+  public static boolean canDisplayCharacter(final char character) {
+    return new JLabel().getFont().canDisplay(character);
+  }
 }


### PR DESCRIPTION
Not all fonts can render all unicode characters. This update adds a check
if the current font can render the 'right' and 'down' arrows printed
on collapsible panel title bar, if not we print an empty string otherwise
we print the arrow.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

