### PR TITLE
OOL take into account isMarine & Clean up parameters to UnitBattleComparator

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
@@ -60,12 +60,10 @@ public final class ProBattleUtils {
     final List<Unit> sortedUnitsList = new ArrayList<>(attackingUnits);
     sortedUnitsList.sort(
         new UnitBattleComparator(
-                false,
+                false, //
                 proData.getUnitValueMap(),
                 TerritoryEffectHelper.getEffects(t),
-                data,
-                false,
-                false)
+                data)
             .reversed());
     final int attackPower =
         DiceRoll.getTotalPower(
@@ -154,12 +152,7 @@ public final class ProBattleUtils {
     final List<Unit> sortedUnitsList = new ArrayList<>(unitsThatCanFight);
     sortedUnitsList.sort(
         new UnitBattleComparator(
-                !attacking,
-                proData.getUnitValueMap(),
-                TerritoryEffectHelper.getEffects(t),
-                data,
-                false,
-                false)
+                !attacking, proData.getUnitValueMap(), TerritoryEffectHelper.getEffects(t), data)
             .reversed());
     final int myPower =
         DiceRoll.getTotalPower(

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
@@ -166,9 +166,7 @@ public final class ProSortMoveOptionsUtils {
                           false,
                           proData.getUnitValueMap(),
                           TerritoryEffectHelper.getEffects(t),
-                          data,
-                          false,
-                          false)
+                          data)
                       .reversed());
               final int powerWithout =
                   DiceRoll.getTotalPower(
@@ -189,9 +187,7 @@ public final class ProSortMoveOptionsUtils {
                           false,
                           proData.getUnitValueMap(),
                           TerritoryEffectHelper.getEffects(t),
-                          data,
-                          false,
-                          false)
+                          data)
                       .reversed());
               final int powerWith =
                   DiceRoll.getTotalPower(
@@ -229,9 +225,7 @@ public final class ProSortMoveOptionsUtils {
                           false,
                           proData.getUnitValueMap(),
                           TerritoryEffectHelper.getEffects(t),
-                          data,
-                          false,
-                          false)
+                          data)
                       .reversed());
               final int powerWithout =
                   DiceRoll.getTotalPower(
@@ -252,9 +246,7 @@ public final class ProSortMoveOptionsUtils {
                           false,
                           proData.getUnitValueMap(),
                           TerritoryEffectHelper.getEffects(t),
-                          data,
-                          false,
-                          false)
+                          data)
                       .reversed());
               final int powerWith =
                   DiceRoll.getTotalPower(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -1413,9 +1413,7 @@ public class BattleTracker implements Serializable {
                 true,
                 TuvUtils.getCostsForTuv(bridge.getGamePlayer(), gameData),
                 TerritoryEffectHelper.getEffects(territory),
-                gameData,
-                false,
-                false)
+                gameData)
             .reversed());
     return sortedUnitsList;
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
@@ -14,6 +14,7 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.BaseEditDelegate;
 import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.delegate.Matches;
+import games.strategy.triplea.delegate.battle.UnitBattleComparator.CombatModifiers;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
 import games.strategy.triplea.delegate.data.CasualtyList;
 import games.strategy.triplea.formatter.MyFormatter;
