### PR TITLE
Inline wrapper methods to Properties.getX

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -409,7 +409,7 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer {
         && gamePlayer.getRepairFrontier().getRules() != null
         && !gamePlayer.getRepairFrontier().getRules().isEmpty()) {
 
-      if (isDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
+      if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
         Predicate<Unit> myDamaged =
             Matches.unitIsOwnedBy(gamePlayer).and(Matches.unitHasTakenSomeBombingUnitDamage());
         if (isOnlyRepairIfDisabled) {
@@ -746,10 +746,6 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer {
   @Override
   public void confirmOwnCasualties(final UUID battleId, final String message) {
     ui.getBattlePanel().confirmCasualties(battleId, message);
-  }
-
-  private static boolean isDamageFromBombingDoneToUnitsInsteadOfTerritories(final GameData data) {
-    return Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
@@ -50,14 +50,6 @@ class AaInMoveUtil implements Serializable {
     return bridge.getData();
   }
 
-  private boolean isAlwaysOnAaEnabled() {
-    return Properties.getAlwaysOnAa(getData());
-  }
-
-  private boolean isAaTerritoryRestricted() {
-    return Properties.getAaTerritoryRestricted(getData());
-  }
-
   /** Fire aa guns. Returns units to remove. */
   Collection<Unit> fireAa(
       final Route route,
@@ -226,9 +218,9 @@ class AaInMoveUtil implements Serializable {
 
   Collection<Territory> getTerritoriesWhereAaWillFire(
       final Route route, final Collection<Unit> units) {
-    final boolean alwaysOnAa = isAlwaysOnAaEnabled();
+    final boolean alwaysOnAa = Properties.getAlwaysOnAa(getData());
     // Just the attacked territory will have AA firing
-    if (!alwaysOnAa && isAaTerritoryRestricted()) {
+    if (!alwaysOnAa && Properties.getAaTerritoryRestricted(getData())) {
       return List.of();
     }
     final GameData data = getData();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -50,10 +50,6 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate
   private boolean needToInitialize = true;
   private boolean hasPostedTurnSummary = false;
 
-  private boolean isGiveUnitsByTerritory() {
-    return Properties.getGiveUnitsByTerritory(getData());
-  }
-
   private static boolean canPlayerCollectIncome(final GamePlayer player, final GameData data) {
     return TerritoryAttachment.doWeHaveEnoughCapitalsToProduce(player, data);
   }
@@ -228,7 +224,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate
     if (GameStepPropertiesHelper.isRepairUnits(data)) {
       MoveDelegate.repairMultipleHitPointUnits(bridge, bridge.getGamePlayer());
     }
-    if (isGiveUnitsByTerritory()
+    if (Properties.getGiveUnitsByTerritory(getData())
         && pa != null
         && pa.getGiveUnitControl() != null
         && !pa.getGiveUnitControl().isEmpty()) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -220,7 +220,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
         unitsCanBePlacedByThisProducer = new ArrayList<>(unitsLeftToPlace);
       } else {
         unitsCanBePlacedByThisProducer =
-            (isUnitPlacementRestrictions()
+            (Properties.getUnitPlacementRestrictions(getData())
                 ? CollectionUtils.getMatches(
                     unitsLeftToPlace, unitWhichRequiresUnitsHasRequiredUnits(producer, true))
                 : new ArrayList<>(unitsLeftToPlace));
@@ -381,7 +381,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
         // around at all
         if (placeTerritory.isWater()
             && !placeTerritory.equals(producer)
-            && (!isUnitPlacementRestrictions()
+            && (!Properties.getUnitPlacementRestrictions(getData())
                 || placement.getUnits().stream()
                     .noneMatch(Matches.unitRequiresUnitsOnCreation()))) {
           // found placement move of producer that can be taken over
@@ -507,8 +507,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     if (!at.isWater()) {
       return null;
     }
-    if (!canMoveExistingFightersToNewCarriers()
-        || AirThatCantLandUtil.isLhtrCarrierProduction(getData())) {
+    if (!Properties.getMoveExistingFightersToNewCarriers(getData())
+        || Properties.getLhtrCarrierProductionRules(getData())) {
       return null;
     }
     if (units.stream().noneMatch(Matches.unitIsCarrier())) {
@@ -694,13 +694,13 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       return null;
     }
     // make sure some unit has fullfilled requiresUnits requirements
-    if (isUnitPlacementRestrictions()
+    if (Properties.getUnitPlacementRestrictions(getData())
         && !testUnits.isEmpty()
         && testUnits.stream().noneMatch(unitWhichRequiresUnitsHasRequiredUnits(producer, true))) {
       return "You do not have the required units to build in " + producer.getName();
     }
     if (to.isWater()
-        && (!isWW2V2() && !isUnitPlacementInEnemySeas())
+        && (!Properties.getWW2V2(getData()) && !Properties.getUnitPlacementInEnemySeas(getData()))
         && to.getUnitCollection().anyMatch(Matches.enemyUnit(player, getData()))) {
       return "Cannot place sea units with enemy naval units";
     }
@@ -865,7 +865,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       return "Units Cannot Go Over Stacking Limit";
     }
     // now return null (valid placement) if we have placement restrictions disabled in game options
-    if (!isUnitPlacementRestrictions()) {
+    if (!Properties.getUnitPlacementRestrictions(getData())) {
       return null;
     }
     // account for any unit placement restrictions by territory
@@ -920,7 +920,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       final Territory to, final Collection<Unit> allUnits, final GamePlayer player) {
     final boolean water = to.isWater();
     if (water
-        && (!isWW2V2() && !isUnitPlacementInEnemySeas())
+        && (!Properties.getWW2V2(getData()) && !Properties.getUnitPlacementInEnemySeas(getData()))
         && to.getUnitCollection().anyMatch(Matches.enemyUnit(player, getData()))) {
       return null;
     }
@@ -947,12 +947,12 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
             CollectionUtils.getMatches(
                 units, Matches.unitIsAir().and(Matches.unitIsNotConstruction())));
       } else if (((isBid
-                  || canProduceFightersOnCarriers()
-                  || AirThatCantLandUtil.isLhtrCarrierProduction(getData()))
+                  || Properties.getProduceFightersOnCarriers(getData())
+                  || Properties.getLhtrCarrierProductionRules(getData()))
               && allProducedUnits.stream().anyMatch(Matches.unitIsCarrier()))
           || ((isBid
-                  || canProduceNewFightersOnOldCarriers()
-                  || AirThatCantLandUtil.isLhtrCarrierProduction(getData()))
+                  || Properties.getProduceNewFightersOnOldCarriers(getData())
+                  || Properties.getLhtrCarrierProductionRules(getData()))
               && to.getUnitCollection()
                   .anyMatch(
                       Matches.unitIsCarrier()
@@ -1016,7 +1016,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
                   "placementLimit", ut, to, player, getData()),
               Matches.unitIsOfType(ut)));
     }
-    if (!isUnitPlacementRestrictions()) {
+    if (!Properties.getUnitPlacementRestrictions(getData())) {
       return placeableUnits2;
     }
     final Collection<Unit> placeableUnits3 = new ArrayList<>();
@@ -1134,7 +1134,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     final Map<Territory, Integer> currentAvailablePlacementForOtherProducers = new HashMap<>();
     for (final Territory producerTerritory : producers) {
       final Collection<Unit> unitsCanBePlacedByThisProducer =
-          (isUnitPlacementRestrictions()
+          (Properties.getUnitPlacementRestrictions(getData())
               ? CollectionUtils.getMatches(
                   units, unitWhichRequiresUnitsHasRequiredUnits(producerTerritory, true))
               : new ArrayList<>(units));
@@ -1172,7 +1172,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       final Map<Territory, Integer> currentAvailablePlacementForOtherProducers) {
     // we may have special units with requiresUnits restrictions
     final Collection<Unit> unitsCanBePlacedByThisProducer =
-        (isUnitPlacementRestrictions()
+        (Properties.getUnitPlacementRestrictions(getData())
             ? CollectionUtils.getMatches(
                 units, unitWhichRequiresUnitsHasRequiredUnits(producer, true))
             : new ArrayList<>(units));
@@ -1188,7 +1188,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
             .and(producer.isWater() ? Matches.unitIsLand().negate() : Matches.unitIsSea().negate());
     final Collection<Unit> factoryUnits = producer.getUnitCollection().getMatches(factoryMatch);
     // boolean placementRestrictedByFactory = isPlacementRestrictedByFactory();
-    final boolean unitPlacementPerTerritoryRestricted = isUnitPlacementPerTerritoryRestricted();
+    final boolean unitPlacementPerTerritoryRestricted =
+        Properties.getUnitPlacementPerTerritoryRestricted(getData());
     final boolean originalFactory = (ta != null && ta.getOriginalFactory());
     final boolean playerIsOriginalOwner =
         !factoryUnits.isEmpty() && this.player.equals(getOriginalFactoryOwner(producer));
@@ -1273,7 +1274,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
           // to mess with
           // logically, so we ignore them for our special 'move shit around' methods.
           if (!placeTerritory.isWater()
-              || (isUnitPlacementRestrictions()
+              || (Properties.getUnitPlacementRestrictions(getData())
                   && unitsPlacedByCurrentPlacementMove.stream()
                       .anyMatch(Matches.unitRequiresUnitsOnCreation()))) {
             productionCanNotBeMoved += unitsPlacedByCurrentPlacementMove.size();
@@ -1387,7 +1388,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     for (final Unit currentUnit : CollectionUtils.getMatches(units, Matches.unitIsConstruction())) {
       final UnitAttachment ua = UnitAttachment.get(currentUnit.getType());
       // account for any unit placement restrictions by territory
-      if (isUnitPlacementRestrictions()) {
+      if (Properties.getUnitPlacementRestrictions(getData())) {
         final String[] terrs = ua.getUnitPlacementRestrictions();
         final Collection<Territory> listedTerrs = getListedTerritories(terrs);
         if (listedTerrs.contains(to)) {
@@ -1534,7 +1535,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
 
   private boolean getCanAllUnitsWithRequiresUnitsBePlacedCorrectly(
       final Collection<Unit> units, final Territory to) {
-    if (!isUnitPlacementRestrictions()
+    if (!Properties.getUnitPlacementRestrictions(getData())
         || units.stream().noneMatch(Matches.unitRequiresUnitsOnCreation())) {
       return true;
     }
@@ -1731,45 +1732,13 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     return new AirThatCantLandUtil(bridge).getTerritoriesWhereAirCantLand(player);
   }
 
-  private boolean canProduceFightersOnCarriers() {
-    return Properties.getProduceFightersOnCarriers(getData());
-  }
-
-  private boolean canProduceNewFightersOnOldCarriers() {
-    return Properties.getProduceNewFightersOnOldCarriers(getData());
-  }
-
-  private boolean canMoveExistingFightersToNewCarriers() {
-    return Properties.getMoveExistingFightersToNewCarriers(getData());
-  }
-
-  protected boolean isWW2V2() {
-    return Properties.getWW2V2(getData());
-  }
-
-  private boolean isUnitPlacementInEnemySeas() {
-    return Properties.getUnitPlacementInEnemySeas(getData());
-  }
-
   protected boolean wasConquered(final Territory t) {
     final BattleTracker tracker = DelegateFinder.battleDelegate(getData()).getBattleTracker();
     return tracker.wasConquered(t);
   }
 
-  private boolean isPlaceInAnyTerritory() {
-    return Properties.getPlaceInAnyTerritory(getData());
-  }
-
-  private boolean isUnitPlacementPerTerritoryRestricted() {
-    return Properties.getUnitPlacementPerTerritoryRestricted(getData());
-  }
-
-  protected boolean isUnitPlacementRestrictions() {
-    return Properties.getUnitPlacementRestrictions(getData());
-  }
-
   private boolean isPlayerAllowedToPlacementAnyTerritoryOwnedLand(final GamePlayer player) {
-    if (isPlaceInAnyTerritory()) {
+    if (Properties.getPlaceInAnyTerritory(getData())) {
       final RulesAttachment ra =
           (RulesAttachment) player.getAttachment(Constants.RULES_ATTACHMENT_NAME);
       return ra != null && ra.getPlacementAnyTerritory();
@@ -1778,7 +1747,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
   }
 
   private boolean isPlayerAllowedToPlacementAnySeaZoneByOwnedLand(final GamePlayer player) {
-    if (isPlaceInAnyTerritory()) {
+    if (Properties.getPlaceInAnyTerritory(getData())) {
       final RulesAttachment ra =
           (RulesAttachment) player.getAttachment(Constants.RULES_ATTACHMENT_NAME);
       return ra != null && ra.getPlacementAnySeaZone();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirMovementValidator.java
@@ -51,9 +51,8 @@ public final class AirMovementValidator {
         // we can land at the end, nothing left to check
         || Matches.airCanLandOnThisAlliedNonConqueredLandTerritory(player, data)
             .test(route.getEnd())
-        || isKamikazeAircraft(
-            data) // we do not do any validation at all, cus they can all die and we don't care
-    ) {
+        // if kamikaze - we do not do any validation at all, cus they can all die and we don't care
+        || Properties.getKamikazeAirplanes(data)) {
       return result;
     }
     // Find which aircraft cannot find friendly land to land on
@@ -205,8 +204,8 @@ public final class AirMovementValidator {
             .and(Matches.isUnitAllied(player, data))
             .and(Matches.unitIsCarrier());
     final boolean landAirOnNewCarriers =
-        AirThatCantLandUtil.isLhtrCarrierProduction(data)
-            || AirThatCantLandUtil.isLandExistingFightersOnNewCarriers(data);
+        Properties.getLhtrCarrierProductionRules(data)
+            || Properties.getLandExistingFightersOnNewCarriers(data);
     final List<Unit> carriersInProductionQueue =
         GameStepPropertiesHelper.getCombinedTurns(data, player).stream()
             .map(GamePlayer::getUnitCollection)
@@ -839,16 +838,8 @@ public final class AirMovementValidator {
     return territory.getUnitCollection().getMatches(Matches.alliedUnit(player, data));
   }
 
-  private static boolean isKamikazeAircraft(final GameData data) {
-    return Properties.getKamikazeAirplanes(data);
-  }
-
   private static boolean areNeutralsPassableByAir(final GameData data) {
-    return Properties.getNeutralFlyoverAllowed(data) && !isNeutralsImpassable(data);
-  }
-
-  private static boolean isNeutralsImpassable(final GameData data) {
-    return Properties.getNeutralsImpassable(data);
+    return Properties.getNeutralFlyoverAllowed(data) && !Properties.getNeutralsImpassable(data);
   }
 
   private static int getNeutralCharge(final GameData data, final Route route) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
@@ -8,7 +8,6 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.delegate.IDelegateBridge;
-import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.formatter.MyFormatter;
 import java.util.ArrayList;
@@ -21,14 +20,6 @@ public class AirThatCantLandUtil {
 
   public AirThatCantLandUtil(final IDelegateBridge bridge) {
     this.bridge = bridge;
-  }
-
-  public static boolean isLhtrCarrierProduction(final GameData data) {
-    return Properties.getLhtrCarrierProductionRules(data);
-  }
-
-  public static boolean isLandExistingFightersOnNewCarriers(final GameData data) {
-    return Properties.getLandExistingFightersOnNewCarriers(data);
   }
 
   Collection<Territory> getTerritoriesWhereAirCantLand(final GamePlayer player) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -46,7 +46,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
     }
     String victoryMessage;
     final GameData data = getData();
-    if (isPacificTheater()) {
+    if (Properties.getPacificTheater(getData())) {
       final GamePlayer japanese = data.getPlayerList().getPlayerId(Constants.PLAYER_NAME_JAPANESE);
       final PlayerAttachment pa = PlayerAttachment.get(japanese);
       if (pa != null && pa.getVps() >= 22) {
@@ -60,19 +60,19 @@ public class EndRoundDelegate extends BaseTripleADelegate {
       }
     }
     // Check for Winning conditions
-    if (isTotalVictory()) { // Check for Win by Victory Cities
+    if (Properties.getTotalVictory(getData())) { // Check for Win by Victory Cities
       victoryMessage = " achieve TOTAL VICTORY with ";
       checkVictoryCities(bridge, victoryMessage, " Total Victory VCs");
     }
-    if (isHonorableSurrender()) {
+    if (Properties.getHonorableSurrender(getData())) {
       victoryMessage = " achieve an HONORABLE VICTORY with ";
       checkVictoryCities(bridge, victoryMessage, " Honorable Victory VCs");
     }
-    if (isProjectionOfPower()) {
+    if (Properties.getProjectionOfPower(getData())) {
       victoryMessage = " achieve victory through a PROJECTION OF POWER with ";
       checkVictoryCities(bridge, victoryMessage, " Projection of Power VCs");
     }
-    if (isEconomicVictory()) { // Check for regular economic victory
+    if (Properties.getEconomicVictory(getData())) { // Check for regular economic victory
       for (final String allianceName : data.getAllianceTracker().getAlliances()) {
         final int victoryAmount = getEconomicVictoryAmount(data, allianceName);
         final Set<GamePlayer> teamMembers =
@@ -92,7 +92,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
       }
     }
     // now check for generic trigger based victories
-    if (isTriggeredVictory()) {
+    if (Properties.getTriggeredVictory(getData())) {
       // First set up a match for what we want to have fire as a default in this delegate. List out
       // as a composite match
       // OR.
@@ -125,7 +125,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
         // signalGameOver itself
       }
     }
-    if (isWW2V2() || isWW2V3()) {
+    if (Properties.getWW2V2(getData()) || Properties.getWW2V3(getData())) {
       return;
     }
     final PlayerList playerList = data.getPlayerList();
@@ -348,38 +348,6 @@ public class EndRoundDelegate extends BaseTripleADelegate {
       return null;
     }
     return winners;
-  }
-
-  private boolean isWW2V2() {
-    return Properties.getWW2V2(getData());
-  }
-
-  private boolean isWW2V3() {
-    return Properties.getWW2V3(getData());
-  }
-
-  private boolean isPacificTheater() {
-    return Properties.getPacificTheater(getData());
-  }
-
-  private boolean isTotalVictory() {
-    return Properties.getTotalVictory(getData());
-  }
-
-  private boolean isHonorableSurrender() {
-    return Properties.getHonorableSurrender(getData());
-  }
-
-  private boolean isProjectionOfPower() {
-    return Properties.getProjectionOfPower(getData());
-  }
-
-  private boolean isEconomicVictory() {
-    return Properties.getEconomicVictory(getData());
-  }
-
-  private boolean isTriggeredVictory() {
-    return Properties.getTriggeredVictory(getData());
   }
 
   private int getProduction(final GamePlayer gamePlayer) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -48,7 +48,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     final StringBuilder endTurnReport = new StringBuilder();
 
     // do national objectives
-    if (isNationalObjectives()) {
+    if (Properties.getNationalObjectives(getData())) {
       final String nationalObjectivesText = determineNationalObjectives(bridge);
       if (nationalObjectivesText.trim().length() > 0) {
         endTurnReport.append(nationalObjectivesText).append("<br />");
@@ -384,10 +384,6 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     // Now test all the conditions
     return AbstractConditionsAttachment.testAllConditionsRecursive(
         allConditionsNeeded, null, bridge);
-  }
-
-  private boolean isNationalObjectives() {
-    return Properties.getNationalObjectives(getData());
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -241,7 +241,7 @@ public class InitializationDelegate extends BaseTripleADelegate {
   private static void initDestroyerArtillery(final IDelegateBridge bridge) {
     final GameData data = bridge.getData();
     final boolean addArtilleryAndDestroyers = Properties.getUseDestroyersAndArtillery(data);
-    if (!isWW2V2(data) && addArtilleryAndDestroyers) {
+    if (!Properties.getWW2V2(data) && addArtilleryAndDestroyers) {
       final CompositeChange change = new CompositeChange();
       final ProductionRule artillery =
           data.getProductionRuleList().getProductionRule("buyArtillery");
@@ -310,10 +310,6 @@ public class InitializationDelegate extends BaseTripleADelegate {
       bridge.getHistoryWriter().startEvent("Adding shipyard production rules - land/air units");
       bridge.addChange(change);
     }
-  }
-
-  private static boolean isWW2V2(final GameData data) {
-    return Properties.getWW2V2(data);
   }
 
   private static void initTwoHitBattleship(final IDelegateBridge bridge) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -701,8 +701,8 @@ public class MoveDelegate extends AbstractMoveDelegate {
   private void removeAirThatCantLand() {
     final GameData data = getData();
     final boolean lhtrCarrierProd =
-        AirThatCantLandUtil.isLhtrCarrierProduction(data)
-            || AirThatCantLandUtil.isLandExistingFightersOnNewCarriers(data);
+        Properties.getLhtrCarrierProductionRules(data)
+            || Properties.getLandExistingFightersOnNewCarriers(data);
     boolean hasProducedCarriers = false;
     for (final GamePlayer p : GameStepPropertiesHelper.getCombinedTurns(data, player)) {
       if (p.getUnitCollection().anyMatch(Matches.unitIsCarrier())) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -253,7 +253,7 @@ public class MovePerformer implements Serializable {
                 }
               }
               // Ignore Trn on Trn forces.
-              if (isIgnoreTransportInMovement(bridge.getData())) {
+              if (Properties.getIgnoreTransportInMovement(bridge.getData())) {
                 final boolean allOwnedTransports =
                     !arrived.isEmpty()
                         && arrived.stream()
@@ -525,9 +525,5 @@ public class MovePerformer implements Serializable {
             route, units, UnitComparator.getLowestToHighestMovementComparator(), currentMove);
     aaInMoveUtil = null;
     return unitsToRemove;
-  }
-
-  private static boolean isIgnoreTransportInMovement(final GameData data) {
-    return Properties.getIgnoreTransportInMovement(data);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/NoPuPurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/NoPuPurchaseDelegate.java
@@ -26,7 +26,7 @@ public class NoPuPurchaseDelegate extends PurchaseDelegate {
   @Override
   public void start() {
     super.start();
-    isPacific = isPacificTheater();
+    isPacific = Properties.getPacificTheater(getData());
     final GamePlayer player = bridge.getGamePlayer();
     final Collection<Territory> territories = getData().getMap().getTerritoriesOwnedBy(player);
     final Collection<Unit> units = getProductionUnits(territories, player);
@@ -39,7 +39,8 @@ public class NoPuPurchaseDelegate extends PurchaseDelegate {
   private Collection<Unit> getProductionUnits(
       final Collection<Territory> territories, final GamePlayer player) {
     final Collection<Unit> productionUnits = new ArrayList<>();
-    if (!(isProductionPerXTerritoriesRestricted() || isProductionPerValuedTerritoryRestricted())) {
+    if (!(Properties.getProductionPerXTerritoriesRestricted(getData())
+        || Properties.getProductionPerValuedTerritoryRestricted(getData()))) {
       return productionUnits;
     }
     IntegerMap<UnitType> productionPerXTerritories = new IntegerMap<>();
@@ -48,13 +49,13 @@ public class NoPuPurchaseDelegate extends PurchaseDelegate {
     // if they have no rules attachments, but are calling NoPU purchase, and have the game property
     // isProductionPerValuedTerritoryRestricted, then they want 1 infantry for each territory with
     // PU value > 0
-    if (isProductionPerValuedTerritoryRestricted()
+    if (Properties.getProductionPerValuedTerritoryRestricted(getData())
         && (ra == null
             || ra.getProductionPerXTerritories() == null
             || ra.getProductionPerXTerritories().isEmpty())) {
       productionPerXTerritories.put(
           getData().getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INFANTRY), 1);
-    } else if (isProductionPerXTerritoriesRestricted() && ra != null) {
+    } else if (Properties.getProductionPerXTerritoriesRestricted(getData()) && ra != null) {
       productionPerXTerritories = ra.getProductionPerXTerritories();
     } else {
       return productionUnits;
@@ -68,7 +69,7 @@ public class NoPuPurchaseDelegate extends PurchaseDelegate {
       }
       int terrCount = 0;
       for (final Territory current : territories) {
-        if (!isProductionPerValuedTerritoryRestricted()) {
+        if (!Properties.getProductionPerValuedTerritoryRestricted(getData())) {
           terrCount++;
         } else {
           if (TerritoryAttachment.getProduction(current) > 0) {
@@ -100,17 +101,5 @@ public class NoPuPurchaseDelegate extends PurchaseDelegate {
       return 1;
     }
     return 0;
-  }
-
-  private boolean isPacificTheater() {
-    return Properties.getPacificTheater(getData());
-  }
-
-  private boolean isProductionPerValuedTerritoryRestricted() {
-    return Properties.getProductionPerValuedTerritoryRestricted(getData());
-  }
-
-  private boolean isProductionPerXTerritoriesRestricted() {
-    return Properties.getProductionPerXTerritoriesRestricted(getData());
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -159,22 +159,6 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
     return techs;
   }
 
-  private boolean isWW2V2() {
-    return Properties.getWW2V2(getData());
-  }
-
-  private boolean isWW2V3TechModel() {
-    return Properties.getWW2V3TechModel(getData());
-  }
-
-  private boolean isSelectableTechRoll() {
-    return Properties.getSelectableTechRoll(getData());
-  }
-
-  private boolean isLowLuckTechOnly() {
-    return Properties.getLowLuckTechOnly(getData());
-  }
-
   @Override
   public TechResults rollTech(
       final int techRolls,
@@ -182,7 +166,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
       final int newTokens,
       final IntegerMap<GamePlayer> whoPaysHowMuch) {
     int rollCount = techRolls;
-    if (isWW2V3TechModel()) {
+    if (Properties.getWW2V3TechModel(getData())) {
       rollCount = newTokens;
     }
     final boolean canPay = checkEnoughMoney(rollCount, whoPaysHowMuch);
@@ -191,12 +175,12 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
     }
     chargeForTechRolls(rollCount, whoPaysHowMuch);
     int currTokens = 0;
-    if (isWW2V3TechModel()) {
+    if (Properties.getWW2V3TechModel(getData())) {
       currTokens = player.getResources().getQuantity(Constants.TECH_TOKENS);
     }
     final GameData data = getData();
     if (getAvailableTechs(player, data).isEmpty()) {
-      if (isWW2V3TechModel()) {
+      if (Properties.getWW2V3TechModel(getData())) {
         final Resource techTokens = data.getResourceList().getResource(Constants.TECH_TOKENS);
         final String transcriptText = player.getName() + " No more available tech advances.";
         bridge.getHistoryWriter().startEvent(transcriptText);
@@ -215,7 +199,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
       final Player tripleaPlayer = bridge.getRemotePlayer();
       random = tripleaPlayer.selectFixedDice(techRolls, diceSides, annotation, diceSides);
       techHits = getTechHits(random);
-    } else if (isLowLuckTechOnly()) {
+    } else if (Properties.getLowLuckTechOnly(getData())) {
       techHits = techRolls / diceSides;
       remainder = techRolls % diceSides;
       if (remainder > 0) {
@@ -231,10 +215,13 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
       random = bridge.getRandom(diceSides, techRolls, player, DiceType.TECH, annotation);
       techHits = getTechHits(random);
     }
-    final boolean isRevisedModel = isWW2V2() || (isSelectableTechRoll() && !isWW2V3TechModel());
+    final boolean isRevisedModel =
+        Properties.getWW2V2(getData())
+            || (Properties.getSelectableTechRoll(getData())
+                && !Properties.getWW2V3TechModel(getData()));
     final String directedTechInfo = isRevisedModel ? " for " + techToRollFor.getTechs().get(0) : "";
     final DiceRoll renderDice =
-        (isLowLuckTechOnly()
+        (Properties.getLowLuckTechOnly(getData())
             ? new DiceRoll(random, techHits, remainder, false)
             : new DiceRoll(random, techHits, diceSides - 1, true));
     bridge
@@ -249,7 +236,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
                 + " "
                 + MyFormatter.pluralize("hit", techHits),
             renderDice);
-    if (isWW2V3TechModel()
+    if (Properties.getWW2V3TechModel(getData())
         && (techHits > 0 || Properties.getRemoveAllTechTokensAtEndOfTurn(data))) {
       techCategory = techToRollFor;
       // remove all the tokens
@@ -348,7 +335,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
         bridge.addChange(charge);
       }
     }
-    if (isWW2V3TechModel()) {
+    if (Properties.getWW2V3TechModel(getData())) {
       final Resource tokens = getData().getResourceList().getResource(Constants.TECH_TOKENS);
       final Change newTokens =
           ChangeFactory.changeResourcesChange(bridge.getGamePlayer(), tokens, rolls);
@@ -369,7 +356,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
   private Collection<TechAdvance> getTechAdvances(final int initialHits) {
     final List<TechAdvance> available;
     int hits = initialHits;
-    if (hits > 0 && isWW2V3TechModel()) {
+    if (hits > 0 && Properties.getWW2V3TechModel(getData())) {
       available = getAvailableAdvancesForCategory(techCategory);
       hits = 1;
     } else {
@@ -387,7 +374,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
     final Collection<TechAdvance> newAdvances = new ArrayList<>(hits);
     final String annotation = player.getName() + " rolling to see what tech advances are acquired";
     final int[] random;
-    if (isSelectableTechRoll() || BaseEditDelegate.getEditMode(getData())) {
+    if (Properties.getSelectableTechRoll(getData()) || BaseEditDelegate.getEditMode(getData())) {
       final Player tripleaPlayer = bridge.getRemotePlayer();
       random = tripleaPlayer.selectFixedDice(hits, 0, annotation, available.size());
     } else {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
@@ -261,14 +261,6 @@ public class TransportTracker {
     return false;
   }
 
-  private static boolean isWW2V2(final GameData data) {
-    return Properties.getWW2V2(data);
-  }
-
-  private static boolean isTransportUnloadRestricted(final GameData data) {
-    return Properties.getTransportUnloadRestricted(data);
-  }
-
   /**
    * In some versions, a transport can never unload into multiple territories in a given turn. In
    * WW2V1 a transport can unload to multiple territories in non-combat phase, provided they are
@@ -284,7 +276,7 @@ public class TransportTracker {
     final GameData data = transport.getData();
     for (final Unit u : unloaded) {
       final TripleAUnit taUnit = (TripleAUnit) u;
-      if (isWW2V2(data) || isTransportUnloadRestricted(data)) {
+      if (Properties.getWW2V2(data) || Properties.getTransportUnloadRestricted(data)) {
         // cannot unload to two different territories
         if (!taUnit.getUnloadedTo().equals(territory)) {
           return true;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -408,7 +408,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       final BattleTracker battleTracker, final IDelegateBridge bridge) {
     final GamePlayer player = bridge.getGamePlayer();
     final GameData data = bridge.getData();
-    final boolean ignoreTransports = isIgnoreTransportInMovement(data);
+    final boolean ignoreTransports = Properties.getIgnoreTransportInMovement(data);
     final Predicate<Unit> seaTransports =
         Matches.unitIsTransportButNotCombatTransport().and(Matches.unitIsSea());
     final Predicate<Unit> seaTranportsOrSubs = seaTransports.or(Matches.unitCanEvade());
@@ -1642,10 +1642,6 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       whereCanLand.addAll(availableWater);
     }
     return whereCanLand;
-  }
-
-  private static boolean isIgnoreTransportInMovement(final GameData data) {
-    return Properties.getIgnoreTransportInMovement(data);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/CasualtySelector.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/CasualtySelector.java
@@ -148,7 +148,7 @@ public class CasualtySelector {
         !defendingAa.isEmpty()
             && defendingAa.stream()
                 .allMatch(Matches.unitAaShotDamageableInsteadOfKillingInstantly());
-    if (isChooseAa(data)) {
+    if (Properties.getChooseAaCasualties(data)) {
       final String text =
           "Select " + dice.getHits() + " casualties from aa fire in " + terr.getName();
       return selectCasualties(
@@ -184,7 +184,7 @@ public class CasualtySelector {
 
     // priority goes: choose -> individually -> random
     // if none are set, we roll individually
-    if (isRollAaIndividually(data)) {
+    if (Properties.getRollAaIndividually(data)) {
       return individuallyFiredAaCasualties(
           defending,
           planes,
@@ -195,7 +195,7 @@ public class CasualtySelector {
           bridge,
           allowMultipleHitsPerUnit);
     }
-    if (isRandomAaCasualties(data)) {
+    if (Properties.getRandomAaCasualties(data)) {
       return randomAaCasualties(planes, dice, bridge, allowMultipleHitsPerUnit);
     }
     return individuallyFiredAaCasualties(
@@ -634,7 +634,7 @@ public class CasualtySelector {
               allowMultipleHitsPerUnit);
       final List<Unit> killed = editSelection.getKilled();
       // if partial retreat is possible, kill amphibious units first
-      if (isPartialAmphibiousRetreat(data)) {
+      if (Properties.getPartialAmphibiousRetreat(data)) {
         killAmphibiousFirst(killed, targetsToPickFrom);
       }
       return editSelection;
@@ -643,7 +643,7 @@ public class CasualtySelector {
       return new CasualtyDetails(List.of(), List.of(), true);
     }
     int hitsRemaining = dice.getHits();
-    if (isTransportCasualtiesRestricted(data)) {
+    if (Properties.getTransportCasualtiesRestricted(data)) {
       hitsRemaining = extraHits;
     }
     if (!isEditMode && allTargetsOneTypeOneHitPoint(targetsToPickFrom, dependents)) {
@@ -709,7 +709,7 @@ public class CasualtySelector {
     }
     final List<Unit> killed = casualtySelection.getKilled();
     // if partial retreat is possible, kill amphibious units first
-    if (isPartialAmphibiousRetreat(data)) {
+    if (Properties.getPartialAmphibiousRetreat(data)) {
       killAmphibiousFirst(killed, sortedTargetsToPickFrom);
     }
     final List<Unit> damaged = casualtySelection.getDamaged();
@@ -1177,30 +1177,5 @@ public class CasualtySelector {
       return unitCategory.getHitPoints() - unitCategory.getDamaged() <= 1;
     }
     return false;
-  }
-
-  /** Indicates transports can be used as cannon fodder. */
-  private static boolean isTransportCasualtiesRestricted(final GameData data) {
-    return Properties.getTransportCasualtiesRestricted(data);
-  }
-
-  /** Indicates AA casualties are randomly assigned. */
-  private static boolean isRandomAaCasualties(final GameData data) {
-    return Properties.getRandomAaCasualties(data);
-  }
-
-  /** Indicates AA is rolled against each aircraft. */
-  private static boolean isRollAaIndividually(final GameData data) {
-    return Properties.getRollAaIndividually(data);
-  }
-
-  /** Indicates attacker selects AA casualties. */
-  private static boolean isChooseAa(final GameData data) {
-    return Properties.getChooseAaCasualties(data);
-  }
-
-  /** Indicates the attacker can retreat non-amphibious units. */
-  private static boolean isPartialAmphibiousRetreat(final GameData data) {
-    return Properties.getPartialAmphibiousRetreat(data);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
@@ -248,7 +248,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           @Override
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             bridge.getDisplayChannelBroadcaster().gotoBattleStep(battleId, RAID);
-            if (isDamageFromBombingDoneToUnitsInsteadOfTerritories()) {
+            if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(gameData)) {
               bridge
                   .getHistoryWriter()
                   .addChildToEvent(
@@ -272,7 +272,8 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
                           + MyFormatter.pluralize("PU", bombingRaidTotal));
             }
             // TODO remove the reference to the constant.japanese- replace with a rule
-            if (isPacificTheater() || isSbrVictoryPoints()) {
+            if (Properties.getPacificTheater(gameData)
+                || Properties.getSbrVictoryPoints(gameData)) {
               if (defender.getName().equals(Constants.PLAYER_NAME_JAPANESE)) {
                 final PlayerAttachment pa = PlayerAttachment.get(defender);
                 if (pa != null) {
@@ -361,7 +362,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
   }
 
   private void end(final IDelegateBridge bridge) {
-    if (isDamageFromBombingDoneToUnitsInsteadOfTerritories()) {
+    if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(gameData)) {
       bridge
           .getDisplayChannelBroadcaster()
           .battleEnd(
@@ -565,34 +566,6 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
         }
       }
     }
-  }
-
-  private boolean isDamageFromBombingDoneToUnitsInsteadOfTerritories() {
-    return Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(gameData);
-  }
-
-  private boolean isWW2V2() {
-    return Properties.getWW2V2(gameData);
-  }
-
-  private boolean isLimitSbrDamageToProduction() {
-    return Properties.getLimitRocketAndSbrDamageToProduction(gameData);
-  }
-
-  private static boolean isLimitSbrDamagePerTurn(final GameData data) {
-    return Properties.getLimitSbrDamagePerTurn(data);
-  }
-
-  private static boolean isPuCap(final GameData data) {
-    return Properties.getPuCap(data);
-  }
-
-  private boolean isSbrVictoryPoints() {
-    return Properties.getSbrVictoryPoints(gameData);
-  }
-
-  private boolean isPacificTheater() {
-    return Properties.getPacificTheater(gameData);
   }
 
   private CasualtyDetails calculateCasualties(
@@ -883,7 +856,9 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
       int cost = 0;
       final boolean lhtrBombers = Properties.getLhtrHeavyBombers(gameData);
       int index = 0;
-      final boolean limitDamage = isWW2V2() || isLimitSbrDamageToProduction();
+      final boolean limitDamage =
+          Properties.getWW2V2(gameData)
+              || Properties.getLimitRocketAndSbrDamageToProduction(gameData);
       final List<Die> dice = new ArrayList<>();
       final Map<Unit, List<Die>> targetToDiceMap = new HashMap<>();
       // limit to maxDamage
@@ -941,7 +916,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
         }
       }
       // Limit PUs lost if we would like to cap PUs lost at territory value
-      if (isPuCap(gameData) || isLimitSbrDamagePerTurn(gameData)) {
+      if (Properties.getPuCap(gameData) || Properties.getLimitSbrDamagePerTurn(gameData)) {
         final int alreadyLost = DelegateFinder.moveDelegate(gameData).pusAlreadyLost(battleSite);
         final int limit = Math.max(0, damageLimit - alreadyLost);
         cost = Math.min(cost, limit);
@@ -954,7 +929,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
         }
       }
       // If we damage units instead of territories
-      if (isDamageFromBombingDoneToUnitsInsteadOfTerritories()) {
+      if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(gameData)) {
         // at this point, bombingRaidDamage should contain all units that targets contains
         if (!targets.keySet().containsAll(bombingRaidDamage.keySet())) {
           throw new IllegalStateException("targets should contain all damaged units");

--- a/game-core/src/main/java/games/strategy/triplea/ui/ActionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ActionPanel.java
@@ -2,7 +2,6 @@ package games.strategy.triplea.ui;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
-import games.strategy.triplea.Properties;
 import games.strategy.triplea.ui.panels.map.MapPanel;
 import java.awt.Dimension;
 import java.util.concurrent.CountDownLatch;
@@ -47,22 +46,6 @@ public abstract class ActionPanel extends JPanel {
     setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
     setBorder(new EmptyBorder(5, 5, 0, 0));
     setMinimumSize(new Dimension(240, 0));
-  }
-
-  protected final boolean isWW2V2() {
-    return Properties.getWW2V2(data);
-  }
-
-  protected final boolean isWW2V3TechModel() {
-    return Properties.getWW2V3TechModel(data);
-  }
-
-  protected final boolean isRestrictedPurchase() {
-    return Properties.getPlacementRestrictedByFactory(data);
-  }
-
-  protected final boolean isSelectableTechRoll() {
-    return Properties.getSelectableTechRoll(data);
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -207,18 +207,6 @@ class PlacePanel extends AbstractMovePanel implements GameDataChangeListener {
     return placeData;
   }
 
-  private boolean canProduceFightersOnCarriers() {
-    return Properties.getProduceFightersOnCarriers(getData());
-  }
-
-  private boolean canProduceNewFightersOnOldCarriers() {
-    return Properties.getProduceNewFightersOnOldCarriers(getData());
-  }
-
-  private boolean isLhtrCarrierProductionRules() {
-    return Properties.getLhtrCarrierProductionRules(getData());
-  }
-
   private PlaceableUnits getUnitsToPlace(final Territory territory) {
     getData().acquireReadLock();
     try {
@@ -241,9 +229,9 @@ class PlacePanel extends AbstractMovePanel implements GameDataChangeListener {
       // get the units that can be placed on this territory.
       Collection<Unit> units = getCurrentPlayer().getUnits();
       if (territory.isWater()) {
-        if (!(canProduceFightersOnCarriers()
-            || canProduceNewFightersOnOldCarriers()
-            || isLhtrCarrierProductionRules()
+        if (!(Properties.getProduceFightersOnCarriers(getData())
+            || Properties.getProduceNewFightersOnOldCarriers(getData())
+            || Properties.getLhtrCarrierProductionRules(getData())
             || GameStepPropertiesHelper.isBid(getData()))) {
           units = CollectionUtils.getMatches(units, Matches.unitIsSea());
         } else {

--- a/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
@@ -8,6 +8,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Constants;
+import games.strategy.triplea.Properties;
 import games.strategy.triplea.TripleAUnit;
 import games.strategy.triplea.attachments.RulesAttachment;
 import games.strategy.triplea.delegate.Matches;
@@ -146,7 +147,7 @@ public class PurchasePanel extends ActionPanel {
     }
     // give a warning if the
     // player tries to produce too much
-    if (isWW2V2() || isRestrictedPurchase()) {
+    if (Properties.getWW2V2(getData()) || Properties.getPlacementRestrictedByFactory(getData())) {
       getData().acquireReadLock();
       int totalProd = 0;
       try {

--- a/game-core/src/main/java/games/strategy/triplea/ui/TechPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TechPanel.java
@@ -4,6 +4,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.TechnologyFrontier;
 import games.strategy.triplea.Constants;
+import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.PlayerAttachment;
 import games.strategy.triplea.delegate.TechAdvance;
 import games.strategy.triplea.delegate.TechTracker;
@@ -51,7 +52,9 @@ class TechPanel extends ActionPanel {
           "Roll Tech...",
           e -> {
             TechAdvance advance = null;
-            if (isWW2V2() || (isSelectableTechRoll() && !isWW2V3TechModel())) {
+            if (Properties.getWW2V2(getData())
+                || (Properties.getSelectableTechRoll(getData())
+                    && !Properties.getWW2V3TechModel(getData()))) {
               final List<TechAdvance> available = getAvailableTechs();
               if (available.isEmpty()) {
                 JOptionPane.showMessageDialog(TechPanel.this, "No more available tech advances");
@@ -227,7 +230,7 @@ class TechPanel extends ActionPanel {
           removeAll();
           actionLabel.setText(gamePlayer.getName() + " Tech Roll");
           add(actionLabel);
-          if (isWW2V3TechModel()) {
+          if (Properties.getWW2V3TechModel(getData())) {
             add(new JButton(getTechTokenAction));
             add(new JButton(justRollTech));
           } else {

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -48,7 +48,6 @@ import games.strategy.triplea.attachments.PoliticalActionAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.UserActionAttachment;
 import games.strategy.triplea.delegate.AbstractEndTurnDelegate;
-import games.strategy.triplea.delegate.AirThatCantLandUtil;
 import games.strategy.triplea.delegate.GameStepPropertiesHelper;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
@@ -1005,8 +1004,8 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
     }
     sb.append("</ul></html>");
     final boolean lhtrProd =
-        AirThatCantLandUtil.isLhtrCarrierProduction(data)
-            || AirThatCantLandUtil.isLandExistingFightersOnNewCarriers(data);
+        Properties.getLhtrCarrierProductionRules(data)
+            || Properties.getLandExistingFightersOnNewCarriers(data);
     final int carrierCount =
         GameStepPropertiesHelper.getCombinedTurns(data, gamePlayer).stream()
             .map(GamePlayer::getUnitCollection)

--- a/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
@@ -282,7 +282,7 @@ public class MovePanel extends AbstractMovePanel {
             mouseLastUpdatePoint = mouseDetails.getMapPoint();
             final Route route = getRoute(getFirstSelectedTerritory(), t, selectedUnits);
             // Load Bombers with paratroops
-            if ((!nonCombat || isParatroopersCanMoveDuringNonCombat(getData()))
+            if ((!nonCombat || Properties.getParatroopersCanMoveDuringNonCombat(getData()))
                 && TechAttachment.isAirTransportable(getCurrentPlayer())
                 && selectedUnits.stream()
                     .anyMatch(Matches.unitIsAirTransport().and(Matches.unitHasNotMoved()))) {
@@ -1460,10 +1460,6 @@ public class MovePanel extends AbstractMovePanel {
 
   private Territory getSelectedEndpointTerritory() {
     return selectedEndpointTerritory;
-  }
-
-  private static boolean isParatroopersCanMoveDuringNonCombat(final GameData data) {
-    return Properties.getParatroopersCanMoveDuringNonCombat(data);
   }
 
   private List<Unit> userChooseUnits(

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -219,7 +219,7 @@ public class UnitsDrawer extends AbstractDrawable {
     }
     displayHitDamage(bounds, graphics);
     // Display Factory Damage
-    if (isDamageFromBombingDoneToUnitsInsteadOfTerritories(data)
+    if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)
         && Matches.unitTypeCanBeDamaged().test(type)) {
       displayFactoryDamage(bounds, graphics);
     }
@@ -326,9 +326,5 @@ public class UnitsDrawer extends AbstractDrawable {
         + MyFormatter.pluralize(unitType)
         + " in  "
         + territoryName;
-  }
-
-  private static boolean isDamageFromBombingDoneToUnitsInsteadOfTerritories(final GameData data) {
-    return Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data);
   }
 }


### PR DESCRIPTION
There is a large number of methods that simply wrap calls
to Properties. This update inlines all such methods
that are not at least composite checks of multiple properties.

The methods that existed do not seem to serve too much
use other than providing slightly shorter names, typically
they are just aliases and otherwise extra indirection
(which makes tracing which properties are used where more
difficult)


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

