### PR TITLE
Suppress incompatible maps

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
@@ -144,7 +144,10 @@ public final class GameChooserModel extends DefaultListModel<GameChooserEntry> {
     try {
       return Optional.of(GameChooserEntry.newInstance(uri));
     } catch (final EngineVersionException e) {
-      log.log(Level.SEVERE, "Engine version problem:" + uri, e);
+      // suppress any maps that have version problems (map requires a min version
+      // not compatible with current version). Returning empty here should
+      // remove such maps from the map selection list.
+      return Optional.empty();
     } catch (final Exception e) {
       log.log(Level.SEVERE, "Could not parse: " + uri, e);
     }


### PR DESCRIPTION
Currently we throw a hard error if the engine encounters a map
where the min version of the map is greater than the engine.

This update removes the error message and instead suppresses
the map from being selected (it is not displayed in the map
list).


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix: https://github.com/triplea-game/triplea/issues/6079 <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing

= Injected a min version = 3.0 into a map to test the behavior.

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

