### PR TITLE
DoNothingAI - make it truly do nothing and skip purchase and place

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/DoesNothingAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/DoesNothingAi.java
@@ -36,11 +36,6 @@ public class DoesNothingAi extends AbstractAi {
       final IPurchaseDelegate purchaseDelegate,
       final GameData data,
       final GamePlayer player) {
-    // spend whatever we have
-    if (!player.getResources().isEmpty()) {
-      new WeakAi(this.getName())
-          .purchase(purchaseForBid, pusToSpend, purchaseDelegate, data, player);
-    }
     pause();
   }
 
@@ -65,10 +60,6 @@ public class DoesNothingAi extends AbstractAi {
       final IAbstractPlaceDelegate placeDelegate,
       final GameData data,
       final GamePlayer player) {
-    // place whatever we have
-    if (!player.getUnitCollection().isEmpty()) {
-      new WeakAi(this.getName()).place(placeForBid, placeDelegate, data, player);
-    }
     pause();
   }
 


### PR DESCRIPTION
Update DoNothingAI to be truly do-nothing. Before do-nothing AI
would invoke WeakAI for purchase and placement, after this update
do-nothing update will no longer call WeakAI and will instead
no-op for purchase and placement.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
- Checked a local World At War game with all do-nothing AI

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

