### PR TITLE
Speed up code in UnitsHitChange.

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/ChangeFactory.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/ChangeFactory.java
@@ -129,8 +129,9 @@ public class ChangeFactory {
   }
 
   /** Must already include existing damage to the unit. This does not add damage, it sets damage. */
-  public static Change unitsHit(final IntegerMap<Unit> newHits) {
-    return new UnitHitsChange(newHits);
+  public static Change unitsHit(
+      final IntegerMap<Unit> newHits, final Collection<Territory> territoriesToNotify) {
+    return new UnitHitsChange(newHits, territoriesToNotify);
   }
 
   /** Must already include existing damage to the unit. This does not add damage, it sets damage. */

--- a/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAUnit.java
@@ -533,7 +533,7 @@ public class TripleAUnit extends Unit {
       }
     }
     if (!hits.isEmpty()) {
-      changes.add(ChangeFactory.unitsHit(hits));
+      changes.add(ChangeFactory.unitsHit(hits, List.of(t)));
     }
     final int unitDamage = taUnit.getUnitDamage();
     final IntegerMap<Unit> damageMap = new IntegerMap<>();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
@@ -343,7 +343,7 @@ class AaInMoveUtil implements Serializable {
         .reportMessage(
             casualties.size() + " " + currentTypeAa + " hits in " + territory.getName(),
             casualties.size() + " " + currentTypeAa + " hits in " + territory.getName());
-    BattleDelegate.markDamaged(new ArrayList<>(casualties.getDamaged()), bridge);
+    BattleDelegate.markDamaged(new ArrayList<>(casualties.getDamaged()), bridge, territory);
     bridge
         .getHistoryWriter()
         .addChildToEvent(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -257,7 +257,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
             + " owned units to: "
             + MyFormatter.integerUnitMapToString(unitDamageMap, ", ", " = ", false),
         unitsFinal);
-    bridge.addChange(ChangeFactory.unitsHit(unitDamageMap));
+    bridge.addChange(ChangeFactory.unitsHit(unitDamageMap, List.of(territory)));
     // territory.notifyChanged();
     return null;
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -477,6 +477,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
     }
     final Map<Unit, Territory> fullyRepaired = new HashMap<>();
     final IntegerMap<Unit> newHitsMap = new IntegerMap<>();
+    final var territoriesToNotify = new HashSet<Territory>();
     for (final Entry<Territory, Set<Unit>> entry : damagedMap.entrySet()) {
       for (final Unit u : entry.getValue()) {
         final int repairAmount = getLargestRepairRateForThisUnit(u, entry.getKey(), data);
@@ -484,6 +485,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
         final int newHits = Math.max(0, Math.min(currentHits, (currentHits - repairAmount)));
         if (newHits != currentHits) {
           newHitsMap.put(u, newHits);
+          territoriesToNotify.add(entry.getKey());
         }
         if (newHits <= 0) {
           fullyRepaired.put(u, entry.getKey());
@@ -498,7 +500,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
                 + MyFormatter.pluralize("unit", newHitsMap.size())
                 + " repaired.",
             new HashSet<>(newHitsMap.keySet()));
-    bridge.addChange(ChangeFactory.unitsHit(newHitsMap));
+    bridge.addChange(ChangeFactory.unitsHit(newHitsMap, territoriesToNotify));
 
     // now if damaged includes any carriers that are repairing, and have damaged abilities set for
     // not allowing air

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/AbstractBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/AbstractBattle.java
@@ -357,7 +357,7 @@ abstract class AbstractBattle implements IBattle {
   }
 
   void markDamaged(final Collection<Unit> damaged, final IDelegateBridge bridge) {
-    BattleDelegate.markDamaged(damaged, bridge);
+    BattleDelegate.markDamaged(damaged, bridge, battleSite);
   }
 
   protected static Player getRemote(final IDelegateBridge bridge) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -1513,7 +1513,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       } else {
         final IntegerMap<Unit> hitMap = new IntegerMap<>();
         hitMap.put(unitUnderFire, hits);
-        change.add(newDamageChange(hitMap, bridge));
+        change.add(newDamageChange(hitMap, bridge, location));
       }
     }
     if (!change.isEmpty()) {
@@ -1531,7 +1531,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         .reportMessageToPlayers(playersInvolved, null, title + dice, title);
   }
 
-  public static void markDamaged(final Collection<Unit> damaged, final IDelegateBridge bridge) {
+  public static void markDamaged(
+      final Collection<Unit> damaged, final IDelegateBridge bridge, final Territory territory) {
     if (damaged.isEmpty()) {
       return;
     }
@@ -1539,16 +1540,16 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     for (final Unit u : damaged) {
       damagedMap.add(u, 1);
     }
-    bridge.addChange(newDamageChange(damagedMap, bridge));
+    bridge.addChange(newDamageChange(damagedMap, bridge, territory));
   }
 
   private static Change newDamageChange(
-      final IntegerMap<Unit> damagedMap, final IDelegateBridge bridge) {
+      final IntegerMap<Unit> damagedMap, final IDelegateBridge bridge, final Territory territory) {
     final Set<Unit> units = new HashSet<>(damagedMap.keySet());
     for (final Unit u : units) {
       damagedMap.add(u, u.getHits());
     }
-    final Change damagedChange = ChangeFactory.unitsHit(damagedMap);
+    final Change damagedChange = ChangeFactory.unitsHit(damagedMap, List.of(territory));
     bridge
         .getHistoryWriter()
         .addChildToEvent("Units damaged: " + MyFormatter.unitsToText(units), units);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -517,7 +517,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
         CollectionUtils.getMatches(killed, Matches.unitAtMaxHitPointDamageChangesInto())) {
       lethallyDamagedMap.put(unit, unit.getUnitAttachment().getHitPoints());
     }
-    final Change lethallyDamagedChange = ChangeFactory.unitsHit(lethallyDamagedMap);
+    final Change lethallyDamagedChange =
+        ChangeFactory.unitsHit(lethallyDamagedMap, List.of(battleSite));
     bridge.addChange(lethallyDamagedChange);
 
     // Remove units


### PR DESCRIPTION
Previously, this code would need to look at all units in all territories to figure out which territories were affected, so that they can be notified. This was quite slow, taking 254 sec of CPU time over one round of all-AI Domination 1914 (across all threads - this was mostly affected battle simulation which was split across 8 threads on my machine).

This change explicitly passes the list of affected territories to the change object, eliminating that extra work. On the same Domination 1914 all-AI round, UnitsHitsChange.perform() now only takes 200 ms (instead of 254 sec).


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[X] Other:   Optimization

## Testing
Played one round of all-AI Domination 1914.
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

