### PR TITLE
Websocket async connection single retry

### DIFF
--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -118,8 +118,7 @@ class WebSocketConnection {
     Preconditions.checkState(client == null);
     Preconditions.checkState(!closed);
 
-    connectAsync()
-        .thenRun(pingSender::start)
+    connectAsyncAndStartPingSender()
         .exceptionally(
             throwable -> {
               errorHandler.accept("Failed to connect: " + throwable.getMessage());
@@ -127,11 +126,12 @@ class WebSocketConnection {
             });
   }
 
-  private CompletableFuture<WebSocket> connectAsync() {
+  private CompletableFuture<Void> connectAsyncAndStartPingSender() {
     return httpClient
         .newWebSocketBuilder()
         .connectTimeout(Duration.ofMillis(DEFAULT_CONNECT_TIMEOUT_MILLIS))
-        .buildAsync(this.serverUri, internalListener);
+        .buildAsync(this.serverUri, internalListener)
+        .thenRun(pingSender::start);
   }
 
   /**

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -122,9 +122,7 @@ class WebSocketConnection {
         .thenRun(pingSender::start)
         .exceptionally(
             throwable -> {
-              errorHandler.accept("Failed to connect to: " + serverUri);
-              log.log(
-                  Level.SEVERE, "Unexpected exception completing websocket connection", throwable);
+              errorHandler.accept("Failed to connect: " + throwable.getMessage());
               return null;
             });
   }


### PR DESCRIPTION
## Overview
Adds a single retry attempt to establish websocket connection.  With a local lobby have observed connection failures that succeed on a subsequent retry.


## Commits

commit 76bccdeefac7683d9d44d6eca58777ee33463970

    Delegate error messaging to error handling.
    
    Do not call logger when we fail to connect, allow 'errorHandler'
    to control all error messaging and logging in such cases.

commit f5f5c8d7f42f7a7554e3979a3e525be79f34b9a0

    Merge ping-send starter with connect method

commit 7578ec2b46da77de2f2271dc7f453d8a3468e70c

    Add websocket connection retry
    
    - Single retry connection attempt
    - Fixed backoff of 1 second, long enough to give a decent
      pause between attempts but not so long a user will notice
      too excessive of a delay.

<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

