### PR TITLE
Fix escape key, should deselect units

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -284,7 +284,7 @@ public abstract class AbstractMovePanel extends ActionPanel {
           }
           listening = true;
           if (getRootPane() != null) {
-            SwingKeyBinding.addKeyBinding(this, KeyCode.ESCAPE, this::cancelMove);
+            SwingKeyBinding.addKeyBinding(getRootPane(), KeyCode.ESCAPE, this::cancelMove);
           }
         });
   }


### PR DESCRIPTION
Escape key listener to deselect units needs to be attached to move panel
root pane, not the root move panel itself. A recent consolidation
of listeners broke this: a9f88fc

Addresses escape key listener not working, reported in: https://github.com/triplea-game/triplea/issues/6279


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
- did a quick check that after selecting units 'escape' key will deselect them

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->

## Additional Review Notes

Checked 1.9.0.0.13066 code and this was the only place where the root pane was added as the listener target.
