### PR TITLE
Fix NPE in WeakAi.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/Utils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/Utils.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
+import javax.annotation.Nullable;
 import org.triplea.java.collections.CollectionUtils;
 
 final class Utils {
@@ -45,7 +46,7 @@ final class Utils {
     return strength;
   }
 
-  static Route findNearest(
+  static @Nullable Route findNearest(
       final Territory start,
       final Predicate<Territory> endCondition,
       final Predicate<Territory> routeCondition,


### PR DESCRIPTION
Fix NPE in WeakAi.

It was sometimes constructing a MoveDescription with a null route, which we disallowed as part of MoveDescription refactoring in 2.0.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[X] Problem fix:  https://github.com/triplea-game/triplea/issues/6590
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->
Just sanity testing of an all Weak-AI game for a couple of rounds.


<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

