### PR TITLE
Add lobby_user FK to access_log

### DIFF
--- a/http-server/src/main/java/org/triplea/db/dao/access/log/AccessLogDao.java
+++ b/http-server/src/main/java/org/triplea/db/dao/access/log/AccessLogDao.java
@@ -17,8 +17,8 @@ public interface AccessLogDao {
           + "    username,"
           + "    ip,"
           + "    system_id,"
-          + "    registered"
-          + "  from access_log"
+          + "    (lobby_user_id is not null) as registered"
+          + "  from access_log al"
           + "  where username like :username"
           + "     and host(ip) like :ip"
           + "     and system_id like :systemId"
@@ -33,14 +33,12 @@ public interface AccessLogDao {
       @Bind("systemId") String systemId);
 
   @SqlUpdate(
-      "insert into access_log(username, ip, system_id, registered)\n"
-          + "values(:username, :ip::inet, :systemId, true)")
-  int insertRegisteredUserRecord(
-      @Bind("username") String username, @Bind("ip") String ip, @Bind("systemId") String systemId);
-
-  @SqlUpdate(
-      "insert into access_log(username, ip, system_id, registered)\n"
-          + "values(:username, :ip::inet, :systemId, false)")
-  int insertAnonymousUserRecord(
+      "insert into access_log(username, ip, system_id, lobby_user_id)\n"
+          + "values ("
+          + "  :username,"
+          + "  :ip::inet,"
+          + "  :systemId,"
+          + "  (select id from lobby_user where username = :username))")
+  int insertUserAccessRecord(
       @Bind("username") String username, @Bind("ip") String ip, @Bind("systemId") String systemId);
 }

