### PR TITLE
Fix row indexing for moderator lobby table actions

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -213,7 +213,7 @@ class LobbyGamePanel extends JPanel {
 
     FetchChatHistory.builder()
         .parentWindow(parent)
-        .gameId(gameTableModel.getGameIdForRow(selectedIndex))
+        .gameId(gameTableModel.getGameIdForRow(gameTable.convertRowIndexToModel(selectedIndex)))
         .gameHostName(gameTableModel.get(selectedIndex).getHostedBy().getName())
         .playerToLobbyConnection(lobbyClient.getPlayerToLobbyConnection())
         .build()
@@ -235,7 +235,7 @@ class LobbyGamePanel extends JPanel {
       return;
     }
 
-    gameTableModel.bootGame(selectedIndex);
+    gameTableModel.bootGame(gameTable.convertRowIndexToModel(selectedIndex));
     JOptionPane.showMessageDialog(
         null, "The game you selected has been disconnected from the lobby.");
   }
@@ -255,7 +255,8 @@ class LobbyGamePanel extends JPanel {
       return;
     }
 
-    final String gameId = gameTableModel.getGameIdForRow(selectedIndex);
+    final String gameId =
+        gameTableModel.getGameIdForRow(gameTable.convertRowIndexToModel(selectedIndex));
     lobbyClient.getPlayerToLobbyConnection().sendShutdownRequest(gameId);
     JOptionPane.showMessageDialog(null, "The game you selected was sent a shutdown signal");
   }


### PR DESCRIPTION
Model row numbers and UI-with-sort row numbers are not in-sync,
this update updates the selected row number to match the table
model's row number. This fixes the case where if moderators sort
the lobby table then row actions are executed against the 'wrong'
game.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
- verified locally
  - launched a local lobby
  - connected to it with a mod account (test:test)
  - hosted two games with different maps
  - typed a few chat messages in one game
  - verified that after sorting the two games by map in either order that 'show chat history' showed the history of the correct game

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

