### PR TITLE
Suppress option to submerge if subs attacking undefended V3+ transports

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -1681,7 +1681,8 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
     if (!canAttackerRetreatSubs()) {
       return;
     }
-    if (attackingUnits.stream().anyMatch(Matches.unitCanEvade())) {
+    if (attackingUnits.stream().anyMatch(Matches.unitCanEvade())
+        && !onlyDefenselessDefendingTransportsLeft()) {
       queryRetreat(false, RetreatType.SUBS, bridge, getAttackerRetreatTerritories());
     }
   }


### PR DESCRIPTION
If subs are attacking undefended V3 transports, or if after
a round of combat only V3 transports are left, then subs should
not be able to retreat and the transports are auto-destroyed.

This update adds a check to see if we have such a case and if so
skips the subs submerge prompt.

Address: Part (2) of https://github.com/triplea-game/triplea/issues/4688


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
- Checked that on global 1940 2nd edition if subs attack an undefended transport, then there is no submerge & retreat prompt, the transport is auto-destroyed
- Checked that on global if 3 subs attack a cruiser and transport (with LL), then:
  -  there is a submerge prompt at the start of the battle
  - after the first round of combat, where the subs sink the cruiser, and it is then 3 subs vs transport, there is no submerge prompt

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

