### PR TITLE
Inline single-use-constant & remove unnecessary default constructor

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/image/ResourceImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/ResourceImageFactory.java
@@ -20,13 +20,10 @@ import org.triplea.java.collections.IntegerMap;
 public class ResourceImageFactory extends AbstractImageFactory {
 
   public static final int IMAGE_SIZE = 20;
-  private static final String FILE_NAME_BASE = "resources/";
-
-  public ResourceImageFactory() {}
 
   @Override
   protected String getFileNameBase() {
-    return FILE_NAME_BASE;
+    return "resources/";
   }
 
   public JLabel getLabel(final Resource resource, final IntegerMap<Resource> resources) {

--- a/game-core/src/main/java/games/strategy/triplea/image/TerritoryEffectImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/TerritoryEffectImageFactory.java
@@ -3,12 +3,8 @@ package games.strategy.triplea.image;
 /** Used to manage territory effect images. */
 public class TerritoryEffectImageFactory extends AbstractImageFactory {
 
-  static final String FILE_NAME_BASE = "territoryEffects/";
-
-  public TerritoryEffectImageFactory() {}
-
   @Override
   protected String getFileNameBase() {
-    return FILE_NAME_BASE;
+    return "territoryEffects/";
   }
 }


### PR DESCRIPTION
A single use constant that rephrases the method name that returns
that constant value is not extremely helpful and adds indirection.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

