### PR TITLE
Update Travis to Cache gradle caches folder

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ dist: xenial
 sudo: false
 language: java
 jdk: openjdk11
-cache: { directories: [ ".gradle" ] }
+cache: { directories: [ ".gradle", "~/.gradle/caches" ] }
 install: skip
 
 env:

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,3 @@
 org.gradle.caching=true
 org.gradle.parallel=true
 
-# increase number of retries from a default of 3
-org.gradle.internal.repository.max.retries=4
-
-# initial retry default is 125ms
-# backoff is exponential, increasing to get longer
-# retries on final attempts.
-org.gradle.internal.repository.initial.backoff=250
-


### PR DESCRIPTION
- also remove gradle retry config, does not seem to help prevent
  errors downloading dependency (typically connection reset errors)

Note, we do not cache the entirety of the ~/.gradle folder in case
there are any problems downloading or installing the gradle
wrapper into ~/.gradle/wrapper.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix: https://github.com/triplea-game/triplea/issues/6208 <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes

We used to have pretty good stability with most dependencies before we removed gradle cache caching: https://github.com/triplea-game/triplea/pull/6020; this update hopefully avoids the poisoned cache scenario and avoids excessive downloads of dependencies.
