### PR TITLE
Execute 'set status' on async thread instead of EDT

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/MessengersChatTransmitter.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/MessengersChatTransmitter.java
@@ -4,10 +4,14 @@ import games.strategy.engine.message.MessageContext;
 import games.strategy.engine.message.RemoteName;
 import games.strategy.net.Messengers;
 import java.util.Collection;
+import java.util.logging.Level;
+import lombok.extern.java.Log;
 import org.triplea.domain.data.ChatParticipant;
 import org.triplea.domain.data.UserName;
+import org.triplea.java.concurrency.AsyncRunner;
 
 /** Chat transmitter that sends and receives messages over Java NIO sockets. */
+@Log
 public class MessengersChatTransmitter implements ChatTransmitter {
   private final UserName userName;
   private final Messengers messengers;
@@ -95,7 +99,8 @@ public class MessengersChatTransmitter implements ChatTransmitter {
   public void updateStatus(final String status) {
     final RemoteName chatControllerName = ChatController.getChatControllerRemoteName(chatName);
     final IChatController controller = (IChatController) messengers.getRemote(chatControllerName);
-    controller.setStatus(status);
+    AsyncRunner.runAsync(() -> controller.setStatus(status))
+        .exceptionally(throwable -> log.log(Level.WARNING, "Error updating status", throwable));
   }
 
   @Override


### PR DESCRIPTION
<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
Tested locally that could set status and the warning of executing a blocking action on EDT is gone.

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

