### PR TITLE
Update Flyway deployment

### DIFF
--- a/infrastructure/ansible/roles/flyway/defaults/main.yml
+++ b/infrastructure/ansible/roles/flyway/defaults/main.yml
@@ -1,5 +1,4 @@
 flyway_user: "flyway"
 flyway_version: "5.2.4"
 flyway_download_location: "https://repo1.maven.org/maven2/org/flywaydb/flyway-commandline/{{ flyway_version }}/flyway-commandline-{{ flyway_version }}-linux-x64.tar.gz"
-flyway_downloaded_file_location: "/home/flyway/flyway-cli.tar.gz"
 flyway_extracted_location: "/home/flyway/flyway-{{ flyway_version }}"

--- a/infrastructure/ansible/roles/flyway/tasks/main.yml
+++ b/infrastructure/ansible/roles/flyway/tasks/main.yml
@@ -7,43 +7,41 @@
 
 - name: Download flyway CLI
   become: true
-  become_user: flyway
   get_url:
     url: "{{ flyway_download_location }}"
-    dest: "{{ flyway_downloaded_file_location }}"
+    dest: "/home/flyway/flyway-cli.tar.gz"
     mode: "644"
     checksum: "md5:57f496acc6399fe30ee1fd957545abf1"
+    owner: flyway
+    group: flyway
 
 - name: extract flyway
   become: true
-  become_user: flyway
   unarchive:
     copy: no
-    src: "{{ flyway_downloaded_file_location }}"
+    src: "/home/flyway/flyway-cli.tar.gz"
     dest: "/home/flyway/"
     creates: "{{ flyway_extracted_location }}"
+    owner: flyway
+    group: flyway
 
 - name: deploy flyway conf file
   become: true
-  become_user: flyway
   template:
     src: flyway.conf.j2
     dest: "{{ flyway_extracted_location }}/conf/flyway.conf"
     mode: "644"
-
-- name: install unzip
-  become: true
-  apt:
-    state: present
-    name: unzip
+    owner: flyway
+    group: flyway
 
 - name: extract migrations
   become: true
-  become_user: flyway
   unarchive:
      src: migrations.zip
      dest: "{{ flyway_extracted_location }}/sql/"
      mode: "644"
+     owner: flyway
+     group: flyway
 
 - name: run flyway
   become: true
@@ -51,3 +49,4 @@
   command: "{{ flyway_extracted_location }}/flyway migrate"
   register: flyway
   changed_when: '"is up to date. No migration necessary" not in flyway.stdout'
+


### PR DESCRIPTION
- Instead of changing user to flyway (brittle if not already root),
  instead use explicit ownership commands to change ownership
  of flyway download artifacts.
- Inline deployment zip variable (to simplify)


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing

Verified with a vagrant modified to Ubuntu 20.04
```
cd infrastructure
vagrant up
./run_ansible_vagrant
```

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

