### PR TITLE
Enhance PerfTimer with Runnable API and Print out Accumulations

### DIFF
--- a/game-core/src/main/java/org/triplea/performance/PerfTimer.java
+++ b/game-core/src/main/java/org/triplea/performance/PerfTimer.java
@@ -1,6 +1,10 @@
 package org.triplea.performance;
 
 import java.io.Closeable;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 import lombok.extern.java.Log;
 
 /**
@@ -10,6 +14,9 @@ import lombok.extern.java.Log;
  * try(PerfTimer timer = PerfTimer.startTimer("timer_name_0")) {
  *   // code to be timed
  * }
+ * </code> Example usage with inline runnable: <code>
+ *   long someValue = PerfTimer.time("timer name", () -> exampleValueComputation());
+ *   PerfTimer.time("timer name", () -> exampleCodeToBeTimed());
  * </code>
  */
 @SuppressWarnings("unused") // used on-demand by dev where needed and removed afterwards.
@@ -17,6 +24,7 @@ import lombok.extern.java.Log;
 public class PerfTimer implements Closeable {
 
   private static final PerfTimer DISABLED_TIMER = new PerfTimer("disabled");
+  private static final Map<String, AtomicLong> runningTotal = new HashMap<>();
   final String title;
   private final long startMillis;
 
@@ -39,11 +47,41 @@ public class PerfTimer implements Closeable {
     return new PerfTimer(title);
   }
 
-  private static void processResult(final long stopNanos, final PerfTimer perfTimer) {
+  private static synchronized void processResult(final long stopNanos, final PerfTimer perfTimer) {
     final long stopMicros = stopNanos / 1000;
 
     final long milliFraction = (stopMicros % 1000) / 100;
     final long millis = (stopMicros / 1000);
-    log.info(millis + "." + milliFraction + " ms - " + perfTimer.title + ", " + stopNanos + " ns");
+
+    final AtomicLong totalNanos =
+        runningTotal.computeIfAbsent(perfTimer.title, key -> new AtomicLong(0));
+    totalNanos.set(totalNanos.get() + stopNanos);
+
+    final long totalNano = totalNanos.get();
+    final long totalMillis = (totalNano / (1000 * 1000));
+
+    log.info(
+        String.format(
+            "%s: %s.%s ms; %s total ms;   %s ns; %s total ns",
+            perfTimer.title, //
+            millis,
+            milliFraction,
+            stopNanos,
+            totalMillis,
+            totalNano));
+  }
+
+  public static <T> T time(final String title, final Supplier<T> functionToTime) {
+    final T value;
+    try (PerfTimer timer = startTimer(title)) {
+      value = functionToTime.get();
+    }
+    return value;
+  }
+
+  public static void time(final String title, final Runnable functionToTime) {
+    try (PerfTimer timer = startTimer(title)) {
+      functionToTime.run();
+    }
   }
 }


### PR DESCRIPTION
1. Add a 'time' API that accepts a runnable and also a supplier,
   to be used for convenience for inline timing. With this
   API can time a function call without having to wrap a
   try-with-resources around it.

EG:
```
final long value;
try(PerfTimer timer = PerfTimer.startTimer("title")) {
  value = someComputation();
}
```
Can be re-written as:
```
final long value = PerfTimer.time("title", () -> someComputation());
```

2. Print out accumulated timed values per timer. This indicates
   the total time something has taken across all iterations in
   addition to the previously reported time-per-iteration.

As a simplified example to illustrate:
```
"timer - 10 ms;  10ms total"
"timer - 20 ms;  30ms total"
"timer - 10 ms;  40ms total"
```


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] (internal) Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
- verified via manual testing while timing various functions.
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

