### PR TITLE
Improve error message when failing to connect to the lobby

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -230,7 +230,12 @@ public class LobbyLogin {
         .lobbyUri(serverProperties.getUri())
         .apiKey(ApiKey.of(loginResponse.getApiKey()))
         .errorHandler(
-            error -> SwingComponents.showError(null, "Error communicating with lobby", error))
+            error ->
+                SwingComponents.showError(
+                    parentWindow,
+                    "Error communicating with lobby",
+                    "Please reconnect. Error: "
+                        + (error.isBlank() ? "No error details given by server" : error)))
         .build();
   }
 


### PR DESCRIPTION
We are seeing cases where connections to lobby can fail with no error message.
When this happens the user is unable to do anything with at least chat
(their chat messages are not sent nor received).

This update improves the error message and informs the user that they should
reconnect.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

