### PR TITLE
Add an API to specify tables by rows with mapper

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/player/info/PlayerAliasesTab.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/player/info/PlayerAliasesTab.java
@@ -1,7 +1,7 @@
 package games.strategy.engine.lobby.client.ui.action.player.info;
 
 import java.awt.Component;
-import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
@@ -26,21 +26,19 @@ class PlayerAliasesTab {
 
   Component getTabContents() {
     return SwingComponents.newJScrollPane(
-        new JTableBuilder()
+        new JTableBuilder<Alias>()
             .columnNames("Name", "Last Date Used", "IP", "System ID")
-            .tableData(toTableData(playerSummaryForModerator.getAliases()))
+            .rowData(
+                playerSummaryForModerator.getAliases().stream()
+                    .sorted(Comparator.comparing(Alias::getEpochMilliDate))
+                    .collect(Collectors.toList()))
+            .rowMapper(
+                alias ->
+                    List.of(
+                        alias.getName(),
+                        DateTimeFormatterUtil.formatEpochMilli(alias.getEpochMilliDate()),
+                        alias.getIp(),
+                        alias.getSystemId()))
             .build());
-  }
-
-  private List<List<String>> toTableData(final Collection<Alias> aliases) {
-    return aliases.stream()
-        .map(
-            alias ->
-                List.of(
-                    alias.getName(),
-                    DateTimeFormatterUtil.formatEpochMilli(alias.getEpochMilliDate()),
-                    alias.getIp(),
-                    alias.getSystemId()))
-        .collect(Collectors.toList());
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/player/info/PlayerBansTab.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/player/info/PlayerBansTab.java
@@ -1,7 +1,7 @@
 package games.strategy.engine.lobby.client.ui.action.player.info;
 
 import java.awt.Component;
-import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
@@ -21,22 +21,20 @@ class PlayerBansTab {
 
   Component getTabContents() {
     return SwingComponents.newJScrollPane(
-        new JTableBuilder()
+        new JTableBuilder<BanInformation>()
             .columnNames("Name", "Date Banned", "Ban Expiry", "IP", "System ID")
-            .tableData(toTableData(playerSummaryForModerator.getBans()))
+            .rowData(
+                playerSummaryForModerator.getBans().stream()
+                    .sorted(Comparator.comparing(BanInformation::getEpochMilliStartDate))
+                    .collect(Collectors.toList()))
+            .rowMapper(
+                ban ->
+                    List.of(
+                        ban.getName(),
+                        DateTimeFormatterUtil.formatEpochMilli(ban.getEpochMilliStartDate()),
+                        DateTimeFormatterUtil.formatEpochMilli(ban.getEpochMillEndDate()),
+                        ban.getIp(),
+                        ban.getSystemId()))
             .build());
-  }
-
-  private List<List<String>> toTableData(final Collection<BanInformation> bans) {
-    return bans.stream()
-        .map(
-            ban ->
-                List.of(
-                    ban.getName(),
-                    DateTimeFormatterUtil.formatEpochMilli(ban.getEpochMilliStartDate()),
-                    DateTimeFormatterUtil.formatEpochMilli(ban.getEpochMillEndDate()),
-                    ban.getIp(),
-                    ban.getSystemId()))
-        .collect(Collectors.toList());
   }
 }

--- a/swing-lib/src/main/java/org/triplea/swing/JTableBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/JTableBuilder.java
@@ -5,6 +5,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.swing.JTable;
 import javax.swing.table.DefaultTableModel;
@@ -19,27 +21,37 @@ import lombok.NoArgsConstructor;
  * </pre></code>
  */
 @NoArgsConstructor
-public class JTableBuilder {
+public class JTableBuilder<T> {
 
-  private List<List<String>> rowData;
+  private Function<T, List<String>> rowMapper;
+  private List<T> rowData;
+  private List<List<String>> tableData;
   private List<String> columnNames;
 
-  public static JTableBuilder builder() {
-    return new JTableBuilder();
+  public static <X> JTableBuilder<X> builder() {
+    return new JTableBuilder<>();
   }
 
   /** Constructs the JTable swing component. */
   public JTable build() {
     Preconditions.checkNotNull(columnNames);
-    Optional.ofNullable(rowData)
+    Preconditions.checkState(
+        rowData == null ^ tableData == null,
+        "Must either user tableData + rowMapper or specify rowData");
+    Preconditions.checkState(
+        rowData != null || rowMapper != null,
+        "If specifying row data, must specify a mapper for the row data");
+    Optional.ofNullable(tableData)
         .ifPresent(data -> verifyRowLengthsMatchHeader(data, columnNames.size()));
+
+    final List<List<String>> data =
+        Optional.ofNullable(tableData)
+            .orElseGet(() -> rowData.stream().map(rowMapper).collect(Collectors.toList()));
 
     final DefaultTableModel model = new DefaultTableModel();
     columnNames.forEach(model::addColumn);
 
-    Optional.ofNullable(rowData)
-        .ifPresent(
-            data -> data.stream().map(row -> row.toArray(new String[0])).forEach(model::addRow));
+    data.stream().map(row -> row.toArray(new String[0])).forEach(model::addRow);
     return new JTable(model);
   }
 
@@ -77,18 +89,28 @@ public class JTableBuilder {
     addRows(table, rows);
   }
 
-  public JTableBuilder columnNames(final String... columnNames) {
+  public JTableBuilder<T> columnNames(final String... columnNames) {
     return columnNames(List.of(columnNames));
   }
 
-  public JTableBuilder columnNames(final List<String> columnNames) {
+  public JTableBuilder<T> columnNames(final List<String> columnNames) {
     checkArgument(!columnNames.isEmpty());
     this.columnNames = columnNames;
     return this;
   }
 
-  public JTableBuilder tableData(final List<List<String>> rowData) {
+  public JTableBuilder<T> tableData(final List<List<String>> tableData) {
+    this.tableData = tableData;
+    return this;
+  }
+
+  public JTableBuilder<T> rowData(final List<T> rowData) {
     this.rowData = rowData;
+    return this;
+  }
+
+  public JTableBuilder<T> rowMapper(final Function<T, List<String>> rowMapper) {
+    this.rowMapper = rowMapper;
     return this;
   }
 }

--- a/swing-lib/src/main/java/org/triplea/swing/JTableBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/JTableBuilder.java
@@ -13,12 +13,22 @@ import javax.swing.table.DefaultTableModel;
 import lombok.NoArgsConstructor;
 
 /**
- * Example usage:. <code><pre>
+ * Example usage: <code><pre>
  *   final JTable panel = JTableBuilder.builder()
  *       .columnNames(columns)
  *       .tableData(rows)
  *       .build();
+ * </pre></code> Example usage with row mapper: <code><pre>
+ *   final JTable panel = new JTableBuilder&lt;Person&gt;()
+ *       .columnNames(columns)
+ *       .rowData(personsList)
+ *       .rowMapper(person -> List.of(person.getFirstName(), person.getLastName())
+ *       .build();
  * </pre></code>
+ *
+ * @param <T> The value type that can be mapped to each row. If not specified will implicitly be a
+ *     list of strings. Otherwise you can specify a list 'rowData' objects and how to map each one
+ *     to a row with 'rowMapper'.
  */
 @NoArgsConstructor
 public class JTableBuilder<T> {


### PR DESCRIPTION
Adds a convenience capability where we can define a table as a
list of a given type and a mapper to map each element of the list
to a table row.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

