### PR TITLE
Fix prod2 inventory file

### DIFF
--- a/infrastructure/ansible/inventory/prod2
+++ b/infrastructure/ansible/inventory/prod2
@@ -1,4 +1,4 @@
-[dropwizardHosts:children]
+[dropwizardHosts]
 prod2-lobby.triplea-game.org
 
 [letsEncrypt:children]
@@ -7,7 +7,7 @@ dropwizardHosts
 [postgresHosts:children]
 dropwizardHosts
 
-[botHosts:children]
+[botHosts]
 prod2-bot01.triplea-game.org  bot_prefix=1 bot_name=Jersey
 prod2-bot02.triplea-game.org  bot_prefix=2 bot_name=Texas
 prod2-bot03.triplea-game.org  bot_prefix=3 bot_name=California


### PR DESCRIPTION
:children suffix implies the children of the host group are other hostgroups.
This update fixes the syntax of the prod2 inventory file where host groups
that contained machine names mistakenly had the ':children' suffix

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

