### PR TITLE
Store lobby chat messages in database

### DIFF
--- a/http-server/src/main/java/org/triplea/db/dao/api/key/ApiKeyLookupRecord.java
+++ b/http-server/src/main/java/org/triplea/db/dao/api/key/ApiKeyLookupRecord.java
@@ -20,11 +20,13 @@ import org.triplea.java.Postconditions;
 @EqualsAndHashCode
 @ToString
 public class ApiKeyLookupRecord {
+  public static final String API_KEY_ID_COLUMN = "api_key_id";
   public static final String PLAYER_CHAT_ID_COLUMN = "player_chat_id";
   public static final String ROLE_COLUMN = "role";
   public static final String USERNAME_COLUMN = "username";
   public static final String USER_ID_COLUMN = "id";
 
+  private int apiKeyId;
   private @Nullable Integer userId;
   private @Nullable String username;
   private String playerChatId;
@@ -35,6 +37,7 @@ public class ApiKeyLookupRecord {
     return (rs, ctx) -> {
       final var userWithRoleRecord =
           ApiKeyLookupRecord.builder()
+              .apiKeyId(rs.getInt(API_KEY_ID_COLUMN))
               .userId(rs.getInt(USER_ID_COLUMN) == 0 ? null : rs.getInt(USER_ID_COLUMN))
               .playerChatId(Preconditions.checkNotNull(rs.getString(PLAYER_CHAT_ID_COLUMN)))
               .role(Preconditions.checkNotNull(rs.getString(ROLE_COLUMN)))

--- a/http-server/src/main/java/org/triplea/db/dao/api/key/LobbyApiKeyDao.java
+++ b/http-server/src/main/java/org/triplea/db/dao/api/key/LobbyApiKeyDao.java
@@ -30,6 +30,8 @@ interface LobbyApiKeyDao {
   @SqlQuery(
       "select lu.id as "
           + ApiKeyLookupRecord.USER_ID_COLUMN
+          + ", ak.id as "
+          + ApiKeyLookupRecord.API_KEY_ID_COLUMN
           + ", ak.username as "
           + ApiKeyLookupRecord.USERNAME_COLUMN
           + ", ur.name as "

--- a/http-server/src/main/java/org/triplea/db/dao/chat/history/LobbyChatHistoryDao.java
+++ b/http-server/src/main/java/org/triplea/db/dao/chat/history/LobbyChatHistoryDao.java
@@ -1,0 +1,34 @@
+package org.triplea.db.dao.chat.history;
+
+import com.google.common.base.Ascii;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+import org.triplea.http.client.web.socket.messages.envelopes.chat.ChatReceivedMessage;
+
+/** Lobby chat history records lobby chat messages. */
+public interface LobbyChatHistoryDao {
+  int MESSAGE_COLUMN_LENGTH = 240;
+
+  default void recordMessage(ChatReceivedMessage chatReceivedMessage, int apiKeyId) {
+    insertMessage(
+        chatReceivedMessage.getSender().getValue(),
+        apiKeyId,
+        Ascii.truncate(chatReceivedMessage.getMessage(), MESSAGE_COLUMN_LENGTH, ""));
+  }
+
+  /**
+   * Stores a chat message record to database.
+   *
+   * @param username The name of the user that sent the chat message.
+   * @param apiKeyId The ID of the API key the user used to sign in to the lobby. This is useful for
+   *     cross-referencing to know the users IP and system-id.
+   * @param message The chat message contents.
+   */
+  @SqlUpdate(
+      "insert into lobby_chat_history (username, lobby_api_key_id, message) "
+          + "values(:username, :apiKeyId, :message)")
+  void insertMessage(
+      @Bind("username") String username,
+      @Bind("apiKeyId") int apiKeyId,
+      @Bind("message") String message);
+}

--- a/http-server/src/main/java/org/triplea/http/ServerApplication.java
+++ b/http-server/src/main/java/org/triplea/http/ServerApplication.java
@@ -136,7 +136,7 @@ public class ServerApplication extends Application<AppConfig> {
     setupWebSocket(playerConnectionWebsocket, playerConnectionMessagingBus, sessionIsBannedCheck);
 
     final var chatters = Chatters.build(jdbi);
-    ChatMessagingService.build(chatters).configure(playerConnectionMessagingBus);
+    ChatMessagingService.build(chatters, jdbi).configure(playerConnectionMessagingBus);
 
     endPointControllers(
             configuration, jdbi, chatters, playerConnectionMessagingBus, gameConnectionMessagingBus)

--- a/http-server/src/main/java/org/triplea/modules/chat/ChatMessagingService.java
+++ b/http-server/src/main/java/org/triplea/modules/chat/ChatMessagingService.java
@@ -2,6 +2,7 @@ package org.triplea.modules.chat;
 
 import com.google.common.base.Preconditions;
 import lombok.Builder;
+import org.jdbi.v3.core.Jdbi;
 import org.triplea.http.client.web.socket.messages.envelopes.chat.ChatSentMessage;
 import org.triplea.http.client.web.socket.messages.envelopes.chat.ConnectToChatMessage;
 import org.triplea.http.client.web.socket.messages.envelopes.chat.PlayerSlapSentMessage;
@@ -21,11 +22,11 @@ public class ChatMessagingService {
   private final SlapListener slapListener;
   private final PlayerLeftListener playerLeftListener;
 
-  public static ChatMessagingService build(final Chatters chatters) {
+  public static ChatMessagingService build(final Chatters chatters, final Jdbi jdbi) {
     Preconditions.checkNotNull(chatters);
     return ChatMessagingService.builder()
         .playerConnectedListener(new PlayerConnectedListener(chatters))
-        .chatMessageListener(new ChatMessageListener(chatters))
+        .chatMessageListener(ChatMessageListener.build(chatters, jdbi))
         .statusUpdateListener(new StatusUpdateListener(chatters))
         .slapListener(new SlapListener(chatters))
         .playerLeftListener(new PlayerLeftListener(chatters))

--- a/http-server/src/main/java/org/triplea/modules/chat/ChatParticipantAdapter.java
+++ b/http-server/src/main/java/org/triplea/modules/chat/ChatParticipantAdapter.java
@@ -1,13 +1,24 @@
 package org.triplea.modules.chat;
 
-import java.util.function.Function;
+import java.util.function.BiFunction;
+import javax.websocket.Session;
 import org.triplea.db.dao.api.key.ApiKeyLookupRecord;
 import org.triplea.db.data.UserRole;
 import org.triplea.domain.data.ChatParticipant;
+import org.triplea.modules.chat.Chatters.ChatterSession;
 
-class ChatParticipantAdapter implements Function<ApiKeyLookupRecord, ChatParticipant> {
+class ChatParticipantAdapter implements BiFunction<Session, ApiKeyLookupRecord, ChatterSession> {
+
   @Override
-  public ChatParticipant apply(final ApiKeyLookupRecord apiKeyLookupRecord) {
+  public ChatterSession apply(final Session session, final ApiKeyLookupRecord apiKeyLookupRecord) {
+    return ChatterSession.builder()
+        .apiKeyId(apiKeyLookupRecord.getApiKeyId())
+        .chatParticipant(buildChatParticipant(apiKeyLookupRecord))
+        .session(session)
+        .build();
+  }
+
+  private ChatParticipant buildChatParticipant(final ApiKeyLookupRecord apiKeyLookupRecord) {
     return ChatParticipant.builder()
         .userName(apiKeyLookupRecord.getUsername())
         .isModerator(

--- a/http-server/src/main/java/org/triplea/modules/chat/event/processing/ChatMessageListener.java
+++ b/http-server/src/main/java/org/triplea/modules/chat/event/processing/ChatMessageListener.java
@@ -1,30 +1,65 @@
 package org.triplea.modules.chat.event.processing;
 
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.function.Consumer;
-import lombok.AllArgsConstructor;
+import javax.annotation.Nonnull;
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+import org.jdbi.v3.core.Jdbi;
+import org.triplea.db.dao.chat.history.LobbyChatHistoryDao;
 import org.triplea.domain.data.ChatParticipant;
 import org.triplea.http.client.web.socket.messages.envelopes.chat.ChatReceivedMessage;
 import org.triplea.http.client.web.socket.messages.envelopes.chat.ChatSentMessage;
 import org.triplea.modules.chat.Chatters;
+import org.triplea.modules.chat.Chatters.ChatterSession;
 import org.triplea.web.socket.WebSocketMessageContext;
 
-@AllArgsConstructor
+@Builder
+@Slf4j
 public class ChatMessageListener implements Consumer<WebSocketMessageContext<ChatSentMessage>> {
 
-  private final Chatters chatters;
+  @Nonnull private final Chatters chatters;
+  @Nonnull private final LobbyChatHistoryDao lobbyChatHistoryDao;
+  private final ExecutorService threadpool = Executors.newCachedThreadPool();
+
+  public static ChatMessageListener build(final Chatters chatters, final Jdbi jdbi) {
+    return ChatMessageListener.builder()
+        .chatters(chatters)
+        .lobbyChatHistoryDao(jdbi.onDemand(LobbyChatHistoryDao.class))
+        .build();
+  }
 
   @Override
   public void accept(final WebSocketMessageContext<ChatSentMessage> messageContext) {
     chatters
         .lookupPlayerBySession(messageContext.getSenderSession())
-        .ifPresent(sender -> broadcastChatMessage(messageContext, sender));
+        .ifPresent(session -> recordAndSendMessage(session, messageContext));
   }
 
-  private static void broadcastChatMessage(
-      final WebSocketMessageContext<ChatSentMessage> messageContext, final ChatParticipant sender) {
+  private void recordAndSendMessage(
+      final ChatterSession session, final WebSocketMessageContext<ChatSentMessage> messageContext) {
+    final var chatReceivedMessage =
+        convertMessage(session.getChatParticipant(), messageContext.getMessage().getChatMessage());
+    recordInHistory(chatReceivedMessage, session);
+    messageContext.broadcastMessage(chatReceivedMessage);
+  }
 
-    messageContext.broadcastMessage(
-        new ChatReceivedMessage(
-            sender.getUserName(), messageContext.getMessage().getChatMessage()));
+  private static ChatReceivedMessage convertMessage(
+      final ChatParticipant sender, final String message) {
+    return new ChatReceivedMessage(sender.getUserName(), message);
+  }
+
+  private void recordInHistory(
+      final ChatReceivedMessage chatReceivedMessage, final ChatterSession session) {
+    CompletableFuture.runAsync(
+            () -> lobbyChatHistoryDao.recordMessage(chatReceivedMessage, session.getApiKeyId()),
+            threadpool)
+        .exceptionally(
+            e -> {
+              log.error("Error recording chat message in database history table", e);
+              return null;
+            });
   }
 }

--- a/http-server/src/main/java/org/triplea/modules/chat/event/processing/ChatMessageListener.java
+++ b/http-server/src/main/java/org/triplea/modules/chat/event/processing/ChatMessageListener.java
@@ -1,8 +1,6 @@
 package org.triplea.modules.chat.event.processing;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import lombok.Builder;
@@ -22,7 +20,6 @@ public class ChatMessageListener implements Consumer<WebSocketMessageContext<Cha
 
   @Nonnull private final Chatters chatters;
   @Nonnull private final LobbyChatHistoryDao lobbyChatHistoryDao;
-  private final ExecutorService threadpool = Executors.newCachedThreadPool();
 
   public static ChatMessageListener build(final Chatters chatters, final Jdbi jdbi) {
     return ChatMessageListener.builder()
@@ -54,8 +51,7 @@ public class ChatMessageListener implements Consumer<WebSocketMessageContext<Cha
   private void recordInHistory(
       final ChatReceivedMessage chatReceivedMessage, final ChatterSession session) {
     CompletableFuture.runAsync(
-            () -> lobbyChatHistoryDao.recordMessage(chatReceivedMessage, session.getApiKeyId()),
-            threadpool)
+            () -> lobbyChatHistoryDao.recordMessage(chatReceivedMessage, session.getApiKeyId()))
         .exceptionally(
             e -> {
               log.error("Error recording chat message in database history table", e);

--- a/http-server/src/main/java/org/triplea/modules/chat/event/processing/SlapListener.java
+++ b/http-server/src/main/java/org/triplea/modules/chat/event/processing/SlapListener.java
@@ -16,7 +16,9 @@ public class SlapListener implements Consumer<WebSocketMessageContext<PlayerSlap
   public void accept(final WebSocketMessageContext<PlayerSlapSentMessage> messageContext) {
     chatters
         .lookupPlayerBySession(messageContext.getSenderSession())
-        .ifPresent(chatParticipant -> broadCastSlapMessage(messageContext, chatParticipant));
+        .ifPresent(
+            chatterSession ->
+                broadCastSlapMessage(messageContext, chatterSession.getChatParticipant()));
   }
 
   private static void broadCastSlapMessage(

--- a/http-server/src/main/java/org/triplea/modules/chat/event/processing/StatusUpdateListener.java
+++ b/http-server/src/main/java/org/triplea/modules/chat/event/processing/StatusUpdateListener.java
@@ -19,7 +19,8 @@ public class StatusUpdateListener
     chatters
         .lookupPlayerBySession(messageContext.getSenderSession())
         .ifPresent(
-            chatParticipant -> broadcastStatusUpdateMessage(messageContext, chatParticipant));
+            chatterSession ->
+                broadcastStatusUpdateMessage(messageContext, chatterSession.getChatParticipant()));
   }
 
   private static void broadcastStatusUpdateMessage(

--- a/http-server/src/test/java/org/triplea/db/dao/api/key/ApiKeyLookupRecordTest.java
+++ b/http-server/src/test/java/org/triplea/db/dao/api/key/ApiKeyLookupRecordTest.java
@@ -22,6 +22,8 @@ import org.triplea.db.data.UserRole;
 class ApiKeyLookupRecordTest {
   private static final String ROLE = UserRole.PLAYER;
   private static final int USER_ID = 55;
+  private static final int API_KEY_ID = 99;
+
   private static final String NAME = "player-name";
   private static final String CHAT_ID = "chat-id";
 
@@ -29,11 +31,12 @@ class ApiKeyLookupRecordTest {
 
   @Test
   void buildResultMapper() throws Exception {
-    givenResults(USER_ID, CHAT_ID, ROLE, NAME);
+    givenResults(USER_ID, API_KEY_ID, CHAT_ID, ROLE, NAME);
 
     final ApiKeyLookupRecord result = ApiKeyLookupRecord.buildResultMapper().map(resultSet, null);
 
     assertThat(result.getUserId(), is(USER_ID));
+    assertThat(result.getApiKeyId(), is(API_KEY_ID));
     assertThat(result.getRole(), is(UserRole.PLAYER));
     assertThat(result.getUsername(), is(NAME));
     assertThat(result.getPlayerChatId(), is(CHAT_ID));
@@ -41,9 +44,14 @@ class ApiKeyLookupRecordTest {
 
   @SuppressWarnings("SameParameterValue")
   private void givenResults(
-      final int userId, final String chatId, final String role, final String name)
+      final int userId,
+      final int apiKeyId,
+      final String chatId,
+      final String role,
+      final String name)
       throws Exception {
     when(resultSet.getInt(ApiKeyLookupRecord.USER_ID_COLUMN)).thenReturn(userId);
+    when(resultSet.getInt(ApiKeyLookupRecord.API_KEY_ID_COLUMN)).thenReturn(apiKeyId);
     when(resultSet.getString(ApiKeyLookupRecord.PLAYER_CHAT_ID_COLUMN)).thenReturn(chatId);
     when(resultSet.getString(ApiKeyLookupRecord.ROLE_COLUMN)).thenReturn(role);
     when(resultSet.getString(ApiKeyLookupRecord.USERNAME_COLUMN)).thenReturn(name);
@@ -51,7 +59,7 @@ class ApiKeyLookupRecordTest {
 
   @Test
   void zeroUserIdIsMappedToNull() throws Exception {
-    givenResults(0, CHAT_ID, UserRole.HOST, null);
+    givenResults(0, API_KEY_ID, CHAT_ID, UserRole.HOST, null);
 
     final ApiKeyLookupRecord result = ApiKeyLookupRecord.buildResultMapper().map(resultSet, null);
 
@@ -61,7 +69,7 @@ class ApiKeyLookupRecordTest {
   @ParameterizedTest
   @ValueSource(strings = {UserRole.PLAYER, UserRole.MODERATOR, UserRole.MODERATOR})
   void assertInvalidStatesRolesThatMustHaveUserId(final String userRole) throws Exception {
-    givenResults(0, CHAT_ID, userRole, NAME);
+    givenResults(0, API_KEY_ID, CHAT_ID, userRole, NAME);
 
     assertPostconditionFailure();
   }
@@ -74,7 +82,7 @@ class ApiKeyLookupRecordTest {
   @ParameterizedTest
   @ValueSource(strings = {UserRole.ANONYMOUS, UserRole.HOST})
   void assertInvalidStatesRolesThatMustNotHaveUserId(final String userRole) throws Exception {
-    givenResults(USER_ID, CHAT_ID, userRole, NAME);
+    givenResults(USER_ID, API_KEY_ID, CHAT_ID, userRole, NAME);
 
     assertPostconditionFailure();
   }
@@ -92,14 +100,14 @@ class ApiKeyLookupRecordTest {
   @MethodSource("mustHaveUserName")
   void assertInvalidStatesRolesThatMustHaveName(final int userId, final String roleName)
       throws Exception {
-    givenResults(userId, CHAT_ID, roleName, null);
+    givenResults(userId, API_KEY_ID, CHAT_ID, roleName, null);
 
     assertPostconditionFailure();
   }
 
   @Test
   void assertInvalidStatesHostRoleMayNotHaveName() throws Exception {
-    givenResults(0, CHAT_ID, UserRole.HOST, NAME);
+    givenResults(0, API_KEY_ID, CHAT_ID, UserRole.HOST, NAME);
 
     assertPostconditionFailure();
   }

--- a/http-server/src/test/java/org/triplea/db/dao/api/key/LobbyApiKeyDaoTest.java
+++ b/http-server/src/test/java/org/triplea/db/dao/api/key/LobbyApiKeyDaoTest.java
@@ -25,12 +25,14 @@ class LobbyApiKeyDaoTest extends DaoTest {
           .username("registered-user")
           .role(UserRole.MODERATOR)
           .playerChatId("chat-id0")
+          .apiKeyId(1000)
           .build();
   private static final ApiKeyLookupRecord EXPECTED_ANONYMOUS_DATA =
       ApiKeyLookupRecord.builder()
           .username("some-other-name")
           .role(UserRole.ANONYMOUS)
           .playerChatId("chat-id1")
+          .apiKeyId(1001)
           .build();
 
   private final LobbyApiKeyDao lobbyApiKeyDao = DaoTest.newDao(LobbyApiKeyDao.class);

--- a/http-server/src/test/java/org/triplea/db/dao/chat/history/LobbyChatHistoryDaoTest.java
+++ b/http-server/src/test/java/org/triplea/db/dao/chat/history/LobbyChatHistoryDaoTest.java
@@ -1,0 +1,18 @@
+package org.triplea.db.dao.chat.history;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import org.junit.jupiter.api.Test;
+import org.triplea.db.dao.DaoTest;
+
+class LobbyChatHistoryDaoTest extends DaoTest {
+
+  private final LobbyChatHistoryDao lobbyChatHistoryDao = DaoTest.newDao(LobbyChatHistoryDao.class);
+
+  @Test
+  @DataSet(cleanBefore = true, value = "chat_history/insert_into_lobby_chat_history_before.yml")
+  @ExpectedDataSet("chat_history/insert_into_lobby_chat_history_after.yml")
+  void insertChatMessage() {
+    lobbyChatHistoryDao.insertMessage("username", 3000, "message");
+  }
+}

--- a/http-server/src/test/java/org/triplea/modules/chat/ChatMessagingServiceTest.java
+++ b/http-server/src/test/java/org/triplea/modules/chat/ChatMessagingServiceTest.java
@@ -3,13 +3,13 @@ package org.triplea.modules.chat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.db.dao.chat.history.LobbyChatHistoryDao;
 import org.triplea.web.socket.WebSocketMessagingBus;
@@ -24,7 +24,7 @@ class ChatMessagingServiceTest {
   @Test
   @DisplayName("Verify that we add listeners to messaging bus when configure is called")
   void configureAddsListeners() {
-    Mockito.when(jdbi.onDemand(LobbyChatHistoryDao.class)).thenReturn(lobbyChatHistoryDao);
+    when(jdbi.onDemand(LobbyChatHistoryDao.class)).thenReturn(lobbyChatHistoryDao);
 
     ChatMessagingService.build(chatters, jdbi).configure(webSocketMessagingBus);
 

--- a/http-server/src/test/java/org/triplea/modules/chat/ChatMessagingServiceTest.java
+++ b/http-server/src/test/java/org/triplea/modules/chat/ChatMessagingServiceTest.java
@@ -4,22 +4,29 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.verify;
 
+import org.jdbi.v3.core.Jdbi;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.db.dao.chat.history.LobbyChatHistoryDao;
 import org.triplea.web.socket.WebSocketMessagingBus;
 
 @ExtendWith(MockitoExtension.class)
 class ChatMessagingServiceTest {
   @Mock private Chatters chatters;
+  @Mock private Jdbi jdbi;
+  @Mock private LobbyChatHistoryDao lobbyChatHistoryDao;
   @Mock private WebSocketMessagingBus webSocketMessagingBus;
 
   @Test
   @DisplayName("Verify that we add listeners to messaging bus when configure is called")
   void configureAddsListeners() {
-    ChatMessagingService.build(chatters).configure(webSocketMessagingBus);
+    Mockito.when(jdbi.onDemand(LobbyChatHistoryDao.class)).thenReturn(lobbyChatHistoryDao);
+
+    ChatMessagingService.build(chatters, jdbi).configure(webSocketMessagingBus);
 
     verify(webSocketMessagingBus, atLeastOnce()).addListener(any(), any());
   }

--- a/http-server/src/test/java/org/triplea/modules/chat/event/processing/ChatMessageListenerTest.java
+++ b/http-server/src/test/java/org/triplea/modules/chat/event/processing/ChatMessageListenerTest.java
@@ -2,8 +2,10 @@ package org.triplea.modules.chat.event.processing;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -16,6 +18,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.db.dao.chat.history.LobbyChatHistoryDao;
 import org.triplea.domain.data.ChatParticipant;
 import org.triplea.domain.data.PlayerChatId;
 import org.triplea.domain.data.UserName;
@@ -28,6 +31,7 @@ import org.triplea.web.socket.WebSocketMessageContext;
 class ChatMessageListenerTest {
 
   @Mock private Chatters chatters;
+  @Mock private LobbyChatHistoryDao lobbyChatHistoryDao;
   @InjectMocks private ChatMessageListener chatMessageListener;
 
   @Mock private Session session;
@@ -45,6 +49,7 @@ class ChatMessageListenerTest {
     chatMessageListener.accept(messageContext);
 
     verify(messageContext, never()).broadcastMessage(any());
+    verify(lobbyChatHistoryDao, never()).recordMessage(any(), anyInt());
   }
 
   @Test
@@ -62,12 +67,20 @@ class ChatMessageListenerTest {
     chatMessageListener.accept(messageContext);
 
     verify(messageContext).broadcastMessage(messageCaptor.capture());
+    final ChatReceivedMessage chatReceivedMessage = messageCaptor.getValue();
     verifyMessageContents(messageCaptor.getValue());
+    verify(lobbyChatHistoryDao, timeout(100)).recordMessage(chatReceivedMessage, 123);
   }
 
   private void givenChatterSession(final Session session, final ChatParticipant chatParticipant) {
-    when(chatters.lookupPlayerBySession(session)) //
-        .thenReturn(Optional.of(chatParticipant));
+    when(chatters.lookupPlayerBySession(session))
+        .thenReturn(
+            Optional.of(
+                Chatters.ChatterSession.builder()
+                    .session(session)
+                    .chatParticipant(chatParticipant)
+                    .apiKeyId(123)
+                    .build()));
   }
 
   private static void verifyMessageContents(final ChatReceivedMessage chatReceivedMessage) {

--- a/http-server/src/test/java/org/triplea/modules/chat/event/processing/SlapListenerTest.java
+++ b/http-server/src/test/java/org/triplea/modules/chat/event/processing/SlapListenerTest.java
@@ -65,8 +65,14 @@ class SlapListenerTest {
   }
 
   private void givenChatterSession(final Session session, final ChatParticipant chatParticipant) {
-    when(chatters.lookupPlayerBySession(session)) //
-        .thenReturn(Optional.of(chatParticipant));
+    when(chatters.lookupPlayerBySession(session))
+        .thenReturn(
+            Optional.of(
+                Chatters.ChatterSession.builder()
+                    .session(session)
+                    .chatParticipant(chatParticipant)
+                    .apiKeyId(123)
+                    .build()));
   }
 
   private static void verifyMessageContents(final PlayerSlapReceivedMessage chatReceivedMessage) {

--- a/http-server/src/test/java/org/triplea/modules/chat/event/processing/StatusUpdateListenerTest.java
+++ b/http-server/src/test/java/org/triplea/modules/chat/event/processing/StatusUpdateListenerTest.java
@@ -64,8 +64,14 @@ class StatusUpdateListenerTest {
   }
 
   private void givenChatterSession(final Session session, final ChatParticipant chatParticipant) {
-    when(chatters.lookupPlayerBySession(session)) //
-        .thenReturn(Optional.of(chatParticipant));
+    when(chatters.lookupPlayerBySession(session))
+        .thenReturn(
+            Optional.of(
+                Chatters.ChatterSession.builder()
+                    .session(session)
+                    .chatParticipant(chatParticipant)
+                    .apiKeyId(123)
+                    .build()));
   }
 
   private static void verifyMessageContents(

--- a/http-server/src/test/resources/datasets/chat_history/insert_into_lobby_chat_history_after.yml
+++ b/http-server/src/test/resources/datasets/chat_history/insert_into_lobby_chat_history_after.yml
@@ -1,0 +1,4 @@
+lobby_chat_history:
+  - username: "username"
+    lobby_api_key_id: 3000
+    message: "message"

--- a/http-server/src/test/resources/datasets/chat_history/insert_into_lobby_chat_history_before.yml
+++ b/http-server/src/test/resources/datasets/chat_history/insert_into_lobby_chat_history_before.yml
@@ -1,0 +1,21 @@
+user_role:
+  - id: 324
+    name: PLAYER
+
+lobby_user:
+  - id: 50
+    user_role_id: 324
+    username: existing-name
+    bcrypt_password: $2a$56789_123456789_123456789_123456789_123456789_123456789_
+    email: email@
+
+lobby_api_key:
+  - id: 3000
+    username: user-name
+    lobby_user_id: 50
+    user_role_id: 324
+    key: zapi-key1
+    player_chat_id: chat-id0
+    system_id: system-id0
+    ip: 127.0.0.1
+    date_created: 2000-01-01 23:59:20.0

--- a/http-server/src/test/resources/datasets/user_role/initial.yml
+++ b/http-server/src/test/resources/datasets/user_role/initial.yml
@@ -4,4 +4,6 @@ user_role:
   - id: 2
     name: HOST
 
+lobby_chat_history:
+lobby_api_key:
 lobby_user:

--- a/lobby-db/src/main/resources/db/migration/V2.00.01__add_chat_history.sql
+++ b/lobby-db/src/main/resources/db/migration/V2.00.01__add_chat_history.sql
@@ -1,0 +1,23 @@
+create table lobby_chat_history
+(
+    id               serial primary key,
+    date             timestamp without time zone not null default now(),
+    username         character varying(40)       not null,
+    lobby_api_key_id int                         not null references lobby_api_key (id),
+    message          character varying(240)      not null
+);
+
+comment on table lobby_chat_history is
+    $$Table recording history of all chat messages in the lobby$$;
+comment on column lobby_chat_history.username is
+    $$De-normalized column representing the name of the user that
+    sent the chat message. It is denormalized for query convenience.$$;
+comment on column lobby_chat_history.lobby_api_key_id is
+    $$Foreign key reference to the API-key used by the user when logging in. Useful to
+    know the users IP and system id information for cross-reference.$$;
+
+comment on column lobby_chat_history.message is
+    $$The contents of the chat message sent by the user$$;
+
+create index lobby_chat_date on lobby_chat_history (date);
+create index lobby_chat_username on lobby_chat_history (username);


### PR DESCRIPTION
- Adds a table to store lobby chat messages
- Adds a DAO to execute insert statements
- Updates http-server chat message listener to store
  messages via DAO.

Notes:
- Most of the updates here involve wiring API-Key ID
  to API-key lookup so that we can then store the API-Key
  ID in database. When chatters join, we look up their
  API key, to be able to later store their API-Key ID,
  we attach the API-Key ID to their chatter session where
  later it is available when we store chat messages.
- We use a background threadpool to store chat messages
  to avoid any kind of extra latency when issuing a chat
  message response.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

