### PR TITLE
Change checkbox label text to 'Login Without An Account'

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LoginPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LoginPanel.java
@@ -41,7 +41,7 @@ final class LoginPanel extends JPanel {
   private final JCheckBox rememberPassword =
       new JCheckBoxBuilder("Remember Password").bind(ClientSetting.rememberLoginPassword).build();
   private final JCheckBox anonymousLogin =
-      new JCheckBoxBuilder("Login Anonymously")
+      new JCheckBoxBuilder("Login Without An Account")
           .bind(ClientSetting.loginAnonymously)
           .actionListener(selected -> updateComponents())
           .build();


### PR DESCRIPTION
Replaces "login anonymously" text label to be more explicit.
Should help new players as 'anonymous login' is domain
terminology that a new player perhaps has not yet learned,
they may be very unsure of what exactly that means.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
## Screens Shots

### Before
![Screenshot from 2020-04-14 20-20-53](https://user-images.githubusercontent.com/12397753/79295502-ad3a7780-7e8d-11ea-8393-9f1e544bfb2a.png)

### After
![Screenshot from 2020-04-14 20-20-20](https://user-images.githubusercontent.com/12397753/79295499-aca1e100-7e8d-11ea-84a9-b0ec7b35c045.png)

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

