### PR TITLE
Install certbot python3 module

### DIFF
--- a/infrastructure/ansible/roles/certbot/tasks/main.yml
+++ b/infrastructure/ansible/roles/certbot/tasks/main.yml
@@ -3,17 +3,6 @@
   apt:
     state: present
     name: software-properties-common
-  
-- name: install certbot apt-repositories
-  become: true
-  apt_repository:
-    state: present
-    repo: "{{ item }}"
-  loop:
-    - "deb http://archive.ubuntu.com/ubuntu/ bionic universe"
-    - "deb http://archive.ubuntu.com/ubuntu/ bionic-updates universe"
-    - "deb http://security.ubuntu.com/ubuntu/ bionic-security universe"
-    - "ppa:certbot/certbot"
 
 - name: install certbot and python for certbot on nginx
   become: true
@@ -21,7 +10,7 @@
     update_cache: yes
     name:
       - certbot
-      - python-certbot-nginx
+      - python3-certbot-nginx
 
 - name: look for certbot generated key file
   become: true


### PR DESCRIPTION
Certbot on ubuntu 20.04 does not need a PPA to be installed, we
can instead simply install the certbot and certbot-python3 modules.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
Ran deployment from local machine setting up prod2 production environment
```
cd infrastructure
# created vault_password file
./run_ansible_production
# delete vault_password file
```

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

