### PR TITLE
Infrastructure: Fix path to http-server jar file

### DIFF
--- a/infrastructure/ansible/roles/http_server/tasks/main.yml
+++ b/infrastructure/ansible/roles/http_server/tasks/main.yml
@@ -5,13 +5,23 @@
     create_home: yes
     system: yes
 
+- name: create bin folder for jar file
+  when: using_latest
+  become: true
+  file:
+    state: directory
+    path: "{{ http_server_home_folder }}/bin/"
+    mode: "0755"
+    owner: "{{ http_server_user }}"
+    group: "{{ http_server_user }}"
+
 - name: deploy jar file
   when: using_latest
   become: true
   register: deploy_jar_file
   copy:
     src: "{{ http_server_jar }}"
-    dest: "{{ http_server_home_folder }}/{{ http_server_jar }}"
+    dest: "{{ http_server_home_folder }}/bin/{{ http_server_jar }}"
     owner: "{{ http_server_user }}"
     group: "{{ http_server_user }}"
 
@@ -35,7 +45,6 @@
     dest: "{{ http_server_home_folder }}/"
     owner: "{{ http_server_user }}"
     group: "{{ http_server_user }}"
-
 
 - name: deploy run_server script
   become: true

--- a/infrastructure/ansible/roles/http_server/templates/run_server.j2
+++ b/infrastructure/ansible/roles/http_server/templates/run_server.j2
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 cd $(dirname $0)
-java -jar {{ http_server_jar }}
+java -jar bin/{{ http_server_jar }}


### PR DESCRIPTION
The jar file for http-server is extracted to a 'bin/' folder.
This update corrects the path of run scripts to refer to that
folder and updates the 'latest deployment' variant to copy
a jar file to that same location. We did not catch this before as
prerelease builds are from source and pushes artifacts from local
to remote, while version specific builds (for production) are
downloaded and then unzipped.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

