### PR TITLE
Update error report title to use TripleA class from stack trace

### DIFF
--- a/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceErrorReportFormatter.java
+++ b/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceErrorReportFormatter.java
@@ -7,6 +7,7 @@ import games.strategy.engine.framework.system.SystemProperties;
 import java.io.ByteArrayOutputStream;
 import java.io.PrintWriter;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Optional;
 import java.util.function.BiFunction;
 import java.util.function.Supplier;
@@ -44,35 +45,85 @@ class StackTraceErrorReportFormatter implements BiFunction<String, LogRecord, Er
    * exception.
    */
   private static String createTitle(final LogRecord logRecord) {
+    // if we have a stack trace with a triplea class in it, use that for the title;
+    // EG: org.triplea.TripleaClass.method:[lineNumber] - [exception]; Caused by: [exception cause]
+    return extractTripleAClassAndLine(logRecord)
+        .map(
+            title ->
+                title + " - " + extractExceptionCauseNameOrUseExceptionName(logRecord.getThrown()))
+        .orElseGet(
+            // Use the log record to create a title.
+            () -> {
+              final String classNameWithoutPackage =
+                  logRecord.getSourceClassName().contains(".")
+                      ? logRecord
+                          .getSourceClassName()
+                          .substring(logRecord.getSourceClassName().lastIndexOf(".") + 1)
+                      : logRecord.getSourceClassName();
 
-    // an exception is optional, eg: 'log.severe("message only, no exception")'
-    final String exceptionNamePrefix =
-        Optional.ofNullable(logRecord.getThrown())
-            .map(Throwable::getClass)
-            .map(Class::getSimpleName)
-            .map(simpleName -> simpleName + " - ")
-            .orElse("");
+              return classNameWithoutPackage
+                  + "#"
+                  + logRecord.getSourceMethodName()
+                  + Optional.ofNullable(logRecord.getMessage())
+                      .map(message -> " - " + message)
+                      .orElse("");
+            });
+  }
 
-    final String classShortName =
-        logRecord.getSourceClassName().contains(".")
-            ? logRecord
-                .getSourceClassName()
-                .substring(logRecord.getSourceClassName().lastIndexOf('.') + 1)
-            : logRecord.getSourceClassName();
+  private static String extractExceptionCauseNameOrUseExceptionName(final Throwable thrown) {
+    return Optional.ofNullable(thrown.getCause()) //
+        .orElse(thrown)
+        .getClass()
+        .getSimpleName();
+  }
 
-    final String sourceLocation = classShortName + "." + logRecord.getSourceMethodName();
+  private static Optional<String> extractTripleAClassAndLine(final LogRecord logRecord) {
+    // Try to use any exception cause if we have it otherwise use our exception.
+    // Once we have an exception send the stack trace for formatting.
+    // If the stack trace contains a triplea class we'll get a formatted message back,
+    // otherwise we will get an empty value back.
+    return Optional.ofNullable(logRecord.getThrown())
+        .map(Throwable::getCause)
+        .or(() -> Optional.ofNullable(logRecord.getThrown()))
+        .map(Throwable::getStackTrace)
+        .map(StackTraceErrorReportFormatter::extractTripleAClassAndLineNumberFromStackTrace);
+  }
 
-    // for title prefer to use the exception message when we have it, if not fall back to the log
-    // message
-    final String message =
-        Optional.ofNullable(
-                Optional.ofNullable(logRecord.getThrown())
-                    .map(Throwable::getMessage)
-                    .orElse(logRecord.getMessage()))
-            .map(m -> ": " + m)
-            .orElse("");
+  /**
+   * Searches a stack trace for the first triplea class reported (as identified by package name),
+   * using that stack trace element we create a formatted message with exception class name, method
+   * name and line number.
+   */
+  @Nullable
+  private static String extractTripleAClassAndLineNumberFromStackTrace(
+      final StackTraceElement[] stackTrace) {
+    return Arrays.stream(stackTrace)
+        .filter(
+            stackTraceElement ->
+                stackTraceElement.getClassName().contains("triplea")
+                    || stackTraceElement.getClassName().contains("games.strategy"))
+        .findFirst()
+        .map(StackTraceErrorReportFormatter::formatStackTraceElement)
+        .orElse(null);
+  }
 
-    return exceptionNamePrefix + sourceLocation + message;
+  /**
+   * Parses a stack trace element to return a value in this format:
+   * [ClassSimpleName]#[MethodName]:[lineNumber]
+   */
+  @Nullable
+  private static String formatStackTraceElement(final StackTraceElement stackTraceElement) {
+    final String fileName = stackTraceElement.getFileName();
+    if (fileName == null) {
+      return null;
+    }
+    final String fileNameWithoutExtension =
+        fileName.contains(".") ? fileName.substring(0, fileName.lastIndexOf('.')) : fileName;
+    return fileNameWithoutExtension
+        + "#"
+        + stackTraceElement.getMethodName()
+        + ":"
+        + stackTraceElement.getLineNumber();
   }
 
   /**


### PR DESCRIPTION
This update changes the preferred title for triplea error report uploads
to look for any exceptions in the reported log record, look for
any exception causes, and if so to look for any TripleA classes
from the stack trace and use that class, method and line number
in the error report title.

For example:

> 2.0.0: PlayerAttachment#getCanTheseUnitsMoveWithoutViolatingStackingLimit:253 - RuntimeException


Before we reported the class name where the logging was being done. For the
general uncaught exception handler this was always where we initialized
the general exception handler and was not as useful, for example:

> NullPointerException - HeadedGameRunner.lambda$initializeClientSettingAndLogging$0


The above example after this update would be instead reported as:

> 2.0.0: TripleAFrame#showGame:2266 - NullPointerException


Noting that the stack trace looked like this:
> games.strategy.triplea.ui.TripleAFrame.lambda$showGame$58(TripleAFrame.java:2266)


If there is no exception message attached to a logging, then we'll go with old
behavior of reporting the class where the logging was done with logging message.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing

Beyond the automated tests, did some additional testing to verify a known case that had an issue title like:

> RuntimeException - HeadedGameRunner.lambda$initializeClientSettingAndLogging$0


With this update, that would appear as:

> 2.0.0: PlayerAttachment#getCanTheseUnitsMoveWithoutViolatingStackingLimit:250 - UnsupportedOperationException


If we instead were to do a logging at that location with an exception:
> 2.0.0: PlayerAttachment#getCanTheseUnitsMoveWithoutViolatingStackingLimit:253 - RuntimeException

And if we do a logging at that location without an exception:
> 2.0.0: PlayerAttachment#getCanTheseUnitsMoveWithoutViolatingStackingLimit - Example message!




<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes

We were getting a number of error reports with titles like this:
> RuntimeException - HeadedGameRunner.lambda$initializeClientSettingAndLogging$0: Exception on remote 


The `initializeClientSettingAndLogging` is where we set our uncaught exception handler, this update essentially tries to avoid having so many titles like that and we instead will favor using exception source location instead of logger location. Furthermore, we are usually interested in the place in TripleA code where an exception was thrown, so there is parsing of  the stack trace to try and find the last triplea class reached before the exception was thrown.

