### PR TITLE
Local runnable prod deployment script

### DIFF
--- a/.travis/stages/deploy/prerelease/deploy-to-prerelease-servers/run
+++ b/.travis/stages/deploy/prerelease/deploy-to-prerelease-servers/run
@@ -9,5 +9,5 @@ eval "$(ssh-agent -s)"
 cd infrastructure
 ./build_deployment_artifacts
 echo "$ANSIBLE_VAULT_PASSWORD" > vault_password
-./run_deployment "$version" -i ansible/inventory/prerelease 
-
+./run_ansible_prerelease "$version" -i ansible/inventory/prerelease
+ 

--- a/.travis/stages/deploy/prod/deploy-prod2-servers/run
+++ b/.travis/stages/deploy/prod/deploy-prod2-servers/run
@@ -3,26 +3,6 @@
 set -eEu
 
 cd infrastructure
-
 echo "$ANSIBLE_VAULT_PASSWORD" > vault_password
-
-# Start up ssh-agent
-eval "$(ssh-agent -s)"
-
-# Decrypt SSH key and add it to ssh agent
-# Once available to SSH agent, when making SSH connections
-# this key will be offered by SSH for authentication.
-# This allows ansible to SSH to target servers and run
-# deployment commands. We assume servers have been created
-# with the corresponding public key already installed.
-ansible-vault view \
-    --vault-password-file=vault_password \
-    ansible_ssh_key.ed25519 \
-  | ssh-add -
-
-# Run deployment
-ansible-playbook \
-    --vault-password-file vault_password \
-    -i ansible/inventory/prod2 \
- ansible/site.yml
+./run_ansible_production
 

--- a/infrastructure/run_ansible_prerelease
+++ b/infrastructure/run_ansible_prerelease
@@ -7,11 +7,11 @@
 # to /home/ansible.
 
 function usage() {
-  echo "Usage: $0 [Version] [ansible_args]"
+  echo "Usage: $0 [Version] (ansible_args)"
   echo "  version: The version of tripleA we will deploy eg: 1.10.5252"
-  echo "  ansible_args: Args passed to ansible-playbook"
-  echo "Example: $0 1.10.5252 -i ansible/inventory/prerelease"
-  echo "Example: $0 1.10.5252 --diff -v -i ansible/inventory/prerelease"
+  echo "  (options) ansible_args: Additional args passed to ansible-playbook"
+  echo "Example: $0 1.10.5252"
+  echo "Example: $0 1.10.5252 --diff -v"
   exit 1
 }
 
@@ -50,5 +50,6 @@ ansible-vault view --vault-password-file="$VAULT_PASSWORD_FILE" ansible_ssh_key.
 
 ansible-playbook \
   --vault-password-file "$VAULT_PASSWORD_FILE" \
+  -i ansible/inventory/prerelease \
  "$@" \
  ansible/site.yml

--- a/infrastructure/run_ansible_production
+++ b/infrastructure/run_ansible_production
@@ -24,7 +24,7 @@ ansible-vault view \
 # Run deployment
 ansible-playbook \
     --vault-password-file vault_password \
-    $@ \
+    "$@" \
     -i ansible/inventory/prod2 \
  ansible/site.yml
 

--- a/infrastructure/run_ansible_production
+++ b/infrastructure/run_ansible_production
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+set -eEu
+
+if [ ! -f "vault_password" ]; then
+  echo "Error: vault_password file must exist at $(pwd)"
+  exit 1
+fi
+
+# Start up ssh-agent
+eval "$(ssh-agent -s)"
+
+# Decrypt SSH key and add it to ssh agent
+# Once available to SSH agent, when making SSH connections
+# this key will be offered by SSH for authentication.
+# This allows ansible to SSH to target servers and run
+# deployment commands. We assume servers have been created
+# with the corresponding public key already installed.
+ansible-vault view \
+    --vault-password-file=vault_password \
+    ansible_ssh_key.ed25519 \
+  | ssh-add -
+
+# Run deployment
+ansible-playbook \
+    --vault-password-file vault_password \
+    -i ansible/inventory/prod2 \
+ ansible/site.yml
+

--- a/infrastructure/run_ansible_production
+++ b/infrastructure/run_ansible_production
@@ -24,6 +24,7 @@ ansible-vault view \
 # Run deployment
 ansible-playbook \
     --vault-password-file vault_password \
+    $@ \
     -i ansible/inventory/prod2 \
  ansible/site.yml
 


### PR DESCRIPTION
Unify the name of the deployment scripts in 'infrastructure'.
After this update we now have:
  - run_ansible_vagrant
  - run_ansible_prerelease
  - run_ansible_production
Each is similar and can be run locally. The travis scripts
are now updated to set up any preconditions, notably copying
the ansible vault secret variable to a vault file and then
kicking off the respective 'run_ansible' script.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes

The only thing new in `infrastructure/run_ansible_production` is the check that the vault file exists. The rest of the script is migrated from the travis run script.
