### PR TITLE
Change Vagrant server to Ubuntu 20.04

### DIFF
--- a/infrastructure/Vagrantfile
+++ b/infrastructure/Vagrantfile
@@ -1,5 +1,5 @@
 Vagrant.configure("2") do |config|
-  config.vm.box = "bento/ubuntu-19.04"
+  config.vm.box = "bento/ubuntu-20.04"
 
   config.vm.define "vagrantHost" do |vagrantHost|
     vagrantHost.vm.network "forwarded_port", guest: 22, host: 2010, host_ip: "127.0.0.1", id: "ssh"


### PR DESCRIPTION
Mirrors latest configuration, new servers and the prod2
environment are deployed on Ubuntu 20.04


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

