### PR TITLE
Specify additional ansible.cfg properties

### DIFF
--- a/infrastructure/ansible.cfg
+++ b/infrastructure/ansible.cfg
@@ -1,10 +1,15 @@
 [defaults]
 host_key_checking = False
+forks = 10
+strategy = linear
+serial = 100%
+gathering = no
+poll_interval = 3
 
 [ssh_connection]
 pipelining = True
 control_path = /tmp/ansible-ssh-%%h-%%p-%%r
-ControlPersist = 60s
+ControlMaster = auto
 ssh_args = -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
 
 [persistent_connection]


### PR DESCRIPTION
```
forks = 10, this increases the number of machines that can be deployed
    to in parallel from 5 to 10
strategy = linear, this changes from the default 'free' to do one task
    for all machines before moving to another. This is slower than 'free'
    but means will stay in lock-step and the output from task execution
    is easier to follow.
serial = 100%, this means to deploy to 100% of the machines at the same
    time.
gathering = no, this turns off the gather-facts phase. Fact gathering
    is needed if we used any host variables, currently we do not.
    Facts include most all information about a machine, cores, IP address,
    memory, etc. By default gather facts is run at the start of any play.
poll_interval = 3, lowers polling interval from 15s to 3s, this is the
    interval at which ansible checks if tasks are completed. With luck
    a 3s interval will mean ansible will move on to subsequent tasks sooner.
ControlMaster = auto, turns on ssh session multi-plexing
ControlPersist removed, controlPersist determines what to do when a master
    session is closed, since we did not have that enabled, this option
    did nothing. With control master turned on, we'll use the default value
    now.
```

<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
- ran ansible on a local vagrant
```
cd infrastructure
vagrant up
./run_ansible_vagrant
```
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes
- note, these settings allow us to remove equivalent commands from playbook. Playbook will be updated in another PR. In any merge ordering deployment should work just fine, perhaps not as performant or with as clear of output. For now splitting the changes for ease of review.
