### PR TITLE
Suppress NPE error message when init pro-log window

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogWindow.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogWindow.java
@@ -376,7 +376,7 @@ class ProLogWindow extends JDialog {
       }
       // Note, some players have observed a NPE here in initialization
       // java.lang.NullPointerException
-      //at java.desktop/javax.swing.text.PlainView.calculateLongestLine(PlainView.java:782)
+      // at java.desktop/javax.swing.text.PlainView.calculateLongestLine(PlainView.java:782)
       // See: https://github.com/triplea-game/triplea/issues/6481
       currentLogTextArea.append(message + "\r\n");
     } catch (

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogWindow.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogWindow.java
@@ -374,10 +374,14 @@ class ProLogWindow extends JDialog {
       if (currentLogTextArea == null) {
         currentLogTextArea = aiOutputLogArea;
       }
+      // Note, some players have observed a NPE here in initialization
+      // java.lang.NullPointerException
+      //at java.desktop/javax.swing.text.PlainView.calculateLongestLine(PlainView.java:782)
+      // See: https://github.com/triplea-game/triplea/issues/6481
       currentLogTextArea.append(message + "\r\n");
     } catch (
         final Exception ex) { // This is bad, but we don't want TripleA crashing because of this...
-      log.log(Level.SEVERE, "Error adding Pro log message! Message: " + message, ex);
+      log.log(Level.INFO, "Error adding Pro log message! Message: " + message, ex);
     }
   }
 


### PR DESCRIPTION
Related to: https://github.com/triplea-game/triplea/issues/6481
The user impact seems to be quite minor as the pro-log window
will still render.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

