### PR TITLE
Use a modifiable collection in PlayerAttachment to avoid UnsupportedOperationException

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -244,7 +244,7 @@ public class PlayerAttachment extends DefaultAttachment {
       final int max = currentLimit.getFirst();
       final String type = currentLimit.getSecond();
       final Set<UnitType> unitsToTest = currentLimit.getThird();
-      final Collection<Unit> currentInTerritory = toMoveInto.getUnits();
+      final Collection<Unit> currentInTerritory = new ArrayList<>(toMoveInto.getUnits());
       // first remove units that do not apply to our current type
       if (type.equals("owned")) {
         currentInTerritory.removeAll(


### PR DESCRIPTION
Following shortly after an assignment of a collection we invoke 'removeAll'.
The collection reference passed is an unmodifiable, this is fixed by creating
a modifiable collection copy.

Addresses: https://github.com/triplea-game/triplea/issues/6311


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

