### PR TITLE
Add config to deploy to prod2 on merge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,15 @@ jobs:
       addons: { apt: { packages: [ python3, python3-yaml ] } }
       script: [ $DEPLOY_PROD_STAGE/update-maps-on-website/run || $REPORT_FAIL "push maps to website" ]
     
+    - stage: DeployProd
+      name: "Ansible Deploy to Prod2"
+      if: (branch = master) and (repo = 'triplea-game/triplea') and (type != 'pull_request')
+      language: python
+      python: "3.8"
+      addons: { apt: { packages: [ sshpass ] } }
+      install: [ pip install ansible ]
+      script: [ $DEPLOY_PROD_STAGE/deploy-prod2-servers/run || $REPORT_FAIL "prerelease deployment" ]
+
     ########################################################################
     
     - stage: Finish

--- a/.travis/stages/deploy/prod/deploy-prod2-servers/run
+++ b/.travis/stages/deploy/prod/deploy-prod2-servers/run
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -eEu
+
+cd infrastructure
+
+echo "$ANSIBLE_VAULT_PASSWORD" > vault_password
+
+# Start up ssh-agent
+eval "$(ssh-agent -s)"
+
+# Decrypt SSH key and add it to ssh agent
+# Once available to SSH agent, when making SSH connections
+# this key will be offered by SSH for authentication.
+# This allows ansible to SSH to target servers and run
+# deployment commands. We assume servers have been created
+# with the corresponding public key already installed.
+ansible-vault view \
+    --vault-password-file=vault_password \
+    ansible_ssh_key.ed25519 \
+  | ssh-add -
+
+# Run deployment
+ansible-playbook \
+    --vault-password-file vault_password \
+    -i ansible/inventory/prod2 \
+ ansible/site.yml
+

--- a/infrastructure/ansible/roles/bot/tasks/main.yml
+++ b/infrastructure/ansible/roles/bot/tasks/main.yml
@@ -84,7 +84,7 @@
   become: true
   copy:
     remote_src: true
-    src: "{{ bot_install_home }}/bin/triplea-game-headless-{{ version }}-all.jar"
+    src: "{{ bot_install_home }}/bin/triplea-game-headless-{{ version }}.jar"
     dest: "{{ bot_jar }}"
     owner: "{{ bot_user }}"
     group: "{{ bot_user }}"

--- a/infrastructure/ansible/roles/http_server/defaults/main.yml
+++ b/infrastructure/ansible/roles/http_server/defaults/main.yml
@@ -16,3 +16,4 @@ http_server_db_user: "{{ lobby_db_user }}"
 
 create_issues_github_api_token: test
 
+http_server_zip_download: "https://github.com/triplea-game/triplea/releases/download/{{ version }}/triplea-http-server-{{ version }}.zip"

--- a/infrastructure/ansible/roles/http_server/tasks/main.yml
+++ b/infrastructure/ansible/roles/http_server/tasks/main.yml
@@ -6,6 +6,7 @@
     system: yes
 
 - name: deploy jar file
+  when: using_latest
   become: true
   register: deploy_jar_file
   copy:
@@ -13,6 +14,28 @@
     dest: "{{ http_server_home_folder }}/{{ http_server_jar }}"
     owner: "{{ http_server_user }}"
     group: "{{ http_server_user }}"
+
+
+- name: download zip file if not using latest
+  when: not using_latest
+  become: true
+  register: deploy_jar_file
+  get_url:
+    url: "{{ http_server_zip_download }}"
+    dest: "{{ http_server_home_folder }}/triplea-http-server-{{ version }}.zip"
+    owner: "{{ http_server_user }}"
+    group: "{{ http_server_user }}"
+
+- name: extract zip file if not using latest
+  when: not using_latest
+  become: true
+  unarchive:
+    remote_src: yes
+    src: "{{ http_server_home_folder }}/triplea-http-server-{{ version }}.zip"
+    dest: "{{ http_server_home_folder }}/"
+    owner: "{{ http_server_user }}"
+    group: "{{ http_server_user }}"
+
 
 - name: deploy run_server script
   become: true

--- a/infrastructure/ansible/roles/postgres/tasks/main.yml
+++ b/infrastructure/ansible/roles/postgres/tasks/main.yml
@@ -13,14 +13,11 @@
 - name: Install PostgreSQL
   become: true
   apt:
-    name: "{{ packages }}"
     state: present
-  vars:
-    packages:
+    name:
       - postgresql
       - postgresql-contrib
       - libpq-dev
-      - python-psycopg2
       - python3-psycopg2
 
 - name: Ensure the PostgreSQL service is running


### PR DESCRIPTION
- Add Travis script to deploy to prod2
- Update http-server install to download binary files when
  not using latest (eg: on prod2 deployments). Previously
  we only had a config suitable for prerelease where we
  built a binary file from latest source.
- We will be deploying to servers with Ubuntu 20.04, which has
  python3 by default and not python2. This update removes the
  install of psycopg2 which may not be available (and is now
  unnecessary).
- Fix config error when deploying non-latest bot, unzipped shadow
  jar file is not suffixed '-all.jar', this is removed


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

