### PR TITLE
Fix NPE for routeDescription being null

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
@@ -872,13 +872,16 @@ public class MapPanel extends ImageScrollerLargeView {
     movementLeftForCurrentUnits =
         movementLeft.getFirst()
             + (movementLeft.getSecond().compareTo(movementLeft.getFirst()) > 0 ? "+" : "");
-    gameData.acquireReadLock();
-    try {
-      movementFuelCost =
-          Route.getMovementFuelCostCharge(
-              units, routeDescription.getRoute(), units.iterator().next().getOwner(), gameData);
-    } finally {
-      gameData.releaseReadLock();
+    if (routeDescription != null) {
+      gameData.acquireReadLock();
+      try {
+
+        movementFuelCost =
+            Route.getMovementFuelCostCharge(
+                units, routeDescription.getRoute(), units.iterator().next().getOwner(), gameData);
+      } finally {
+        gameData.releaseReadLock();
+      }
     }
 
     final Set<UnitCategory> categories = UnitSeparator.categorize(units);


### PR DESCRIPTION
Was able to repro via attempting non-combat moves in edit
mode on map 'Middle Earth Battle for Arda' while 'Perform Move'
was not selected. After some effort was able to trigger the code
for calculating a move without a routeDescription set.

This update adds a simple NPE check to avoid dereferncing a
null routeDescription. The fule cost is later used to render a
movement route, considering there might be none this should be fine.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes

Was trying to repro: https://github.com/triplea-game/triplea/issues/6495, instead got the stack trace below:

```
Jun. 01, 2020 9:35:50 P.M. org.triplea.game.client.HeadedGameRunner lambda$initializeClientSettingAndLogging$0
SEVERE: null
java.lang.NullPointerException
	at games.strategy.triplea.ui.panels.map.MapPanel.setMouseShadowUnits(MapPanel.java:879)
	at games.strategy.triplea.ui.EditPanel$2.mouseMoved(EditPanel.java:314)
	at games.strategy.triplea.ui.panels.map.MapPanel.notifyMouseMoved(MapPanel.java:498)
	at games.strategy.triplea.ui.panels.map.MapPanel.updateMouseHoverState(MapPanel.java:318)
	at games.strategy.triplea.ui.panels.map.MapPanel$4.mouseMoved(MapPanel.java:266)
	at java.desktop/java.awt.AWTEventMulticaster.mouseMoved(AWTEventMulticaster.java:338)
```

Recommend to review without whitespace changes: https://github.com/triplea-game/triplea/pull/6577/files?w=1