### PR TITLE
Cache unit support information to speed up AI.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/UnitTypeList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitTypeList.java
@@ -16,7 +16,8 @@ public class UnitTypeList extends GameDataComponent implements Iterable<UnitType
   private static final long serialVersionUID = 9002927658524651749L;
 
   private final Map<String, UnitType> unitTypes = new LinkedHashMap<>();
-  private @Nullable Set<UnitSupportAttachment> supportRules;
+  // Cached support rules. Marked transient as the cache does not need to be part of saved games.
+  private transient @Nullable Set<UnitSupportAttachment> supportRules;
 
   public UnitTypeList(final GameData data) {
     super(data);
@@ -52,8 +53,7 @@ public class UnitTypeList extends GameDataComponent implements Iterable<UnitType
   public Set<UnitSupportAttachment> getSupportRules() {
     if (supportRules == null) {
       supportRules =
-          UnitSupportAttachment.get(getData())
-              .parallelStream()
+          UnitSupportAttachment.get(getData()).stream()
               .filter(usa -> (usa.getRoll() || usa.getStrength()))
               .collect(Collectors.toSet());
     }

--- a/game-core/src/main/java/games/strategy/engine/data/UnitTypeList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitTypeList.java
@@ -1,18 +1,22 @@
 package games.strategy.engine.data;
 
 import com.google.common.annotations.VisibleForTesting;
+import games.strategy.triplea.attachments.UnitSupportAttachment;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 
 /** A collection of unit types. */
 public class UnitTypeList extends GameDataComponent implements Iterable<UnitType> {
   private static final long serialVersionUID = 9002927658524651749L;
 
   private final Map<String, UnitType> unitTypes = new LinkedHashMap<>();
+  private @Nullable Set<UnitSupportAttachment> supportRules;
 
   public UnitTypeList(final GameData data) {
     super(data);
@@ -38,6 +42,22 @@ public class UnitTypeList extends GameDataComponent implements Iterable<UnitType
       types.add(type);
     }
     return types;
+  }
+
+  /**
+   * Returns the unit support rules for the unit types. Computed once and cached afterwards.
+   *
+   * @return The unit support rules.
+   */
+  public Set<UnitSupportAttachment> getSupportRules() {
+    if (supportRules == null) {
+      supportRules =
+          UnitSupportAttachment.get(getData())
+              .parallelStream()
+              .filter(usa -> (usa.getRoll() || usa.getStrength()))
+              .collect(Collectors.toSet());
+    }
+    return supportRules;
   }
 
   public int size() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -997,14 +997,9 @@ public class DiceRoll implements Externalizable {
       final GameData data,
       final boolean defence,
       final boolean allies) {
-    final Set<UnitSupportAttachment> rules =
-        UnitSupportAttachment.get(data)
-            .parallelStream()
-            .filter(usa -> (usa.getRoll() || usa.getStrength()))
-            .collect(Collectors.toSet());
     getSupport(
         unitsGivingTheSupport,
-        rules,
+        data.getUnitTypeList().getSupportRules(),
         supportsAvailable,
         supportLeft,
         supportUnitsLeft,


### PR DESCRIPTION
Cache unit support information to speed up AI. 

Computing this dominated the battle simulation code, which is also
used heavily in AI logic.

The cpu time (across threads) of DiceRoll.getSortedSupport() over
one round of an all-AI Domination 1914 game took 175 seconds prior
to this change. After this change, it was 14 seconds.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[X] Other:  Optimization

## Testing
- Ran unit tests from IntelliJ in game-core.
- Ran one round of an all-AI game on Domination 1914 without errors.

