### PR TITLE
Replace for loops that can be converted to foreach with IntRange

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
@@ -15,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.stream.IntStream;
 
 /** An abstraction of MoveDelegate in order to allow other delegates to extend this. */
 public abstract class AbstractMoveDelegate extends BaseTripleADelegate implements IMoveDelegate {
@@ -94,9 +95,8 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
   }
 
   private void updateUndoableMoveIndexes() {
-    for (int i = 0; i < movesToUndo.size(); i++) {
-      movesToUndo.get(i).setIndex(i);
-    }
+    IntStream.range(0, movesToUndo.size()) //
+        .forEach(i -> movesToUndo.get(i).setIndex(i));
   }
 
   protected void updateUndoableMoves(final UndoableMove currentMove) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -30,6 +30,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.function.Predicate;
+import java.util.stream.IntStream;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.sound.SoundPath;
@@ -165,9 +166,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
   }
 
   private void updateUndoablePlacementIndexes() {
-    for (int i = 0; i < placements.size(); i++) {
-      placements.get(i).setIndex(i);
-    }
+    IntStream.range(0, placements.size()) //
+        .forEach(i -> placements.get(i).setIndex(i));
   }
 
   @Override


### PR DESCRIPTION
Resolves Codacy warning:
> This for loop can be replaced by a foreach loop

This update converts for loops that simply need to be executed
a set number of times to an IntRange (arguably an IntRange is more
direct towards that intent)


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

