### PR TITLE
Remove end of script travis failure catch block

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,3 @@ jobs:
       if: (branch = master) and (repo = 'triplea-game/triplea') and (type != 'pull_request')
       script: [ ".travis/shared/report-build-status SUCCESS" ] 
 
-after_failure:
-  - echo "================ Build step 'after_failure' =================" > /dev/null
-  - $REPORT_FAIL "end of script failure catch block"
-


### PR DESCRIPTION
So far it looks like we will consistently report a failure if any step
fails. This update removes a travis catch block that triggers on failure
and also reported a failure. This should simplify the messaging we get
in any 'master branch build failed' issue and list a failure just once.

A risk from this update is if we get a failure in an unexpected place
that is not explicitly handled.

-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing

<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

