### PR TITLE
Fix show comment log not being added to view menu

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -93,17 +93,18 @@ final class ViewMenu extends JMenu {
   }
 
   private void addShowCommentLog() {
-    new JMenuItemCheckBoxBuilder("Show Comment Log", 'L')
-        .bindSetting(ClientSetting.showCommentLog)
-        .actionListener(
-            value -> {
-              if (value) {
-                frame.showCommentLog();
-              } else {
-                frame.hideCommentLog();
-              }
-            })
-        .build();
+    add(
+        new JMenuItemCheckBoxBuilder("Show Comment Log", 'L')
+            .bindSetting(ClientSetting.showCommentLog)
+            .actionListener(
+                value -> {
+                  if (value) {
+                    frame.showCommentLog();
+                  } else {
+                    frame.hideCommentLog();
+                  }
+                })
+            .build());
   }
 
   private void addZoomMenu() {


### PR DESCRIPTION
Fix, add a missing 'add' to have the show comment log menu item appear again.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->
