### PR TITLE
Fix lobby chat messages not being sent with 'enter'

### DIFF
--- a/swing-lib/src/main/java/org/triplea/swing/key/binding/SwingKeyBinding.java
+++ b/swing-lib/src/main/java/org/triplea/swing/key/binding/SwingKeyBinding.java
@@ -77,8 +77,9 @@ public class SwingKeyBinding {
 
     final AtomicBoolean enabled = new AtomicBoolean(true);
 
-    if (keyCombination.getButtonDownMask() == ButtonDownMask.NONE
-        || keyCombination.getButtonDownMask() == ButtonDownMask.SHIFT) {
+    if (keyCombination.getKeyCode() != KeyCode.ENTER
+        && (keyCombination.getButtonDownMask() == ButtonDownMask.NONE
+            || keyCombination.getButtonDownMask() == ButtonDownMask.SHIFT)) {
       // Disable single-key keybindings or 'shift+key" keybindings if focus is on a text component.
       // We do not want to fire keybindings while user is typing (chatting).
 


### PR DESCRIPTION
This update fixes it so that pressing enter once again sends chat messages.
The problem was after consolidating all key bindings to use the same utility
class, that utility class suppressed all key actions when a text component
was active (to prevent for example from the 'f' key firing its binding
while a person is simply typing). As part of collateral damage from
this is bindings to the 'enter' key. This update simply creates
an exception for the 'enter' key so if a text component is in focus,
keybindings to the enter key will fire.

Addresses: https://github.com/triplea-game/triplea/issues/6353


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
- verified could send chat messages with enter key on a local lobby instance

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