--- a/http-server/src/main/java/org/triplea/db/dao/access/log/AccessLogDao.java
+++ b/http-server/src/main/java/org/triplea/db/dao/access/log/AccessLogDao.java
@@ -18,7 +18,7 @@ public interface AccessLogDao {
           + "    ip,"
           + "    system_id,"
           + "    (lobby_user_id is not null) as registered"
-          + "  from access_log al"
+          + "  from access_log"
           + "  where username like :username"
           + "     and host(ip) like :ip"
           + "     and system_id like :systemId"

--- a/http-server/src/main/java/org/triplea/db/dao/moderator/ModeratorUserDaoData.java
+++ b/http-server/src/main/java/org/triplea/db/dao/moderator/ModeratorUserDaoData.java
@@ -14,9 +14,6 @@ import org.triplea.db.TimestampMapper;
 @NoArgsConstructor
 @Getter
 public class ModeratorUserDaoData {
-  public static final String USERNAME_COLUMN = "username";
-  public static final String LAST_LOGIN_COLUMN = "last_login";
-
   private String username;
   private Instant lastLogin;
 
@@ -25,7 +22,7 @@ public class ModeratorUserDaoData {
     return (rs, ctx) ->
         ModeratorUserDaoData.builder()
             .username(rs.getString("username"))
-            .lastLogin(TimestampMapper.map(rs, "last_login"))
+            .lastLogin(TimestampMapper.map(rs, "access_time"))
             .build();
   }
 }

--- a/http-server/src/main/java/org/triplea/db/dao/moderator/ModeratorsDao.java
+++ b/http-server/src/main/java/org/triplea/db/dao/moderator/ModeratorsDao.java
@@ -14,11 +14,13 @@ public interface ModeratorsDao {
   @SqlQuery(
       "select "
           + "    lu.username,"
-          + "    lu.last_login"
+          + "    max(al.access_time) access_time"
           + "  from lobby_user lu"
+          + "  left join access_log al on al.lobby_user_id = lu.id"
           + "  join user_role ur on ur.id = lu.user_role_id"
           + "  where ur.name in (<roles>)"
-          + "  order by username")
+          + "  group by lu.username"
+          + "  order by lu.username")
   List<ModeratorUserDaoData> getUserByRole(@BindList("roles") Collection<String> roles);
 
   default List<ModeratorUserDaoData> getModerators() {

--- a/http-server/src/main/java/org/triplea/db/dao/user/UserJdbiDao.java
+++ b/http-server/src/main/java/org/triplea/db/dao/user/UserJdbiDao.java
@@ -15,9 +15,6 @@ public interface UserJdbiDao {
   @SqlQuery("select bcrypt_password from lobby_user where username = :username")
   Optional<String> getPassword(@Bind("username") String username);
 
-  @SqlUpdate("update lobby_user set last_login = now() where username = :username")
-  int updateLastLoginTime(@Bind("username") String username);
-
   @SqlUpdate(
       "update lobby_user set password = null, bcrypt_password = :newPassword where id = :userId")
   int updatePassword(@Bind("userId") int userId, @Bind("newPassword") String newPassword);

--- a/http-server/src/main/java/org/triplea/modules/user/account/login/AccessLogUpdater.java
+++ b/http-server/src/main/java/org/triplea/modules/user/account/login/AccessLogUpdater.java
@@ -21,15 +21,10 @@ class AccessLogUpdater implements Consumer<LoginRecord> {
   @Override
   public void accept(final LoginRecord loginRecord) {
     final int updateCount =
-        loginRecord.isRegistered()
-            ? accessLogDao.insertRegisteredUserRecord(
-                loginRecord.getUserName().getValue(),
-                loginRecord.getIp(),
-                loginRecord.getSystemId().getValue())
-            : accessLogDao.insertAnonymousUserRecord(
-                loginRecord.getUserName().getValue(),
-                loginRecord.getIp(),
-                loginRecord.getSystemId().getValue());
+        accessLogDao.insertUserAccessRecord(
+            loginRecord.getUserName().getValue(),
+            loginRecord.getIp(),
+            loginRecord.getSystemId().getValue());
 
     Postconditions.assertState(updateCount == 1);
   }

--- a/http-server/src/main/java/org/triplea/modules/user/account/login/LoginModule.java
+++ b/http-server/src/main/java/org/triplea/modules/user/account/login/LoginModule.java
@@ -67,16 +67,14 @@ class LoginModule {
 
     if (hasPassword && registeredLogin.test(loginRequest)) {
       final ApiKey apiKey =
-          recordRegisteredLoginAndGenerateApiKey(
-              loginRequest, playerSystemId, PlayerChatId.newId(), ip);
+          recordLoginAndGenerateApiKey(loginRequest, playerSystemId, PlayerChatId.newId(), ip);
       return LobbyLoginResponse.builder()
           .apiKey(apiKey.getValue())
           .moderator(isModerator(loginRequest.getName()))
           .build();
     } else if (hasPassword && tempPasswordLogin.test(loginRequest)) {
       final ApiKey apiKey =
-          recordRegisteredLoginAndGenerateApiKey(
-              loginRequest, playerSystemId, PlayerChatId.newId(), ip);
+          recordLoginAndGenerateApiKey(loginRequest, playerSystemId, PlayerChatId.newId(), ip);
       return LobbyLoginResponse.builder()
           .apiKey(apiKey.getValue())
           .passwordChangeRequired(true)
@@ -93,42 +91,23 @@ class LoginModule {
         return LobbyLoginResponse.builder().failReason(errorMessage.get()).build();
       } else {
         final ApiKey apiKey =
-            recordAnonymousLoginAndGenerateApiKey(
-                loginRequest, playerSystemId, PlayerChatId.newId(), ip);
+            recordLoginAndGenerateApiKey(loginRequest, playerSystemId, PlayerChatId.newId(), ip);
         return LobbyLoginResponse.builder().apiKey(apiKey.getValue()).build();
       }
     }
-  }
-
-  private ApiKey recordRegisteredLoginAndGenerateApiKey(
-      final LoginRequest loginRequest,
-      final SystemId systemId,
-      final PlayerChatId playerChatId,
-      final String ip) {
-    return recordLoginAndGenerateApiKey(loginRequest, systemId, playerChatId, ip, true);
-  }
-
-  private ApiKey recordAnonymousLoginAndGenerateApiKey(
-      final LoginRequest loginRequest,
-      final SystemId systemId,
-      final PlayerChatId playerChatId,
-      final String ip) {
-    return recordLoginAndGenerateApiKey(loginRequest, systemId, playerChatId, ip, false);
   }
 
   private ApiKey recordLoginAndGenerateApiKey(
       final LoginRequest loginRequest,
       final SystemId systemId,
       final PlayerChatId playerchatId,
-      final String ip,
-      final boolean isRegistered) {
+      final String ip) {
     final var loginRecord =
         LoginRecord.builder()
             .userName(UserName.of(loginRequest.getName()))
             .systemId(systemId)
             .playerChatId(playerchatId)
             .ip(ip)
-            .registered(isRegistered)
             .build();
     accessLogUpdater.accept(loginRecord);
     return apiKeyGenerator.apply(loginRecord);

--- a/http-server/src/main/java/org/triplea/modules/user/account/login/LoginRecord.java
+++ b/http-server/src/main/java/org/triplea/modules/user/account/login/LoginRecord.java
@@ -14,5 +14,4 @@ public class LoginRecord {
   @Nonnull private String ip;
   @Nonnull private final SystemId systemId;
   @Nonnull private final PlayerChatId playerChatId;
-  private final boolean registered;
 }

--- a/http-server/src/test/java/org/triplea/db/dao/access/log/AccessLogDaoTest.java
+++ b/http-server/src/test/java/org/triplea/db/dao/access/log/AccessLogDaoTest.java
@@ -103,13 +103,13 @@ class AccessLogDaoTest extends DaoTest {
   @DataSet(cleanBefore = true, value = "access_log/empty_data.yml")
   @ExpectedDataSet("access_log/insert_registered_after.yml")
   void insertRegisteredUserAccessLog() {
-    accessLogDao.insertRegisteredUserRecord("registered", "127.0.0.20", "registered-system-id");
+    accessLogDao.insertUserAccessRecord("registered", "127.0.0.20", "registered-system-id");
   }
 
   @Test
   @DataSet(cleanBefore = true, value = "access_log/empty_data.yml")
   @ExpectedDataSet("access_log/insert_anonymous_after.yml")
   void insertAnonymousAccessLog() {
-    accessLogDao.insertAnonymousUserRecord("anonymous", "127.0.0.50", "anonymous-system-id");
+    accessLogDao.insertUserAccessRecord("anonymous", "127.0.0.50", "anonymous-system-id");
   }
 }

--- a/http-server/src/test/java/org/triplea/db/dao/user/UserJdbiDaoTest.java
+++ b/http-server/src/test/java/org/triplea/db/dao/user/UserJdbiDaoTest.java
@@ -39,12 +39,6 @@ class UserJdbiDaoTest extends DaoTest {
     assertThat(userDao.getPassword("DNE"), isEmpty());
   }
 
-  @Test
-  void updateLastLogin() {
-    assertThat(userDao.updateLastLoginTime(USERNAME), is(1));
-    assertThat(userDao.updateLastLoginTime("DNE"), is(0));
-  }
-
   @DataSet(cleanBefore = true, value = "user/change_password_before.yml")
   @ExpectedDataSet("user/change_password_after.yml")
   @Test

--- a/http-server/src/test/java/org/triplea/modules/user/account/login/AccessLogUpdaterTest.java
+++ b/http-server/src/test/java/org/triplea/modules/user/account/login/AccessLogUpdaterTest.java
@@ -17,18 +17,8 @@ import org.triplea.domain.data.UserName;
 @ExtendWith(MockitoExtension.class)
 class AccessLogUpdaterTest {
 
-  private static final LoginRecord REGISTEREDLOGIN_RECORD =
+  private static final LoginRecord REGISTERED_LOGIN_RECORD =
       LoginRecord.builder()
-          .registered(true)
-          .systemId(SystemId.of("system-id"))
-          .playerChatId(PlayerChatId.newId())
-          .ip("ip")
-          .userName(UserName.of("player-name"))
-          .build();
-
-  private static final LoginRecord ANONYMOUS_LOGIN_RECORD =
-      LoginRecord.builder()
-          .registered(false)
           .systemId(SystemId.of("system-id"))
           .playerChatId(PlayerChatId.newId())
           .ip("ip")
@@ -45,28 +35,15 @@ class AccessLogUpdaterTest {
   }
 
   @Test
-  void acceptRegistered() {
-    when(accessLogDao.insertRegisteredUserRecord(any(), any(), any())).thenReturn(1);
+  void insertUserAccessRecord() {
+    when(accessLogDao.insertUserAccessRecord(any(), any(), any())).thenReturn(1);
 
-    accessLogUpdater.accept(REGISTEREDLOGIN_RECORD);
-
-    verify(accessLogDao)
-        .insertRegisteredUserRecord(
-            REGISTEREDLOGIN_RECORD.getUserName().getValue(),
-            REGISTEREDLOGIN_RECORD.getIp(),
-            REGISTEREDLOGIN_RECORD.getSystemId().getValue());
-  }
-
-  @Test
-  void acceptAnonymous() {
-    when(accessLogDao.insertAnonymousUserRecord(any(), any(), any())).thenReturn(1);
-
-    accessLogUpdater.accept(ANONYMOUS_LOGIN_RECORD);
+    accessLogUpdater.accept(REGISTERED_LOGIN_RECORD);
 
     verify(accessLogDao)
-        .insertAnonymousUserRecord(
-            ANONYMOUS_LOGIN_RECORD.getUserName().getValue(),
-            ANONYMOUS_LOGIN_RECORD.getIp(),
-            ANONYMOUS_LOGIN_RECORD.getSystemId().getValue());
+        .insertUserAccessRecord(
+            REGISTERED_LOGIN_RECORD.getUserName().getValue(),
+            REGISTERED_LOGIN_RECORD.getIp(),
+            REGISTERED_LOGIN_RECORD.getSystemId().getValue());
   }
 }

--- a/http-server/src/test/java/org/triplea/modules/user/account/login/LoginModuleTest.java
+++ b/http-server/src/test/java/org/triplea/modules/user/account/login/LoginModuleTest.java
@@ -152,7 +152,6 @@ class LoginModuleTest {
       final ArgumentCaptor<LoginRecord> loginRecordArgumentCaptor =
           ArgumentCaptor.forClass(LoginRecord.class);
       verify(accessLogUpdater).accept(loginRecordArgumentCaptor.capture());
-      assertThat(loginRecordArgumentCaptor.getValue().isRegistered(), is(false));
     }
   }
 
@@ -191,7 +190,6 @@ class LoginModuleTest {
       final ArgumentCaptor<LoginRecord> loginRecordArgumentCaptor =
           ArgumentCaptor.forClass(LoginRecord.class);
       verify(accessLogUpdater).accept(loginRecordArgumentCaptor.capture());
-      assertThat(loginRecordArgumentCaptor.getValue().isRegistered(), is(true));
     }
   }
 

--- a/http-server/src/test/resources/datasets/access_log/empty_data.yml
+++ b/http-server/src/test/resources/datasets/access_log/empty_data.yml
@@ -1,1 +1,14 @@
+lobby_api_key:
+
+user_role:
+  - id: 9898
+    name: PLAYER
+
+lobby_user:
+  - id: 5230
+    user_role_id: 9898
+    username: registered
+    bcrypt_password: $2a$56789_123456789_123456789_123456789_123456789_123456789_
+    email: email@
+
 access_log:

--- a/http-server/src/test/resources/datasets/access_log/insert_anonymous_after.yml
+++ b/http-server/src/test/resources/datasets/access_log/insert_anonymous_after.yml
@@ -2,4 +2,4 @@ access_log:
   - username: anonymous
     ip: 127.0.0.50
     system_id: anonymous-system-id
-    registered: false
+    lobby_user_id: null

--- a/http-server/src/test/resources/datasets/access_log/insert_registered_after.yml
+++ b/http-server/src/test/resources/datasets/access_log/insert_registered_after.yml
@@ -2,4 +2,4 @@ access_log:
   - username: registered
     ip: 127.0.0.20
     system_id: registered-system-id
-    registered: true
+    lobby_user_id: 5230

--- a/http-server/src/test/resources/datasets/access_log/two_rows.yml
+++ b/http-server/src/test/resources/datasets/access_log/two_rows.yml
@@ -1,11 +1,24 @@
+lobby_api_key:
+
+user_role:
+  - id: 9111
+    name: PLAYER
+
+lobby_user:
+  - id: 6424
+    user_role_id: 9111
+    username: registered_user
+    bcrypt_password: $2a$56789_123456789_123456789_123456789_123456789_123456789_
+    email: email@
+
 access_log:
   - access_time: 2016-01-01 23:59:20.0
     username: first
     ip: 127.0.0.1
     system_id: system-id1
-    registered: true
+    lobby_user_id: 6424
   - access_time: 2016-01-03 23:59:20.0
     username: second
     ip: 127.0.0.2
     system_id: system-id2
-    registered: false
+    lobby_user_id: null

--- a/http-server/src/test/resources/datasets/integration.yml
+++ b/http-server/src/test/resources/datasets/integration.yml
@@ -90,7 +90,7 @@ access_log:
     username: example
     ip: 1.1.1.1
     system_id: system-id
-    registered: false
+    lobby_user_id: null
 
 lobby_api_key:
   - key: 238b90e6e2382ddafadc35266b2fa9a371fb3962b675ccab1b5538321f469070d0f3762f29b21ac7ad772eb6bd299d09f8e75d38ed8b7067965d5d5f26ebc3f5

--- a/http-server/src/test/resources/datasets/moderator_player_lookup/lookup_player_aliases_select_data.yml
+++ b/http-server/src/test/resources/datasets/moderator_player_lookup/lookup_player_aliases_select_data.yml
@@ -3,29 +3,29 @@ access_log:
     username: name1
     ip: 1.1.1.1
     system_id: system-id
-    registered: false
+    lobby_user_id: null
   - access_time: 2152-01-01 23:59:20.0
     username: name2
     ip: 1.1.1.1
     system_id: system-id2
-    registered: false
+    lobby_user_id: null
   - access_time: 2153-01-01 23:59:20.0
     username: name3
     ip: 2.2.2.2
     system_id: system-id
-    registered: false
+    lobby_user_id: null
   - access_time: 2154-01-01 23:59:20.0
     username: name3
     ip: 2.2.2.2
     system_id: system-id
-    registered: false
+    lobby_user_id: null
   - access_time: 2000-01-01 23:59:20.0
     username: far-past-is-filtered
     ip: 2.2.2.2
     system_id: system-id
-    registered: false
+    lobby_user_id: null
   - access_time: 2150-01-01 23:59:20.0
     username: this-record-matches-no-query
     ip: 5.5.5.5
     system_id: some-other-system-id
-    registered: false
+    lobby_user_id: null

--- a/http-server/src/test/resources/datasets/moderators/select.yml
+++ b/http-server/src/test/resources/datasets/moderators/select.yml
@@ -5,6 +5,7 @@ user_role:
     name: MODERATOR
   - id: 3
     name: ADMIN
+
 lobby_user:
   - id: 100000
     username: not moderator
@@ -16,10 +17,15 @@ lobby_user:
     password: 12345678901234567890123456
     email: email@
     user_role_id: 2
-    last_login: 2001-01-01 23:59:20.0
   - id: 900001
     username: Super! moderator
     password: 12345678901234567890123456
     email: email@
     user_role_id: 3
-    last_login:
+
+access_log:
+  - username: registered
+    ip: 127.0.0.20
+    system_id: registered-system-id
+    lobby_user_id: 900000
+    access_time: 2001-01-01 23:59:20.0

--- a/http-server/src/test/resources/datasets/moderators/select_post_update_roles.yml
+++ b/http-server/src/test/resources/datasets/moderators/select_post_update_roles.yml
@@ -9,10 +9,8 @@ lobby_user:
     password: 12345678901234567890123456
     email: email@
     user_role_id: 3
-    last_login: 2001-01-01 23:59:20.0
   - id: 900001
     username: Super! moderator
     password: 12345678901234567890123456
     email: email@
     user_role_id: 1
-    last_login:

--- a/lobby-db/sample_data.sql
+++ b/lobby-db/sample_data.sql
@@ -24,12 +24,12 @@ values (1000, 'test', 'email@email.com', (select id from user_role where name = 
        (1001, 'user1', 'email@email.com', (select id from user_role where name = 'PLAYER'),
         '$2a$10$C4rHfjK/seKexc6KlyknP.oFVBZ7Wi.kp91qUQFgmkKajwgczXzcS');
 
-insert into access_log(access_time, username, ip, system_id, registered)
-values (now() - interval '1 days', 'user1', '1.1.1.1', 'system-id1', false),
-       (now() - interval '2 days', 'user2', '1.1.1.2', 'system-id2', false),
-       (now() - interval '3 days', 'user3', '1.1.1.3', 'system-id3', true),
-       (now() - interval '4 days', 'user1', '1.1.1.2', 'system-id4', false),
-       (now() - interval '5 days', 'user2', '1.1.1.4', 'system-id5', false);
+insert into access_log(access_time, username, ip, system_id, lobby_user_id)
+values (now() - interval '1 days', 'user1', '1.1.1.1', 'system-id1', null),
+       (now() - interval '2 days', 'user2', '1.1.1.2', 'system-id2', null),
+       (now() - interval '3 days', 'user3', '1.1.1.3', 'system-id3', null),
+       (now() - interval '4 days', 'user1', '1.1.1.2', 'system-id4', null),
+       (now() - interval '5 days', 'user2', '1.1.1.4', 'system-id5', null);
 
 insert into moderator_action_history(lobby_user_id, action_name, action_target)
 values (1000, 'ACTION_1', 'TARGET_1'),

--- a/lobby-db/src/main/resources/db/migration/V2.00.04__add_lobby_user_fk_to_access_log.sql
+++ b/lobby-db/src/main/resources/db/migration/V2.00.04__add_lobby_user_fk_to_access_log.sql
@@ -1,0 +1,2 @@
+alter table access_log drop column registered;
+alter table access_log add column lobby_user_id int references lobby_user(id);

--- a/lobby-db/src/main/resources/db/migration/V2.00.04__add_lobby_user_fk_to_access_log.sql
+++ b/lobby-db/src/main/resources/db/migration/V2.00.04__add_lobby_user_fk_to_access_log.sql
@@ -1,2 +1,3 @@
 alter table access_log drop column registered;
 alter table access_log add column lobby_user_id int references lobby_user(id);
+alter table lobby_user drop column last_login;


### PR DESCRIPTION
## Overview

Lobby_user table last_login column was not being updated. This update drops that column and update access_log to have a FK column to lobby_user. We can then use the access_log table to determine last login time. 

## Commits

commit 485d7433583706166c759813f4e4428900c08aff

    Update access_log table, replace registered column with FK to lobby_user
    
    Instead of adding a 'true/false' value to a registered column
    in access_log, we can use a nullable foreign key to the lobby_user
    table. We'll insert a null FK value if the user is anonymous,
    otherwise we'll insert into the access_log table their lobby_user.id

commit 3df952b9a5e2837300e1dacb9084dca081f875f8

    Drop last_login from lobby_user and replace with access_log.access_time
    
    - The value in lobby_user is buggy and is not being updated.
    - Access log table now has a FK to the lobby_user table which
      give us the last login time. To know the last login time of a user
      we can join lobby_user with access_log and select the max
      access_time to know their last login.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix: https://github.com/triplea-game/triplea/issues/6453 "moderator last access is missing in toolbox"
[] Other:   <!-- Please specify -->

## Testing
- verified in a local lobby
- automated test coverage is good

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
## Screens Shots

### Before

![Screenshot from 2020-05-18 22-35-57](https://user-images.githubusercontent.com/12397753/82288733-ff246080-9957-11ea-91c7-e7160d48d432.png)

### After

(Notice 'last_login' is now populated)
![Screenshot from 2020-05-18 22-17-43](https://user-images.githubusercontent.com/12397753/82288744-051a4180-9958-11ea-90f6-296a3579be20.png)


