### PR TITLE
Remove unused sonar config and move checktyle version to a variable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ subprojects {
         awaitilityVersion = '4.0.3'
         bcryptVersion = '0.9.0'
         caffeineVersion = '2.8.1'
+        checkstyleVersion = '8.23'
         commonsCliVersion = '1.4'
         commonsCodecVersion = '1.14'
         commonsIoVersion = '2.7'
@@ -175,7 +176,7 @@ subprojects {
     }
 
     checkstyle {
-        toolVersion = '8.23'
+        toolVersion = "$checkstyleVersion"
         configFile = rootProject.file('config/checkstyle/checkstyle.xml')
         configProperties = [samedir: configFile.parent]
     }

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,6 @@ plugins {
     id 'io.franzbecker.gradle-lombok' version '4.0.0' apply false
     id 'net.ltgt.errorprone' version '1.2.0' apply false
     id 'com.diffplug.gradle.spotless' version '4.0.1' apply false
-    id "org.sonarqube" version "2.8"
 }
 
 apply from: 'gradle/scripts/yaml.gradle'
@@ -23,14 +22,6 @@ check {
 
 wrapper {
     distributionType = Wrapper.DistributionType.ALL
-}
-
-sonarqube {
-    properties {
-        property "sonar.host.url", "https://sonarcloud.io/"
-        property "sonar.organization", "triplea-game"
-        property "sonar.projectKey", "triplea-game-sonar"
-    }
 }
 
 task validateYamls(group: 'verification', description: 'Validates YAML files.') {


### PR DESCRIPTION
## Overview

Clean up dependency config in build.gradle.
I did a check that all dependency version variables were actually used, it appears they are.

## Commits

commit a7d1c7c61fc4af4fe0113c844f541810185bae30

    Remove sonarqube plugin and confiuration
    
    We turned off sonarqube analysis because of OOM exceptions
    during analysis and for a lack of inline PR comments.
    It appears we failed to remove the configuration when it
    was turned off, the sonar plugin and configuration are otherwise
    now unused.

commit f5779b4717409be0d3c50bbb6647d244386c5d0e

    Move checkstyle version to a variable
    
    We define, relatively consistently, the version of dependencies
    as a variable in the 'ext' block in the top-most build.gradle file.
    This update moves the version value of checkstyle to that ext block.



<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

