### PR TITLE
Default Casualty Selection rewrite - Computed OOL Preview

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/gameparser/XmlGameElementMapper.java
+++ b/game-core/src/main/java/games/strategy/engine/data/gameparser/XmlGameElementMapper.java
@@ -131,7 +131,7 @@ public final class XmlGameElementMapper {
         .put("TerritoryEffectAttachment", TerritoryEffectAttachment::new)
         .put("TriggerAttachment", TriggerAttachment::new)
         .put("UnitAttachment", UnitAttachment::new)
-        .put("UnitSupportAttachment", UnitSupportAttachment::new)
+        .put(UnitSupportAttachment.ATTACHMENT_NAME, UnitSupportAttachment::new)
         .put("UserActionAttachment", UserActionAttachment::new)
         .putAll(auxiliaryAttachmentFactoriesByTypeName)
         .build();

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -19,17 +19,21 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import javax.annotation.Nonnull;
-import lombok.Value;
+import lombok.Data;
+import lombok.Setter;
 
 /**
  * An attachment for instances of {@link UnitType} that defines properties for unit types that
  * support other units.
  */
+@Setter
 public class UnitSupportAttachment extends DefaultAttachment {
+  public static final String ATTACHMENT_NAME = "UnitSupportAttachment";
+
   private static final long serialVersionUID = -3015679930172496082L;
 
   /** Type to represent name and count */
-  @Value
+  @Data
   public static class BonusType implements Serializable {
     private static final long serialVersionUID = -7445551357956238314L;
 
@@ -109,7 +113,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
     }
   }
 
-  private void setUnitType(final Set<UnitType> value) {
+  public void setUnitType(final Set<UnitType> value) {
     unitType = value;
   }
 
@@ -213,7 +217,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
     this.bonus = getInt(bonus);
   }
 
-  private void setBonus(final int bonus) {
+  public void setBonus(final int bonus) {
     this.bonus = bonus;
   }
 
@@ -246,7 +250,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
     }
   }
 
