### PR TITLE
Convert 'removeGame' call to lobby to be async

### DIFF
--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/client/connections/GameToLobbyConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/client/connections/GameToLobbyConnection.java
@@ -2,8 +2,11 @@ package org.triplea.http.client.web.socket.client.connections;
 
 import java.net.InetAddress;
 import java.net.URI;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
+import java.util.logging.Level;
 import lombok.Getter;
+import lombok.extern.java.Log;
 import org.triplea.domain.data.ApiKey;
 import org.triplea.domain.data.LobbyGame;
 import org.triplea.http.client.IpAddressParser;
@@ -22,6 +25,7 @@ import org.triplea.http.client.web.socket.messages.WebSocketMessage;
  * a game update so that the lobby updates the game listing. A hosted game will receive messages
  * from lobby for example like a player banned notification.
  */
+@Log
 public class GameToLobbyConnection {
 
   private final HttpLobbyClient lobbyClient;
@@ -64,7 +68,12 @@ public class GameToLobbyConnection {
   }
 
   public void disconnect(final String gameId) {
-    lobbyWatcherClient.removeGame(gameId);
+    CompletableFuture.runAsync(() -> lobbyWatcherClient.removeGame(gameId))
+        .exceptionally(
+            e -> {
+              log.log(Level.INFO, "Could not complete lobby game remove call", e);
+              return null;
+            });
   }
 
   public boolean checkConnectivity(final int localPort) {


### PR DESCRIPTION
If we close a lobby connected game it triggers a 'removeGame' call
to lobby. If that fails with exception, then the shutdown logic
is aborted resulting in a game that stays open.

This update moves the 'removeGame' call to be async so that any
we do not wait for a lobby response to shut down a game and
any exceptions are logged as part of the async call.

Address: https://github.com/triplea-game/triplea/issues/6336


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
- launched a local lobby
- connected to it
- hosted a game
- terminated the local lobby 
- clicked 'quit'
- verified that the game closes.

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

