### PR TITLE
Toggle edit mode async

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -52,6 +52,7 @@ import javax.swing.SwingUtilities;
 import lombok.extern.java.Log;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
+import org.triplea.java.concurrency.AsyncRunner;
 import org.triplea.sound.ClipPlayer;
 import org.triplea.sound.SoundPath;
 import org.triplea.util.Tuple;
@@ -77,7 +78,9 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer {
           // All GameDataChangeListeners will be notified upon success
           final IEditDelegate editDelegate =
               (IEditDelegate) getPlayerBridge().getRemotePersistentDelegate("edit");
-          editDelegate.setEditMode(editMode);
+          AsyncRunner.runAsync(() -> editDelegate.setEditMode(editMode))
+              .exceptionally(
+                  throwable -> log.log(Level.SEVERE, "Failed to toggle edit mode", throwable));
         } catch (final Exception exception) {
           log.log(Level.SEVERE, "Failed to set edit mode to " + editMode, exception);
           // toggle back to previous state since setEditMode failed


### PR DESCRIPTION
Avoids executing a bridge (network) call on EDT thread, instead
do so on a background thread that does not block the UI. Fixes
warning for performing a blocking operation on UI thread.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
Verified on single player could still enter edit mode without warning for blocking UI thread.
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