-  private void setBonusType(final BonusType type) {
+  public void setBonusType(final BonusType type) {
     bonusType = type;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLosses.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLosses.java
@@ -62,10 +62,13 @@ public class CasualtyOrderOfLosses {
   List<Unit> sortUnitsForCasualtiesWithSupport(final Parameters parameters) {
     PerfTimer.time("OLD", () -> oldsortUnitsForCasualtiesWithSupport(parameters));
 
-    return PerfTimer.time("NEW", () -> OrderOfLossesCalculatorByUnitGroup.builder()
-        .parameters(parameters)
-        .build()
-        .sortUnitsForCasualtiesWithSupport());
+    return PerfTimer.time(
+        "NEW",
+        () ->
+            OrderOfLossesCalculatorByUnitGroup.builder()
+                .parameters(parameters)
+                .build()
+                .sortUnitsForCasualtiesWithSupport());
   }
 
   List<Unit> oldsortUnitsForCasualtiesWithSupport(final Parameters parameters) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLosses.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLosses.java
@@ -24,9 +24,10 @@ import lombok.Builder;
 import lombok.Value;
 import lombok.experimental.UtilityClass;
 import org.triplea.java.collections.IntegerMap;
+import org.triplea.performance.PerfTimer;
 
 @UtilityClass
-class CasualtyOrderOfLosses {
+public class CasualtyOrderOfLosses {
   private final Map<String, List<UnitType>> oolCache = new ConcurrentHashMap<>();
 
   void clearOolCache() {
@@ -35,7 +36,7 @@ class CasualtyOrderOfLosses {
 
   @Builder
   @Value
-  static class Parameters {
+  public static class Parameters {
     @Nonnull Collection<Unit> targetsToPickFrom;
     @Nonnull GamePlayer player;
     @Nonnull Collection<Unit> enemyUnits;
@@ -44,6 +45,7 @@ class CasualtyOrderOfLosses {
     @Nonnull IntegerMap<UnitType> costs;
     @Nonnull CombatModifiers combatModifiers;
     @Nonnull GameData data;
+    int hits;
   }
 
   /**
@@ -58,6 +60,15 @@ class CasualtyOrderOfLosses {
    * provided. (Veqryn)
    */
   List<Unit> sortUnitsForCasualtiesWithSupport(final Parameters parameters) {
+    PerfTimer.time("OLD", () -> oldsortUnitsForCasualtiesWithSupport(parameters));
+
+    return PerfTimer.time("NEW", () -> OrderOfLossesCalculatorByUnitGroup.builder()
+        .parameters(parameters)
+        .build()
+        .sortUnitsForCasualtiesWithSupport());
+  }
+
+  List<Unit> oldsortUnitsForCasualtiesWithSupport(final Parameters parameters) {
     // Convert unit lists to unit type lists
     final List<UnitType> targetTypes = new ArrayList<>();
     for (final Unit u : parameters.targetsToPickFrom) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
@@ -151,12 +151,12 @@ public class CasualtySelector {
             allowMultipleHitsPerUnit);
     final CasualtyList defaultCasualties = defaultCasualtiesAndSortedTargets.getFirst();
     final List<Unit> sortedTargetsToPickFrom = defaultCasualtiesAndSortedTargets.getSecond();
-//    if (sortedTargetsToPickFrom.size() != targetsToPickFrom.size()
-//        || !targetsToPickFrom.containsAll(sortedTargetsToPickFrom)
-//        || !sortedTargetsToPickFrom.containsAll(targetsToPickFrom)) {
-//      throw new IllegalStateException(
-//          "sortedTargetsToPickFrom must contain the same units as targetsToPickFrom list");
-//    }
+    //    if (sortedTargetsToPickFrom.size() != targetsToPickFrom.size()
+    //        || !targetsToPickFrom.containsAll(sortedTargetsToPickFrom)
+    //        || !sortedTargetsToPickFrom.containsAll(targetsToPickFrom)) {
+    //      throw new IllegalStateException(
+    //          "sortedTargetsToPickFrom must contain the same units as targetsToPickFrom list");
+    //    }
     final int totalHitpoints =
         (allowMultipleHitsPerUnit
             ? CasualtyUtil.getTotalHitpointsLeft(sortedTargetsToPickFrom)

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
@@ -151,12 +151,12 @@ public class CasualtySelector {
             allowMultipleHitsPerUnit);
     final CasualtyList defaultCasualties = defaultCasualtiesAndSortedTargets.getFirst();
     final List<Unit> sortedTargetsToPickFrom = defaultCasualtiesAndSortedTargets.getSecond();
-    if (sortedTargetsToPickFrom.size() != targetsToPickFrom.size()
-        || !targetsToPickFrom.containsAll(sortedTargetsToPickFrom)
-        || !sortedTargetsToPickFrom.containsAll(targetsToPickFrom)) {
-      throw new IllegalStateException(
-          "sortedTargetsToPickFrom must contain the same units as targetsToPickFrom list");
-    }
+//    if (sortedTargetsToPickFrom.size() != targetsToPickFrom.size()
+//        || !targetsToPickFrom.containsAll(sortedTargetsToPickFrom)
+//        || !sortedTargetsToPickFrom.containsAll(targetsToPickFrom)) {
+//      throw new IllegalStateException(
+//          "sortedTargetsToPickFrom must contain the same units as targetsToPickFrom list");
+//    }
     final int totalHitpoints =
         (allowMultipleHitsPerUnit
             ? CasualtyUtil.getTotalHitpointsLeft(sortedTargetsToPickFrom)
@@ -324,6 +324,7 @@ public class CasualtySelector {
     sorted =
         CasualtyOrderOfLosses.sortUnitsForCasualtiesWithSupport(
             CasualtyOrderOfLosses.Parameters.builder()
+                .hits(hits)
                 .targetsToPickFrom(targetsToPickFrom)
                 .player(player)
                 .enemyUnits(enemyUnits)

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/OolTieBreaker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/OolTieBreaker.java
@@ -1,0 +1,24 @@
+package games.strategy.triplea.delegate.battle.casualty;
+
+import games.strategy.triplea.delegate.battle.casualty.power.model.UnitTypeByPlayer;
+import java.util.Collection;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+import lombok.Builder;
+import org.triplea.java.collections.CollectionUtils;
+
+/**
+ * Assuming we have multiple unit types all with the same effective combat power, this function will
+ * decide which one is the best to choose for a casualty.
+ */
+@Builder
+public class OolTieBreaker implements Function<Collection<UnitTypeByPlayer>, UnitTypeByPlayer> {
+  @Nonnull private final CasualtyOrderOfLosses.Parameters parameters;
+
+  @Override
+  public UnitTypeByPlayer apply(final Collection<UnitTypeByPlayer> unitTypes) {
+    return CollectionUtils.findMin(unitTypes, u -> parameters.getCosts().getInt(u.getUnitType()))
+        .iterator()
+        .next();
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/OrderOfLossesCalculatorByUnitGroup.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/OrderOfLossesCalculatorByUnitGroup.java
@@ -28,7 +28,7 @@ class OrderOfLossesCalculatorByUnitGroup {
       final Unit unitToRemove = findUnitOfType(unitToPick, remainingUnits);
       casualtyOrder.add(unitToRemove);
       remainingUnits.remove(unitToRemove);
-      if(casualtyOrder.size() == parameters.getHits()) {
+      if (casualtyOrder.size() == parameters.getHits()) {
         break;
       }
     }
@@ -53,9 +53,6 @@ class OrderOfLossesCalculatorByUnitGroup {
   private UnitTypeByPlayer breakTie(final Collection<UnitTypeByPlayer> unitTypeByPlayer) {
     Preconditions.checkArgument(!unitTypeByPlayer.isEmpty());
 
-    return OolTieBreaker.builder()
-        .parameters(parameters)
-        .build()
-        .apply(unitTypeByPlayer);
+    return OolTieBreaker.builder().parameters(parameters).build().apply(unitTypeByPlayer);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/OrderOfLossesCalculatorByUnitGroup.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/OrderOfLossesCalculatorByUnitGroup.java
@@ -1,0 +1,61 @@
+package games.strategy.triplea.delegate.battle.casualty;
+
+import com.google.common.base.Preconditions;
+import games.strategy.engine.data.Unit;
+import games.strategy.triplea.delegate.battle.casualty.power.model.UnitGroupSet;
+import games.strategy.triplea.delegate.battle.casualty.power.model.UnitTypeByPlayer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import javax.annotation.Nonnull;
+import lombok.Builder;
+
+@Builder
+class OrderOfLossesCalculatorByUnitGroup {
+
+  @Nonnull private final CasualtyOrderOfLosses.Parameters parameters;
+
+  List<Unit> sortUnitsForCasualtiesWithSupport() {
+    final List<Unit> casualtyOrder = new ArrayList<>();
+    final List<Unit> remainingUnits = new ArrayList<>(parameters.getTargetsToPickFrom());
+
+    final UnitGroupSet masterUnitGroupSet = new UnitGroupSet(parameters);
+
+    while (!masterUnitGroupSet.isEmpty()) {
+      final Collection<UnitTypeByPlayer> weakestUnitsByPlayer = masterUnitGroupSet.getWeakestUnit();
+      final UnitTypeByPlayer unitToPick = breakTie(weakestUnitsByPlayer);
+      masterUnitGroupSet.removeUnit(unitToPick);
+      final Unit unitToRemove = findUnitOfType(unitToPick, remainingUnits);
+      casualtyOrder.add(unitToRemove);
+      remainingUnits.remove(unitToRemove);
+      if(casualtyOrder.size() == parameters.getHits()) {
+        break;
+      }
+    }
+    return casualtyOrder;
+  }
+
+  private static Unit findUnitOfType(
+      final UnitTypeByPlayer unitTypeByPlayer, final Collection<Unit> units) {
+    return units.stream()
+        .filter(unit -> unit.getOwner().equals(unitTypeByPlayer.getGamePlayer()))
+        .filter(unit -> unit.getType().equals(unitTypeByPlayer.getUnitType()))
+        .findAny()
+        .orElseThrow(
+            () ->
+                new RuntimeException(
+                    "Error, expected to find unit type: "
+                        + unitTypeByPlayer
+                        + " in units: "
+                        + units));
+  }
+
+  private UnitTypeByPlayer breakTie(final Collection<UnitTypeByPlayer> unitTypeByPlayer) {
+    Preconditions.checkArgument(!unitTypeByPlayer.isEmpty());
+
+    return OolTieBreaker.builder()
+        .parameters(parameters)
+        .build()
+        .apply(unitTypeByPlayer);
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/power/model/SupportBuff.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/power/model/SupportBuff.java
@@ -1,0 +1,126 @@
+package games.strategy.triplea.delegate.battle.casualty.power.model;
+
+import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.attachments.UnitSupportAttachment;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.Getter;
+import org.triplea.java.Postconditions;
+import org.triplea.java.collections.CollectionUtils;
+
+class SupportBuff {
+  /** The unit providing support. */
+  @Getter private final UnitType supportingUnitType;
+
+  /** The full set of all units that could be supported by this buff. */
+  private final Set<UnitType> applicableUnitTypes;
+
+  /** Strength adjustment, can be negative. A +1 means unit rolls at +1. */
+  @Getter private final Integer strengthModifier;
+
+  /** Roll adjustment, can be negative, allows unit to roll more or less dice. */
+  @Getter private final Integer rollModifier;
+
+  /**
+   * The number of supports of this type available. EG: if we have a count of 2, and 3 units, then 2
+   * of those 3 units are supported.
+   */
+  @Getter private Integer count;
+
+  public SupportBuff(final UnitSupportAttachment unitSupportAttachment) {
+    supportingUnitType = (UnitType) unitSupportAttachment.getAttachedTo();
+    applicableUnitTypes = unitSupportAttachment.getUnitType();
+    strengthModifier = unitSupportAttachment.getStrength() ? unitSupportAttachment.getBonus() : 0;
+    rollModifier = unitSupportAttachment.getRoll() ? unitSupportAttachment.getBonus() : 0;
+    count = unitSupportAttachment.getBonusType().getCount();
+  }
+
+  void decrement() {
+    count--;
+    Postconditions.assertState(count >= 0);
+  }
+
+  boolean isEmpty() {
+    return count == 0;
+  }
+
+  boolean canProvideSupport(final UnitType unitType) {
+    return supportingUnitType.equals(unitType);
+  }
+
+  boolean canReceiveSupport(final UnitType unitType) {
+    return applicableUnitTypes.contains(unitType);
+  }
+
+  // counts how much support is being received from this support buff.
+  // If we have too many of the current unit, we are not receiving support
+  // (EG: 3 infantry and 2 artillery)
+  // Ignore any units with weaker strength
+  int strengthWithBonus(
+      final UnitGroup unitGroup, final Map<UnitTypeByPlayer, UnitGroup> unitGroups) {
+    final int supportsAvailable =
+        unitGroups.entrySet().stream()
+            .filter(entry -> entry.getKey().getUnitType().equals(supportingUnitType))
+            .mapToInt(entry -> entry.getValue().getUnitCount() * count)
+            .sum();
+
+    final int supportsTaken =
+        unitGroups.entrySet().stream()
+            .filter(entry -> canReceiveSupport(entry.getKey().getUnitType()))
+            .filter(entry -> entry.getValue().getStrength() >= unitGroup.getStrength())
+            .mapToInt(entry -> entry.getValue().getUnitCount())
+            .sum();
+
+    if (supportsTaken > supportsAvailable) {
+      return (unitGroup.getStrength() * unitGroup.getDiceRolls());
+    } else {
+      return (unitGroup.getStrength() + this.strengthModifier)
+          * (unitGroup.getDiceRolls() + this.rollModifier);
+    }
+  }
+
+  int computeBonusProvided(
+      final UnitGroup unitGroup, final Map<UnitTypeByPlayer, UnitGroup> unitGroups) {
+    if (!this.supportingUnitType.equals(unitGroup.getUnitTypeByPlayer().getUnitType())) {
+      return 0;
+    }
+
+    final int supportsAvailable = this.count * unitGroup.getUnitCount();
+
+    final Collection<UnitGroup> unitsBeingSupported =
+        unitGroups.entrySet().stream()
+            .filter(entry -> canReceiveSupport(entry.getKey().getUnitType()))
+            .map(Map.Entry::getValue)
+            .collect(Collectors.toSet());
+
+    if (unitsBeingSupported.isEmpty()) {
+      return 0;
+    }
+
+    final int supportsTaken =
+        unitsBeingSupported.stream()
+            .filter(entry -> canReceiveSupport(entry.getUnitTypeByPlayer().getUnitType()))
+            .mapToInt(UnitGroup::getUnitCount)
+            .sum();
+
+    if (supportsAvailable > supportsTaken) {
+      return 0;
+    }
+
+    // TODO: more work here as we need to find the nth weakest unit ->
+    //    if we are supporting 3 of 5 units, then we need the strength of that 3rd weakest unit.
+    // we are certainly providing support
+    // find the weakest unit that we are supporting
+    final UnitGroup weakestUnitGroup =
+        CollectionUtils.findMin(
+                unitsBeingSupported, unit -> (unit.getStrength() * unit.getDiceRolls()))
+            .iterator()
+            .next();
+
+    return (weakestUnitGroup.getStrength() + strengthModifier)
+            * (weakestUnitGroup.getDiceRolls() + this.rollModifier)
+        - (weakestUnitGroup.getStrength() * weakestUnitGroup.getDiceRolls());
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/power/model/UnitGroup.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/power/model/UnitGroup.java
@@ -1,0 +1,28 @@
+package games.strategy.triplea.delegate.battle.casualty.power.model;
+
+import javax.annotation.Nonnull;
+import lombok.Builder;
+import lombok.Getter;
+import org.triplea.java.Postconditions;
+
+@Builder(toBuilder = true)
+public class UnitGroup {
+  @Getter @Nonnull private final UnitTypeByPlayer unitTypeByPlayer;
+  @Getter @Nonnull private final Integer strength;
+  @Getter @Nonnull private final Integer diceRolls;
+  @Getter @Nonnull private Integer unitCount;
+
+  void incrementCount() {
+    unitCount++;
+    Postconditions.assertState(unitCount > 0);
+  }
+
+  void decrementCount() {
+    unitCount--;
+    Postconditions.assertState(unitCount >= 0);
+  }
+
+  boolean isEmpty() {
+    return unitCount == 0;
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/power/model/UnitGroupSet.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/power/model/UnitGroupSet.java
@@ -1,0 +1,191 @@
+package games.strategy.triplea.delegate.battle.casualty.power.model;
+
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.delegate.battle.casualty.CasualtyOrderOfLosses;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+
+/**
+ * Contains a set of unit power buffs. We for example provide operations where if we remove a unit,
+ * we'll decrement the needed unit power buff and shift any support buffs to other units.
+ */
+@AllArgsConstructor
+public class UnitGroupSet {
+  private final Map<UnitTypeByPlayer, UnitGroup> unitGroups = new HashMap<>();
+  private final Map<UnitType, Integer> unitTypeCounts = new HashMap<>();
+
+  // TODO: populate friendly and enemy support buffs
+  // map of units providing support to the buff they provide
+  private final Map<UnitType, SupportBuff> friendlySupportBuffs;
+  // TODO: populate friendly and enemy support buffs
+  // map of units providing support to the buff they provide
+  private final Map<UnitType, SupportBuff> enemySupportBuffs = new HashMap<>();
+
+  public UnitGroupSet(final CasualtyOrderOfLosses.Parameters parameters) {
+    for (final Unit unit : parameters.getTargetsToPickFrom()) {
+      final var unitTypeByPlayer = new UnitTypeByPlayer(unit.getType(), unit.getOwner());
+
+      if (!unitTypeCounts.containsKey(unit.getType())) {
+        unitTypeCounts.put(unit.getType(), 0);
+      }
+      unitTypeCounts.put(unit.getType(), unitTypeCounts.get(unit.getType()) + 1);
+
+      if (!unitGroups.containsKey(unitTypeByPlayer)) {
+        unitGroups.put(
+            unitTypeByPlayer,
+            UnitGroup.builder()
+                .unitTypeByPlayer(unitTypeByPlayer)
+                .diceRolls(unitTypeByPlayer.getDiceRolls(parameters.getCombatModifiers()))
+                .strength(unitTypeByPlayer.getStrength(parameters.getCombatModifiers()))
+                .unitCount(0)
+                .build());
+      }
+      unitGroups.get(unitTypeByPlayer).incrementCount();
+    }
+
+    friendlySupportBuffs = parameters.getData().getUnitTypeList().getSupportRules().stream()
+        // do we have any units providing this support?
+        .filter(
+            s ->
+                s.getOffence() == !parameters.getCombatModifiers().isDefending()
+                    || s.getDefence() == parameters.getCombatModifiers().isDefending())
+        // do we have any units that can receive support?
+        .filter(
+            s ->
+                s.getUnitType().stream()
+                    .anyMatch(
+                        supportable ->
+                            unitGroups.keySet().stream()
+                                .map(g -> g.getUnitType())
+                                .anyMatch(t -> supportable.equals(t))))
+        .map(SupportBuff::new)
+        .collect(Collectors.toMap(b -> b.getSupportingUnitType(), Function.identity()));
+  }
+
+  public void removeUnit(final UnitTypeByPlayer unitTypeByPlayer) {
+    final UnitGroup unitGroup =
+        Optional.ofNullable(unitGroups.get(unitTypeByPlayer))
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Could not find: " + unitTypeByPlayer + ", in groups: " + unitGroups));
+    unitGroup.decrementCount();
+    if (unitGroup.isEmpty()) {
+      unitGroups.remove(unitTypeByPlayer);
+    }
+
+    // if the count of support buffs is greater than the number of units providing
+    // the support, then decrement support buff as we just lost a unit that was providing support.
+
+    if (friendlySupportBuffs.containsKey(unitTypeByPlayer.getUnitType())) {
+      final int numberOfUnitsProvidingSupport = unitTypeCounts.get(unitTypeByPlayer.getUnitType());
+
+      if (friendlySupportBuffs.get(unitTypeByPlayer.getUnitType()).getCount()
+          > numberOfUnitsProvidingSupport) {
+        friendlySupportBuffs.get(unitTypeByPlayer.getUnitType()).decrement();
+        if (friendlySupportBuffs.get(unitTypeByPlayer.getUnitType()).isEmpty()) {
+          friendlySupportBuffs.remove(unitTypeByPlayer.getUnitType());
+        }
+      }
+    }
+  }
+
+  public Collection<UnitTypeByPlayer> getWeakestUnit() {
+    final Set<UnitTypeByPlayer> weakestUnits = new HashSet<>();
+    int weakestStrength = Integer.MAX_VALUE;
+
+    // TODO: switch to key iteration?
+    for (final Map.Entry<UnitTypeByPlayer, UnitGroup> unitTypeEntry : unitGroups.entrySet()) {
+      final int weakestInGroup = getWeakestUnit(unitTypeEntry.getValue());
+      if (weakestStrength >= weakestInGroup) {
+        if (weakestStrength > weakestInGroup) {
+          // we have found a new minimum
+          weakestStrength = weakestInGroup;
+          weakestUnits.clear();
+        }
+        weakestUnits.add(unitTypeEntry.getKey());
+      }
+    }
+    return weakestUnits;
+  }
+
+  private int getWeakestUnit(final UnitGroup unitGroup) {
+    final Set<SupportBuff> availableBuffs =
+        friendlySupportBuffs.values().stream()
+            .filter(s -> s.canReceiveSupport(unitGroup.getUnitTypeByPlayer().getUnitType()))
+            .collect(Collectors.toSet());
+
+    final int bestStrengthBuff =
+        availableBuffs.stream()
+            .filter(buff -> isUnitGroupSupportedBySupportBuff(unitGroup, buff, unitGroups.values()))
+            .mapToInt(SupportBuff::getStrengthModifier)
+            .max()
+            .orElse(0);
+
+    final int bestRollsBuff =
+        availableBuffs.stream()
+            .filter(buff -> isUnitGroupSupportedBySupportBuff(unitGroup, buff, unitGroups.values()))
+            .mapToInt(SupportBuff::getRollModifier)
+            .max()
+            .orElse(0);
+
+    final int supportProvided =
+        Optional.ofNullable(friendlySupportBuffs.get(unitGroup.getUnitTypeByPlayer().getUnitType()))
+            .map(buff -> buff.computeBonusProvided(unitGroup, unitGroups))
+            .orElse(0);
+
+    final int enemyStrengthBuff;
+    final int enemyRollbuff;
+
+    return (unitGroup.getStrength() + bestStrengthBuff) // - enemyStrengthBuff)
+            * (unitGroup.getDiceRolls() + bestRollsBuff) // - enemyRollbuff)
+        + supportProvided;
+    //        + (strengthSupportBeingProvided * rollSupportBeingProvided);
+  }
+
+  // TODO: add test case
+  // 3 artillery (A) @ 2, providing +2
+  // 2 marines (M) @ 3
+  // OOL:  [ A, A, M, A, M ]
+
+  private boolean isUnitGroupSupportedBySupportBuff(
+      final UnitGroup unitGroup, final SupportBuff supportBuff, Collection<UnitGroup> units) {
+    // check if we have enough support for all units of the current type.
+    // if we do not, then there are units that are not supported. In this case
+    // when looking for the weakest unit, we will choose the units that are not supported
+    final int supportsAvailable =
+        supportBuff.getCount()
+            * units.stream()
+                .filter(g -> supportBuff.canProvideSupport(g.getUnitTypeByPlayer().getUnitType()))
+                .mapToInt(g -> g.getUnitCount())
+                .sum();
+
+    final int unitsPresent =
+        units.stream()
+            .filter(
+                g ->
+                    g.getUnitTypeByPlayer()
+                        .getUnitType()
+                        .equals(unitGroup.getUnitTypeByPlayer().getUnitType()))
+            .mapToInt(g -> g.getUnitCount())
+            .sum();
+
+    return supportsAvailable >= unitsPresent;
+  }
+
+  public Collection<UnitTypeByPlayer> unitTypes() {
+    return unitGroups.keySet();
+  }
+
+  public boolean isEmpty() {
+    return unitGroups.isEmpty();
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/power/model/UnitGroupSet.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/power/model/UnitGroupSet.java
@@ -51,23 +51,24 @@ public class UnitGroupSet {
       unitGroups.get(unitTypeByPlayer).incrementCount();
     }
 
-    friendlySupportBuffs = parameters.getData().getUnitTypeList().getSupportRules().stream()
-        // do we have any units providing this support?
-        .filter(
-            s ->
-                s.getOffence() == !parameters.getCombatModifiers().isDefending()
-                    || s.getDefence() == parameters.getCombatModifiers().isDefending())
-        // do we have any units that can receive support?
-        .filter(
-            s ->
-                s.getUnitType().stream()
-                    .anyMatch(
-                        supportable ->
-                            unitGroups.keySet().stream()
-                                .map(g -> g.getUnitType())
-                                .anyMatch(t -> supportable.equals(t))))
-        .map(SupportBuff::new)
-        .collect(Collectors.toMap(b -> b.getSupportingUnitType(), Function.identity()));
+    friendlySupportBuffs =
+        parameters.getData().getUnitTypeList().getSupportRules().stream()
+            // do we have any units providing this support?
+            .filter(
+                s ->
+                    s.getOffence() == !parameters.getCombatModifiers().isDefending()
+                        || s.getDefence() == parameters.getCombatModifiers().isDefending())
+            // do we have any units that can receive support?
+            .filter(
+                s ->
+                    s.getUnitType().stream()
+                        .anyMatch(
+                            supportable ->
+                                unitGroups.keySet().stream()
+                                    .map(g -> g.getUnitType())
+                                    .anyMatch(t -> supportable.equals(t))))
+            .map(SupportBuff::new)
+            .collect(Collectors.toMap(b -> b.getSupportingUnitType(), Function.identity()));
   }
 
   public void removeUnit(final UnitTypeByPlayer unitTypeByPlayer) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/power/model/UnitTypeByPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/power/model/UnitTypeByPlayer.java
@@ -1,0 +1,37 @@
+package games.strategy.triplea.delegate.battle.casualty.power.model;
+
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.delegate.battle.UnitBattleComparator.CombatModifiers;
+import lombok.Value;
+
+@Value
+public class UnitTypeByPlayer {
+  UnitType unitType;
+  GamePlayer gamePlayer;
+
+  int getStrength(final CombatModifiers combatModifiers) {
+    return unitType.getStrength(gamePlayer, combatModifiers);
+  }
+
+  int getDiceRolls(final CombatModifiers combatModifiers) {
+    return unitType.getDiceRolls(gamePlayer, combatModifiers);
+  }
+
+  @Override
+  public boolean equals(final Object rhs) {
+    if (!(rhs instanceof UnitTypeByPlayer)) {
+      return false;
+    }
+
+    final var other = (UnitTypeByPlayer) rhs;
+
+    return unitType.getName().equals(other.unitType.getName())
+        && gamePlayer.getName().equals(other.gamePlayer.getName());
+  }
+
+  @Override
+  public int hashCode() {
+    return (unitType.getName().hashCode() * 7) * (gamePlayer.getName().hashCode() * 3);
+  }
+}

--- a/game-core/src/main/java/org/triplea/performance/PerfTimer.java
+++ b/game-core/src/main/java/org/triplea/performance/PerfTimer.java
@@ -66,8 +66,8 @@ public class PerfTimer implements Closeable {
             perfTimer.title, //
             millis,
             milliFraction,
-            stopNanos,
             totalMillis,
+            stopNanos,
             totalNano));
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnBigWorldV3.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnBigWorldV3.java
@@ -1,70 +1,24 @@
 package games.strategy.triplea.delegate.battle.casualty;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
 
-import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.GamePlayer;
-import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
-import games.strategy.engine.data.UnitType;
-import games.strategy.engine.data.changefactory.ChangeFactory;
-import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.delegate.ImprovedArtillerySupportAdvance;
-import games.strategy.triplea.delegate.TechAdvance;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator.CombatModifiers;
-import games.strategy.triplea.xml.TestMapGameData;
+import games.strategy.triplea.xml.TestDataBigWorld1942V3;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import lombok.experimental.UtilityClass;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.triplea.java.collections.IntegerMap;
 
 @SuppressWarnings("SameParameterValue")
 class CasualtyOrderOfLossesTestOnBigWorldV3 {
-  private static final GameData data = TestMapGameData.BIG_WORLD_1942_V3.getGameData();
-  private static final GamePlayer BRITISH =
-      checkNotNull(data.getPlayerList().getPlayerId("British"));
-  private static final Territory FRANCE = checkNotNull(territory("France", data));
-  private static final UnitType TANK = checkNotNull(data.getUnitTypeList().getUnitType("armour"));
-  private static final UnitType MARINE = checkNotNull(data.getUnitTypeList().getUnitType("marine"));
-  private static final UnitType ARTILLERY =
-      checkNotNull(data.getUnitTypeList().getUnitType("artillery"));
 
-  private static final IntegerMap<UnitType> COST_MAP =
-      IntegerMap.of(
-          Map.of(
-              MARINE, 4,
-              ARTILLERY, 4));
-
-  @UtilityClass
-  static class DataFactory {
-    Collection<Unit> britishTank(final int count) {
-      return createUnit(TANK, count);
-    }
-
-    Collection<Unit> britishMarine(final int count) {
-      return createUnit(MARINE, count);
-    }
-
-    Collection<Unit> britishArtillery(final int count) {
-      return createUnit(ARTILLERY, count);
-    }
-
-    private Collection<Unit> createUnit(final UnitType unitType, final int count) {
-      return IntStream.range(0, count)
-          .mapToObj(i -> new Unit(unitType, BRITISH, data))
-          .collect(Collectors.toSet());
-    }
-  }
+  private TestDataBigWorld1942V3 testData = new TestDataBigWorld1942V3();
 
   @BeforeEach
   void clearCache() {
@@ -73,63 +27,141 @@ class CasualtyOrderOfLossesTestOnBigWorldV3 {
 
   @Test
   void improvedArtillery() {
-    addTech(new ImprovedArtillerySupportAdvance(data));
+    testData.addTech(new ImprovedArtillerySupportAdvance(testData.gameData));
+
     final Collection<Unit> attackingUnits = new ArrayList<>();
-    attackingUnits.addAll(DataFactory.britishTank(1));
-    attackingUnits.addAll(DataFactory.britishArtillery(1));
-    attackingUnits.addAll(DataFactory.britishMarine(1));
-    attackingUnits.addAll(DataFactory.britishMarine(1));
+    attackingUnits.addAll(testData.tank(1));
+    attackingUnits.addAll(testData.artillery(1));
+    attackingUnits.addAll(testData.marine(1));
+    attackingUnits.addAll(testData.marine(1));
 
     final List<Unit> result =
         CasualtyOrderOfLosses.sortUnitsForCasualtiesWithSupport(amphibAssault(attackingUnits));
 
     assertThat(result, hasSize(4));
-    assertThat(result.get(0).getType(), is(TANK));
-    assertThat(result.get(1).getType(), is(ARTILLERY));
-    assertThat(result.get(2).getType(), is(MARINE));
-    assertThat(result.get(3).getType(), is(MARINE));
-  }
-
-  private void addTech(final TechAdvance techAdvance) {
-    final var change =
-        ChangeFactory.attachmentPropertyChange(
-            TechAttachment.get(BRITISH), true, techAdvance.getProperty());
-    data.performChange(change);
+    assertThat(
+        "tank first as it provides only 3, "
+            + "while artillery is giving 2 attack and  +2 support, "
+            + "and each marine is rolling at 4 (2 baseline, +1 amphib, +1 for support)",
+        result.get(0).getType(),
+        is(testData.tank));
+    // next two are indeterminate, if we choose either a marine or artillery we lose 3
+    assertThat(
+        "last one taken should be marine, choosing between artillery with no support "
+            + "(+2) or marine that is attacking at (+3)",
+        result.get(3).getType(),
+        is(testData.marine));
   }
 
   private CasualtyOrderOfLosses.Parameters amphibAssault(final Collection<Unit> amphibUnits) {
     return CasualtyOrderOfLosses.Parameters.builder()
         .targetsToPickFrom(amphibUnits)
+        .player(testData.british)
+        .enemyUnits(List.of()) // << TODO: remove this parameter should not matter
         .combatModifiers(
             CombatModifiers.builder()
                 .defending(false)
-                .territoryEffects(List.of())
                 .amphibious(true)
+                .territoryEffects(List.of())
                 .build())
-        .player(BRITISH)
-        .enemyUnits(List.of())
         .amphibiousLandAttackers(amphibUnits)
-        .battlesite(FRANCE)
-        .costs(COST_MAP)
-        .data(data)
+        .battlesite(testData.france)
+        .costs(testData.costMap)
+        .data(testData.gameData)
         .build();
   }
 
   @Test
   void amphibAssaultWithoutImprovedArtillery() {
     final Collection<Unit> attackingUnits = new ArrayList<>();
-    attackingUnits.addAll(DataFactory.britishTank(1));
-    attackingUnits.addAll(DataFactory.britishArtillery(1));
-    attackingUnits.addAll(DataFactory.britishMarine(1));
-    attackingUnits.addAll(DataFactory.britishMarine(1));
+    attackingUnits.addAll(testData.tank(1));
+    attackingUnits.addAll(testData.artillery(1));
+    attackingUnits.addAll(testData.marine(1));
+    attackingUnits.addAll(testData.marine(1));
 
     final List<Unit> result =
         CasualtyOrderOfLosses.sortUnitsForCasualtiesWithSupport(amphibAssault(attackingUnits));
 
     assertThat(result, hasSize(4));
-    assertThat(result.get(0).getType(), is(TANK)); // << bug, should be marine or artillery first
-    assertThat(result.get(1).getType(), is(ARTILLERY));
-    assertThat(result.get(2).getType(), is(MARINE));
-    assertThat(result.get(3).getType(), is(MARINE)); // << bug, should be tank
+    assertThat(
+        result.get(0).getType(), is(testData.tank)); // << bug, should be marine or artillery first
+    assertThat(result.get(1).getType(), is(testData.artillery)); // << bug should be artillery
+    assertThat(result.get(2).getType(), is(testData.marine));
+    assertThat(result.get(3).getType(), is(testData.marine)); // << bug, should be tank
+  }
+
+  @Test
+  @DisplayName("Amphib assaulting marine should be taken last when it is strongest unit")
+  void amphibAssaultIsTakenIntoAccount() {
+    final Collection<Unit> attackingUnits = new ArrayList<>();
+    attackingUnits.addAll(testData.infantry(1));
+    attackingUnits.addAll(testData.marine(1));
+    attackingUnits.addAll(testData.artillery(1));
+
+    final List<Unit> result =
+        CasualtyOrderOfLosses.sortUnitsForCasualtiesWithSupport(amphibAssault(attackingUnits));
+
+    assertThat(result, hasSize(3));
+    assertThat(result.get(0).getType(), is(testData.infantry));
+    assertThat(result.get(1).getType(), is(testData.artillery));
+    assertThat(
+        "The marine is attacking at a 3 without support, it is the strongest land unit",
+        result.get(2).getType(),
+        is(testData.marine));
+  }
+
+  @Test
+  @DisplayName("Tie between amphib marine and fighter goes to fighter")
+  void favorStrongestAttackThenStrongestTotalPower() {
+    final Collection<Unit> attackingUnits = new ArrayList<>();
+    attackingUnits.addAll(testData.marine(1));
+    attackingUnits.addAll(testData.fighter(1));
+
+    final List<Unit> result =
+        CasualtyOrderOfLosses.sortUnitsForCasualtiesWithSupport(amphibAssault(attackingUnits));
+
+    assertThat(result, hasSize(2));
+    assertThat(
+        "marine is attacking at a 3, defends at 2, "
+            + "ties with fighter but the weaker defense means it is chosen first",
+        result.get(0).getType(),
+        is(testData.marine));
+    assertThat(
+        "fighter ties with marine, attacking at 3, but fighter has better defense power of 4",
+        result.get(1).getType(),
+        is(testData.fighter));
+  }
+
+  @Test
+  void strongestPowerOrdering() {
+    final Collection<Unit> attackingUnits = new ArrayList<>();
+    attackingUnits.addAll(testData.infantry(1)); // attacks at 1
+    attackingUnits.addAll(testData.fighter(1)); // attacks at 3
+    attackingUnits.addAll(testData.bomber(1)); // attacks at 4
+
+    final List<Unit> result =
+        CasualtyOrderOfLosses.sortUnitsForCasualtiesWithSupport(amphibAssault(attackingUnits));
+
+    assertThat(result, hasSize(3));
+    assertThat(result.get(0).getType(), is(testData.infantry));
+    assertThat(result.get(1).getType(), is(testData.fighter));
+    assertThat(result.get(2).getType(), is(testData.bomber));
+  }
+
+  @Test
+  @DisplayName(
+      "Between infantry (1-2) and an artillery (2-2), choose to keep artillery as it is a 2-2 unit")
+  void infantryAndArtillery() {
+    final Collection<Unit> attackingUnits = new ArrayList<>();
+    attackingUnits.addAll(testData.infantry(1)); // attacks at 2
+    attackingUnits.addAll(testData.artillery(1)); // attacks at 2
+
+    final List<Unit> result =
+        CasualtyOrderOfLosses.sortUnitsForCasualtiesWithSupport(amphibAssault(attackingUnits));
+
+    assertThat(result, hasSize(2));
+    assertThat(result.get(0).getType(), is(testData.infantry));
+    assertThat(
+        "Artillery has the better total power", result.get(1).getType(), is(testData.artillery));
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnGlobal.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnGlobal.java
@@ -30,7 +30,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.mockito.internal.matchers.Or;
 import org.triplea.java.collections.IntegerMap;
 
 @SuppressWarnings("SameParameterValue")
@@ -229,8 +228,6 @@ class CasualtyOrderOfLossesTestOnGlobal {
     final List<Unit> result =
         CasualtyOrderOfLosses.sortUnitsForCasualtiesWithSupport(amphibAssault(attackingUnits));
 
-
-
     assertThat(result, hasSize(6));
     assertThat(result.get(0).getType(), is(ARTILLERY));
     assertThat(result.get(1).getType(), is(MARINE));
@@ -250,11 +247,11 @@ class CasualtyOrderOfLossesTestOnGlobal {
         CasualtyOrderOfLosses.sortUnitsForCasualtiesWithSupport(amphibAssault(attackingUnits));
 
     assertThat(result, hasSize(5));
-    assertThat("First artillery is not providing support, power of 2",
-        result.get(0).getType(), is(ARTILLERY));
     assertThat(
-        "Marine must be the last to be chosen",
-        result.get(4).getType(), is(MARINE));
+        "First artillery is not providing support, power of 2",
+        result.get(0).getType(),
+        is(ARTILLERY));
+    assertThat("Marine must be the last to be chosen", result.get(4).getType(), is(MARINE));
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnNapoleonic.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnNapoleonic.java
@@ -90,15 +90,15 @@ class CasualtyOrderOfLossesTestOnNapoleonic {
   private CasualtyOrderOfLosses.Parameters attackingWith(final Collection<Unit> units) {
     return CasualtyOrderOfLosses.Parameters.builder()
         .targetsToPickFrom(units)
+        .player(BRITISH)
+        .enemyUnits(List.of()) // << TODO: remove this parameter should not matter
+        .amphibiousLandAttackers(List.of())
         .combatModifiers(
             CombatModifiers.builder()
                 .defending(false)
                 .amphibious(false)
                 .territoryEffects(List.of())
                 .build())
-        .player(BRITISH)
-        .enemyUnits(List.of())
-        .amphibiousLandAttackers(List.of())
         .battlesite(NORMANDY)
         .costs(COST_MAP)
         .data(data)
@@ -116,8 +116,8 @@ class CasualtyOrderOfLossesTestOnNapoleonic {
 
     assertThat(result, hasSize(4));
     assertThat(result.get(0).getType(), is(HOWITZER));
-    assertThat(result.get(1).getType(), is(HOWITZER));
-    assertThat(result.get(2).getType(), is(FUSILIER));
+    assertThat(result.get(1).getType(), is(FUSILIER));
+    assertThat(result.get(2).getType(), is(HOWITZER));
     assertThat(result.get(3).getType(), is(FUSILIER));
   }
 
@@ -138,8 +138,8 @@ class CasualtyOrderOfLossesTestOnNapoleonic {
     assertThat(result.get(2).getType(), is(FUSILIER));
     assertThat(result.get(3).getType(), is(FUSILIER));
     assertThat(result.get(4).getType(), is(ARTILLERY));
-    assertThat(result.get(5).getType(), is(ARTILLERY));
-    assertThat(result.get(6).getType(), is(GRENADIERS));
+    assertThat(result.get(5).getType(), is(GRENADIERS));
+    assertThat(result.get(6).getType(), is(ARTILLERY));
     assertThat(result.get(7).getType(), is(GRENADIERS));
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/xml/TestDataBigWorld1942V3.java
+++ b/game-core/src/test/java/games/strategy/triplea/xml/TestDataBigWorld1942V3.java
@@ -1,0 +1,89 @@
+package games.strategy.triplea.xml;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
+import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.triplea.attachments.TechAttachment;
+import games.strategy.triplea.delegate.TechAdvance;
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.triplea.java.collections.IntegerMap;
+
+public class TestDataBigWorld1942V3 {
+
+  public final GameData gameData;
+  public final GamePlayer british;
+  public final Territory france;
+
+  public final UnitType tank;
+  public final UnitType infantry;
+  public final UnitType marine;
+  public final UnitType artillery;
+  public final UnitType fighter;
+  public final UnitType bomber;
+  public final IntegerMap<UnitType> costMap;
+
+  public TestDataBigWorld1942V3() {
+    gameData = TestMapGameData.BIG_WORLD_1942_V3.getGameData();
+    british = checkNotNull(gameData.getPlayerList().getPlayerId("British"));
+    france = checkNotNull(gameData.getMap().getTerritory("France"));
+    tank = checkNotNull(gameData.getUnitTypeList().getUnitType("armour"));
+    infantry = checkNotNull(gameData.getUnitTypeList().getUnitType("infantry"));
+    marine = checkNotNull(gameData.getUnitTypeList().getUnitType("marine"));
+    artillery = checkNotNull(gameData.getUnitTypeList().getUnitType("artillery"));
+    fighter = checkNotNull(gameData.getUnitTypeList().getUnitType("fighter"));
+    bomber = checkNotNull(gameData.getUnitTypeList().getUnitType("bomber"));
+
+    costMap =
+        IntegerMap.of(
+            Map.of(
+                marine, 4,
+                artillery, 4,
+                tank, 5,
+                fighter, 10));
+  }
+
+  public Collection<Unit> tank(final int count) {
+    return createUnit(tank, count);
+  }
+
+  public Collection<Unit> infantry(final int count) {
+    return createUnit(infantry, count);
+  }
+
+  public Collection<Unit> marine(final int count) {
+    return createUnit(marine, count);
+  }
+
+  public Collection<Unit> artillery(final int count) {
+    return createUnit(artillery, count);
+  }
+
+  public Collection<Unit> fighter(final int count) {
+    return createUnit(fighter, count);
+  }
+
+  public Collection<Unit> bomber(final int count) {
+    return createUnit(bomber, count);
+  }
+
+  private Collection<Unit> createUnit(final UnitType unitType, final int count) {
+    return IntStream.range(0, count)
+        .mapToObj(i -> new Unit(unitType, british, gameData))
+        .collect(Collectors.toSet());
+  }
+
+  public void addTech(final TechAdvance techAdvance) {
+    final var change =
+        ChangeFactory.attachmentPropertyChange(
+            TechAttachment.get(british), true, techAdvance.getProperty());
+    gameData.performChange(change);
+  }
+}

--- a/java-extras/src/main/java/org/triplea/java/collections/CollectionUtils.java
+++ b/java-extras/src/main/java/org/triplea/java/collections/CollectionUtils.java
@@ -9,11 +9,16 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import javax.annotation.concurrent.ThreadSafe;
 import lombok.experimental.UtilityClass;
+import org.triplea.java.Postconditions;
 
 /** A collection of useful methods for working with instances of {@link Collection}. */
 @ThreadSafe
@@ -112,5 +117,37 @@ public class CollectionUtils {
 
     return Iterables.elementsEqual(c1, c2)
         || (c1.size() == c2.size() && c2.containsAll(c1) && c1.containsAll(c2));
+  }
+
+  public static <T> Collection<T> findMin(
+      final Collection<T> collection, final Function<T, Integer> scoringFunction) {
+    if (collection.isEmpty()) {
+      return Set.of();
+    }
+
+    final Collection<T> results = new HashSet<>();
+    final Iterator<T> iter = collection.iterator();
+
+    final T first = iter.next();
+    results.add(first);
+    int min = scoringFunction.apply(first);
+
+    while (iter.hasNext()) {
+      final T next = iter.next();
+      final int score = scoringFunction.apply(next);
+      if (score <= min) {
+        if (score < min) {
+          results.clear();
+          min = score;
+        }
+        results.add(next);
+      }
+    }
+    Postconditions.assertState(!results.isEmpty());
+    // TODO: enable a debug flag to disable or just move this to a test.
+    for (final T t : collection) {
+      Postconditions.assertState(min <= scoringFunction.apply(t));
+    }
+    return results;
   }
 }


### PR DESCRIPTION
Still quite rough, posting for early feedback. 

The classes to look at would be:
- game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/power/model/SupportBuff.java
- game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/power/model/UnitGroup.java
- game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/OrderOfLossesCalculatorByUnitGroup.java


This update rewrites the default casualty selection logic.
- The performance is starting to approach the original algorithm, still slower but only by 3x. 
- The update fixes a few casualty selection bugs, starting to get some better results, but still need some refinement.

I'll try to break off the test case updates in a near future PR as well as the `CollectionUtils.findMin` function if I can find more usages for it elsewhere.

To summarize the new algorithm:
- we first convert the set of units into a UnitGroup datastructure. The collection of unitGroups are  essentially a pivot table with each unit group storing a count of units, their type, and player. The idea behind this is we can calculate unit powers and supports via simple multiplication and compation and do not need to do iteration.
- for each casualty we ask each unit group what their weakest unit is*
- we add the weakest attacker to the OOL list 
- we subtract one from the corresponding unit group
- we keep iterating until we have selected enough attackers.

* The unit group selects its weakest unit by looking for any units that do not get support, in which case that is the weakest unit. If the unit group is providing support, it computes if there are any units to receive support. If no units are receiving support, then we choose the base power of the unit otherwise we consider the power of the unit to be its base power plus supporting power.

Roll support and strength support are both taken into account, enemy negative buffs are not yet incorporated. Calculating roll support and strength support is quite complex because of potential stacking and needing to choose the best support buff. There likely will be some more updates to the support calculation.

There is room for more performance optimizations:
- currently there is no caching. This is good so far as changes in cost and unit attack and defense strengths due to technology were previously not accounted for once the cache was computed. 
- a significant cost is re-pivoting the set of units to the unit group sets after each casualty is selected, if this can be computed once per battle then things should go much faster.
- there is potential to compute 'n' casualties in one go, IE: choose 80 infantry before selecting a new unit.