### PR TITLE
Simplify parameters to getEmptyOrFriendlySeaNeighbors

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -1022,7 +1022,7 @@ public class MustFightBattle extends DependentBattle
 
   @VisibleForTesting
   protected Collection<Territory> getEmptyOrFriendlySeaNeighbors(
-      final GamePlayer player, final Collection<Unit> unitsToRetreat) {
+      final Collection<Unit> unitsToRetreat) {
     Collection<Territory> possible = gameData.getMap().getNeighbors(battleSite);
     if (headless) {
       return possible;
@@ -1035,7 +1035,7 @@ public class MustFightBattle extends DependentBattle
         };
     final Predicate<Territory> match =
         Matches.territoryIsWater()
-            .and(Matches.territoryHasNoEnemyUnits(player, gameData))
+            .and(Matches.territoryHasNoEnemyUnits(defender, gameData))
             .and(canalMatch);
     possible = CollectionUtils.getMatches(possible, match);
     return possible;
@@ -1601,7 +1601,6 @@ public class MustFightBattle extends DependentBattle
     if (!RetreatChecks.canDefenderRetreatSubs(
         attackingUnits,
         attackingWaitingToDie,
-        defender,
         defendingUnits,
         gameData,
         this::getEmptyOrFriendlySeaNeighbors)) {
@@ -1613,7 +1612,7 @@ public class MustFightBattle extends DependentBattle
           RetreatType.SUBS,
           bridge,
           getEmptyOrFriendlySeaNeighbors(
-              defender, CollectionUtils.getMatches(defendingUnits, Matches.unitCanEvade())));
+              CollectionUtils.getMatches(defendingUnits, Matches.unitCanEvade())));
     }
   }
 
@@ -1980,10 +1979,9 @@ public class MustFightBattle extends DependentBattle
               if (RetreatChecks.canDefenderRetreatSubs(
                       attackingUnits,
                       attackingWaitingToDie,
-                      defender,
                       defendingUnits,
                       gameData,
-                      (player, units) -> getEmptyOrFriendlySeaNeighbors(player, units))
+                      units -> getEmptyOrFriendlySeaNeighbors(units))
                   && !Properties.getSubRetreatBeforeBattle(gameData)) {
                 defenderRetreatSubs(bridge);
               }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleSteps.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleSteps.java
