### PR TITLE
Increase github issue truncation limit to its max

### DIFF
--- a/http-clients/src/main/java/org/triplea/http/client/github/issues/GithubIssueClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/github/issues/GithubIssueClient.java
@@ -19,10 +19,9 @@ public class GithubIssueClient {
    */
   public static final int TITLE_MAX_LENGTH = 125;
   /**
-   * Arbitrarily chosen large value to give us hopefully full details of just about any error report
-   * without getting to be too extremely long.
+   * Max length for github issue body text.
    */
-  public static final int REPORT_BODY_MAX_LENGTH = 20000;
+  public static final int REPORT_BODY_MAX_LENGTH = 65536;
 
   /** If this client is set to 'test' mode, we will return a stubbed response. */
   @VisibleForTesting


### PR DESCRIPTION
Affects error reports and where we truncate long messages. Typically
this will truncate very long stack traces. This update changes
the truncation threshold to the max that github allows for issue body.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

