### PR TITLE
Infrastructure - by default install unzip

### DIFF
--- a/infrastructure/ansible/roles/apt_update/tasks/main.yml
+++ b/infrastructure/ansible/roles/apt_update/tasks/main.yml
@@ -4,3 +4,12 @@
     upgrade: yes
     cache_valid_time: 86400 # One day, only updates if caches are older than this.
 
+- name: apt install standard utilities and packages
+  become: true
+  apt:
+    state: present
+    update_cache: true
+    name:
+      - htop
+      - iftop
+      - unzip

--- a/infrastructure/ansible/roles/bot/tasks/main.yml
+++ b/infrastructure/ansible/roles/bot/tasks/main.yml
@@ -6,12 +6,6 @@
     proto: tcp
   with_items: "{{ bot_numbers }}"
 
-- name: apt install unzip
-  become: true
-  apt:
-    name: unzip
-    state: present
-
 - name: create service user to run the app
   become: true
   user:

--- a/infrastructure/ansible/roles/flyway/tasks/main.yml
+++ b/infrastructure/ansible/roles/flyway/tasks/main.yml
@@ -31,12 +31,6 @@
     dest: "{{ flyway_extracted_location }}/conf/flyway.conf"
     mode: "644"
 
-- name: install unzip
-  become: true
-  apt:
-    state: present
-    name: unzip
-
 - name: extract migrations
   become: true
   become_user: flyway


### PR DESCRIPTION
Install unzip and htop and iftop utility applications to all
servers. Remove ad-hoc install of unzip per-role now that it is
globally installed.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

