### PR TITLE
Build fix, build artifacts from root folder

### DIFF
--- a/infrastructure/run_ansible_prerelease
+++ b/infrastructure/run_ansible_prerelease
@@ -36,7 +36,10 @@ function main() {
 }
 
 function buildArtifacts() {
-  ../gradlew :http-server:shadowJar :game-headless:shadowJar :lobby-db:release
+  (
+    cd ..
+    ./gradlew :http-server:shadowJar :game-headless:shadowJar :lobby-db:release
+  )
   copyBuildArtifact "../lobby-db/build/artifacts/migrations.zip" "ansible/roles/database/flyway/files/"
   copyBuildArtifact "../http-server/build/artifacts/triplea-http-server-$VERSION.jar" "ansible/roles/http_server/files/"
   copyBuildArtifact "../game-headless/build/artifacts/triplea-game-headless-$VERSION.jar" "ansible/roles/bot/files/"


### PR DESCRIPTION
Invoking gradle from a sub-folder that is not part of the
project fails. This update does a 'cd' up one folder
so we can build artifacts from root folder, then when
the subshell exits (parens), we'll back in the infrastructure
folder for subsequent commands.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

