### PR TITLE
When banning players, disconnect all chatters with a matching IP

### DIFF
--- a/http-server/src/main/java/org/triplea/modules/chat/Chatters.java
+++ b/http-server/src/main/java/org/triplea/modules/chat/Chatters.java
@@ -81,7 +81,7 @@ public class Chatters {
    * @return True if any sessions were disconnected, false if none (indicating player was no longer
    *     in chat).
    */
-  public boolean disconnectPlayerSessions(final UserName userName, final String disconnectMessage) {
+  public boolean disconnectPlayerByName(final UserName userName, final String disconnectMessage) {
     final Set<Session> sessions =
         participants.values().stream()
             .filter(
@@ -90,8 +90,13 @@ public class Chatters {
             .map(ChatterSession::getSession)
             .collect(Collectors.toSet());
 
-    // Do the session disconnects as a second step after gathering sessions to be disconnected.
-    // This is to avoid concurrent modification of sessions.
+    disconnectSession(sessions, disconnectMessage);
+    return !sessions.isEmpty();
+  }
+
+  private void disconnectSession(
+      final Collection<Session> sessions, final String disconnectMessage) {
+    // Do session disconnects as its own step to avoid concurrent modification.
     sessions.forEach(
         session -> {
           try {
@@ -105,6 +110,25 @@ public class Chatters {
                 e);
           }
         });
+  }
+
+  /**
+   * Disconnects all sessions belonging to a given player identified by IP. A disconnected session
+   * is closed, the closure will trigger a notification on the client of the disconnected player.
+   *
+   * @param ip The IP address of the player whose sessions will be disconnected.
+   * @param disconnectMessage Message that will be displayed to the disconnected player.
+   * @return True if any sessions were disconnected, false if none (indicating player was no longer
+   *     in chat).
+   */
+  public boolean disconnectIp(final InetAddress ip, final String disconnectMessage) {
+    final Set<Session> sessions =
+        participants.values().stream()
+            .filter(chatterSession -> chatterSession.getIp().equals(ip))
+            .map(ChatterSession::getSession)
+            .collect(Collectors.toSet());
+
+    disconnectSession(sessions, disconnectMessage);
     return !sessions.isEmpty();
   }
 

--- a/http-server/src/main/java/org/triplea/modules/moderation/ban/user/UserBanService.java
+++ b/http-server/src/main/java/org/triplea/modules/moderation/ban/user/UserBanService.java
@@ -14,7 +14,7 @@ import org.triplea.db.dao.api.key.PlayerIdentifiersByApiKeyLookup;
 import org.triplea.db.dao.moderator.ModeratorAuditHistoryDao;
 import org.triplea.db.dao.user.ban.UserBanDao;
 import org.triplea.domain.data.PlayerChatId;
-import org.triplea.domain.data.UserName;
+import org.triplea.http.client.IpAddressParser;
 import org.triplea.http.client.lobby.moderator.BanDurationFormatter;
 import org.triplea.http.client.lobby.moderator.BanPlayerRequest;
 import org.triplea.http.client.lobby.moderator.toolbox.banned.user.UserBanData;
@@ -135,8 +135,8 @@ public class UserBanService {
   }
 
   private boolean removePlayerFromChat(final UserBanParams userBanParams) {
-    return chatters.disconnectPlayerSessions(
-        UserName.of(userBanParams.getUsername()),
+    return chatters.disconnectIp(
+        IpAddressParser.fromString(userBanParams.getIp()),
         String.format(
             "You have been banned for %s for violating lobby rules",
             BanDurationFormatter.formatBanMinutes(userBanParams.getMinutesToBan())));

--- a/http-server/src/main/java/org/triplea/modules/moderation/disconnect/user/DisconnectUserAction.java
+++ b/http-server/src/main/java/org/triplea/modules/moderation/disconnect/user/DisconnectUserAction.java
@@ -40,7 +40,7 @@ public class DisconnectUserAction {
       return false;
     }
 
-    if (chatters.disconnectPlayerSessions(
+    if (chatters.disconnectPlayerByName(
         gamePlayerLookup.getUserName(), "Disconnected by moderator")) {
       playerConnections.broadcastMessage(
           new ChatEventReceivedMessage(

--- a/http-server/src/test/java/org/triplea/modules/chat/ChattersTest.java
+++ b/http-server/src/test/java/org/triplea/modules/chat/ChattersTest.java
@@ -122,11 +122,11 @@ class ChattersTest {
   }
 
   @Nested
-  class DisconnectPlayerSessions {
+  class DisconnectPlayerByName {
     @Test
     void noOpIfPlayerNotConnected() {
       final boolean result =
-          chatters.disconnectPlayerSessions(CHAT_PARTICIPANT.getUserName(), "disconnect message");
+          chatters.disconnectPlayerByName(CHAT_PARTICIPANT.getUserName(), "disconnect message");
       assertThat(result, is(false));
     }
 
@@ -136,7 +136,7 @@ class ChattersTest {
       chatters.connectPlayer(buildChatterSession(session));
 
       final boolean result =
-          chatters.disconnectPlayerSessions(CHAT_PARTICIPANT.getUserName(), "disconnect message");
+          chatters.disconnectPlayerByName(CHAT_PARTICIPANT.getUserName(), "disconnect message");
       assertThat(result, is(true));
 
       verify(session).close(any(CloseReason.class));
@@ -152,7 +152,46 @@ class ChattersTest {
       chatters.connectPlayer(buildChatterSession(session2));
 
       final boolean result =
-          chatters.disconnectPlayerSessions(CHAT_PARTICIPANT.getUserName(), "disconnect message");
+          chatters.disconnectPlayerByName(CHAT_PARTICIPANT.getUserName(), "disconnect message");
+      assertThat(result, is(true));
+
+      verify(session).close(any(CloseReason.class));
+      verify(session2).close(any(CloseReason.class));
+    }
+  }
+
+  @Nested
+  class DisconnectPlayerByIp {
+    @Test
+    void noOpIfPlayerNotConnected() {
+      final boolean result =
+          chatters.disconnectIp(IpAddressParser.fromString("1.1.1.1"), "disconnect message");
+      assertThat(result, is(false));
+    }
+
+    @Test
+    void singleSessionDisconnected() throws Exception {
+      when(session.getId()).thenReturn("100");
+      final ChatterSession chatterSession = buildChatterSession(session);
+      chatters.connectPlayer(chatterSession);
+
+      final boolean result = chatters.disconnectIp(chatterSession.getIp(), "disconnect message");
+      assertThat(result, is(true));
+
+      verify(session).close(any(CloseReason.class));
+    }
+
+    @Test
+    @DisplayName("Players can have multiple sessions, verify they are all closed")
+    void allSameIpsAreDisconnected() throws Exception {
+      when(session.getId()).thenReturn("1");
+      when(session2.getId()).thenReturn("2");
+
+      final ChatterSession session1 = buildChatterSession(session);
+      chatters.connectPlayer(session1);
+      chatters.connectPlayer(buildChatterSession(session2));
+
+      final boolean result = chatters.disconnectIp(session1.getIp(), "disconnect message");
       assertThat(result, is(true));
 
       verify(session).close(any(CloseReason.class));

--- a/http-server/src/test/java/org/triplea/modules/moderation/ban/user/UserBanServiceTest.java
+++ b/http-server/src/test/java/org/triplea/modules/moderation/ban/user/UserBanServiceTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -26,7 +25,7 @@ import org.triplea.db.dao.api.key.PlayerApiKeyDaoWrapper;
 import org.triplea.db.dao.moderator.ModeratorAuditHistoryDao;
 import org.triplea.db.dao.user.ban.UserBanDao;
 import org.triplea.db.dao.user.ban.UserBanRecord;
-import org.triplea.domain.data.UserName;
+import org.triplea.http.client.IpAddressParser;
 import org.triplea.http.client.lobby.moderator.toolbox.banned.user.UserBanData;
 import org.triplea.http.client.lobby.moderator.toolbox.banned.user.UserBanParams;
 import org.triplea.modules.chat.Chatters;
@@ -170,8 +169,7 @@ class UserBanServiceTest {
   @Test
   void banUserSuccessCase() {
     givenBanDaoUpdateCount(1);
-    when(chatters.disconnectPlayerSessions(
-            eq(UserName.of(USER_BAN_PARAMS.getUsername())), anyString()))
+    when(chatters.disconnectIp(eq(IpAddressParser.fromString(USER_BAN_PARAMS.getIp())), any()))
         .thenReturn(true);
 
     bannedUsersService.banUser(MODERATOR_ID, USER_BAN_PARAMS);
@@ -183,8 +181,6 @@ class UserBanServiceTest {
                 .moderatorUserId(MODERATOR_ID)
                 .build());
 
-    verify(chatters)
-        .disconnectPlayerSessions(eq(UserName.of(USER_BAN_PARAMS.getUsername())), any());
     verify(chatMessagingBus).broadcastMessage(any());
     verify(gameMessagingBus).broadcastMessage(any());
   }

--- a/http-server/src/test/java/org/triplea/modules/moderation/disconnect/user/DisconnectUserActionTest.java
+++ b/http-server/src/test/java/org/triplea/modules/moderation/disconnect/user/DisconnectUserActionTest.java
@@ -61,7 +61,7 @@ class DisconnectUserActionTest {
     }
 
     private void verifyNoOp() {
-      verify(chatters, never()).disconnectPlayerSessions(any(), any());
+      verify(chatters, never()).disconnectPlayerByName(any(), any());
       verify(playerConnections, never()).broadcastMessage(any());
       verify(moderatorAuditHistoryDao, never()).addAuditRecord(any());
     }
@@ -90,7 +90,7 @@ class DisconnectUserActionTest {
       when(apiKeyDaoWrapper.lookupPlayerByChatId(PLAYER_CHAT_ID))
           .thenReturn(Optional.of(PLAYER_ID_LOOKUP));
       when(chatters.isPlayerConnected(PLAYER_ID_LOOKUP.getUserName())).thenReturn(true);
-      when(chatters.disconnectPlayerSessions(eq(PLAYER_ID_LOOKUP.getUserName()), any()))
+      when(chatters.disconnectPlayerByName(eq(PLAYER_ID_LOOKUP.getUserName()), any()))
           .thenReturn(true);
 
       disconnectUserAction.disconnectPlayer(MODERATOR_ID, PLAYER_CHAT_ID);
@@ -103,7 +103,7 @@ class DisconnectUserActionTest {
     private void verifyPlayerIsDisconnected() {
       final ArgumentCaptor<String> disconnectMessageCaptor = ArgumentCaptor.forClass(String.class);
       verify(chatters)
-          .disconnectPlayerSessions(
+          .disconnectPlayerByName(
               eq(PLAYER_ID_LOOKUP.getUserName()), disconnectMessageCaptor.capture());
       assertThat(
           "Disconnect message should contain the word 'disconnect'",


### PR DESCRIPTION
- Restores previous behavior (from an early 2.0) where all such sessions were disconnected
- The removal of all same IP is to remove any player aliases that have joined

Resolves: https://github.com/triplea-game/triplea/issues/6412


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
- launched a local lobby
- connected as a moderator
- connected as a second player
- banned the second player from toolbox and verified both sessions were disconnected

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

