### PR TITLE
Handle null must-move-with-unit value

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/data/MustMoveWithDetails.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/data/MustMoveWithDetails.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * A response to a must move query. Returns a mapping of unit -> collection of units. Units that
@@ -29,6 +30,6 @@ public class MustMoveWithDetails implements Serializable {
   }
 
   public Collection<Unit> getMustMoveWithForUnit(final Unit unit) {
-    return mapping.getOrDefault(unit, List.of());
+    return Optional.ofNullable(mapping.get(unit)).orElse(List.of());
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/data/MustMoveWithDetailsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/data/MustMoveWithDetailsTest.java
@@ -1,0 +1,28 @@
+package games.strategy.triplea.delegate.data;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
+import static org.hamcrest.core.Is.is;
+
+import games.strategy.engine.data.Unit;
+import java.util.HashMap;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class MustMoveWithDetailsTest {
+
+  @Mock private Unit unit;
+
+  @Test
+  @DisplayName(
+      "Verify getMustMoveWithForUnit will convert null mapped values to an empty collection")
+  void getMustMoveWithForUnitReturnsEmptyCollectionsWhenValueIsNull() {
+    final MustMoveWithDetails mustMoveWithDetails = new MustMoveWithDetails(new HashMap<>());
+    mustMoveWithDetails.getMustMoveWith().put(unit, null);
+    assertThat(mustMoveWithDetails.getMustMoveWithForUnit(unit), is(empty()));
+  }
+}


### PR DESCRIPTION
This update replaces a 'getOrDefault' call to to convert any
returned null value to be an empty list.

If we place a null value into a map explicitly, then
a 'getOrDefault(key, default)' call will return the null value
and not the default.

Addresses NPE reported in:
https://github.com/triplea-game/triplea/issues/6448


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

