### PR TITLE
DiceRoll - Support sort extracted

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
@@ -285,7 +285,13 @@ public class ProPurchaseOption {
     final Set<List<UnitSupportAttachment>> supportsAvailable = new HashSet<>();
     final IntegerMap<UnitSupportAttachment> supportLeft = new IntegerMap<>();
     DiceRoll.getSortedSupport(
-        units, supportsAvailable, supportLeft, new HashMap<>(), data, defense, true);
+        units,
+        supportsAvailable,
+        supportLeft,
+        new HashMap<>(),
+        data.getUnitTypeList().getSupportRules(),
+        defense,
+        true);
     double totalSupportFactor = 0;
     for (final UnitSupportAttachment usa : unitSupportAttachments) {
       for (final List<UnitSupportAttachment> bonusType : supportsAvailable) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -19,6 +19,7 @@ import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.Die.DieType;
 import games.strategy.triplea.delegate.battle.AirBattle;
 import games.strategy.triplea.delegate.battle.IBattle;
+import games.strategy.triplea.delegate.power.calculator.SupportRuleSort;
 import games.strategy.triplea.formatter.MyFormatter;
 import java.io.Externalizable;
 import java.io.IOException;
@@ -1012,7 +1013,15 @@ public class DiceRoll implements Externalizable {
         supportUnitsLeft,
         defence,
         allies);
-    sortAaSupportRules(supportsAvailable, defence, allies);
+
+    final SupportRuleSort supportRuleSort =
+        SupportRuleSort.builder()
+            .defense(defence)
+            .friendly(allies)
+            .roll(UnitSupportAttachment::getAaRoll)
+            .strength(UnitSupportAttachment::getAaStrength)
+            .build();
+    supportsAvailable.forEach(unitSupportAttachment -> unitSupportAttachment.sort(supportRuleSort));
   }
 
   /** Sorts 'supportsAvailable' lists based on unit support attachment rules. */
@@ -1032,7 +1041,15 @@ public class DiceRoll implements Externalizable {
         supportUnitsLeft,
         defence,
         allies);
