### PR TITLE
Fix display of Can't Target info in tooltips.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -3592,7 +3592,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   private void addLabeledUnitTypes(
-      String label,
+      final String label,
       final Collection<UnitType> unitTypes,
       final List<Tuple<String, String>> tuples) {
     if (!unitTypes.isEmpty()) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -3366,16 +3366,20 @@ public class UnitAttachment extends DefaultAttachment {
     if (getCanBeMovedThroughByEnemies()) {
       tuples.add(Tuple.of("Can Be Moved Through By Enemies", ""));
     }
-    if (!getCanNotTarget().isEmpty()) {
-      if (getCanNotTarget().size() <= 4) {
-        tuples.add(Tuple.of("Can't Target: ", getCanNotTarget().toString()));
+    final Collection<UnitType> cannotTarget = getCanNotTarget();
+    if (!cannotTarget.isEmpty()) {
+      if (cannotTarget.size() <= 4) {
+        tuples.add(Tuple.of("Can't Target", MyFormatter.defaultNamedToTextList(cannotTarget)));
       } else {
         tuples.add(Tuple.of("Can't Target Some Units", ""));
       }
     }
-    if (!getCanNotBeTargetedBy().isEmpty()) {
-      if (getCanNotBeTargetedBy().size() <= 4) {
-        tuples.add(Tuple.of("Can't Be Targeted By: ", getCanNotBeTargetedBy().toString()));
+    final Collection<UnitType> cannotBeTargettedBy = getCanNotBeTargetedBy();
+    if (!cannotBeTargettedBy.isEmpty()) {
+      if (cannotBeTargettedBy.size() <= 4) {
+        tuples.add(
+            Tuple.of(
+                "Can't Be Targeted By", MyFormatter.defaultNamedToTextList(cannotBeTargettedBy)));
       } else {
         tuples.add(Tuple.of("Can't Be Targeted By Some Units", ""));
       }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -3366,24 +3366,8 @@ public class UnitAttachment extends DefaultAttachment {
     if (getCanBeMovedThroughByEnemies()) {
       tuples.add(Tuple.of("Can Be Moved Through By Enemies", ""));
     }
-    final Collection<UnitType> cannotTarget = getCanNotTarget();
-    if (!cannotTarget.isEmpty()) {
-      if (cannotTarget.size() <= 4) {
-        tuples.add(Tuple.of("Can't Target", MyFormatter.defaultNamedToTextList(cannotTarget)));
-      } else {
-        tuples.add(Tuple.of("Can't Target Some Units", ""));
-      }
-    }
-    final Collection<UnitType> cannotBeTargettedBy = getCanNotBeTargetedBy();
-    if (!cannotBeTargettedBy.isEmpty()) {
-      if (cannotBeTargettedBy.size() <= 4) {
-        tuples.add(
-            Tuple.of(
-                "Can't Be Targeted By", MyFormatter.defaultNamedToTextList(cannotBeTargettedBy)));
-      } else {
-        tuples.add(Tuple.of("Can't Be Targeted By Some Units", ""));
-      }
-    }
+    addLabeledUnitTypes("Can't Target", getCanNotTarget(), tuples);
+    addLabeledUnitTypes("Can't Be Targeted By", getCanNotBeTargetedBy(), tuples);
     if (getIsDestroyer()) {
       tuples.add(Tuple.of("Is Anti-Stealth", ""));
     }
@@ -3605,6 +3589,19 @@ public class UnitAttachment extends DefaultAttachment {
       result.append("<br />");
     }
     return result.toString();
+  }
+
+  private void addLabeledUnitTypes(
+      String label,
+      final Collection<UnitType> unitTypes,
+      final List<Tuple<String, String>> tuples) {
+    if (!unitTypes.isEmpty()) {
+      if (unitTypes.size() <= 4) {
+        tuples.add(Tuple.of(label, MyFormatter.defaultNamedToTextList(unitTypes)));
+      } else {
+        tuples.add(Tuple.of(label + " Some Units", ""));
+      }
+    }
   }
 
   private static <T extends DefaultNamed> void addIntegerMapDescription(


### PR DESCRIPTION
The list of unit types was previously incorrectly formatted.
Also makes the getter get called only once, since the getter
does work in generating the list.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[X] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
Manual.

## Screens Shots

### Before
![Screen Shot 2020-05-06 at 6 01 44 PM](https://user-images.githubusercontent.com/17648/81235812-d56b5100-8fc9-11ea-8bee-b1b2e5bb76b1.png)

### After
![Screen Shot 2020-05-06 at 6 01 15 PM](https://user-images.githubusercontent.com/17648/81235828-db613200-8fc9-11ea-84d3-d5f9cf65b45b.png)
