### PR TITLE
Fix improved artillery support not being applied

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -1086,7 +1086,7 @@ public class DiceRoll implements Externalizable {
       supportLeft.put(rule, numSupport * rule.getNumber());
       final IntegerMap<Unit> unitsForRule = new IntegerMap<>();
       supporters.forEach(unit -> unitsForRule.put(unit, rule.getNumber()));
-      impArtTechUnits.forEach(unit -> unitsForRule.put(unit, rule.getNumber()));
+      impArtTechUnits.forEach(unit -> unitsForRule.add(unit, rule.getNumber()));
       supportUnitsLeft.put(rule, unitsForRule);
       final Iterator<List<UnitSupportAttachment>> iter2 = supportsAvailable.iterator();
       List<UnitSupportAttachment> ruleType = null;


### PR DESCRIPTION
This update fixes improved artillery support. Essentially
the problem is a 'put' and 'add' was replaced with a 'put' and 'put'.
In the first case we put a value of '1' and then added to it, in the
latter (buggy) case we replaced the existing '1' vlaue with another
'1'.

To explain a bit further, support is tracked with three data structures,
- one for units that can receive support
- one for the support rules
- one for units providing support.

Improved artillery support works by double adding artillery units
to the map of units that can provide support.

When removing a custom data structure we replaced a map add
with a map put, causing the data structure for artillery units
to be written twice with a value of '1' rather than adding '1'

Addresses: https://github.com/triplea-game/triplea/issues/6282


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing

Verified after this patch improved artillery gives support to 2 units.
- load up 1941 v3
- use edit mode to give germany improved artillery tech
- end turn (select all other factions to be Do-Nothing-AI so that they quickly skip)
- on the next turn, tech is active, attack with 2 infantry and 1 artillery into baltic states
- verified that artillery now supports 2 infantry instead of just 1.

These save game files are at the above described state:

Save game compatible with 2.0 @ 438013ccc691ba82c09df1f56ad86c4a8ad135f9
[2.0-improved-arty-test.zip](https://github.com/triplea-game/triplea/files/4590688/2.0-improved-arty-test.zip)

Save game compatible with 1.9 release, 1.9.0.0.13066:
[13066-improved-arty-test.zip](https://github.com/triplea-game/triplea/files/4590689/13066-improved-arty-test.zip)



<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
## Screens Shots

This diff shows the problem, notice the 'put + add' is turned into a 'put + put':
![Screenshot from 2020-05-06 21-07-06](https://user-images.githubusercontent.com/12397753/81254321-a6f87080-8fdf-11ea-94eb-ce2141f7568a.png)


<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

