### PR TITLE
Update tests for map search path 'getCandidates'

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
@@ -101,7 +101,8 @@ public final class MapDownloadController {
 
       @Override
       public List<File> getZipFileCandidates(final String mapName) {
-        return ResourceLoader.getMapZipFileCandidates(mapName);
+        return ResourceLoader.getMapZipFileCandidates(
+            mapName, ClientFileSystemHelper.getUserMapsFolder());
       }
     };
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/MapNotFoundException.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/MapNotFoundException.java
@@ -1,7 +1,7 @@
 package games.strategy.engine.framework.startup.launcher;
 
 import java.io.File;
-import java.util.List;
+import java.util.Collection;
 import java.util.stream.Collectors;
 
 /**
@@ -11,7 +11,7 @@ import java.util.stream.Collectors;
 public class MapNotFoundException extends IllegalStateException {
   private static final long serialVersionUID = -1027460394367073991L;
 
-  public MapNotFoundException(final String mapName, final List<File> candidatePaths) {
+  public MapNotFoundException(final String mapName, final Collection<File> candidatePaths) {
     super(
         "Could not find map: "
             + mapName

--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -117,10 +117,9 @@ public class ResourceLoader implements Closeable {
    * @return A list of candidate directories; never {@code null}.
    */
   @VisibleForTesting
