### PR TITLE
Battle display as dialog - remove always on top setting

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
+++ b/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
@@ -28,21 +28,10 @@ import org.triplea.util.ExitStatus;
  * error we wait until we get a good roll before returning.
  */
 public class PbemDiceRoller implements IRandomSource {
-  private static Frame focusWindow;
-
   private final IRemoteDiceServer remoteDiceServer;
 
   public PbemDiceRoller(final IRemoteDiceServer diceServer) {
     remoteDiceServer = diceServer;
-  }
-
-  /**
-   * If the game has multiple frames, allows the UI to set what frame should be the parent of the
-   * dice rolling window. If set to null, or not set, we try to guess by finding the currently
-   * focused window (or a visible window if none are focused).
-   */
-  public static void setFocusWindow(final Frame w) {
-    focusWindow = w;
   }
 
   /** Do a test roll, leaving the dialog open after the roll is done. */
@@ -74,9 +63,6 @@ public class PbemDiceRoller implements IRandomSource {
   }
 
   private static Frame getFocusedFrame() {
-    if (focusWindow != null) {
-      return focusWindow;
-    }
     final Frame[] frames = Frame.getFrames();
     Frame focusedFrame = null;
     for (final Frame frame : frames) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/ActionButtons.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ActionButtons.java
@@ -69,7 +69,7 @@ public class ActionButtons extends JPanel {
       final MovePanel movePanel,
       final TripleAFrame parent) {
     registerKeyBindings(parent);
-    battlePanel = new BattlePanel(data, map);
+    battlePanel = new BattlePanel(data, map, parent);
     this.movePanel = movePanel;
     purchasePanel = new PurchasePanel(data, map);
     repairPanel = new RepairPanel(data, map);

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -184,7 +184,6 @@ public final class BattlePanel extends ActionPanel {
       battleDisplay.cleanUp();
       battleWindow.getContentPane().removeAll();
       battleDisplay = null;
-      //      PbemDiceRoller.setFocusWindow(battleFrame);
     }
   }
 
@@ -264,7 +263,6 @@ public final class BattlePanel extends ActionPanel {
           battleWindow.getContentPane().add(battleDisplay);
           battleWindow.setMinimumSize(new Dimension(800, 600));
           battleWindow.setLocationRelativeTo(JOptionPane.getFrameForComponent(BattlePanel.this));
-          //          PbemDiceRoller.setFocusWindow(battleFrame);
           boolean foundHumanInBattle = false;
           for (final Player gamePlayer :
               getMap().getUiContext().getLocalPlayers().getLocalPlayers()) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -57,13 +57,13 @@ public final class BattlePanel extends ActionPanel {
   // only be set after
   // the display is shown on the screen
   private volatile UUID currentBattleDisplayed;
-  private final JDialog battleFrame;
+  private final JDialog battleWindow;
   private Map<BattleType, Collection<Territory>> battles;
 
   BattlePanel(final GameData data, final MapPanel map, final JFrame parent) {
     super(data, map);
-    battleFrame = new JDialog(parent);
-    battleFrame.addWindowListener(
+    battleWindow = new JDialog(parent);
+    battleWindow.addWindowListener(
         new WindowAdapter() {
           @Override
           public void windowActivated(final WindowEvent e) {
@@ -71,7 +71,7 @@ public final class BattlePanel extends ActionPanel {
                 () -> Optional.ofNullable(battleDisplay).ifPresent(BattleDisplay::takeFocus));
           }
         });
-    getMap().getUiContext().addShutdownWindow(battleFrame);
+    getMap().getUiContext().addShutdownWindow(battleWindow);
   }
 
   void setBattlesAndBombing(final Map<BattleType, Collection<Territory>> battles) {
@@ -173,7 +173,7 @@ public final class BattlePanel extends ActionPanel {
     SwingUtilities.invokeLater(
         () -> {
           if (battleDisplay != null) {
-            battleDisplay.endBattle(message, battleFrame);
+            battleDisplay.endBattle(message, battleWindow);
           }
         });
   }
@@ -182,7 +182,7 @@ public final class BattlePanel extends ActionPanel {
     if (battleDisplay != null) {
       currentBattleDisplayed = null;
       battleDisplay.cleanUp();
-      battleFrame.getContentPane().removeAll();
+      battleWindow.getContentPane().removeAll();
       battleDisplay = null;
       //      PbemDiceRoller.setFocusWindow(battleFrame);
     }
@@ -209,7 +209,7 @@ public final class BattlePanel extends ActionPanel {
   }
 
   boolean isBattleShowing() {
-    return battleFrame.isVisible();
+    return battleWindow.isVisible();
   }
 
   public void listBattle(final List<String> steps) {
@@ -258,12 +258,12 @@ public final class BattlePanel extends ActionPanel {
                   isAmphibious,
                   battleType,
                   amphibiousLandAttackers);
-          battleFrame.setTitle(
+          battleWindow.setTitle(
               attacker.getName() + " attacks " + defender.getName() + " in " + location.getName());
-          battleFrame.getContentPane().removeAll();
-          battleFrame.getContentPane().add(battleDisplay);
-          battleFrame.setMinimumSize(new Dimension(800, 600));
-          battleFrame.setLocationRelativeTo(JOptionPane.getFrameForComponent(BattlePanel.this));
+          battleWindow.getContentPane().removeAll();
+          battleWindow.getContentPane().add(battleDisplay);
+          battleWindow.setMinimumSize(new Dimension(800, 600));
+          battleWindow.setLocationRelativeTo(JOptionPane.getFrameForComponent(BattlePanel.this));
           //          PbemDiceRoller.setFocusWindow(battleFrame);
           boolean foundHumanInBattle = false;
           for (final Player gamePlayer :
@@ -276,17 +276,17 @@ public final class BattlePanel extends ActionPanel {
             }
           }
           if (ClientSetting.showBattlesWhenObserving.getValueOrThrow() || foundHumanInBattle) {
-            battleFrame.setVisible(true);
-            battleFrame.validate();
-            battleFrame.invalidate();
-            battleFrame.repaint();
-            battleFrame.toFront();
+            battleWindow.setVisible(true);
+            battleWindow.validate();
+            battleWindow.invalidate();
+            battleWindow.repaint();
+            battleWindow.toFront();
           } else {
-            battleFrame.setVisible(false);
+            battleWindow.setVisible(false);
           }
-          battleFrame.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
+          battleWindow.setDefaultCloseOperation(WindowConstants.DO_NOTHING_ON_CLOSE);
           currentBattleDisplayed = battleId;
-          SwingUtilities.invokeLater(battleFrame::toFront);
+          SwingUtilities.invokeLater(battleWindow::toFront);
         });
   }
 


### PR DESCRIPTION
<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->
## Changes

commit c36cdc0711dd992009755fd24fa8982a2b4ec304

    BattleWindow from JFrame to JDialog
    
    - Remove always on top property of the battle window
    On some OS this seems to always win out over any other
    notifications that are supposed to appear on top
    of the battle window
    
    - The conversion to JDialog will help ensure that the
    battle window stays on top of the map and does not
    get hidden behind it. This should have the same effect
    as always set on top being set to true.

commit ab6379439ad57dc9de6fdd69eef4534136a08ec6

    Rename BattleFrame to BattleWindow as it is no longer a frame

commit 801a58713996827eeef4292d95b2b4f18d9e0ee5

    Remove PBEM.setFocusWindow
    
    It appears to still work even with battle panel shown in a dialog
    instead of in a frame.


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  https://github.com/triplea-game/triplea/issues/6248 <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
- Did some smoke testing on tutorial and with PBEM dice roller enabled to verify dialogs still appear on top of battle window, and also that battle window stays on top of the map.

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

