### PR TITLE
Execute 'updateMoves' async

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import java.util.logging.Level;
 import javax.swing.Box;
 import javax.swing.BoxLayout;
 import javax.swing.JButton;
@@ -23,11 +24,14 @@ import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.extern.java.Log;
+import org.triplea.java.concurrency.AsyncRunner;
 import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.SwingComponents;
 import org.triplea.swing.key.binding.KeyCode;
 import org.triplea.swing.key.binding.SwingKeyBinding;
 
+@Log
 public abstract class AbstractMovePanel extends ActionPanel {
   private static final long serialVersionUID = -4153574987414031433L;
   private static final int entryPadding = 15;
@@ -278,7 +282,9 @@ public abstract class AbstractMovePanel extends ActionPanel {
         () -> {
           setUpSpecific();
           this.playerBridge = bridge;
-          updateMoves();
+          AsyncRunner.runAsync(this::updateMoves)
+              .exceptionally(e -> log.log(Level.WARNING, "Failed to receive move updates", e));
+
           if (listening) {
             throw new IllegalStateException("Not listening");
           }


### PR DESCRIPTION
Changes bridge code to be run async when fetching moves for
the abstract-move-panel. The invoked code downstream
will already update UI in a swing background thread, which implies
sending this code to be async should be safe as we already
execute the final update in a 'scheduled-later' thread.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing

- verified in a single player could do combat moves and view moves in history accurately and undo some moves. (Blocking operation on EDT warning was triggered via single player game, tested that scenario)
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

