### PR TITLE
Is instant matcher

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,6 +74,7 @@ subprojects {
     version = getProductVersion()
 
     ext {
+        apacheCommonsLangVersion = '3.10'
         awaitilityVersion = '4.0.2'
         bcryptVersion = '0.9.0'
         caffeineVersion = '2.8.1'

--- a/http-server/src/test/java/org/triplea/db/dao/ModeratorAuditHistoryDaoTest.java
+++ b/http-server/src/test/java/org/triplea/db/dao/ModeratorAuditHistoryDaoTest.java
@@ -4,10 +4,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.triplea.test.common.IsInstant.isInstant;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
-import java.time.Instant;
 import java.util.List;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
 import org.junit.jupiter.api.Test;
@@ -55,17 +55,17 @@ class ModeratorAuditHistoryDaoTest extends DaoTest {
     assertThat(results, hasSize(3));
 
     assertThat(results.get(0).getUsername(), is("moderator2"));
-    assertThat(results.get(0).getDateCreated(), is(Instant.parse("2016-01-05T23:59:20Z")));
+    assertThat(results.get(0).getDateCreated(), isInstant(2016, 1, 5, 23, 59, 20));
     assertThat(results.get(0).getActionName(), is("BAN_USERNAME"));
     assertThat(results.get(0).getActionTarget(), is("ACTION_TARGET5"));
 
     assertThat(results.get(1).getUsername(), is("moderator1"));
-    assertThat(results.get(1).getDateCreated(), is(Instant.parse("2016-01-04T23:59:20Z")));
+    assertThat(results.get(1).getDateCreated(), isInstant(2016, 1, 4, 23, 59, 20));
     assertThat(results.get(1).getActionName(), is("BOOT_PLAYER"));
     assertThat(results.get(1).getActionTarget(), is("ACTION_TARGET4"));
 
     assertThat(results.get(2).getUsername(), is("moderator2"));
-    assertThat(results.get(2).getDateCreated(), is(Instant.parse("2016-01-03T23:59:20Z")));
+    assertThat(results.get(2).getDateCreated(), isInstant(2016, 1, 3, 23, 59, 20));
     assertThat(results.get(2).getActionName(), is("BAN_USERNAME"));
     assertThat(results.get(2).getActionTarget(), is("ACTION_TARGET3"));
 
@@ -73,12 +73,12 @@ class ModeratorAuditHistoryDaoTest extends DaoTest {
     results = moderatorAuditHistoryDao.lookupHistoryItems(3, 3);
     assertThat(results, hasSize(2));
     assertThat(results.get(0).getUsername(), is("moderator2"));
-    assertThat(results.get(0).getDateCreated(), is(Instant.parse("2016-01-02T23:59:20Z")));
+    assertThat(results.get(0).getDateCreated(), isInstant(2016, 1, 2, 23, 59, 20));
     assertThat(results.get(0).getActionName(), is("MUTE_USERNAME"));
     assertThat(results.get(0).getActionTarget(), is("ACTION_TARGET2"));
 
     assertThat(results.get(1).getUsername(), is("moderator1"));
-    assertThat(results.get(1).getDateCreated(), is(Instant.parse("2016-01-01T23:59:20Z")));
+    assertThat(results.get(1).getDateCreated(), isInstant(2016, 1, 1, 23, 59, 20));
     assertThat(results.get(1).getActionName(), is("BAN_USERNAME"));
     assertThat(results.get(1).getActionTarget(), is("ACTION_TARGET1"));
 

--- a/http-server/src/test/java/org/triplea/db/dao/ModeratorsDaoTest.java
+++ b/http-server/src/test/java/org/triplea/db/dao/ModeratorsDaoTest.java
@@ -4,10 +4,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.nullValue;
+import static org.triplea.test.common.IsInstant.isInstant;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
-import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.triplea.db.data.ModeratorUserDaoData;
@@ -33,7 +33,7 @@ class ModeratorsDaoTest extends DaoTest {
         hasSize(2));
 
     assertThat(moderators.get(0).getUsername(), is("moderator"));
-    assertThat(moderators.get(0).getLastLogin(), is(Instant.parse("2001-01-01T23:59:20Z")));
+    assertThat(moderators.get(0).getLastLogin(), isInstant(2001, 1, 1, 23, 59, 20));
 
     assertThat(moderators.get(1).getUsername(), is("Super! moderator"));
     assertThat(moderators.get(1).getLastLogin(), nullValue());

--- a/http-server/src/test/java/org/triplea/db/dao/access/log/AccessLogDaoTest.java
+++ b/http-server/src/test/java/org/triplea/db/dao/access/log/AccessLogDaoTest.java
@@ -3,10 +3,10 @@ package org.triplea.db.dao.access.log;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
+import static org.triplea.test.common.IsInstant.isInstant;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
-import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.triplea.db.dao.DaoTest;
@@ -30,7 +30,7 @@ class AccessLogDaoTest extends DaoTest {
     List<AccessLogRecord> data = accessLogDao.fetchAccessLogRows(0, 1);
     assertThat(data, hasSize(1));
 
-    assertThat(data.get(0).getAccessTime(), is(Instant.parse("2016-01-03T23:59:20.0Z")));
+    assertThat(data.get(0).getAccessTime(), isInstant(2016, 1, 3, 23, 59, 20));
     assertThat(data.get(0).getIp(), is("127.0.0.2"));
     assertThat(data.get(0).getSystemId(), is("system-id2"));
     assertThat(data.get(0).getUsername(), is("second"));
@@ -39,7 +39,7 @@ class AccessLogDaoTest extends DaoTest {
     data = accessLogDao.fetchAccessLogRows(1, 1);
     assertThat(data, hasSize(1));
 
-    assertThat(data.get(0).getAccessTime(), is(Instant.parse("2016-01-01T23:59:20.0Z")));
+    assertThat(data.get(0).getAccessTime(), isInstant(2016, 1, 1, 23, 59, 20));
     assertThat(data.get(0).getIp(), is("127.0.0.1"));
     assertThat(data.get(0).getSystemId(), is("system-id1"));
     assertThat(data.get(0).getUsername(), is("first"));

--- a/http-server/src/test/java/org/triplea/db/dao/user/ban/UserBanDaoTest.java
+++ b/http-server/src/test/java/org/triplea/db/dao/user/ban/UserBanDaoTest.java
@@ -5,6 +5,7 @@ import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
+import static org.triplea.test.common.IsInstant.isInstant;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
@@ -47,15 +48,15 @@ class UserBanDaoTest extends DaoTest {
       final List<UserBanRecord> result = userBanDao.lookupBans();
 
       assertThat(result, hasSize(2));
-      assertThat(result.get(0).getBanExpiry(), is(Instant.parse("2100-01-01T23:59:59.0Z")));
-      assertThat(result.get(0).getDateCreated(), is(Instant.parse("2020-01-01T23:59:59.0Z")));
+      assertThat(result.get(0).getBanExpiry(), isInstant(2100, 1, 1, 23, 59, 59));
+      assertThat(result.get(0).getDateCreated(), isInstant(2020, 1, 1, 23, 59, 59));
       assertThat(result.get(0).getIp(), is("127.0.0.2"));
       assertThat(result.get(0).getPublicBanId(), is("public-id2"));
       assertThat(result.get(0).getSystemId(), is("system-id2"));
       assertThat(result.get(0).getUsername(), is("username2"));
 
-      assertThat(result.get(1).getBanExpiry(), is(Instant.parse("2021-01-01T23:59:59.0Z")));
-      assertThat(result.get(1).getDateCreated(), is(Instant.parse("2010-01-01T23:59:59.0Z")));
+      assertThat(result.get(1).getBanExpiry(), isInstant(2021, 1, 1, 23, 59, 59));
+      assertThat(result.get(1).getDateCreated(), isInstant(2010, 1, 1, 23, 59, 59));
       assertThat(result.get(1).getIp(), is("127.0.0.1"));
       assertThat(result.get(1).getPublicBanId(), is("public-id1"));
       assertThat(result.get(1).getSystemId(), is("system-id1"));

--- a/http-server/src/test/java/org/triplea/db/dao/username/ban/UsernameBanDaoTest.java
+++ b/http-server/src/test/java/org/triplea/db/dao/username/ban/UsernameBanDaoTest.java
@@ -3,10 +3,10 @@ package org.triplea.db.dao.username.ban;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
+import static org.triplea.test.common.IsInstant.isInstant;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
-import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -24,10 +24,10 @@ class UsernameBanDaoTest extends DaoTest {
     assertThat(result, hasSize(2));
 
     assertThat(result.get(0).getUsername(), is("username1"));
-    assertThat(result.get(0).getDateCreated(), is(Instant.parse("2001-01-01T23:59:59.0Z")));
+    assertThat(result.get(0).getDateCreated(), isInstant(2001, 1, 1, 23, 59, 59));
 
     assertThat(result.get(1).getUsername(), is("username2"));
-    assertThat(result.get(1).getDateCreated(), is(Instant.parse("2000-01-01T23:59:59.0Z")));
+    assertThat(result.get(1).getDateCreated(), isInstant(2000, 1, 1, 23, 59, 59));
   }
 
   @Test

--- a/test-common/build.gradle
+++ b/test-common/build.gradle
@@ -3,4 +3,5 @@ description = 'Test utility library, generic test utilities useful for TripleA p
 dependencies {
     implementation "org.hamcrest:java-hamcrest:$hamcrestVersion"
     implementation "org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion"
+    implementation "org.apache.commons:commons-lang3:$apacheCommonsLangVersion"
 }

--- a/test-common/build.gradle
+++ b/test-common/build.gradle
@@ -3,5 +3,4 @@ description = 'Test utility library, generic test utilities useful for TripleA p
 dependencies {
     implementation "org.hamcrest:java-hamcrest:$hamcrestVersion"
     implementation "org.junit.jupiter:junit-jupiter-api:$junitJupiterVersion"
-    implementation "org.apache.commons:commons-lang3:$apacheCommonsLangVersion"
 }

--- a/test-common/src/main/java/org/triplea/test/common/IsInstant.java
+++ b/test-common/src/main/java/org/triplea/test/common/IsInstant.java
@@ -3,10 +3,10 @@ package org.triplea.test.common;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsEqual.equalTo;
 
-import com.google.common.base.Preconditions;
 import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import lombok.experimental.UtilityClass;
-import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.Matcher;
 
 @UtilityClass
@@ -37,23 +37,8 @@ public class IsInstant {
       final int hour,
       final int minute,
       final int second) {
-
-    Preconditions.checkArgument(month > 0 && month < 13);
-    Preconditions.checkArgument(day > 0 && day < 32);
-    Preconditions.checkArgument(hour >= 0 && hour < 24);
-    Preconditions.checkArgument(minute >= 0 && minute < 60);
-    Preconditions.checkArgument(second >= 0 && second < 60);
-
     return is(
         equalTo(
-            Instant.parse(
-                String.format(
-                    "%s-%s-%sT%s:%s:%sZ",
-                    StringUtils.leftPad(String.valueOf(year), 4, '0'),
-                    StringUtils.leftPad(String.valueOf(month), 2, '0'),
-                    StringUtils.leftPad(String.valueOf(day), 2, '0'),
-                    StringUtils.leftPad(String.valueOf(hour), 2, '0'),
-                    StringUtils.leftPad(String.valueOf(minute), 2, '0'),
-                    StringUtils.leftPad(String.valueOf(second), 2, '0')))));
+            LocalDateTime.of(year, month, day, hour, minute, second).toInstant(ZoneOffset.UTC)));
   }
 }

--- a/test-common/src/main/java/org/triplea/test/common/IsInstant.java
+++ b/test-common/src/main/java/org/triplea/test/common/IsInstant.java
@@ -1,0 +1,59 @@
+package org.triplea.test.common;
+
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
+
+import com.google.common.base.Preconditions;
+import java.time.Instant;
+import lombok.experimental.UtilityClass;
+import org.apache.commons.lang3.StringUtils;
+import org.hamcrest.Matcher;
+
+@UtilityClass
+public class IsInstant {
+
+  /**
+   * Matches if a given instant has the equivalent date as defined by the parameters (parameters are
+   * assumed to be UTC).
+   *
+   * <p>Example usage: <code>
+   *   assertThat(Instant.now(), isInstant(2020, 12, 24, 23, 59, 59));
+   * </code> <br>
+   * The above is equivalent to:<code>
+   *   assertThat(Instant.now(), is(Instant.parse("2020-12-24T23:59:59Z")));
+   * </code>
+   *
+   * @param year The year to match (should be YYYY format, eg: 2020)
+   * @param month The month to match (1-12)
+   * @param day The day to match (1-31)
+   * @param hour The hour of day to match (1-23)
+   * @param minute The minute of the hour to match (0-59)
+   * @param second The second of the minute to match (0-59)
+   */
+  public static Matcher<Instant> isInstant(
+      final int year,
+      final int month,
+      final int day,
+      final int hour,
+      final int minute,
+      final int second) {
+
+    Preconditions.checkArgument(month > 0 && month < 13);
+    Preconditions.checkArgument(day > 0 && day < 32);
+    Preconditions.checkArgument(hour >= 0 && hour < 24);
+    Preconditions.checkArgument(minute >= 0 && minute < 60);
+    Preconditions.checkArgument(second >= 0 && second < 60);
+
+    return is(
+        equalTo(
+            Instant.parse(
+                String.format(
+                    "%s-%s-%sT%s:%s:%sZ",
+                    StringUtils.leftPad(String.valueOf(year), 4, '0'),
+                    StringUtils.leftPad(String.valueOf(month), 2, '0'),
+                    StringUtils.leftPad(String.valueOf(day), 2, '0'),
+                    StringUtils.leftPad(String.valueOf(hour), 2, '0'),
+                    StringUtils.leftPad(String.valueOf(minute), 2, '0'),
+                    StringUtils.leftPad(String.valueOf(second), 2, '0')))));
+  }
+}

--- a/test-common/src/test/java/org/triplea/test/common/IsInstantTest.java
+++ b/test-common/src/test/java/org/triplea/test/common/IsInstantTest.java
@@ -1,0 +1,33 @@
+package org.triplea.test.common;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.triplea.test.common.IsInstant.isInstant;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class IsInstantTest {
+
+  @Test
+  void sampleMatch() {
+    assertThat(Instant.parse("2020-12-24T23:59:59Z"), isInstant(2020, 12, 24, 23, 59, 59));
+  }
+
+  @Test
+  void verifyValuesAreZeroPadded() {
+    assertThat(Instant.parse("2020-01-01T01:01:01Z"), isInstant(2020, 1, 1, 1, 1, 1));
+  }
+
+  @Test
+  void verifyCanHandleZeros() {
+    assertThat(Instant.parse("0000-01-01T00:00:00Z"), isInstant(0, 1, 1, 0, 0, 0));
+  }
+
+  @Test
+  void verifyNegativeCaseWhereDoesNotMatch() {
+    assertThrows(
+        AssertionError.class,
+        () -> assertThat(Instant.parse("1111-01-01T00:00:00Z"), isInstant(0, 1, 1, 0, 0, 0)));
+  }
+}


### PR DESCRIPTION
<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->
## Commits

commit c420bd1e7bd325923d278e1ac0bcab9ca1de7610

    Add IsInstant matcher to facilitate matching instant values
    
    - Rather than parsing an instant value from a formatted string
    and comparing against a target instant, this matcher allows for
    an instant to be matched against a numerically specified instant,
    eg: 'assertThat(Instant.now(), isInstant(2020, 2, 20, 23, 59, 0));'

commit 5a4f7e6d962542b18cb9e73cbecc642e7083ff2e

    Convert tests to use 'isInstant(...)' in preference to 'is(Instant.parse(...))'


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

