### PR TITLE
Default anonymous login checkbox to true

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -86,7 +86,7 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
       new ProtectedStringClientSetting("LOBBY_LOGIN_SAVED_PASSWORD");
   public static final BooleanClientSetting lockMap = new BooleanClientSetting("LOCK_MAP");
   public static final BooleanClientSetting loginAnonymously =
-      new BooleanClientSetting("LOGIN_ANONYMOUSLY", false);
+      new BooleanClientSetting("LOGIN_ANONYMOUSLY", true);
   public static final ClientSetting<String> lookAndFeel =
       new StringClientSetting("LOOK_AND_FEEL_PREF", LookAndFeel.getDefaultLookAndFeelClassName());
   public static final ClientSetting<Integer> mapEdgeScrollSpeed =


### PR DESCRIPTION
UX improvement for new users to default the anonymous login
checkbox to true. When seeing a login screen for the first time,
the presence of a password and "create account" button field
is enough to trigger an assumption that the user must register.

The assumption you must register is not true.

To facilitate as much as possible the initial login, default
the anonymous login to true, as brand new users will not
have accounts, nor are they required to have them. So long
as accounts are not required, it's a misleading UX to make
it appear that accounts *are* required.

Note: any selection made to the anonymous login checkbox is
remembered between game sessions. This update is oriented
towards brand new users.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes

- Current UX for new users is misleading, this fixes that, see description for full background.
