### PR TITLE
Move fields to top of classes (before any inner classes)

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/util/BreadthFirstSearch.java
+++ b/game-core/src/main/java/games/strategy/engine/data/util/BreadthFirstSearch.java
@@ -16,6 +16,11 @@ import org.triplea.java.ObjectUtils;
  * visit() and shouldContinueSearch() for customizing the behavior.
  */
 public final class BreadthFirstSearch {
+  private final GameMap map;
+  private final Set<Territory> visited;
+  private final ArrayDeque<Territory> territoriesToCheck;
+  private final Predicate<Territory> neighborCondition;
+
   public abstract static class Visitor {
     /**
      * Called when a new territory is encountered.
@@ -35,11 +40,6 @@ public final class BreadthFirstSearch {
       return true;
     }
   }
-
-  private final GameMap map;
-  private final Set<Territory> visited;
-  private final ArrayDeque<Territory> territoriesToCheck;
-  private final Predicate<Territory> neighborCondition;
 
   /**
    * @param startTerritory The territory from where to start the search.

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/login/ClientLoginValidator.java
@@ -24,6 +24,9 @@ import org.triplea.util.Version;
 public final class ClientLoginValidator implements ILoginValidator {
   static final String PASSWORD_REQUIRED_PROPERTY = "Password Required";
 
+  @Setter private IServerMessenger serverMessenger;
+  private @Nullable String password;
+
   @VisibleForTesting
   interface ErrorMessages {
     String NO_ERROR = null;
@@ -31,9 +34,6 @@ public final class ClientLoginValidator implements ILoginValidator {
     String UNABLE_TO_OBTAIN_MAC = "Unable to obtain mac address";
     String YOU_HAVE_BEEN_BANNED = "The host has banned you from this game";
   }
-
-  @Setter private IServerMessenger serverMessenger;
-  private @Nullable String password;
 
   /** Set the password required for the game. If {@code null} or empty, no password is required. */
   public void setGamePassword(final @Nullable String password) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -28,23 +28,6 @@ import lombok.Value;
 public class UnitSupportAttachment extends DefaultAttachment {
   private static final long serialVersionUID = -3015679930172496082L;
 
-  /** Type to represent name and count */
-  @Value
-  public static class BonusType implements Serializable {
-    private static final long serialVersionUID = -7445551357956238314L;
-
-    @Nonnull String name;
-    @Nonnull Integer count;
-
-    public int getCount() {
-      return count < 0 ? Integer.MAX_VALUE : count;
-    }
-
-    boolean isOldArtilleryRule() {
-      return name.equals(Constants.OLD_ART_RULE_NAME);
-    }
-  }
-
   private Set<UnitType> unitType = null;
   private boolean offence = false;
   private boolean defence = false;
@@ -65,6 +48,23 @@ public class UnitSupportAttachment extends DefaultAttachment {
   // offence or defence
   private String side;
   private String faction;
+
+  /** Type to represent name and count */
+  @Value
+  public static class BonusType implements Serializable {
+    private static final long serialVersionUID = -7445551357956238314L;
+
+    @Nonnull String name;
+    @Nonnull Integer count;
+
+    public int getCount() {
+      return count < 0 ? Integer.MAX_VALUE : count;
+    }
+
+    boolean isOldArtilleryRule() {
+      return name.equals(Constants.OLD_ART_RULE_NAME);
+    }
+  }
 
   public UnitSupportAttachment(
       final String name, final Attachable attachable, final GameData gameData) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovableUnitsFilter.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovableUnitsFilter.java
@@ -33,6 +33,14 @@ import org.triplea.java.collections.CollectionUtils;
  * Utility class for filtering a unit list to the subset of those units that can move on a route.
  */
 final class MovableUnitsFilter {
+  private final GamePlayer player;
+  private final GameData data;
+  private final Route route;
+  private final boolean nonCombat;
+  private final MoveType moveType;
+  private final List<UndoableMove> undoableMoves;
+  private final Map<Unit, Collection<Unit>> dependentUnits;
+
   /** The result of the filter operation. */
   @Getter
   public static class FilterOperationResult {
@@ -80,14 +88,6 @@ final class MovableUnitsFilter {
     private final MoveValidationResult result;
     private final Collection<Unit> unitsWithDependents;
   }
-
-  private final GamePlayer player;
-  private final GameData data;
-  private final Route route;
-  private final boolean nonCombat;
-  private final MoveType moveType;
-  private final List<UndoableMove> undoableMoves;
-  private final Map<Unit, Collection<Unit>> dependentUnits;
 
   MovableUnitsFilter(
       final GameData data,

--- a/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/statistics/StatisticsDialog.java
@@ -18,6 +18,9 @@ import org.triplea.swing.JTabbedPaneBuilder;
 
 public class StatisticsDialog extends JPanel {
 
+  private final XYChartBuilder xyChartDefaults =
+      new XYChartBuilder().theme(Styler.ChartTheme.Matlab).xAxisTitle("#Rounds");
+
   @Getter
   @RequiredArgsConstructor
   private static class OverTimeChart {
@@ -25,9 +28,6 @@ public class StatisticsDialog extends JPanel {
     private final String axisTitle;
     private final Table<String, Round, Double> data;
   }
-
-  private final XYChartBuilder xyChartDefaults =
-      new XYChartBuilder().theme(Styler.ChartTheme.Matlab).xAxisTitle("#Rounds");
 
   public StatisticsDialog(final GameData game) {
     final Statistics statistics = new StatisticsAggregator(game).aggregate();

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/messages/envelopes/chat/ChatterListingMessage.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/messages/envelopes/chat/ChatterListingMessage.java
@@ -15,6 +15,8 @@ public class ChatterListingMessage implements WebSocketMessage {
   public static final MessageType<ChatterListingMessage> TYPE =
       MessageType.of(ChatterListingMessage.class);
 
+  private final List<Chatter> chatters;
+
   @Builder
   private static class Chatter {
     private final String userName;
@@ -22,8 +24,6 @@ public class ChatterListingMessage implements WebSocketMessage {
     private final boolean isModerator;
     private final String status;
   }
-
-  private final List<Chatter> chatters;
 
   public ChatterListingMessage(final Collection<ChatParticipant> chatParticipants) {
     chatters =

--- a/http-server/src/test/java/org/triplea/web/socket/MessageSenderTest.java
+++ b/http-server/src/test/java/org/triplea/web/socket/MessageSenderTest.java
@@ -21,6 +21,15 @@ import org.triplea.http.client.web.socket.messages.WebSocketMessage;
 @ExtendWith(MockitoExtension.class)
 class MessageSenderTest {
 
+  private static final MessageEnvelope MESSAGE_ENVELOPE =
+      new StringMessage("message!").toEnvelope();
+
+  private static final String SERVER_MESSAGE_JSON = new Gson().toJson(MESSAGE_ENVELOPE);
+
+  @Mock private Session session;
+  @Mock private RemoteEndpoint.Async asyncRemote;
+  @Mock private Future<Void> future;
+
   @AllArgsConstructor
   private static class StringMessage implements WebSocketMessage {
     private static final MessageType<StringMessage> TYPE = MessageType.of(StringMessage.class);
@@ -33,15 +42,6 @@ class MessageSenderTest {
       return MessageEnvelope.packageMessage(TYPE, this);
     }
   }
-
-  private static final MessageEnvelope MESSAGE_ENVELOPE =
-      new StringMessage("message!").toEnvelope();
-
-  private static final String SERVER_MESSAGE_JSON = new Gson().toJson(MESSAGE_ENVELOPE);
-
-  @Mock private Session session;
-  @Mock private RemoteEndpoint.Async asyncRemote;
-  @Mock private Future<Void> future;
 
   @Test
   void sendToOnlyOpenSession() {

--- a/http-server/src/test/java/org/triplea/web/socket/WebSocketMessagingBusTest.java
+++ b/http-server/src/test/java/org/triplea/web/socket/WebSocketMessagingBusTest.java
@@ -34,6 +34,11 @@ import org.triplea.http.client.web.socket.messages.envelopes.ServerErrorMessage;
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("InnerClassMayBeStatic")
 class WebSocketMessagingBusTest {
+  @Mock private Consumer<WebSocketMessageContext<BooleanMessage>> booleanMessageListener;
+  @Mock private Consumer<WebSocketMessageContext<BooleanMessage>> booleanMessageListenerSecond;
+  @Mock private Consumer<WebSocketMessageContext<StringMessage>> stringMessageListener;
+  @Mock private Session session;
+
   private static class StringMessage implements WebSocketMessage {
     private static final MessageType<StringMessage> TYPE = MessageType.of(StringMessage.class);
 
@@ -55,11 +60,6 @@ class WebSocketMessagingBusTest {
       return MessageEnvelope.packageMessage(TYPE, this);
     }
   }
-
-  @Mock private Consumer<WebSocketMessageContext<BooleanMessage>> booleanMessageListener;
-  @Mock private Consumer<WebSocketMessageContext<BooleanMessage>> booleanMessageListenerSecond;
-  @Mock private Consumer<WebSocketMessageContext<StringMessage>> stringMessageListener;
-  @Mock private Session session;
 
   @Nested
   class MessageListening {


### PR DESCRIPTION
Simply moves fields up higher in class to be before inner classes.
Resolves Codacy warning:
> Fields should be declared at the top of the class, before any method
declarations, constructors, initializers or inner classes.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

