### PR TITLE
Add distinct callback for websocket terminated

### DIFF
--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocket.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocket.java
@@ -15,4 +15,13 @@ public interface WebSocket {
   void sendMessage(WebSocketMessage message);
 
   void addConnectionClosedListener(Runnable connectionClosedListener);
+
+  /**
+   * Adds a listener that is invoked when the connection is closed for any reason other than the
+   * client initiated a disconnect. EG: bans, server shuts down.
+   *
+   * @param connectionTerminatedListener Callback handler invoked on the disconnect, the passed in
+   *     string arg is the close reason reported from server.
+   */
+  void addConnectionTerminatedListener(Consumer<String> connectionTerminatedListener);
 }

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -38,7 +38,7 @@ import org.triplea.java.timer.Timers;
 class WebSocketConnection {
   @VisibleForTesting static final int DEFAULT_CONNECT_TIMEOUT_MILLIS = 5000;
 
-  private static final String CLIENT_DISCONNECT_MESSAGE = "Client disconnect.";
+  @VisibleForTesting static final String CLIENT_DISCONNECT_MESSAGE = "Client disconnect.";
 
   private WebSocketConnectionListener listener;
 
@@ -205,7 +205,11 @@ class WebSocketConnection {
     public CompletionStage<?> onClose(
         final WebSocket webSocket, final int statusCode, final String reason) {
       pingSender.cancel();
-      listener.connectionClosed(reason);
+      if (reason.equals(WebSocketConnection.CLIENT_DISCONNECT_MESSAGE)) {
+        listener.connectionClosed();
+      } else {
+        listener.connectionTerminated(reason.isBlank() ? "Server disconnected" : reason);
+      }
       return null;
     }
 

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnectionListener.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnectionListener.java
@@ -4,7 +4,9 @@ interface WebSocketConnectionListener {
 
   void messageReceived(String message);
 
-  void connectionClosed(String reason);
+  void connectionClosed();
+
+  void connectionTerminated(String reason);
 
   void handleError(Throwable error);
 }

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/client/connections/PlayerToLobbyConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/client/connections/PlayerToLobbyConnection.java
@@ -89,6 +89,15 @@ public class PlayerToLobbyConnection {
     httpLobbyClient.getRemoteActionsClient().sendShutdownRequest(gameId);
   }
 
+  /**
+   * Adds a listener that is invoked when the server closes the connection or we have an unexpected
+   * close connection reason.
+   */
+  public void addConnectionTerminatedListener(final Consumer<String> closedListener) {
+    webSocket.addConnectionTerminatedListener(closedListener);
+  }
+
+  /** Adds a listener that is invoked when the client disconnects. */
   public void addConnectionClosedListener(final Runnable closedListener) {
     webSocket.addConnectionClosedListener(closedListener);
   }

--- a/http-clients/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
@@ -82,9 +82,15 @@ class WebSocketConnectionTest {
     }
 
     @Test
-    void onClose() {
+    void onCloseDueToClientDisconnect() {
+      listener.onClose(mock(WebSocket.class), 0, WebSocketConnection.CLIENT_DISCONNECT_MESSAGE);
+      verify(webSocketConnectionListener).connectionClosed();
+    }
+
+    @Test
+    void onCloseDueToTermination() {
       listener.onClose(mock(WebSocket.class), 0, REASON);
-      verify(webSocketConnectionListener).connectionClosed(REASON);
+      verify(webSocketConnectionListener).connectionTerminated(REASON);
     }
 
     @Test


### PR DESCRIPTION
Currently we have only one callback whenever a websocket
is closed. This update creates a distinction between
when a websocket is 'terminated' (closed by server)
vs 'closed' (standard close by client).

The 'closed' callback remains just a runnable and continues
to be just for client side cleanup. The 'terminated' callback
is invoked with the disconnect error reason, which for the
case of bans will be the ban message from the server.

If the server gives no message, then we default that message
to a generic "the server disconnected" message.

After this update users are given a notification when they
are disconnected due to ban, before they were given no notification.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix: https://github.com/triplea-game/triplea/issues/6222 <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
- verified before there was no message when a user is banned
- verified when banned there is a disconnect message
- verified when server is shutdown there is a disconnect message
- verified leaving lobby (normal disconnect) does not yield a disconnect message
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
## Screens Shots

Message when disconnected due to ban:
![Screenshot from 2020-04-13 12-34-17](https://user-images.githubusercontent.com/12397753/79156176-46329b00-7d87-11ea-990d-218a3922ee47.png)

Message when disconnected due to server shutdown:
![Screenshot from 2020-04-13 12-38-00](https://user-images.githubusercontent.com/12397753/79156180-46cb3180-7d87-11ea-8d2c-644618b85c98.png)


<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

