### PR TITLE
Add a separate setting for AI combat step pause duration.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
@@ -476,7 +476,7 @@ public abstract class AbstractAi extends AbstractBasePlayer {
 
   @Override
   public void confirmOwnCasualties(final UUID battleId, final String message) {
-    pause();
+    combatStepPause();
   }
 
   @Override
@@ -697,7 +697,12 @@ public abstract class AbstractAi extends AbstractBasePlayer {
   }
 
   /** Pause the game to allow the human player to see what is going on. */
-  protected static void pause() {
-    Interruptibles.sleep(ClientSetting.aiPauseDuration.getValueOrThrow());
+  public static void movePause() {
+    Interruptibles.sleep(ClientSetting.aiMovePauseDuration.getValueOrThrow());
+  }
+
+  /** Pause the combat to allow the human player to see what is going on. */
+  public static void combatStepPause() {
+    Interruptibles.sleep(ClientSetting.aiCombatStepPauseDuration.getValueOrThrow());
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -9,6 +9,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.UnitUtils;
+import games.strategy.triplea.ai.AbstractAi;
 import games.strategy.triplea.ai.pro.data.ProBattleResult;
 import games.strategy.triplea.ai.pro.data.ProOtherMoveOptions;
 import games.strategy.triplea.ai.pro.data.ProPlaceTerritory;
@@ -2623,6 +2624,6 @@ class ProPurchaseAi {
         ProLogger.warn("Attempt was at: " + t + " with: " + unit);
       }
     }
-    ProUtils.pause();
+    AbstractAi.movePause();
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -7,6 +7,7 @@ import games.strategy.engine.data.MoveDescription;
 import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
+import games.strategy.triplea.ai.AbstractAi;
 import games.strategy.triplea.ai.pro.ProData;
 import games.strategy.triplea.ai.pro.data.ProTerritory;
 import games.strategy.triplea.ai.pro.logging.ProLogger;
@@ -459,7 +460,7 @@ public final class ProMoveUtils {
                 + result);
       }
       if (!proData.isSimulation()) {
-        ProUtils.pause();
+        AbstractAi.movePause();
       }
     }
   }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
@@ -11,14 +11,12 @@ import games.strategy.engine.data.Territory;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.Matches;
-import games.strategy.triplea.settings.ClientSetting;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.triplea.java.Interruptibles;
 import org.triplea.java.collections.CollectionUtils;
 
 /** Pro AI utilities (these are very general and maybe should be moved into delegate or engine). */
@@ -301,10 +299,5 @@ public final class ProUtils {
                 player.equals(s.getPlayerId())
                     && s.getName().endsWith("CombatMove")
                     && !s.getName().endsWith("NonCombatMove"));
-  }
-
-  /** Pause the game to allow the human player to see what is going on. */
-  public static void pause() {
-    Interruptibles.sleep(ClientSetting.aiPauseDuration.getValueOrThrow());
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/DoesNothingAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/DoesNothingAi.java
@@ -41,23 +41,18 @@ public class DoesNothingAi extends AbstractAi {
       new WeakAi(this.getName())
           .purchase(purchaseForBid, pusToSpend, purchaseDelegate, data, player);
     }
-    pause();
   }
 
   @Override
   protected void tech(
-      final ITechDelegate techDelegate, final GameData data, final GamePlayer player) {
-    pause();
-  }
+      final ITechDelegate techDelegate, final GameData data, final GamePlayer player) {}
 
   @Override
   protected void move(
       final boolean nonCombat,
       final IMoveDelegate moveDel,
       final GameData data,
-      final GamePlayer player) {
-    pause();
-  }
+      final GamePlayer player) {}
 
   @Override
   protected void place(
@@ -69,13 +64,10 @@ public class DoesNothingAi extends AbstractAi {
     if (!player.getUnitCollection().isEmpty()) {
       new WeakAi(this.getName()).place(placeForBid, placeDelegate, data, player);
     }
-    pause();
   }
 
   @Override
-  public void politicalActions() {
-    pause();
-  }
+  public void politicalActions() {}
 
   @Override
   protected void endTurn(

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -119,7 +119,7 @@ public class WeakAi extends AbstractAi {
     } else {
       doCombatMove(moveDel, player, data);
     }
-    pause();
+    movePause();
   }
 
   private void doNonCombatMove(
@@ -229,7 +229,7 @@ public class WeakAi extends AbstractAi {
   private static void doMove(final List<MoveDescription> moves, final IMoveDelegate moveDel) {
     for (final MoveDescription move : moves) {
       moveDel.performMove(move);
-      pause();
+      movePause();
     }
   }
 
@@ -784,7 +784,7 @@ public class WeakAi extends AbstractAi {
         }
       }
       purchaseDelegate.purchase(purchase);
-      pause();
+      movePause();
       return;
     }
     final boolean isAmphib = isAmphibAttack(player, data);
@@ -1029,7 +1029,7 @@ public class WeakAi extends AbstractAi {
       }
     }
     purchaseDelegate.purchase(purchase);
