### PR TITLE
Remove -x flag from report build status script

### DIFF
--- a/.travis/shared/report-build-status
+++ b/.travis/shared/report-build-status
@@ -17,7 +17,7 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ] || [ "$TRAVIS_BRANCH" != "master" ]; th
   exit 1
 fi
 
-set -eux
+set -eu
 
 # Should be one of {SUCCESS|FAILURE}
 RESULT=${1-}


### PR DESCRIPTION
Build output with -x flag is often useful, the report build status
script is pretty solid at this point and the logging it creates at
the tail of a failed build tends to be more noisy than useful.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

