### PR TITLE
Code climate increase thresholds and add sonar

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -27,3 +27,6 @@ plugins:
   # https://docs.codeclimate.com/docs/shellcheck
   shellcheck:
     enabled: true
+  sonar-java:
+    enabled: true
+

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,12 +4,12 @@ version: "2"
 # https://docs.codeclimate.com/docs/maintainability#section-checks
 # https://docs.codeclimate.com/docs/advanced-configuration
 checks:
-  - method-complexity: 
-      config:
-        threshold: 7
-  - method-lines:
-      config:
-        threshold: 30
+  method-complexity: 
+    config:
+      threshold: 7
+  method-lines:
+    config:
+      threshold: 30
 plugins:
   # https://docs.codeclimate.com/docs/git-legal
   git-legal:

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,3 +1,15 @@
+version: "2"
+
+# https://docs.codeclimate.com/docs/cognitive-complexity
+# https://docs.codeclimate.com/docs/maintainability#section-checks
+# https://docs.codeclimate.com/docs/advanced-configuration
+checks:
+  - method-complexity: 
+      config:
+        threshold: 7
+  - method-lines:
+      config:
+        threshold: 30
 plugins:
   # https://docs.codeclimate.com/docs/git-legal
   git-legal:


### PR DESCRIPTION
commit b1abccabd109ce609950987798c69039d79074fb

    Increate codeclimate thresholds
    
    Cognitive complexity of 7 seems to be a more reasonable
    threshold where methods are actually quite difficult. We have
    had some examples where 6 and 7 are hard to reduce down further.
    
    Method line count of 25 is almost about right, breaking 30 starts
    to be more clear cut and reduces noise at that threshold.

commit 15cc8196bc060ed668d8cc3e1fcca367cfde8728

    Add sonar plugin to code climate, should enable sonar analysis checks


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

