### PR TITLE
Add player registration date to player info

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/player/info/PlayerInfoSummaryTextArea.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/player/info/PlayerInfoSummaryTextArea.java
@@ -1,32 +1,40 @@
 package games.strategy.engine.lobby.client.ui.action.player.info;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.sql.Date;
+import java.text.DateFormat;
+import java.time.Instant;
 import javax.swing.JComponent;
 import javax.swing.JDialog;
 import javax.swing.JTextPane;
 import lombok.experimental.UtilityClass;
-import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.moderator.PlayerSummary;
 import org.triplea.swing.SwingComponents;
 
 @UtilityClass
 class PlayerInfoSummaryTextArea {
   /** Returns a text area with the players name, their IP and system ID. */
-  JComponent buildPlayerInfoSummary(
-      final JDialog dialog, final UserName playerName, final PlayerSummary playerSummary) {
+  JComponent buildPlayerInfoSummary(final JDialog dialog, final PlayerSummary playerSummary) {
     final JTextPane textPane = new JTextPane();
     textPane.setEditable(false);
-    textPane.setText(buildPlayerInfoText(playerName, playerSummary));
+    textPane.setText(buildPlayerInfoText(playerSummary));
     textPane.addKeyListener(SwingComponents.escapeKeyListener(dialog::dispose));
     return textPane;
   }
 
   @VisibleForTesting
-  static String buildPlayerInfoText(final UserName playerName, final PlayerSummary playerSummary) {
-    return playerName.getValue()
+  static String buildPlayerInfoText(final PlayerSummary playerSummary) {
+    return (playerSummary.getRegistrationDateEpochMillis() == null
+            ? "Not registered"
+            : "Registered on: " + formatEpochMillis(playerSummary.getRegistrationDateEpochMillis()))
         + (playerSummary.getIp() == null ? "" : "\nIP: " + playerSummary.getIp())
         + (playerSummary.getSystemId() == null
             ? ""
             : "\nSystem ID: " + playerSummary.getSystemId());
+  }
+
+  private static String formatEpochMillis(final long epochMillis) {
+    return DateFormat.getDateInstance(DateFormat.MEDIUM) //
+        .format(Date.from(Instant.ofEpochMilli(epochMillis)));
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/player/info/PlayerInformationPopup.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/player/info/PlayerInformationPopup.java
@@ -21,17 +21,14 @@ class PlayerInformationPopup {
         () -> {
           new JDialogBuilder()
               .parent(parent)
-              .title("Player Info: " + playerName.getValue())
-              .add(
-                  dialog ->
-                      PlayerInformationPopup.buildContentPanel(dialog, playerName, playerSummary))
+              .title("Player: " + playerName.getValue())
+              .add(dialog -> PlayerInformationPopup.buildContentPanel(dialog, playerSummary))
               .escapeKeyCloses()
               .buildAndShow();
         });
   }
 
-  private JPanel buildContentPanel(
-      final JDialog dialog, final UserName playerName, final PlayerSummary playerSummary) {
+  private JPanel buildContentPanel(final JDialog dialog, final PlayerSummary playerSummary) {
     final JTabbedPaneBuilder tabbedPaneBuilder = new JTabbedPaneBuilder();
 
     final var playerGamesTab = new PlayerGamesTab(playerSummary);
@@ -50,12 +47,7 @@ class PlayerInformationPopup {
 
     return new JPanelBuilder()
         .borderLayout()
-        .addNorth(
-            // moderators will get IP and system-id information
-            playerSummary.getIp() == null
-                ? new JPanel()
-                : PlayerInfoSummaryTextArea.buildPlayerInfoSummary(
-                    dialog, playerName, playerSummary))
+        .addNorth(PlayerInfoSummaryTextArea.buildPlayerInfoSummary(dialog, playerSummary))
         .addCenter(tabbedPaneBuilder.build())
         .addSouth(new JButtonBuilder("Close").actionListener(dialog::dispose).build())
         .build();

--- a/game-core/src/test/java/games/strategy/engine/lobby/client/ui/action/player/info/PlayerInfoSummaryTextAreaTest.java
+++ b/game-core/src/test/java/games/strategy/engine/lobby/client/ui/action/player/info/PlayerInfoSummaryTextAreaTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
 
 import org.junit.jupiter.api.Test;
-import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.moderator.PlayerSummary;
 
 class PlayerInfoSummaryTextAreaTest {
@@ -14,22 +13,24 @@ class PlayerInfoSummaryTextAreaTest {
   void buildPlayerSummaryWithoutModeratorOnlyData() {
     final PlayerSummary playerSummary = PlayerSummary.builder().build();
 
-    final String result =
-        PlayerInfoSummaryTextArea.buildPlayerInfoText(UserName.of("player-name"), playerSummary);
+    final String result = PlayerInfoSummaryTextArea.buildPlayerInfoText(playerSummary);
 
-    assertThat(result, is("player-name"));
+    assertThat(result, is("Not registered"));
   }
 
   @Test
   void buildPlayerSummaryWithFullData() {
     final PlayerSummary playerSummary =
-        PlayerSummary.builder().ip("3.3.3.3").systemId("system-id").build();
+        PlayerSummary.builder()
+            .ip("3.3.3.3")
+            .systemId("system-id")
+            .registrationDateEpochMillis(600L)
+            .build();
 
-    final String result =
-        PlayerInfoSummaryTextArea.buildPlayerInfoText(UserName.of("player-name"), playerSummary);
+    final String result = PlayerInfoSummaryTextArea.buildPlayerInfoText(playerSummary);
 
-    assertThat(result, containsString("player-name"));
     assertThat(result, containsString("IP: 3.3.3.3"));
     assertThat(result, containsString("System ID: system-id"));
+    assertThat(result, containsString("Registered on:"));
   }
 }

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/PlayerSummary.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/moderator/PlayerSummary.java
@@ -22,6 +22,7 @@ public class PlayerSummary {
   @Nullable private Collection<Alias> aliases;
   @Nullable private Collection<BanInformation> bans;
   private Collection<String> currentGames;
+  @Nullable private Long registrationDateEpochMillis;
 
   @Builder
   @Getter

--- a/http-server/src/main/java/org/triplea/db/JdbiDatabase.java
+++ b/http-server/src/main/java/org/triplea/db/JdbiDatabase.java
@@ -19,6 +19,7 @@ import org.triplea.db.dao.moderator.player.info.PlayerAliasRecord;
 import org.triplea.db.dao.moderator.player.info.PlayerBanRecord;
 import org.triplea.db.dao.user.ban.BanLookupRecord;
 import org.triplea.db.dao.user.ban.UserBanRecord;
+import org.triplea.db.dao.user.history.PlayerHistoryRecord;
 import org.triplea.db.dao.user.role.UserRoleLookup;
 import org.triplea.db.dao.username.ban.UsernameBanRecord;
 
@@ -60,6 +61,7 @@ public final class JdbiDatabase {
     jdbi.registerRowMapper(
         PlayerApiKeyLookupRecord.class, PlayerApiKeyLookupRecord.buildResultMapper());
     jdbi.registerRowMapper(PlayerAliasRecord.class, PlayerAliasRecord.buildResultMapper());
+    jdbi.registerRowMapper(PlayerHistoryRecord.class, PlayerHistoryRecord.buildResultMapper());
     jdbi.registerRowMapper(PlayerBanRecord.class, PlayerBanRecord.buildResultMapper());
     jdbi.registerRowMapper(UserBanRecord.class, UserBanRecord.buildResultMapper());
     jdbi.registerRowMapper(UsernameBanRecord.class, UsernameBanRecord.buildResultMapper());

--- a/http-server/src/main/java/org/triplea/db/dao/api/key/PlayerApiKeyDao.java
+++ b/http-server/src/main/java/org/triplea/db/dao/api/key/PlayerApiKeyDao.java
@@ -52,4 +52,11 @@ interface PlayerApiKeyDao {
           + " where player_chat_id = :playerChatId")
   Optional<PlayerIdentifiersByApiKeyLookup> lookupByPlayerChatId(
       @Bind("playerChatId") String playerChatId);
+
+  @SqlQuery(
+      "select "
+          + "    lobby_user_id"
+          + " from lobby_api_key "
+          + " where player_chat_id = :playerChatId")
+  Optional<Integer> lookupPlayerIdByPlayerChatId(@Bind("playerChatId") String playerChatId);
 }

--- a/http-server/src/main/java/org/triplea/db/dao/api/key/PlayerApiKeyDaoWrapper.java
+++ b/http-server/src/main/java/org/triplea/db/dao/api/key/PlayerApiKeyDaoWrapper.java
@@ -103,4 +103,8 @@ public class PlayerApiKeyDaoWrapper {
       final PlayerChatId playerChatId) {
     return lobbyApiKeyDao.lookupByPlayerChatId(playerChatId.getValue());
   }
+
+  public Optional<Integer> lookupUserIdByChatId(final PlayerChatId playerChatId) {
+    return lobbyApiKeyDao.lookupPlayerIdByPlayerChatId(playerChatId.getValue());
+  }
 }

--- a/http-server/src/main/java/org/triplea/db/dao/user/history/PlayerHistoryDao.java
+++ b/http-server/src/main/java/org/triplea/db/dao/user/history/PlayerHistoryDao.java
@@ -1,0 +1,16 @@
+package org.triplea.db.dao.user.history;
+
+import java.util.Optional;
+import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
+
+/** DAO to look up a players stats. Intended to be used when getting player information. */
+public interface PlayerHistoryDao {
+
+  @SqlQuery(
+      "select"
+          + "    date_created as date_registered"
+          + "  from lobby_user"
+          + "  where id = :userId")
+  Optional<PlayerHistoryRecord> lookupPlayerHistoryByUserId(@Bind("userId") int userId);
+}

--- a/http-server/src/main/java/org/triplea/db/dao/user/history/PlayerHistoryRecord.java
+++ b/http-server/src/main/java/org/triplea/db/dao/user/history/PlayerHistoryRecord.java
@@ -1,0 +1,24 @@
+package org.triplea.db.dao.user.history;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.jdbi.v3.core.mapper.RowMapper;
+import org.triplea.db.TimestampMapper;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class PlayerHistoryRecord {
+
+  private long registrationDate;
+
+  public static RowMapper<PlayerHistoryRecord> buildResultMapper() {
+    return (rs, ctx) ->
+        PlayerHistoryRecord.builder()
+            .registrationDate(TimestampMapper.map(rs, "date_registered").toEpochMilli())
+            .build();
+  }
+}

--- a/http-server/src/test/java/org/triplea/db/dao/api/key/PlayerApiKeyDaoTest.java
+++ b/http-server/src/test/java/org/triplea/db/dao/api/key/PlayerApiKeyDaoTest.java
@@ -99,4 +99,19 @@ class PlayerApiKeyDaoTest extends DaoTest {
                 .ip("127.0.0.1")
                 .build()));
   }
+
+  @Test
+  //    @DataSet(cleanBefore = true, value = "lobby_api_key/initial.yml")
+  void foundCase() {
+    final Optional<Integer> result = playerApiKeyDao.lookupPlayerIdByPlayerChatId("chat-id0");
+
+    assertThat(result, isPresentAndIs(50));
+  }
+
+  @Test
+  void notFoundCase() {
+    final Optional<Integer> result = playerApiKeyDao.lookupPlayerIdByPlayerChatId("DNE");
+
+    assertThat(result, isEmpty());
+  }
 }

--- a/http-server/src/test/java/org/triplea/db/dao/api/key/PlayerApiKeyDaoWrapperTest.java
+++ b/http-server/src/test/java/org/triplea/db/dao/api/key/PlayerApiKeyDaoWrapperTest.java
@@ -152,4 +152,24 @@ class PlayerApiKeyDaoWrapperTest {
 
     assertThat(result, isPresentAndIs(PLAYER_ID_LOOKUP));
   }
+
+  @Test
+  void lookupUserByPlayerChatId() {
+    when(lobbyApiKeyDao.lookupPlayerIdByPlayerChatId(PLAYER_CHAT_ID.getValue()))
+        .thenReturn(Optional.of(123));
+
+    final Optional<Integer> result = wrapper.lookupUserIdByChatId(PLAYER_CHAT_ID);
+
+    assertThat(result, isPresentAndIs(123));
+  }
+
+  @Test
+  void lookupUserByPlayerChatIdNotFoundCase() {
+    when(lobbyApiKeyDao.lookupPlayerIdByPlayerChatId(PLAYER_CHAT_ID.getValue()))
+        .thenReturn(Optional.empty());
+
+    final Optional<Integer> result = wrapper.lookupUserIdByChatId(PLAYER_CHAT_ID);
+
+    assertThat(result, isEmpty());
+  }
 }


### PR DESCRIPTION
Lookup player registration date when fetching 'player info'
(available as a right click menu on lobby chatters). If
player is not registered, display "Not registered"


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
- verified with local lobby, registered, non-registered user, and as a moderator
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->

## Screens Shots

### Before
![Screenshot from 2020-05-25 18-24-52](https://user-images.githubusercontent.com/12397753/82851583-13ff7780-9eb5-11ea-9ce8-be20f36831b5.png)


### After

![Screenshot from 2020-05-25 18-20-13](https://user-images.githubusercontent.com/12397753/82851457-bcf9a280-9eb4-11ea-839a-c058a7ba9cfd.png)

![Screenshot from 2020-05-25 18-20-22](https://user-images.githubusercontent.com/12397753/82851458-bcf9a280-9eb4-11ea-8815-f08e345bb316.png)


<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->


