### PR TITLE
Extract JEditorPane with clickable links to its own class

### DIFF
--- a/swing-lib/src/main/java/org/triplea/swing/JEditorPaneWithClickableLinks.java
+++ b/swing-lib/src/main/java/org/triplea/swing/JEditorPaneWithClickableLinks.java
@@ -1,0 +1,35 @@
+package org.triplea.swing;
+
+import javax.swing.JEditorPane;
+import javax.swing.border.EmptyBorder;
+import javax.swing.event.HyperlinkEvent;
+import org.triplea.awt.OpenFileUtility;
+
+/**
+ * Creates a JEditorPane with clickable HTML links. Text content accepted is HTML, the links should
+ * be HTML style anchor tags with an href.
+ */
+public class JEditorPaneWithClickableLinks extends JEditorPane {
+
+  /** Creates an HTML anchor tag (a link) with given title and link location. */
+  public static String toLink(final String title, final String link) {
+    return String.format("<a href=\"%s\">%s</a>", link, title);
+  }
+
+  public JEditorPaneWithClickableLinks() {
+    this("");
+  }
+
+  public JEditorPaneWithClickableLinks(final String htmlTextContent) {
+    super("text/html", htmlTextContent);
+    setEditable(false);
+    setOpaque(false);
+    setBorder(new EmptyBorder(10, 0, 20, 0));
+    addHyperlinkListener(
+        e -> {
+          if (HyperlinkEvent.EventType.ACTIVATED.equals(e.getEventType())) {
+            OpenFileUtility.openUrl(e.getURL().toString());
+          }
+        });
+  }
+}

--- a/swing-lib/src/main/java/org/triplea/swing/JEditorPaneWithClickableLinks.java
+++ b/swing-lib/src/main/java/org/triplea/swing/JEditorPaneWithClickableLinks.java
@@ -11,11 +11,6 @@ import org.triplea.awt.OpenFileUtility;
  */
 public class JEditorPaneWithClickableLinks extends JEditorPane {
 
-  /** Creates an HTML anchor tag (a link) with given title and link location. */
-  public static String toLink(final String title, final String link) {
-    return String.format("<a href=\"%s\">%s</a>", link, title);
-  }
-
   public JEditorPaneWithClickableLinks() {
     this("");
   }
@@ -31,5 +26,10 @@ public class JEditorPaneWithClickableLinks extends JEditorPane {
             OpenFileUtility.openUrl(e.getURL().toString());
           }
         });
+  }
+
+  /** Creates an HTML anchor tag (a link) with given title and link location. */
+  public static String toLink(final String title, final String link) {
+    return String.format("<a href=\"%s\">%s</a>", link, title);
   }
 }

--- a/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
+++ b/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
@@ -37,8 +37,6 @@ import javax.swing.JTabbedPane;
 import javax.swing.ListModel;
 import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
-import javax.swing.border.EmptyBorder;
-import javax.swing.event.HyperlinkEvent;
 import javax.swing.filechooser.FileFilter;
 import javax.swing.filechooser.FileNameExtensionFilter;
 import lombok.AllArgsConstructor;
@@ -391,16 +389,7 @@ public final class SwingComponents {
 
   /** Displays a pop-up dialog with clickable HTML links. */
   public static void showDialogWithLinks(final DialogWithLinksParams params) {
-    final JEditorPane editorPane = new JEditorPane("text/html", params.dialogText);
-    editorPane.setEditable(false);
-    editorPane.setOpaque(false);
-    editorPane.setBorder(new EmptyBorder(10, 0, 20, 0));
-    editorPane.addHyperlinkListener(
-        e -> {
-          if (HyperlinkEvent.EventType.ACTIVATED.equals(e.getEventType())) {
-            OpenFileUtility.openUrl(e.getURL().toString());
-          }
-        });
+    final JEditorPane editorPane = new JEditorPaneWithClickableLinks(params.dialogText);
 
     final JPanel messageToShow = new JPanelBuilder().border(10).add(editorPane).build();
 


### PR DESCRIPTION
In case we want to use an editor pane with clickable HTML links
on its own without a dialog, this update extracts that to its
own class.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

