### PR TITLE
Moderator tab remove button col headers & rename super-mod -> admin

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/moderators/ModeratorsTab.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/moderators/ModeratorsTab.java
@@ -49,7 +49,7 @@ public final class ModeratorsTab implements Supplier<Component> {
             .addCenter(SwingComponents.newJScrollPane(dataTable))
             .build();
 
-    if (moderatorsTabModel.isSuperMod()) {
+    if (moderatorsTabModel.isAdmin()) {
       panel.add(buildAddModeratorPanel(), BorderLayout.SOUTH);
     }
     return panel;
@@ -61,10 +61,9 @@ public final class ModeratorsTab implements Supplier<Component> {
             .columnNames(moderatorsTabModel.fetchTableHeaders())
             .tableData(moderatorsTabModel.fetchTableData())
             .build();
-    if (moderatorsTabModel.isSuperMod()) {
+    if (moderatorsTabModel.isAdmin()) {
       ButtonColumn.attachButtonColumn(table, 2, moderatorsTabActions.removeModAction(parentFrame));
-      ButtonColumn.attachButtonColumn(
-          table, 3, moderatorsTabActions.addSuperModAction(parentFrame));
+      ButtonColumn.attachButtonColumn(table, 3, moderatorsTabActions.addAdminAction(parentFrame));
     }
     return table;
   }

--- a/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/moderators/ModeratorsTabActions.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/moderators/ModeratorsTabActions.java
@@ -42,7 +42,7 @@ final class ModeratorsTabActions {
     return (String) tableModel.getValueAt(rowNum, 0);
   }
 
-  BiConsumer<Integer, DefaultTableModel> addSuperModAction(final JFrame parentFrame) {
+  BiConsumer<Integer, DefaultTableModel> addAdminAction(final JFrame parentFrame) {
     return (rowNum, tableModel) -> {
       final String user = extractUserName(rowNum, tableModel);
 
@@ -50,7 +50,7 @@ final class ModeratorsTabActions {
           "Add Super-Moderator Status?",
           "Are you sure you want to add super-moderator to: " + user + "?",
           () -> {
-            moderatorsTabModel.addSuperMod(user);
+            moderatorsTabModel.addAdmin(user);
             MessagePopup.showMessage(parentFrame, user + " is now a super-moderator.");
           });
     };

--- a/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/moderators/ModeratorsTabModel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/moderators/ModeratorsTabModel.java
@@ -16,7 +16,7 @@ class ModeratorsTabModel {
   static final List<String> SUPER_MOD_HEADERS = List.of("Name", "Last Login", "", "");
 
   @VisibleForTesting static final String REMOVE_MOD_BUTTON_TEXT = "Remove Mod";
-  @VisibleForTesting static final String ADD_SUPER_MOD_BUTTON = "Add Super-Mod";
+  @VisibleForTesting static final String MAKE_ADMIN_BUTTON_TEXT = "Make Admin";
 
   private static final Function<Long, String> dateTimeFormatter =
       epochMillis ->
@@ -25,29 +25,29 @@ class ModeratorsTabModel {
 
   private final ToolboxModeratorManagementClient toolboxModeratorManagementClient;
 
-  @Getter private final boolean isSuperMod;
+  @Getter private final boolean isAdmin;
 
   ModeratorsTabModel(final ToolboxModeratorManagementClient toolboxModeratorManagementClient) {
     this.toolboxModeratorManagementClient = toolboxModeratorManagementClient;
-    isSuperMod = toolboxModeratorManagementClient.isCurrentUserSuperMod();
+    isAdmin = toolboxModeratorManagementClient.isCurrentUserAdmin();
   }
 
   List<String> fetchTableHeaders() {
-    return isSuperMod() ? SUPER_MOD_HEADERS : HEADERS;
+    return isAdmin() ? SUPER_MOD_HEADERS : HEADERS;
   }
 
   List<List<String>> fetchTableData() {
     return toolboxModeratorManagementClient.fetchModeratorList().stream()
         .map(
             modInfo ->
-                isSuperMod
+                isAdmin
                     ? List.of(
                         modInfo.getName(),
                         Optional.ofNullable(modInfo.getLastLoginEpochMillis())
                             .map(dateTimeFormatter)
                             .orElse(""),
                         REMOVE_MOD_BUTTON_TEXT,
-                        ADD_SUPER_MOD_BUTTON)
+                        MAKE_ADMIN_BUTTON_TEXT)
                     : List.of(
                         modInfo.getName(),
                         Optional.ofNullable(modInfo.getLastLoginEpochMillis())
@@ -60,8 +60,8 @@ class ModeratorsTabModel {
     toolboxModeratorManagementClient.removeMod(user);
   }
 
-  void addSuperMod(final String user) {
-    toolboxModeratorManagementClient.addSuperMod(user);
+  void addAdmin(final String user) {
+    toolboxModeratorManagementClient.addAdmin(user);
   }
 
   boolean checkUserExists(final String user) {

--- a/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/moderators/ModeratorsTabModel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/moderators/ModeratorsTabModel.java
@@ -13,8 +13,7 @@ class ModeratorsTabModel {
   @VisibleForTesting static final List<String> HEADERS = List.of("Name", "Last Login");
 
   @VisibleForTesting
-  static final List<String> SUPER_MOD_HEADERS =
-      List.of("Name", "Last Login", "Remove Mod", "Add Super-Mod");
+  static final List<String> SUPER_MOD_HEADERS = List.of("Name", "Last Login", "", "");
 
   @VisibleForTesting static final String REMOVE_MOD_BUTTON_TEXT = "Remove Mod";
   @VisibleForTesting static final String ADD_SUPER_MOD_BUTTON = "Add Super-Mod";

--- a/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/moderators/ModeratorsTabModel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/moderators/ModeratorsTabModel.java
@@ -13,7 +13,7 @@ class ModeratorsTabModel {
   @VisibleForTesting static final List<String> HEADERS = List.of("Name", "Last Login");
 
   @VisibleForTesting
-  static final List<String> SUPER_MOD_HEADERS = List.of("Name", "Last Login", "", "");
+  static final List<String> HEADERS_FOR_ADMIN = List.of("Name", "Last Login", "", "");
 
   @VisibleForTesting static final String REMOVE_MOD_BUTTON_TEXT = "Remove Mod";
   @VisibleForTesting static final String MAKE_ADMIN_BUTTON_TEXT = "Make Admin";
@@ -33,7 +33,7 @@ class ModeratorsTabModel {
   }
 
   List<String> fetchTableHeaders() {
-    return isAdmin() ? SUPER_MOD_HEADERS : HEADERS;
+    return isAdmin() ? HEADERS_FOR_ADMIN : HEADERS;
   }
 
   List<List<String>> fetchTableData() {

--- a/game-core/src/test/java/games/strategy/engine/lobby/moderator/toolbox/tabs/moderators/ModeratorsTabModelTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/moderator/toolbox/tabs/moderators/ModeratorsTabModelTest.java
@@ -44,8 +44,8 @@ class ModeratorsTabModelTest {
   @Nested
   final class FetchTableHeadersTest {
     @Test
-    void superModeratorHeaders() {
-      when(toolboxModeratorManagementClient.isCurrentUserSuperMod()).thenReturn(true);
+    void adminHeaders() {
+      when(toolboxModeratorManagementClient.isCurrentUserAdmin()).thenReturn(true);
 
       moderatorsTabModel = new ModeratorsTabModel(toolboxModeratorManagementClient);
 
@@ -54,7 +54,7 @@ class ModeratorsTabModelTest {
 
     @Test
     void moderatorHeaders() {
-      when(toolboxModeratorManagementClient.isCurrentUserSuperMod()).thenReturn(false);
+      when(toolboxModeratorManagementClient.isCurrentUserAdmin()).thenReturn(false);
 
       moderatorsTabModel = new ModeratorsTabModel(toolboxModeratorManagementClient);
 
@@ -65,8 +65,8 @@ class ModeratorsTabModelTest {
   @Nested
   final class FetchTableData {
     @Test
-    void superModerator() {
-      when(toolboxModeratorManagementClient.isCurrentUserSuperMod()).thenReturn(true);
+    void admin() {
+      when(toolboxModeratorManagementClient.isCurrentUserAdmin()).thenReturn(true);
       when(toolboxModeratorManagementClient.fetchModeratorList())
           .thenReturn(List.of(MODERATOR_INFO, MODERATOR_INFO_WITH_NULL));
 
@@ -82,19 +82,19 @@ class ModeratorsTabModelTest {
           MODERATOR_INFO.getName(),
           "2020-5-8 10:54",
           ModeratorsTabModel.REMOVE_MOD_BUTTON_TEXT,
-          ModeratorsTabModel.ADD_SUPER_MOD_BUTTON);
+          ModeratorsTabModel.MAKE_ADMIN_BUTTON_TEXT);
       ToolboxTabModelTestUtil.verifyTableDataAtRow(
           tableData,
           1,
           MODERATOR_INFO.getName(),
           "",
           ModeratorsTabModel.REMOVE_MOD_BUTTON_TEXT,
-          ModeratorsTabModel.ADD_SUPER_MOD_BUTTON);
+          ModeratorsTabModel.MAKE_ADMIN_BUTTON_TEXT);
     }
 
     @Test
     void moderator() {
-      when(toolboxModeratorManagementClient.isCurrentUserSuperMod()).thenReturn(false);
+      when(toolboxModeratorManagementClient.isCurrentUserAdmin()).thenReturn(false);
       when(toolboxModeratorManagementClient.fetchModeratorList())
           .thenReturn(List.of(MODERATOR_INFO, MODERATOR_INFO_WITH_NULL));
 
@@ -117,10 +117,10 @@ class ModeratorsTabModelTest {
   }
 
   @Test
-  void addSuperMod() {
-    new ModeratorsTabModel(toolboxModeratorManagementClient).addSuperMod(USERNAME);
+  void addAdmin() {
+    new ModeratorsTabModel(toolboxModeratorManagementClient).addAdmin(USERNAME);
 
-    verify(toolboxModeratorManagementClient).addSuperMod(USERNAME);
+    verify(toolboxModeratorManagementClient).addAdmin(USERNAME);
   }
 
   @Nested

--- a/game-core/src/test/java/games/strategy/engine/lobby/moderator/toolbox/tabs/moderators/ModeratorsTabModelTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/moderator/toolbox/tabs/moderators/ModeratorsTabModelTest.java
@@ -49,7 +49,7 @@ class ModeratorsTabModelTest {
 
       moderatorsTabModel = new ModeratorsTabModel(toolboxModeratorManagementClient);
 
-      assertThat(moderatorsTabModel.fetchTableHeaders(), is(ModeratorsTabModel.SUPER_MOD_HEADERS));
+      assertThat(moderatorsTabModel.fetchTableHeaders(), is(ModeratorsTabModel.HEADERS_FOR_ADMIN));
     }
 
     @Test
@@ -75,7 +75,7 @@ class ModeratorsTabModelTest {
       final List<List<String>> tableData = moderatorsTabModel.fetchTableData();
 
       ToolboxTabModelTestUtil.verifyTableDimensions(
-          tableData, ModeratorsTabModel.SUPER_MOD_HEADERS);
+          tableData, ModeratorsTabModel.HEADERS_FOR_ADMIN);
       ToolboxTabModelTestUtil.verifyTableDataAtRow(
           tableData,
           0,

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/toolbox/management/ToolboxModeratorManagementClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/toolbox/management/ToolboxModeratorManagementClient.java
@@ -17,11 +17,11 @@ import org.triplea.http.client.HttpClient;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ToolboxModeratorManagementClient {
   public static final String FETCH_MODERATORS_PATH = "/moderator-toolbox/fetch-moderators";
-  public static final String IS_SUPER_MOD_PATH = "/moderator-toolbox/is-super-mod";
-  public static final String REMOVE_MOD_PATH = "/moderator-toolbox/super-mod/remove-mod";
-  public static final String ADD_SUPER_MOD_PATH = "/moderator-toolbox/super-mod/add-super-mod";
+  public static final String IS_ADMIN_PATH = "/moderator-toolbox/is-admin";
   public static final String CHECK_USER_EXISTS_PATH = "/moderator-toolbox/does-user-exist";
-  public static final String ADD_MODERATOR_PATH = "/moderator-toolbox/super-mod/add-moderator";
+  public static final String REMOVE_MOD_PATH = "/moderator-toolbox/admin/remove-mod";
+  public static final String ADD_ADMIN_PATH = "/moderator-toolbox/admin/add-super-mod";
+  public static final String ADD_MODERATOR_PATH = "/moderator-toolbox/admin/add-moderator";
 
   private final AuthenticationHeaders httpHeaders;
   private final ToolboxModeratorManagementFeignClient client;
@@ -37,8 +37,8 @@ public class ToolboxModeratorManagementClient {
     return client.fetchModerators(httpHeaders.createHeaders());
   }
 
-  public boolean isCurrentUserSuperMod() {
-    return client.isSuperMod(httpHeaders.createHeaders());
+  public boolean isCurrentUserAdmin() {
+    return client.isAdmin(httpHeaders.createHeaders());
   }
 
   public void removeMod(final String moderatorName) {
@@ -46,9 +46,9 @@ public class ToolboxModeratorManagementClient {
     client.removeMod(httpHeaders.createHeaders(), moderatorName);
   }
 
-  public void addSuperMod(final String moderatorName) {
+  public void addAdmin(final String moderatorName) {
     checkArgument(moderatorName != null);
-    client.addSuperMod(httpHeaders.createHeaders(), moderatorName);
+    client.addAdmin(httpHeaders.createHeaders(), moderatorName);
   }
 
   public boolean checkUserExists(final String usernameRequested) {

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/toolbox/management/ToolboxModeratorManagementFeignClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/toolbox/management/ToolboxModeratorManagementFeignClient.java
@@ -12,11 +12,11 @@ interface ToolboxModeratorManagementFeignClient {
   @RequestLine("GET " + ToolboxModeratorManagementClient.FETCH_MODERATORS_PATH)
   List<ModeratorInfo> fetchModerators(@HeaderMap Map<String, Object> headerMap);
 
-  @RequestLine("GET " + ToolboxModeratorManagementClient.IS_SUPER_MOD_PATH)
-  boolean isSuperMod(@HeaderMap Map<String, Object> headerMap);
+  @RequestLine("GET " + ToolboxModeratorManagementClient.IS_ADMIN_PATH)
+  boolean isAdmin(@HeaderMap Map<String, Object> headerMap);
 
-  @RequestLine("POST " + ToolboxModeratorManagementClient.ADD_SUPER_MOD_PATH)
-  void addSuperMod(@HeaderMap Map<String, Object> headers, String moderatorName);
+  @RequestLine("POST " + ToolboxModeratorManagementClient.ADD_ADMIN_PATH)
+  void addAdmin(@HeaderMap Map<String, Object> headers, String moderatorName);
 
   @RequestLine("POST " + ToolboxModeratorManagementClient.REMOVE_MOD_PATH)
   void removeMod(@HeaderMap Map<String, Object> headers, String moderatorName);

--- a/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/management/ToolboxModeratorManagementClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/lobby/moderator/toolbox/management/ToolboxModeratorManagementClientTest.java
@@ -46,26 +46,26 @@ class ToolboxModeratorManagementClientTest extends WireMockTest {
   }
 
   @Nested
-  final class IsCurrentUserSuperMod {
+  final class IsCurrentUserAdmin {
     @Test
     void positiveCase(@WiremockResolver.Wiremock final WireMockServer server) {
-      expectIsSuperModAndReturn(server, true);
+      expectIsAdminAndReturn(server, true);
 
-      assertThat(newClient(server).isCurrentUserSuperMod(), is(true));
+      assertThat(newClient(server).isCurrentUserAdmin(), is(true));
     }
 
-    void expectIsSuperModAndReturn(final WireMockServer server, final boolean value) {
+    void expectIsAdminAndReturn(final WireMockServer server, final boolean value) {
       server.stubFor(
-          WireMock.get(ToolboxModeratorManagementClient.IS_SUPER_MOD_PATH)
+          WireMock.get(ToolboxModeratorManagementClient.IS_ADMIN_PATH)
               .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
               .willReturn(WireMock.aResponse().withStatus(200).withBody(String.valueOf(value))));
     }
 
     @Test
     void negativeCase(@WiremockResolver.Wiremock final WireMockServer server) {
-      expectIsSuperModAndReturn(server, false);
+      expectIsAdminAndReturn(server, false);
 
-      assertThat(newClient(server).isCurrentUserSuperMod(), is(false));
+      assertThat(newClient(server).isCurrentUserAdmin(), is(false));
     }
   }
 
@@ -78,19 +78,19 @@ class ToolboxModeratorManagementClientTest extends WireMockTest {
   }
 
   @Test
-  void addSuperMod(@WiremockResolver.Wiremock final WireMockServer server) {
+  void addAdmin(@WiremockResolver.Wiremock final WireMockServer server) {
     serve200ForToolboxPostWithBody(
-        server, ToolboxModeratorManagementClient.ADD_SUPER_MOD_PATH, MODERATOR_NAME);
+        server, ToolboxModeratorManagementClient.ADD_ADMIN_PATH, MODERATOR_NAME);
 
-    newClient(server).addSuperMod(MODERATOR_NAME);
+    newClient(server).addAdmin(MODERATOR_NAME);
   }
 
   @Test
   void checkUserExists(@WiremockResolver.Wiremock final WireMockServer server) {
     serve200ForToolboxPostWithBody(
-        server, ToolboxModeratorManagementClient.ADD_SUPER_MOD_PATH, MODERATOR_NAME);
+        server, ToolboxModeratorManagementClient.ADD_ADMIN_PATH, MODERATOR_NAME);
 
-    newClient(server).addSuperMod(MODERATOR_NAME);
+    newClient(server).addAdmin(MODERATOR_NAME);
   }
 
   @Test

--- a/http-server/src/main/java/org/triplea/modules/moderation/moderators/ModeratorsController.java
+++ b/http-server/src/main/java/org/triplea/modules/moderation/moderators/ModeratorsController.java
@@ -45,9 +45,9 @@ public class ModeratorsController extends HttpController {
   }
 
   @GET
-  @Path(ToolboxModeratorManagementClient.IS_SUPER_MOD_PATH)
+  @Path(ToolboxModeratorManagementClient.IS_ADMIN_PATH)
   @RolesAllowed(UserRole.MODERATOR)
-  public Response isSuperMod(@Auth final AuthenticatedUser authenticatedUser) {
+  public Response isAdmin(@Auth final AuthenticatedUser authenticatedUser) {
     return Response.ok().entity(authenticatedUser.getUserRole().equals(UserRole.ADMIN)).build();
   }
 
@@ -61,11 +61,11 @@ public class ModeratorsController extends HttpController {
   }
 
   @POST
-  @Path(ToolboxModeratorManagementClient.ADD_SUPER_MOD_PATH)
+  @Path(ToolboxModeratorManagementClient.ADD_ADMIN_PATH)
   @RolesAllowed(UserRole.ADMIN)
-  public Response setSuperMod(
+  public Response setAdmin(
       @Auth final AuthenticatedUser authenticatedUser, final String moderatorName) {
-    moderatorsService.addSuperMod(authenticatedUser.getUserIdOrThrow(), moderatorName);
+    moderatorsService.addAdmin(authenticatedUser.getUserIdOrThrow(), moderatorName);
     return Response.ok().build();
   }
 

--- a/http-server/src/main/java/org/triplea/modules/moderation/moderators/ModeratorsService.java
+++ b/http-server/src/main/java/org/triplea/modules/moderation/moderators/ModeratorsService.java
@@ -87,7 +87,7 @@ class ModeratorsService {
   }
 
   /** Promotes a user to super-moderator. Can only be done by super moderators. */
-  void addSuperMod(final int moderatorIdRequesting, final String username) {
+  void addAdmin(final int moderatorIdRequesting, final String username) {
     final int userId =
         userJdbiDao
             .lookupUserIdByName(username)

--- a/http-server/src/test/java/org/triplea/modules/moderation/moderators/ModeratorsControllerIntegrationTest.java
+++ b/http-server/src/test/java/org/triplea/modules/moderation/moderators/ModeratorsControllerIntegrationTest.java
@@ -12,8 +12,8 @@ class ModeratorsControllerIntegrationTest
   }
 
   @Test
-  void isSuperMod() {
-    verifyEndpoint(ToolboxModeratorManagementClient::isCurrentUserSuperMod);
+  void isAdmin() {
+    verifyEndpoint(ToolboxModeratorManagementClient::isCurrentUserAdmin);
   }
 
   @Test
@@ -22,7 +22,7 @@ class ModeratorsControllerIntegrationTest
   }
 
   @Test
-  void setSuperMod() {
-    verifyEndpoint(AllowedUserRole.ADMIN, client -> client.addSuperMod("mod3"));
+  void setAdmin() {
+    verifyEndpoint(AllowedUserRole.ADMIN, client -> client.addAdmin("mod3"));
   }
 }

--- a/http-server/src/test/java/org/triplea/modules/moderation/moderators/ModeratorsControllerTest.java
+++ b/http-server/src/test/java/org/triplea/modules/moderation/moderators/ModeratorsControllerTest.java
@@ -52,19 +52,19 @@ class ModeratorsControllerTest {
   }
 
   @Test
-  void isSuperModPositiveCase() {
+  void isAdminPositiveCase() {
     when(authenticatedUser.getUserRole()).thenReturn(UserRole.ADMIN);
 
-    final Response response = moderatorsController.isSuperMod(authenticatedUser);
+    final Response response = moderatorsController.isAdmin(authenticatedUser);
 
     verifyResponse(response, true);
   }
 
   @Test
-  void isSuperModNegativeCase() {
+  void isAdminNegativeCase() {
     when(authenticatedUser.getUserRole()).thenReturn(UserRole.MODERATOR);
 
-    final Response response = moderatorsController.isSuperMod(authenticatedUser);
+    final Response response = moderatorsController.isAdmin(authenticatedUser);
 
     verifyResponse(response, false);
   }
@@ -79,11 +79,11 @@ class ModeratorsControllerTest {
   }
 
   @Test
-  void setSuperMod() {
-    final Response response = moderatorsController.setSuperMod(AUTHENTICATED_USER, MODERATOR_NAME);
+  void setAdmin() {
+    final Response response = moderatorsController.setAdmin(AUTHENTICATED_USER, MODERATOR_NAME);
 
     assertThat(response.getStatus(), is(200));
-    verify(moderatorsService).addSuperMod(AUTHENTICATED_USER.getUserIdOrThrow(), MODERATOR_NAME);
+    verify(moderatorsService).addAdmin(AUTHENTICATED_USER.getUserIdOrThrow(), MODERATOR_NAME);
   }
 
   @Test

--- a/http-server/src/test/java/org/triplea/modules/moderation/moderators/ModeratorsServiceTest.java
+++ b/http-server/src/test/java/org/triplea/modules/moderation/moderators/ModeratorsServiceTest.java
@@ -105,22 +105,21 @@ class ModeratorsServiceTest {
   }
 
   @Nested
-  final class AddSuperModTest {
+  final class AddAdminTest {
     @Test
     void throwsIfUserNotFound() {
       when(userJdbiDao.lookupUserIdByName(USERNAME)).thenReturn(Optional.empty());
       assertThrows(
-          IllegalArgumentException.class,
-          () -> moderatorsService.addSuperMod(MODERATOR_ID, USERNAME));
+          IllegalArgumentException.class, () -> moderatorsService.addAdmin(MODERATOR_ID, USERNAME));
     }
 
     @Test
-    void throwsIfSuperModNotAdded() {
+    void throwsIfAdminNotAdded() {
       when(userJdbiDao.lookupUserIdByName(USERNAME)).thenReturn(Optional.of(USER_ID));
       when(moderatorsDao.setRole(USER_ID, UserRole.ADMIN)).thenReturn(0);
 
       assertThrows(
-          IllegalStateException.class, () -> moderatorsService.addSuperMod(MODERATOR_ID, USERNAME));
+          IllegalStateException.class, () -> moderatorsService.addAdmin(MODERATOR_ID, USERNAME));
     }
 
     @Test
@@ -128,7 +127,7 @@ class ModeratorsServiceTest {
       when(userJdbiDao.lookupUserIdByName(USERNAME)).thenReturn(Optional.of(USER_ID));
       when(moderatorsDao.setRole(USER_ID, UserRole.ADMIN)).thenReturn(1);
 
-      moderatorsService.addSuperMod(MODERATOR_ID, USERNAME);
+      moderatorsService.addAdmin(MODERATOR_ID, USERNAME);
 
       verify(moderatorAuditHistoryDao)
           .addAuditRecord(


### PR DESCRIPTION
## Overview
This update does two things:
1. Removes moderator tabs button column headers (cosmetic improvement)
2. Renames the term 'super-mod'  to 'admin'

## Commits

commit 8dfe711eb65ada8f5e933d6e5f2782412126b82e

    Update Toolbox:ModeratorsTab - remove button column headers
    
    Remove column headers "Remove Mod" and "Make Admin". The column
    headers are redundant for button columns where buttons appear
    in every row with the same name as the column header.

commit f70449872c5e8b5d75abe3f38afa326842623a95

    Rename 'Super-Mod' to 'Admin'
    
    Historically a moderator was called an admin. In 2.0 with
    user-roles, the 'admin' role is now called a 'moderator'.
    To avoid previous confusion the term 'super-mod' was used
    to refer to an admin. This update replaces the 'super-mod'
    term with 'admin' (to recall, an admin is someone that
    can add and remove moderators).


<!--

  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
## Screens Shots

### Before
![Screenshot from 2020-05-18 22-35-57](https://user-images.githubusercontent.com/12397753/82289518-d7ce9300-9959-11ea-8034-3d57a905a61e.png)

### After
![Screenshot from 2020-05-18 22-47-58](https://user-images.githubusercontent.com/12397753/82289514-d56c3900-9959-11ea-9440-06dd4215816f.png)

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

