### PR TITLE
WeakAI - handle null capitol lookup

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -66,6 +66,9 @@ public class WeakAi extends AbstractAi {
     }
     final Territory ourCapitol =
         TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
+    if (ourCapitol == null) {
+      return null;
+    }
     final Predicate<Territory> endMatch =
         o -> {
           final boolean impassable =
@@ -1040,8 +1043,10 @@ public class WeakAi extends AbstractAi {
     }
     final @Nullable Territory capitol =
         TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
-    // place in capitol first
-    placeAllWeCanOn(data, capitol, placeDelegate, player);
+    if (capitol != null) {
+      // place in capitol first
+      placeAllWeCanOn(data, capitol, placeDelegate, player);
+    }
     final List<Territory> randomTerritories = new ArrayList<>(data.getMap().getTerritories());
     Collections.shuffle(randomTerritories);
     for (final Territory t : randomTerritories) {


### PR DESCRIPTION
Add some null checks if in case we cannot find a capitol when computing
aphibious routes or when doing placements. The null amphib route
looks to be handled by any caller code, the null capitol lookup will
be handled by skipping capitol placement and weak AI then places
randomly in any available territory it can.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

