### PR TITLE
Fix MoveValidator.java NPEs from player.getData()

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameDataComponent.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameDataComponent.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import javax.annotation.Nullable;
 
 /**
  * Superclass for all game data components (i.e. any domain object contained in an instance of
@@ -18,6 +19,7 @@ public class GameDataComponent implements Serializable {
     this.gameData = gameData;
   }
 
+  @Nullable
   public GameData getData() {
     return gameData;
   }

--- a/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -247,7 +247,9 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
         player == null
             ? neighborFilter
             : neighborFilter.and(
-                t -> MoveValidator.canAnyUnitsPassCanal(territory, t, units, player)));
+                t ->
+                    new MoveValidator(getData())
+                        .canAnyUnitsPassCanal(territory, t, units, player)));
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -2543,7 +2543,8 @@ class ProNonCombatMoveAi {
                       u,
                       player);
           final MoveValidationResult mvr =
-              MoveValidator.validateMove(new MoveDescription(List.of(u), r), player, true, null);
+              new MoveValidator(data)
+                  .validateMove(new MoveDescription(List.of(u), r), player, true, null);
           if (!mvr.isMoveValid()) {
             continue;
           }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
@@ -433,7 +433,7 @@ final class ProTechAi {
           }
           if (sea) {
             final Route r = new Route(neighbor, current);
-            if (MoveValidator.validateCanal(r, null, player) != null) {
+            if (new MoveValidator(data).validateCanal(r, null, player) != null) {
               continue;
             }
           }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -1211,7 +1211,8 @@ public class ProTerritoryManager {
                         ProMatches.territoryCanMoveSeaUnitsThrough(player, data, isCombatMove));
             for (final Territory possibleNeighborTerritory : possibleNeighborTerritories) {
               final Route route = new Route(currentTerritory, possibleNeighborTerritory);
-              if (MoveValidator.validateCanal(route, List.of(myTransportUnit), player) == null) {
+              if (new MoveValidator(data).validateCanal(route, List.of(myTransportUnit), player)
+                  == null) {
                 nextTerritories.add(possibleNeighborTerritory);
               }
             }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -234,7 +234,8 @@ public final class ProMoveUtils {
                 Integer.MIN_VALUE; // Used to move to farthest away loading territory first
             for (final Territory neighbor : neighbors) {
               final Route route = new Route(transportTerritory, neighbor);
-              if (MoveValidator.validateCanal(route, List.of(transport), player) != null) {
+              if (new MoveValidator(data).validateCanal(route, List.of(transport), player)
+                  != null) {
                 continue;
               }
               int distanceFromUnloadTerritory = 0;

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -317,7 +317,7 @@ public class WeakAi extends AbstractAi {
     final Predicate<Territory> routeCond =
         Matches.territoryIsWater()
             .and(Matches.territoryHasEnemyUnits(player, data).negate())
-            .and(Matches.territoryHasNonAllowedCanal(player, null).negate());
+            .and(Matches.territoryHasNonAllowedCanal(player, data).negate());
     Route r = data.getMap().getRoute(start, destination, routeCond);
     if (r == null || r.hasNoSteps() || !routeCond.test(destination)) {
       return null;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
@@ -121,15 +121,16 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
   public abstract String performMove(MoveDescription move);
 
   public static MoveValidationResult validateMove(
+      final GameData gameData,
       final MoveType moveType,
       final MoveDescription move,
       final GamePlayer player,
       final boolean isNonCombat,
       final List<UndoableMove> undoableMoves) {
     if (moveType == MoveType.SPECIAL) {
-      return SpecialMoveDelegate.validateMove(move.getUnits(), move.getRoute(), player);
+      return SpecialMoveDelegate.validateMove(gameData, move.getUnits(), move.getRoute(), player);
     }
-    return MoveValidator.validateMove(move, player, isNonCombat, undoableMoves);
+    return new MoveValidator(gameData).validateMove(move, player, isNonCombat, undoableMoves);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1524,10 +1524,9 @@ public final class Matches {
     return u -> TechTracker.hasImprovedArtillerySupport(u.getOwner());
   }
 
-  // TODO: Eventually remove as only used by AI and doesn't handle canals very well
   public static Predicate<Territory> territoryHasNonAllowedCanal(
-      final GamePlayer player, final Collection<Unit> unitsMoving) {
-    return t -> MoveValidator.validateCanal(new Route(t), unitsMoving, player) != null;
+      final GamePlayer player, final GameData gameData) {
+    return t -> new MoveValidator(gameData).validateCanal(new Route(t), null, player) != null;
   }
 
   public static Predicate<Territory> territoryIsBlockedSea(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -615,8 +615,9 @@ public class MoveDelegate extends AbstractMoveDelegate {
     // the current player
     final GamePlayer player = getUnitsOwner(move.getUnits());
     final MoveValidationResult result =
-        MoveValidator.validateMove(
-            move, player, GameStepPropertiesHelper.isNonCombatMove(data, false), movesToUndo);
+        new MoveValidator(data)
+            .validateMove(
+                move, player, GameStepPropertiesHelper.isNonCombatMove(data, false), movesToUndo);
     final StringBuilder errorMsg = new StringBuilder(100);
     final int numProblems = result.getTotalWarningCount() - (result.hasError() ? 0 : 1);
     final String numErrorsMsg =

--- a/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -104,7 +104,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
     // player.
     final GamePlayer player = getUnitsOwner(units);
     // here we have our own new validation method....
-    final MoveValidationResult result = validateMove(units, route, player);
+    final MoveValidationResult result = validateMove(getData(), units, route, player);
     final StringBuilder errorMsg = new StringBuilder(100);
     final int numProblems = result.getTotalWarningCount() - (result.hasError() ? 0 : 1);
     final String numErrorsMsg =
@@ -173,15 +173,19 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
   }
 
   static MoveValidationResult validateMove(
-      final Collection<Unit> units, final Route route, final GamePlayer player) {
+      final GameData gameData,
+      final Collection<Unit> units,
+      final Route route,
+      final GamePlayer player) {
     final MoveValidationResult result = new MoveValidationResult();
     if (route.hasNoSteps()) {
       return result;
     }
-    if (MoveValidator.validateFirst(units, route, player, result).getError() != null) {
+    if (new MoveValidator(gameData).validateFirst(units, route, player, result).getError()
+        != null) {
       return result;
     }
-    if (MoveValidator.validateFuel(units, route, player, result).getError() != null) {
+    if (new MoveValidator(gameData).validateFuel(units, route, player, result).getError() != null) {
       return result;
     }
     final boolean isEditMode = getEditMode(player.getData());

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -242,7 +242,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     }
     // TODO: This checks for ignored sub/trns and skips the set of the attackers to 0 movement left
     // If attacker stops in an occupied territory, movement stops (battle is optional)
-    if (MoveValidator.onlyIgnoredUnitsOnPath(route, attacker, false)) {
+    if (new MoveValidator(gameData).onlyIgnoredUnitsOnPath(route, attacker, false)) {
       return change;
     }
     change.add(ChangeFactory.markNoMovementChange(nonAir));
@@ -1160,7 +1160,7 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     final Predicate<Territory> canalMatch =
         t -> {
           final Route r = new Route(battleSite, t);
-          return MoveValidator.validateCanal(r, unitsToRetreat, defender) == null;
+          return new MoveValidator(gameData).validateCanal(r, unitsToRetreat, defender) == null;
         };
     final Predicate<Territory> match =
         Matches.territoryIsWater()

--- a/game-core/src/main/java/games/strategy/triplea/util/MovableUnitsFilter.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/MovableUnitsFilter.java
@@ -227,7 +227,8 @@ public final class MovableUnitsFilter {
               : TransportUtils.mapTransports(route, units, transportsToLoad);
       final MoveDescription move =
           new MoveDescription(unitsWithDependents, route, unitsToTransports, dependentUnits);
-      result = AbstractMoveDelegate.validateMove(moveType, move, player, nonCombat, undoableMoves);
+      result =
+          AbstractMoveDelegate.validateMove(data, moveType, move, player, nonCombat, undoableMoves);
     } finally {
       data.releaseReadLock();
     }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MoveValidatorTest.java
@@ -114,35 +114,46 @@ class MoveValidatorTest extends AbstractDelegateTestCase {
     final Route r = new Route(berlin, easternGermany);
     List<Unit> toMove = berlin.getUnitCollection().getMatches(Matches.unitCanMove());
     MoveValidationResult results =
-        MoveValidator.validateMove(new MoveDescription(toMove, r), germans, false, null);
+        new MoveValidator(twwGameData)
+            .validateMove(new MoveDescription(toMove, r), germans, false, null);
     assertTrue(results.isMoveValid());
 
     // Add germanTrain to units which fails since it requires germainRail
     addTo(berlin, GameDataTestUtil.germanTrain(twwGameData).create(1, germans));
     toMove = berlin.getUnitCollection().getMatches(Matches.unitCanMove());
-    results = MoveValidator.validateMove(new MoveDescription(toMove, r), germans, false, null);
+    results =
+        new MoveValidator(twwGameData)
+            .validateMove(new MoveDescription(toMove, r), germans, false, null);
     assertFalse(results.isMoveValid());
 
     // Add germanRail to only destination so it fails
     final Collection<Unit> germanRail = GameDataTestUtil.germanRail(twwGameData).create(1, germans);
     addTo(easternGermany, germanRail);
-    results = MoveValidator.validateMove(new MoveDescription(toMove, r), germans, false, null);
+    results =
+        new MoveValidator(twwGameData)
+            .validateMove(new MoveDescription(toMove, r), germans, false, null);
     assertFalse(results.isMoveValid());
 
     // Add germanRail to start so move succeeds
     addTo(berlin, GameDataTestUtil.germanRail(twwGameData).create(1, germans));
-    results = MoveValidator.validateMove(new MoveDescription(toMove, r), germans, false, null);
+    results =
+        new MoveValidator(twwGameData)
+            .validateMove(new MoveDescription(toMove, r), germans, false, null);
     assertTrue(results.isMoveValid());
 
     // Remove germanRail from destination so move fails
     GameDataTestUtil.removeFrom(easternGermany, germanRail);
-    results = MoveValidator.validateMove(new MoveDescription(toMove, r), germans, false, null);
+    results =
+        new MoveValidator(twwGameData)
+            .validateMove(new MoveDescription(toMove, r), germans, false, null);
     assertFalse(results.isMoveValid());
 
     // Add allied owned germanRail to destination so move succeeds
     final GamePlayer japan = GameDataTestUtil.japan(twwGameData);
     addTo(easternGermany, GameDataTestUtil.germanRail(twwGameData).create(1, japan));
-    results = MoveValidator.validateMove(new MoveDescription(toMove, r), germans, false, null);
+    results =
+        new MoveValidator(twwGameData)
+            .validateMove(new MoveDescription(toMove, r), germans, false, null);
     assertTrue(results.isMoveValid());
   }
 
@@ -160,43 +171,43 @@ class MoveValidatorTest extends AbstractDelegateTestCase {
     GameDataTestUtil.truck(twwGameData).create(1, germans);
     addTo(berlin, GameDataTestUtil.truck(twwGameData).create(1, germans));
     MoveValidationResult results =
-        MoveValidator.validateMove(
-            new MoveDescription(berlin.getUnitCollection(), r), germans, true, null);
+        new MoveValidator(twwGameData)
+            .validateMove(new MoveDescription(berlin.getUnitCollection(), r), germans, true, null);
     assertTrue(results.isMoveValid());
 
     // Add an infantry for truck to transport
     addTo(berlin, GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
     results =
-        MoveValidator.validateMove(
-            new MoveDescription(berlin.getUnitCollection(), r), germans, true, null);
+        new MoveValidator(twwGameData)
+            .validateMove(new MoveDescription(berlin.getUnitCollection(), r), germans, true, null);
     assertTrue(results.isMoveValid());
 
     // Add an infantry and the truck can't transport both
     addTo(berlin, GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
     results =
-        MoveValidator.validateMove(
-            new MoveDescription(berlin.getUnitCollection(), r), germans, true, null);
+        new MoveValidator(twwGameData)
+            .validateMove(new MoveDescription(berlin.getUnitCollection(), r), germans, true, null);
     assertFalse(results.isMoveValid());
 
     // Add a large truck (has capacity for 2 infantry) to transport second infantry
     addTo(berlin, GameDataTestUtil.largeTruck(twwGameData).create(1, germans));
     results =
-        MoveValidator.validateMove(
-            new MoveDescription(berlin.getUnitCollection(), r), germans, true, null);
+        new MoveValidator(twwGameData)
+            .validateMove(new MoveDescription(berlin.getUnitCollection(), r), germans, true, null);
     assertTrue(results.isMoveValid());
 
     // Add an infantry that the large truck can also transport
     addTo(berlin, GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
     results =
-        MoveValidator.validateMove(
-            new MoveDescription(berlin.getUnitCollection(), r), germans, true, null);
+        new MoveValidator(twwGameData)
+            .validateMove(new MoveDescription(berlin.getUnitCollection(), r), germans, true, null);
     assertTrue(results.isMoveValid());
 
     // Add an infantry that can't be transported
     addTo(berlin, GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
     results =
-        MoveValidator.validateMove(
-            new MoveDescription(berlin.getUnitCollection(), r), germans, true, null);
+        new MoveValidator(twwGameData)
+            .validateMove(new MoveDescription(berlin.getUnitCollection(), r), germans, true, null);
     assertFalse(results.isMoveValid());
   }
 
@@ -215,11 +226,12 @@ class MoveValidatorTest extends AbstractDelegateTestCase {
     Map<Unit, Unit> unitsToTransports =
         TransportUtils.mapTransports(r, northernGermany.getUnitCollection(), transport);
     MoveValidationResult results =
-        MoveValidator.validateMove(
-            new MoveDescription(northernGermany.getUnitCollection(), r, unitsToTransports),
-            germans,
-            false,
-            null);
+        new MoveValidator(twwGameData)
+            .validateMove(
+                new MoveDescription(northernGermany.getUnitCollection(), r, unitsToTransports),
+                germans,
+                false,
+                null);
     assertTrue(results.isMoveValid());
 
     // Add USA ship to transport sea zone
@@ -228,11 +240,12 @@ class MoveValidatorTest extends AbstractDelegateTestCase {
     unitsToTransports =
         TransportUtils.mapTransports(r, northernGermany.getUnitCollection(), transport);
     results =
-        MoveValidator.validateMove(
-            new MoveDescription(northernGermany.getUnitCollection(), r, unitsToTransports),
-            germans,
-            false,
-            null);
+        new MoveValidator(twwGameData)
+            .validateMove(
+                new MoveDescription(northernGermany.getUnitCollection(), r, unitsToTransports),
+                germans,
+                false,
+                null);
     assertFalse(results.isMoveValid());
 
     // Set 'Units Can Load In Hostile Sea Zones' to true
@@ -240,11 +253,12 @@ class MoveValidatorTest extends AbstractDelegateTestCase {
     unitsToTransports =
         TransportUtils.mapTransports(r, northernGermany.getUnitCollection(), transport);
     results =
-        MoveValidator.validateMove(
-            new MoveDescription(northernGermany.getUnitCollection(), r, unitsToTransports),
-            germans,
-            false,
-            null);
+        new MoveValidator(twwGameData)
+            .validateMove(
+                new MoveDescription(northernGermany.getUnitCollection(), r, unitsToTransports),
+                germans,
+                false,
+                null);
     assertTrue(results.isMoveValid());
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -1406,7 +1406,8 @@ class WW2V3Year41Test {
         france.getUnitCollection().getMatches(Matches.unitIsAirTransportable());
     assertFalse(paratroopers.isEmpty());
     final MoveValidationResult results =
-        MoveValidator.validateMove(new MoveDescription(paratroopers, r), germans, false, null);
+        new MoveValidator(gameData)
+            .validateMove(new MoveDescription(paratroopers, r), germans, false, null);
     assertFalse(results.isMoveValid());
   }
 
@@ -1427,7 +1428,8 @@ class WW2V3Year41Test {
     toMove.addAll(germany.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()));
     assertEquals(2, toMove.size());
     final MoveValidationResult results =
-        MoveValidator.validateMove(new MoveDescription(toMove, r), germans, false, null);
+        new MoveValidator(gameData)
+            .validateMove(new MoveDescription(toMove, r), germans, false, null);
     assertFalse(results.isMoveValid());
   }
 
@@ -1448,7 +1450,8 @@ class WW2V3Year41Test {
     toMove.addAll(germany.getUnitCollection().getMatches(Matches.unitIsStrategicBomber()));
     assertEquals(2, toMove.size());
     final MoveValidationResult results =
-        MoveValidator.validateMove(new MoveDescription(toMove, r), germans, false, null);
+        new MoveValidator(gameData)
+            .validateMove(new MoveDescription(toMove, r), germans, false, null);
     assertFalse(results.isMoveValid());
   }
 


### PR DESCRIPTION
- Marked GameDataComponent#getGameData as nullable
- The NULL_PLAYER is initialized with a nulled game data, which is then
  retrieved via 'GameDataComponent#getGameData' making it nullable.
  This implies any calls to 'player.getData()' can return a null reference.
- Fix NPE from 'player.getData()' in MoveValidator by making MoveValidator
  stateful, initialize it with a non-null 'GameData' and then use that
  gameData object instead of the potentially null 'player.getGameData'

Fix NPE reported in: https://github.com/triplea-game/triplea/issues/6365


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

