### PR TITLE
Infrastructure: deploy admin scripts to http-server

### DIFF
--- a/infrastructure/ansible/roles/http_server/files/admin_scripts/server-logs.sh
+++ b/infrastructure/ansible/roles/http_server/files/admin_scripts/server-logs.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo journalctl -u http_server

--- a/infrastructure/ansible/roles/http_server/files/admin_scripts/server-start.sh
+++ b/infrastructure/ansible/roles/http_server/files/admin_scripts/server-start.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo systemctl start http_server

--- a/infrastructure/ansible/roles/http_server/files/admin_scripts/server-status.sh
+++ b/infrastructure/ansible/roles/http_server/files/admin_scripts/server-status.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo systemctl status http_server

--- a/infrastructure/ansible/roles/http_server/files/admin_scripts/server-stop.sh
+++ b/infrastructure/ansible/roles/http_server/files/admin_scripts/server-stop.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+sudo systemctl stop http_server

--- a/infrastructure/ansible/roles/http_server/tasks/main.yml
+++ b/infrastructure/ansible/roles/http_server/tasks/main.yml
@@ -92,3 +92,14 @@
     name: http_server
     state: restarted
     enabled: yes
+
+- name: deploy admin scripts to facilite server operations, EG. check logs, start, stop
+  become: true
+  copy:
+    src: "{{ item }}"
+    dest: /home/admin/
+    owner: admin
+    group: admin
+    mode: "0700"
+  with_fileglob:
+    - "admin_scripts/*"


### PR DESCRIPTION
When logging in to http-server as admin, this update
deploys utility scripts to /home/admin, like 'server-start.sh'
to start the server, 'server-logs.sh' to see logs. This is to
make it very easy to know which commands need to be run
in order to start/stop the server and view logs.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