-  static List<File> getMapDirectoryCandidates(final String mapName) {
+  static List<File> getMapDirectoryCandidates(final String mapName, final File userMapsFolder) {
     checkNotNull(mapName);
 
-    final File userMapsFolder = ClientFileSystemHelper.getUserMapsFolder();
     final String dirName = File.separator + mapName;
     final String normalizedMapName = File.separator + normalizeMapName(mapName) + "-master";
     return List.of(
@@ -140,10 +139,10 @@ public class ResourceLoader implements Closeable {
    * @param mapName The map name; must not be {@code null}.
    * @return A list of candidate zip files; never {@code null}.
    */
-  public static List<File> getMapZipFileCandidates(final String mapName) {
+  public static List<File> getMapZipFileCandidates(
+      final String mapName, final File userMapsFolder) {
     checkNotNull(mapName);
 
-    final File userMapsFolder = ClientFileSystemHelper.getUserMapsFolder();
     final String normalizedMapName = normalizeMapName(mapName);
     return List.of(
         new File(userMapsFolder, mapName + ".zip"),
@@ -210,8 +209,9 @@ public class ResourceLoader implements Closeable {
 
   private static List<File> getCandidatePaths(final String mapName) {
     final List<File> candidates = new ArrayList<>();
-    candidates.addAll(getMapDirectoryCandidates(mapName));
-    candidates.addAll(getMapZipFileCandidates(mapName));
+    candidates.addAll(
+        getMapDirectoryCandidates(mapName, ClientFileSystemHelper.getUserMapsFolder()));
+    candidates.addAll(getMapZipFileCandidates(mapName, ClientFileSystemHelper.getUserMapsFolder()));
     return candidates;
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
@@ -2,9 +2,10 @@ package games.strategy.triplea;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.triplea.io.FileUtils.newFile;
 
 import com.google.common.collect.Maps;
-import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -12,87 +13,44 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
-import java.util.stream.StreamSupport;
-import org.hamcrest.Matcher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.triplea.test.common.CustomMatcher;
 
+@SuppressWarnings("InnerClassMayBeStatic")
 final class ResourceLoaderTest {
+  private static final File userMapsFolder = newFile("user", "maps");
+
   @Nested
-  final class GetMapDirectoryCandidatesTest extends AbstractClientSettingTestCase {
+  final class GetMapDirectoryCandidatesTest {
     @Test
-    void shouldIncludeNameThenMap() {
-      final List<File> candidates = ResourceLoader.getMapDirectoryCandidates("MapName");
-      assertThat(candidates, containsDirectoryEndingWith("MapName" + File.separator + "map"));
-    }
+    void getMapDirectoryCandidates() {
+      final List<File> candidates =
+          ResourceLoader.getMapDirectoryCandidates("MapName", userMapsFolder);
 
-    @Test
-    void shouldIncludeName() {
-      final List<File> candidates = ResourceLoader.getMapDirectoryCandidates("MapName");
-      assertThat(candidates, containsDirectoryEndingWith("MapName"));
-    }
-
-    @Test
-    void shouldIncludeGithubNameThenMap() {
-      final List<File> candidates = ResourceLoader.getMapDirectoryCandidates("MapName");
-      assertThat(
-          candidates, containsDirectoryEndingWith("map_name-master" + File.separator + "map"));
-    }
-
-    @Test
-    void shouldIncludeGithubName() {
-      final List<File> candidates = ResourceLoader.getMapDirectoryCandidates("MapName");
-      assertThat(candidates, containsDirectoryEndingWith("map_name-master"));
+      assertThat(candidates, hasSize(4));
+      assertThat(candidates.get(0), is(newFile("user", "maps", "MapName", "map")));
+      assertThat(candidates.get(1), is(newFile("user", "maps", "MapName")));
+      assertThat(candidates.get(2), is(newFile("user", "maps", "map_name-master", "map")));
+      assertThat(candidates.get(3), is(newFile("user", "maps", "map_name-master")));
     }
   }
 
   @Nested
-  final class GetMapZipFileCandidatesTest extends AbstractClientSettingTestCase {
+  final class GetMapZipFileCandidatesTest {
     @Test
-    void shouldIncludeDefaultZipFile() {
-      final List<File> candidates = ResourceLoader.getMapZipFileCandidates("MapName");
+    void getMapZipFileCandidatesTest() {
 
-      assertThat(candidates, containsFileWithName("MapName.zip"));
+      final List<File> candidates =
+          ResourceLoader.getMapZipFileCandidates("MapName", userMapsFolder);
+
+      assertThat(candidates, hasSize(3));
+
+      assertThat(candidates.get(0), is(newFile("user", "maps", "MapName.zip")));
+      assertThat(candidates.get(1), is(newFile("user", "maps", "map_name-master.zip")));
+      assertThat(candidates.get(2), is(newFile("user", "maps", "map_name.zip")));
     }
-
-    @Test
-    void shouldIncludeNormalizedZipFile() {
-      final List<File> candidates = ResourceLoader.getMapZipFileCandidates("MapName");
-
-      assertThat(candidates, containsFileWithName("map_name.zip"));
-    }
-
-    @Test
-    void shouldIncludeGitHubZipFile() {
-      final List<File> candidates = ResourceLoader.getMapZipFileCandidates("MapName");
-
-      assertThat(candidates, containsFileWithName("map_name-master.zip"));
-    }
-  }
-
-  private static Matcher<Iterable<File>> containsDirectoryEndingWith(final String name) {
-    return CustomMatcher.<Iterable<File>>builder()
-        .description("iterable with directory ending with: " + name)
-        .checkCondition(
-            files ->
-                StreamSupport.stream(files.spliterator(), false)
-                    .map(File::getPath)
-                    .anyMatch(p -> p.endsWith(name)))
-        .build();
-  }
-
-  private static Matcher<Iterable<File>> containsFileWithName(final String name) {
-    return CustomMatcher.<Iterable<File>>builder()
-        .description("iterable containing file with name " + name)
-        .checkCondition(
-            files ->
-                StreamSupport.stream(files.spliterator(), false)
-                    .map(File::getName)
-                    .anyMatch(name::equals))
-        .build();
   }
 
   @Nested

--- a/java-extras/src/main/java/org/triplea/io/FileUtils.java
+++ b/java-extras/src/main/java/org/triplea/io/FileUtils.java
@@ -3,7 +3,7 @@ package org.triplea.io;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.File;
-import java.util.ArrayList;
+import java.nio.file.Path;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -18,10 +18,7 @@ public final class FileUtils {
    * method to concatenate the path together with an OS specific file separator.
    */
   public static File newFile(final String parentDir, final String... childDirs) {
-    final List<String> dirs = new ArrayList<>();
-    dirs.add(parentDir);
-    dirs.addAll(List.of(childDirs));
-    return new File(String.join(File.separator, dirs));
+    return Path.of(parentDir, childDirs).toFile();
   }
 
   /**

--- a/java-extras/src/main/java/org/triplea/io/FileUtils.java
+++ b/java-extras/src/main/java/org/triplea/io/FileUtils.java
@@ -3,13 +3,26 @@ package org.triplea.io;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
+import lombok.experimental.UtilityClass;
 
 /** A collection of useful methods related to files. */
+@UtilityClass
 public final class FileUtils {
-  private FileUtils() {}
+
+  /**
+   * Creates a new file with a parent folder and any number of child folders. This is a convenience
+   * method to concatenate the path together with an OS specific file separator.
+   */
+  public static File newFile(final String parentDir, final String... childDirs) {
+    final List<String> dirs = new ArrayList<>();
+    dirs.add(parentDir);
+    dirs.addAll(List.of(childDirs));
+    return new File(String.join(File.separator, dirs));
+  }
 
   /**
    * Returns a collection of abstract pathnames denoting the files and directories in the specified

--- a/java-extras/src/test/java/org/triplea/io/FileUtilsTest.java
+++ b/java-extras/src/test/java/org/triplea/io/FileUtilsTest.java
@@ -13,7 +13,22 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+@SuppressWarnings("InnerClassMayBeStatic")
 final class FileUtilsTest {
+
+  @Nested
+  final class NewFile {
+    @Test
+    void createNewFile() {
+      assertThat(FileUtils.newFile("file", "path"), is(new File("file" + File.separator + "path")));
+    }
+
+    @Test
+    void createNewFileFromSingleton() {
+      assertThat(FileUtils.newFile("file"), is(new File("file")));
+    }
+  }
+
   @ExtendWith(MockitoExtension.class)
   @Nested
   final class ListFilesTest {


### PR DESCRIPTION
- Avoid using Client settings, instead pass in user maps root folder
- Check explicitly the returned values in test.
- Update MapNotFoundException API to accept a collection, the exception does not
  care what kind of collection is received (it is overspecified)


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[x] Other: test improvement  <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