@@ -324,15 +325,18 @@ public class CasualtySelector {
         CasualtyOrderOfLosses.sortUnitsForCasualtiesWithSupport(
             CasualtyOrderOfLosses.Parameters.builder()
                 .targetsToPickFrom(targetsToPickFrom)
-                .defending(defending)
                 .player(player)
                 .enemyUnits(enemyUnits)
-                .amphibious(amphibious)
+                .combatModifiers(
+                    CombatModifiers.builder()
+                        .territoryEffects(territoryEffects)
+                        .amphibious(amphibious)
+                        .defending(defending)
+                        .build())
                 .amphibiousLandAttackers(
                     amphibiousLandAttackers == null ? List.of() : amphibiousLandAttackers)
                 .battlesite(battlesite)
                 .costs(costs)
-                .territoryEffects(territoryEffects)
                 .data(data)
                 .build());
     // Remove two hit bb's selecting them first for default casualties

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -1428,8 +1428,7 @@ class BattleCalculatorPanel extends JPanel {
       defenderUnitsTotalHitpoints.setText("HP: " + defenseHitPoints);
       final Collection<TerritoryEffect> territoryEffects = getTerritoryEffects();
       final IntegerMap<UnitType> costs = TuvUtils.getCostsForTuv(getAttacker(), data);
-      attackers.sort(
-          new UnitBattleComparator(false, costs, territoryEffects, data, false, false).reversed());
+      attackers.sort(new UnitBattleComparator(false, costs, territoryEffects, data).reversed());
       final int attackPower =
           DiceRoll.getTotalPower(
               DiceRoll.getUnitPowerAndRollsForNormalBattles(

--- a/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -693,12 +693,7 @@ class EditPanel extends ActionPanel {
             sortUnitsToRemove(units);
             units.sort(
                 new UnitBattleComparator(
-                        false,
-                        TuvUtils.getCostsForTuv(player, getData()),
-                        null,
-                        getData(),
-                        true,
-                        false)
+                        false, TuvUtils.getCostsForTuv(player, getData()), null, getData(), true)
                     .reversed());
             // unit mapped to <max, min, current>
             final Map<Unit, Triple<Integer, Integer, Integer>> currentDamageMap = new HashMap<>();
@@ -772,12 +767,7 @@ class EditPanel extends ActionPanel {
             sortUnitsToRemove(units);
             units.sort(
                 new UnitBattleComparator(
-                        false,
-                        TuvUtils.getCostsForTuv(player, getData()),
-                        null,
-                        getData(),
-                        true,
-                        false)
+                        false, TuvUtils.getCostsForTuv(player, getData()), null, getData(), true)
                     .reversed());
             // unit mapped to <max, min, current>
             final Map<Unit, Triple<Integer, Integer, Integer>> currentDamageMap = new HashMap<>();

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1441,8 +1441,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
                         TuvUtils.getCostsForTuv(units.get(0).getOwner(), data),
                         TerritoryEffectHelper.getEffects(entry.getKey()),
                         data,
-                        true,
-                        false)
+                        true)
                     .reversed());
             possibleUnitsToAttackStringForm.put(entry.getKey().getName(), units);
           }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnBigWorldV3.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnBigWorldV3.java
