### PR TITLE
Skip smoke-testing 'test' step when running unit tests

### DIFF
--- a/.travis/stages/verify/unit-testing/run
+++ b/.travis/stages/verify/unit-testing/run
@@ -3,10 +3,8 @@
 set -eEux
 
 # Run Tests
-./gradlew --parallel test
+./gradlew -x :smoke-testing:test -parallel test jacocoTestReport
 
-# Generate reports
-./gradlew --parallel jacocoTestReport
 
 # upload coverage report - https://github.com/codecov/example-gradle
 bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
1. We have a dedicated build stage for running the 'tests' in the smoke-testing
  project, it is redundant to run them in the 'unit test' stage. The separation
  is there for performance, so we do not slow down unit tests and to make
  debugging easier in case there is a test failure (with isolated stages,
  if one fails, there are fewer things being run and so there are fewer
  reasons to see a failure)

2. Minor, combine gradle steps together.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

