### PR TITLE
Update 0 vs 0 stalemate check to take into account dice rolls

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -885,6 +885,11 @@ public class DiceRoll implements Externalizable {
     @Nonnull Integer totalPower;
     @Nonnull Integer totalRolls;
 
+    /** Returns the product of power and dice rolls. */
+    public int getEffectivePower() {
+      return totalPower * totalRolls;
+    }
+
     public TotalPowerAndTotalRolls subtractPower(final int powerToSubtract) {
       return TotalPowerAndTotalRolls.builder()
           .totalPower(totalPower - powerToSubtract)
@@ -900,7 +905,7 @@ public class DiceRoll implements Externalizable {
     }
   }
 
-  private static TotalPowerAndTotalRolls getTotalPowerAndRolls(
+  public static TotalPowerAndTotalRolls getTotalPowerAndRolls(
       final Map<Unit, TotalPowerAndTotalRolls> unitPowerAndRollsMap, final GameData data) {
 
     final int diceSides = data.getDiceSides();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -2007,31 +2007,33 @@ public class MustFightBattle extends DependentBattle implements BattleStepString
               nobodyWins(bridge);
             } else {
               final int attackPower =
-                  DiceRoll.getTotalPower(
-                      DiceRoll.getUnitPowerAndRollsForNormalBattles(
-                          attackingUnits,
-                          defendingUnits,
-                          attackingUnits,
-                          false,
-                          gameData,
-                          battleSite,
-                          territoryEffects,
-                          isAmphibious,
-                          amphibiousLandAttackers),
-                      gameData);
+                  DiceRoll.getTotalPowerAndRolls(
+                          DiceRoll.getUnitPowerAndRollsForNormalBattles(
+                              attackingUnits,
+                              defendingUnits,
+                              attackingUnits,
+                              false,
+                              gameData,
+                              battleSite,
+                              territoryEffects,
+                              isAmphibious,
+                              amphibiousLandAttackers),
+                          gameData)
+                      .getEffectivePower();
               final int defensePower =
-                  DiceRoll.getTotalPower(
-                      DiceRoll.getUnitPowerAndRollsForNormalBattles(
-                          defendingUnits,
-                          attackingUnits,
-                          defendingUnits,
-                          true,
-                          gameData,
-                          battleSite,
-                          territoryEffects,
-                          isAmphibious,
-                          amphibiousLandAttackers),
-                      gameData);
+                  DiceRoll.getTotalPowerAndRolls(
+                          DiceRoll.getUnitPowerAndRollsForNormalBattles(
+                              defendingUnits,
+                              attackingUnits,
+                              defendingUnits,
+                              true,
+                              gameData,
+                              battleSite,
+                              territoryEffects,
+                              isAmphibious,
+                              amphibiousLandAttackers),
+                          gameData)
+                      .getEffectivePower();
               if (attackPower == 0 && defensePower == 0) {
                 if (canAttackerRetreatInStalemate()) {
                   attackerRetreat(bridge);


### PR DESCRIPTION
Instead of only looking at just attack power for determining
if both defense and offense have zero power, also look at the
number of dice rolls available and consider the battle
a stalemate if both sides either have no rolls or no power.
This is done simply by multiplying the power and rolls together,
if either is zero the product will be zero.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
- none

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

