### PR TITLE
Convert bot start/stop scripts to use systemctl

### DIFF
--- a/infrastructure/ansible/roles/bot/templates/start-all.j2
+++ b/infrastructure/ansible/roles/bot/templates/start-all.j2
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 {% for item in bot_numbers %}
-sudo service bot@{{ item }} start
+sudo systemctl start bot@{{ item }}
 {% endfor %}

--- a/infrastructure/ansible/roles/bot/templates/stop-all.j2
+++ b/infrastructure/ansible/roles/bot/templates/stop-all.j2
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 {% for item in bot_numbers %}
-sudo service bot@{{ item }} stop
+sudo systemctl stop bot@{{ item }}
 {% endfor %}


### PR DESCRIPTION
'service' command is considered legacy, systemctl
is the preferred replacement.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

