### PR TITLE
Infrastructure - default using_latest to true for all

### DIFF
--- a/infrastructure/ansible/group_vars/all.yml
+++ b/infrastructure/ansible/group_vars/all.yml
@@ -7,7 +7,14 @@ ansible_user: root
 java_open_jdk_version_major: "11"
 lobby_db_name: lobby_db
 lobby_db_user: lobby_user
-version: "{{ lookup('env', 'VERSION') }}"
 
 admin_user: "admin"
 admin_home: "/home/{{ admin_user }}"
+
+# If using latest we will build jar files from source,
+# otherwise they will be downloaded.
+# When set to 'false', the version' variable will
+# typically be specified.
+using_latest: true
+version: "{{ lookup('env', 'VERSION') }}"
+

--- a/infrastructure/ansible/group_vars/prerelease.yml
+++ b/infrastructure/ansible/group_vars/prerelease.yml
@@ -1,3 +1,2 @@
 lobby_uri: "https://prerelease.triplea-game.org"
-using_latest: true
 bot_numbers: ["01", "02"]


### PR DESCRIPTION
Most environments (vagrant + prerelease) will build from source,
only production should download artifacts. The using_latest=true
value will build from source, this updates moves that variable
to apply to all by default. We will going forward add an override
in group_vars/prod to set this to false for production. This also
has the effect that the using latest variable is by default
defined for all environments as well (and not just in prerelease)


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

