### PR TITLE
Cleanup: remove unnecessary use fully qualified name

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
+++ b/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/UnifiedMessenger.java
@@ -291,7 +291,7 @@ public class UnifiedMessenger {
       synchronized (pendingLock) {
         results.put(methodId, spokeInvocationResults.results);
         final CountDownLatch latch = pendingInvocations.remove(methodId);
-        Preconditions.checkNotNull(
+        checkNotNull(
             latch,
             String.format(
                 "method id: %s, was not present in pending invocations: %s, "

--- a/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -520,7 +520,7 @@ class DiceRollTest {
   @Test
   void testHeavyBombersDefend() {
     gameData = TestMapGameData.IRON_BLITZ.getGameData();
-    final GamePlayer british = GameDataTestUtil.british(gameData);
+    final GamePlayer british = british(gameData);
     final IDelegateBridge testDelegateBridge = newDelegateBridge(british);
     TechTracker.addAdvance(
         british,

--- a/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -453,8 +453,8 @@ class RevisedTest {
     final Territory sz5 = gameData.getMap().getTerritory("5 Sea Zone");
     final Territory eastEurope = gameData.getMap().getTerritory("Eastern Europe");
     final Territory norway = gameData.getMap().getTerritory("Norway");
-    final UnitType infantryType = GameDataTestUtil.infantry(gameData);
-    final GamePlayer germans = GameDataTestUtil.germans(gameData);
+    final UnitType infantryType = infantry(gameData);
+    final GamePlayer germans = germans(gameData);
     final MoveDelegate moveDelegate = (MoveDelegate) gameData.getDelegate("move");
     final IDelegateBridge bridge = newDelegateBridge(germans);
     advanceToStep(bridge, "CombatMove");
@@ -538,10 +538,10 @@ class RevisedTest {
   @Test
   void testLoadUnloadAlliedTransport() {
     // you cant load and unload an allied transport the same turn
-    final UnitType infantryType = GameDataTestUtil.infantry(gameData);
+    final UnitType infantryType = infantry(gameData);
     final Territory eastEurope = gameData.getMap().getTerritory("Eastern Europe");
     // add japanese infantry to eastern europe
-    final GamePlayer japanese = GameDataTestUtil.japanese(gameData);
+    final GamePlayer japanese = japanese(gameData);
     final Change change = ChangeFactory.addUnits(eastEurope, infantryType.create(1, japanese));
     gameData.performChange(change);
     final Territory sz5 = gameData.getMap().getTerritory("5 Sea Zone");
@@ -852,8 +852,8 @@ class RevisedTest {
   void testStratBombCasualties() {
     final Territory germany = gameData.getMap().getTerritory("Germany");
     final Territory uk = gameData.getMap().getTerritory("United Kingdom");
-    final GamePlayer germans = GameDataTestUtil.germans(gameData);
-    final GamePlayer british = GameDataTestUtil.british(gameData);
+    final GamePlayer germans = germans(gameData);
+    final GamePlayer british = british(gameData);
     final BattleTracker tracker = new BattleTracker();
     final IBattle battle = new StrategicBombingRaidBattle(germany, gameData, british, tracker);
     final List<Unit> bombers = uk.getUnitCollection().getMatches(Matches.unitIsStrategicBomber());

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -206,7 +206,7 @@ class WW2V3Year41Test {
   @Test
   void testAaCasualtiesLowLuckMixedWithRollingRadar() {
     // moved from BattleCalculatorTest because "revised" does not have "radar"
-    final GamePlayer british = GameDataTestUtil.british(gameData);
+    final GamePlayer british = british(gameData);
     final IDelegateBridge bridge = newDelegateBridge(british);
     makeGameLowLuck(gameData);
     // setSelectAACasualties(data, false);
@@ -604,7 +604,7 @@ class WW2V3Year41Test {
     final IntegerMap<UnitType> map = new IntegerMap<>();
     map.add(aaGun, 1);
     // Set up the test
-    final GamePlayer germans = GameDataTestUtil.germans(gameData);
+    final GamePlayer germans = germans(gameData);
     delegateBridge = newDelegateBridge(germans);
     final PlaceDelegate placeDelegate = placeDelegate(gameData);
     advanceToStep(delegateBridge, "Place");
@@ -769,7 +769,7 @@ class WW2V3Year41Test {
     final Territory kiangsu = territory("Kiangsu", gameData);
     final Territory hupeh = territory("Hupeh", gameData);
     // Set up the unit types
-    final UnitType infantryType = GameDataTestUtil.infantry(gameData);
+    final UnitType infantryType = infantry(gameData);
     // Remove all units
     removeFrom(kiangsu, kiangsu.getUnits());
     // add a VALID attack


### PR DESCRIPTION
Items are already statically imported, we do not need to use
fully qualified name in such cases.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