-    sortSupportRules(supportsAvailable, defence, allies);
+
+    final SupportRuleSort supportRuleSort =
+        SupportRuleSort.builder()
+            .defense(defence)
+            .friendly(allies)
+            .roll(UnitSupportAttachment::getRoll)
+            .strength(UnitSupportAttachment::getStrength)
+            .build();
+    supportsAvailable.forEach(unitSupportAttachment -> unitSupportAttachment.sort(supportRuleSort));
   }
 
   /**
@@ -1180,149 +1197,6 @@ public class DiceRoll implements Externalizable {
           return Integer.compare(v1, v2);
         };
     units.sort(comp);
-  }
-
-  private static void sortAaSupportRules(
-      final Set<List<UnitSupportAttachment>> support,
-      final boolean defense,
-      final boolean friendly) {
-    sortSupportRules(
-        support,
-        defense,
-        friendly,
-        UnitSupportAttachment::getAaRoll,
-        UnitSupportAttachment::getAaStrength);
-  }
-
-  private static void sortSupportRules(
-      final Set<List<UnitSupportAttachment>> support,
-      final boolean defense,
-      final boolean friendly) {
-    sortSupportRules(
-        support,
-        defense,
-        friendly,
-        UnitSupportAttachment::getRoll,
-        UnitSupportAttachment::getStrength);
-  }
-
-  private static void sortSupportRules(
-      final Set<List<UnitSupportAttachment>> support,
-      final boolean defense,
-      final boolean friendly,
-      final Predicate<UnitSupportAttachment> roll,
-      final Predicate<UnitSupportAttachment> strength) {
-
-    // First, sort the lists inside each set
-    final Comparator<UnitSupportAttachment> compList =
-        (u1, u2) -> {
-          int compareTo;
-
-          // Make sure stronger supports are ordered first if friendly, and worst are ordered first
-          // if enemy
-          // TODO: it is possible that we will waste negative support if we reduce a units power to
-          // less than zero.
-          // We should actually apply enemy negative support in order from worst to least bad, on a
-          // unit list that is
-          // ordered from strongest to weakest.
-          final boolean u1CanBonus = defense ? u1.getDefence() : u1.getOffence();
-          final boolean u2CanBonus = defense ? u2.getDefence() : u2.getOffence();
-          if (friendly) {
-            // favor rolls over strength
-            if (roll.test(u1) || roll.test(u2)) {
-              final int u1Bonus = roll.test(u1) && u1CanBonus ? u1.getBonus() : 0;
-              final int u2Bonus = roll.test(u2) && u2CanBonus ? u2.getBonus() : 0;
-              compareTo = Integer.compare(u2Bonus, u1Bonus);
-              if (compareTo != 0) {
-                return compareTo;
-              }
-            }
-            if (strength.test(u1) || strength.test(u2)) {
-              final int u1Bonus = strength.test(u1) && u1CanBonus ? u1.getBonus() : 0;
-              final int u2Bonus = strength.test(u2) && u2CanBonus ? u2.getBonus() : 0;
-              compareTo = Integer.compare(u2Bonus, u1Bonus);
-              if (compareTo != 0) {
-                return compareTo;
-              }
-            }
-          } else {
-            if (roll.test(u1) || roll.test(u2)) {
-              final int u1Bonus = roll.test(u1) && u1CanBonus ? u1.getBonus() : 0;
-              final int u2Bonus = roll.test(u2) && u2CanBonus ? u2.getBonus() : 0;
-              compareTo = Integer.compare(u1Bonus, u2Bonus);
-              if (compareTo != 0) {
-                return compareTo;
-              }
-            }
-            if (strength.test(u1) || strength.test(u2)) {
-              final int u1Bonus = strength.test(u1) && u1CanBonus ? u1.getBonus() : 0;
-              final int u2Bonus = strength.test(u2) && u2CanBonus ? u2.getBonus() : 0;
-              compareTo = Integer.compare(u1Bonus, u2Bonus);
-              if (compareTo != 0) {
-                return compareTo;
-              }
-            }
-          }
-
-          // If the bonuses are the same, we want to make sure any support which only supports 1
-          // single unit type goes
-          // first because there could be Support1 which supports both infantry and mech infantry,
-          // and Support2
-          // which only supports mech infantry. If the Support1 goes first, and the mech infantry is
-          // first in the unit list
-          // (highly probable), then Support1 will end up using all of itself up on the mech
-          // infantry then when the Support2
-          // comes up, all the mech infantry are used up, and it does nothing. Instead, we want
-          // Support2 to come first,
-          // support all mech infantry that it can, then have Support1 come in and support whatever
-          // is left, that way no
-          // support is wasted.
-          // TODO: this breaks down completely if we have Support1 having a higher bonus than
-          // Support2, because it will
-          // come first. It should come first, unless we would have support wasted otherwise. This
-          // ends up being a pretty
-          // tricky math puzzle.
-          final Set<UnitType> types1 = u1.getUnitType();
-          final Set<UnitType> types2 = u2.getUnitType();
-          final int s1 = types1 == null ? 0 : types1.size();
-          final int s2 = types2 == null ? 0 : types2.size();
-          compareTo = Integer.compare(s1, s2);
-          if (compareTo != 0) {
-            return compareTo;
-          }
-
-          // Now we need to sort so that the supporters who are the most powerful go before the less
-          // powerful. This is not
-          // necessary for the providing of support, but is necessary for our default casualty
-          // selection method.
-          final UnitType unitType1 = (UnitType) u1.getAttachedTo();
-          final UnitType unitType2 = (UnitType) u2.getAttachedTo();
-          final UnitAttachment ua1 = UnitAttachment.get(unitType1);
-          final UnitAttachment ua2 = UnitAttachment.get(unitType2);
-          final int unitPower1;
-          final int unitPower2;
-          if (u1.getDefence()) {
-            unitPower1 =
-                ua1.getDefenseRolls(GamePlayer.NULL_PLAYERID)
-                    * ua1.getDefense(GamePlayer.NULL_PLAYERID);
-            unitPower2 =
-                ua2.getDefenseRolls(GamePlayer.NULL_PLAYERID)
-                    * ua2.getDefense(GamePlayer.NULL_PLAYERID);
-          } else {
-            unitPower1 =
-                ua1.getAttackRolls(GamePlayer.NULL_PLAYERID)
-                    * ua1.getAttack(GamePlayer.NULL_PLAYERID);
-            unitPower2 =
-                ua2.getAttackRolls(GamePlayer.NULL_PLAYERID)
-                    * ua2.getAttack(GamePlayer.NULL_PLAYERID);
-          }
-
-          return Integer.compare(unitPower2, unitPower1);
-        };
-
-    for (final List<UnitSupportAttachment> attachments : support) {
-      attachments.sort(compList);
-    }
   }
 
   public static DiceRoll airBattle(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -737,7 +737,7 @@ public class DiceRoll implements Externalizable {
         supportRulesFriendly,
         supportLeftFriendly,
         supportUnitsLeftFriendly,
-        data,
+        data.getUnitTypeList().getSupportRules(),
         defending,
         true);
     final Set<List<UnitSupportAttachment>> supportRulesEnemy = new HashSet<>();
@@ -748,7 +748,7 @@ public class DiceRoll implements Externalizable {
         supportRulesEnemy,
         supportLeftEnemy,
         supportUnitsLeftEnemy,
-        data,
+        data.getUnitTypeList().getSupportRules(),
         !defending,
         false);
 
@@ -1005,23 +1005,14 @@ public class DiceRoll implements Externalizable {
             .parallelStream()
             .filter(usa -> (usa.getAaRoll() || usa.getAaStrength()))
             .collect(Collectors.toSet());
-    getSupport(
+    getSortedSupport(
         unitsGivingTheSupport,
-        rules,
         supportsAvailable,
         supportLeft,
         supportUnitsLeft,
+        rules,
         defence,
         allies);
-
-    final SupportRuleSort supportRuleSort =
-        SupportRuleSort.builder()
-            .defense(defence)
-            .friendly(allies)
-            .roll(UnitSupportAttachment::getAaRoll)
-            .strength(UnitSupportAttachment::getAaStrength)
-            .build();
-    supportsAvailable.forEach(unitSupportAttachment -> unitSupportAttachment.sort(supportRuleSort));
   }
 
   /** Sorts 'supportsAvailable' lists based on unit support attachment rules. */