-    pause();
+    movePause();
   }
 
   @Override
@@ -1104,7 +1104,7 @@ public class WeakAi extends AbstractAi {
   private static void doPlace(
       final Territory where, final Collection<Unit> toPlace, final IAbstractPlaceDelegate del) {
     del.placeUnits(new ArrayList<>(toPlace), where, IAbstractPlaceDelegate.BidMode.NOT_BID);
-    pause();
+    movePause();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -36,10 +36,10 @@ import lombok.extern.java.Log;
  *
  * <p>Typical usage: <code><pre>
  * // loading a value
- * String value = ClientSetting.aiPauseDuration.getValueOrThrow();
+ * String value = ClientSetting.aiMovePauseDuration.getValueOrThrow();
  *
  * // saving value
- * ClientSetting.aiPauseDuration.setValue(500);
+ * ClientSetting.aiMovePauseDuration.setValue(500);
  * ClientSetting.flush();
  * </pre></code>
  *
@@ -48,8 +48,10 @@ import lombok.extern.java.Log;
 @SuppressWarnings("StaticInitializerReferencesSubClass")
 @Log
 public abstract class ClientSetting<T> implements GameSetting<T> {
-  public static final ClientSetting<Integer> aiPauseDuration =
-      new IntegerClientSetting("AI_PAUSE_DURATION", 400);
+  public static final ClientSetting<Integer> aiMovePauseDuration =
+      new IntegerClientSetting("AI_PAUSE_DURATION", 300);
+  public static final ClientSetting<Integer> aiCombatStepPauseDuration =
+      new IntegerClientSetting("AI_COMBAT_STEP_PAUSE_DURATION", 1000);
   public static final ClientSetting<Integer> arrowKeyScrollSpeed =
       new IntegerClientSetting("ARROW_KEY_SCROLL_SPEED", 70);
   public static final ClientSetting<Integer> battleCalcSimulationCountDice =

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -28,11 +28,21 @@ import lombok.Getter;
  */
 @AllArgsConstructor
 enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
-  AI_PAUSE_DURATION_BINDING(
-      "AI Pause Duration", SettingType.AI, "Time (in milliseconds) between AI moves") {
+  AI_MOVE_PAUSE_DURATION_BINDING(
+      "AI Move Pause Duration", SettingType.AI, "Time (in milliseconds) between AI moves") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return intValueRange(ClientSetting.aiPauseDuration, 0, 3000);
+      return intValueRange(ClientSetting.aiMovePauseDuration, 0, 3000);
+    }
+  },
+
+  AI_COMBAT_STEP_PAUSE_DURATION_BINDING(
+      "AI Combat Step Pause Duration",
+      SettingType.AI,
+      "Time (in milliseconds) between AI combat steps") {
+    @Override
+    public SelectionComponent<JComponent> newSelectionComponent() {
+      return intValueRange(ClientSetting.aiCombatStepPauseDuration, 0, 3000);
     }
   },
 

--- a/game-headed-javafx/src/main/java/org/triplea/game/client/ui/javafx/util/ClientSettingJavaFxUiBinding.java
+++ b/game-headed-javafx/src/main/java/org/triplea/game/client/ui/javafx/util/ClientSettingJavaFxUiBinding.java
@@ -26,10 +26,17 @@ import lombok.Getter;
  */
 @AllArgsConstructor
 public enum ClientSettingJavaFxUiBinding implements GameSettingUiBinding<Region> {
-  AI_PAUSE_DURATION_BINDING(SettingType.AI) {
+  AI_MOVE_PAUSE_DURATION_BINDING(SettingType.AI) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {
-      return intValueRange(ClientSetting.aiPauseDuration, 0, 3000);
+      return intValueRange(ClientSetting.aiMovePauseDuration, 0, 3000);
+    }
+  },
+
+  AI_COMBAT_STEP_PAUSE_DURATION_BINDING(SettingType.AI) {
+    @Override
+    public SelectionComponent<Region> newSelectionComponent() {
+      return intValueRange(ClientSetting.aiCombatStepPauseDuration, 0, 3000);
     }
   },
 


### PR DESCRIPTION
Add a separate setting for AI combat step pause duration.

Motivation:
  - During combat, it can be useful to have a bit more time
    to see the dice rolls.
  - On the other hand, while AI is moving units, not as much
    time is needed.

So this change introduces a new setting with a higher default and
also reduces the existing setting (since I suspect the higher
default was to accomodate the time needed to view combat dice
rolls).

I believe these new default settings will actually make games
against AIs faster as there's much more time spent by AIs moving
units than doing dice rolls.

Also removes some unnecessary pause() calls from DoNothingAI,
as there's no reason to pause when the AI isn't doing anything.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[X] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
Manual testing.

## Screens Shots

### Before

### After

![Screen Shot 2020-05-23 at 9 30 45 AM](https://user-images.githubusercontent.com/17648/82732045-cd552600-9cd8-11ea-91a5-d0c82005926b.png)
