### PR TITLE
Add right click menu for moderators to view game chat history

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -55,7 +55,7 @@ public class LobbyFrame extends JFrame implements QuitHandler {
         new LobbyGameTableModel(
             lobbyClient.isModerator(), lobbyClient.getPlayerToLobbyConnection());
     final LobbyGamePanel gamePanel =
-        new LobbyGamePanel(lobbyClient, serverProperties.getUri(), tableModel);
+        new LobbyGamePanel(this, lobbyClient, serverProperties.getUri(), tableModel);
 
     final JSplitPane leftSplit = new JSplitPane();
     leftSplit.setOrientation(JSplitPane.VERTICAL_SPLIT);

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -3,6 +3,7 @@ package games.strategy.engine.lobby.client.ui;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.startup.ui.ServerOptions;
 import games.strategy.engine.lobby.client.LobbyClient;
+import games.strategy.engine.lobby.client.ui.action.FetchChatHistory;
 import java.awt.BorderLayout;
 import java.awt.event.MouseEvent;
 import java.net.URI;
@@ -10,6 +11,7 @@ import java.util.Collection;
 import java.util.List;
 import javax.swing.Action;
 import javax.swing.JButton;
+import javax.swing.JFrame;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
@@ -24,6 +26,7 @@ import org.triplea.swing.SwingAction;
 
 class LobbyGamePanel extends JPanel {
   private static final long serialVersionUID = -2576314388949606337L;
+  private final JFrame parent;
   private JButton joinGame;
   private LobbyGameTableModel gameTableModel;
   private final LobbyClient lobbyClient;
@@ -31,9 +34,11 @@ class LobbyGamePanel extends JPanel {
   private final URI lobbyUri;
 
   LobbyGamePanel(
+      final JFrame parent,
       final LobbyClient lobbyClient,
       final URI lobbyUri,
       final LobbyGameTableModel lobbyGameTableModel) {
+    this.parent = parent;
     this.lobbyClient = lobbyClient;
     this.gameTableModel = lobbyGameTableModel;
     this.lobbyUri = lobbyUri;
@@ -166,7 +171,9 @@ class LobbyGamePanel extends JPanel {
 
   private Collection<Action> getGeneralAdminGamesListContextActions() {
     return List.of(
-        SwingAction.of("Boot Game", e -> bootGame()), SwingAction.of("Shutdown", e -> shutdown()));
+        SwingAction.of("Show Chat History", e -> showChatHistory()),
+        SwingAction.of("Boot Game", e -> bootGame()),
+        SwingAction.of("Shutdown", e -> shutdown()));
   }
 
   private void joinGame() {
@@ -196,6 +203,21 @@ class LobbyGamePanel extends JPanel {
         options.getComments(),
         options.getPassword(),
         lobbyUri);
+  }
+
+  private void showChatHistory() {
+    final int selectedIndex = gameTable.getSelectedRow();
+    if (selectedIndex == -1) {
+      return;
+    }
+
+    FetchChatHistory.builder()
+        .parentWindow(parent)
+        .gameId(gameTableModel.getGameIdForRow(selectedIndex))
+        .gameHostName(gameTableModel.get(selectedIndex).getHostedBy().getName())
+        .playerToLobbyConnection(lobbyClient.getPlayerToLobbyConnection())
+        .build()
+        .fetchAndShowChatHistory();
   }
 
   private void bootGame() {

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/FetchChatHistory.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/FetchChatHistory.java
@@ -1,0 +1,75 @@
+package games.strategy.engine.lobby.client.ui.action;
+
+import java.awt.Component;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.logging.Level;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
+import lombok.Builder;
+import lombok.extern.java.Log;
+import org.triplea.http.client.lobby.moderator.ChatHistoryMessage;
+import org.triplea.http.client.web.socket.client.connections.PlayerToLobbyConnection;
+import org.triplea.java.DateTimeFormatterUtil;
+import org.triplea.swing.JDialogBuilder;
+import org.triplea.swing.JTextAreaBuilder;
+import org.triplea.swing.SwingComponents;
+
+/**
+ * Does an async call to server to fetch chat history for a given game and then renders the returned
+ * results in a dialog box.
+ */
+@Builder
+@Log
+public class FetchChatHistory {
+  @Nonnull private final String gameHostName;
+  @Nonnull private final String gameId;
+  @Nonnull private final JFrame parentWindow;
+  @Nonnull private final PlayerToLobbyConnection playerToLobbyConnection;
+
+  public void fetchAndShowChatHistory() {
+    CompletableFuture.runAsync(
+            () -> {
+              final List<ChatHistoryMessage> chatHistory =
+                  playerToLobbyConnection.fetchChatHistoryForGame(gameId);
+              SwingUtilities.invokeLater(() -> showChatHistory(chatHistory));
+            })
+        .exceptionally(
+            e -> {
+              log.log(Level.SEVERE, "Error fetching game chat history", e);
+              return null;
+            });
+  }
+
+  private void showChatHistory(final List<ChatHistoryMessage> chatHistory) {
+    new JDialogBuilder()
+        .parent(parentWindow)
+        .size(700, 500)
+        .title(
+            String.format(
+                "Game Chat History for: %s, as of %s",
+                gameHostName, DateTimeFormatterUtil.formatInstant(Instant.now())))
+        .add(SwingComponents.newJScrollPane(buildChatHistoryTextArea(chatHistory)))
+        .buildAndShow();
+  }
+
+  private Component buildChatHistoryTextArea(final List<ChatHistoryMessage> chatHistory) {
+    final String text =
+        chatHistory.stream() //
+            .map(FetchChatHistory::toChatLine)
+            .collect(Collectors.joining("\n"));
+
+    return new JTextAreaBuilder().text(text).readOnly().build();
+  }
+
+  private static String toChatLine(final ChatHistoryMessage chatHistoryMessage) {
+    return String.format(
+        "(%s) %s: %s",
+        DateTimeFormatterUtil.formatEpochMilli(chatHistoryMessage.getEpochMilliDate()),
+        chatHistoryMessage.getUsername(),
+        chatHistoryMessage.getMessage());
+  }
+}

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/ChatHistoryMessage.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/ChatHistoryMessage.java
@@ -1,0 +1,20 @@
+package org.triplea.http.client.lobby.moderator;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@EqualsAndHashCode
+@ToString
+@Getter
+public class ChatHistoryMessage {
+  private String username;
+  private long epochMilliDate;
+  private String message;
+}

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/ModeratorChatClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/ModeratorChatClient.java
@@ -1,6 +1,7 @@
 package org.triplea.http.client.lobby.moderator;
 
 import java.net.URI;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import org.triplea.domain.data.ApiKey;
@@ -14,6 +15,7 @@ public class ModeratorChatClient {
   public static final String DISCONNECT_PLAYER_PATH = "/lobby/moderator/disconnect-player";
   public static final String BAN_PLAYER_PATH = "/lobby/moderator/ban-player";
   public static final String FETCH_PLAYER_INFORMATION = "/lobby/moderator/fetch-player-info";
+  public static final String FETCH_GAME_CHAT_HISTORY = "/lobby/moderator/fetch-game-chat-history";
 
   private AuthenticationHeaders authenticationHeaders;
   private ModeratorChatFeignClient moderatorLobbyFeignClient;
@@ -36,5 +38,10 @@ public class ModeratorChatClient {
   public PlayerSummaryForModerator fetchPlayerInformation(final PlayerChatId playerChatId) {
     return moderatorLobbyFeignClient.fetchPlayerInformation(
         authenticationHeaders.createHeaders(), playerChatId.getValue());
+  }
+
+  public List<ChatHistoryMessage> fetchChatHistoryForGame(final String gameId) {
+    return moderatorLobbyFeignClient.fetchChatHistoryForGame(
+        authenticationHeaders.createHeaders(), gameId);
   }
 }

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/ModeratorChatFeignClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/ModeratorChatFeignClient.java
@@ -3,6 +3,7 @@ package org.triplea.http.client.lobby.moderator;
 import feign.HeaderMap;
 import feign.Headers;
 import feign.RequestLine;
+import java.util.List;
 import java.util.Map;
 import org.triplea.http.client.HttpConstants;
 
@@ -18,4 +19,8 @@ public interface ModeratorChatFeignClient {
   @RequestLine("POST " + ModeratorChatClient.FETCH_PLAYER_INFORMATION)
   PlayerSummaryForModerator fetchPlayerInformation(
       @HeaderMap Map<String, Object> headers, String value);
+
+  @RequestLine("POST " + ModeratorChatClient.FETCH_GAME_CHAT_HISTORY)
+  List<ChatHistoryMessage> fetchChatHistoryForGame(
+      @HeaderMap Map<String, Object> headers, String gameId);
 }

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/PlayerChatHistory.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/PlayerChatHistory.java
@@ -1,3 +1,0 @@
-package org.triplea.http.client.lobby.moderator;
-
-public class PlayerChatHistory {}

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/client/connections/PlayerToLobbyConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/client/connections/PlayerToLobbyConnection.java
@@ -12,6 +12,7 @@ import org.triplea.http.client.lobby.HttpLobbyClient;
 import org.triplea.http.client.lobby.game.lobby.watcher.GameListingClient;
 import org.triplea.http.client.lobby.game.lobby.watcher.LobbyGameListing;
 import org.triplea.http.client.lobby.moderator.BanPlayerRequest;
+import org.triplea.http.client.lobby.moderator.ChatHistoryMessage;
 import org.triplea.http.client.lobby.moderator.PlayerSummaryForModerator;
 import org.triplea.http.client.lobby.moderator.toolbox.HttpModeratorToolboxClient;
 import org.triplea.http.client.web.socket.GenericWebSocketClient;
@@ -125,5 +126,9 @@ public class PlayerToLobbyConnection {
 
   public PlayerSummaryForModerator fetchPlayerInformation(final PlayerChatId playerChatId) {
     return httpLobbyClient.getModeratorLobbyClient().fetchPlayerInformation(playerChatId);
+  }
+
+  public List<ChatHistoryMessage> fetchChatHistoryForGame(final String gameId) {
+    return httpLobbyClient.getModeratorLobbyClient().fetchChatHistoryForGame(gameId);
   }
 }

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/ModeratorChatClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/ModeratorChatClientTest.java
@@ -2,10 +2,13 @@ package org.triplea.http.client.lobby.moderator;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
 import static org.triplea.http.client.HttpClientTesting.EXPECTED_API_KEY;
 
 import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.triplea.domain.data.PlayerChatId;
 import org.triplea.http.client.AuthenticationHeaders;
@@ -19,6 +22,30 @@ class ModeratorChatClientTest extends WireMockTest {
           .banMinutes(20)
           .build();
   private static final PlayerChatId PLAYER_CHAT_ID = PlayerChatId.of("player-chat-id");
+
+  private static final PlayerSummaryForModerator PLAYER_SUMMARY_FOR_MODERATOR =
+      PlayerSummaryForModerator.builder()
+          .name("name")
+          .systemId("system-id")
+          .ip("5.5.3.3")
+          .aliases(List.of())
+          .bans(
+              List.of(
+                  PlayerSummaryForModerator.BanInformation.builder()
+                      .epochMillEndDate(1000)
+                      .epochMilliStartDate(2000)
+                      .name("name-banned")
+                      .systemId("id")
+                      .ip("ip")
+                      .build()))
+          .build();
+
+  private static final ChatHistoryMessage CHAT_HISTORY_MESSAGE =
+      ChatHistoryMessage.builder()
+          .username("chatter")
+          .message("Message")
+          .epochMilliDate(6000)
+          .build();
 
   private static ModeratorChatClient newClient(final WireMockServer wireMockServer) {
     return newClient(wireMockServer, ModeratorChatClient::newClient);
@@ -52,8 +79,28 @@ class ModeratorChatClientTest extends WireMockTest {
         WireMock.post(ModeratorChatClient.FETCH_PLAYER_INFORMATION)
             .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
             .withRequestBody(equalTo(PLAYER_CHAT_ID.getValue()))
-            .willReturn(WireMock.aResponse().withStatus(200)));
+            .willReturn(
+                WireMock.aResponse()
+                    .withStatus(200)
+                    .withBody(toJson(PLAYER_SUMMARY_FOR_MODERATOR))));
 
-    newClient(server).fetchPlayerInformation(PLAYER_CHAT_ID);
+    final var result = newClient(server).fetchPlayerInformation(PLAYER_CHAT_ID);
+    assertThat(result, is(PLAYER_SUMMARY_FOR_MODERATOR));
+  }
+
+  @Test
+  void fetchGameChatHistory(@WiremockResolver.Wiremock final WireMockServer server) {
+    server.stubFor(
+        WireMock.post(ModeratorChatClient.FETCH_GAME_CHAT_HISTORY)
+            .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
+            .withRequestBody(equalTo("game-id"))
+            .willReturn(
+                WireMock.aResponse()
+                    .withStatus(200)
+                    .withBody(toJson(List.of(CHAT_HISTORY_MESSAGE)))));
+
+    final List<ChatHistoryMessage> chats = newClient(server).fetchChatHistoryForGame("game-id");
+
+    assertThat(chats.get(0), is(CHAT_HISTORY_MESSAGE));
   }
 }

--- a/http-server/src/main/java/org/triplea/db/JdbiDatabase.java
+++ b/http-server/src/main/java/org/triplea/db/JdbiDatabase.java
@@ -14,6 +14,7 @@ import org.triplea.db.dao.api.key.ApiKeyLookupRecord;
 import org.triplea.db.dao.api.key.GamePlayerLookup;
 import org.triplea.db.dao.moderator.ModeratorAuditHistoryDaoData;
 import org.triplea.db.dao.moderator.ModeratorUserDaoData;
+import org.triplea.db.dao.moderator.chat.history.ChatHistoryRecord;
 import org.triplea.db.dao.moderator.player.info.PlayerAliasRecord;
 import org.triplea.db.dao.moderator.player.info.PlayerBanRecord;
 import org.triplea.db.dao.user.ban.BanLookupRecord;
@@ -53,6 +54,7 @@ public final class JdbiDatabase {
   public static void registerRowMappers(final Jdbi jdbi) {
     jdbi.registerRowMapper(AccessLogRecord.class, AccessLogRecord.buildResultMapper());
     jdbi.registerRowMapper(BanLookupRecord.class, BanLookupRecord.buildResultMapper());
+    jdbi.registerRowMapper(ChatHistoryRecord.class, ChatHistoryRecord.buildResultMapper());
     jdbi.registerRowMapper(GamePlayerLookup.class, GamePlayerLookup.buildResultMapper());
     jdbi.registerRowMapper(ApiKeyLookupRecord.class, ApiKeyLookupRecord.buildResultMapper());
     jdbi.registerRowMapper(PlayerAliasRecord.class, PlayerAliasRecord.buildResultMapper());

--- a/http-server/src/main/java/org/triplea/db/dao/moderator/chat/history/ChatHistoryRecord.java
+++ b/http-server/src/main/java/org/triplea/db/dao/moderator/chat/history/ChatHistoryRecord.java
@@ -1,0 +1,39 @@
+package org.triplea.db.dao.moderator.chat.history;
+
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.triplea.db.TimestampMapper;
+import org.triplea.http.client.lobby.moderator.ChatHistoryMessage;
+
+/** Represents most of a row of the game_chat_history table, who said what and when. */
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class ChatHistoryRecord {
+  private Instant date;
+  private String username;
+  private String message;
+
+  /** Returns a JDBI row mapper used to convert results into an instance of this bean object. */
+  public static RowMapper<ChatHistoryRecord> buildResultMapper() {
+    return (rs, ctx) ->
+        ChatHistoryRecord.builder()
+            .date(TimestampMapper.map(rs, "date"))
+            .username(rs.getString("username"))
+            .message(rs.getString("message"))
+            .build();
+  }
+
+  public ChatHistoryMessage toChatHistoryMessage() {
+    return ChatHistoryMessage.builder()
+        .epochMilliDate(date.toEpochMilli())
+        .username(username)
+        .message(message)
+        .build();
+  }
+}

--- a/http-server/src/main/java/org/triplea/db/dao/moderator/chat/history/GameChatHistoryDao.java
+++ b/http-server/src/main/java/org/triplea/db/dao/moderator/chat/history/GameChatHistoryDao.java
@@ -1,0 +1,24 @@
+package org.triplea.db.dao.moderator.chat.history;
+
+import java.util.List;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+
+/**
+ * DAO to access history of in-game chat messages stored in database. Chat messages are stored for
+ * all lobby-connected games.
+ */
+public interface GameChatHistoryDao {
+
+  @SqlQuery(
+      "select "
+          + "    gch.date,"
+          + "    gch.username,"
+          + "    gch.message"
+          + "  from game_chat_history gch"
+          + "  join lobby_game lg on lg.id = gch.lobby_game_id"
+          + "  where"
+          + "    lg.game_id = :gameId"
+          + "    and date > (now() - '6 hour'::interval)")
+  List<ChatHistoryRecord> getChatHistory(@Bind("gameId") String gameId);
+}

--- a/http-server/src/main/java/org/triplea/http/ServerApplication.java
+++ b/http-server/src/main/java/org/triplea/http/ServerApplication.java
@@ -50,6 +50,7 @@ import org.triplea.modules.moderation.audit.history.ModeratorAuditHistoryControl
 import org.triplea.modules.moderation.bad.words.BadWordsController;
 import org.triplea.modules.moderation.ban.name.UsernameBanController;
 import org.triplea.modules.moderation.ban.user.UserBanController;
+import org.triplea.modules.moderation.chat.history.GameChatHistoryController;
 import org.triplea.modules.moderation.disconnect.user.DisconnectUserController;
 import org.triplea.modules.moderation.moderators.ModeratorsController;
 import org.triplea.modules.moderation.player.info.PlayerInfoController;
@@ -223,6 +224,7 @@ public class ServerApplication extends Application<AppConfig> {
         CreateAccountController.build(jdbi),
         DisconnectUserController.build(jdbi, chatters, playerMessagingBus),
         ForgotPasswordController.build(appConfig, jdbi),
+        GameChatHistoryController.build(jdbi),
         GameHostingController.build(jdbi),
         GameListingController.build(gameListing),
         LobbyWatcherController.build(jdbi, gameListing),

--- a/http-server/src/main/java/org/triplea/modules/moderation/chat/history/FetchGameChatHistoryModule.java
+++ b/http-server/src/main/java/org/triplea/modules/moderation/chat/history/FetchGameChatHistoryModule.java
@@ -1,0 +1,26 @@
+package org.triplea.modules.moderation.chat.history;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import org.jdbi.v3.core.Jdbi;
+import org.triplea.db.dao.moderator.chat.history.ChatHistoryRecord;
+import org.triplea.db.dao.moderator.chat.history.GameChatHistoryDao;
+import org.triplea.http.client.lobby.moderator.ChatHistoryMessage;
+
+@AllArgsConstructor
+class FetchGameChatHistoryModule implements Function<String, List<ChatHistoryMessage>> {
+  private final GameChatHistoryDao gameChatHistoryDao;
+
+  static FetchGameChatHistoryModule build(final Jdbi jdbi) {
+    return new FetchGameChatHistoryModule(jdbi.onDemand(GameChatHistoryDao.class));
+  }
+
+  @Override
+  public List<ChatHistoryMessage> apply(final String gameId) {
+    return gameChatHistoryDao.getChatHistory(gameId).stream()
+        .map(ChatHistoryRecord::toChatHistoryMessage)
+        .collect(Collectors.toList());
+  }
+}

--- a/http-server/src/main/java/org/triplea/modules/moderation/chat/history/GameChatHistoryController.java
+++ b/http-server/src/main/java/org/triplea/modules/moderation/chat/history/GameChatHistoryController.java
@@ -1,0 +1,38 @@
+package org.triplea.modules.moderation.chat.history;
+
+import es.moki.ratelimij.dropwizard.annotation.Rate;
+import es.moki.ratelimij.dropwizard.annotation.RateLimited;
+import es.moki.ratelimij.dropwizard.filter.KeyPart;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import javax.annotation.security.RolesAllowed;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import org.jdbi.v3.core.Jdbi;
+import org.triplea.db.dao.user.role.UserRole;
+import org.triplea.http.HttpController;
+import org.triplea.http.client.lobby.moderator.ChatHistoryMessage;
+import org.triplea.http.client.lobby.moderator.ModeratorChatClient;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@RolesAllowed(UserRole.MODERATOR)
+public class GameChatHistoryController extends HttpController {
+
+  private final Function<String, List<ChatHistoryMessage>> fetchChatHistoryAction;
+
+  public static GameChatHistoryController build(final Jdbi jdbi) {
+    return new GameChatHistoryController(FetchGameChatHistoryModule.build(jdbi));
+  }
+
+  @POST
+  @Path(ModeratorChatClient.FETCH_GAME_CHAT_HISTORY)
+  @RateLimited(
+      keys = {KeyPart.IP},
+      rates = {@Rate(limit = 10, duration = 1, timeUnit = TimeUnit.MINUTES)})
+  public List<ChatHistoryMessage> fetchGameChatHistory(final String gameId) {
+    return fetchChatHistoryAction.apply(gameId);
+  }
+}

--- a/http-server/src/test/java/org/triplea/db/dao/moderator/chat/history/ChatHistoryRecordTest.java
+++ b/http-server/src/test/java/org/triplea/db/dao/moderator/chat/history/ChatHistoryRecordTest.java
@@ -1,0 +1,23 @@
+package org.triplea.db.dao.moderator.chat.history;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+
+class ChatHistoryRecordTest {
+
+  @Test
+  void toChatHistoryMessage() {
+    final var chatHistoryRecord =
+        ChatHistoryRecord.builder().date(Instant.now()).message("message").username("user").build();
+
+    final var chatHistoryMessage = chatHistoryRecord.toChatHistoryMessage();
+
+    assertThat(
+        chatHistoryMessage.getEpochMilliDate(), is(chatHistoryRecord.getDate().toEpochMilli()));
+    assertThat(chatHistoryMessage.getUsername(), is(chatHistoryRecord.getUsername()));
+    assertThat(chatHistoryMessage.getMessage(), is(chatHistoryRecord.getMessage()));
+  }
+}

--- a/http-server/src/test/java/org/triplea/db/dao/moderator/chat/history/GameChatHistoryDaoTest.java
+++ b/http-server/src/test/java/org/triplea/db/dao/moderator/chat/history/GameChatHistoryDaoTest.java
@@ -1,0 +1,88 @@
+package org.triplea.db.dao.moderator.chat.history;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.core.Is.is;
+import static org.triplea.test.common.IsInstant.isInstant;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import java.util.List;
+import org.hamcrest.collection.IsCollectionWithSize;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.triplea.db.dao.DaoTest;
+
+@DataSet(cleanBefore = true, value = "chat_history/select_game_chat_history.yml")
+class GameChatHistoryDaoTest extends DaoTest {
+  private static final String SIR_HOSTS_A_LOT = "sir_hosts_a_lot";
+  private static final String SIR_HOSTS_A_LITTLE = "sir_hosts_a_little";
+  private static final String PLAYER1 = "player1";
+
+  private final GameChatHistoryDao gameChatHistoryDao = DaoTest.newDao(GameChatHistoryDao.class);
+
+  @Test
+  void gameDoesNotExist() {
+    assertThat(gameChatHistoryDao.getChatHistory("dne"), is(empty()));
+  }
+
+  @Test
+  @DisplayName("Chat history for a game with no chat messages should be empty")
+  void emptyChatHistory() {
+    assertThat(gameChatHistoryDao.getChatHistory("game-empty-chat"), is(empty()));
+  }
+
+  @Test
+  @DisplayName("Chat history does not select all chat messages, only recent past")
+  void oldChatMessagesAreFiltered() {
+    assertThat(gameChatHistoryDao.getChatHistory("game-far-past"), is(empty()));
+  }
+
+  @Test
+  void viewChatHistoryForSirHostALotsGame() {
+    final List<ChatHistoryRecord> chats = gameChatHistoryDao.getChatHistory("game-hosts-a-lot");
+
+    assertThat(chats, IsCollectionWithSize.hasSize(4));
+
+    int i = 0;
+    assertThat(chats.get(i).getUsername(), is(PLAYER1));
+    assertThat(chats.get(i).getDate(), isInstant(2100, 1, 1, 23, 0, 20));
+    assertThat(chats.get(i).getMessage(), is("Hello good sir"));
+
+    i++;
+    assertThat(chats.get(i).getUsername(), is(SIR_HOSTS_A_LOT));
+    assertThat(chats.get(i).getDate(), isInstant(2100, 1, 1, 23, 1, 20));
+    assertThat(chats.get(i).getMessage(), is("Why hello to you"));
+
+    i++;
+    assertThat(chats.get(i).getUsername(), is(PLAYER1));
+    assertThat(chats.get(i).getDate(), isInstant(2100, 1, 1, 23, 2, 20));
+    assertThat(chats.get(i).getMessage(), is("What a fine day it is my good sir"));
+
+    i++;
+    assertThat(chats.get(i).getUsername(), is(SIR_HOSTS_A_LOT));
+    assertThat(chats.get(i).getDate(), isInstant(2100, 1, 1, 23, 3, 20));
+    assertThat(chats.get(i).getMessage(), is("What a fine day it is indeed!"));
+  }
+
+  @Test
+  void viewChatHistoryForSirHostALittlesGame() {
+    final List<ChatHistoryRecord> chats = gameChatHistoryDao.getChatHistory("game-hosts-a-little");
+
+    assertThat(chats, IsCollectionWithSize.hasSize(3));
+
+    int i = 0;
+    assertThat(chats.get(i).getUsername(), is(SIR_HOSTS_A_LITTLE));
+    assertThat(chats.get(i).getDate(), isInstant(2100, 1, 1, 23, 1, 20));
+    assertThat(chats.get(i).getMessage(), is("hello!"));
+
+    i++;
+    assertThat(chats.get(i).getUsername(), is(SIR_HOSTS_A_LOT));
+    assertThat(chats.get(i).getDate(), isInstant(2100, 1, 1, 23, 2, 20));
+    assertThat(chats.get(i).getMessage(), is("join my game?"));
+
+    i++;
+    assertThat(chats.get(i).getUsername(), is(SIR_HOSTS_A_LITTLE));
+    assertThat(chats.get(i).getDate(), isInstant(2100, 1, 1, 23, 3, 20));
+    assertThat(chats.get(i).getMessage(), is("Maybe another day"));
+  }
+}

--- a/http-server/src/test/java/org/triplea/modules/moderation/chat/history/FetchGameChatHistoryModuleTest.java
+++ b/http-server/src/test/java/org/triplea/modules/moderation/chat/history/FetchGameChatHistoryModuleTest.java
@@ -1,0 +1,60 @@
+package org.triplea.modules.moderation.chat.history;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.db.dao.moderator.chat.history.ChatHistoryRecord;
+import org.triplea.db.dao.moderator.chat.history.GameChatHistoryDao;
+import org.triplea.http.client.lobby.moderator.ChatHistoryMessage;
+
+@ExtendWith(MockitoExtension.class)
+class FetchGameChatHistoryModuleTest {
+
+  private static final ChatHistoryRecord CHAT_HISTORY_RECORD_0 =
+      ChatHistoryRecord.builder() //
+          .username("user")
+          .message("message")
+          .date(Instant.now())
+          .build();
+
+  private static final ChatHistoryRecord CHAT_HISTORY_RECORD_1 =
+      ChatHistoryRecord.builder() //
+          .username("user2")
+          .message(" ")
+          .date(Instant.EPOCH)
+          .build();
+
+  @Mock private GameChatHistoryDao gameChatHistoryDao;
+
+  @InjectMocks private FetchGameChatHistoryModule fetchGameChatHistoryModule;
+
+  @Test
+  void emptyCase() {
+    when(gameChatHistoryDao.getChatHistory("game-id")).thenReturn(List.of());
+
+    assertThat(fetchGameChatHistoryModule.apply("game-id"), is(empty()));
+  }
+
+  @Test
+  void convertsChatRecordsToChatHistoryMessagesInOrder() {
+    when(gameChatHistoryDao.getChatHistory("game-id"))
+        .thenReturn(List.of(CHAT_HISTORY_RECORD_0, CHAT_HISTORY_RECORD_1));
+
+    final List<ChatHistoryMessage> results = fetchGameChatHistoryModule.apply("game-id");
+
+    assertThat(results, hasSize(2));
+
+    assertThat(results.get(0), is(CHAT_HISTORY_RECORD_0.toChatHistoryMessage()));
+    assertThat(results.get(1), is(CHAT_HISTORY_RECORD_1.toChatHistoryMessage()));
+  }
+}

--- a/http-server/src/test/java/org/triplea/modules/moderation/chat/history/GameChatHistoryControllerIntegrationTest.java
+++ b/http-server/src/test/java/org/triplea/modules/moderation/chat/history/GameChatHistoryControllerIntegrationTest.java
@@ -1,0 +1,18 @@
+package org.triplea.modules.moderation.chat.history;
+
+import org.junit.jupiter.api.Test;
+import org.triplea.http.client.lobby.moderator.ModeratorChatClient;
+import org.triplea.modules.http.AllowedUserRole;
+import org.triplea.modules.http.ProtectedEndpointTest;
+
+class GameChatHistoryControllerIntegrationTest extends ProtectedEndpointTest<ModeratorChatClient> {
+
+  GameChatHistoryControllerIntegrationTest() {
+    super(AllowedUserRole.MODERATOR, ModeratorChatClient::newClient);
+  }
+
+  @Test
+  void fetchGameChatHistory() {
+    verifyEndpoint(client -> client.fetchChatHistoryForGame("game-id"));
+  }
+}

--- a/http-server/src/test/resources/datasets/chat_history/select_game_chat_history.yml
+++ b/http-server/src/test/resources/datasets/chat_history/select_game_chat_history.yml
@@ -1,0 +1,73 @@
+game_hosting_api_key:
+ - id: 70000
+   key: "key0"
+   ip: "1.1.1.1"
+   date_created: 2000-01-01 23:59:20.0
+ - id: 70001
+   key: "key1"
+   ip: "1.1.1.1"
+   date_created: 2000-01-01 23:59:20.0
+
+lobby_game:
+  - id: 6000
+    host_name: "sir_hosts_a_lot"
+    game_id: "game-hosts-a-lot"
+    game_hosting_api_key_id: 70000
+    date_created: 2000-01-01 23:59:20.0
+  - id: 6001
+    host_name: "sir_hosts_a_lot"
+    game_id: "game-empty-chat"
+    game_hosting_api_key_id: 70000
+    date_created: 2000-01-01 23:59:20.0
+  - id: 6002
+    host_name: "sir_hosts_a_little"
+    game_id: "game-hosts-a-little"
+    game_hosting_api_key_id: 70000
+    date_created: 2000-01-01 23:59:20.0
+  - id: 7000
+    host_name: "sir_hosts_a_little"
+    game_id: "game-far-past"
+    game_hosting_api_key_id: 70001
+    date_created: 2001-01-01 23:59:20.0
+
+game_chat_history:
+  - id: 500
+    lobby_game_id: 6000
+    date: 2100-01-01 23:00:20.0
+    username: "player1"
+    message: "Hello good sir"
+  - id: 501
+    lobby_game_id: 6000
+    date: 2100-01-01 23:01:20.0
+    username: "sir_hosts_a_lot"
+    message: "Why hello to you"
+  - id: 502
+    lobby_game_id: 6000
+    date: 2100-01-01 23:02:20.0
+    username: "player1"
+    message: "What a fine day it is my good sir"
+  - id: 503
+    lobby_game_id: 6000
+    date: 2100-01-01 23:03:20.0
+    username: "sir_hosts_a_lot"
+    message: "What a fine day it is indeed!"
+  - id: 504
+    lobby_game_id: 6002
+    date: 2100-01-01 23:01:20.0
+    username: "sir_hosts_a_little"
+    message: "hello!"
+  - id: 505
+    lobby_game_id: 6002
+    date: 2100-01-01 23:02:20.0
+    username: "sir_hosts_a_lot"
+    message: "join my game?"
+  - id: 506
+    lobby_game_id: 6002
+    date: 2100-01-01 23:03:20.0
+    username: "sir_hosts_a_little"
+    message: "Maybe another day"
+  - id: 507
+    lobby_game_id: 7000
+    date: 2000-01-01 23:03:20.0
+    username: "sir_hosts_a_little"
+    message: "this is a very old message"

--- a/java-extras/src/main/java/org/triplea/java/DateTimeFormatterUtil.java
+++ b/java-extras/src/main/java/org/triplea/java/DateTimeFormatterUtil.java
@@ -12,18 +12,27 @@ import lombok.experimental.UtilityClass;
 public class DateTimeFormatterUtil {
 
   /**
+   * Converts an instant into a Date formatted string that contains the date and timezone offset.
+   * EG: "2000-12-1 23:59 (GMT-5)"
+   */
+  public static String formatInstant(final Instant instant) {
+    return formatEpochMilli(instant, Locale.getDefault(), ZoneId.systemDefault());
+  }
+
+  /**
    * Converts an epoch milli timestamp into a Date formatted string that contains the date and
    * timezone offset. EG: "2000-12-1 23:59 (GMT-5)"
    */
   public static String formatEpochMilli(final long epochMilli) {
-    return formatEpochMilli(epochMilli, Locale.getDefault(), ZoneId.systemDefault());
+    return formatEpochMilli(
+        Instant.ofEpochMilli(epochMilli), Locale.getDefault(), ZoneId.systemDefault());
   }
 
   @VisibleForTesting
-  static String formatEpochMilli(final long epochMilli, final Locale locale, final ZoneId zoneId) {
+  static String formatEpochMilli(final Instant instant, final Locale locale, final ZoneId zoneId) {
     return DateTimeFormatter.ofPattern("y-M-d H:m (O)")
         .withLocale(locale)
         .withZone(zoneId)
-        .format(Instant.ofEpochMilli(epochMilli));
+        .format(instant);
   }
 }

--- a/java-extras/src/test/java/org/triplea/java/DateTimeFormatterUtilTest.java
+++ b/java-extras/src/test/java/org/triplea/java/DateTimeFormatterUtilTest.java
@@ -3,6 +3,7 @@ package org.triplea.java;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
+import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
@@ -18,8 +19,9 @@ class DateTimeFormatterUtilTest {
 
   @Test
   void verifyFormatting() {
-    final String result = //
-        DateTimeFormatterUtil.formatEpochMilli(DEC_FIRST_EPOCH_MILLIS, Locale.ENGLISH, ZONE_ID);
+    final String result =
+        DateTimeFormatterUtil.formatEpochMilli(
+            Instant.ofEpochMilli(DEC_FIRST_EPOCH_MILLIS), Locale.ENGLISH, ZONE_ID);
     assertThat(result, is("2000-12-1 23:59 (GMT+8)"));
   }
 }

--- a/lobby-db/src/main/resources/db/migration/V2.00.03__change_game_history_index.sql
+++ b/lobby-db/src/main/resources/db/migration/V2.00.03__change_game_history_index.sql
@@ -1,0 +1,11 @@
+drop index lobby_game_host_name_game_id;
+create index lobby_game_game_id on lobby_game (game_id);
+
+alter table lobby_chat_history
+    alter column date type timestamptz;
+alter table game_chat_history
+    alter column date type timestamptz;
+alter table lobby_game
+    alter column date_created type timestamptz;
+alter table bad_word
+    alter column date_created type timestamptz;

--- a/swing-lib/src/main/java/org/triplea/swing/JDialogBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/JDialogBuilder.java
@@ -1,0 +1,75 @@
+package org.triplea.swing;
+
+import com.google.common.base.Preconditions;
+import java.awt.Component;
+import java.awt.Dimension;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
+
+/**
+ * Builder to construct a JDialog. A JDialog is essentially a pop-up window, it generally should be
+ * used in preference to using a JFrame.
+ *
+ * <p>Example usage: <code>
+ *   new JDialogBuilder()
+ *     .parent(parentFrame)
+ *     .title("Title of the dialog")
+ *     .add(new JLabel("A label"))
+ *     .add(new JButton("A Button"))
+ *     .buildAndShow();
+ * </code>
+ */
+public class JDialogBuilder {
+
+  private JFrame parent;
+  private String title;
+  private Dimension size;
+  private final List<Component> components = new ArrayList<>();
+
+  public JDialog build() {
+    Preconditions.checkNotNull(parent);
+    Preconditions.checkNotNull(title);
+
+    final JDialog dialog = new JDialog(parent, title);
+    components.forEach(component -> dialog.getContentPane().add(component));
+    dialog.setLocationRelativeTo(parent);
+    dialog.pack();
+    Optional.ofNullable(size).ifPresent(dialog::setSize);
+    return dialog;
+  }
+
+  public JDialog buildAndShow() {
+    final JDialog dialog = build();
+    dialog.setVisible(true);
+    return dialog;
+  }
+
+  public JDialogBuilder parent(final JFrame parent) {
+    this.parent = parent;
+    return this;
+  }
+
+  public JDialogBuilder title(final String title) {
+    this.title = title;
+    return this;
+  }
+
+  public JDialogBuilder add(final Component component) {
+    components.add(component);
+    return this;
+  }
+
+  public JDialogBuilder add(final Collection<Component> components) {
+    this.components.addAll(components);
+    return this;
+  }
+
+  public JDialogBuilder size(final int width, final int height) {
+    size = new Dimension(width, height);
+    return this;
+  }
+}

--- a/swing-lib/src/main/java/org/triplea/swing/JTextAreaBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/JTextAreaBuilder.java
@@ -37,7 +37,7 @@ public final class JTextAreaBuilder {
   private boolean selectAllOnFocus;
   @Nullable private String toolTip;
 
-  private JTextAreaBuilder() {}
+  public JTextAreaBuilder() {}
 
   public static JTextAreaBuilder builder() {
     return new JTextAreaBuilder();


### PR DESCRIPTION
Enables a 'show chat history" option for moderators to view the chat
history of any lobby game.

Change summary:
- add moderator right click option
- add client side module to query lobby for chat history of a game id
  and display results in a pop-up in a text area box
- add http client call to fetch game chat history
- add moderator only http server endpoint to fetch game chat history
- add http server chat history module to request chat history
  from DB and marshall into a response object
- adds a game chat history DAO to query game chat history table.

Of note:
- changed indices on lobby_game table to match expected query pattern
- changed types of date columns that did not have timezones. Testing
  revealed that timestamps returned from those tables were in local
  time, these were all changed to be 'timestamptz' to keep all times
  in UTC (the only non-UTC times should be when we are displaying a
  last-mile date value to a user, otherwise we want all UTC or epoch
  millis everywhere else).


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[x] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
- manual verified UI on a local lobby

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
## Screens Shots
![Screenshot from 2020-05-05 18-15-28](https://user-images.githubusercontent.com/12397753/81130395-71c72200-8efc-11ea-91c5-0c57294ca7f2.png)

![Screenshot from 2020-05-05 18-13-58](https://user-images.githubusercontent.com/12397753/81130394-712e8b80-8efc-11ea-86dc-e483e9021a77.png)

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