@@ -85,11 +85,9 @@ class CasualtyOrderOfLossesTestOnBigWorldV3 {
 
     assertThat(result, hasSize(4));
     assertThat(result.get(0).getType(), is(TANK));
-    assertThat(result.get(1).getType(), is(MARINE));
+    assertThat(result.get(1).getType(), is(ARTILLERY));
     assertThat(result.get(2).getType(), is(MARINE));
-    assertThat(
-        result.get(3).getType(),
-        is(ARTILLERY)); // << bug we should pick the artillery second or third
+    assertThat(result.get(3).getType(), is(MARINE));
   }
 
   private void addTech(final TechAdvance techAdvance) {
@@ -130,8 +128,8 @@ class CasualtyOrderOfLossesTestOnBigWorldV3 {
 
     assertThat(result, hasSize(4));
     assertThat(result.get(0).getType(), is(TANK)); // << bug, should be marine or artillery first
-    assertThat(result.get(1).getType(), is(MARINE)); // << bug should be artillery
+    assertThat(result.get(1).getType(), is(ARTILLERY));
     assertThat(result.get(2).getType(), is(MARINE));
-    assertThat(result.get(3).getType(), is(ARTILLERY)); // << bug, should be tank
+    assertThat(result.get(3).getType(), is(MARINE)); // << bug, should be tank
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnBigWorldV3.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnBigWorldV3.java
@@ -15,6 +15,7 @@ import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.delegate.ImprovedArtillerySupportAdvance;
 import games.strategy.triplea.delegate.TechAdvance;
+import games.strategy.triplea.delegate.battle.UnitBattleComparator.CombatModifiers;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -101,14 +102,17 @@ class CasualtyOrderOfLossesTestOnBigWorldV3 {
   private CasualtyOrderOfLosses.Parameters amphibAssault(final Collection<Unit> amphibUnits) {
     return CasualtyOrderOfLosses.Parameters.builder()
         .targetsToPickFrom(amphibUnits)
-        .defending(false)
+        .combatModifiers(
+            CombatModifiers.builder()
+                .defending(false)
+                .territoryEffects(List.of())
+                .amphibious(true)
+                .build())
         .player(BRITISH)
-        .enemyUnits(List.of()) // << TODO: remove this parameter should not matter
-        .amphibious(true)
+        .enemyUnits(List.of())
         .amphibiousLandAttackers(amphibUnits)
         .battlesite(FRANCE)
         .costs(COST_MAP)
-        .territoryEffects(List.of())
         .data(data)
         .build();
   }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnGlobal.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnGlobal.java
@@ -15,6 +15,7 @@ import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.delegate.HeavyBomberAdvance;
 import games.strategy.triplea.delegate.TechAdvance;
+import games.strategy.triplea.delegate.battle.UnitBattleComparator.CombatModifiers;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -128,14 +129,17 @@ class CasualtyOrderOfLossesTestOnGlobal {
   private CasualtyOrderOfLosses.Parameters attackingWith(final Collection<Unit> units) {
     return CasualtyOrderOfLosses.Parameters.builder()
         .targetsToPickFrom(units)
-        .defending(false)
+        .combatModifiers(
+            CombatModifiers.builder()
+                .defending(false)
+                .amphibious(false)
+                .territoryEffects(List.of())
+                .build())
         .player(BRITISH)
-        .enemyUnits(List.of()) // << TODO: remove this parameter should not matter
-        .amphibious(false)
+        .enemyUnits(List.of())
         .amphibiousLandAttackers(List.of())
         .battlesite(FRANCE)
         .costs(COST_MAP)
-        .territoryEffects(List.of())
         .data(data)
         .build();
   }
@@ -201,14 +205,17 @@ class CasualtyOrderOfLossesTestOnGlobal {
   private CasualtyOrderOfLosses.Parameters amphibAssault(final Collection<Unit> amphibUnits) {
     return CasualtyOrderOfLosses.Parameters.builder()
         .targetsToPickFrom(amphibUnits)
-        .defending(false)
+        .combatModifiers(
+            CombatModifiers.builder()
+                .defending(false)
+                .amphibious(true)
+                .territoryEffects(List.of())
+                .build())
         .player(BRITISH)
-        .enemyUnits(List.of()) // << TODO: remove this parameter should not matter
-        .amphibious(true)
+        .enemyUnits(List.of())
         .amphibiousLandAttackers(amphibUnits)
         .battlesite(FRANCE)
         .costs(COST_MAP)
-        .territoryEffects(List.of())
         .data(data)
         .build();
   }
@@ -267,14 +274,17 @@ class CasualtyOrderOfLossesTestOnGlobal {
   private CasualtyOrderOfLosses.Parameters defendingWith(final Collection<Unit> units) {
     return CasualtyOrderOfLosses.Parameters.builder()
         .targetsToPickFrom(units)
-        .defending(true)
+        .combatModifiers(
+            CombatModifiers.builder()
+                .defending(true)
+                .territoryEffects(List.of())
+                .amphibious(false)
+                .build())
         .player(BRITISH)
         .enemyUnits(List.of()) // << TODO: remove this parameter should not matter
-        .amphibious(false)
         .amphibiousLandAttackers(List.of())
         .battlesite(FRANCE)
         .costs(COST_MAP)
-        .territoryEffects(List.of())
         .data(data)
         .build();
   }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnGlobal.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnGlobal.java
@@ -196,10 +196,10 @@ class CasualtyOrderOfLossesTestOnGlobal {
     assertThat(result, hasSize(6));
     assertThat(result.get(0).getType(), is(INFANTRY));
     assertThat(result.get(1).getType(), is(INFANTRY));
-    assertThat(result.get(2).getType(), is(MARINE));
-    assertThat(result.get(3).getType(), is(MARINE));
-    assertThat(result.get(4).getType(), is(ARTILLERY));
-    assertThat(result.get(5).getType(), is(ARTILLERY));
+    assertThat(result.get(2).getType(), is(ARTILLERY));
+    assertThat(result.get(3).getType(), is(ARTILLERY));
+    assertThat(result.get(4).getType(), is(MARINE));
+    assertThat(result.get(5).getType(), is(MARINE));
   }
 
   private CasualtyOrderOfLosses.Parameters amphibAssault(final Collection<Unit> amphibUnits) {
@@ -221,8 +221,7 @@ class CasualtyOrderOfLossesTestOnGlobal {
   }
 
   @Test
-  @DisplayName("Verify that amphib assualting marines and artillery are interleaved")
-  void interleaveArtilleryAndMarines() {
+  void amphibAssaultingMarinesWithEqualNumberOfArtillery() {
     final Collection<Unit> attackingUnits = new ArrayList<>();
     attackingUnits.addAll(DataFactory.britishMarine(3));
     attackingUnits.addAll(DataFactory.britishArtillery(3));
@@ -231,12 +230,12 @@ class CasualtyOrderOfLossesTestOnGlobal {
         CasualtyOrderOfLosses.sortUnitsForCasualtiesWithSupport(amphibAssault(attackingUnits));
 
     assertThat(result, hasSize(6));
-    assertThat(result.get(0).getType(), is(MARINE));
-    assertThat(result.get(1).getType(), is(MARINE));
-    assertThat(result.get(2).getType(), is(MARINE));
-    assertThat(result.get(3).getType(), is(ARTILLERY));
-    assertThat(result.get(4).getType(), is(ARTILLERY));
-    assertThat(result.get(5).getType(), is(ARTILLERY));
+    assertThat(result.get(0).getType(), is(ARTILLERY));
+    assertThat(result.get(1).getType(), is(ARTILLERY));
+    assertThat(result.get(2).getType(), is(ARTILLERY));
+    assertThat(result.get(3).getType(), is(MARINE));
+    assertThat(result.get(4).getType(), is(MARINE));
+    assertThat(result.get(5).getType(), is(MARINE));
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnNapoleonic.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnNapoleonic.java
@@ -11,6 +11,7 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.delegate.battle.UnitBattleComparator.CombatModifiers;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -89,14 +90,17 @@ class CasualtyOrderOfLossesTestOnNapoleonic {
   private CasualtyOrderOfLosses.Parameters attackingWith(final Collection<Unit> units) {
     return CasualtyOrderOfLosses.Parameters.builder()
         .targetsToPickFrom(units)
-        .defending(false)
+        .combatModifiers(
+            CombatModifiers.builder()
+                .defending(false)
+                .amphibious(false)
+                .territoryEffects(List.of())
+                .build())
         .player(BRITISH)
-        .enemyUnits(List.of()) // << TODO: remove this parameter should not matter
-        .amphibious(false)
+        .enemyUnits(List.of())
         .amphibiousLandAttackers(List.of())
         .battlesite(NORMANDY)
         .costs(COST_MAP)
-        .territoryEffects(List.of())
         .data(data)
         .build();
   }


### PR DESCRIPTION
commit 1bd460294cb24732b684e39ca87be41b333850c9

    Fix 'isAmphibious' now used in UnitBattleComparator and create parameter object
    
    - FIX: Wire 'isAmphibious' to UnitBattleComparator to take into account 
      amphibious attack bonus
    - Refactor: Add CombatModifiers parameter object. This object holds parameters
      that are used to calculator combat modifiers, like "are we on defense", 
      "territory effects", "is amphibious".
    - Refactor: Add additional constructor APIs to UnitBattleComparator.java to 
      avoid excessive boolean parameters EG: (.., data, false, false);

commit 917b5848bff1610d4a45c0d06ffcc188ae873999

    Update OrderOfLoss test cases now that we take into account (isMarine) 
    amphib assault.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

