### PR TITLE
Fix battle dialogs appearing behind the battle window.

### DIFF
--- a/swing-lib/src/main/java/org/triplea/swing/JFrameBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/JFrameBuilder.java
@@ -95,7 +95,6 @@ public class JFrameBuilder {
     if (pack) {
       frame.pack();
     }
-    frame.setModalExclusionType(Dialog.ModalExclusionType.APPLICATION_EXCLUDE);
     frame.setVisible(visible);
     return frame;
   }

--- a/swing-lib/src/main/java/org/triplea/swing/JFrameBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/JFrameBuilder.java
@@ -1,7 +1,6 @@
 package org.triplea.swing;
 
 import java.awt.Component;
-import java.awt.Dialog;
 import java.awt.Dimension;
 import java.awt.Image;
 import java.awt.LayoutManager;


### PR DESCRIPTION
This update removes the setting: Dialog.ModalExclusionType.APPLICATION_EXCLUDE

When this setting is on, battle dialogs become "associated" with JFrame that
renders the map instead of the battle dialog frame. This means that if you
minimize the map, then the dialog is also minimized. Instead we battle dialogs
to be associated with the battle dialog.

With the 'bad' association we 'fixed' it by having the battle window
always being on top. Usually this meant that the map was rendered, then
the battle window, then any dialogs. 'always on top' has OS specific
behavior and this set us up for a situation where the 'always on top' would
'win out' over the modal dialog being displayed by the battle dialog.

After removing the APPLICATION_EXCLUDE modal type, battle dialogs become
associated with the battle window once again helping ensure that battle
dialogs will always be in front of the battle window, and the battle window
still has always on top so it should always be in front of the map.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
- launched game
- launched a single player game on revised
- skipped to combat move, sent units into combat
- started combat
- when prompted to select casualties, verified:
  - casualties prompt was above the combat window
  - minimizing combat window minimized the select casualties prompt
  - un-minimzing the combat window brought the prompt to the foreground
  - minimizing and un-minimizing the map did not effect the dialog prompt
  - there seemed to be no way for the dialog to be moved behind the battle window, and in turn no way for the battle window to be moved behind the map

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