@@ -19,7 +19,6 @@ import games.strategy.triplea.delegate.battle.steps.retreat.sub.SubmergeSubsVsOn
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import lombok.Builder;
@@ -60,8 +59,7 @@ public class BattleSteps implements BattleStepStrings, BattleState {
   final @NonNull Boolean isBattleSiteWater;
   final @NonNull Boolean isAmphibious;
   final @NonNull Supplier<Collection<Territory>> getAttackerRetreatTerritories;
-  final @NonNull Function<Collection<Unit>, Collection<Territory>>
-      getEmptyOrFriendlySeaNeighbors;
+  final @NonNull Function<Collection<Unit>, Collection<Territory>> getEmptyOrFriendlySeaNeighbors;
   final @NonNull BattleActions battleActions;
 
   public List<String> get() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleSteps.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleSteps.java
@@ -60,7 +60,7 @@ public class BattleSteps implements BattleStepStrings, BattleState {
   final @NonNull Boolean isBattleSiteWater;
   final @NonNull Boolean isAmphibious;
   final @NonNull Supplier<Collection<Territory>> getAttackerRetreatTerritories;
-  final @NonNull BiFunction<GamePlayer, Collection<Unit>, Collection<Territory>>
+  final @NonNull Function<Collection<Unit>, Collection<Territory>>
       getEmptyOrFriendlySeaNeighbors;
   final @NonNull BattleActions battleActions;
 
@@ -232,7 +232,6 @@ public class BattleSteps implements BattleStepStrings, BattleState {
         if (RetreatChecks.canDefenderRetreatSubs(
             attackingUnits,
             attackingWaitingToDie,
-            defender,
             defendingUnits,
             gameData,
             getEmptyOrFriendlySeaNeighbors)) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/RetreatChecks.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/RetreatChecks.java
@@ -9,6 +9,7 @@ import games.strategy.triplea.delegate.Matches;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.function.Supplier;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
@@ -34,18 +35,16 @@ public class RetreatChecks {
   public static boolean canDefenderRetreatSubs(
       final @NonNull Collection<Unit> attackingUnits,
       final @NonNull Collection<Unit> attackingWaitingToDie,
-      final @NonNull GamePlayer defender,
       final @NonNull Collection<Unit> defendingUnits,
       final @NonNull GameData gameData,
-      final @NonNull BiFunction<GamePlayer, Collection<Unit>, Collection<Territory>>
-              getEmptyOrFriendlySeaNeighbors) {
+      final @NonNull Function<Collection<Unit>, Collection<Territory>>
+          getEmptyOrFriendlySeaNeighbors) {
     if (attackingUnits.stream().anyMatch(Matches.unitIsDestroyer())) {
       return false;
     }
     return attackingWaitingToDie.stream().noneMatch(Matches.unitIsDestroyer())
         && (getEmptyOrFriendlySeaNeighbors
                     .apply(
-                        defender,
                         CollectionUtils.getMatches(defendingUnits, Matches.unitCanEvade()))
                     .size()
                 != 0

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/RetreatChecks.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/RetreatChecks.java
@@ -1,14 +1,12 @@
 package games.strategy.triplea.delegate.battle.steps;
 
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.Matches;
 import java.util.Collection;
 import java.util.List;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import lombok.NonNull;
@@ -38,14 +36,13 @@ public class RetreatChecks {
       final @NonNull Collection<Unit> defendingUnits,
       final @NonNull GameData gameData,
       final @NonNull Function<Collection<Unit>, Collection<Territory>>
-          getEmptyOrFriendlySeaNeighbors) {
+              getEmptyOrFriendlySeaNeighbors) {
     if (attackingUnits.stream().anyMatch(Matches.unitIsDestroyer())) {
       return false;
     }
     return attackingWaitingToDie.stream().noneMatch(Matches.unitIsDestroyer())
         && (getEmptyOrFriendlySeaNeighbors
-                    .apply(
-                        CollectionUtils.getMatches(defendingUnits, Matches.unitCanEvade()))
+                    .apply(CollectionUtils.getMatches(defendingUnits, Matches.unitCanEvade()))
                     .size()
                 != 0
             || Properties.getSubmersibleSubs(gameData));

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleExecutablesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleExecutablesTest.java
@@ -685,7 +685,7 @@ class MustFightBattleExecutablesTest {
   void defendingSubsRetreatIfNoDestroyersAndCanRetreatBeforeBattle() {
     final MustFightBattle battle = spy(newBattle(WATER));
     doNothing().when(battle).queryRetreat(anyBoolean(), any(), any(), any());
-    doReturn(List.of(battleSite)).when(battle).getEmptyOrFriendlySeaNeighbors(any(), any());
+    doReturn(List.of(battleSite)).when(battle).getEmptyOrFriendlySeaNeighbors(any());
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(true);
 
     final Unit canEvadeUnit = givenUnitCanEvade();
@@ -735,7 +735,7 @@ class MustFightBattleExecutablesTest {
           + "SUB_RETREAT_BEFORE_BATTLE is true, SUBMERSIBLE_SUBS is false, and no retreat")
   void defendingSubsCanNotRetreatIfRetreatBeforeBattleAndSubmersibleAndNoRetreatTerritories() {
     final MustFightBattle battle = spy(newBattle(WATER));
-    doReturn(List.of()).when(battle).getEmptyOrFriendlySeaNeighbors(any(), any());
+    doReturn(List.of()).when(battle).getEmptyOrFriendlySeaNeighbors(any());
 
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(true);
     when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
@@ -792,7 +792,7 @@ class MustFightBattleExecutablesTest {
   void defendingFirstStrikeSubmergeBeforeBattleIfSubmersibleSubsAndRetreatBeforeBattle() {
     final MustFightBattle battle = spy(newBattle(WATER));
     doNothing().when(battle).queryRetreat(anyBoolean(), any(), any(), any());
-    doReturn(List.of()).when(battle).getEmptyOrFriendlySeaNeighbors(any(), any());
+    doReturn(List.of()).when(battle).getEmptyOrFriendlySeaNeighbors(any());
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(true);
     when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
     when(gameProperties.get(WW2V2, false)).thenReturn(false);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
@@ -51,7 +51,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -74,7 +73,7 @@ public class BattleStepsTest {
   @Mock Supplier<Collection<Territory>> getAttackerRetreatTerritories;
 
   @Mock
-  BiFunction<GamePlayer, Collection<Unit>, Collection<Territory>> getEmptyOrFriendlySeaNeighbors;
+  Function<Collection<Unit>, Collection<Territory>> getEmptyOrFriendlySeaNeighbors;
 
   @Mock Territory battleSite;
   @Mock GamePlayer attacker;
@@ -100,11 +99,11 @@ public class BattleStepsTest {
   }
 
   private void givenDefenderNoRetreatTerritories() {
-    when(getEmptyOrFriendlySeaNeighbors.apply(any(), any())).thenReturn(List.of());
+    when(getEmptyOrFriendlySeaNeighbors.apply(any())).thenReturn(List.of());
   }
 
   private void givenDefenderRetreatTerritories(final Territory... territories) {
-    when(getEmptyOrFriendlySeaNeighbors.apply(any(), any())).thenReturn(Arrays.asList(territories));
+    when(getEmptyOrFriendlySeaNeighbors.apply(any())).thenReturn(Arrays.asList(territories));
   }
 
   @Value

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
@@ -72,8 +72,7 @@ public class BattleStepsTest {
   @Mock Function<Collection<Unit>, Collection<Unit>> getDependentUnits;
   @Mock Supplier<Collection<Territory>> getAttackerRetreatTerritories;
 
-  @Mock
-  Function<Collection<Unit>, Collection<Territory>> getEmptyOrFriendlySeaNeighbors;
+  @Mock Function<Collection<Unit>, Collection<Territory>> getEmptyOrFriendlySeaNeighbors;
 
   @Mock Territory battleSite;
   @Mock GamePlayer attacker;


### PR DESCRIPTION
The value passed into the `player` parameter in getEmptyOrFriendlySeaNeighobrs is always the `defender`.  So this removes that parameter and just uses `defender`.  Simplifies a few places that call it.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

