### PR TITLE
Fix use of checkArgument().

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/random/PlainRandomSource.java
+++ b/game-core/src/main/java/games/strategy/engine/random/PlainRandomSource.java
@@ -17,8 +17,8 @@ public final class PlainRandomSource implements IRandomSource {
 
   @Override
   public int[] getRandom(final int max, final int count, final String annotation) {
-    checkArgument(max > 0, String.format("max must be > 0 (%s)", annotation));
-    checkArgument(count > 0, String.format("count must be > 0 (%s)", annotation));
+    checkArgument(max > 0, "max must be > 0 (%s)", annotation);
+    checkArgument(count > 0, "count must be > 0 (%s)", annotation);
 
     final int[] numbers = new int[count];
     for (int i = 0; i < count; i++) {
@@ -29,7 +29,7 @@ public final class PlainRandomSource implements IRandomSource {
 
   @Override
   public int getRandom(final int max, final String annotation) {
-    checkArgument(max > 0, String.format("max must be > 0 (%s)", annotation));
+    checkArgument(max > 0, "max must be > 0 (%s)", annotation);
 
     synchronized (lock) {
       return random.nextInt(max);


### PR DESCRIPTION
The code in PlainRandomSource was passing a String.format() result to checkArgument() instead of letting checkArgument() do the formatting. The latter is preferred because then the formatting will only be done if the precondition fails. The random number generation is pretty hot (used in combat in battle simulations) and this was showing up in profiles (e.g. 30s CPU time over a 1914 Domination round)

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[X] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
None
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

