### PR TITLE
Fix bots to do shallow parsing of zipped maps

### DIFF
--- a/game-core/src/main/java/org/triplea/game/server/AvailableGames.java
+++ b/game-core/src/main/java/org/triplea/game/server/AvailableGames.java
@@ -57,6 +57,7 @@ final class AvailableGames {
         .parallelStream()
         .forEach(
             map -> {
+              log.info("Loading map: " + map);
               if (map.isDirectory()) {
                 populateFromDirectory(
                     map,
@@ -121,7 +122,7 @@ final class AvailableGames {
     final Optional<InputStream> inputStream = UrlStreams.openStream(uri);
     if (inputStream.isPresent()) {
       try (InputStream input = inputStream.get()) {
-        final GameData data = GameParser.parse(uri.toString(), input);
+        final GameData data = GameParser.parseShallow(uri.toString(), input);
         final String name = data.getGameName();
         if (!availableGames.containsKey(name)) {
           availableGames.put(name, uri);


### PR DESCRIPTION
This update changes:
1. bots to do 'shallow' parsing of zipped map files.
   A shallow parse fetches only a limited amount of data.
2. Add logging to bots to print which map is being loaded.

Bots do 'shallow' parsing of expanded maps (folder) but were doing
full parsing of zipped maps when fetching the list of available games.
Full parsing is slower and evaluates the full Map XML converting
all nodes into a GameData object. This is unnecessary work when
we only need the game name and version from the XML.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix: https://github.com/triplea-game/triplea/issues/6632 2.0 Bots are Running out of Memory (Map Parsing Related)  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
- checked locally, map load speed is faster.
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

