### PR TITLE
Exclude test classes from code climate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -31,4 +31,5 @@ plugins:
 exclude_patterns:
   - "gradlew"
   - ".github/ISSUE_TEMPLATES/*"
+  - "*Test.java"
 


### PR DESCRIPTION
This update disables code climate analysis of test code to
avoid false-positives.

Tests seem to generate more false positives than actual items
to fix. For example, tests can often have numerous areas of similar
code and be fine.

While tests should certainly be kept clean as they are a maintenance
burden and like prod code need to be read, understood, and maintained,
the analysis does not seem to be generating actionable items for
test code.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

