### PR TITLE
Update fix instructions for unmatched test to mention suppression

### DIFF
--- a/.travis/stages/verify/find-unused-or-unmatched-tests/find-unmatched-test-packages
+++ b/.travis/stages/verify/find-unused-or-unmatched-tests/find-unmatched-test-packages
@@ -61,7 +61,10 @@ done <<<"$(cat "$srcFiles")"
 if [ "$status" -eq 1 ]; then
   echo ""
   echo -e "${bold}Found test files in packages that did not match the corresponding source file.${normal}"
-  echo -e "${bold}To fix, move either the test file or source file so that the packages match.${normal}"
+  echo -e "${bold}To fix, either: ${normal}"
+  echo -e "${bold}   1.  Move either the test file or source file so that the packages match.${normal}"
+  echo -e "${bold}   2.  If we do not expect there to be a matching source file, add a @SuppressWarnings(\"UnmatchedTest\")${normal}"
+  echo -e "${bold}       to the test class${normal}"
 fi
 
 exit "$status"


### PR DESCRIPTION
Give an example in the fix instructions of the suppression annotation
when we do not expect a test file to match a source file.


