### PR TITLE
Disable codeclimate check to start lists at beginning of line

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -24,6 +24,11 @@ plugins:
   # https://docs.codeclimate.com/docs/markdownlint
   markdownlint:
     enabled: true
+    checks:
+      MD006:
+        # Disable "Consider starting bulleted lists at the beginning of the line"
+        enabled: false
+
   # https://docs.codeclimate.com/docs/shellcheck
   shellcheck:
     enabled: true


### PR DESCRIPTION
This code climate rule conflicts with codacy, this update is to prefer
the codacy check that lists are indented.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
## Additional Review Notes

Resolves code climate violations triggered in: https://github.com/triplea-game/triplea/pull/6668
