### PR TITLE
Simplify Vagrant Config & Update to Simulate Prod Deployment

### DIFF
--- a/infrastructure/ansible/group_vars/vagrant.yml
+++ b/infrastructure/ansible/group_vars/vagrant.yml
@@ -7,17 +7,8 @@ lobby_db_password: "vagrant-db-password"
 nginx_ssl_certificate: "/vagrant/.vagrant/{{ lookup('env','CRT_FILE') }}"
 
 bot_numbers: ["01", "02"]
-bot_run_args:
-  triplea.game: ""
-  triplea.lobby.game.comments: "automated_host"
-  triplea.lobby.game.hostedBy: "{{ bot_name }}-${BOT_NUMBER}"
-  triplea.lobby.game.supportEmail: "do-not-send@triplea-game.org"
-  triplea.lobby.game.supportPassword: ""
-  triplea.lobby.host: "localhost"
-  triplea.lobby.port: "3304"
-  triplea.map.folder: "$MAPS_FOLDER"
-  triplea.name: "{{ bot_name }}-${BOT_NUMBER}"
-  triplea.port: "${BOT_PORT}"
-  triplea.server: true
-  triplea.server.password: ""
-  triplea.lobby.game.reconnection: "172800"
+
+# Comment out both using_latest and version to test prerelease deployment which
+# deploys the latest binaries built from source.
+using_latest: false
+version: "2.0.19463"


### PR DESCRIPTION
- Remove unnecessary bot server overrides. When deploying 2.x
  bots, we no longer need as many parameters and the defaults
  run-args in the bot role defaults work suffice.

- Set using_latest to false & override version variable. This
  triggers a specific version of software to be downloaded
  and installed. This simulates a production deployment.
  With a preelease deployment we instead build from source and
  deploy those built artifacts rather than downloading.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
- verified locally running vagrant deployments:
```
cd infrastructure
vagrant up
./run_ansible_vagrant
```
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

