### PR TITLE
Fix error report preview window appearing behind error dialog.

### DIFF
--- a/game-core/src/main/java/org/triplea/debug/error/reporting/ReportPreviewSwingView.java
+++ b/game-core/src/main/java/org/triplea/debug/error/reporting/ReportPreviewSwingView.java
@@ -1,16 +1,21 @@
 package org.triplea.debug.error.reporting;
 
+import java.awt.Component;
 import java.util.function.Consumer;
 import javax.swing.JOptionPane;
+import lombok.AllArgsConstructor;
 import org.triplea.http.client.error.report.ErrorReportRequest;
 import org.triplea.swing.JTextAreaBuilder;
 import org.triplea.swing.SwingComponents;
 
+@AllArgsConstructor
 class ReportPreviewSwingView implements Consumer<ErrorReportRequest> {
+  private final Component parent;
+
   @Override
   public void accept(final ErrorReportRequest errorReport) {
     JOptionPane.showMessageDialog(
-        null,
+        parent,
         SwingComponents.newJScrollPane(
             JTextAreaBuilder.builder()
                 .columns(45)

--- a/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceReportView.java
+++ b/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceReportView.java
@@ -42,7 +42,7 @@ public interface StackTraceReportView {
                     .successConfirmation(ConfirmationDialogController::showSuccessConfirmation)
                     .failureConfirmation(ConfirmationDialogController::showFailureConfirmation)
                     .build())
-            .preview(new ReportPreviewSwingView())
+            .preview(new ReportPreviewSwingView(parentWindow))
             .build();
 
     window.bindActions(viewModel);


### PR DESCRIPTION
The error report dialog has a 'preview' button to show what was being
uploaded. The dialog being opened by that was appearing behind
the error dialog. This update fixes it so the preview dialog
appears in front of the error dialog instead of behind.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

