### PR TITLE
Cleanup: remove redundant fully qualified static import

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -1,9 +1,9 @@
 package games.strategy.engine.data;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.MoveValidator;
@@ -150,7 +150,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    */
   public Set<Territory> getNeighbors(
       final Territory territory, final int distance, final Predicate<Territory> cond) {
-    Preconditions.checkArgument(distance >= 0, "Distance must be non-negative: " + distance);
+    checkArgument(distance >= 0, "Distance must be non-negative: " + distance);
     if (distance == 0) {
       return Set.of();
     }
@@ -202,7 +202,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
    */
   public Set<Territory> getNeighborsIgnoreEnd(
       final Territory territory, final int distance, final Predicate<Territory> cond) {
-    Preconditions.checkArgument(distance >= 0, "Distance must be non-negative: " + distance);
+    checkArgument(distance >= 0, "Distance must be non-negative: " + distance);
     if (distance == 0) {
       return Set.of();
     }
@@ -263,8 +263,8 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
       final Unit unit,
       final BigDecimal movementLeft,
       final Predicate<Territory> cond) {
-    Preconditions.checkNotNull(unit);
-    Preconditions.checkArgument(
+    checkNotNull(unit);
+    checkArgument(
         movementLeft.compareTo(BigDecimal.ZERO) >= 0,
         "MovementLeft must be non-negative: " + movementLeft);
     if (movementLeft.compareTo(BigDecimal.ZERO) == 0) {

--- a/game-core/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameParser.java
@@ -3,7 +3,6 @@ package games.strategy.engine.data;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.data.gameparser.XmlGameElementMapper;

--- a/game-core/src/main/java/games/strategy/engine/data/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameParser.java
@@ -69,7 +69,7 @@ public final class GameParser {
       final GameData gameData,
       final String mapName,
       final XmlGameElementMapper xmlGameElementMapper) {
-    data = Preconditions.checkNotNull(gameData);
+    data = checkNotNull(gameData);
     this.mapName = mapName;
     this.xmlGameElementMapper = xmlGameElementMapper;
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
@@ -2,7 +2,6 @@ package games.strategy.engine.framework.map.download;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 import java.io.IOException;
 import java.io.InputStream;
@@ -49,17 +48,13 @@ final class DownloadFileParser {
         .map(Map.class::cast)
         .forEach(
             yaml -> {
-              final String url = (String) Preconditions.checkNotNull(yaml.get(Tags.url.toString()));
+              final String url = (String) checkNotNull(yaml.get(Tags.url.toString()));
               final String description =
-                  (String) Preconditions.checkNotNull(yaml.get(Tags.description.toString()));
-              final String mapName =
-                  (String) Preconditions.checkNotNull(yaml.get(Tags.mapName.toString()));
+                  (String) checkNotNull(yaml.get(Tags.description.toString()));
+              final String mapName = (String) checkNotNull(yaml.get(Tags.mapName.toString()));
 
               final Version version =
-                  new Version(
-                      Preconditions.checkNotNull((Integer) yaml.get(Tags.version.toString())),
-                      0,
-                      0);
+                  new Version(checkNotNull((Integer) yaml.get(Tags.version.toString())), 0, 0);
               final DownloadFileDescription.DownloadType downloadType =
                   optEnum(
                       yaml,

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/background/BackgroundTaskRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/background/BackgroundTaskRunner.java
@@ -3,7 +3,6 @@ package games.strategy.engine.framework.ui.background;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicReference;
@@ -21,7 +20,7 @@ public final class BackgroundTaskRunner {
   private static JFrame mainFrame;
 
   public static void setMainFrame(final JFrame mainFrame) {
-    Preconditions.checkState(BackgroundTaskRunner.mainFrame == null);
+    checkState(BackgroundTaskRunner.mainFrame == null);
     BackgroundTaskRunner.mainFrame = mainFrame;
   }
 

--- a/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
+++ b/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
@@ -180,7 +180,7 @@ public class UnifiedMessenger {
   public Object getImplementor(final String name) {
     synchronized (endPointMutex) {
       final EndPoint endPoint = localEndPoints.get(name);
-      Preconditions.checkNotNull(
+      checkNotNull(
           endPoint,
           "local endpoints: "
               + localEndPoints

--- a/game-core/src/main/java/games/strategy/net/nio/Encoder.java
+++ b/game-core/src/main/java/games/strategy/net/nio/Encoder.java
@@ -2,7 +2,6 @@ package games.strategy.net.nio;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Preconditions;
 import games.strategy.net.IObjectStreamFactory;
 import games.strategy.net.MessageHeader;
 import java.io.IOException;
@@ -37,7 +36,7 @@ class Encoder {
   }
 
   private void write(final MessageHeader header, final ObjectOutputStream out) throws IOException {
-    Preconditions.checkNotNull(header.getFrom());
+    checkNotNull(header.getFrom());
     out.writeObject(header);
     out.reset();
   }

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -344,8 +344,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
       "When scrolling through units, whether to also highlight territory") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return SelectionComponentFactory.booleanRadioButtons(
-          ClientSetting.unitScrollerHighlightTerritory);
+      return booleanRadioButtons(ClientSetting.unitScrollerHighlightTerritory);
     }
   };
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
@@ -2,7 +2,6 @@ package games.strategy.triplea.ui.panels.map;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import com.google.common.base.Preconditions;
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.ChangeAttachmentChange;
 import games.strategy.engine.data.CompositeChange;
@@ -386,7 +385,7 @@ public class MapPanel extends ImageScrollerLargeView {
    * an null args
    */
   public void setUnitHighlight(@Nonnull final Collection<Collection<Unit>> units) {
-    highlightedUnits = Preconditions.checkNotNull(units);
+    highlightedUnits = checkNotNull(units);
     SwingUtilities.invokeLater(this::repaint);
   }
 

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessServerSetupPanelModel.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessServerSetupPanelModel.java
@@ -3,7 +3,6 @@ package org.triplea.game.server;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static games.strategy.engine.framework.CliProperties.LOBBY_URI;
 
-import com.google.common.base.Preconditions;
 import games.strategy.engine.framework.startup.LobbyWatcherThread;
 import games.strategy.engine.framework.startup.login.ClientLoginValidator;
 import games.strategy.engine.framework.startup.mc.ServerModel;
@@ -31,9 +30,8 @@ public class HeadlessServerSetupPanelModel implements ServerSetupModel {
   @Override
   public void onServerMessengerCreated(
       final ServerModel serverModel, final GameHostingResponse gameHostingResponse) {
-    Preconditions.checkNotNull(
-        gameHostingResponse, "hosting response is null, did the bot connect to lobby?");
-    Preconditions.checkNotNull(System.getProperty(LOBBY_URI));
+    checkNotNull(gameHostingResponse, "hosting response is null, did the bot connect to lobby?");
+    checkNotNull(System.getProperty(LOBBY_URI));
 
     Optional.ofNullable(headlessServerSetup).ifPresent(HeadlessServerSetup::cancel);
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -491,7 +491,7 @@ class DiceRollTest {
   @Test
   void testHeavyBombers() {
     gameData = TestMapGameData.IRON_BLITZ.getGameData();
-    final GamePlayer british = GameDataTestUtil.british(gameData);
+    final GamePlayer british = british(gameData);
     final IDelegateBridge testDelegateBridge = newDelegateBridge(british);
     TechTracker.addAdvance(
         british,

--- a/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -22,6 +22,7 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.move;
 import static games.strategy.triplea.delegate.GameDataTestUtil.moveDelegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.placeDelegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.removeFrom;
+import static games.strategy.triplea.delegate.GameDataTestUtil.russians;
 import static games.strategy.triplea.delegate.GameDataTestUtil.submarine;
 import static games.strategy.triplea.delegate.GameDataTestUtil.techDelegate;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
@@ -172,7 +173,7 @@ class RevisedTest {
 
   @Test
   void testMoveThroughSubmergedSubs() {
-    final GamePlayer british = GameDataTestUtil.british(gameData);
+    final GamePlayer british = british(gameData);
     final Territory sz1 = gameData.getMap().getTerritory("1 Sea Zone");
     final Territory sz7 = gameData.getMap().getTerritory("7 Sea Zone");
     final Territory sz8 = gameData.getMap().getTerritory("8 Sea Zone");
@@ -195,8 +196,8 @@ class RevisedTest {
 
   @Test
   void testRetreatBug() {
-    final GamePlayer russians = GameDataTestUtil.russians(gameData);
-    final GamePlayer americans = GameDataTestUtil.americans(gameData);
+    final GamePlayer russians = russians(gameData);
+    final GamePlayer americans = americans(gameData);
     final IDelegateBridge bridge = newDelegateBridge(russians);
     // we need to initialize the original owner
     final InitializationDelegate initDel =
@@ -207,7 +208,7 @@ class RevisedTest {
     // make sinkian japanese owned, put one infantry in it
     final Territory sinkiang = gameData.getMap().getTerritory("Sinkiang");
     gameData.performChange(ChangeFactory.removeUnits(sinkiang, sinkiang.getUnits()));
-    final GamePlayer japanese = GameDataTestUtil.japanese(gameData);
+    final GamePlayer japanese = japanese(gameData);
     sinkiang.setOwner(japanese);
     final UnitType infantryType = infantry(gameData);
     gameData.performChange(ChangeFactory.addUnits(sinkiang, infantryType.create(1, japanese)));
@@ -243,7 +244,7 @@ class RevisedTest {
 
   @Test
   void testContinuedBattles() {
-    final GamePlayer russians = GameDataTestUtil.russians(gameData);
+    final GamePlayer russians = russians(gameData);
     final GamePlayer germans = germans(gameData);
     final IDelegateBridge bridge = newDelegateBridge(germans);
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
@@ -401,7 +402,7 @@ class RevisedTest {
   void testTransportAttack() {
     final Territory sz14 = gameData.getMap().getTerritory("14 Sea Zone");
     final Territory sz13 = gameData.getMap().getTerritory("13 Sea Zone");
-    final GamePlayer germans = GameDataTestUtil.germans(gameData);
+    final GamePlayer germans = germans(gameData);
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
@@ -417,8 +418,8 @@ class RevisedTest {
   void testLoadUndo() {
     final Territory sz5 = gameData.getMap().getTerritory("5 Sea Zone");
     final Territory eastEurope = gameData.getMap().getTerritory("Eastern Europe");
-    final UnitType infantryType = GameDataTestUtil.infantry(gameData);
-    final GamePlayer germans = GameDataTestUtil.germans(gameData);
+    final UnitType infantryType = infantry(gameData);
+    final GamePlayer germans = germans(gameData);
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
@@ -715,10 +716,10 @@ class RevisedTest {
   void testMoveSubAwayFromSubmergedSubsInBattleZone() {
     final Territory sz45 = gameData.getMap().getTerritory("45 Sea Zone");
     final Territory sz50 = gameData.getMap().getTerritory("50 Sea Zone");
-    final GamePlayer british = GameDataTestUtil.british(gameData);
-    final GamePlayer japanese = GameDataTestUtil.japanese(gameData);
+    final GamePlayer british = british(gameData);
+    final GamePlayer japanese = japanese(gameData);
     // put 1 british sub in sz 45, this simulates a submerged enemy sub
-    final UnitType sub = GameDataTestUtil.submarine(gameData);
+    final UnitType sub = submarine(gameData);
     final Change c = ChangeFactory.addUnits(sz45, sub.create(1, british));
     gameData.performChange(c);
     // new move delegate

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -153,7 +153,7 @@ class WW2V3Year41Test {
   @Test
   void testAaCasualtiesLowLuckMixedRadar() {
     // moved from BattleCalculatorTest because "revised" does not have "radar"
-    final GamePlayer british = GameDataTestUtil.british(gameData);
+    final GamePlayer british = british(gameData);
     final IDelegateBridge bridge = newDelegateBridge(british);
     makeGameLowLuck(gameData);
     // setSelectAACasualties(data, false);
@@ -369,7 +369,7 @@ class WW2V3Year41Test {
   @Test
   void testTechTokens() {
     // Set up the test
-    final GamePlayer germans = GameDataTestUtil.germans(gameData);
+    final GamePlayer germans = germans(gameData);
     final IDelegateBridge delegateBridge = newDelegateBridge(germans);
     advanceToStep(delegateBridge, "germanTech");
     final TechnologyDelegate techDelegate = techDelegate(gameData);
@@ -600,7 +600,7 @@ class WW2V3Year41Test {
     /*
      * Test Building one
      */
-    final UnitType aaGun = GameDataTestUtil.aaGun(gameData);
+    final UnitType aaGun = aaGun(gameData);
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(aaGun, 1);
     // Set up the test
@@ -639,7 +639,7 @@ class WW2V3Year41Test {
     final Territory eastPoland = territory("East Poland", gameData);
     final Territory belorussia = territory("Belorussia", gameData);
     // Set up the unit types
-    final UnitType infantryType = GameDataTestUtil.infantry(gameData);
+    final UnitType infantryType = infantry(gameData);
     // Remove all units from east poland
     removeFrom(eastPoland, eastPoland.getUnits());
     // Get total number of units in territories to start
@@ -681,7 +681,7 @@ class WW2V3Year41Test {
     final Territory poland = territory("Poland", gameData);
     final Territory eastPoland = territory("East Poland", gameData);
     // Set up the unit types
-    final UnitType fighterType = GameDataTestUtil.fighter(gameData);
+    final UnitType fighterType = fighter(gameData);
     advanceToStep(delegateBridge, "germanBattle");
     while (!gameData.getSequence().getStep().getName().equals("germanBattle")) {
       gameData.getSequence().next();
@@ -730,7 +730,7 @@ class WW2V3Year41Test {
     // Set up the territories
     final Territory egypt = territory("Union of South Africa", gameData);
     // Set up the unit types
-    final UnitType factoryType = GameDataTestUtil.factory(gameData);
+    final UnitType factoryType = factory(gameData);
     // Set up the move delegate
     final PlaceDelegate placeDelegate = placeDelegate(gameData);
     advanceToStep(delegateBridge, "Place");
@@ -758,7 +758,7 @@ class WW2V3Year41Test {
      * with up to 3 Chinese units in them.
      */
     // Set up game
-    final GamePlayer chinese = GameDataTestUtil.chinese(gameData);
+    final GamePlayer chinese = chinese(gameData);
     final IDelegateBridge delegateBridge = newDelegateBridge(chinese);
     advanceToStep(delegateBridge, "CombatMove");
     final MoveDelegate moveDelegate = moveDelegate(gameData);
@@ -843,7 +843,7 @@ class WW2V3Year41Test {
     removeFrom(sz5, sz5.getUnits());
     addTo(sz5, destroyer(gameData).create(1, british(gameData)));
     // Set up the unit types
-    final UnitType transportType = GameDataTestUtil.transport(gameData);
+    final UnitType transportType = transport(gameData);
     // Set up the move delegate
     final PlaceDelegate placeDelegate = placeDelegate(gameData);
     advanceToStep(delegateBridge, "Place");
@@ -1229,7 +1229,7 @@ class WW2V3Year41Test {
     final GamePlayer british = GameDataTestUtil.british(gameData);
     addTo(eg, infantry(gameData).create(2, british));
     // create/load the destroyers and transports
-    final GamePlayer italians = GameDataTestUtil.italians(gameData);
+    final GamePlayer italians = italians(gameData);
     addTo(sz14, transport(gameData).create(1, italians));
     addTo(sz14, destroyer(gameData).create(2, italians));
     // load the transports
@@ -1518,8 +1518,7 @@ class WW2V3Year41Test {
     move(bomber, new Route(germany, poland));
     // Pick up a paratrooper
     final List<Unit> bomberAndParatroop = new ArrayList<>(bomber);
-    bomberAndParatroop.addAll(
-        poland.getUnitCollection().getUnits(GameDataTestUtil.infantry(gameData), 1));
+    bomberAndParatroop.addAll(poland.getUnitCollection().getUnits(infantry(gameData), 1));
     // move them
     final String error =
         moveDelegate(gameData).move(bomberAndParatroop, new Route(poland, bulgaria, ukraine));
@@ -1542,8 +1541,7 @@ class WW2V3Year41Test {
     final List<Unit> bomberAndParatroop = new ArrayList<>();
     bomberAndParatroop.addAll(germany.getUnitCollection().getMatches(Matches.unitIsAirTransport()));
     // add 2 infantry
-    bomberAndParatroop.addAll(
-        germany.getUnitCollection().getUnits(GameDataTestUtil.infantry(gameData), 2));
+    bomberAndParatroop.addAll(germany.getUnitCollection().getUnits(infantry(gameData), 2));
     // move the units to east poland
     final String error =
         moveDelegate(gameData).move(bomberAndParatroop, new Route(germany, poland, eastPoland));

--- a/game-core/src/test/java/games/strategy/triplea/odds/calculator/BattleCalculatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/odds/calculator/BattleCalculatorTest.java
@@ -1,7 +1,12 @@
 package games.strategy.triplea.odds.calculator;
 
 import static games.strategy.triplea.delegate.GameDataTestUtil.americans;
+import static games.strategy.triplea.delegate.GameDataTestUtil.bomber;
+import static games.strategy.triplea.delegate.GameDataTestUtil.british;
+import static games.strategy.triplea.delegate.GameDataTestUtil.fighter;
 import static games.strategy.triplea.delegate.GameDataTestUtil.germans;
+import static games.strategy.triplea.delegate.GameDataTestUtil.infantry;
+import static games.strategy.triplea.delegate.GameDataTestUtil.russians;
 import static games.strategy.triplea.delegate.GameDataTestUtil.submarine;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static games.strategy.triplea.delegate.GameDataTestUtil.transport;
@@ -12,7 +17,6 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
-import games.strategy.triplea.delegate.GameDataTestUtil;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.ArrayList;
@@ -27,9 +31,9 @@ class BattleCalculatorTest {
   void testUnbalancedFight() {
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final Collection<Unit> defendingUnits = new ArrayList<>(germany.getUnits());
-    final GamePlayer russians = GameDataTestUtil.russians(gameData);
-    final GamePlayer germans = GameDataTestUtil.germans(gameData);
-    final List<Unit> attackingUnits = GameDataTestUtil.infantry(gameData).create(100, russians);
+    final GamePlayer russians = russians(gameData);
+    final GamePlayer germans = germans(gameData);
+    final List<Unit> attackingUnits = infantry(gameData).create(100, russians);
     final List<Unit> bombardingUnits = List.of();
     final BattleCalculator calculator = new BattleCalculator(gameData, false);
     final AggregateResults results =
@@ -53,12 +57,12 @@ class BattleCalculatorTest {
     // 1 bomber and 1 infantry attacking
     // 1 fighter
     // if one attacking inf must live, the odds much worse
-    final GamePlayer germans = GameDataTestUtil.germans(gameData);
-    final GamePlayer british = GameDataTestUtil.british(gameData);
+    final GamePlayer germans = germans(gameData);
+    final GamePlayer british = british(gameData);
     final Territory eastCanada = gameData.getMap().getTerritory("Eastern Canada");
-    final List<Unit> defendingUnits = GameDataTestUtil.fighter(gameData).create(1, british, false);
-    final List<Unit> attackingUnits = GameDataTestUtil.infantry(gameData).create(1, germans, false);
-    attackingUnits.addAll(GameDataTestUtil.bomber(gameData).create(1, germans, false));
+    final List<Unit> defendingUnits = fighter(gameData).create(1, british, false);
+    final List<Unit> attackingUnits = infantry(gameData).create(1, germans, false);
+    attackingUnits.addAll(bomber(gameData).create(1, germans, false));
     final List<Unit> bombardingUnits = List.of();
     final BattleCalculator calculator = new BattleCalculator(gameData, false);
     calculator.setKeepOneAttackingLandUnit(true);

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -72,7 +72,7 @@ class WebSocketConnection {
   @Getter(
       value = AccessLevel.PACKAGE,
       onMethod_ = {@VisibleForTesting})
-  private final java.net.http.WebSocket.Listener internalListener = new InternalWebSocketListener();
+  private final Listener internalListener = new InternalWebSocketListener();
 
   @Getter(
       value = AccessLevel.PACKAGE,

--- a/http-clients/src/test/java/org/triplea/http/client/HttpClientTesting.java
+++ b/http-clients/src/test/java/org/triplea/http/client/HttpClientTesting.java
@@ -56,10 +56,10 @@ public final class HttpClientTesting {
   public static void serve200ForToolboxPostWithBody(
       final WireMockServer server, final String path, final String body) {
     server.stubFor(
-        WireMock.post(path)
+        post(path)
             .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
             .withRequestBody(equalTo(body))
-            .willReturn(WireMock.aResponse().withStatus(200)));
+            .willReturn(aResponse().withStatus(200)));
   }
 
   /**
@@ -69,10 +69,10 @@ public final class HttpClientTesting {
   public static <T> void serve200ForToolboxPostWithBodyJson(
       final WireMockServer server, final String path, final T jsonObject) {
     server.stubFor(
-        WireMock.post(path)
+        post(path)
             .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo(EXPECTED_API_KEY))
             .withRequestBody(equalToJson(WireMockTest.toJson(jsonObject)))
-            .willReturn(WireMock.aResponse().withStatus(200)));
+            .willReturn(aResponse().withStatus(200)));
   }
 
   /**


### PR DESCRIPTION
If we already have a static import, then we do not need a fully
qualified static call. This update removes the fully qualified
call in favor of the static import, ie:
'Preconditions.checkNotNull' -> 'checkNotNull'


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

