### PR TITLE
Remove lobby disconnect+reconnect notification to hosted games

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/LobbyWatcherThread.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/LobbyWatcherThread.java
@@ -26,11 +26,7 @@ public class LobbyWatcherThread {
 
   public void createLobbyWatcher(final GameToLobbyConnection gameToLobbyConnection) {
     InGameLobbyWatcher.newInGameLobbyWatcher(
-            serverMessenger,
-            gameToLobbyConnection,
-            watcherThreadMessaging::connectionLostReporter,
-            watcherThreadMessaging::connectionReEstablishedReporter,
-            lobbyWatcher.getInGameLobbyWatcher())
+            serverMessenger, gameToLobbyConnection, lobbyWatcher.getInGameLobbyWatcher())
         .ifPresent(
             watcher -> {
               watcher.setGameSelectorModel(gameSelectorModel);

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/WatcherThreadMessaging.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/WatcherThreadMessaging.java
@@ -8,29 +8,14 @@ import javax.swing.SwingUtilities;
 import lombok.AllArgsConstructor;
 import lombok.extern.java.Log;
 import org.triplea.awt.OpenFileUtility;
-import org.triplea.swing.DialogBuilder;
 
 /** Interface to communicate lobby watcher events to user. */
 public interface WatcherThreadMessaging {
-  void connectionLostReporter(String message);
-
-  void connectionReEstablishedReporter(String message);
-
   void serverNotAvailableHandler(String message);
 
   /** Simply logs notifications */
   @Log
   class HeadlessWatcherThreadMessaging implements WatcherThreadMessaging {
-    @Override
-    public void connectionLostReporter(final String message) {
-      log.warning(message);
-    }
-
-    @Override
-    public void connectionReEstablishedReporter(final String message) {
-      log.info(message);
-    }
-
     @Override
     public void serverNotAvailableHandler(final String message) {
       log.severe(message);
@@ -41,24 +26,6 @@ public interface WatcherThreadMessaging {
   @AllArgsConstructor
   class HeadedWatcherThreadMessaging implements WatcherThreadMessaging {
     private final Component parent;
-
-    @Override
-    public void connectionLostReporter(final String message) {
-      DialogBuilder.builder()
-          .parent(parent)
-          .title("Connection to Lobby Lost")
-          .errorMessage(message)
-          .showDialog();
-    }
-
-    @Override
-    public void connectionReEstablishedReporter(final String message) {
-      DialogBuilder.builder()
-          .parent(parent)
-          .title("Re-Connected to Lobby")
-          .infoMessage(message)
-          .showDialog();
-    }
 
     @Override
     public void serverNotAvailableHandler(final String message) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -13,7 +13,6 @@ import java.time.Instant;
 import java.util.Observer;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import java.util.logging.Level;
 import javax.annotation.Nullable;
 import lombok.Getter;
@@ -50,14 +49,10 @@ public class InGameLobbyWatcher {
   private InGameLobbyWatcher(
       final IServerMessenger serverMessenger,
       final GameToLobbyConnection gameToLobbyConnection,
-      final Consumer<String> errorReporter,
-      final Consumer<String> reconnectionReporter,
       @Nullable final InGameLobbyWatcher oldWatcher) {
     this(
         serverMessenger,
         gameToLobbyConnection,
-        errorReporter,
-        reconnectionReporter,
         Optional.ofNullable(oldWatcher).map(old -> old.gameDescription).orElse(null),
         Optional.ofNullable(oldWatcher).map(old -> old.game).orElse(null));
   }
@@ -65,8 +60,6 @@ public class InGameLobbyWatcher {
   private InGameLobbyWatcher(
       final IServerMessenger serverMessenger,
       final GameToLobbyConnection gameToLobbyConnection,
-      final Consumer<String> errorReporter,
-      final Consumer<String> reconnectionReporter,
       @Nullable final GameDescription oldGameDescription,
       @Nullable final IGame oldGame) {
     this.serverMessenger = serverMessenger;
@@ -124,8 +117,6 @@ public class InGameLobbyWatcher {
                 LobbyWatcherKeepAliveTask.builder()
                     .gameId(gameId)
                     .gameIdSetter(id -> gameId = id)
-                    .connectionLostReporter(errorReporter)
-                    .connectionReEstablishedReporter(reconnectionReporter)
                     .keepAliveSender(gameToLobbyConnection::sendKeepAlive)
                     .gamePoster(() -> gameToLobbyConnection.postGame(gameDescription.toLobbyGame()))
                     .build())
@@ -160,17 +151,10 @@ public class InGameLobbyWatcher {
   public static Optional<InGameLobbyWatcher> newInGameLobbyWatcher(
       final IServerMessenger serverMessenger,
       final GameToLobbyConnection gameToLobbyConnection,
-      final Consumer<String> errorReporter,
-      final Consumer<String> reconnectionReporter,
       final InGameLobbyWatcher oldWatcher) {
     try {
       return Optional.of(
-          new InGameLobbyWatcher(
-              serverMessenger,
-              gameToLobbyConnection,
-              errorReporter,
-              reconnectionReporter,
-              oldWatcher));
+          new InGameLobbyWatcher(serverMessenger, gameToLobbyConnection, oldWatcher));
     } catch (final Exception e) {
       log.log(Level.SEVERE, "Failed to create in-game lobby watcher", e);
       return Optional.empty();

--- a/game-core/src/test/java/games/strategy/engine/framework/startup/ui/LobbyWatcherKeepAliveTaskTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/startup/ui/LobbyWatcherKeepAliveTaskTest.java
@@ -2,7 +2,6 @@ package games.strategy.engine.framework.startup.ui;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -23,8 +22,6 @@ class LobbyWatcherKeepAliveTaskTest {
   private static final String ID_2 = "id2";
 
   @Mock private Consumer<String> gameIdSetter;
-  @Mock private Consumer<String> connectionLostReporter;
-  @Mock private Consumer<String> connectionReEstablishedReporter;
   @Mock private Predicate<String> keepAliveSender;
   @Mock private Supplier<String> gamePoster;
 
@@ -38,8 +35,6 @@ class LobbyWatcherKeepAliveTaskTest {
         LobbyWatcherKeepAliveTask.builder()
             .gameId(ID_0)
             .gameIdSetter(gameIdSetter)
-            .connectionLostReporter(connectionLostReporter)
-            .connectionReEstablishedReporter(connectionReEstablishedReporter)
             .keepAliveSender(keepAliveSender)
             .gamePoster(gamePoster)
             .build();
@@ -54,8 +49,6 @@ class LobbyWatcherKeepAliveTaskTest {
 
     verify(gamePoster, never()).get();
     verify(gameIdSetter, never()).accept(any());
-    verify(connectionLostReporter, never()).accept(any());
-    verify(connectionReEstablishedReporter, never()).accept(any());
   }
 
   /**
@@ -71,8 +64,6 @@ class LobbyWatcherKeepAliveTaskTest {
     lobbyWatcherKeepAliveTask.run();
 
     verify(gameIdSetter).accept(ID_1);
-    verify(connectionReEstablishedReporter).accept(any());
-    verify(connectionLostReporter, never()).accept(any());
   }
 
   /**
@@ -88,8 +79,6 @@ class LobbyWatcherKeepAliveTaskTest {
     lobbyWatcherKeepAliveTask.run();
 
     verify(gameIdSetter, never()).accept(any());
-    verify(connectionLostReporter, never()).accept(any());
-    verify(connectionReEstablishedReporter, never()).accept(any());
   }
 
   /**
@@ -111,9 +100,7 @@ class LobbyWatcherKeepAliveTaskTest {
     lobbyWatcherKeepAliveTask.run();
 
     verify(gameIdSetter, never()).accept(ID_1);
-    verify(connectionLostReporter, never()).accept(any());
     verify(gameIdSetter).accept(ID_2);
-    verify(connectionReEstablishedReporter).accept(any());
   }
 
   /**
@@ -126,9 +113,6 @@ class LobbyWatcherKeepAliveTaskTest {
     when(keepAliveSender.test(ID_0)).thenThrow(feignException);
 
     lobbyWatcherKeepAliveTask.run();
-
-    verify(connectionLostReporter).accept(any());
-    verify(connectionReEstablishedReporter, never()).accept(any());
   }
 
   /**
@@ -144,9 +128,6 @@ class LobbyWatcherKeepAliveTaskTest {
 
     lobbyWatcherKeepAliveTask.run();
     lobbyWatcherKeepAliveTask.run();
-
-    verify(connectionLostReporter).accept(any());
-    verify(connectionReEstablishedReporter, never()).accept(any());
   }
 
   /**
@@ -166,32 +147,6 @@ class LobbyWatcherKeepAliveTaskTest {
     lobbyWatcherKeepAliveTask.run();
 
     verify(gameIdSetter).accept(ID_1);
-    verify(connectionLostReporter).accept(any());
-    verify(connectionReEstablishedReporter).accept(any());
-  }
-
-  /**
-   * We'll lose connection (keep alive = false), get a new ID. We'll regain connection with a new
-   * ID, and then the next keep alive will fail. We expect to be notified twice of connection lost.
-   * <br>
-   * Run #1: id0 fails<br>
-   * -> connection lost reported<br>
-   * Run #2: id0 does not keep alive, we re-post for new ID_1, ID_1 keeps alive<br>
-   * -> connection re-established Run #3: id1 fails<br>
-   * -> connection lost reported a second time.
-   */
-  @Test
-  void connectionLostIsReportedAgainAfterSuccesfulReConnectionAndLostAgain() {
-    when(keepAliveSender.test(ID_0)).thenThrow(feignException).thenReturn(false);
-    when(gamePoster.get()).thenReturn(ID_1);
-    when(keepAliveSender.test(ID_1)).thenReturn(true).thenThrow(feignException);
-
-    lobbyWatcherKeepAliveTask.run();
-    lobbyWatcherKeepAliveTask.run();
-    lobbyWatcherKeepAliveTask.run();
-
-    verify(connectionLostReporter, times(2)).accept(any());
-    verify(connectionReEstablishedReporter).accept(any());
   }
 
   /**
@@ -213,8 +168,6 @@ class LobbyWatcherKeepAliveTaskTest {
 
     verify(gameIdSetter, never()).accept(any());
     verify(gamePoster, never()).get();
-    verify(connectionLostReporter).accept(any());
-    verify(connectionReEstablishedReporter).accept(any());
   }
 
   /**
@@ -234,7 +187,5 @@ class LobbyWatcherKeepAliveTaskTest {
     lobbyWatcherKeepAliveTask.run();
 
     verify(gameIdSetter, never()).accept(any());
-    verify(connectionLostReporter).accept(any());
-    verify(connectionReEstablishedReporter, never()).accept(any());
   }
 }


### PR DESCRIPTION
Removing to prevent a potential message storm if the connection
to lobby is dropped and re-established repeatedly. This was
observed after putting laptop to sleep and then opening again
(result in 20+ some notifications).

It is perhaps better to just let be and have the reconnect
be silent, avoid interrupting a possibly in-progress game.
If the player is on a staging screen, likely they are connected
to lobby chat and will see notifications there when their
chat is disconnected, so user will potentially still be
notified.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[x] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

