### PR TITLE
Remove unnecessary call to historyPanel.gotoEnd

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -2262,7 +2262,6 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
               historySyncher.deactivate();
               historySyncher = null;
             }
-            historyPanel.goToEnd();
             historyPanel = null;
             mapPanel.getData().removeDataChangeListener(dataChangeListener);
             statsPanel.setGameData(data);


### PR DESCRIPTION
- The call to 'gotoEnd' is unnecessary as in the very next line we null
out the history panel. The 'gotoEnd' does not change how we show the current
game, when re-rendering the history panel we will be at the last node without
this call.

- The 'gotoEnd' can result in a NPE, reported in:
https://github.com/triplea-game/triplea/issues/6366


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

