### PR TITLE
ProMoveUtils, do not NPE in MoveDescription if unable to calculate route

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -142,14 +142,15 @@ public final class ProMoveUtils {
               data.getSequence().getRound()
                   + "-"
                   + data.getSequence().getStep().getName()
-                  + ": route is null "
+                  + ": route is null (could not calculate route)"
                   + startTerritory
                   + " to "
                   + t
                   + ", units="
                   + unitList);
+        } else {
+          moves.add(new MoveDescription(unitList, route));
         }
-        moves.add(new MoveDescription(unitList, route));
       }
     }
     return moves;


### PR DESCRIPTION
If 'route' is null we will get a NPE in moveDescription.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->

## Additional Review Notes

Addresses: https://github.com/triplea-game/triplea/issues/6426

