### PR TITLE
Server options password as char array

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -119,7 +119,7 @@ public final class GameRunner {
       final int port,
       final String playerName,
       final String comments,
-      final String password,
+      final char[] password,
       final URI lobbyUri) {
     final List<String> commands = new ArrayList<>();
     ProcessRunnerUtil.populateBasicJavaArgs(commands);
@@ -128,8 +128,8 @@ public final class GameRunner {
     commands.add("-D" + TRIPLEA_NAME + "=" + playerName);
     commands.add("-D" + LOBBY_URI + "=" + lobbyUri);
     commands.add("-D" + LOBBY_GAME_COMMENTS + "=" + comments);
-    if (password != null && password.length() > 0) {
-      commands.add("-D" + SERVER_PASSWORD + "=" + password);
+    if (password != null && password.length > 0) {
+      commands.add("-D" + SERVER_PASSWORD + "=" + String.valueOf(password));
     }
     final String fileName = System.getProperty(TRIPLEA_GAME, "");
     if (fileName.length() > 0) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerConnectionProps.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerConnectionProps.java
@@ -17,9 +17,9 @@ class ServerConnectionProps {
   /** Player name, the desired name for the current player connecting to remote host. */
   @Nonnull private final String name;
   /** Remote host address. */
-  @Nonnull private final int port;
+  @Nonnull private final Integer port;
   /**
    * Password to use to connect to the remotely hosted game, this is set by the host of the game.
    */
-  private final String password;
+  private final char[] password;
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -351,7 +351,10 @@ public class ServerModel extends Observable implements IConnectionChangeListener
           ServerConnectionProps.builder()
               .name(System.getProperty(TRIPLEA_NAME))
               .port(Integer.parseInt(System.getProperty(TRIPLEA_PORT)))
-              .password(System.getProperty(SERVER_PASSWORD))
+              .password(
+                  Optional.ofNullable(System.getProperty(SERVER_PASSWORD))
+                      .map(String::toCharArray)
+                      .orElse(null))
               .build());
     }
     final UserName userName = UserName.of(ClientSetting.playerName.getValueOrThrow());

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerOptions.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerOptions.java
@@ -64,12 +64,10 @@ public class ServerOptions extends JDialog {
     return s;
   }
 
-  public String getPassword() {
-    if (!requirePasswordCheckBox.isSelected()) {
-      return null;
-    }
-    final String password = new String(passwordField.getPassword());
-    return password.isBlank() ? null : password;
+  public char[] getPassword() {
+    return !requirePasswordCheckBox.isSelected() || passwordField.getPassword().length == 0
+        ? null
+        : passwordField.getPassword();
   }
 
   public int getPort() {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerOptions.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerOptions.java
@@ -69,10 +69,7 @@ public class ServerOptions extends JDialog {
       return null;
     }
     final String password = new String(passwordField.getPassword());
-    if (password.trim().length() == 0) {
-      return null;
-    }
-    return password;
+    return password.isBlank() ? null : password;
   }
 
   public int getPort() {


### PR DESCRIPTION
## Commits

commit 1a310bae7753843d7c68bbfc51d4fe24e4ed62bc

    Convert String.trim().isEmpty() check to a 'isBlank()'

commit 9ea89afc6d46d54b8e43e5dd2f713adbbe2090b3

    Use char[] for password in ServerOptions to reduce conversions to String
    
    Reasons:
    1. We get fewer conversions to strings, yields simpler code
    2. While we do not require passwords to be handled as char[], we should
    try to avoid using Strings for password where conveniently possible.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
- launched a locally hosted game with a password.

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

