### PR TITLE
Fix NPE in auto-placement-finder when finding islands

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -515,14 +515,18 @@ public class MapData {
   /**
    * Returns the polygons for any territories contained within a given territory.
    *
-   * @param territoryName Name of the territory, expected to be a sea territory, where we will be
-   *     checking for any contained 'island' territories.
+   * @param territoryName Name of the territory, where we will be checking for any contained
+   *     'island' territories.
+   * @return Empty if the parameter is not a sea territory or contains no 'islands', otherwise
+   *     returns any 'islands' contained within the given territory.
    */
   public Set<Polygon> getContainedTerritoryPolygons(final String territoryName) {
-    return contains.get(territoryName).stream()
-        .map(this::getPolygons)
-        .flatMap(Collection::stream)
-        .collect(Collectors.toSet());
+    return contains.get(territoryName) == null
+        ? Set.of()
+        : contains.get(territoryName).stream()
+            .map(this::getPolygons)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toSet());
   }
 
   public void verify(final GameData data) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -521,12 +521,10 @@ public class MapData {
    *     returns any 'islands' contained within the given territory.
    */
   public Set<Polygon> getContainedTerritoryPolygons(final String territoryName) {
-    return contains.get(territoryName) == null
-        ? Set.of()
-        : contains.get(territoryName).stream()
-            .map(this::getPolygons)
-            .flatMap(Collection::stream)
-            .collect(Collectors.toSet());
+    return contains.getOrDefault(territoryName, Set.of()).stream()
+        .map(this::getPolygons)
+        .flatMap(Collection::stream)
+        .collect(Collectors.toSet());
   }
 
   public void verify(final GameData data) {


### PR DESCRIPTION
The contract of MapData#getContainedTerritoryPolygons (in javadoc)
states the parameter should be a sea territory. The caller passes
all territories to this method which then results in a NPE in
the method. To fix, relax the contract and return an empty collection
if the parameter is not a sea territory.

Reported in: https://github.com/triplea-game/triplea/issues/6469


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix: #6469 <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
Repo by:
- unzip a downloaded map
- launch game
- launch map maker tools
- find the auto-placement finder
- enter the name of the unzipped map folder name, eg: "napoleonic_empires-master"
- select 'yes' on all prompts
- observe a NPE (consistent)

After fix verified that the auto-placement-finder could run to completion.

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

