### PR TITLE
Make playerChatId non-null

### DIFF
--- a/domain-data/src/main/java/org/triplea/domain/data/ChatParticipant.java
+++ b/domain-data/src/main/java/org/triplea/domain/data/ChatParticipant.java
@@ -23,7 +23,7 @@ public class ChatParticipant implements Serializable {
    * Identifier attached to players when joining chat so that front-end can pass values to backend
    * to identify players, specifically useful example for moderator actions.
    */
-  private final String playerChatId;
+  @NonNull private final String playerChatId;
 
   /** True if the player has moderator privileges. */
   private final boolean isModerator;

--- a/http-server/src/test/java/org/triplea/http/server/LobbyChatIntegrationTest.java
+++ b/http-server/src/test/java/org/triplea/http/server/LobbyChatIntegrationTest.java
@@ -62,6 +62,7 @@ class LobbyChatIntegrationTest extends DropwizardTest {
           .userName(MODERATOR_NAME.getValue())
           .isModerator(true)
           .status("")
+          .playerChatId("moderator-chat-id")
           .build();
 
   private static final UserName CHATTER_NAME = UserName.of("chatter");
@@ -70,6 +71,7 @@ class LobbyChatIntegrationTest extends DropwizardTest {
           .userName(CHATTER_NAME.getValue())
           .isModerator(false)
           .status("")
+          .playerChatId("player-chat-id")
           .build();
 
   private List<PlayerStatusUpdateReceivedMessage> modPlayerStatusEvents = new ArrayList<>();
@@ -155,13 +157,9 @@ class LobbyChatIntegrationTest extends DropwizardTest {
     waitForMessage(modPlayerJoinedEvents, 2);
     // moderator is notified that chatter has joined
     assertThat(
-        modPlayerJoinedEvents.get(1).getChatParticipant(),
-        is(
-            ChatParticipant.builder()
-                .userName(CHATTER_NAME.getValue())
-                .isModerator(true)
-                .status("")
-                .build()));
+        modPlayerJoinedEvents.get(1).getChatParticipant().getUserName().getValue(),
+        is(CHATTER_NAME.getValue()));
+    assertThat(modPlayerJoinedEvents.get(1).getChatParticipant().isModerator(), is(false));
     // moderator should *not* receive a connected event when chatter joins
     assertThat(modConnectedEvents, hasSize(1));
   }

--- a/http-server/src/test/java/org/triplea/modules/chat/ChatParticipantAdapterTest.java
+++ b/http-server/src/test/java/org/triplea/modules/chat/ChatParticipantAdapterTest.java
@@ -41,7 +41,8 @@ class ChatParticipantAdapterTest {
 
     final ChatParticipant result = chatParticipantAdapter.apply(userWithRoleRecord);
 
-    assertThat(result, is(ChatParticipant.builder().isModerator(true).userName(USERNAME).build()));
+    assertThat(result.isModerator(), is(true));
+    assertThat(result.getUserName().getValue(), is(USERNAME));
   }
 
   private ApiKeyLookupRecord givenUserRecordWithRole(final String userRole) {
@@ -60,6 +61,7 @@ class ChatParticipantAdapterTest {
 
     final ChatParticipant result = chatParticipantAdapter.apply(userWithRoleRecord);
 
-    assertThat(result, is(ChatParticipant.builder().isModerator(true).userName(USERNAME).build()));
+    assertThat(result.isModerator(), is(false));
+    assertThat(result.getUserName().getValue(), is(USERNAME));
   }
 }

--- a/http-server/src/test/java/org/triplea/modules/chat/event/processing/ChatMessageListenerTest.java
+++ b/http-server/src/test/java/org/triplea/modules/chat/event/processing/ChatMessageListenerTest.java
@@ -17,6 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.domain.data.ChatParticipant;
+import org.triplea.domain.data.PlayerChatId;
 import org.triplea.domain.data.UserName;
 import org.triplea.http.client.web.socket.messages.envelopes.chat.ChatReceivedMessage;
 import org.triplea.http.client.web.socket.messages.envelopes.chat.ChatSentMessage;
@@ -51,7 +52,12 @@ class ChatMessageListenerTest {
   void ifPlayerSessionDoesExistThenRelayTheirMessage() {
     when(messageContext.getSenderSession()).thenReturn(session);
     when(messageContext.getMessage()).thenReturn(new ChatSentMessage("message"));
-    givenChatterSession(session, ChatParticipant.builder().userName("user-name").build());
+    givenChatterSession(
+        session,
+        ChatParticipant.builder()
+            .playerChatId(PlayerChatId.newId().getValue())
+            .userName("user-name")
+            .build());
 
     chatMessageListener.accept(messageContext);
 

--- a/http-server/src/test/java/org/triplea/modules/chat/event/processing/SlapListenerTest.java
+++ b/http-server/src/test/java/org/triplea/modules/chat/event/processing/SlapListenerTest.java
@@ -17,6 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.domain.data.ChatParticipant;
+import org.triplea.domain.data.PlayerChatId;
 import org.triplea.domain.data.UserName;
 import org.triplea.http.client.web.socket.messages.envelopes.chat.PlayerSlapReceivedMessage;
 import org.triplea.http.client.web.socket.messages.envelopes.chat.PlayerSlapSentMessage;
@@ -50,7 +51,12 @@ class SlapListenerTest {
     when(messageContext.getSenderSession()).thenReturn(session);
     when(messageContext.getMessage())
         .thenReturn(new PlayerSlapSentMessage(UserName.of("slapped-player")));
-    givenChatterSession(session, ChatParticipant.builder().userName("user-name").build());
+    givenChatterSession(
+        session,
+        ChatParticipant.builder()
+            .playerChatId(PlayerChatId.newId().getValue())
+            .userName("user-name")
+            .build());
 
     slapListener.accept(messageContext);
 

--- a/http-server/src/test/java/org/triplea/modules/chat/event/processing/StatusUpdateListenerTest.java
+++ b/http-server/src/test/java/org/triplea/modules/chat/event/processing/StatusUpdateListenerTest.java
@@ -17,6 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.domain.data.ChatParticipant;
+import org.triplea.domain.data.PlayerChatId;
 import org.triplea.domain.data.UserName;
 import org.triplea.http.client.web.socket.messages.envelopes.chat.PlayerStatusUpdateReceivedMessage;
 import org.triplea.http.client.web.socket.messages.envelopes.chat.PlayerStatusUpdateSentMessage;
@@ -49,7 +50,12 @@ class StatusUpdateListenerTest {
   void ifPlayerSessionDoesExistThenRelayTheirMessage() {
     when(messageContext.getSenderSession()).thenReturn(session);
     when(messageContext.getMessage()).thenReturn(new PlayerStatusUpdateSentMessage("status"));
-    givenChatterSession(session, ChatParticipant.builder().userName("user-name").build());
+    givenChatterSession(
+        session,
+        ChatParticipant.builder()
+            .playerChatId(PlayerChatId.newId().getValue())
+            .userName("user-name")
+            .build());
 
     statusUpdateListener.accept(messageContext);
 


### PR DESCRIPTION
Assigns a player-chat-id to chatters that are connected to java RMI
games. This satisfies an assumption/desire for player chat id to always
be non-null. For java RMI games this is not immediately helpful, players
are still identified by their 'node' which contains IP address (security risk).

With player chat id, we have a unique, public, ID that can be used to
refer to players and could be used to replace 'node' as an identifier.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  https://github.com/triplea-game/triplea/issues/6136 <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
Did some smoke testing joining a local lobby and joining a locally hosted game.

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

