### PR TITLE
Use 'ctrl-y' for history hotkey on Mac

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -64,7 +64,8 @@ final class GameMenu extends JMenu {
     add(SoundOptions.buildSoundOptionsMenuItem());
     addSeparator();
     addMenuItemWithHotkey(frame.getShowGameAction(), KeyEvent.VK_G);
-    addMenuItemWithHotkey(frame.getShowHistoryAction(),
+    addMenuItemWithHotkey(
+        frame.getShowHistoryAction(),
         // 'H' is a reserved hotkey in Mac, used to minimize apps use 'Y' instead for MacOs.
         SystemProperties.isMac() ? KeyEvent.VK_Y : KeyEvent.VK_H);
     addSeparator();

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -4,6 +4,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.properties.PropertiesUi;
 import games.strategy.engine.framework.ClientGame;
 import games.strategy.engine.framework.IGame;
+import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.engine.random.IRandomStats;
 import games.strategy.engine.random.RandomStatsDetails;
 import games.strategy.triplea.odds.calculator.BattleCalculatorDialog;
@@ -63,7 +64,9 @@ final class GameMenu extends JMenu {
     add(SoundOptions.buildSoundOptionsMenuItem());
     addSeparator();
     addMenuItemWithHotkey(frame.getShowGameAction(), KeyEvent.VK_G);
-    addMenuItemWithHotkey(frame.getShowHistoryAction(), KeyEvent.VK_H);
+    addMenuItemWithHotkey(frame.getShowHistoryAction(),
+        // 'H' is a reserved hotkey in Mac, used to minimize apps use 'Y' instead for MacOs.
+        SystemProperties.isMac() ? KeyEvent.VK_Y : KeyEvent.VK_H);
     addSeparator();
     addGameOptionsMenu();
     addShowVerifiedDice();


### PR DESCRIPTION
'ctrl-h' is alredy bound on Mac, does nothing. To have *a* hotkey
for toggling history mode, use 'ctrl-y' (the rest of the letters in
"histor_Y_" are almost all taken already)

Address: https://github.com/triplea-game/triplea/issues/5254


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

