### PR TITLE
Consider left over run count for BattleCalc

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/ConcurrentBattleCalculator.java
@@ -8,7 +8,6 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.framework.GameDataUtils;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -17,7 +16,9 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import org.triplea.java.Interruptibles;
 import org.triplea.java.concurrency.CountUpAndDownLatch;
 
@@ -223,44 +224,43 @@ public class ConcurrentBattleCalculator implements IBattleCalculator {
       final Collection<Unit> bombarding,
       final Collection<TerritoryEffect> territoryEffects,
       final boolean retreatWhenOnlyAirLeft,
-      final int initialRunCount)
+      final int runCount)
       throws IllegalStateException {
     synchronized (mutexCalcIsRunning) {
       awaitLatch();
       final long start = System.currentTimeMillis();
+      final AtomicBoolean overflowRunsAvailable = new AtomicBoolean(true);
       // Create worker thread pool and start all workers
-      int totalRunCount = 0;
-      int runCount = initialRunCount;
-      final int workerNum = workers.size();
-      final int workerRunCount = Math.max(1, (runCount / Math.max(1, workerNum)));
-      final List<Future<AggregateResults>> list = new ArrayList<>();
-      for (final BattleCalculator worker : workers) {
-        if (!getIsReady()) {
-          // we could have attempted to set a new game data, while the old one was still being set,
-          // causing it to abort with null data
-          return new AggregateResults(0);
-        }
-        final int currentWorkedRunCount = (runCount <= 0 ? 0 : workerRunCount);
-        if (currentWorkedRunCount > 0) {
-          totalRunCount += currentWorkedRunCount;
-          list.add(
-              executor.submit(
-                  () ->
-                      worker.calculate(
-                          attacker,
-                          defender,
-                          location,
-                          attacking,
-                          defending,
-                          bombarding,
-                          territoryEffects,
-                          retreatWhenOnlyAirLeft,
-                          currentWorkedRunCount)));
-        }
-        runCount -= workerRunCount;
+      final int runsPerWorker = runCount / workers.size();
+      final List<Future<AggregateResults>> list =
+          workers.stream()
+              .map(
+                  worker ->
+                      executor.submit(
+                          () ->
+                              worker.calculate(
+                                  attacker,
+                                  defender,
+                                  location,
+                                  attacking,
+                                  defending,
+                                  bombarding,
+                                  territoryEffects,
+                                  retreatWhenOnlyAirLeft,
+                                  // Ensure that we always achieve the target run count even if
+                                  // the number is not dividable by workers.size()
+                                  (overflowRunsAvailable.getAndSet(false)
+                                          ? runCount % workers.size()
+                                          : 0)
+                                      + runsPerWorker)))
+              .collect(Collectors.toList());
+      if (!getIsReady()) {
+        // we could have attempted to set a new game data, while the old one was still being set,
+        // causing it to abort with null data
+        return new AggregateResults(0);
       }
       // Wait for all worker futures to complete and combine results
-      final AggregateResults results = new AggregateResults(totalRunCount);
+      final AggregateResults results = new AggregateResults(runCount);
       for (final Future<AggregateResults> future : list) {
         try {
           final AggregateResults result = future.get();

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/RunCountDistributor.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/RunCountDistributor.java
@@ -1,0 +1,45 @@
+package games.strategy.triplea.odds.calculator;
+
+import com.google.common.base.Preconditions;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Helper class to divide any integer into smaller integers that are the original integer when
+ * summed up.
+ */
+@ThreadSafe
+class RunCountDistributor {
+  private final int runsPerWorker;
+  private final int targetLeftover;
+  private final AtomicInteger leftoverRuns;
+
+  /**
+   * Creates a new RunCountDistributorInstance.
+   *
+   * @param runCount What all of the individual run-counts should sum up to
+   * @param parallelism How many times {@link #nextRunCount()} will get called.
+   */
+  RunCountDistributor(final int runCount, final int parallelism) {
+    Preconditions.checkState(parallelism > 0, "The parallelism level has to be positive!");
+
+    runsPerWorker = runCount / parallelism;
+    leftoverRuns = new AtomicInteger(runCount % parallelism);
+    targetLeftover = leftoverRuns.get() - parallelism;
+  }
+
+  /**
+   * Returns the next run-count.
+   *
+   * @throws IllegalStateException If this method was called more often than provided level of
+   *     parallelism.
+   */
+  int nextRunCount() {
+    final int leftoverRuns = this.leftoverRuns.getAndDecrement();
+    if (leftoverRuns <= targetLeftover) {
+      throw new IllegalStateException(
+          "nextRunCount() was called more times than specified by provided level of parallelism");
+    }
+    return (leftoverRuns > 0 ? 1 : 0) + runsPerWorker;
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/odds/calculator/RunCountDistributorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/odds/calculator/RunCountDistributorTest.java
@@ -1,0 +1,74 @@
+package games.strategy.triplea.odds.calculator;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.stream.IntStream;
+import org.junit.jupiter.api.Test;
+
+public class RunCountDistributorTest {
+
+  @Test
+  void verifyEvenDistributionWhenCleanlyDividable() {
+    final var runCountDistributor = new RunCountDistributor(20, 4);
+
+    assertThat(runCountDistributor.nextRunCount(), is(equalTo(5)));
+    assertThat(runCountDistributor.nextRunCount(), is(equalTo(5)));
+    assertThat(runCountDistributor.nextRunCount(), is(equalTo(5)));
+    assertThat(runCountDistributor.nextRunCount(), is(equalTo(5)));
+  }
+
+  @Test
+  void verifyDistributionWhenNotCleanlyDividable() {
+    final var runCountDistributor = new RunCountDistributor(13, 3);
+
+    assertThat(runCountDistributor.nextRunCount(), is(equalTo(5)));
+    assertThat(runCountDistributor.nextRunCount(), is(equalTo(4)));
+    assertThat(runCountDistributor.nextRunCount(), is(equalTo(4)));
+  }
+
+  @Test
+  void verifyDistributionWhenParallelismTooHigh() {
+    final var runCountDistributor = new RunCountDistributor(1, 3);
+
+    assertThat(runCountDistributor.nextRunCount(), is(equalTo(1)));
+    assertThat(runCountDistributor.nextRunCount(), is(equalTo(0)));
+    assertThat(runCountDistributor.nextRunCount(), is(equalTo(0)));
+  }
+
+  @Test
+  void verifyExceptionWhenUsingInvalidParallelism() {
+    assertThrows(IllegalStateException.class, () -> new RunCountDistributor(1, 0));
+    assertThrows(IllegalStateException.class, () -> new RunCountDistributor(1, -20));
+  }
+
+  @Test
+  void verifyExceptionWhenCallingNextRunCountTooOften() {
+    final var runCountDistributor = new RunCountDistributor(1, 1);
+
+    assertThat(runCountDistributor.nextRunCount(), is(equalTo(1)));
+
+    assertThrows(IllegalStateException.class, runCountDistributor::nextRunCount);
+  }
+
+  /**
+   * Obviously this test isn't guaranteed to fail if {@link RunCountDistributor} is not actually
+   * thread-safe, but in case is does fail we have a bad implementation.
+   */
+  @Test
+  void verifyParallelExecutionWorksWithoutException() {
+    final int parallelism = 64;
+    final int runCount = 1337;
+    final var runCountDistributor = new RunCountDistributor(runCount, parallelism);
+
+    final int summedRunCount =
+        IntStream.range(0, parallelism)
+            .parallel()
+            .map(i -> runCountDistributor.nextRunCount())
+            .sum();
+
+    assertThat(summedRunCount, is(runCount));
+  }
+}


### PR DESCRIPTION
<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

This change makes the "run count distribution" consider the fact that some integers are not cleanly dividable by the ampunmt of threads on your machine this is what happens on my machine using current master:
![Screenshot](https://user-images.githubusercontent.com/8350879/80894447-45808b00-8cdb-11ea-882f-6c05481e2f39.png)
As you can see even I told it to run 1337 times, it only ran 1332 times because `floor(1337/12) * 12 = 1332`


## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

I verified I could run the battle calc as usual

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

