### PR TITLE
Check 'canRetreatOnStalemate' property on max combat round stalemate

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -2019,6 +2019,10 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
               endBattle(bridge);
               attackerWins(bridge);
             } else if (maxRounds > 0 && maxRounds <= round) {
+              if (canAttackerRetreatInStalemate()) {
+                attackerRetreat(bridge);
+              }
+
               endBattle(bridge);
               nobodyWins(bridge);
             } else {


### PR DESCRIPTION
If a combat is over due to max rounds, check property of 'canRetreatOnStalemate'
whether to allow retreat. If any are set to 'true' and none are set to false,
then retreat is allowed. By default, with no property set, retreat would
not be allowed (existing behavior)


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
- none
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes
Related to: https://github.com/triplea-game/triplea/issues/6532
