### PR TITLE
Add an explicit log message when handling unified messenger remote exceptions

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
+++ b/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
@@ -152,8 +152,10 @@ public class UnifiedMessenger {
           endPoint.invokeLocal(call, number, getLocalNode());
       for (final RemoteMethodCallResults r : results) {
         if (r.getException() != null) {
-          // don't swallow errors
-          log.log(Level.WARNING, r.getException().getMessage(), r.getException());
+          log.log(
+              Level.WARNING,
+              "Remote method call exception: " + r.getException().getMessage(),
+              r.getException());
         }
       }
     }


### PR DESCRIPTION
Using just an exception message for a log message can make it hard to correlate
an observed message to the location in code that generated that message. Notably
using an exception message and the message can be variable and secondarily
there won't be any code that has an exact matching string.

This update adds an explicit message prefix so we can have more context
if we ever see an exception handled by unified messenger.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

