### PR TITLE
Convert Offensive/Defensive AA Fire Steps

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleActions.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleActions.java
@@ -7,5 +7,9 @@ import java.util.Collection;
 /** Actions that can occur in a battle that require interaction with {@link IDelegateBridge} */
 public interface BattleActions {
 
+  void fireOffensiveAaGuns();
+
+  void fireDefensiveAaGuns();
+
   void submergeUnits(Collection<Unit> units, boolean defender, IDelegateBridge bridge);
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea.delegate.battle;
 
+import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Unit;
 import java.util.Collection;
 
@@ -9,4 +10,12 @@ public interface BattleState {
   Collection<Unit> getAttackingUnits();
 
   Collection<Unit> getDefendingUnits();
+
+  Collection<Unit> getOffensiveAa();
+
+  Collection<Unit> getDefendingAa();
+
+  GamePlayer getAttacker();
+
+  GamePlayer getDefender();
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -382,13 +382,11 @@ public class MustFightBattle extends DependentBattle
 
   @Override
   public List<Unit> getOffensiveAa() {
-    updateOffensiveAaUnits();
     return offensiveAa;
   }
 
   @Override
   public List<Unit> getDefendingAa() {
-    updateDefendingAaUnits();
     return defendingAa;
   }
 
@@ -874,6 +872,12 @@ public class MustFightBattle extends DependentBattle
 
   @VisibleForTesting
   public List<String> determineStepStrings(final boolean showFirstRun) {
+    if (offensiveAa == null) {
+      updateOffensiveAaUnits();
+    }
+    if (defendingAa == null) {
+      updateDefendingAaUnits();
+    }
     return BattleSteps.builder()
         .showFirstRun(showFirstRun)
         .attacker(attacker)
@@ -1086,6 +1090,12 @@ public class MustFightBattle extends DependentBattle
   }
 
   private void addFightStartSteps(final boolean firstRun, final List<IExecutable> steps) {
+    if (offensiveAa == null) {
+      updateOffensiveAaUnits();
+    }
+    if (defendingAa == null) {
+      updateDefendingAaUnits();
+    }
     final boolean offensiveAa = canFireOffensiveAa();
     final boolean defendingAa = canFireDefendingAa();
     final BattleStep offensiveAaStep = new OffensiveAaFire(this, this);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -1103,13 +1103,11 @@ public class MustFightBattle extends DependentBattle
     if (offensiveAaStep.valid()) {
       steps.add(offensiveAaStep);
     }
-    // see Save Game Compatibility Note on getBattleExecutables
     new IExecutable() {
       private static final long serialVersionUID = 3802352588499530533L;
 
       @Override
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-        // if this gets deserialized, then forward the work to the new BattleStep
         final BattleStep offensiveAaStep =
             new OffensiveAaFire(MustFightBattle.this, MustFightBattle.this);
         offensiveAaStep.execute(stack, bridge);
@@ -1118,13 +1116,11 @@ public class MustFightBattle extends DependentBattle
     if (defensiveAaStep.valid()) {
       steps.add(defensiveAaStep);
     }
-    // see Save Game Compatibility Note on getBattleExecutables
     new IExecutable() {
       private static final long serialVersionUID = -1370090785540214199L;
 
       @Override
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-        // if this gets deserialized, then forward the work to the new BattleStep
         final BattleStep defensiveAaStep =
             new DefensiveAaFire(MustFightBattle.this, MustFightBattle.this);
         defensiveAaStep.execute(stack, bridge);
@@ -1491,13 +1487,11 @@ public class MustFightBattle extends DependentBattle
 
     final BattleStep submergeSubsVsOnlyAir = new SubmergeSubsVsOnlyAirStep(this, this);
     steps.add(submergeSubsVsOnlyAir);
-    // see Save Game Compatibility Note on getBattleExecutables
     new IExecutable() {
       private static final long serialVersionUID = 99990L;
 
       @Override
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-        // if this gets deserialized, then forward the work to the new BattleStep
         final BattleStep submergeSubsVsOnlyAir =
             new SubmergeSubsVsOnlyAirStep(MustFightBattle.this, MustFightBattle.this);
         submergeSubsVsOnlyAir.execute(stack, bridge);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -31,6 +31,8 @@ import games.strategy.triplea.delegate.battle.steps.BattleStep;
 import games.strategy.triplea.delegate.battle.steps.BattleSteps;
 import games.strategy.triplea.delegate.battle.steps.RetreatChecks;
 import games.strategy.triplea.delegate.battle.steps.SubsChecks;
+import games.strategy.triplea.delegate.battle.steps.fire.aa.DefensiveAaFire;
+import games.strategy.triplea.delegate.battle.steps.fire.aa.OffensiveAaFire;
 import games.strategy.triplea.delegate.battle.steps.retreat.sub.SubmergeSubsVsOnlyAirStep;
 import games.strategy.triplea.delegate.data.BattleRecord;
 import games.strategy.triplea.formatter.MyFormatter;
@@ -73,26 +75,6 @@ public class MustFightBattle extends DependentBattle
     SUBS,
     PLANES,
     PARTIAL_AMPHIB
-  }
-
-  /**
-   * An action representing attacking aa guns firing during a battle.
-   *
-   * <p>NOTE: This type exists solely for tests to interrogate the execution stack looking for an
-   * action of this type.
-   */
-  public abstract static class FireOffensiveAaGuns implements IExecutable {
-    private static final long serialVersionUID = 7266708569436973099L;
-  }
-
-  /**
-   * An action representing defending aa guns firing during a battle.
-   *
-   * <p>NOTE: This type exists solely for tests to interrogate the execution stack looking for an
-   * action of this type.
-   */
-  public abstract static class FireDefensiveAaGuns implements IExecutable {
-    private static final long serialVersionUID = 2124868665883519949L;
   }
 
   /**
@@ -396,6 +378,18 @@ public class MustFightBattle extends DependentBattle
               Matches.unitIsOwnedBy(defender).or(Matches.enemyUnit(attacker, gameData))));
     }
     return new ArrayList<>(remaining);
+  }
+
+  @Override
+  public List<Unit> getOffensiveAa() {
+    updateOffensiveAaUnits();
+    return offensiveAa;
+  }
+
+  @Override
+  public List<Unit> getDefendingAa() {
+    updateDefendingAaUnits();
+    return defendingAa;
   }
 
   /**
@@ -881,13 +875,11 @@ public class MustFightBattle extends DependentBattle
   @VisibleForTesting
   public List<String> determineStepStrings(final boolean showFirstRun) {
     return BattleSteps.builder()
-        .canFireOffensiveAa(canFireOffensiveAa())
-        .canFireDefendingAa(canFireDefendingAa())
         .showFirstRun(showFirstRun)
         .attacker(attacker)
         .defender(defender)
-        .offensiveAa(offensiveAa)
-        .defendingAa(defendingAa)
+        .offensiveAa(getOffensiveAa())
+        .defendingAa(getDefendingAa())
         .attackingUnits(attackingUnits)
         .defendingUnits(defendingUnits)
         .attackingWaitingToDie(attackingWaitingToDie)
@@ -1073,6 +1065,16 @@ public class MustFightBattle extends DependentBattle
    * It is allowed for an IExecutable to add other IExecutables to the stack. If you read the code
    * in linear order, ignore wrapping stuff in anonymous IExecutables, then the code can be read as
    * it will execute. The steps are added to the stack and then reversed at the end.
+   *
+   * <p>Save Game Compatibility Note:
+   *
+   * <p>Because of saved game compatibility issues, the original steps are left behind as inner
+   * anonymous classes. The reason for this is that their class name is defined by the order in
+   * which they are defined. As an example, the first inner anonymous class is MustFightBattle$0 and
+   * the next one is MustFightBattle$1 and so on. When a saved game is deserialized, it will match
+   * the step by the class name and so if the order of inner anonymous classes change, it will not
+   * deserialize. So even though these old steps aren't being added to the steps array, they are
+   * still needed. They can be safely removed once save compatibility can be broken.
    */
   @VisibleForTesting
   public List<IExecutable> getBattleExecutables(final boolean firstRun) {
@@ -1086,28 +1088,32 @@ public class MustFightBattle extends DependentBattle
   private void addFightStartSteps(final boolean firstRun, final List<IExecutable> steps) {
     final boolean offensiveAa = canFireOffensiveAa();
     final boolean defendingAa = canFireDefendingAa();
-    if (offensiveAa) {
-      steps.add(
-          new FireOffensiveAaGuns() {
-            private static final long serialVersionUID = 3802352588499530533L;
-
-            @Override
-            public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-              fireOffensiveAaGuns();
-            }
-          });
+    final BattleStep offensiveAaStep = new OffensiveAaFire(this, this);
+    final BattleStep defensiveAaStep = new DefensiveAaFire(this, this);
+    if (offensiveAaStep.valid()) {
+      steps.add(offensiveAaStep);
     }
-    if (defendingAa) {
-      steps.add(
-          new FireDefensiveAaGuns() {
-            private static final long serialVersionUID = -1370090785540214199L;
+    // see Save Game Compatibility Note on getBattleExecutables
+    new IExecutable() {
+      private static final long serialVersionUID = 3802352588499530533L;
 
-            @Override
-            public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-              fireDefensiveAaGuns();
-            }
-          });
+      @Override
+      public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+        offensiveAaStep.execute(stack, bridge);
+      }
+    };
+    if (defensiveAaStep.valid()) {
+      steps.add(defensiveAaStep);
     }
+    // see Save Game Compatibility Note on getBattleExecutables
+    new IExecutable() {
+      private static final long serialVersionUID = -1370090785540214199L;
+
+      @Override
+      public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+        defensiveAaStep.execute(stack, bridge);
+      }
+    };
     if (offensiveAa || defendingAa) {
       steps.add(
           new ClearAaWaitingToDieAndDamagedChangesInto() {
@@ -1170,7 +1176,8 @@ public class MustFightBattle extends DependentBattle
     }
   }
 
-  private void fireOffensiveAaGuns() {
+  @Override
+  public void fireOffensiveAaGuns() {
     final List<Unit> allFriendlyUnitsAliveOrWaitingToDie = new ArrayList<>(attackingUnits);
     allFriendlyUnitsAliveOrWaitingToDie.addAll(attackingWaitingToDie);
     final List<Unit> allEnemyUnitsAliveOrWaitingToDie = new ArrayList<>(defendingUnits);
@@ -1192,7 +1199,8 @@ public class MustFightBattle extends DependentBattle
             offensiveAaTypes));
   }
 
-  private void fireDefensiveAaGuns() {
+  @Override
+  public void fireDefensiveAaGuns() {
     final List<Unit> allFriendlyUnitsAliveOrWaitingToDie = new ArrayList<>(defendingUnits);
     allFriendlyUnitsAliveOrWaitingToDie.addAll(defendingWaitingToDie);
     final List<Unit> allEnemyUnitsAliveOrWaitingToDie = new ArrayList<>(attackingUnits);
@@ -1467,11 +1475,7 @@ public class MustFightBattle extends DependentBattle
 
     final BattleStep submergeSubsVsOnlyAir = new SubmergeSubsVsOnlyAirStep(this, this);
     steps.add(submergeSubsVsOnlyAir);
-    // Each of the original steps were defined as inner anonymous classes, so the order in which
-    // they were defined affects their serializing/deserializing since their class name looks like
-    // MustFightBattle$5. For save compatibility, we must leave the anonymous classes around, though
-    // they don't need to be added to the steps. They can be removed once save compatibility can be
-    // broken.
+    // see Save Game Compatibility Note on getBattleExecutables
     new IExecutable() {
       private static final long serialVersionUID = 99990L;
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -1099,6 +1099,9 @@ public class MustFightBattle extends DependentBattle
 
       @Override
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+        // if this gets deserialized, then forward the work to the new BattleStep
+        final BattleStep offensiveAaStep =
+            new OffensiveAaFire(MustFightBattle.this, MustFightBattle.this);
         offensiveAaStep.execute(stack, bridge);
       }
     };
@@ -1111,6 +1114,9 @@ public class MustFightBattle extends DependentBattle
 
       @Override
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+        // if this gets deserialized, then forward the work to the new BattleStep
+        final BattleStep defensiveAaStep =
+            new DefensiveAaFire(MustFightBattle.this, MustFightBattle.this);
         defensiveAaStep.execute(stack, bridge);
       }
     };
@@ -1482,6 +1488,8 @@ public class MustFightBattle extends DependentBattle
       @Override
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
         // if this gets deserialized, then forward the work to the new BattleStep
+        final BattleStep submergeSubsVsOnlyAir =
+            new SubmergeSubsVsOnlyAirStep(MustFightBattle.this, MustFightBattle.this);
         submergeSubsVsOnlyAir.execute(stack, bridge);
       }
     };

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleSteps.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleSteps.java
@@ -6,12 +6,13 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.TechAttachment;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.BattleStepStrings;
 import games.strategy.triplea.delegate.battle.MustFightBattle.ReturnFire;
+import games.strategy.triplea.delegate.battle.steps.fire.aa.DefensiveAaFire;
+import games.strategy.triplea.delegate.battle.steps.fire.aa.OffensiveAaFire;
 import games.strategy.triplea.delegate.battle.steps.fire.air.AirAttackVsNonSubsStep;
 import games.strategy.triplea.delegate.battle.steps.fire.air.AirDefendVsNonSubsStep;
 import games.strategy.triplea.delegate.battle.steps.retreat.sub.SubmergeSubsVsOnlyAirStep;
@@ -30,12 +31,18 @@ import org.triplea.java.collections.CollectionUtils;
 @Builder
 public class BattleSteps implements BattleStepStrings, BattleState {
 
-  final @NonNull Boolean canFireOffensiveAa;
-  final @NonNull Boolean canFireDefendingAa;
   final @NonNull Boolean showFirstRun;
+
+  @Getter(onMethod = @__({@Override}))
   final @NonNull GamePlayer attacker;
+
+  @Getter(onMethod = @__({@Override}))
   final @NonNull GamePlayer defender;
+
+  @Getter(onMethod = @__({@Override}))
   final @NonNull Collection<Unit> offensiveAa;
+
+  @Getter(onMethod = @__({@Override}))
   final @NonNull Collection<Unit> defendingAa;
 
   @Getter(onMethod = @__({@Override}))
@@ -59,25 +66,21 @@ public class BattleSteps implements BattleStepStrings, BattleState {
 
   public List<String> get() {
 
+    final BattleStep offensiveAaStep = new OffensiveAaFire(this, battleActions);
+    final BattleStep defensiveAaStep = new DefensiveAaFire(this, battleActions);
     final BattleStep submergeSubsVsOnlyAir = new SubmergeSubsVsOnlyAirStep(this, battleActions);
     final BattleStep airAttackVsNonSubs = new AirAttackVsNonSubsStep(this);
     final BattleStep airDefendVsNonSubs = new AirDefendVsNonSubsStep(this);
 
     final List<String> steps = new ArrayList<>();
-    if (canFireOffensiveAa) {
-      for (final String typeAa : UnitAttachment.getAllOfTypeAas(offensiveAa)) {
-        steps.add(attacker.getName() + " " + typeAa + AA_GUNS_FIRE_SUFFIX);
-        steps.add(defender.getName() + SELECT_PREFIX + typeAa + CASUALTIES_SUFFIX);
-        steps.add(defender.getName() + REMOVE_PREFIX + typeAa + CASUALTIES_SUFFIX);
-      }
+    if (offensiveAaStep.valid()) {
+      steps.addAll(offensiveAaStep.getNames());
     }
-    if (canFireDefendingAa) {
-      for (final String typeAa : UnitAttachment.getAllOfTypeAas(defendingAa)) {
-        steps.add(defender.getName() + " " + typeAa + AA_GUNS_FIRE_SUFFIX);
-        steps.add(attacker.getName() + SELECT_PREFIX + typeAa + CASUALTIES_SUFFIX);
-        steps.add(attacker.getName() + REMOVE_PREFIX + typeAa + CASUALTIES_SUFFIX);
-      }
+
+    if (defensiveAaStep.valid()) {
+      steps.addAll(defensiveAaStep.getNames());
     }
+
     if (showFirstRun) {
       if (!isBattleSiteWater && !bombardingUnits.isEmpty()) {
         steps.add(NAVAL_BOMBARDMENT);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleSteps.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleSteps.java
@@ -73,13 +73,9 @@ public class BattleSteps implements BattleStepStrings, BattleState {
     final BattleStep airDefendVsNonSubs = new AirDefendVsNonSubsStep(this);
 
     final List<String> steps = new ArrayList<>();
-    if (offensiveAaStep.valid()) {
-      steps.addAll(offensiveAaStep.getNames());
-    }
+    steps.addAll(offensiveAaStep.getNames());
 
-    if (defensiveAaStep.valid()) {
-      steps.addAll(defensiveAaStep.getNames());
-    }
+    steps.addAll(defensiveAaStep.getNames());
 
     if (showFirstRun) {
       if (!isBattleSiteWater && !bombardingUnits.isEmpty()) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/AaFireAndCasualtyStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/AaFireAndCasualtyStep.java
@@ -26,6 +26,9 @@ public abstract class AaFireAndCasualtyStep implements BattleStep {
   @Override
   public List<String> getNames() {
     final List<String> steps = new ArrayList<>();
+    if (!valid()) {
+      return steps;
+    }
     for (final String typeAa : UnitAttachment.getAllOfTypeAas(aaGuns())) {
       steps.add(firingPlayer().getName() + " " + typeAa + AA_GUNS_FIRE_SUFFIX);
       steps.add(firedAtPlayer().getName() + SELECT_PREFIX + typeAa + CASUALTIES_SUFFIX);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/AaFireAndCasualtyStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/AaFireAndCasualtyStep.java
@@ -1,0 +1,47 @@
+package games.strategy.triplea.delegate.battle.steps.fire.aa;
+
+import static games.strategy.triplea.delegate.battle.BattleStepStrings.AA_GUNS_FIRE_SUFFIX;
+import static games.strategy.triplea.delegate.battle.BattleStepStrings.CASUALTIES_SUFFIX;
+import static games.strategy.triplea.delegate.battle.BattleStepStrings.REMOVE_PREFIX;
+import static games.strategy.triplea.delegate.battle.BattleStepStrings.SELECT_PREFIX;
+
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Unit;
+import games.strategy.triplea.attachments.UnitAttachment;
+import games.strategy.triplea.delegate.battle.BattleActions;
+import games.strategy.triplea.delegate.battle.BattleState;
+import games.strategy.triplea.delegate.battle.steps.BattleStep;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public abstract class AaFireAndCasualtyStep implements BattleStep {
+
+  protected final BattleState battleState;
+
+  protected final BattleActions battleActions;
+
+  @Override
+  public List<String> getNames() {
+    final List<String> steps = new ArrayList<>();
+    for (final String typeAa : UnitAttachment.getAllOfTypeAas(aaGuns())) {
+      steps.add(firingPlayer().getName() + " " + typeAa + AA_GUNS_FIRE_SUFFIX);
+      steps.add(firedAtPlayer().getName() + SELECT_PREFIX + typeAa + CASUALTIES_SUFFIX);
+      steps.add(firedAtPlayer().getName() + REMOVE_PREFIX + typeAa + CASUALTIES_SUFFIX);
+    }
+    return steps;
+  }
+
+  @Override
+  public boolean valid() {
+    return !aaGuns().isEmpty();
+  }
+
+  abstract GamePlayer firingPlayer();
+
+  abstract GamePlayer firedAtPlayer();
+
+  abstract Collection<Unit> aaGuns();
+}

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFire.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFire.java
@@ -10,9 +10,6 @@ import java.util.Collection;
 
 /**
  * Offensive Aa units can fire and the player can select their casualties
- *
- * <p>This step always occurs at the start of the battle so PRE_ROUND and IN_ROUND checks are the
- * same
  */
 public class DefensiveAaFire extends AaFireAndCasualtyStep {
   private static final long serialVersionUID = 3220057715007657960L;
@@ -23,7 +20,9 @@ public class DefensiveAaFire extends AaFireAndCasualtyStep {
 
   @Override
   public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-    battleActions.fireDefensiveAaGuns();
+    if (valid()) {
+      battleActions.fireDefensiveAaGuns();
+    }
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFire.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFire.java
@@ -1,0 +1,43 @@
+package games.strategy.triplea.delegate.battle.steps.fire.aa;
+
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.delegate.ExecutionStack;
+import games.strategy.triplea.delegate.battle.BattleActions;
+import games.strategy.triplea.delegate.battle.BattleState;
+import java.util.Collection;
+
+/**
+ * Offensive Aa units can fire and the player can select their casualties
+ *
+ * <p>This step always occurs at the start of the battle so PRE_ROUND and IN_ROUND checks are the
+ * same
+ */
+public class DefensiveAaFire extends AaFireAndCasualtyStep {
+  private static final long serialVersionUID = 3220057715007657960L;
+
+  public DefensiveAaFire(final BattleState battleState, final BattleActions battleActions) {
+    super(battleState, battleActions);
+  }
+
+  @Override
+  public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+    battleActions.fireDefensiveAaGuns();
+  }
+
+  @Override
+  GamePlayer firingPlayer() {
+    return battleState.getDefender();
+  }
+
+  @Override
+  GamePlayer firedAtPlayer() {
+    return battleState.getAttacker();
+  }
+
+  @Override
+  Collection<Unit> aaGuns() {
+    return battleState.getDefendingAa();
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFire.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFire.java
@@ -8,9 +8,7 @@ import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.Collection;
 
-/**
- * Offensive Aa units can fire and the player can select their casualties
- */
+/** Offensive Aa units can fire and the player can select their casualties */
 public class DefensiveAaFire extends AaFireAndCasualtyStep {
   private static final long serialVersionUID = 3220057715007657960L;
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFire.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFire.java
@@ -10,9 +10,6 @@ import java.util.Collection;
 
 /**
  * Offensive Aa units can fire and the player can select their casualties
- *
- * <p>This step always occurs at the start of the battle so PRE_ROUND and IN_ROUND checks are the
- * same
  */
 public class OffensiveAaFire extends AaFireAndCasualtyStep {
   private static final long serialVersionUID = 5843852442617511691L;
@@ -23,7 +20,9 @@ public class OffensiveAaFire extends AaFireAndCasualtyStep {
 
   @Override
   public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-    battleActions.fireOffensiveAaGuns();
+    if (valid()) {
+      battleActions.fireOffensiveAaGuns();
+    }
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFire.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFire.java
@@ -1,0 +1,43 @@
+package games.strategy.triplea.delegate.battle.steps.fire.aa;
+
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.delegate.ExecutionStack;
+import games.strategy.triplea.delegate.battle.BattleActions;
+import games.strategy.triplea.delegate.battle.BattleState;
+import java.util.Collection;
+
+/**
+ * Offensive Aa units can fire and the player can select their casualties
+ *
+ * <p>This step always occurs at the start of the battle so PRE_ROUND and IN_ROUND checks are the
+ * same
+ */
+public class OffensiveAaFire extends AaFireAndCasualtyStep {
+  private static final long serialVersionUID = 5843852442617511691L;
+
+  public OffensiveAaFire(final BattleState battleState, final BattleActions battleActions) {
+    super(battleState, battleActions);
+  }
+
+  @Override
+  public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+    battleActions.fireOffensiveAaGuns();
+  }
+
+  @Override
+  GamePlayer firingPlayer() {
+    return battleState.getAttacker();
+  }
+
+  @Override
+  GamePlayer firedAtPlayer() {
+    return battleState.getDefender();
+  }
+
+  @Override
+  Collection<Unit> aaGuns() {
+    return battleState.getOffensiveAa();
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFire.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFire.java
@@ -8,9 +8,7 @@ import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.Collection;
 
-/**
- * Offensive Aa units can fire and the player can select their casualties
- */
+/** Offensive Aa units can fire and the player can select their casualties */
 public class OffensiveAaFire extends AaFireAndCasualtyStep {
   private static final long serialVersionUID = 5843852442617511691L;
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/FakeBattleState.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/FakeBattleState.java
@@ -1,7 +1,11 @@
 package games.strategy.triplea.delegate.battle;
 
+import static org.mockito.Mockito.mock;
+
+import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Unit;
 import java.util.Collection;
+import java.util.List;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NonNull;
@@ -16,12 +20,30 @@ import lombok.NonNull;
 public class FakeBattleState implements BattleState {
 
   @Getter(onMethod = @__({@Override}))
+  final @NonNull GamePlayer attacker;
+
+  @Getter(onMethod = @__({@Override}))
+  final @NonNull GamePlayer defender;
+
+  @Getter(onMethod = @__({@Override}))
   final @NonNull Collection<Unit> attackingUnits;
 
   @Getter(onMethod = @__({@Override}))
   final @NonNull Collection<Unit> defendingUnits;
 
+  @Getter(onMethod = @__({@Override}))
+  final @NonNull Collection<Unit> offensiveAa;
+
+  @Getter(onMethod = @__({@Override}))
+  final @NonNull Collection<Unit> defendingAa;
+
   public static FakeBattleState.FakeBattleStateBuilder givenBattleStateBuilder() {
-    return FakeBattleState.builder();
+    return FakeBattleState.builder()
+        .attackingUnits(List.of())
+        .defendingUnits(List.of())
+        .attacker(mock(GamePlayer.class))
+        .defender(mock(GamePlayer.class))
+        .offensiveAa(List.of())
+        .defendingAa(List.of());
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleExecutablesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleExecutablesTest.java
@@ -56,6 +56,8 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.IExecutable;
+import games.strategy.triplea.delegate.battle.steps.fire.aa.DefensiveAaFire;
+import games.strategy.triplea.delegate.battle.steps.fire.aa.OffensiveAaFire;
 import java.math.BigDecimal;
 import java.util.EnumMap;
 import java.util.List;
@@ -344,7 +346,7 @@ class MustFightBattleExecutablesTest {
 
     assertThat(
         "FireOffensiveAaGuns should be the first step",
-        getIndex(execs, MustFightBattle.FireOffensiveAaGuns.class),
+        getIndex(execs, OffensiveAaFire.class),
         is(0));
 
     assertThat(
@@ -352,7 +354,7 @@ class MustFightBattleExecutablesTest {
         getIndex(execs, MustFightBattle.ClearAaWaitingToDieAndDamagedChangesInto.class),
         is(1));
 
-    assertThatStepIsMissing(execs, MustFightBattle.FireDefensiveAaGuns.class);
+    assertThatStepIsMissing(execs, DefensiveAaFire.class);
   }
 
   @Test
@@ -381,7 +383,7 @@ class MustFightBattleExecutablesTest {
 
     assertThat(
         "FireDefensiveAaGuns should be the first step",
-        getIndex(execs, MustFightBattle.FireDefensiveAaGuns.class),
+        getIndex(execs, DefensiveAaFire.class),
         is(0));
 
     assertThat(
@@ -389,7 +391,7 @@ class MustFightBattleExecutablesTest {
         getIndex(execs, MustFightBattle.ClearAaWaitingToDieAndDamagedChangesInto.class),
         is(1));
 
-    assertThatStepIsMissing(execs, MustFightBattle.FireOffensiveAaGuns.class);
+    assertThatStepIsMissing(execs, OffensiveAaFire.class);
   }
 
   @Test
@@ -427,12 +429,12 @@ class MustFightBattleExecutablesTest {
 
     assertThat(
         "FireOffensiveAaGuns should be the first step",
-        getIndex(execs, MustFightBattle.FireOffensiveAaGuns.class),
+        getIndex(execs, OffensiveAaFire.class),
         is(0));
 
     assertThat(
         "FireDefensiveAaGuns should be the second step",
-        getIndex(execs, MustFightBattle.FireDefensiveAaGuns.class),
+        getIndex(execs, DefensiveAaFire.class),
         is(1));
 
     assertThat(

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
@@ -221,8 +221,6 @@ public class BattleStepsTest {
 
   private BattleSteps.BattleStepsBuilder newStepBuilder() {
     return BattleSteps.builder()
-        .canFireOffensiveAa(false)
-        .canFireDefendingAa(false)
         .showFirstRun(true)
         .attacker(attacker)
         .defender(defender)
@@ -477,7 +475,6 @@ public class BattleStepsTest {
 
     final List<String> steps =
         newStepBuilder()
-            .canFireOffensiveAa(true)
             .offensiveAa(List.of(unit1))
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
@@ -509,7 +506,6 @@ public class BattleStepsTest {
 
     final List<String> steps =
         newStepBuilder()
-            .canFireDefendingAa(true)
             .defendingAa(List.of(unit2))
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
@@ -541,8 +537,6 @@ public class BattleStepsTest {
 
     final List<String> steps =
         newStepBuilder()
-            .canFireOffensiveAa(true)
-            .canFireDefendingAa(true)
             .offensiveAa(List.of(unit1))
             .defendingAa(List.of(unit2))
             .attackingUnits(List.of(unit1))

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFireTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFireTest.java
@@ -18,9 +18,6 @@ import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -35,7 +32,8 @@ class DefensiveAaFireTest {
   class IsValid {
     @Test
     void validIfAaIsAvailable() {
-      final BattleState battleState = givenBattleStateBuilder().defendingAa(List.of(mock(Unit.class))).build();
+      final BattleState battleState =
+          givenBattleStateBuilder().defendingAa(List.of(mock(Unit.class))).build();
       final DefensiveAaFire defensiveAaFire = new DefensiveAaFire(battleState, battleActions);
       assertThat(defensiveAaFire.valid(), is(true));
     }
@@ -52,7 +50,8 @@ class DefensiveAaFireTest {
   class GetNames {
     @Test
     void hasNamesIfAaIsAvailable() {
-      final BattleState battleState = givenBattleStateBuilder().defendingAa(List.of(givenUnitWithTypeAa())).build();
+      final BattleState battleState =
+          givenBattleStateBuilder().defendingAa(List.of(givenUnitWithTypeAa())).build();
       final DefensiveAaFire defensiveAaFire = new DefensiveAaFire(battleState, battleActions);
       assertThat(defensiveAaFire.getNames(), hasSize(3));
     }
@@ -83,8 +82,7 @@ class DefensiveAaFireTest {
     void notFiredIfNoAaAreAvailable() {
       final DefensiveAaFire defensiveAaFire =
           new DefensiveAaFire(
-              givenBattleStateBuilder().defendingAa(List.of()).build(),
-              battleActions);
+              givenBattleStateBuilder().defendingAa(List.of()).build(), battleActions);
 
       defensiveAaFire.execute(executionStack, delegateBridge);
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFireTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFireTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import games.strategy.engine.data.Unit;
@@ -14,6 +15,7 @@ import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.List;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -29,38 +31,64 @@ class DefensiveAaFireTest {
   @Mock IDelegateBridge delegateBridge;
   @Mock BattleActions battleActions;
 
-  @ParameterizedTest(name = "[{index}] {0} is {2}")
-  @MethodSource
-  void testWhatIsValid(
-      final String displayName, final BattleState battleState, final boolean expected) {
-    final DefensiveAaFire defensiveAaFire = new DefensiveAaFire(battleState, battleActions);
-    assertThat(defensiveAaFire.valid(), is(expected));
-    if (expected) {
+  @Nested
+  class IsValid {
+    @Test
+    void validIfAaIsAvailable() {
+      final BattleState battleState = givenBattleStateBuilder().defendingAa(List.of(mock(Unit.class))).build();
+      final DefensiveAaFire defensiveAaFire = new DefensiveAaFire(battleState, battleActions);
+      assertThat(defensiveAaFire.valid(), is(true));
+    }
+
+    @Test
+    void notValidIfNoAaIsAvailable() {
+      final BattleState battleState = givenBattleStateBuilder().defendingAa(List.of()).build();
+      final DefensiveAaFire defensiveAaFire = new DefensiveAaFire(battleState, battleActions);
+      assertThat(defensiveAaFire.valid(), is(false));
+    }
+  }
+
+  @Nested
+  class GetNames {
+    @Test
+    void hasNamesIfAaIsAvailable() {
+      final BattleState battleState = givenBattleStateBuilder().defendingAa(List.of(givenUnitWithTypeAa())).build();
+      final DefensiveAaFire defensiveAaFire = new DefensiveAaFire(battleState, battleActions);
       assertThat(defensiveAaFire.getNames(), hasSize(3));
-    } else {
+    }
+
+    @Test
+    void hasNoNamesIfNoAaIsAvailable() {
+      final BattleState battleState = givenBattleStateBuilder().defendingAa(List.of()).build();
+      final DefensiveAaFire defensiveAaFire = new DefensiveAaFire(battleState, battleActions);
       assertThat(defensiveAaFire.getNames(), hasSize(0));
     }
   }
 
-  static List<Arguments> testWhatIsValid() {
-    return List.of(
-        Arguments.of(
-            "No Defensive Aa", givenBattleStateBuilder().defendingAa(List.of()).build(), false),
-        Arguments.of(
-            "Some Defensive Aa",
-            givenBattleStateBuilder().defendingAa(List.of(givenUnitWithTypeAa())).build(),
-            true));
-  }
+  @Nested
+  class FireAa {
+    @Test
+    void firedIfAaAreAvailable() {
+      final DefensiveAaFire defensiveAaFire =
+          new DefensiveAaFire(
+              givenBattleStateBuilder().defendingAa(List.of(mock(Unit.class))).build(),
+              battleActions);
 
-  @Test
-  void testFiringAaGuns() {
-    final DefensiveAaFire defensiveAaFire =
-        new DefensiveAaFire(
-            givenBattleStateBuilder().defendingAa(List.of(mock(Unit.class))).build(),
-            battleActions);
+      defensiveAaFire.execute(executionStack, delegateBridge);
 
-    defensiveAaFire.execute(executionStack, delegateBridge);
+      verify(battleActions).fireDefensiveAaGuns();
+    }
 
-    verify(battleActions).fireDefensiveAaGuns();
+    @Test
+    void notFiredIfNoAaAreAvailable() {
+      final DefensiveAaFire defensiveAaFire =
+          new DefensiveAaFire(
+              givenBattleStateBuilder().defendingAa(List.of()).build(),
+              battleActions);
+
+      defensiveAaFire.execute(executionStack, delegateBridge);
+
+      verify(battleActions, never()).fireDefensiveAaGuns();
+    }
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFireTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFireTest.java
@@ -33,12 +33,12 @@ class DefensiveAaFireTest {
   @MethodSource
   void testWhatIsValid(
       final String displayName, final BattleState battleState, final boolean expected) {
-    final DefensiveAaFire underTest = new DefensiveAaFire(battleState, battleActions);
-    assertThat(underTest.valid(), is(expected));
+    final DefensiveAaFire defensiveAaFire = new DefensiveAaFire(battleState, battleActions);
+    assertThat(defensiveAaFire.valid(), is(expected));
     if (expected) {
-      assertThat(underTest.getNames(), hasSize(3));
+      assertThat(defensiveAaFire.getNames(), hasSize(3));
     } else {
-      assertThat(underTest.getNames(), hasSize(0));
+      assertThat(defensiveAaFire.getNames(), hasSize(0));
     }
   }
 
@@ -54,12 +54,12 @@ class DefensiveAaFireTest {
 
   @Test
   void testFiringAaGuns() {
-    final DefensiveAaFire underTest =
+    final DefensiveAaFire defensiveAaFire =
         new DefensiveAaFire(
             givenBattleStateBuilder().defendingAa(List.of(mock(Unit.class))).build(),
             battleActions);
 
-    underTest.execute(executionStack, delegateBridge);
+    defensiveAaFire.execute(executionStack, delegateBridge);
 
     verify(battleActions).fireDefensiveAaGuns();
   }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFireTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFireTest.java
@@ -1,0 +1,57 @@
+package games.strategy.triplea.delegate.battle.steps.fire.aa;
+
+import static games.strategy.triplea.delegate.battle.FakeBattleState.givenBattleStateBuilder;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.delegate.ExecutionStack;
+import games.strategy.triplea.delegate.battle.BattleActions;
+import games.strategy.triplea.delegate.battle.BattleState;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DefensiveAaFireTest {
+
+  @Mock ExecutionStack executionStack;
+  @Mock IDelegateBridge delegateBridge;
+  @Mock BattleActions battleActions;
+
+  @ParameterizedTest(name = "[{index}] {0} is {2}")
+  @MethodSource
+  void testWhatIsValid(
+      final String displayName, final BattleState battleState, final boolean expected) {
+    final DefensiveAaFire underTest = new DefensiveAaFire(battleState, battleActions);
+    assertThat(underTest.valid(), is(expected));
+  }
+
+  static List<Arguments> testWhatIsValid() {
+    return List.of(
+        Arguments.of(
+            "No Defensive Aa", givenBattleStateBuilder().defendingAa(List.of()).build(), false),
+        Arguments.of(
+            "Some Defensive Aa",
+            givenBattleStateBuilder().defendingAa(List.of(mock(Unit.class))).build(),
+            true));
+  }
+
+  @Test
+  void testFiringAaGuns() {
+    final DefensiveAaFire underTest =
+        new DefensiveAaFire(givenBattleStateBuilder().build(), battleActions);
+
+    underTest.execute(executionStack, delegateBridge);
+
+    verify(battleActions).fireDefensiveAaGuns();
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFireTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFireTest.java
@@ -1,7 +1,9 @@
 package games.strategy.triplea.delegate.battle.steps.fire.aa;
 
 import static games.strategy.triplea.delegate.battle.FakeBattleState.givenBattleStateBuilder;
+import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitWithTypeAa;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -33,6 +35,11 @@ class DefensiveAaFireTest {
       final String displayName, final BattleState battleState, final boolean expected) {
     final DefensiveAaFire underTest = new DefensiveAaFire(battleState, battleActions);
     assertThat(underTest.valid(), is(expected));
+    if (expected) {
+      assertThat(underTest.getNames(), hasSize(3));
+    } else {
+      assertThat(underTest.getNames(), hasSize(0));
+    }
   }
 
   static List<Arguments> testWhatIsValid() {
@@ -41,14 +48,16 @@ class DefensiveAaFireTest {
             "No Defensive Aa", givenBattleStateBuilder().defendingAa(List.of()).build(), false),
         Arguments.of(
             "Some Defensive Aa",
-            givenBattleStateBuilder().defendingAa(List.of(mock(Unit.class))).build(),
+            givenBattleStateBuilder().defendingAa(List.of(givenUnitWithTypeAa())).build(),
             true));
   }
 
   @Test
   void testFiringAaGuns() {
     final DefensiveAaFire underTest =
-        new DefensiveAaFire(givenBattleStateBuilder().build(), battleActions);
+        new DefensiveAaFire(
+            givenBattleStateBuilder().defendingAa(List.of(mock(Unit.class))).build(),
+            battleActions);
 
     underTest.execute(executionStack, delegateBridge);
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFireTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFireTest.java
@@ -18,9 +18,6 @@ import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -35,7 +32,8 @@ class OffensiveAaFireTest {
   class IsValid {
     @Test
     void validIfAaIsAvailable() {
-      final BattleState battleState = givenBattleStateBuilder().offensiveAa(List.of(mock(Unit.class))).build();
+      final BattleState battleState =
+          givenBattleStateBuilder().offensiveAa(List.of(mock(Unit.class))).build();
       final OffensiveAaFire offensiveAaFire = new OffensiveAaFire(battleState, battleActions);
       assertThat(offensiveAaFire.valid(), is(true));
     }
@@ -52,7 +50,8 @@ class OffensiveAaFireTest {
   class GetNames {
     @Test
     void hasNamesIfAaIsAvailable() {
-      final BattleState battleState = givenBattleStateBuilder().offensiveAa(List.of(givenUnitWithTypeAa())).build();
+      final BattleState battleState =
+          givenBattleStateBuilder().offensiveAa(List.of(givenUnitWithTypeAa())).build();
       final OffensiveAaFire offensiveAaFire = new OffensiveAaFire(battleState, battleActions);
       assertThat(offensiveAaFire.getNames(), hasSize(3));
     }
@@ -83,8 +82,7 @@ class OffensiveAaFireTest {
     void notFiredIfNoAaAreAvailable() {
       final OffensiveAaFire offensiveAaFire =
           new OffensiveAaFire(
-              givenBattleStateBuilder().offensiveAa(List.of()).build(),
-              battleActions);
+              givenBattleStateBuilder().offensiveAa(List.of()).build(), battleActions);
 
       offensiveAaFire.execute(executionStack, delegateBridge);
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFireTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFireTest.java
@@ -1,7 +1,9 @@
 package games.strategy.triplea.delegate.battle.steps.fire.aa;
 
 import static games.strategy.triplea.delegate.battle.FakeBattleState.givenBattleStateBuilder;
+import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitWithTypeAa;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -33,6 +35,11 @@ class OffensiveAaFireTest {
       final String displayName, final BattleState battleState, final boolean expected) {
     final OffensiveAaFire underTest = new OffensiveAaFire(battleState, battleActions);
     assertThat(underTest.valid(), is(expected));
+    if (expected) {
+      assertThat(underTest.getNames(), hasSize(3));
+    } else {
+      assertThat(underTest.getNames(), hasSize(0));
+    }
   }
 
   static List<Arguments> testWhatIsValid() {
@@ -41,14 +48,16 @@ class OffensiveAaFireTest {
             "No Offensive Aa", givenBattleStateBuilder().offensiveAa(List.of()).build(), false),
         Arguments.of(
             "Some Offensive Aa",
-            givenBattleStateBuilder().offensiveAa(List.of(mock(Unit.class))).build(),
+            givenBattleStateBuilder().offensiveAa(List.of(givenUnitWithTypeAa())).build(),
             true));
   }
 
   @Test
   void testFiringAaGuns() {
     final OffensiveAaFire underTest =
-        new OffensiveAaFire(givenBattleStateBuilder().build(), battleActions);
+        new OffensiveAaFire(
+            givenBattleStateBuilder().offensiveAa(List.of(mock(Unit.class))).build(),
+            battleActions);
 
     underTest.execute(executionStack, delegateBridge);
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFireTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFireTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import games.strategy.engine.data.Unit;
@@ -14,6 +15,7 @@ import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.List;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -29,38 +31,64 @@ class OffensiveAaFireTest {
   @Mock IDelegateBridge delegateBridge;
   @Mock BattleActions battleActions;
 
-  @ParameterizedTest(name = "[{index}] {0} is {2}")
-  @MethodSource
-  void testWhatIsValid(
-      final String displayName, final BattleState battleState, final boolean expected) {
-    final OffensiveAaFire offensiveAaFire = new OffensiveAaFire(battleState, battleActions);
-    assertThat(offensiveAaFire.valid(), is(expected));
-    if (expected) {
+  @Nested
+  class IsValid {
+    @Test
+    void validIfAaIsAvailable() {
+      final BattleState battleState = givenBattleStateBuilder().offensiveAa(List.of(mock(Unit.class))).build();
+      final OffensiveAaFire offensiveAaFire = new OffensiveAaFire(battleState, battleActions);
+      assertThat(offensiveAaFire.valid(), is(true));
+    }
+
+    @Test
+    void notValidIfNoAaIsAvailable() {
+      final BattleState battleState = givenBattleStateBuilder().offensiveAa(List.of()).build();
+      final OffensiveAaFire offensiveAaFire = new OffensiveAaFire(battleState, battleActions);
+      assertThat(offensiveAaFire.valid(), is(false));
+    }
+  }
+
+  @Nested
+  class GetNames {
+    @Test
+    void hasNamesIfAaIsAvailable() {
+      final BattleState battleState = givenBattleStateBuilder().offensiveAa(List.of(givenUnitWithTypeAa())).build();
+      final OffensiveAaFire offensiveAaFire = new OffensiveAaFire(battleState, battleActions);
       assertThat(offensiveAaFire.getNames(), hasSize(3));
-    } else {
+    }
+
+    @Test
+    void hasNoNamesIfNoAaIsAvailable() {
+      final BattleState battleState = givenBattleStateBuilder().offensiveAa(List.of()).build();
+      final OffensiveAaFire offensiveAaFire = new OffensiveAaFire(battleState, battleActions);
       assertThat(offensiveAaFire.getNames(), hasSize(0));
     }
   }
 
-  static List<Arguments> testWhatIsValid() {
-    return List.of(
-        Arguments.of(
-            "No Offensive Aa", givenBattleStateBuilder().offensiveAa(List.of()).build(), false),
-        Arguments.of(
-            "Some Offensive Aa",
-            givenBattleStateBuilder().offensiveAa(List.of(givenUnitWithTypeAa())).build(),
-            true));
-  }
+  @Nested
+  class FireAa {
+    @Test
+    void firedIfAaAreAvailable() {
+      final OffensiveAaFire offensiveAaFire =
+          new OffensiveAaFire(
+              givenBattleStateBuilder().offensiveAa(List.of(mock(Unit.class))).build(),
+              battleActions);
 
-  @Test
-  void testFiringAaGuns() {
-    final OffensiveAaFire offensiveAaFire =
-        new OffensiveAaFire(
-            givenBattleStateBuilder().offensiveAa(List.of(mock(Unit.class))).build(),
-            battleActions);
+      offensiveAaFire.execute(executionStack, delegateBridge);
 
-    offensiveAaFire.execute(executionStack, delegateBridge);
+      verify(battleActions).fireOffensiveAaGuns();
+    }
 
-    verify(battleActions).fireOffensiveAaGuns();
+    @Test
+    void notFiredIfNoAaAreAvailable() {
+      final OffensiveAaFire offensiveAaFire =
+          new OffensiveAaFire(
+              givenBattleStateBuilder().offensiveAa(List.of()).build(),
+              battleActions);
+
+      offensiveAaFire.execute(executionStack, delegateBridge);
+
+      verify(battleActions, never()).fireOffensiveAaGuns();
+    }
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFireTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFireTest.java
@@ -33,12 +33,12 @@ class OffensiveAaFireTest {
   @MethodSource
   void testWhatIsValid(
       final String displayName, final BattleState battleState, final boolean expected) {
-    final OffensiveAaFire underTest = new OffensiveAaFire(battleState, battleActions);
-    assertThat(underTest.valid(), is(expected));
+    final OffensiveAaFire offensiveAaFire = new OffensiveAaFire(battleState, battleActions);
+    assertThat(offensiveAaFire.valid(), is(expected));
     if (expected) {
-      assertThat(underTest.getNames(), hasSize(3));
+      assertThat(offensiveAaFire.getNames(), hasSize(3));
     } else {
-      assertThat(underTest.getNames(), hasSize(0));
+      assertThat(offensiveAaFire.getNames(), hasSize(0));
     }
   }
 
@@ -54,12 +54,12 @@ class OffensiveAaFireTest {
 
   @Test
   void testFiringAaGuns() {
-    final OffensiveAaFire underTest =
+    final OffensiveAaFire offensiveAaFire =
         new OffensiveAaFire(
             givenBattleStateBuilder().offensiveAa(List.of(mock(Unit.class))).build(),
             battleActions);
 
-    underTest.execute(executionStack, delegateBridge);
+    offensiveAaFire.execute(executionStack, delegateBridge);
 
     verify(battleActions).fireOffensiveAaGuns();
   }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFireTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFireTest.java
@@ -1,0 +1,57 @@
+package games.strategy.triplea.delegate.battle.steps.fire.aa;
+
+import static games.strategy.triplea.delegate.battle.FakeBattleState.givenBattleStateBuilder;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.delegate.ExecutionStack;
+import games.strategy.triplea.delegate.battle.BattleActions;
+import games.strategy.triplea.delegate.battle.BattleState;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class OffensiveAaFireTest {
+
+  @Mock ExecutionStack executionStack;
+  @Mock IDelegateBridge delegateBridge;
+  @Mock BattleActions battleActions;
+
+  @ParameterizedTest(name = "[{index}] {0} is {2}")
+  @MethodSource
+  void testWhatIsValid(
+      final String displayName, final BattleState battleState, final boolean expected) {
+    final OffensiveAaFire underTest = new OffensiveAaFire(battleState, battleActions);
+    assertThat(underTest.valid(), is(expected));
+  }
+
+  static List<Arguments> testWhatIsValid() {
+    return List.of(
+        Arguments.of(
+            "No Offensive Aa", givenBattleStateBuilder().offensiveAa(List.of()).build(), false),
+        Arguments.of(
+            "Some Offensive Aa",
+            givenBattleStateBuilder().offensiveAa(List.of(mock(Unit.class))).build(),
+            true));
+  }
+
+  @Test
+  void testFiringAaGuns() {
+    final OffensiveAaFire underTest =
+        new OffensiveAaFire(givenBattleStateBuilder().build(), battleActions);
+
+    underTest.execute(executionStack, delegateBridge);
+
+    verify(battleActions).fireOffensiveAaGuns();
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirAttackVsNonSubsStepTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirAttackVsNonSubsStepTest.java
@@ -27,12 +27,12 @@ class AirAttackVsNonSubsStepTest {
   @MethodSource
   void testWhatIsValid(
       final String displayName, final BattleState battleState, final boolean expected) {
-    final AirAttackVsNonSubsStep underTest = new AirAttackVsNonSubsStep(battleState);
-    assertThat(underTest.valid(), is(expected));
+    final AirAttackVsNonSubsStep airAttackVsNonSubsStep = new AirAttackVsNonSubsStep(battleState);
+    assertThat(airAttackVsNonSubsStep.valid(), is(expected));
     if (expected) {
-      assertThat(underTest.getNames(), hasSize(1));
+      assertThat(airAttackVsNonSubsStep.getNames(), hasSize(1));
     } else {
-      assertThat(underTest.getNames(), hasSize(0));
+      assertThat(airAttackVsNonSubsStep.getNames(), hasSize(0));
     }
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirDefendVsNonSubsStepTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirDefendVsNonSubsStepTest.java
@@ -27,12 +27,12 @@ class AirDefendVsNonSubsStepTest {
   @MethodSource
   void testWhatIsValid(
       final String displayName, final BattleState battleState, final boolean expected) {
-    final AirDefendVsNonSubsStep underTest = new AirDefendVsNonSubsStep(battleState);
-    assertThat(underTest.valid(), is(expected));
+    final AirDefendVsNonSubsStep airDefendVsNonSubsStep = new AirDefendVsNonSubsStep(battleState);
+    assertThat(airDefendVsNonSubsStep.valid(), is(expected));
     if (expected) {
-      assertThat(underTest.getNames(), hasSize(1));
+      assertThat(airDefendVsNonSubsStep.getNames(), hasSize(1));
     } else {
-      assertThat(underTest.getNames(), hasSize(0));
+      assertThat(airDefendVsNonSubsStep.getNames(), hasSize(0));
     }
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStepTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStepTest.java
@@ -34,13 +34,13 @@ class SubmergeSubsVsOnlyAirStepTest {
   @MethodSource
   void testWhatIsValid(
       final String displayName, final BattleState battleState, final boolean expected) {
-    final SubmergeSubsVsOnlyAirStep underTest =
+    final SubmergeSubsVsOnlyAirStep submergeSubsVsOnlyAirStep =
         new SubmergeSubsVsOnlyAirStep(battleState, battleActions);
-    assertThat(underTest.valid(), is(expected));
+    assertThat(submergeSubsVsOnlyAirStep.valid(), is(expected));
     if (expected) {
-      assertThat(underTest.getNames(), hasSize(1));
+      assertThat(submergeSubsVsOnlyAirStep.getNames(), hasSize(1));
     } else {
-      assertThat(underTest.getNames(), hasSize(0));
+      assertThat(submergeSubsVsOnlyAirStep.getNames(), hasSize(0));
     }
   }
 
@@ -101,10 +101,10 @@ class SubmergeSubsVsOnlyAirStepTest {
       final BattleState battleState,
       final List<Unit> expectedSubmergingSubs,
       final boolean expectedSide) {
-    final SubmergeSubsVsOnlyAirStep underTest =
+    final SubmergeSubsVsOnlyAirStep submergeSubsVsOnlyAirStep =
         new SubmergeSubsVsOnlyAirStep(battleState, battleActions);
 
-    underTest.execute(executionStack, delegateBridge);
+    submergeSubsVsOnlyAirStep.execute(executionStack, delegateBridge);
 
     verify(battleActions).submergeUnits(expectedSubmergingSubs, expectedSide, delegateBridge);
   }


### PR DESCRIPTION
This converts the Offensive/Defensive AA Fire steps to the new BattleStep.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
I created a save file before a battle with AA guns, during AA casualty selection, after AA casualty selection, and after the battle.

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

