### PR TITLE
Add property 'canRetreatOnStalemate' and allow v3 transport vs transport retreat

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -75,6 +75,7 @@ public class UnitAttachment extends DefaultAttachment {
   private int attackRolls = 1;
   private int defenseRolls = 1;
   private boolean chooseBestRoll = false;
+  private Boolean canRetreatOnStalemate;
 
   // sub/destroyer related
   private boolean canEvade = false;
@@ -2610,6 +2611,22 @@ public class UnitAttachment extends DefaultAttachment {
     tuv = -1;
   }
 
+  public void setCanRetreatOnStalemate(final boolean value) {
+    canRetreatOnStalemate = value;
+  }
+
+  public void setCanRetreatOnStalemate(final String value) {
+    canRetreatOnStalemate = getBool(value);
+  }
+
+  public Boolean getCanRetreatOnStalemate() {
+    return canRetreatOnStalemate;
+  }
+
+  public void resetCanRetreatOnStalemate() {
+    canRetreatOnStalemate = null;
+  }
+
   /**
    * Returns the maximum number of units of the specified type that can be placed in the specified
    * territory according to the specified stacking limit (movement, attack, or placement).
@@ -4363,6 +4380,11 @@ public class UnitAttachment extends DefaultAttachment {
             "isAAmovement",
             MutableProperty.<Boolean>ofWriteOnly(this::setIsAaMovement, this::setIsAaMovement))
         .put("isTwoHit", MutableProperty.<Boolean>ofWriteOnly(this::setIsTwoHit, this::setIsTwoHit))
+        .put(
+            "canRetreatOnStalemate",
+            MutableProperty.of(
+                this::setCanRetreatOnStalemate, this::setCanRetreatOnStalemate,
+                this::getCanRetreatOnStalemate, this::resetCanRetreatOnStalemate))
         .build();
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -38,6 +38,7 @@ import java.util.Iterator;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
@@ -1051,6 +1052,51 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     return !getAttackerRetreatTerritories().isEmpty();
   }
 
+  private boolean canAttackerRetreatInStalemate() {
+    // First check if any units have an explicit "can retreat on stalemate"
+    // property. If none do (all are null), then we will use a fallback algorithm.
+    // If any unit has "can retreat on stalemate" set, then we will return true
+    // only if all units either have the property set to null or true, if any
+    // are set to false then we will return false.
+
+    // Otherwise, if we do not have an explicit property, then we fallback
+    // to enforcing the V3 transport vs transport rule that allows retreat in
+    // that situation. Ideally all maps would explicitly use the "can retreat
+    // on stalemate property", but not all do so we need to account for the
+    // V3 transport vs transport rule as a fallback algorithm without it.
+
+    // First, collect all of the non-null 'can retreat on stalemate' option values.
+    final Set<Boolean> canRetreatOptions =
+        attackingUnits.stream()
+            .map(Unit::getType)
+            .map(UnitAttachment::get)
+            .map(UnitAttachment::getCanRetreatOnStalemate)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+    final boolean propertyIsSetAtLeastOnce = !canRetreatOptions.isEmpty();
+
+    // next, check if all of the non-null properties are set to true.
+    final boolean allowRetreatFromProperty = canRetreatOptions.stream().allMatch(b -> b);
+
+    return (propertyIsSetAtLeastOnce && allowRetreatFromProperty)
+        || (!propertyIsSetAtLeastOnce && transportsVsTransports());
+  }
+
+  private boolean transportsVsTransports() {
+    // Check if both sides have only V3 (non-combat) transports remaining.
+    // See: https://github.com/triplea-game/triplea/issues/2367
+    // Rule: "In a sea battle, if both sides have only transports remaining, the
+    // attacker’s transports can remain in the contested sea zone or retreat.
+    return onlyPowerlessAttackingTransportsLeft() && onlyDefenselessDefendingTransportsLeft();
+  }
+
+  private boolean onlyPowerlessAttackingTransportsLeft() {
+    return Properties.getTransportCasualtiesRestricted(gameData)
+        && !attackingUnits.isEmpty()
+        && attackingUnits.stream().allMatch(Matches.unitIsTransportButNotCombatTransport());
+  }
+
   private boolean onlyDefenselessDefendingTransportsLeft() {
     return Properties.getTransportCasualtiesRestricted(gameData)
         && !defendingUnits.isEmpty()
@@ -2002,6 +2048,10 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
                           amphibiousLandAttackers),
                       gameData);
               if (attackPower == 0 && defensePower == 0) {
+                if (canAttackerRetreatInStalemate()) {
+                  attackerRetreat(bridge);
+                }
+
                 endBattle(bridge);
                 nobodyWins(bridge);
               }


### PR DESCRIPTION
- Update stalemate battle to check if attacker can retreat, and allow retreat if so.
- Add a stalemate battle check that first looks for a new 'canRetreatOnStalemate'
  property. If any unit has the property set, we will use the property value. If the
  property value has a mix of 'true' & 'false' any 'false' values will prevail.
  Otherwise, if no property, we will fallback to checking if we are in a 
  V3 transport vs transport situation which should allow retreat. We do 
  the fallback to avoid updating all maps to have an explicit property and still
  have a rule fix.
- Finally, add the 'canRetreatOnStalemate' property that can be added as a unit
  attachment option. If it is not specified then we default to not looking at it
  and will only check if we have V3 transport vs transport.

Resolves: https://github.com/triplea-game/triplea/issues/2367

<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
On 1941 v3, set up a cruiser & transport vs cruiser & transport battle (gives good odds both cruisers will hit leaving transport vs transport).
- verified that without any properties set that a transport vs transport is offered retreat. 
- verified that setting 'canRetreatOnStalemate=false' to a transport removes the retreat prompt

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes

This is a better fix of v3 transport vs transport rules compared to the one initially proposed in: https://github.com/triplea-game/triplea/pull/6033, and adds a property that can be used to customize this behavior on other maps as desired.
