### PR TITLE
Simplify ConcurrentBattleCalculator code

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/GameDataUtils.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameDataUtils.java
@@ -28,6 +28,20 @@ public final class GameDataUtils {
     return dataCopy;
   }
 
+  public static byte[] serializeGameDataWithoutHistory(final GameData data) {
+    final History temp = data.getHistory();
+    data.resetHistory();
+    final byte[] bytes;
+    try {
+      bytes = IoUtils.writeToMemory(os -> GameDataManager.saveGame(os, data, false));
+    } catch (final IOException e) {
+      throw new RuntimeException("Failed to serialize GameData", e);
+    } finally {
+      data.setHistory(temp);
+    }
+    return bytes;
+  }
+
   public static GameData cloneGameData(final GameData data) {
     return cloneGameData(data, false);
   }

--- a/game-core/src/main/java/games/strategy/triplea/ai/fast/FastOddsEstimator.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/fast/FastOddsEstimator.java
@@ -17,9 +17,6 @@ import java.util.List;
 class FastOddsEstimator implements IBattleCalculator {
 
   private final ProData proData;
-  private Territory location = null;
-  private Collection<Unit> attackingUnits = new ArrayList<>();
-  private Collection<Unit> defendingUnits = new ArrayList<>();
 
   FastOddsEstimator(final ProData proData) {
     this.proData = proData;
@@ -29,22 +26,15 @@ class FastOddsEstimator implements IBattleCalculator {
   public void setGameData(final GameData data) {}
 
   @Override
-  public void setCalculateData(
-      final GamePlayer attacker,
-      final GamePlayer defender,
-      final Territory location,
-      final Collection<Unit> attackingUnits,
-      final Collection<Unit> defendingUnits,
-      final Collection<Unit> bombardingUnits,
-      final Collection<TerritoryEffect> territoryEffects,
-      final int runCount) {
-    this.location = location;
-    this.attackingUnits = attackingUnits;
-    this.defendingUnits = defendingUnits;
-  }
-
-  @Override
-  public AggregateResults calculate() {
+  public AggregateResults calculate(
+          final GamePlayer attacker,
+          final GamePlayer defender,
+          final Territory location,
+          final Collection<Unit> attackingUnits,
+          final Collection<Unit> defendingUnits,
+          final Collection<Unit> bombardingUnits,
+          final Collection<TerritoryEffect> territoryEffects,
+          final int runCount) {
     final double winPercentage =
         ProBattleUtils.estimateStrengthDifference(
             proData, location, new ArrayList<>(attackingUnits), new ArrayList<>(defendingUnits));
@@ -66,26 +56,6 @@ class FastOddsEstimator implements IBattleCalculator {
     final int battleRoundsFought = 3;
     return new AggregateEstimate(
         battleRoundsFought, winPercentage / 100, remainingAttackingUnits, remainingDefendingUnits);
-  }
-
-  @Override
-  public AggregateResults setCalculateDataAndCalculate(
-      final GamePlayer attacker,
-      final GamePlayer defender,
-      final Territory location,
-      final Collection<Unit> attacking,
-      final Collection<Unit> defending,
-      final Collection<Unit> bombarding,
-      final Collection<TerritoryEffect> territoryEffects,
-      final int runCount) {
-    setCalculateData(
-        attacker, defender, location, attacking, defending, bombarding, territoryEffects, runCount);
-    return calculate();
-  }
-
-  @Override
-  public int getRunCount() {
-    return 1;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/ai/fast/FastOddsEstimator.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/fast/FastOddsEstimator.java
@@ -27,14 +27,14 @@ class FastOddsEstimator implements IBattleCalculator {
 
   @Override
   public AggregateResults calculate(
-          final GamePlayer attacker,
-          final GamePlayer defender,
-          final Territory location,
-          final Collection<Unit> attackingUnits,
-          final Collection<Unit> defendingUnits,
-          final Collection<Unit> bombardingUnits,
-          final Collection<TerritoryEffect> territoryEffects,
-          final int runCount) {
+      final GamePlayer attacker,
+      final GamePlayer defender,
+      final Territory location,
+      final Collection<Unit> attackingUnits,
+      final Collection<Unit> defendingUnits,
+      final Collection<Unit> bombardingUnits,
+      final Collection<TerritoryEffect> territoryEffects,
+      final int runCount) {
     final double winPercentage =
         ProBattleUtils.estimateStrengthDifference(
             proData, location, new ArrayList<>(attackingUnits), new ArrayList<>(defendingUnits));

--- a/game-core/src/main/java/games/strategy/triplea/ai/fast/FastOddsEstimator.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/fast/FastOddsEstimator.java
@@ -59,11 +59,6 @@ class FastOddsEstimator implements IBattleCalculator {
   }
 
   @Override
-  public boolean getIsReady() {
-    return true;
-  }
-
-  @Override
   public void setKeepOneAttackingLandUnit(final boolean bool) {}
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProOddsCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProOddsCalculator.java
@@ -229,7 +229,7 @@ public class ProOddsCalculator {
       calc.setRetreatWhenOnlyAirLeft(true);
     }
     final AggregateResults results =
-        calc.setCalculateDataAndCalculate(
+        calc.calculate(
             attacker,
             defender,
             t,

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java
@@ -95,16 +95,16 @@ class BattleCalculator implements IBattleCalculator {
 
   @Override
   public AggregateResults calculate(
-          final GamePlayer attacker,
-          final GamePlayer defender,
-          final Territory location,
-          final Collection<Unit> attacking,
-          final Collection<Unit> defending,
-          final Collection<Unit> bombarding,
-          final Collection<TerritoryEffect> territoryEffects,
-          final int runCount) {
+      final GamePlayer attacker,
+      final GamePlayer defender,
+      final Territory location,
+      final Collection<Unit> attacking,
+      final Collection<Unit> defending,
+      final Collection<Unit> bombarding,
+      final Collection<TerritoryEffect> territoryEffects,
+      final int runCount) {
     setCalculateData(
-            attacker, defender, location, attacking, defending, bombarding, territoryEffects);
+        attacker, defender, location, attacking, defending, bombarding, territoryEffects);
     if (!getIsReady()) {
       throw new IllegalStateException("Called calculate before setting calculate data!");
     }
@@ -116,12 +116,10 @@ class BattleCalculator implements IBattleCalculator {
     final long start = System.currentTimeMillis();
     final AggregateResults aggregateResults = new AggregateResults(count);
     final BattleTracker battleTracker = new BattleTracker();
-    // CasualtySortingCaching can cause issues if there is more than 1 one battle being calced at
-    // the same time (like if
-    // the AI and a human are both using the calc)
+    // CasualtySortingCaching can cause issues if there is more than 1 one battle being calculated
+    // at the same time (like if the AI and a human are both using the calc)
     // TODO: first, see how much it actually speeds stuff up by, and if it does make a difference
-    // then convert it to a
-    // per-thread, per-calc caching
+    // then convert it to a per-thread, per-calc caching
     final List<Unit> attackerOrderOfLosses =
         OrderOfLossesInputPanel.getUnitListByOrderOfLoss(
             this.attackerOrderOfLosses, attackingUnits, gameData);

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java
@@ -166,7 +166,6 @@ class BattleCalculator implements IBattleCalculator {
     return aggregateResults;
   }
 
-  @Override
   public boolean getIsReady() {
     return isDataSet && isCalcSet;
   }

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculator.java
@@ -156,6 +156,7 @@ class BattleCalculator implements IBattleCalculator {
       battle.fight(bridge);
       aggregateResults.addResult(new BattleResults(battle, gameData));
       // restore the game to its original state
+      gameData.performChange(allChanges.invert());
       battleTracker.clear();
       battleTracker.clearBattleRecords();
     }

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -1253,7 +1253,7 @@ class BattleCalculatorPanel extends JPanel {
                 defenders.set(defending);
                 attackers.set(attacking);
                 results.set(
-                    calculator.setCalculateDataAndCalculate(
+                    calculator.calculate(
                         getAttacker(),
                         getDefender(),
                         location,

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java
@@ -141,7 +141,7 @@ public class ConcurrentBattleCalculator implements IBattleCalculator {
       final Collection<Unit> bombarding,
       final Collection<TerritoryEffect> territoryEffects,
       final int runs) {
-    BattleCalculator calculator = new BattleCalculator();
+    final BattleCalculator calculator = new BattleCalculator();
     calculator.setKeepOneAttackingLandUnit(keepOneAttackingLandUnit);
     calculator.setAmphibious(amphibious);
     calculator.setRetreatAfterRound(retreatAfterRound);
@@ -174,12 +174,12 @@ public class ConcurrentBattleCalculator implements IBattleCalculator {
   private static AggregateResults aggregateResults(
       final List<Future<AggregateResults>> results, final int runsPerWorker) {
     final AggregateResults result = new AggregateResults(runsPerWorker);
-    for (Future<AggregateResults> future : results) {
+    for (final Future<AggregateResults> future : results) {
       try {
         result.addResults(future.get().getResults());
-      } catch (InterruptedException e) {
+      } catch (final InterruptedException e) {
         Thread.currentThread().interrupt();
-      } catch (ExecutionException e) {
+      } catch (final ExecutionException e) {
         throw new IllegalStateException("Exception from worker", e);
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java
@@ -22,7 +22,6 @@ import java.util.concurrent.Future;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.annotation.concurrent.ThreadSafe;
-import lombok.extern.java.Log;
 import org.triplea.io.IoUtils;
 
 /**
@@ -30,7 +29,6 @@ import org.triplea.io.IoUtils;
  * the run count across these workers. This is mainly to be used by AIs since they call the
  * OddsCalculator a lot.
  */
-@Log
 @ThreadSafe
 public class ConcurrentBattleCalculator implements IBattleCalculator {
   private static final int MAX_THREADS = Math.max(1, Runtime.getRuntime().availableProcessors());

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java
@@ -137,11 +137,6 @@ public class ConcurrentBattleCalculator implements IBattleCalculator {
   }
 
   @Override
-  public boolean getIsReady() {
-    return isDataSet && !isShutDown;
-  }
-
-  @Override
   public void setKeepOneAttackingLandUnit(final boolean bool) {
     keepOneAttackingLandUnit = bool;
   }

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java
@@ -92,6 +92,7 @@ public class ConcurrentBattleCalculator implements IBattleCalculator {
                                     final Collection<Unit> bombarding,
                                     final Collection<TerritoryEffect> territoryEffects,
                                     final int runCount) throws IllegalStateException {
+    final long start = System.currentTimeMillis();
     final List<Future<AggregateResults>> results = new ArrayList<>();
     int remainingRuns = runCount;
     final int runsPerWorker = runCount / MAX_THREADS;
@@ -118,15 +119,14 @@ public class ConcurrentBattleCalculator implements IBattleCalculator {
     final AggregateResults result = new AggregateResults(runsPerWorker);
     for (Future<AggregateResults> future : results) {
       try {
-        final AggregateResults currentResult = future.get();
-        result.addResults(currentResult.getResults());
-        result.setTime(result.getTime() + currentResult.getTime());
+        result.addResults(future.get().getResults());
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
       } catch (ExecutionException e) {
         throw new IllegalStateException("Exception from worker", e);
       }
     }
+    result.setTime(System.currentTimeMillis() - start);
     return result;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java
@@ -96,6 +96,7 @@ public class ConcurrentBattleCalculator implements IBattleCalculator {
     int remainingRuns = runCount;
     final int runsPerWorker = runCount / MAX_THREADS;
     while (remainingRuns > 0) {
+      final int individualRemaining = Math.min(remainingRuns, runsPerWorker);
       remainingRuns -= runsPerWorker;
       results.add(executor.submit(() -> {
         BattleCalculator calculator = new BattleCalculator();
@@ -111,7 +112,7 @@ public class ConcurrentBattleCalculator implements IBattleCalculator {
         } catch (final IOException e) {
           throw new RuntimeException("Failed to deserialize", e);
         }
-        return calculator.calculate(attacker, defender, location, attacking, defending, bombarding, territoryEffects, runsPerWorker);
+        return calculator.calculate(attacker, defender, location, attacking, defending, bombarding, territoryEffects, individualRemaining);
       }));
     }
     final AggregateResults result = new AggregateResults(runsPerWorker);

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java
@@ -7,25 +7,19 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
+import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.GameDataUtils;
+
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.logging.Level;
 import lombok.extern.java.Log;
-import org.triplea.java.Interruptibles;
-import org.triplea.java.concurrency.CountUpAndDownLatch;
+import org.triplea.io.IoUtils;
 
 /**
  * Concurrent wrapper class for the OddsCalculator. It spawns multiple worker threads and splits up
@@ -36,29 +30,20 @@ import org.triplea.java.concurrency.CountUpAndDownLatch;
 public class ConcurrentBattleCalculator implements IBattleCalculator {
   private static final int MAX_THREADS = Math.max(1, Runtime.getRuntime().availableProcessors());
 
-  private int currentThreads = MAX_THREADS;
   private final ExecutorService executor;
-  private final List<BattleCalculator> workers = new CopyOnWriteArrayList<>();
-  // do not let calc be set up til data is set
-  private volatile boolean isDataSet = false;
   // do not let calc start until it is set
-  private volatile boolean isCalcSet = false;
+  private volatile boolean isDataSet = false;
   // shortcut everything if we are shutting down
   private volatile boolean isShutDown = false;
-  // shortcut setting of previous game data if we are trying to set it to a new one, or shutdown
-  private final AtomicInteger cancelCurrentOperation = new AtomicInteger(0);
-  // do not let calcing happen while we are setting game data
-  private final CountUpAndDownLatch latchSetData = new CountUpAndDownLatch();
-  // do not let setting of game data happen multiple times while we offload creating workers and
-  // copying data to a
-  // different thread
-  private final CountUpAndDownLatch latchWorkerThreadsCreation = new CountUpAndDownLatch();
-
-  // do not let setting of game data happen at same time
-  private final Object mutexSetGameData = new Object();
-  // do not let multiple calculations or setting calc data happen at same time
-  private final Object mutexCalcIsRunning = new Object();
   private final Runnable dataLoadedAction;
+  private byte[] bytes = new byte[0];
+  private boolean keepOneAttackingLandUnit = false;
+  private boolean amphibious = false;
+  private int retreatAfterRound = -1;
+  private int retreatAfterXUnitsLeft = -1;
+  private boolean retreatWhenOnlyAirLeft = false;
+  private String attackerOrderOfLosses = null;
+  private String defenderOrderOfLosses = null;
 
   public ConcurrentBattleCalculator(final String threadNamePrefix) {
     this(threadNamePrefix, Runnables.doNothing());
@@ -77,195 +62,21 @@ public class ConcurrentBattleCalculator implements IBattleCalculator {
 
   @Override
   public void setGameData(final GameData data) {
-    // increment so that a new calc doesn't take place (since they all wait on this latch)
-    latchSetData.increment();
-    // cancel any current setting of data
-    cancelCurrentOperation.decrementAndGet();
-    // cancel any existing calcing (it won't stop immediately, just quicker)
-    cancel();
-    synchronized (mutexSetGameData) {
-      try {
-        // since setting data takes place on a different thread, this is our token. wait on it since
-        latchWorkerThreadsCreation.await();
-        // we could have exited the synchronized block already.
-      } catch (final InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
-      cancel();
-      isDataSet = false;
-      isCalcSet = false;
-      if (data == null || isShutDown) {
-        workers.clear();
-        cancelCurrentOperation.incrementAndGet();
-        // allow calcing and other stuff to go ahead
-        latchSetData.countDown();
-      } else {
-        cancelCurrentOperation.incrementAndGet();
-        // increment our token, so that we can set the data in a different thread and return from
-        // this one
-        latchWorkerThreadsCreation.increment();
-        executor.execute(() -> createWorkers(data));
-      }
-    }
+    bytes = data == null ? new byte[0] : GameDataUtils.serializeGameDataWithoutHistory(data);
+    isDataSet = data != null;
+    dataLoadedAction.run();
   }
 
   @Override
   public int getThreadCount() {
-    return currentThreads;
-  }
-
-  // use both time and memory left to determine how many copies to make
-  private static int getThreadsToUse(
-      final long timeToCopyInMillis, final long memoryUsedBeforeCopy) {
-    if (timeToCopyInMillis > 20000 || MAX_THREADS == 1) {
-      // just use 1 thread if we took more than 20 seconds to copy
-      return 1;
-    }
-    final Runtime runtime = Runtime.getRuntime();
-    final long usedMemoryAfterCopy = runtime.totalMemory() - runtime.freeMemory();
-    // we cannot predict how the gc works
-    final long memoryLeftBeforeMax =
-        runtime.maxMemory() - Math.max(usedMemoryAfterCopy, memoryUsedBeforeCopy);
-    // make sure it is a decent size
-    final long memoryUsedByCopy = Math.max(100000, (usedMemoryAfterCopy - memoryUsedBeforeCopy));
-    // regardless of how stupid the gc is we leave some memory left over just in case
-    final int numberOfTimesWeCanCopyMax =
-        Math.max(1, (int) Math.min(Integer.MAX_VALUE, (memoryLeftBeforeMax / memoryUsedByCopy)));
-
-    if (timeToCopyInMillis > 3000) {
-      // use half the number of threads available if we took more than 3 seconds to copy
-      return Math.min(numberOfTimesWeCanCopyMax, Math.max(1, (MAX_THREADS / 2)));
-    }
-    // use all threads
-    return Math.min(numberOfTimesWeCanCopyMax, MAX_THREADS);
-  }
-
-  private void createWorkers(final GameData data) {
-    workers.clear();
-    if (data != null && cancelCurrentOperation.get() >= 0) {
-      // see how long 1 copy takes (some games can get REALLY big)
-      final long startTime = System.currentTimeMillis();
-      final long startMemory =
-          Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory();
-      final GameData newData;
-      try {
-        // make first copy, then release lock on it so game can continue (ie: we don't want to lock
-        // on it while we copy
-        // it 16 times, when once is enough) don't let the data change while we make the first copy
-        data.acquireWriteLock();
-        newData = GameDataUtils.cloneGameDataWithoutHistory(data, false);
-      } finally {
-        data.releaseWriteLock();
-      }
-      currentThreads = getThreadsToUse((System.currentTimeMillis() - startTime), startMemory);
-      try {
-        // make sure all workers are using the same data
-        newData.acquireReadLock();
-        int i = 0;
-        // we are already in 1 executor thread, so we have MAX_THREADS-1 threads left to use
-        if (currentThreads <= 2 || MAX_THREADS <= 2) {
-          // if 2 or fewer threads, do not multi-thread the copying (we have already copied it once
-          // above, so at most
-          // only 1 more copy to make)
-          while (cancelCurrentOperation.get() >= 0 && i < currentThreads) {
-            // the last one will use our already copied data from above, without copying it again
-            workers.add(new BattleCalculator(newData, (currentThreads == ++i)));
-          }
-        } else { // multi-thread our copying, cus why the heck not (it increases the speed of
-          // copying by about double)
-          final CountDownLatch workerLatch = new CountDownLatch(currentThreads - 1);
-          while (i < (currentThreads - 1)) {
-            ++i;
-            executor.execute(
-                () -> {
-                  if (cancelCurrentOperation.get() >= 0) {
-                    workers.add(new BattleCalculator(newData, false));
-                  }
-                  workerLatch.countDown();
-                });
-          }
-          // the last one will use our already copied data from above, without copying it again
-          workers.add(new BattleCalculator(newData, true));
-          Interruptibles.await(workerLatch);
-        }
-      } finally {
-        newData.releaseReadLock();
-      }
-    }
-    if (cancelCurrentOperation.get() < 0 || data == null) {
-      // we could have cancelled while setting data, so clear the workers again if so
-      workers.clear();
-      isDataSet = false;
-    } else {
-      // should make sure that all workers have their game data set before we can call calculate and
-      // other things
-      isDataSet = true;
-      dataLoadedAction.run();
-    }
-    // allow setting new data to take place if it is waiting on us
-    latchWorkerThreadsCreation.countDown();
-    // allow calcing and other stuff to go ahead
-    latchSetData.countDown();
+    return MAX_THREADS;
   }
 
   @Override
   public void shutdown() {
     isShutDown = true;
-    cancelCurrentOperation.set(Integer.MIN_VALUE / 2);
     cancel();
     executor.shutdown();
-  }
-
-  private void awaitLatch() {
-    try {
-      // there is a small chance calculate or setCalculateData or something could be called in
-      // between calls to
-      // setGameData
-      latchSetData.await();
-    } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
-    }
-  }
-
-  @Override
-  public void setCalculateData(
-      final GamePlayer attacker,
-      final GamePlayer defender,
-      final Territory location,
-      final Collection<Unit> attacking,
-      final Collection<Unit> defending,
-      final Collection<Unit> bombarding,
-      final Collection<TerritoryEffect> territoryEffects,
-      final int initialRunCount) {
-    synchronized (mutexCalcIsRunning) {
-      awaitLatch();
-      isCalcSet = false;
-      int runCount = initialRunCount;
-      final int workerNum = workers.size();
-      final int workerRunCount = Math.max(1, (runCount / Math.max(1, workerNum)));
-      for (final BattleCalculator worker : workers) {
-        if (!isDataSet || isShutDown) {
-          // we could have attempted to set a new game data, while the old one was still being set,
-          // causing it to abort
-          // with null data
-          return;
-        }
-        worker.setCalculateData(
-            attacker,
-            defender,
-            location,
-            attacking,
-            defending,
-            bombarding,
-            territoryEffects,
-            (runCount <= 0 ? 0 : workerRunCount));
-        runCount -= workerRunCount;
-      }
-      if (!isDataSet || isShutDown || workerNum <= 0) {
-        return;
-      }
-      isCalcSet = true;
-    }
   }
 
   /**
@@ -273,190 +84,92 @@ public class ConcurrentBattleCalculator implements IBattleCalculator {
    * results. Then waits for all the future results and combines them together.
    */
   @Override
-  public AggregateResults calculate() throws IllegalStateException {
-    synchronized (mutexCalcIsRunning) {
-      awaitLatch();
-      final long start = System.currentTimeMillis();
-      // Create worker thread pool and start all workers
-      int totalRunCount = 0;
-      final List<Future<AggregateResults>> list = new ArrayList<>();
-      for (final BattleCalculator worker : workers) {
-        if (!getIsReady()) {
-          // we could have attempted to set a new game data, while the old one was still being set,
-          // causing it to abort
-          // with null data
-          return new AggregateResults(0);
-        }
-        if (!worker.getIsReady()) {
-          throw new IllegalStateException("Called calculate before setting calculate data!");
-        }
-        if (worker.getRunCount() > 0) {
-          totalRunCount += worker.getRunCount();
-          final Future<AggregateResults> workerResult = executor.submit(worker);
-          list.add(workerResult);
-        }
-      }
-      // Wait for all worker futures to complete and combine results
-      final AggregateResults results = new AggregateResults(totalRunCount);
-      final Set<InterruptedException> interruptExceptions = new HashSet<>();
-      final Map<String, Set<ExecutionException>> executionExceptions = new HashMap<>();
-      for (final Future<AggregateResults> future : list) {
+  public AggregateResults calculate(final GamePlayer attacker,
+                                    final GamePlayer defender,
+                                    final Territory location,
+                                    final Collection<Unit> attacking,
+                                    final Collection<Unit> defending,
+                                    final Collection<Unit> bombarding,
+                                    final Collection<TerritoryEffect> territoryEffects,
+                                    final int runCount) throws IllegalStateException {
+    final List<Future<AggregateResults>> results = new ArrayList<>();
+    int remainingRuns = runCount;
+    final int runsPerWorker = runCount / MAX_THREADS;
+    while (remainingRuns > 0) {
+      remainingRuns -= runsPerWorker;
+      results.add(executor.submit(() -> {
+        BattleCalculator calculator = new BattleCalculator();
+        calculator.setKeepOneAttackingLandUnit(keepOneAttackingLandUnit);
+        calculator.setAmphibious(amphibious);
+        calculator.setRetreatAfterRound(retreatAfterRound);
+        calculator.setRetreatAfterXUnitsLeft(retreatAfterXUnitsLeft);
+        calculator.setRetreatWhenOnlyAirLeft(retreatWhenOnlyAirLeft);
+        calculator.setAttackerOrderOfLosses(attackerOrderOfLosses);
+        calculator.setDefenderOrderOfLosses(defenderOrderOfLosses);
         try {
-          final AggregateResults result = future.get();
-          results.addResults(result.getResults());
-        } catch (final InterruptedException e) {
-          Thread.currentThread().interrupt();
-          interruptExceptions.add(e);
-        } catch (final ExecutionException e) {
-          final String cause = e.getCause().getLocalizedMessage();
-          Set<ExecutionException> exceptions = executionExceptions.get(cause);
-          if (exceptions == null) {
-            exceptions = new HashSet<>();
-          }
-          exceptions.add(e);
-          executionExceptions.put(cause, exceptions);
+          calculator.setGameData(IoUtils.readFromMemory(bytes, GameDataManager::loadGame));
+        } catch (final IOException e) {
+          throw new RuntimeException("Failed to deserialize", e);
         }
-      }
-      // we don't want to scare the user with 8+ errors all for the same thing
-      if (!interruptExceptions.isEmpty()) {
-        log.log(
-            Level.SEVERE,
-            interruptExceptions.size() + " Battle results workers interrupted",
-            interruptExceptions.iterator().next());
-      }
-      if (!executionExceptions.isEmpty()) {
-        Exception e = null;
-        for (final Set<ExecutionException> entry : executionExceptions.values()) {
-          if (!entry.isEmpty()) {
-            e = entry.iterator().next();
-            log.log(
-                Level.SEVERE,
-                entry.size() + " Battle results workers aborted by exception",
-                e.getCause());
-          }
-        }
-        if (e != null) {
-          throw new IllegalStateException(e.getCause());
-        }
-      }
-      results.setTime(System.currentTimeMillis() - start);
-      return results;
+        return calculator.calculate(attacker, defender, location, attacking, defending, bombarding, territoryEffects, runsPerWorker);
+      }));
     }
-  }
-
-  @Override
-  public AggregateResults setCalculateDataAndCalculate(
-      final GamePlayer attacker,
-      final GamePlayer defender,
-      final Territory location,
-      final Collection<Unit> attacking,
-      final Collection<Unit> defending,
-      final Collection<Unit> bombarding,
-      final Collection<TerritoryEffect> territoryEffects,
-      final int runCount) {
-    synchronized (mutexCalcIsRunning) {
-      setCalculateData(
-          attacker,
-          defender,
-          location,
-          attacking,
-          defending,
-          bombarding,
-          territoryEffects,
-          runCount);
-      return calculate();
+    final AggregateResults result = new AggregateResults(runsPerWorker);
+    for (Future<AggregateResults> future : results) {
+      try {
+        final AggregateResults currentResult = future.get();
+        result.addResults(currentResult.getResults());
+        result.setTime(result.getTime() + currentResult.getTime());
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } catch (ExecutionException e) {
+        throw new IllegalStateException("Exception from worker", e);
+      }
     }
+    return result;
   }
 
   @Override
   public boolean getIsReady() {
-    return isDataSet && isCalcSet && !isShutDown;
-  }
-
-  @Override
-  public int getRunCount() {
-    int totalRunCount = 0;
-    for (final BattleCalculator worker : workers) {
-      totalRunCount += worker.getRunCount();
-    }
-    return totalRunCount;
+    return isDataSet && !isShutDown;
   }
 
   @Override
   public void setKeepOneAttackingLandUnit(final boolean bool) {
-    synchronized (mutexCalcIsRunning) {
-      awaitLatch();
-      for (final BattleCalculator worker : workers) {
-        worker.setKeepOneAttackingLandUnit(bool);
-      }
-    }
+    keepOneAttackingLandUnit = bool;
   }
 
   @Override
   public void setAmphibious(final boolean bool) {
-    synchronized (mutexCalcIsRunning) {
-      awaitLatch();
-      for (final BattleCalculator worker : workers) {
-        worker.setAmphibious(bool);
-      }
-    }
+    amphibious = bool;
   }
 
   @Override
   public void setRetreatAfterRound(final int value) {
-    synchronized (mutexCalcIsRunning) {
-      awaitLatch();
-      for (final BattleCalculator worker : workers) {
-        worker.setRetreatAfterRound(value);
-      }
-    }
+    retreatAfterRound = value;
   }
 
   @Override
   public void setRetreatAfterXUnitsLeft(final int value) {
-    synchronized (mutexCalcIsRunning) {
-      awaitLatch();
-      for (final BattleCalculator worker : workers) {
-        worker.setRetreatAfterXUnitsLeft(value);
-      }
-    }
+    retreatAfterXUnitsLeft = value;
   }
 
   @Override
   public void setRetreatWhenOnlyAirLeft(final boolean value) {
-    synchronized (mutexCalcIsRunning) {
-      awaitLatch();
-      for (final BattleCalculator worker : workers) {
-        worker.setRetreatWhenOnlyAirLeft(value);
-      }
-    }
+    retreatWhenOnlyAirLeft = value;
   }
 
   @Override
   public void setAttackerOrderOfLosses(final String attackerOrderOfLosses) {
-    synchronized (mutexCalcIsRunning) {
-      awaitLatch();
-      for (final BattleCalculator worker : workers) {
-        worker.setAttackerOrderOfLosses(attackerOrderOfLosses);
-      }
-    }
+    this.attackerOrderOfLosses = attackerOrderOfLosses;
   }
 
   @Override
   public void setDefenderOrderOfLosses(final String defenderOrderOfLosses) {
-    synchronized (mutexCalcIsRunning) {
-      awaitLatch();
-      for (final BattleCalculator worker : workers) {
-        worker.setDefenderOrderOfLosses(defenderOrderOfLosses);
-      }
-    }
+    this.defenderOrderOfLosses = defenderOrderOfLosses;
   }
 
   // not on purpose, we need to be able to cancel at any time
   @Override
-  public void cancel() {
-    for (final BattleCalculator worker : workers) {
-      worker.cancel();
-    }
-  }
+  public void cancel() {}
 }

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/IBattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/IBattleCalculator.java
@@ -14,14 +14,15 @@ import java.util.Collection;
 public interface IBattleCalculator {
   void setGameData(GameData data);
 
-  AggregateResults calculate(GamePlayer attacker,
-                             GamePlayer defender,
-                             Territory location,
-                             Collection<Unit> attacking,
-                             Collection<Unit> defending,
-                             Collection<Unit> bombarding,
-                             Collection<TerritoryEffect> territoryEffects,
-                             int runCount);
+  AggregateResults calculate(
+      GamePlayer attacker,
+      GamePlayer defender,
+      Territory location,
+      Collection<Unit> attacking,
+      Collection<Unit> defending,
+      Collection<Unit> bombarding,
+      Collection<TerritoryEffect> territoryEffects,
+      int runCount);
 
   void setKeepOneAttackingLandUnit(boolean bool);
 

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/IBattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/IBattleCalculator.java
@@ -14,29 +14,14 @@ import java.util.Collection;
 public interface IBattleCalculator {
   void setGameData(GameData data);
 
-  void setCalculateData(
-      GamePlayer attacker,
-      GamePlayer defender,
-      Territory location,
-      Collection<Unit> attacking,
-      Collection<Unit> defending,
-      Collection<Unit> bombarding,
-      Collection<TerritoryEffect> territoryEffects,
-      int runCount);
-
-  AggregateResults calculate();
-
-  AggregateResults setCalculateDataAndCalculate(
-      GamePlayer attacker,
-      GamePlayer defender,
-      Territory location,
-      Collection<Unit> attacking,
-      Collection<Unit> defending,
-      Collection<Unit> bombarding,
-      Collection<TerritoryEffect> territoryEffects,
-      int runCount);
-
-  int getRunCount();
+  AggregateResults calculate(GamePlayer attacker,
+                             GamePlayer defender,
+                             Territory location,
+                             Collection<Unit> attacking,
+                             Collection<Unit> defending,
+                             Collection<Unit> bombarding,
+                             Collection<TerritoryEffect> territoryEffects,
+                             int runCount);
 
   boolean getIsReady();
 

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/IBattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/IBattleCalculator.java
@@ -23,8 +23,6 @@ public interface IBattleCalculator {
                              Collection<TerritoryEffect> territoryEffects,
                              int runCount);
 
-  boolean getIsReady();
-
   void setKeepOneAttackingLandUnit(boolean bool);
 
   void setAmphibious(boolean bool);

--- a/game-core/src/test/java/games/strategy/triplea/odds/calculator/BattleCalculatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/odds/calculator/BattleCalculatorTest.java
@@ -31,9 +31,10 @@ class BattleCalculatorTest {
     final GamePlayer germans = GameDataTestUtil.germans(gameData);
     final List<Unit> attackingUnits = GameDataTestUtil.infantry(gameData).create(100, russians);
     final List<Unit> bombardingUnits = List.of();
-    final IBattleCalculator calculator = new BattleCalculator(gameData);
+    final IBattleCalculator calculator = new BattleCalculator();
+    calculator.setGameData(gameData);
     final AggregateResults results =
-        calculator.setCalculateDataAndCalculate(
+        calculator.calculate(
             russians,
             germans,
             germany,
@@ -60,10 +61,11 @@ class BattleCalculatorTest {
     final List<Unit> attackingUnits = GameDataTestUtil.infantry(gameData).create(1, germans, false);
     attackingUnits.addAll(GameDataTestUtil.bomber(gameData).create(1, germans, false));
     final List<Unit> bombardingUnits = List.of();
-    final IBattleCalculator calculator = new BattleCalculator(gameData);
+    final IBattleCalculator calculator = new BattleCalculator();
+    calculator.setGameData(gameData);
     calculator.setKeepOneAttackingLandUnit(true);
     final AggregateResults results =
-        calculator.setCalculateDataAndCalculate(
+        calculator.calculate(
             germans,
             british,
             eastCanada,
@@ -82,10 +84,11 @@ class BattleCalculatorTest {
     final Territory sz1 = territory("1 Sea Zone", gameData);
     final List<Unit> attacking = transport(gameData).create(2, americans(gameData));
     final List<Unit> defending = submarine(gameData).create(2, germans(gameData));
-    final IBattleCalculator calculator = new BattleCalculator(gameData);
+    final IBattleCalculator calculator = new BattleCalculator();
+    calculator.setGameData(gameData);
     calculator.setKeepOneAttackingLandUnit(false);
     final AggregateResults results =
-        calculator.setCalculateDataAndCalculate(
+        calculator.calculate(
             americans(gameData),
             germans(gameData),
             sz1,
@@ -106,10 +109,11 @@ class BattleCalculatorTest {
     final Territory sz1 = territory("1 Sea Zone", gameData);
     final List<Unit> attacking = submarine(gameData).create(2, americans(gameData));
     final List<Unit> defending = transport(gameData).create(2, germans(gameData));
-    final IBattleCalculator calculator = new BattleCalculator(gameData);
+    final IBattleCalculator calculator = new BattleCalculator();
+    calculator.setGameData(gameData);
     calculator.setKeepOneAttackingLandUnit(false);
     final AggregateResults results =
-        calculator.setCalculateDataAndCalculate(
+        calculator.calculate(
             americans(gameData),
             germans(gameData),
             sz1,


### PR DESCRIPTION
<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

This PR tries to simplify the code within `ConcurrentBattleCalculator` by removing some heuristics and using more "standard" approaches in general.

I ran some benchmarks and the time seems to be about equal (which is to be expected because the approach didn't really change)

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->
I verified BattleCalc works as usual and let the Hard AI play a game of classic WW2, which worked without any problems.

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

