### PR TITLE
Merge Network Proxy and Network Timeouts pref tabs.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -169,9 +169,21 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
     }
   },
 
+  PROXY_CHOICE(
+      "Network Proxy",
+      SettingType.NETWORK,
+      "Configure TripleA's Network and Proxy Settings\n"
+          + "This only effects Play-By-Forum games, dice servers, and map downloads.") {
+    @Override
+    public SelectionComponent<JComponent> newSelectionComponent() {
+      return proxySettings(
+          ClientSetting.proxyChoice, ClientSetting.proxyHost, ClientSetting.proxyPort);
+    }
+  },
+
   SERVER_START_GAME_SYNC_WAIT_TIME_BINDING(
       "Start game timeout",
-      SettingType.NETWORK_TIMEOUTS,
+      SettingType.NETWORK,
       "Maximum time (in seconds) to wait for all clients to sync data on game start") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
@@ -181,7 +193,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
 
   SERVER_OBSERVER_JOIN_WAIT_TIME_BINDING(
       "Observer join timeout",
-      SettingType.NETWORK_TIMEOUTS,
+      SettingType.NETWORK,
       "Maximum time (in seconds) for host to wait for clients and observers") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
@@ -276,18 +288,6 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
       return intValueRange(ClientSetting.wheelScrollAmount, 10, 300);
-    }
-  },
-
-  PROXY_CHOICE(
-      "Network Proxy",
-      SettingType.NETWORK_PROXY,
-      "Configure TripleA's Network and Proxy Settings\n"
-          + "This only effects Play-By-Forum games, dice servers, and map downloads.") {
-    @Override
-    public SelectionComponent<JComponent> newSelectionComponent() {
-      return proxySettings(
-          ClientSetting.proxyChoice, ClientSetting.proxyHost, ClientSetting.proxyPort);
     }
   },
 

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
@@ -82,6 +82,15 @@ final class SelectionComponentFactory {
                               .boxLayoutHorizontal()
                               .addLeftJustified(new JLabel("Proxy Host:"))
                               .addLeftJustified(hostText)
+                              .build())
+                      .build())
+              .addLeftJustified(
+                  new JPanelBuilder()
+                      .boxLayoutHorizontal()
+                      .addHorizontalStrut(getRadioButtonLabelHorizontalOffset())
+                      .add(
+                          new JPanelBuilder()
+                              .boxLayoutHorizontal()
                               .addLeftJustified(new JLabel("Proxy Port:"))
                               .addLeftJustified(portText)
                               .build())

--- a/game-core/src/main/java/games/strategy/triplea/settings/SettingType.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SettingType.java
@@ -16,9 +16,7 @@ public enum SettingType {
 
   MAP_SCROLLING("Map Scrolling"),
 
-  NETWORK_PROXY("Network Proxy"),
-
-  NETWORK_TIMEOUTS("Network Timeouts"),
+  NETWORK("Network"),
 
   LOOK_AND_FEEL("UI Theme"),
 

--- a/game-headed-javafx/src/main/java/org/triplea/game/client/ui/javafx/util/ClientSettingJavaFxUiBinding.java
+++ b/game-headed-javafx/src/main/java/org/triplea/game/client/ui/javafx/util/ClientSettingJavaFxUiBinding.java
@@ -96,14 +96,22 @@ public enum ClientSettingJavaFxUiBinding implements GameSettingUiBinding<Region>
     }
   },
 
-  SERVER_START_GAME_SYNC_WAIT_TIME_BINDING(SettingType.NETWORK_TIMEOUTS) {
+  PROXY_CHOICE(SettingType.NETWORK) {
+    @Override
+    public SelectionComponent<Region> newSelectionComponent() {
+      return proxySettings(
+          ClientSetting.proxyChoice, ClientSetting.proxyHost, ClientSetting.proxyPort);
+    }
+  },
+
+  SERVER_START_GAME_SYNC_WAIT_TIME_BINDING(SettingType.NETWORK) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
       return intValueRange(ClientSetting.serverStartGameSyncWaitTime, 120, 1500);
     }
   },
 
-  SERVER_OBSERVER_JOIN_WAIT_TIME_BINDING(SettingType.NETWORK_TIMEOUTS) {
+  SERVER_OBSERVER_JOIN_WAIT_TIME_BINDING(SettingType.NETWORK) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
       return intValueRange(ClientSetting.serverObserverJoinWaitTime, 60, 1500);
@@ -158,14 +166,6 @@ public enum ClientSettingJavaFxUiBinding implements GameSettingUiBinding<Region>
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
       return intValueRange(ClientSetting.wheelScrollAmount, 10, 300);
-    }
-  },
-
-  PROXY_CHOICE(SettingType.NETWORK_PROXY) {
-    @Override
-    public SelectionComponent<Region> newSelectionComponent() {
-      return proxySettings(
-          ClientSetting.proxyChoice, ClientSetting.proxyHost, ClientSetting.proxyPort);
     }
   };
 


### PR DESCRIPTION
Merge Network Proxy and Network Timeouts pref tabs.

This combines the two tabs together. One of the benefits is the set of tabs no longer makes the tab strip need scrolling behavior with the Mac look and feel.

(Also, moves the port text box to a new line so that the descriptions on the right aren't too narrow.)

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[X] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
Open engine prefs.

## Screens Shots

### Before

![Screen Shot 2020-05-23 at 9 05 24 AM](https://user-images.githubusercontent.com/17648/82731430-d7752580-9cd4-11ea-9029-391f287f5db7.png)
![Screen Shot 2020-05-23 at 9 08 02 AM](https://user-images.githubusercontent.com/17648/82731444-eeb41300-9cd4-11ea-871a-781667bcd7b6.png)

### After

![Screen Shot 2020-05-23 at 9 15 46 AM](https://user-images.githubusercontent.com/17648/82731580-06d86200-9cd6-11ea-8bab-dc762fb30f95.png)

-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->


