### PR TITLE
Infrastructure: download flyway migrations when not using latest

### DIFF
--- a/infrastructure/ansible/roles/flyway/tasks/main.yml
+++ b/infrastructure/ansible/roles/flyway/tasks/main.yml
@@ -34,10 +34,30 @@
     owner: flyway
     group: flyway
 
+- name: copy flyway migrations zip if deploying latest
+  become: true
+  when: using_latest
+  copy:
+    src: migrations.zip
+    dest: /home/flyway/migrations.zip
+    mode: "644"
+    owner: flyway
+    group: flyway
+
+- name: download flyway migrations if deploying a specific version
+  become: true
+  when: not using_latest
+  get_url:
+    url: "https://github.com/triplea-game/triplea/releases/download/{{ version }}/migrations.zip"
+    dest: /home/flyway/migrations.zip
+    owner: flyway
+    group: flyway
+
 - name: extract migrations
   become: true
   unarchive:
-     src: migrations.zip
+     src: /home/flyway/migrations.zip
+     remote: true
      dest: "{{ flyway_extracted_location }}/sql/"
      mode: "644"
      owner: flyway


### PR DESCRIPTION
The existing deployment code was set up for building for source
and not well tested when deploying specific versions. This update
fixes this so that we will download the flyway migrations zip file
when deploying a specific version (ie: production deployments)


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

