### PR TITLE
Remove Tuple usage in BattleStepsTest and MustFightBattleExecutablesTest

### DIFF
--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleExecutablesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleExecutablesTest.java
@@ -14,6 +14,7 @@ import static games.strategy.triplea.Constants.WW2V3;
 import static games.strategy.triplea.delegate.GameDataTestUtil.getIndex;
 import static games.strategy.triplea.delegate.battle.MustFightBattleExecutablesTest.BattleTerrain.LAND;
 import static games.strategy.triplea.delegate.battle.MustFightBattleExecutablesTest.BattleTerrain.WATER;
+import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.UnitAndAttachment;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnit;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitAirTransport;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitCanEvade;
@@ -69,7 +70,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.sound.ISound;
-import org.triplea.util.Tuple;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("UnmatchedTest")
@@ -848,18 +848,18 @@ class MustFightBattleExecutablesTest {
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
     when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(true);
 
-    final Tuple<Unit, UnitAttachment> unitAndAttachment = newUnitAndAttachment();
-    final Unit unit = unitAndAttachment.getFirst();
+    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    final Unit unit = unitAndAttachment.getUnit();
     when(unit.getOwner()).thenReturn(attacker);
-    final UnitAttachment attachment1 = unitAndAttachment.getSecond();
+    final UnitAttachment attachment1 = unitAndAttachment.getUnitAttachment();
     when(attachment1.getIsCombatTransport()).thenReturn(false);
     when(attachment1.getTransportCapacity()).thenReturn(2);
     when(attachment1.getIsSea()).thenReturn(true);
 
-    final Tuple<Unit, UnitAttachment> unitAndAttachment2 = newUnitAndAttachment();
-    final Unit unit2 = unitAndAttachment2.getFirst();
+    final UnitAndAttachment unitAndAttachment2 = newUnitAndAttachment();
+    final Unit unit2 = unitAndAttachment2.getUnit();
     when(unit2.getOwner()).thenReturn(defender);
-    final UnitAttachment attachment2 = unitAndAttachment2.getSecond();
+    final UnitAttachment attachment2 = unitAndAttachment2.getUnitAttachment();
     when(attachment2.getTransportCapacity()).thenReturn(-1);
     when(attachment2.getMovement(attacker)).thenReturn(1);
     when(attachment2.getAttack(attacker)).thenReturn(1);
@@ -923,10 +923,10 @@ class MustFightBattleExecutablesTest {
     final Unit unit = givenUnitDestroyer();
     when(unit.getOwner()).thenReturn(attacker);
 
-    final Tuple<Unit, UnitAttachment> unitAndAttachment2 = newUnitAndAttachment();
-    final Unit unit2 = unitAndAttachment2.getFirst();
+    final UnitAndAttachment unitAndAttachment2 = newUnitAndAttachment();
+    final Unit unit2 = unitAndAttachment2.getUnit();
     when(unit2.getOwner()).thenReturn(defender);
-    final UnitAttachment attachment2 = unitAndAttachment2.getSecond();
+    final UnitAttachment attachment2 = unitAndAttachment2.getUnitAttachment();
     when(attachment2.getTransportCapacity()).thenReturn(-1);
     when(attachment2.getIsSea()).thenReturn(true);
 
@@ -955,18 +955,18 @@ class MustFightBattleExecutablesTest {
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
     when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(true);
 
-    final Tuple<Unit, UnitAttachment> unitAndAttachment = newUnitAndAttachment();
-    final Unit unit = unitAndAttachment.getFirst();
+    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    final Unit unit = unitAndAttachment.getUnit();
     when(unit.getOwner()).thenReturn(attacker);
-    final UnitAttachment attachment1 = unitAndAttachment.getSecond();
+    final UnitAttachment attachment1 = unitAndAttachment.getUnitAttachment();
     when(attachment1.getIsCombatTransport()).thenReturn(false);
     when(attachment1.getTransportCapacity()).thenReturn(2);
     when(attachment1.getIsSea()).thenReturn(true);
 
-    final Tuple<Unit, UnitAttachment> unitAndAttachment2 = newUnitAndAttachment();
-    final Unit unit2 = unitAndAttachment2.getFirst();
+    final UnitAndAttachment unitAndAttachment2 = newUnitAndAttachment();
+    final Unit unit2 = unitAndAttachment2.getUnit();
     when(unit2.getOwner()).thenReturn(defender);
-    final UnitAttachment attachment2 = unitAndAttachment2.getSecond();
+    final UnitAttachment attachment2 = unitAndAttachment2.getUnitAttachment();
     when(attachment2.getTransportCapacity()).thenReturn(-1);
     when(attachment2.getMovement(attacker)).thenReturn(0);
     when(attachment2.getIsSea()).thenReturn(true);
@@ -995,18 +995,18 @@ class MustFightBattleExecutablesTest {
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
     when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(true);
 
-    final Tuple<Unit, UnitAttachment> unitAndAttachment = newUnitAndAttachment();
-    final Unit unit = unitAndAttachment.getFirst();
+    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    final Unit unit = unitAndAttachment.getUnit();
     when(unit.getOwner()).thenReturn(defender);
-    final UnitAttachment attachment1 = unitAndAttachment.getSecond();
+    final UnitAttachment attachment1 = unitAndAttachment.getUnitAttachment();
     when(attachment1.getIsCombatTransport()).thenReturn(false);
     when(attachment1.getTransportCapacity()).thenReturn(2);
     when(attachment1.getIsSea()).thenReturn(true);
 
-    final Tuple<Unit, UnitAttachment> unitAndAttachment2 = newUnitAndAttachment();
-    final Unit unit2 = unitAndAttachment2.getFirst();
+    final UnitAndAttachment unitAndAttachment2 = newUnitAndAttachment();
+    final Unit unit2 = unitAndAttachment2.getUnit();
     when(unit2.getOwner()).thenReturn(attacker);
-    final UnitAttachment attachment2 = unitAndAttachment2.getSecond();
+    final UnitAttachment attachment2 = unitAndAttachment2.getUnitAttachment();
     when(attachment2.getTransportCapacity()).thenReturn(-1);
     when(attachment2.getMovement(defender)).thenReturn(1);
     when(attachment2.getAttack(defender)).thenReturn(1);
@@ -1043,10 +1043,10 @@ class MustFightBattleExecutablesTest {
     final Unit unit = givenUnitDestroyer();
     when(unit.getOwner()).thenReturn(defender);
 
-    final Tuple<Unit, UnitAttachment> unitAndAttachment2 = newUnitAndAttachment();
-    final Unit unit2 = unitAndAttachment2.getFirst();
+    final UnitAndAttachment unitAndAttachment2 = newUnitAndAttachment();
+    final Unit unit2 = unitAndAttachment2.getUnit();
     when(unit2.getOwner()).thenReturn(attacker);
-    final UnitAttachment attachment2 = unitAndAttachment2.getSecond();
+    final UnitAttachment attachment2 = unitAndAttachment2.getUnitAttachment();
     when(attachment2.getIsSea()).thenReturn(true);
 
     when(battleSite.getUnits()).thenReturn(List.of(unit, unit2));
@@ -1074,18 +1074,18 @@ class MustFightBattleExecutablesTest {
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
     when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(true);
 
-    final Tuple<Unit, UnitAttachment> unitAndAttachment = newUnitAndAttachment();
-    final Unit unit = unitAndAttachment.getFirst();
+    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    final Unit unit = unitAndAttachment.getUnit();
     when(unit.getOwner()).thenReturn(defender);
-    final UnitAttachment attachment1 = unitAndAttachment.getSecond();
+    final UnitAttachment attachment1 = unitAndAttachment.getUnitAttachment();
     when(attachment1.getIsCombatTransport()).thenReturn(false);
     when(attachment1.getTransportCapacity()).thenReturn(2);
     when(attachment1.getIsSea()).thenReturn(true);
 
-    final Tuple<Unit, UnitAttachment> unitAndAttachment2 = newUnitAndAttachment();
-    final Unit unit2 = unitAndAttachment2.getFirst();
+    final UnitAndAttachment unitAndAttachment2 = newUnitAndAttachment();
+    final Unit unit2 = unitAndAttachment2.getUnit();
     when(unit2.getOwner()).thenReturn(attacker);
-    final UnitAttachment attachment2 = unitAndAttachment2.getSecond();
+    final UnitAttachment attachment2 = unitAndAttachment2.getUnitAttachment();
     when(attachment2.getMovement(defender)).thenReturn(0);
     when(attachment2.getIsSea()).thenReturn(true);
 
@@ -1117,7 +1117,7 @@ class MustFightBattleExecutablesTest {
             FirstStrikeBattleStep.STANDARD));
   }
 
-  private Tuple<MustFightBattle, List<IExecutable>> givenFirstStrikeBattleSetup(
+  private MustFightBattle givenFirstStrikeBattleSetup(
       final boolean attackerDestroyer,
       final boolean defenderDestroyer,
       final boolean ww2v2,
@@ -1140,9 +1140,8 @@ class MustFightBattleExecutablesTest {
 
     battle.setUnits(
         List.of(defenderUnit), List.of(attackerUnit), List.of(), List.of(), defender, List.of());
-    final List<IExecutable> execs = battle.getBattleExecutables(true);
 
-    return Tuple.of(battle, execs);
+    return battle;
   }
 
   private enum FirstStrikeBattleStep {
@@ -1152,9 +1151,8 @@ class MustFightBattleExecutablesTest {
   }
 
   private void assertThatFirstStrikeStepOrder(
-      final Tuple<MustFightBattle, List<IExecutable>> battleTuple,
-      final List<FirstStrikeBattleStep> stepOrder) {
-    final List<IExecutable> execs = battleTuple.getSecond();
+      final MustFightBattle battle, final List<FirstStrikeBattleStep> stepOrder) {
+    final List<IExecutable> execs = battle.getBattleExecutables(true);
 
     final EnumMap<FirstStrikeBattleStep, Integer> indices =
         new EnumMap<>(FirstStrikeBattleStep.class);
@@ -1174,11 +1172,10 @@ class MustFightBattleExecutablesTest {
   }
 
   private void assertThatFirstStrikeReturnFireIs(
-      final Tuple<MustFightBattle, List<IExecutable>> battleTuple,
+      final MustFightBattle battle,
       final MustFightBattle.ReturnFire returnFire,
       final boolean attacker) {
-    final MustFightBattle battle = battleTuple.getFirst();
-    final List<IExecutable> execs = battleTuple.getSecond();
+    final List<IExecutable> execs = battle.getBattleExecutables(true);
     final int index =
         getIndex(
             execs,
@@ -1609,10 +1606,10 @@ class MustFightBattleExecutablesTest {
   void attackingCanNotBeTargetedByAllCanSubmergeWithAllAir() {
     final MustFightBattle battle = spy(newBattle(WATER));
 
-    final Tuple<Unit, UnitAttachment> unitAndAttachment = newUnitAndAttachment();
-    final Unit unit1 = unitAndAttachment.getFirst();
+    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    final Unit unit1 = unitAndAttachment.getUnit();
     when(unit1.getOwner()).thenReturn(attacker);
-    final UnitAttachment attachment1 = unitAndAttachment.getSecond();
+    final UnitAttachment attachment1 = unitAndAttachment.getUnitAttachment();
     when(attachment1.getCanEvade()).thenReturn(true);
 
     final Unit unit3 = givenUnitDestroyer();
@@ -1641,10 +1638,10 @@ class MustFightBattleExecutablesTest {
   void defendingCanNotBeTargetedByAllCanSubmergeWithAllAir() {
     final MustFightBattle battle = spy(newBattle(WATER));
 
-    final Tuple<Unit, UnitAttachment> unitAndAttachment = newUnitAndAttachment();
-    final Unit unit1 = unitAndAttachment.getFirst();
+    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    final Unit unit1 = unitAndAttachment.getUnit();
     when(unit1.getOwner()).thenReturn(defender);
-    final UnitAttachment attachment1 = unitAndAttachment.getSecond();
+    final UnitAttachment attachment1 = unitAndAttachment.getUnitAttachment();
     when(attachment1.getCanEvade()).thenReturn(true);
 
     final Unit unit3 = givenUnitDestroyer();

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
@@ -55,13 +55,13 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import lombok.Value;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.triplea.util.Tuple;
 
 @ExtendWith(MockitoExtension.class)
 public class BattleStepsTest {
@@ -105,88 +105,94 @@ public class BattleStepsTest {
     when(getEmptyOrFriendlySeaNeighbors.apply(any(), any())).thenReturn(Arrays.asList(territories));
   }
 
-  public static Tuple<Unit, UnitAttachment> newUnitAndAttachment() {
+  @Value
+  public static class UnitAndAttachment {
+    private Unit unit;
+    private UnitAttachment unitAttachment;
+  }
+
+  public static UnitAndAttachment newUnitAndAttachment() {
     final Unit unit = mock(Unit.class);
     final UnitType unitType = mock(UnitType.class);
     final UnitAttachment unitAttachment = mock(UnitAttachment.class);
     when(unit.getType()).thenReturn(unitType);
     when(unitType.getAttachment(UNIT_ATTACHMENT_NAME)).thenReturn(unitAttachment);
-    return Tuple.of(unit, unitAttachment);
+    return new UnitAndAttachment(unit, unitAttachment);
   }
 
   public static Unit givenUnit() {
-    return newUnitAndAttachment().getFirst();
+    return newUnitAndAttachment().unit;
   }
 
   public static Unit givenUnitCanEvade() {
-    final Tuple<Unit, UnitAttachment> unitAndAttachment = newUnitAndAttachment();
-    when(unitAndAttachment.getSecond().getCanEvade()).thenReturn(true);
-    return unitAndAttachment.getFirst();
+    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    when(unitAndAttachment.unitAttachment.getCanEvade()).thenReturn(true);
+    return unitAndAttachment.unit;
   }
 
   public static Unit givenUnitAttackerFirstStrike() {
-    final Tuple<Unit, UnitAttachment> unitAndAttachment = newUnitAndAttachment();
-    when(unitAndAttachment.getSecond().getIsFirstStrike()).thenReturn(true);
-    when(unitAndAttachment.getSecond().getCanEvade()).thenReturn(true);
-    return unitAndAttachment.getFirst();
+    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    when(unitAndAttachment.unitAttachment.getIsFirstStrike()).thenReturn(true);
+    when(unitAndAttachment.unitAttachment.getCanEvade()).thenReturn(true);
+    return unitAndAttachment.unit;
   }
 
   public static Unit givenUnitAttackerFirstStrikeCanNotBeTargetedBy(final UnitType otherType) {
-    final Tuple<Unit, UnitAttachment> unitAndAttachment = newUnitAndAttachment();
-    when(unitAndAttachment.getSecond().getIsFirstStrike()).thenReturn(true);
-    when(unitAndAttachment.getSecond().getCanEvade()).thenReturn(true);
-    when(unitAndAttachment.getSecond().getCanNotBeTargetedBy()).thenReturn(Set.of(otherType));
-    return unitAndAttachment.getFirst();
+    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    when(unitAndAttachment.unitAttachment.getIsFirstStrike()).thenReturn(true);
+    when(unitAndAttachment.unitAttachment.getCanEvade()).thenReturn(true);
+    when(unitAndAttachment.unitAttachment.getCanNotBeTargetedBy()).thenReturn(Set.of(otherType));
+    return unitAndAttachment.unit;
   }
 
   public static Unit givenUnitDefenderFirstStrike() {
     final UnitType canNotTargetType = mock(UnitType.class);
-    final Tuple<Unit, UnitAttachment> unitAndAttachment = newUnitAndAttachment();
-    when(unitAndAttachment.getSecond().getIsFirstStrike()).thenReturn(true);
-    when(unitAndAttachment.getSecond().getCanEvade()).thenReturn(true);
-    when(unitAndAttachment.getSecond().getCanNotTarget()).thenReturn(Set.of(canNotTargetType));
-    return unitAndAttachment.getFirst();
+    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    when(unitAndAttachment.unitAttachment.getIsFirstStrike()).thenReturn(true);
+    when(unitAndAttachment.unitAttachment.getCanEvade()).thenReturn(true);
+    when(unitAndAttachment.unitAttachment.getCanNotTarget()).thenReturn(Set.of(canNotTargetType));
+    return unitAndAttachment.unit;
   }
 
   public static Unit givenUnitDefenderFirstStrikeCanNotBeTargetedBy(final UnitType otherType) {
     final UnitType canNotTargetType = mock(UnitType.class);
-    final Tuple<Unit, UnitAttachment> unitAndAttachment = newUnitAndAttachment();
-    when(unitAndAttachment.getSecond().getIsFirstStrike()).thenReturn(true);
-    when(unitAndAttachment.getSecond().getCanEvade()).thenReturn(true);
-    when(unitAndAttachment.getSecond().getCanNotTarget()).thenReturn(Set.of(canNotTargetType));
-    when(unitAndAttachment.getSecond().getCanNotBeTargetedBy()).thenReturn(Set.of(otherType));
-    return unitAndAttachment.getFirst();
+    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    when(unitAndAttachment.unitAttachment.getIsFirstStrike()).thenReturn(true);
+    when(unitAndAttachment.unitAttachment.getCanEvade()).thenReturn(true);
+    when(unitAndAttachment.unitAttachment.getCanNotTarget()).thenReturn(Set.of(canNotTargetType));
+    when(unitAndAttachment.unitAttachment.getCanNotBeTargetedBy()).thenReturn(Set.of(otherType));
+    return unitAndAttachment.unit;
   }
 
   public static Unit givenUnitDestroyer() {
-    final Tuple<Unit, UnitAttachment> unitAndAttachment = newUnitAndAttachment();
-    when(unitAndAttachment.getSecond().getIsDestroyer()).thenReturn(true);
-    return unitAndAttachment.getFirst();
+    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    when(unitAndAttachment.unitAttachment.getIsDestroyer()).thenReturn(true);
+    return unitAndAttachment.unit;
   }
 
   public static Unit givenUnitTransport() {
-    final Tuple<Unit, UnitAttachment> unitAndAttachment = newUnitAndAttachment();
-    when(unitAndAttachment.getSecond().getTransportCapacity()).thenReturn(2);
-    when(unitAndAttachment.getSecond().getIsSea()).thenReturn(true);
-    return unitAndAttachment.getFirst();
+    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    when(unitAndAttachment.unitAttachment.getTransportCapacity()).thenReturn(2);
+    when(unitAndAttachment.unitAttachment.getIsSea()).thenReturn(true);
+    return unitAndAttachment.unit;
   }
 
   public static Unit givenUnitAirTransport() {
-    final Tuple<Unit, UnitAttachment> unitAndAttachment = newUnitAndAttachment();
-    when(unitAndAttachment.getSecond().getIsAirTransport()).thenReturn(true);
-    return unitAndAttachment.getFirst();
+    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    when(unitAndAttachment.unitAttachment.getIsAirTransport()).thenReturn(true);
+    return unitAndAttachment.unit;
   }
 
   public static Unit givenUnitWithTypeAa() {
-    final Tuple<Unit, UnitAttachment> unitAndAttachment = newUnitAndAttachment();
-    when(unitAndAttachment.getSecond().getTypeAa()).thenReturn("AntiAirGun");
-    return unitAndAttachment.getFirst();
+    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    when(unitAndAttachment.unitAttachment.getTypeAa()).thenReturn("AntiAirGun");
+    return unitAndAttachment.unit;
   }
 
   public static Unit givenUnitIsAir() {
-    final Tuple<Unit, UnitAttachment> unitAndAttachment = newUnitAndAttachment();
-    when(unitAndAttachment.getSecond().getIsAir()).thenReturn(true);
-    return unitAndAttachment.getFirst();
+    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    when(unitAndAttachment.unitAttachment.getIsAir()).thenReturn(true);
+    return unitAndAttachment.unit;
   }
 
   @SafeVarargs
@@ -782,8 +788,8 @@ public class BattleStepsTest {
   void unescortedAttackingTransportsAreNotRemovedWhenCasualtiesAreNotRestricted() {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
-    final Tuple<Unit, UnitAttachment> unitAndAttachment = newUnitAndAttachment();
-    final Unit unit1 = unitAndAttachment.getFirst();
+    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    final Unit unit1 = unitAndAttachment.unit;
     final Unit unit2 = givenUnit();
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
     when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
@@ -796,7 +802,7 @@ public class BattleStepsTest {
             .get();
 
     assertThat(steps, is(basicFightSteps()));
-    verify(unitAndAttachment.getSecond(), never()).getTransportCapacity();
+    verify(unitAndAttachment.unitAttachment, never()).getTransportCapacity();
   }
 
   @Test
@@ -825,8 +831,8 @@ public class BattleStepsTest {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
     final Unit unit1 = givenUnit();
-    final Tuple<Unit, UnitAttachment> unitAndAttachment = newUnitAndAttachment();
-    final Unit unit2 = unitAndAttachment.getFirst();
+    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    final Unit unit2 = unitAndAttachment.unit;
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
     when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
     when(gameProperties.get(WW2V2, false)).thenReturn(false);
@@ -838,7 +844,7 @@ public class BattleStepsTest {
             .get();
 
     assertThat(steps, is(basicFightSteps()));
-    verify(unitAndAttachment.getSecond(), never()).getTransportCapacity();
+    verify(unitAndAttachment.unitAttachment, never()).getTransportCapacity();
   }
 
   @Test
@@ -1796,8 +1802,8 @@ public class BattleStepsTest {
     givenPlayers();
     givenAttackerRetreatTerritories(battleSite);
     final Unit unit1 = givenUnitAttackerFirstStrike();
-    final Tuple<Unit, UnitAttachment> unitAndAttachment = newUnitAndAttachment();
-    final Unit unit2 = unitAndAttachment.getFirst();
+    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    final Unit unit2 = unitAndAttachment.unit;
 
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
     when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
@@ -1820,7 +1826,7 @@ public class BattleStepsTest {
                 REMOVE_CASUALTIES,
                 attacker.getName() + SUBS_WITHDRAW,
                 attacker.getName() + ATTACKER_WITHDRAW)));
-    verify(unitAndAttachment.getSecond(), never()).getTransportCapacity();
+    verify(unitAndAttachment.unitAttachment, never()).getTransportCapacity();
   }
 
   @Test


### PR DESCRIPTION
Replaces Tuple usage with a value object.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