@@ -1030,12 +1021,12 @@ public class DiceRoll implements Externalizable {
       final Set<List<UnitSupportAttachment>> supportsAvailable,
       final IntegerMap<UnitSupportAttachment> supportLeft,
       final Map<UnitSupportAttachment, IntegerMap<Unit>> supportUnitsLeft,
-      final GameData data,
+      final Set<UnitSupportAttachment> rules,
       final boolean defence,
       final boolean allies) {
     getSupport(
         unitsGivingTheSupport,
-        data.getUnitTypeList().getSupportRules(),
+        rules,
         supportsAvailable,
         supportLeft,
         supportUnitsLeft,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportRuleSort.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportRuleSort.java
@@ -1,0 +1,121 @@
+package games.strategy.triplea.delegate.power.calculator;
+
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.attachments.UnitAttachment;
+import games.strategy.triplea.attachments.UnitSupportAttachment;
+import java.util.Comparator;
+import java.util.Set;
+import java.util.function.Predicate;
+import javax.annotation.Nonnull;
+import lombok.Builder;
+
+@Builder
+public class SupportRuleSort implements Comparator<UnitSupportAttachment> {
+  @Nonnull private final Boolean defense;
+  @Nonnull private final Boolean friendly;
+  @Nonnull private final Predicate<UnitSupportAttachment> roll;
+  @Nonnull private final Predicate<UnitSupportAttachment> strength;
+
+  @Override
+  public int compare(final UnitSupportAttachment u1, final UnitSupportAttachment u2) {
+    int compareTo;
+
+    // Make sure stronger supports are ordered first if friendly, and worst are ordered first
+    // if enemy
+    // TODO: it is possible that we will waste negative support if we reduce a units power to
+    // less than zero.
+    // We should actually apply enemy negative support in order from worst to least bad, on a
+    // unit list that is
+    // ordered from strongest to weakest.
+    final boolean u1CanBonus = defense ? u1.getDefence() : u1.getOffence();
+    final boolean u2CanBonus = defense ? u2.getDefence() : u2.getOffence();
+    if (friendly) {
+      // favor rolls over strength
+      if (roll.test(u1) || roll.test(u2)) {
+        final int u1Bonus = roll.test(u1) && u1CanBonus ? u1.getBonus() : 0;
+        final int u2Bonus = roll.test(u2) && u2CanBonus ? u2.getBonus() : 0;
+        compareTo = Integer.compare(u2Bonus, u1Bonus);
+        if (compareTo != 0) {
+          return compareTo;
+        }
+      }
+      if (strength.test(u1) || strength.test(u2)) {
+        final int u1Bonus = strength.test(u1) && u1CanBonus ? u1.getBonus() : 0;
+        final int u2Bonus = strength.test(u2) && u2CanBonus ? u2.getBonus() : 0;
+        compareTo = Integer.compare(u2Bonus, u1Bonus);
+        if (compareTo != 0) {
+          return compareTo;
+        }
+      }
+    } else {
+      if (roll.test(u1) || roll.test(u2)) {
+        final int u1Bonus = roll.test(u1) && u1CanBonus ? u1.getBonus() : 0;
+        final int u2Bonus = roll.test(u2) && u2CanBonus ? u2.getBonus() : 0;
+        compareTo = Integer.compare(u1Bonus, u2Bonus);
+        if (compareTo != 0) {
+          return compareTo;
+        }
+      }
+      if (strength.test(u1) || strength.test(u2)) {
+        final int u1Bonus = strength.test(u1) && u1CanBonus ? u1.getBonus() : 0;
+        final int u2Bonus = strength.test(u2) && u2CanBonus ? u2.getBonus() : 0;
+        compareTo = Integer.compare(u1Bonus, u2Bonus);
+        if (compareTo != 0) {
+          return compareTo;
+        }
+      }
+    }
+
+    // If the bonuses are the same, we want to make sure any support which only supports 1
+    // single unit type goes
+    // first because there could be Support1 which supports both infantry and mech infantry,
+    // and Support2
+    // which only supports mech infantry. If the Support1 goes first, and the mech infantry is
+    // first in the unit list
+    // (highly probable), then Support1 will end up using all of itself up on the mech
+    // infantry then when the Support2
+    // comes up, all the mech infantry are used up, and it does nothing. Instead, we want
+    // Support2 to come first,
+    // support all mech infantry that it can, then have Support1 come in and support whatever
+    // is left, that way no
+    // support is wasted.
+    // TODO: this breaks down completely if we have Support1 having a higher bonus than
+    // Support2, because it will
+    // come first. It should come first, unless we would have support wasted otherwise. This
+    // ends up being a pretty
+    // tricky math puzzle.
+    final Set<UnitType> types1 = u1.getUnitType();
+    final Set<UnitType> types2 = u2.getUnitType();
+    final int s1 = types1 == null ? 0 : types1.size();
+    final int s2 = types2 == null ? 0 : types2.size();
+    compareTo = Integer.compare(s1, s2);
+    if (compareTo != 0) {
+      return compareTo;
+    }
+
+    // Now we need to sort so that the supporters who are the most powerful go before the less
+    // powerful. This is not
+    // necessary for the providing of support, but is necessary for our default casualty
+    // selection method.
+    final UnitType unitType1 = (UnitType) u1.getAttachedTo();
+    final UnitType unitType2 = (UnitType) u2.getAttachedTo();
+    final UnitAttachment ua1 = UnitAttachment.get(unitType1);
+    final UnitAttachment ua2 = UnitAttachment.get(unitType2);
+    final int unitPower1;
+    final int unitPower2;
+    if (u1.getDefence()) {
+      unitPower1 =
+          ua1.getDefenseRolls(GamePlayer.NULL_PLAYERID) * ua1.getDefense(GamePlayer.NULL_PLAYERID);
+      unitPower2 =
+          ua2.getDefenseRolls(GamePlayer.NULL_PLAYERID) * ua2.getDefense(GamePlayer.NULL_PLAYERID);
+    } else {
+      unitPower1 =
+          ua1.getAttackRolls(GamePlayer.NULL_PLAYERID) * ua1.getAttack(GamePlayer.NULL_PLAYERID);
+      unitPower2 =
+          ua2.getAttackRolls(GamePlayer.NULL_PLAYERID) * ua2.getAttack(GamePlayer.NULL_PLAYERID);
+    }
+
+    return Integer.compare(unitPower2, unitPower1);
+  }
+}


### PR DESCRIPTION
Two refactors, one to extract sort logic, second to combine nearly duplicate logic. Perhaps easier to review commit-by-commit.


## Commits

commit 97b634ab6e828246705c1e0523c574c882d05881

    Extract support attachment sort to its own class and inline usages
    
    1. Create a new class 'SupportRuleSort' implementing comparator to be the new
       home for unit attachment support sorting logic (in DiceRoll.java)
    2. Move sorting logic from DiceRoll.java 'SupportRuleSort'
    3. Inline calls to 'SupportRuleSort'

commit 5a6dee7b2af954bfd2128d84084a2c748d94284a

    Combine duplicated getSortedSupport logic
    
    By accepting a list of rules to 'getSortedSupport', we can nearly
    combine 'getSortedAASupport' with 'getSortedSupport'.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

