### PR TITLE
Fix map drag then right click to deselect bug

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
@@ -278,6 +278,7 @@ public class MovePanel extends AbstractMovePanel {
             }
           }
           if (!selectedUnits.isEmpty()) {
+            map.notifyUnitsAreSelected();
             mouseLastUpdatePoint = mouseDetails.getMapPoint();
             final Route route = getRoute(getFirstSelectedTerritory(), t, selectedUnits);
             // Load Bombers with paratroops

--- a/game-core/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
+++ b/game-core/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
@@ -41,6 +41,23 @@ public class ImageScrollerLargeView extends JComponent {
   protected double scale = 1;
   private int dragScrollingLastX;
   private int dragScrollingLastY;
+  /**
+   * 'wasLastActionDragging' tracks if the last user action was right click dragging the map. It is
+   * used so if we have units selected and drag the map that we will not deselect the units. This
+   * relies on the map dragged event happening before the mouse released event where units are
+   * deselected.
+   *
+   * <p>In more detail, on right click map drag we set this flag to true. Then the release event
+   * will fire and if we have any units selected we will check this flag and unset it. If we drag
+   * the map again, we'll again set the flag and the release event will check and unset. This way we
+   * keep our unit selection and wait for a right click that is not followed by a map drag.
+   *
+   * <p>But, if the map is dragged without any units being selected, this puts us in a bad state
+   * where the next right click will no-op. We get into this state because the unit deselect logic
+   * is never invoked and does not clear the flag. Hence the next right click instead of
+   * de-selecting will no-op. To overcome this, whenever units are selected, we'll set this flag
+   * back to false.
+   */
   private boolean wasLastActionDragging = false;
 
   private final ActionListener timerAction =
@@ -222,6 +239,14 @@ public class ImageScrollerLargeView extends JComponent {
       return true;
     }
     return false;
+  }
+
+  /**
+   * Notifies map mouse listener state to know that the last action was units were selected. This
+   * will clear an override that blocks right click dragging from deselecting units.
+   */
+  public void notifyUnitsAreSelected() {
+    wasLastActionDragging = false;
   }
 
   /** For subclasses needing to set the location of the image. */


### PR DESCRIPTION
This update clears map drag state whenever we select a unit. Map drag
state blocks unit deselection. If we drag the map without a unit
selected, then deselecting a unit is incorrectly blocked.

To repro the bug, drag the map, select a unit, then right click. Notice
the unit is not deselected. Right click again, notice the unit is deselected.

With this update the bug is fixed, after selecting a unit, right clicking
will deselect them, right clicking dragging will move the map (and then
right click will deselect, or you can continue right clicking dragging again).


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
- Verified that if you right click drag the map, then select a unit, then right click, it deselects. In 1.9.0.0.13066 this was not the case and you had to right click twice in this scenario.

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes

Fixes the rigtht click case reported in: https://github.com/triplea-game/triplea/issues/6279
