### PR TITLE
Prune hotkey content from help menu text

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/HelpMenu.java
@@ -120,12 +120,6 @@ final class HelpMenu extends JMenu {
                       + "artwork.<br>"
                       + "Select a new 'Map Skin' from the 'View' menu to show a different kind of "
                       + "artwork (not all maps have skins).<br>"
-                      + "<br><b> Cycling Through Available Units</b><br>"
-                      + "Press 'n' to cycle through units with movement left.<br>"
-                      + "Press 'm' to cycle to previous units with movement left.<br>"
-                      + "Press 'space' to skip current units and not cycle through them anymore."
-                      + "<br>"
-                      + "Press 'c' to center on current units.<br>"
                       + "<br><b> Other Things</b><br>"
                       + "Press 'f' to highlight all units you own that have movement left "
                       + "(move phases only).<br>"
@@ -134,15 +128,7 @@ final class HelpMenu extends JMenu {
                       + "Press 'u' while mousing over a unit to undo all moves that unit has made "
                       + "(beta).<br>"
                       + "To list specific units from a territory in the Territory panel, drag and "
-                      + "drop from the territory on the map to the territory panel.<br>"
-                      + "Press CTRL+(key) to select a specific tab panel "
-                      + "(C-Actions, P-Players, R-Resources, O-Objectives, N-Notes, "
-                      + "T-Territory).<br>"
-                      + "Press CTRL+E to toggle edit mode.<br>"
-                      + "Press CTRL+H and CTRL+G to show history or game modes.<br>"
-                      + "Press CTRL+W to show politics panel.<br>"
-                      + "Press CTRL+L to show unit help list.<br>"
-                      + "Press CTRL+Z to show full screen and minimize right panel.<br>";
+                      + "drop from the territory on the map to the territory panel.<br>";
               editorPane.setText(hints);
               final JScrollPane scroll = new JScrollPane(editorPane);
               JOptionPane.showMessageDialog(


### PR DESCRIPTION
- Remove hotkeys that are already listed on file menus
- Remove unit scroller hotkeys, they are listed in tooltip
- Remove tab hotkeys, they are listed in tooltip
- Remove 'ctrl+z' hotkey, that has been removed


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

