### PR TITLE
Convert link check to only do a HEAD request

### DIFF
--- a/.travis/stages/verify/check-links-and-yaml-syntax/check-links
+++ b/.travis/stages/verify/check-links-and-yaml-syntax/check-links
@@ -17,7 +17,7 @@ fi
 function checkUri() {
   local -r uri="$1"
   local code
-  if ! code=$(curl -Lsf -o /dev/null -w "%{http_code}" "$uri"); then
+  if ! code=$(curl -X HEAD -Lsf -o /dev/null -w "%{http_code}" "$uri"); then
     reportBrokenUri "$uri" "$code"
     FAILURE=1
   else


### PR DESCRIPTION
If all we need is status code, we can simply do just an HTTP HEAD request
and avoid the heavier call that receives the full HTTP body payload
of an HTTP GET request.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

