### PR TITLE
Add missing "displayResult" call to check-custom-style

### DIFF
--- a/.travis/stages/verify/code-convention-checks/check-custom-style
+++ b/.travis/stages/verify/code-convention-checks/check-custom-style
@@ -175,6 +175,8 @@ function useStaticImportsInTest() {
       "$file" \
      && status=1 && found=1
   done <<< "$(cat "$testFiles")"
+
+  displayResult "$found"
 }
 
 main


### PR DESCRIPTION
The displayResult function displays the 'OK' or 'FIX' status
after each custom style check.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

