### PR TITLE
Make displayed dice rolls span multiple lines and other combat UI improvements

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/lookandfeel/LookAndFeel.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkState;
 import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.settings.SettingsWindow;
+import java.awt.Color;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -76,6 +77,18 @@ public final class LookAndFeel {
         : getSubstanceLookAndFeelManager()
             .map(SubstanceLookAndFeelManager::getDefaultLookAndFeelClassName)
             .orElseGet(UIManager::getSystemLookAndFeelClassName);
+  }
+
+  public static boolean isCurrentLookAndFeelDark() {
+    final Color background = UIManager.getColor("Panel.background");
+    return background != null && isColorDark(background);
+  }
+
+  public static boolean isColorDark(final Color color) {
+    // From the Wikipedia definition: https://en.wikipedia.org/wiki/Luma_%28video%29
+    final double luma =
+        (0.299 * color.getRed() + 0.587 * color.getGreen() + 0.114 * color.getBlue()) / 255;
+    return luma < 0.5;
   }
 
   private static void setupLookAndFeel(final String lookAndFeelName) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -164,7 +164,7 @@ public class BattleDisplay extends JPanel {
     attackerModel.setEnemyBattleModel(defenderModel);
     defenderModel.refresh();
     attackerModel.refresh();
-    casualties = new CasualtyNotificationPanel(data, uiContext);
+    casualties = new CasualtyNotificationPanel(uiContext);
     if (!killedUnits.isEmpty()
         || !attackingWaitingToDie.isEmpty()
         || !defendingWaitingToDie.isEmpty()) {
@@ -1029,7 +1029,7 @@ public class BattleDisplay extends JPanel {
     private final JPanel damaged = new JPanel();
     private final UiContext uiContext;
 
-    CasualtyNotificationPanel(final GameData data, final UiContext uiContext) {
+    CasualtyNotificationPanel(final UiContext uiContext) {
       this.uiContext = uiContext;
       setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
       add(killed);

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -16,6 +16,7 @@ import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.panels.map.MapPanel;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.awt.Toolkit;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.util.ArrayList;
@@ -269,7 +270,12 @@ public final class BattlePanel extends ActionPanel {
               attacker.getName() + " attacks " + defender.getName() + " in " + location.getName());
           battleWindow.getContentPane().removeAll();
           battleWindow.getContentPane().add(battleDisplay);
-          battleWindow.setMinimumSize(new Dimension(800, 600));
+          final Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+          if (screenSize.width > 1024 && screenSize.height > 768) {
+            battleWindow.setMinimumSize(new Dimension(1024, 768));
+          } else {
+            battleWindow.setMinimumSize(new Dimension(800, 600));
+          }
           battleWindow.setLocationRelativeTo(JOptionPane.getFrameForComponent(BattlePanel.this));
           boolean foundHumanInBattle = false;
           for (final Player gamePlayer :

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -14,9 +14,10 @@ import games.strategy.triplea.delegate.data.CasualtyList;
 import games.strategy.triplea.delegate.data.FightBattleDetails;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.panels.map.MapPanel;
+import games.strategy.ui.Util;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
-import java.awt.Toolkit;
+import java.awt.Frame;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.util.ArrayList;
@@ -270,13 +271,14 @@ public final class BattlePanel extends ActionPanel {
               attacker.getName() + " attacks " + defender.getName() + " in " + location.getName());
           battleWindow.getContentPane().removeAll();
           battleWindow.getContentPane().add(battleDisplay);
-          final Dimension screenSize = Toolkit.getDefaultToolkit().getScreenSize();
+          final Frame parent = JOptionPane.getFrameForComponent(BattlePanel.this);
+          final Dimension screenSize = Util.getScreenSize(parent);
           if (screenSize.width > 1024 && screenSize.height > 768) {
             battleWindow.setMinimumSize(new Dimension(1024, 768));
           } else {
             battleWindow.setMinimumSize(new Dimension(800, 600));
           }
-          battleWindow.setLocationRelativeTo(JOptionPane.getFrameForComponent(BattlePanel.this));
+          battleWindow.setLocationRelativeTo(parent);
           boolean foundHumanInBattle = false;
           for (final Player gamePlayer :
               getMap().getUiContext().getLocalPlayers().getLocalPlayers()) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
@@ -40,7 +40,11 @@ public class DicePanel extends JPanel {
   /** Sets the dice roll to display. */
   public void setDiceRoll(final DiceRoll diceRoll) {
     removeAll();
-    add(new JLabel("Total hits: " + diceRoll.getHits(), SwingConstants.LEFT));
+    add(
+        new JLabel(
+            "<html><b><font style='font-size:120%'>Total hits: <font color='#8B0000'>"
+                + diceRoll.getHits(),
+            SwingConstants.LEFT));
     add(new JSeparator());
 
     for (int i = 1; i <= data.getDiceSides(); i++) {
@@ -65,8 +69,11 @@ public class DicePanel extends JPanel {
       }
     }
     final String countString = dice.size() == 1 ? "1 die" : dice.size() + " dice";
-    final String hitsString = hits == 1 ? "1 hit" : hits + " hits";
-    return new JLabel("Rolled " + countString + " at " + value + " (" + hitsString + "):");
+    String hitsString = hits == 1 ? "1 hit" : hits + " hits";
+    if (hits != 0) {
+      hitsString = "<font color='#8B0000'>" + hitsString + "</font>";
+    }
+    return new JLabel("<html><b>Rolled " + countString + " at " + value + " (" + hitsString + "):");
   }
 
   private void add(final JComponent component) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
@@ -68,7 +68,7 @@ public class DicePanel extends JPanel {
     return new JLabel("<html><b>Rolled " + countString + " at " + value + " (" + hitsString + "):");
   }
 
-  private static String colorizeHitString(final Object hitString) {
+  private static String colorizeHitString(final Object hitsString) {
     return "<font color='#8B0000'>" + hitsString + "</font>";
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
@@ -40,10 +40,10 @@ public class DicePanel extends JPanel {
   /** Sets the dice roll to display. */
   public void setDiceRoll(final DiceRoll diceRoll) {
     removeAll();
+    final String hitsString = colorizeHitString(diceRoll.getHits());
     add(
         new JLabel(
-            "<html><b><font style='font-size:120%'>Total hits: <font color='#8B0000'>"
-                + diceRoll.getHits(),
+            "<html><b><font style='font-size:120%'>Total hits: " + hitsString,
             SwingConstants.LEFT));
     add(new JSeparator());
 
@@ -62,18 +62,14 @@ public class DicePanel extends JPanel {
   }
 
   private JLabel makeDiceRolledLabel(final List<Die> dice, final int value) {
-    int hits = 0;
-    for (final Die die : dice) {
-      if (die.getType() == Die.DieType.HIT) {
-        hits++;
-      }
-    }
+    final long hits = dice.stream().map(Die::getType).filter(Die.DieType.HIT::equals).count();
     final String countString = dice.size() == 1 ? "1 die" : dice.size() + " dice";
-    String hitsString = hits == 1 ? "1 hit" : hits + " hits";
-    if (hits != 0) {
-      hitsString = "<font color='#8B0000'>" + hitsString + "</font>";
-    }
+    final String hitsString = colorizeHitString(hits == 1 ? "1 hit" : hits + " hits");
     return new JLabel("<html><b>Rolled " + countString + " at " + value + " (" + hitsString + "):");
+  }
+
+  private static String colorizeHitString(final Object hitString) {
+    return "<font color='#8B0000'>" + hitsString + "</font>";
   }
 
   private void add(final JComponent component) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
@@ -57,6 +57,7 @@ public class DicePanel extends JPanel {
     final GridBagConstraints constraints = new GridBagConstraints();
     constraints.fill = GridBagConstraints.HORIZONTAL;
     constraints.weightx = .1;
+    constraints.gridx = 0;
     add(component, constraints);
   }
 
@@ -64,6 +65,7 @@ public class DicePanel extends JPanel {
     final GridBagConstraints constraints = new GridBagConstraints();
     constraints.fill = GridBagConstraints.BOTH;
     constraints.weighty = 1;
+    constraints.gridx = 0;
     label.setVerticalAlignment(SwingConstants.BOTTOM);
     add(label, constraints);
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
@@ -56,7 +56,7 @@ public class DicePanel extends JPanel {
   private void add(final JComponent component) {
     final GridBagConstraints constraints = new GridBagConstraints();
     constraints.fill = GridBagConstraints.HORIZONTAL;
-    constraints.weightx = .1;
+    constraints.weightx = 1;
     constraints.gridx = 0;
     add(component, constraints);
   }
@@ -64,6 +64,7 @@ public class DicePanel extends JPanel {
   private void addBottomLabel(final JLabel label) {
     final GridBagConstraints constraints = new GridBagConstraints();
     constraints.fill = GridBagConstraints.BOTH;
+    constraints.weightx = 1;
     constraints.weighty = 1;
     constraints.gridx = 0;
     label.setVerticalAlignment(SwingConstants.BOTTOM);

--- a/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
@@ -8,6 +8,7 @@ import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.util.List;
 import javax.swing.BorderFactory;
+import javax.swing.Box;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
@@ -21,6 +22,9 @@ import org.triplea.swing.WrapLayout;
  */
 public class DicePanel extends JPanel {
   private static final long serialVersionUID = -7544999867518263506L;
+
+  private static final String DARKER_RED = "#8B0000";
+
   private final UiContext uiContext;
   private final GameData data;
 
@@ -35,7 +39,7 @@ public class DicePanel extends JPanel {
     removeAll();
     add(new JLabel("Cost: " + cost, SwingConstants.LEFT));
     add(create(dice));
-    addBottomLabel(new JLabel());
+    addBottomSpacing();
   }
 
   /** Sets the dice roll to display. */
@@ -56,7 +60,7 @@ public class DicePanel extends JPanel {
       add(makeDiceRolledLabel(dice, i));
       add(create(dice));
     }
-    addBottomLabel(new JLabel());
+    addBottomSpacing();
     invalidate();
     validate();
     repaint();
@@ -71,7 +75,7 @@ public class DicePanel extends JPanel {
 
   private static String colorizeHitString(final Object hitsString) {
     // On a dark theme, use red. Use a darker red with a light theme.
-    final String color = LookAndFeel.isCurrentLookAndFeelDark() ? "red" : "#8B0000";
+    final String color = LookAndFeel.isCurrentLookAndFeelDark() ? "red" : DARKER_RED;
     return "<font color='" + color + "'>" + hitsString + "</font>";
   }
 
@@ -83,14 +87,13 @@ public class DicePanel extends JPanel {
     add(component, constraints);
   }
 
-  private void addBottomLabel(final JLabel label) {
+  private void addBottomSpacing() {
     final GridBagConstraints constraints = new GridBagConstraints();
     constraints.fill = GridBagConstraints.BOTH;
     constraints.weightx = 1;
     constraints.weighty = 1;
     constraints.gridx = 0;
-    label.setVerticalAlignment(SwingConstants.BOTTOM);
-    add(label, constraints);
+    add(Box.createVerticalGlue(), constraints);
   }
 
   private JComponent create(final List<Die> dice) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
@@ -50,8 +50,8 @@ public class DicePanel extends JPanel {
       }
       add(makeDiceRolledLabel(dice, i));
       add(create(dice));
-      addBottomLabel(new JLabel());
     }
+    addBottomLabel(new JLabel());
     invalidate();
     validate();
     repaint();

--- a/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
@@ -1,6 +1,7 @@
 package games.strategy.triplea.ui;
 
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.framework.lookandfeel.LookAndFeel;
 import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.delegate.Die;
 import java.awt.GridBagConstraints;
@@ -69,7 +70,9 @@ public class DicePanel extends JPanel {
   }
 
   private static String colorizeHitString(final Object hitsString) {
-    return "<font color='#8B0000'>" + hitsString + "</font>";
+    // On a dark theme, use red. Use a darker red with a light theme.
+    final String color = LookAndFeel.isCurrentLookAndFeelDark() ? "red" : "#8B0000";
+    return "<font color='" + color + "'>" + hitsString + "</font>";
   }
 
   private void add(final JComponent component) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
@@ -10,8 +10,8 @@ import javax.swing.BorderFactory;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JSeparator;
 import javax.swing.SwingConstants;
-import org.triplea.swing.SwingAction;
 import org.triplea.swing.WrapLayout;
 
 /**
@@ -27,30 +27,42 @@ public class DicePanel extends JPanel {
     this.uiContext = uiContext;
     this.data = data;
     setLayout(new GridBagLayout());
-    setBorder(BorderFactory.createEmptyBorder(0, 16, 0, 0));
+    setBorder(BorderFactory.createEmptyBorder(8, 16, 0, 0));
   }
 
   void setDiceRollForBombing(final List<Die> dice, final int cost) {
     removeAll();
+    add(new JLabel("Cost: " + cost, SwingConstants.LEFT));
     add(create(dice));
-    addBottomLabel(new JLabel("Cost:" + cost));
+    addBottomLabel(new JLabel());
   }
 
   /** Sets the dice roll to display. */
   public void setDiceRoll(final DiceRoll diceRoll) {
-    SwingAction.invokeNowOrLater(
-        () -> {
-          removeAll();
-          for (int i = 1; i <= data.getDiceSides(); i++) {
-            final List<Die> dice = diceRoll.getRolls(i);
-            if (dice.isEmpty()) {
-              continue;
-            }
-            add(new JLabel("Rolled at " + i + ":"));
-            add(create(diceRoll.getRolls(i)));
-          }
-          addBottomLabel(new JLabel("Total hits:" + diceRoll.getHits(), SwingConstants.LEFT));
-        });
+    removeAll();
+    add(new JLabel("Total hits: " + diceRoll.getHits(), SwingConstants.LEFT));
+    add(new JSeparator());
+
+    for (int i = 1; i <= data.getDiceSides(); i++) {
+      final List<Die> dice = diceRoll.getRolls(i);
+      if (dice.isEmpty()) {
+        continue;
+      }
+      add(makeDiceRolledLabel(dice, i));
+      add(create(dice));
+      addBottomLabel(new JLabel());
+    }
+  }
+
+  private JLabel makeDiceRolledLabel(final List<Die> dice, final int value) {
+    int hits = 0;
+    for (final Die die : dice) {
+      if (die.getType() == Die.DieType.HIT) {
+        hits++;
+      }
+    }
+    final String count = dice.size() == 1 ? "1 die" : dice.size() + " dice";
+    return new JLabel("Rolled " + count + " at " + value + " (" + hits + " hits):");
   }
 
   private void add(final JComponent component) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
@@ -61,8 +61,9 @@ public class DicePanel extends JPanel {
         hits++;
       }
     }
-    final String count = dice.size() == 1 ? "1 die" : dice.size() + " dice";
-    return new JLabel("Rolled " + count + " at " + value + " (" + hits + " hits):");
+    final String countString = dice.size() == 1 ? "1 die" : dice.size() + " dice";
+    final String hitsString = hits == 1 ? "1 hit" : hits + " hits";
+    return new JLabel("Rolled " + countString + " at " + value + " (" + hitsString + "):");
   }
 
   private void add(final JComponent component) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
@@ -3,17 +3,16 @@ package games.strategy.triplea.ui;
 import games.strategy.engine.data.GameData;
 import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.delegate.Die;
-import games.strategy.triplea.image.DiceImageFactory;
-import java.awt.Dimension;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
 import java.util.List;
-import javax.swing.Box;
-import javax.swing.BoxLayout;
+import javax.swing.BorderFactory;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
-import javax.swing.JScrollPane;
-import javax.swing.ScrollPaneConstants;
+import javax.swing.SwingConstants;
 import org.triplea.swing.SwingAction;
+import org.triplea.swing.WrapLayout;
 
 /**
  * A UI component used to display a dice roll. One image is displayed per die in a horizontal
@@ -27,15 +26,14 @@ public class DicePanel extends JPanel {
   public DicePanel(final UiContext uiContext, final GameData data) {
     this.uiContext = uiContext;
     this.data = data;
-    setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
+    setLayout(new GridBagLayout());
+    setBorder(BorderFactory.createEmptyBorder(0, 16, 0, 0));
   }
 
   void setDiceRollForBombing(final List<Die> dice, final int cost) {
     removeAll();
     add(create(dice));
-    add(Box.createVerticalGlue());
-    add(new JLabel("Cost:" + cost));
-    invalidate();
+    addBottomLabel(new JLabel("Cost:" + cost));
   }
 
   /** Sets the dice roll to display. */
@@ -51,35 +49,33 @@ public class DicePanel extends JPanel {
             add(new JLabel("Rolled at " + i + ":"));
             add(create(diceRoll.getRolls(i)));
           }
-          add(Box.createVerticalGlue());
-          add(new JLabel("Total hits:" + diceRoll.getHits()));
-          validate();
-          invalidate();
-          repaint();
+          addBottomLabel(new JLabel("Total hits:" + diceRoll.getHits(), SwingConstants.LEFT));
         });
+  }
+
+  private void add(final JComponent component) {
+    final GridBagConstraints constraints = new GridBagConstraints();
+    constraints.fill = GridBagConstraints.HORIZONTAL;
+    constraints.weightx = .1;
+    add(component, constraints);
+  }
+
+  private void addBottomLabel(final JLabel label) {
+    final GridBagConstraints constraints = new GridBagConstraints();
+    constraints.fill = GridBagConstraints.BOTH;
+    constraints.weighty = 1;
+    label.setVerticalAlignment(SwingConstants.BOTTOM);
+    add(label, constraints);
   }
 
   private JComponent create(final List<Die> dice) {
     final JPanel dicePanel = new JPanel();
-    dicePanel.setLayout(new BoxLayout(dicePanel, BoxLayout.X_AXIS));
-    dicePanel.add(Box.createHorizontalStrut(20));
+    dicePanel.setBorder(BorderFactory.createEmptyBorder(2, 0, 2, 0));
+    dicePanel.setLayout(new WrapLayout(WrapLayout.LEFT, 2, 2));
     for (final Die die : dice) {
       final int roll = die.getValue() + 1;
       dicePanel.add(new JLabel(uiContext.getDiceImageFactory().getDieIcon(roll, die.getType())));
-      dicePanel.add(Box.createHorizontalStrut(2));
     }
-    final JScrollPane scroll = new JScrollPane(dicePanel);
-    scroll.setBorder(null);
-    scroll.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_NEVER);
-    // we're adding to a box layout, so to prevent the component from grabbing extra space, set the
-    // max height.
-    // allow room for a dice and a scrollbar
-    scroll.setMinimumSize(
-        new Dimension(scroll.getMinimumSize().width, DiceImageFactory.DIE_HEIGHT + 17));
-    scroll.setMaximumSize(
-        new Dimension(scroll.getMaximumSize().width, DiceImageFactory.DIE_HEIGHT + 17));
-    scroll.setPreferredSize(
-        new Dimension(scroll.getPreferredSize().width, DiceImageFactory.DIE_HEIGHT + 17));
-    return scroll;
+    return dicePanel;
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/DicePanel.java
@@ -52,6 +52,9 @@ public class DicePanel extends JPanel {
       add(create(dice));
       addBottomLabel(new JLabel());
     }
+    invalidate();
+    validate();
+    repaint();
   }
 
   private JLabel makeDiceRolledLabel(final List<Die> dice, final int value) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryDetailsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryDetailsPanel.java
@@ -38,7 +38,7 @@ import org.triplea.swing.ScrollableJPanel;
  * </ul>
  */
 public class HistoryDetailsPanel extends JPanel {
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 5092004144144006960L;
   private final GameData data;
   private final MapPanel mapPanel;
   private final JTextArea title = new JTextArea();

--- a/game-core/src/main/java/games/strategy/ui/Util.java
+++ b/game-core/src/main/java/games/strategy/ui/Util.java
@@ -4,6 +4,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.awt.Color;
 import java.awt.Component;
+import java.awt.Dimension;
 import java.awt.Font;
 import java.awt.GradientPaint;
 import java.awt.Graphics2D;
@@ -62,8 +63,9 @@ public final class Util {
 
   /** Centers the specified window on the screen. */
   public static void center(final Window w) {
-    final int screenWidth = Toolkit.getDefaultToolkit().getScreenSize().width;
-    final int screenHeight = Toolkit.getDefaultToolkit().getScreenSize().height;
+    final Dimension screenSize = getScreenSize(w);
+    final int screenWidth = screenSize.width;
+    final int screenHeight = screenSize.height;
     final int windowWidth = w.getWidth();
     final int windowHeight = w.getHeight();
     if (windowHeight > screenHeight) {
@@ -75,6 +77,16 @@ public final class Util {
     final int x = (screenWidth - windowWidth) / 2;
     final int y = (screenHeight - windowHeight) / 2;
     w.setLocation(x, y);
+  }
+
+  /** Returns the size of the screen associated with the passed window. */
+  public static Dimension getScreenSize(final Window window) {
+    final var graphicsConfiguration = window.getGraphicsConfiguration();
+    if (graphicsConfiguration == null) {
+      return Toolkit.getDefaultToolkit().getScreenSize();
+    }
+    final var displayMode = graphicsConfiguration.getDevice().getDisplayMode();
+    return new Dimension(displayMode.getWidth(), displayMode.getHeight());
   }
 
   /**

--- a/game-core/src/test/java/games/strategy/engine/framework/lookandfeel/LookAndFeelTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/lookandfeel/LookAndFeelTest.java
@@ -8,7 +8,7 @@ import org.junit.jupiter.api.Test;
 
 final class LookAndFeelTest {
   @Test
-  void testIsColorDark() throws Exception {
+  void testIsColorDark() {
     assertThat(LookAndFeel.isColorDark(Color.BLACK), is(true));
     assertThat(LookAndFeel.isColorDark(Color.DARK_GRAY), is(true));
     assertThat(LookAndFeel.isColorDark(Color.WHITE), is(false));

--- a/game-core/src/test/java/games/strategy/engine/framework/lookandfeel/LookAndFeelTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/lookandfeel/LookAndFeelTest.java
@@ -1,0 +1,17 @@
+package games.strategy.engine.framework.lookandfeel;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import java.awt.Color;
+import org.junit.jupiter.api.Test;
+
+final class LookAndFeelTest {
+  @Test
+  void testIsColorDark() throws Exception {
+    assertThat(LookAndFeel.isColorDark(Color.BLACK), is(true));
+    assertThat(LookAndFeel.isColorDark(Color.DARK_GRAY), is(true));
+    assertThat(LookAndFeel.isColorDark(Color.WHITE), is(false));
+    assertThat(LookAndFeel.isColorDark(Color.YELLOW), is(false));
+  }
+}

--- a/swing-lib/src/main/java/org/triplea/swing/ScrollableJPanel.java
+++ b/swing-lib/src/main/java/org/triplea/swing/ScrollableJPanel.java
@@ -10,8 +10,8 @@ import javax.swing.Scrollable;
  * A JPanel implementing Scrollable, with the behavior similar to a JTextArea for resizing. That is,
  * to have the panel's width updated based on the size of the outer scroll area (so if a window is
  * resized down, so is the panel), via getScrollableTracksViewportWidth() returning true. This is
- * especially when used in conjunction with WrapLayout (either as the layout of the panel itself or
- * on some of its children), so that the content is reflowed when the size is updated.
+ * especially useful when used in conjunction with WrapLayout (either as the layout of the panel
+ * itself or on some of its children), so that the content is reflowed when the size is updated.
  */
 public class ScrollableJPanel extends JPanel implements Scrollable {
   private static final long serialVersionUID = 1L;
@@ -21,7 +21,7 @@ public class ScrollableJPanel extends JPanel implements Scrollable {
     final Dimension d = super.getPreferredSize();
     if (getParent() instanceof JViewport) {
       // When directly inside a viewport, preferred height is the greater of the underlying
-      // preferred or the viewport's size - so that we take the available space.
+      // preferred height or the viewport's size - so that we take the available space.
       d.height = Math.max(d.height, ((JViewport) getParent()).getHeight());
     }
     return d;

--- a/swing-lib/src/main/java/org/triplea/swing/ScrollableJPanel.java
+++ b/swing-lib/src/main/java/org/triplea/swing/ScrollableJPanel.java
@@ -1,0 +1,56 @@
+package org.triplea.swing;
+
+import java.awt.Dimension;
+import java.awt.Rectangle;
+import javax.swing.JPanel;
+import javax.swing.JViewport;
+import javax.swing.Scrollable;
+
+/**
+ * A JPanel implementing Scrollable, with the behavior similar to a JTextArea for resizing. That is,
+ * to have the panel's width updated based on the size of the outer scroll area (so if a window is
+ * resized down, so is the panel), via getScrollableTracksViewportWidth() returning true. This is
+ * especially when used in conjunction with WrapLayout (either as the layout of the panel itself or
+ * on some of its children), so that the content is reflowed when the size is updated.
+ */
+public class ScrollableJPanel extends JPanel implements Scrollable {
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  public Dimension getPreferredSize() {
+    final Dimension d = super.getPreferredSize();
+    if (getParent() instanceof JViewport) {
+      // When directly inside a viewport, preferred height is the greater of the underlying
+      // preferred or the viewport's size - so that we take the available space.
+      d.height = Math.max(d.height, ((JViewport) getParent()).getHeight());
+    }
+    return d;
+  }
+
+  @Override
+  public Dimension getPreferredScrollableViewportSize() {
+    return getPreferredSize();
+  }
+
+  @Override
+  public int getScrollableBlockIncrement(
+      final Rectangle visibleRect, final int orientation, final int direction) {
+    return 10;
+  }
+
+  @Override
+  public boolean getScrollableTracksViewportHeight() {
+    return false;
+  }
+
+  @Override
+  public boolean getScrollableTracksViewportWidth() {
+    return true;
+  }
+
+  @Override
+  public int getScrollableUnitIncrement(
+      final Rectangle visibleRect, final int orientation, final int direction) {
+    return 10;
+  }
+}

--- a/swing-lib/src/main/java/org/triplea/swing/WrapLayout.java
+++ b/swing-lib/src/main/java/org/triplea/swing/WrapLayout.java
@@ -18,7 +18,7 @@ import javax.swing.SwingUtilities;
  * <p>Originally from: https://tips4java.wordpress.com/2008/11/06/wrap-layout/.
  */
 public class WrapLayout extends FlowLayout {
-  private static final long serialVersionUID = 2L;
+  private static final long serialVersionUID = 1L;
 
   private boolean revalidateScheduled;
 

--- a/swing-lib/src/main/java/org/triplea/swing/WrapLayout.java
+++ b/swing-lib/src/main/java/org/triplea/swing/WrapLayout.java
@@ -18,7 +18,9 @@ import javax.swing.SwingUtilities;
  * <p>Originally from: https://tips4java.wordpress.com/2008/11/06/wrap-layout/.
  */
 public class WrapLayout extends FlowLayout {
-  private static final long serialVersionUID = 1L;
+  private static final long serialVersionUID = 2L;
+
+  private boolean revalidateScheduled;
 
   /**
    * Constructs a new <code>WrapLayout</code> with a left alignment and a default 5-unit horizontal
@@ -91,18 +93,14 @@ public class WrapLayout extends FlowLayout {
     synchronized (target.getTreeLock()) {
       // Each row must fit with the width allocated to the containter.
       // When the container width = 0, the preferred width of the container
-      // has not yet been calculated so lets ask for the maximum.
-      int targetWidth = target.getSize().width;
-      Container container = target;
+      // has not yet been calculated, so use the FlowLayout implementation which
+      // lays everything out in a line. Also schedule a revalidation so that
+      // the actual size is realized.
 
-      while (container.getSize().width == 0 && container.getParent() != null) {
-        container = container.getParent();
-      }
-
-      targetWidth = container.getSize().width;
-
+      final int targetWidth = target.getWidth();
       if (targetWidth == 0) {
-        targetWidth = Integer.MAX_VALUE;
+        scheduleRevalidate(target);
+        return preferred ? super.preferredLayoutSize(target) : super.minimumLayoutSize(target);
       }
 
       final int hgap = getHgap();
@@ -155,6 +153,17 @@ public class WrapLayout extends FlowLayout {
       }
 
       return dim;
+    }
+  }
+
+  private void scheduleRevalidate(final Container target) {
+    if (!revalidateScheduled) {
+      revalidateScheduled = true;
+      SwingUtilities.invokeLater(
+          () -> {
+            target.revalidate();
+            revalidateScheduled = false;
+          });
     }
   }
 


### PR DESCRIPTION
This change improves the display of dice rolls when there's a lot
of them, by wrapping the dice as opposed to showing them all in
one scrollable line. To accommodate the change, which can increase
the height of the containing components, some UI elements are
restructured to use an outer scrollpane - particularly the combat
and history views.

Also improves the battle window in a few ways:
  - If the screen is more than 1024x768, use 1024x768 size
  - The total hits line is now on top in a larger font
  - For each dice value, show number of hits and number of rolls
  - Show number of hits in red

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[X] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
Manual testing on both existing save games and with map edit to add different, large number of units to verify things are displayed correctly in different scenarios. Tested resize behavior in both the combat window and the history panel to make sure the dice rolls are correctly reflowed. Tested on different themes.

## Screens Shots

### Before (Combat)
<img width="912" alt="Screen Shot 2020-05-08 at 8 52 17 AM" src="https://user-images.githubusercontent.com/17648/81475350-8e53aa80-91d9-11ea-8a32-95515e80b19c.png">
Notice the vertical scrollbar and the fact there's no horizontal scrollbar even though the content is already too tall.

### After (Combat)
![Screen Shot 2020-05-20 at 9 40 50 AM](https://user-images.githubusercontent.com/17648/82453074-1198ba00-9a7e-11ea-8621-fecdd601fc6a.png)

Save game for testing the above (end the combat step to see the battle window):
[before_dice.tsvg.zip](https://github.com/triplea-game/triplea/files/4603589/before_dice.tsvg.zip)

Dark theme, 12-sided dice with lots of rolls to require scrolling:
![Screen Shot 2020-05-22 at 9 16 16 AM](https://user-images.githubusercontent.com/17648/82672872-f1e4cb80-9c0e-11ea-8413-c18255f42732.png)

### Before (History)
Different theme, showing the history panel:
<img width="378" alt="Screen Shot 2020-05-09 at 10 11 07 AM" src="https://user-images.githubusercontent.com/17648/81476068-c957dd00-91dd-11ea-9b90-8132adbcceaf.png">


### After (History)
Different theme, showing the history panel:
![Screen Shot 2020-05-20 at 7 28 49 PM](https://user-images.githubusercontent.com/17648/82507423-30c03780-9ad0-11ea-8675-d49a0b3e44e2.png)

Save game for testing the history view (open saved game and switch to history view and view the combat where Austria attacks Greece): 
[dom_arabia_10.tsvg.zip](https://github.com/triplea-game/triplea/files/4603622/dom_arabia_10.tsvg.zip)


<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->
