### PR TITLE
Replace BattleStep#valid with BattleStep#getOrder

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -1102,7 +1102,7 @@ public class MustFightBattle extends DependentBattle
     final boolean defendingAa = canFireDefendingAa();
     final BattleStep offensiveAaStep = new OffensiveAaFire(this, this);
     final BattleStep defensiveAaStep = new DefensiveAaFire(this, this);
-    if (offensiveAaStep.valid()) {
+    if (offensiveAaStep.getOrder() != BattleStep.Order.SKIP) {
       steps.add(offensiveAaStep);
     }
     new IExecutable() {
@@ -1115,7 +1115,7 @@ public class MustFightBattle extends DependentBattle
         offensiveAaStep.execute(stack, bridge);
       }
     };
-    if (defensiveAaStep.valid()) {
+    if (defensiveAaStep.getOrder() != BattleStep.Order.SKIP) {
       steps.add(defensiveAaStep);
     }
     new IExecutable() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -1102,7 +1102,7 @@ public class MustFightBattle extends DependentBattle
     final boolean defendingAa = canFireDefendingAa();
     final BattleStep offensiveAaStep = new OffensiveAaFire(this, this);
     final BattleStep defensiveAaStep = new DefensiveAaFire(this, this);
-    if (offensiveAaStep.getOrder() != BattleStep.Order.SKIP) {
+    if (offensiveAaStep.getOrder() != BattleStep.Order.NOT_APPLICABLE) {
       steps.add(offensiveAaStep);
     }
     new IExecutable() {
@@ -1115,7 +1115,7 @@ public class MustFightBattle extends DependentBattle
         offensiveAaStep.execute(stack, bridge);
       }
     };
-    if (defensiveAaStep.getOrder() != BattleStep.Order.SKIP) {
+    if (defensiveAaStep.getOrder() != BattleStep.Order.NOT_APPLICABLE) {
       steps.add(defensiveAaStep);
     }
     new IExecutable() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -1102,9 +1102,7 @@ public class MustFightBattle extends DependentBattle
     final boolean defendingAa = canFireDefendingAa();
     final BattleStep offensiveAaStep = new OffensiveAaFire(this, this);
     final BattleStep defensiveAaStep = new DefensiveAaFire(this, this);
-    if (offensiveAaStep.getOrder() != BattleStep.Order.NOT_APPLICABLE) {
-      steps.add(offensiveAaStep);
-    }
+    steps.add(offensiveAaStep);
     new IExecutable() {
       private static final long serialVersionUID = 3802352588499530533L;
 
@@ -1115,9 +1113,7 @@ public class MustFightBattle extends DependentBattle
         offensiveAaStep.execute(stack, bridge);
       }
     };
-    if (defensiveAaStep.getOrder() != BattleStep.Order.NOT_APPLICABLE) {
-      steps.add(defensiveAaStep);
-    }
+    steps.add(defensiveAaStep);
     new IExecutable() {
       private static final long serialVersionUID = -1370090785540214199L;
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleStep.java
@@ -17,13 +17,19 @@ import java.util.List;
  */
 public interface BattleStep extends IExecutable {
 
+  enum Order {
+    // use this enum if the step should be skipped
+    SKIP,
+    AA_OFFENSIVE,
+    AA_DEFENSIVE,
+    SUBMERGE_SUBS_VS_ONLY_AIR,
+    AIR_OFFENSIVE_NON_SUBS,
+    AIR_DEFENSIVE_NON_SUBS,
+  }
+
   /** @return a list of names that will be shown in {@link games.strategy.triplea.ui.BattlePanel} */
   List<String> getNames();
 
-  /**
-   * Determine if this step should run based on the request
-   *
-   * @return true if valid
-   */
-  boolean valid();
+  /** @return The order in which this step should be called */
+  Order getOrder();
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleStep.java
@@ -19,7 +19,7 @@ public interface BattleStep extends IExecutable {
 
   enum Order {
     // use this enum if the step should be skipped
-    SKIP,
+    NOT_APPLICABLE,
     AA_OFFENSIVE,
     AA_DEFENSIVE,
     SUBMERGE_SUBS_VS_ONLY_AIR,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleStep.java
@@ -18,8 +18,6 @@ import java.util.List;
 public interface BattleStep extends IExecutable {
 
   enum Order {
-    // use this enum if the step should be skipped
-    NOT_APPLICABLE,
     AA_OFFENSIVE,
     AA_DEFENSIVE,
     SUBMERGE_SUBS_VS_ONLY_AIR,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleSteps.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleSteps.java
@@ -71,9 +71,12 @@ public class BattleSteps implements BattleStepStrings, BattleState {
     final BattleStep airDefendVsNonSubs = new AirDefendVsNonSubsStep(this);
 
     final List<String> steps = new ArrayList<>();
-    steps.addAll(offensiveAaStep.getNames());
-
-    steps.addAll(defensiveAaStep.getNames());
+    if (offensiveAaStep.getOrder() != BattleStep.Order.SKIP) {
+      steps.addAll(offensiveAaStep.getNames());
+    }
+    if (defensiveAaStep.getOrder() != BattleStep.Order.SKIP) {
+      steps.addAll(defensiveAaStep.getNames());
+    }
 
     if (showFirstRun) {
       if (!isBattleSiteWater && !bombardingUnits.isEmpty()) {
@@ -109,7 +112,9 @@ public class BattleSteps implements BattleStepStrings, BattleState {
             || defendingUnits.stream().anyMatch(Matches.unitIsTransport()))) {
       steps.add(REMOVE_UNESCORTED_TRANSPORTS);
     }
-    steps.addAll(submergeSubsVsOnlyAir.getNames());
+    if (submergeSubsVsOnlyAir.getOrder() != BattleStep.Order.SKIP) {
+      steps.addAll(submergeSubsVsOnlyAir.getNames());
+    }
 
     final boolean defenderSubsFireFirst =
         SubsChecks.defenderSubsFireFirst(attackingUnits, defendingUnits, gameData);
@@ -161,7 +166,9 @@ public class BattleSteps implements BattleStepStrings, BattleState {
       steps.add(REMOVE_SNEAK_ATTACK_CASUALTIES);
     }
 
-    steps.addAll(airAttackVsNonSubs.getNames());
+    if (airAttackVsNonSubs.getOrder() != BattleStep.Order.SKIP) {
+      steps.addAll(airAttackVsNonSubs.getNames());
+    }
 
     if (attackingUnits.stream().anyMatch(Matches.unitIsFirstStrike().negate())) {
       steps.add(attacker.getName() + FIRE);
@@ -178,7 +185,9 @@ public class BattleSteps implements BattleStepStrings, BattleState {
       steps.add(defender.getName() + FIRST_STRIKE_UNITS_FIRE);
       steps.add(attacker.getName() + SELECT_FIRST_STRIKE_CASUALTIES);
     }
-    steps.addAll(airDefendVsNonSubs.getNames());
+    if (airDefendVsNonSubs.getOrder() != BattleStep.Order.SKIP) {
+      steps.addAll(airDefendVsNonSubs.getNames());
+    }
     if (defendingUnits.stream().anyMatch(Matches.unitIsFirstStrike().negate())) {
       steps.add(defender.getName() + FIRE);
       steps.add(attacker.getName() + SELECT_CASUALTIES);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleSteps.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleSteps.java
@@ -71,12 +71,8 @@ public class BattleSteps implements BattleStepStrings, BattleState {
     final BattleStep airDefendVsNonSubs = new AirDefendVsNonSubsStep(this);
 
     final List<String> steps = new ArrayList<>();
-    if (offensiveAaStep.getOrder() != BattleStep.Order.NOT_APPLICABLE) {
-      steps.addAll(offensiveAaStep.getNames());
-    }
-    if (defensiveAaStep.getOrder() != BattleStep.Order.NOT_APPLICABLE) {
-      steps.addAll(defensiveAaStep.getNames());
-    }
+    steps.addAll(offensiveAaStep.getNames());
+    steps.addAll(defensiveAaStep.getNames());
 
     if (showFirstRun) {
       if (!isBattleSiteWater && !bombardingUnits.isEmpty()) {
@@ -112,9 +108,7 @@ public class BattleSteps implements BattleStepStrings, BattleState {
             || defendingUnits.stream().anyMatch(Matches.unitIsTransport()))) {
       steps.add(REMOVE_UNESCORTED_TRANSPORTS);
     }
-    if (submergeSubsVsOnlyAir.getOrder() != BattleStep.Order.NOT_APPLICABLE) {
-      steps.addAll(submergeSubsVsOnlyAir.getNames());
-    }
+    steps.addAll(submergeSubsVsOnlyAir.getNames());
 
     final boolean defenderSubsFireFirst =
         SubsChecks.defenderSubsFireFirst(attackingUnits, defendingUnits, gameData);
@@ -166,9 +160,7 @@ public class BattleSteps implements BattleStepStrings, BattleState {
       steps.add(REMOVE_SNEAK_ATTACK_CASUALTIES);
     }
 
-    if (airAttackVsNonSubs.getOrder() != BattleStep.Order.NOT_APPLICABLE) {
-      steps.addAll(airAttackVsNonSubs.getNames());
-    }
+    steps.addAll(airAttackVsNonSubs.getNames());
 
     if (attackingUnits.stream().anyMatch(Matches.unitIsFirstStrike().negate())) {
       steps.add(attacker.getName() + FIRE);
@@ -185,9 +177,7 @@ public class BattleSteps implements BattleStepStrings, BattleState {
       steps.add(defender.getName() + FIRST_STRIKE_UNITS_FIRE);
       steps.add(attacker.getName() + SELECT_FIRST_STRIKE_CASUALTIES);
     }
-    if (airDefendVsNonSubs.getOrder() != BattleStep.Order.NOT_APPLICABLE) {
-      steps.addAll(airDefendVsNonSubs.getNames());
-    }
+    steps.addAll(airDefendVsNonSubs.getNames());
     if (defendingUnits.stream().anyMatch(Matches.unitIsFirstStrike().negate())) {
       steps.add(defender.getName() + FIRE);
       steps.add(attacker.getName() + SELECT_CASUALTIES);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleSteps.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleSteps.java
@@ -71,10 +71,10 @@ public class BattleSteps implements BattleStepStrings, BattleState {
     final BattleStep airDefendVsNonSubs = new AirDefendVsNonSubsStep(this);
 
     final List<String> steps = new ArrayList<>();
-    if (offensiveAaStep.getOrder() != BattleStep.Order.SKIP) {
+    if (offensiveAaStep.getOrder() != BattleStep.Order.NOT_APPLICABLE) {
       steps.addAll(offensiveAaStep.getNames());
     }
-    if (defensiveAaStep.getOrder() != BattleStep.Order.SKIP) {
+    if (defensiveAaStep.getOrder() != BattleStep.Order.NOT_APPLICABLE) {
       steps.addAll(defensiveAaStep.getNames());
     }
 
@@ -112,7 +112,7 @@ public class BattleSteps implements BattleStepStrings, BattleState {
             || defendingUnits.stream().anyMatch(Matches.unitIsTransport()))) {
       steps.add(REMOVE_UNESCORTED_TRANSPORTS);
     }
-    if (submergeSubsVsOnlyAir.getOrder() != BattleStep.Order.SKIP) {
+    if (submergeSubsVsOnlyAir.getOrder() != BattleStep.Order.NOT_APPLICABLE) {
       steps.addAll(submergeSubsVsOnlyAir.getNames());
     }
 
@@ -166,7 +166,7 @@ public class BattleSteps implements BattleStepStrings, BattleState {
       steps.add(REMOVE_SNEAK_ATTACK_CASUALTIES);
     }
 
-    if (airAttackVsNonSubs.getOrder() != BattleStep.Order.SKIP) {
+    if (airAttackVsNonSubs.getOrder() != BattleStep.Order.NOT_APPLICABLE) {
       steps.addAll(airAttackVsNonSubs.getNames());
     }
 
@@ -185,7 +185,7 @@ public class BattleSteps implements BattleStepStrings, BattleState {
       steps.add(defender.getName() + FIRST_STRIKE_UNITS_FIRE);
       steps.add(attacker.getName() + SELECT_FIRST_STRIKE_CASUALTIES);
     }
-    if (airDefendVsNonSubs.getOrder() != BattleStep.Order.SKIP) {
+    if (airDefendVsNonSubs.getOrder() != BattleStep.Order.NOT_APPLICABLE) {
       steps.addAll(airDefendVsNonSubs.getNames());
     }
     if (defendingUnits.stream().anyMatch(Matches.unitIsFirstStrike().negate())) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/AaFireAndCasualtyStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/AaFireAndCasualtyStep.java
@@ -26,6 +26,9 @@ public abstract class AaFireAndCasualtyStep implements BattleStep {
   @Override
   public List<String> getNames() {
     final List<String> steps = new ArrayList<>();
+    if (!valid()) {
+      return steps;
+    }
     for (final String typeAa : UnitAttachment.getAllOfTypeAas(aaGuns())) {
       steps.add(firingPlayer().getName() + " " + typeAa + AA_GUNS_FIRE_SUFFIX);
       steps.add(firedAtPlayer().getName() + SELECT_PREFIX + typeAa + CASUALTIES_SUFFIX);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/AaFireAndCasualtyStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/AaFireAndCasualtyStep.java
@@ -26,9 +26,6 @@ public abstract class AaFireAndCasualtyStep implements BattleStep {
   @Override
   public List<String> getNames() {
     final List<String> steps = new ArrayList<>();
-    if (!valid()) {
-      return steps;
-    }
     for (final String typeAa : UnitAttachment.getAllOfTypeAas(aaGuns())) {
       steps.add(firingPlayer().getName() + " " + typeAa + AA_GUNS_FIRE_SUFFIX);
       steps.add(firedAtPlayer().getName() + SELECT_PREFIX + typeAa + CASUALTIES_SUFFIX);
@@ -37,8 +34,7 @@ public abstract class AaFireAndCasualtyStep implements BattleStep {
     return steps;
   }
 
-  @Override
-  public boolean valid() {
+  protected boolean valid() {
     return !aaGuns().isEmpty();
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFire.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFire.java
@@ -17,6 +17,11 @@ public class DefensiveAaFire extends AaFireAndCasualtyStep {
   }
 
   @Override
+  public Order getOrder() {
+    return valid() ? Order.AA_DEFENSIVE : Order.SKIP;
+  }
+
+  @Override
   public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
     if (valid()) {
       battleActions.fireDefensiveAaGuns();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFire.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFire.java
@@ -18,7 +18,7 @@ public class DefensiveAaFire extends AaFireAndCasualtyStep {
 
   @Override
   public Order getOrder() {
-    return valid() ? Order.AA_DEFENSIVE : Order.SKIP;
+    return valid() ? Order.AA_DEFENSIVE : Order.NOT_APPLICABLE;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFire.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFire.java
@@ -18,7 +18,7 @@ public class DefensiveAaFire extends AaFireAndCasualtyStep {
 
   @Override
   public Order getOrder() {
-    return valid() ? Order.AA_DEFENSIVE : Order.NOT_APPLICABLE;
+    return Order.AA_DEFENSIVE;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFire.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFire.java
@@ -17,6 +17,11 @@ public class OffensiveAaFire extends AaFireAndCasualtyStep {
   }
 
   @Override
+  public Order getOrder() {
+    return valid() ? Order.AA_OFFENSIVE : Order.SKIP;
+  }
+
+  @Override
   public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
     if (valid()) {
       battleActions.fireOffensiveAaGuns();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFire.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFire.java
@@ -18,7 +18,7 @@ public class OffensiveAaFire extends AaFireAndCasualtyStep {
 
   @Override
   public Order getOrder() {
-    return valid() ? Order.AA_OFFENSIVE : Order.SKIP;
+    return valid() ? Order.AA_OFFENSIVE : Order.NOT_APPLICABLE;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFire.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFire.java
@@ -18,7 +18,7 @@ public class OffensiveAaFire extends AaFireAndCasualtyStep {
 
   @Override
   public Order getOrder() {
-    return valid() ? Order.AA_OFFENSIVE : Order.NOT_APPLICABLE;
+    return Order.AA_OFFENSIVE;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirAttackVsNonSubsStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirAttackVsNonSubsStep.java
@@ -18,7 +18,7 @@ public class AirAttackVsNonSubsStep extends AirVsNonSubsStep {
 
   @Override
   public Order getOrder() {
-    return valid() ? Order.AIR_OFFENSIVE_NON_SUBS : Order.SKIP;
+    return valid() ? Order.AIR_OFFENSIVE_NON_SUBS : Order.NOT_APPLICABLE;
   }
 
   private boolean valid() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirAttackVsNonSubsStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirAttackVsNonSubsStep.java
@@ -13,12 +13,12 @@ public class AirAttackVsNonSubsStep extends AirVsNonSubsStep {
 
   @Override
   public List<String> getNames() {
-    return List.of(AIR_ATTACK_NON_SUBS);
+    return valid() ? List.of(AIR_ATTACK_NON_SUBS) : List.of();
   }
 
   @Override
   public Order getOrder() {
-    return valid() ? Order.AIR_OFFENSIVE_NON_SUBS : Order.NOT_APPLICABLE;
+    return Order.AIR_OFFENSIVE_NON_SUBS;
   }
 
   private boolean valid() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirAttackVsNonSubsStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirAttackVsNonSubsStep.java
@@ -13,11 +13,15 @@ public class AirAttackVsNonSubsStep extends AirVsNonSubsStep {
 
   @Override
   public List<String> getNames() {
-    return valid() ? List.of(AIR_ATTACK_NON_SUBS) : List.of();
+    return List.of(AIR_ATTACK_NON_SUBS);
   }
 
   @Override
-  public boolean valid() {
+  public Order getOrder() {
+    return valid() ? Order.AIR_OFFENSIVE_NON_SUBS : Order.SKIP;
+  }
+
+  private boolean valid() {
     return airWillMissSubs(battleState.getAttackingUnits(), battleState.getDefendingUnits());
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirDefendVsNonSubsStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirDefendVsNonSubsStep.java
@@ -13,11 +13,15 @@ public class AirDefendVsNonSubsStep extends AirVsNonSubsStep {
 
   @Override
   public List<String> getNames() {
-    return valid() ? List.of(AIR_DEFEND_NON_SUBS) : List.of();
+    return List.of(AIR_DEFEND_NON_SUBS);
   }
 
   @Override
-  public boolean valid() {
+  public Order getOrder() {
+    return valid() ? Order.AIR_DEFENSIVE_NON_SUBS : Order.SKIP;
+  }
+
+  private boolean valid() {
     return airWillMissSubs(battleState.getDefendingUnits(), battleState.getAttackingUnits());
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirDefendVsNonSubsStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirDefendVsNonSubsStep.java
@@ -13,12 +13,12 @@ public class AirDefendVsNonSubsStep extends AirVsNonSubsStep {
 
   @Override
   public List<String> getNames() {
-    return List.of(AIR_DEFEND_NON_SUBS);
+    return valid() ? List.of(AIR_DEFEND_NON_SUBS) : List.of();
   }
 
   @Override
   public Order getOrder() {
-    return valid() ? Order.AIR_DEFENSIVE_NON_SUBS : Order.NOT_APPLICABLE;
+    return Order.AIR_DEFENSIVE_NON_SUBS;
   }
 
   private boolean valid() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirDefendVsNonSubsStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirDefendVsNonSubsStep.java
@@ -18,7 +18,7 @@ public class AirDefendVsNonSubsStep extends AirVsNonSubsStep {
 
   @Override
   public Order getOrder() {
-    return valid() ? Order.AIR_DEFENSIVE_NON_SUBS : Order.SKIP;
+    return valid() ? Order.AIR_DEFENSIVE_NON_SUBS : Order.NOT_APPLICABLE;
   }
 
   private boolean valid() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStep.java
@@ -30,12 +30,12 @@ public class SubmergeSubsVsOnlyAirStep implements BattleStep {
 
   @Override
   public List<String> getNames() {
-    return List.of(SUBMERGE_SUBS_VS_AIR_ONLY);
+    return valid() ? List.of(SUBMERGE_SUBS_VS_AIR_ONLY) : List.of();
   }
 
   @Override
   public Order getOrder() {
-    return valid() ? Order.SUBMERGE_SUBS_VS_ONLY_AIR : Order.NOT_APPLICABLE;
+    return Order.SUBMERGE_SUBS_VS_ONLY_AIR;
   }
 
   private boolean valid() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStep.java
@@ -35,7 +35,7 @@ public class SubmergeSubsVsOnlyAirStep implements BattleStep {
 
   @Override
   public Order getOrder() {
-    return valid() ? Order.SUBMERGE_SUBS_VS_ONLY_AIR : Order.SKIP;
+    return valid() ? Order.SUBMERGE_SUBS_VS_ONLY_AIR : Order.NOT_APPLICABLE;
   }
 
   private boolean valid() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStep.java
@@ -30,11 +30,15 @@ public class SubmergeSubsVsOnlyAirStep implements BattleStep {
 
   @Override
   public List<String> getNames() {
-    return valid() ? List.of(SUBMERGE_SUBS_VS_AIR_ONLY) : List.of();
+    return List.of(SUBMERGE_SUBS_VS_AIR_ONLY);
   }
 
   @Override
-  public boolean valid() {
+  public Order getOrder() {
+    return valid() ? Order.SUBMERGE_SUBS_VS_ONLY_AIR : Order.SKIP;
+  }
+
+  private boolean valid() {
     return (isOnlyAirVsSubs(battleState.getAttackingUnits(), battleState.getDefendingUnits())
         || isOnlyAirVsSubs(battleState.getDefendingUnits(), battleState.getAttackingUnits()));
   }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleExecutablesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleExecutablesTest.java
@@ -350,9 +350,7 @@ class MustFightBattleExecutablesTest {
         is(0));
 
     assertThat(
-        "FireDefensiveAaGuns should be second step",
-        getIndex(execs, DefensiveAaFire.class),
-        is(1));
+        "FireDefensiveAaGuns should be second step", getIndex(execs, DefensiveAaFire.class), is(1));
 
     assertThat(
         "ClearAaWaitingToDieAndDamagedChangesInto is after FireOffensiveAaGuns",

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleExecutablesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleExecutablesTest.java
@@ -350,11 +350,14 @@ class MustFightBattleExecutablesTest {
         is(0));
 
     assertThat(
-        "ClearAaWaitingToDieAndDamagedChangesInto is after FireOffensiveAaGuns",
-        getIndex(execs, MustFightBattle.ClearAaWaitingToDieAndDamagedChangesInto.class),
+        "FireDefensiveAaGuns should be second step",
+        getIndex(execs, DefensiveAaFire.class),
         is(1));
 
-    assertThatStepIsMissing(execs, DefensiveAaFire.class);
+    assertThat(
+        "ClearAaWaitingToDieAndDamagedChangesInto is after FireOffensiveAaGuns",
+        getIndex(execs, MustFightBattle.ClearAaWaitingToDieAndDamagedChangesInto.class),
+        is(2));
   }
 
   @Test
@@ -382,16 +385,19 @@ class MustFightBattleExecutablesTest {
     final List<IExecutable> execs = battle.getBattleExecutables(true);
 
     assertThat(
+        "FireOffensiveAaGuns should be the first step",
+        getIndex(execs, OffensiveAaFire.class),
+        is(0));
+
+    assertThat(
         "FireDefensiveAaGuns should be the first step",
         getIndex(execs, DefensiveAaFire.class),
-        is(0));
+        is(1));
 
     assertThat(
         "ClearAaWaitingToDieAndDamagedChangesInto is after FireDefensiveAaGuns",
         getIndex(execs, MustFightBattle.ClearAaWaitingToDieAndDamagedChangesInto.class),
-        is(1));
-
-    assertThatStepIsMissing(execs, OffensiveAaFire.class);
+        is(2));
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFireTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFireTest.java
@@ -1,8 +1,9 @@
 package games.strategy.triplea.delegate.battle.steps.fire.aa;
 
 import static games.strategy.triplea.delegate.battle.FakeBattleState.givenBattleStateBuilder;
+import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitWithTypeAa;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -12,7 +13,6 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
-import games.strategy.triplea.delegate.battle.steps.BattleStep.Order;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -30,18 +30,18 @@ class DefensiveAaFireTest {
   @Nested
   class GetOrder {
     @Test
-    void aaDefensiveIfAaIsAvailable() {
+    void hasNamesIfAaIsAvailable() {
       final BattleState battleState =
-          givenBattleStateBuilder().defendingAa(List.of(mock(Unit.class))).build();
+          givenBattleStateBuilder().defendingAa(List.of(givenUnitWithTypeAa())).build();
       final DefensiveAaFire defensiveAaFire = new DefensiveAaFire(battleState, battleActions);
-      assertThat(defensiveAaFire.getOrder(), is(Order.AA_DEFENSIVE));
+      assertThat(defensiveAaFire.getNames(), hasSize(3));
     }
 
     @Test
-    void skipIfNoAaIsAvailable() {
+    void hasNoNamesIfNoAaIsAvailable() {
       final BattleState battleState = givenBattleStateBuilder().defendingAa(List.of()).build();
       final DefensiveAaFire defensiveAaFire = new DefensiveAaFire(battleState, battleActions);
-      assertThat(defensiveAaFire.getOrder(), is(Order.NOT_APPLICABLE));
+      assertThat(defensiveAaFire.getNames(), hasSize(0));
     }
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFireTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFireTest.java
@@ -28,7 +28,7 @@ class DefensiveAaFireTest {
   @Mock BattleActions battleActions;
 
   @Nested
-  class GetOrder {
+  class GetNames {
     @Test
     void hasNamesIfAaIsAvailable() {
       final BattleState battleState =

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFireTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFireTest.java
@@ -41,7 +41,7 @@ class DefensiveAaFireTest {
     void skipIfNoAaIsAvailable() {
       final BattleState battleState = givenBattleStateBuilder().defendingAa(List.of()).build();
       final DefensiveAaFire defensiveAaFire = new DefensiveAaFire(battleState, battleActions);
-      assertThat(defensiveAaFire.getOrder(), is(Order.SKIP));
+      assertThat(defensiveAaFire.getOrder(), is(Order.NOT_APPLICABLE));
     }
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFireTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/DefensiveAaFireTest.java
@@ -1,9 +1,7 @@
 package games.strategy.triplea.delegate.battle.steps.fire.aa;
 
 import static games.strategy.triplea.delegate.battle.FakeBattleState.givenBattleStateBuilder;
-import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitWithTypeAa;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -14,6 +12,7 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
+import games.strategy.triplea.delegate.battle.steps.BattleStep.Order;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -29,38 +28,20 @@ class DefensiveAaFireTest {
   @Mock BattleActions battleActions;
 
   @Nested
-  class IsValid {
+  class GetOrder {
     @Test
-    void validIfAaIsAvailable() {
+    void aaDefensiveIfAaIsAvailable() {
       final BattleState battleState =
           givenBattleStateBuilder().defendingAa(List.of(mock(Unit.class))).build();
       final DefensiveAaFire defensiveAaFire = new DefensiveAaFire(battleState, battleActions);
-      assertThat(defensiveAaFire.valid(), is(true));
+      assertThat(defensiveAaFire.getOrder(), is(Order.AA_DEFENSIVE));
     }
 
     @Test
-    void notValidIfNoAaIsAvailable() {
+    void skipIfNoAaIsAvailable() {
       final BattleState battleState = givenBattleStateBuilder().defendingAa(List.of()).build();
       final DefensiveAaFire defensiveAaFire = new DefensiveAaFire(battleState, battleActions);
-      assertThat(defensiveAaFire.valid(), is(false));
-    }
-  }
-
-  @Nested
-  class GetNames {
-    @Test
-    void hasNamesIfAaIsAvailable() {
-      final BattleState battleState =
-          givenBattleStateBuilder().defendingAa(List.of(givenUnitWithTypeAa())).build();
-      final DefensiveAaFire defensiveAaFire = new DefensiveAaFire(battleState, battleActions);
-      assertThat(defensiveAaFire.getNames(), hasSize(3));
-    }
-
-    @Test
-    void hasNoNamesIfNoAaIsAvailable() {
-      final BattleState battleState = givenBattleStateBuilder().defendingAa(List.of()).build();
-      final DefensiveAaFire defensiveAaFire = new DefensiveAaFire(battleState, battleActions);
-      assertThat(defensiveAaFire.getNames(), hasSize(0));
+      assertThat(defensiveAaFire.getOrder(), is(Order.SKIP));
     }
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFireTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFireTest.java
@@ -1,9 +1,7 @@
 package games.strategy.triplea.delegate.battle.steps.fire.aa;
 
 import static games.strategy.triplea.delegate.battle.FakeBattleState.givenBattleStateBuilder;
-import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitWithTypeAa;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -14,6 +12,7 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
+import games.strategy.triplea.delegate.battle.steps.BattleStep.Order;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -29,38 +28,20 @@ class OffensiveAaFireTest {
   @Mock BattleActions battleActions;
 
   @Nested
-  class IsValid {
+  class GetStep {
     @Test
-    void validIfAaIsAvailable() {
+    void aaOffensiveIfAaIsAvailable() {
       final BattleState battleState =
           givenBattleStateBuilder().offensiveAa(List.of(mock(Unit.class))).build();
       final OffensiveAaFire offensiveAaFire = new OffensiveAaFire(battleState, battleActions);
-      assertThat(offensiveAaFire.valid(), is(true));
+      assertThat(offensiveAaFire.getOrder(), is(Order.AA_OFFENSIVE));
     }
 
     @Test
-    void notValidIfNoAaIsAvailable() {
+    void skipIfNoAaIsAvailable() {
       final BattleState battleState = givenBattleStateBuilder().offensiveAa(List.of()).build();
       final OffensiveAaFire offensiveAaFire = new OffensiveAaFire(battleState, battleActions);
-      assertThat(offensiveAaFire.valid(), is(false));
-    }
-  }
-
-  @Nested
-  class GetNames {
-    @Test
-    void hasNamesIfAaIsAvailable() {
-      final BattleState battleState =
-          givenBattleStateBuilder().offensiveAa(List.of(givenUnitWithTypeAa())).build();
-      final OffensiveAaFire offensiveAaFire = new OffensiveAaFire(battleState, battleActions);
-      assertThat(offensiveAaFire.getNames(), hasSize(3));
-    }
-
-    @Test
-    void hasNoNamesIfNoAaIsAvailable() {
-      final BattleState battleState = givenBattleStateBuilder().offensiveAa(List.of()).build();
-      final OffensiveAaFire offensiveAaFire = new OffensiveAaFire(battleState, battleActions);
-      assertThat(offensiveAaFire.getNames(), hasSize(0));
+      assertThat(offensiveAaFire.getOrder(), is(Order.SKIP));
     }
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFireTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFireTest.java
@@ -28,7 +28,7 @@ class OffensiveAaFireTest {
   @Mock BattleActions battleActions;
 
   @Nested
-  class GetStep {
+  class GetNames {
     @Test
     void hasNamesIfAaIsAvailable() {
       final BattleState battleState =
@@ -38,7 +38,7 @@ class OffensiveAaFireTest {
     }
 
     @Test
-    void hasNoNamesNoAaIsAvailable() {
+    void hasNoNamesIfNoAaIsAvailable() {
       final BattleState battleState = givenBattleStateBuilder().offensiveAa(List.of()).build();
       final OffensiveAaFire offensiveAaFire = new OffensiveAaFire(battleState, battleActions);
       assertThat(offensiveAaFire.getNames(), hasSize(0));

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFireTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFireTest.java
@@ -41,7 +41,7 @@ class OffensiveAaFireTest {
     void skipIfNoAaIsAvailable() {
       final BattleState battleState = givenBattleStateBuilder().offensiveAa(List.of()).build();
       final OffensiveAaFire offensiveAaFire = new OffensiveAaFire(battleState, battleActions);
-      assertThat(offensiveAaFire.getOrder(), is(Order.SKIP));
+      assertThat(offensiveAaFire.getOrder(), is(Order.NOT_APPLICABLE));
     }
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFireTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/OffensiveAaFireTest.java
@@ -1,8 +1,9 @@
 package games.strategy.triplea.delegate.battle.steps.fire.aa;
 
 import static games.strategy.triplea.delegate.battle.FakeBattleState.givenBattleStateBuilder;
+import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitWithTypeAa;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -12,7 +13,6 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
-import games.strategy.triplea.delegate.battle.steps.BattleStep.Order;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -30,18 +30,18 @@ class OffensiveAaFireTest {
   @Nested
   class GetStep {
     @Test
-    void aaOffensiveIfAaIsAvailable() {
+    void hasNamesIfAaIsAvailable() {
       final BattleState battleState =
-          givenBattleStateBuilder().offensiveAa(List.of(mock(Unit.class))).build();
+          givenBattleStateBuilder().offensiveAa(List.of(givenUnitWithTypeAa())).build();
       final OffensiveAaFire offensiveAaFire = new OffensiveAaFire(battleState, battleActions);
-      assertThat(offensiveAaFire.getOrder(), is(Order.AA_OFFENSIVE));
+      assertThat(offensiveAaFire.getNames(), hasSize(3));
     }
 
     @Test
-    void skipIfNoAaIsAvailable() {
+    void hasNoNamesNoAaIsAvailable() {
       final BattleState battleState = givenBattleStateBuilder().offensiveAa(List.of()).build();
       final OffensiveAaFire offensiveAaFire = new OffensiveAaFire(battleState, battleActions);
-      assertThat(offensiveAaFire.getOrder(), is(Order.NOT_APPLICABLE));
+      assertThat(offensiveAaFire.getNames(), hasSize(0));
     }
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirAttackVsNonSubsStepTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirAttackVsNonSubsStepTest.java
@@ -6,13 +6,12 @@ import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.given
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitDestroyer;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitIsAir;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.mock;
 
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.delegate.battle.BattleState;
-import games.strategy.triplea.delegate.battle.steps.BattleStep.Order;
 import java.util.List;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -25,14 +24,12 @@ class AirAttackVsNonSubsStepTest {
 
   @ParameterizedTest(name = "[{index}] {0} is {2}")
   @MethodSource
-  void stepOrder(final String displayName, final BattleState battleState, final boolean expected) {
+  void stepName(final String displayName, final BattleState battleState, final boolean expected) {
     final AirAttackVsNonSubsStep airAttackVsNonSubsStep = new AirAttackVsNonSubsStep(battleState);
-    assertThat(
-        airAttackVsNonSubsStep.getOrder(),
-        is(expected ? Order.AIR_OFFENSIVE_NON_SUBS : Order.NOT_APPLICABLE));
+    assertThat(airAttackVsNonSubsStep.getNames(), hasSize(expected ? 1 : 0));
   }
 
-  static List<Arguments> stepOrder() {
+  static List<Arguments> stepName() {
     return List.of(
         Arguments.of(
             "Attacker has air units and no destroyers vs Defender subs",

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirAttackVsNonSubsStepTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirAttackVsNonSubsStepTest.java
@@ -29,7 +29,7 @@ class AirAttackVsNonSubsStepTest {
     final AirAttackVsNonSubsStep airAttackVsNonSubsStep = new AirAttackVsNonSubsStep(battleState);
     assertThat(
         airAttackVsNonSubsStep.getOrder(),
-        is(expected ? Order.AIR_OFFENSIVE_NON_SUBS : Order.SKIP));
+        is(expected ? Order.AIR_OFFENSIVE_NON_SUBS : Order.NOT_APPLICABLE));
   }
 
   static List<Arguments> stepOrder() {

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirAttackVsNonSubsStepTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirAttackVsNonSubsStepTest.java
@@ -6,13 +6,13 @@ import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.given
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitDestroyer;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitIsAir;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.delegate.battle.BattleState;
+import games.strategy.triplea.delegate.battle.steps.BattleStep.Order;
 import java.util.List;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -25,18 +25,14 @@ class AirAttackVsNonSubsStepTest {
 
   @ParameterizedTest(name = "[{index}] {0} is {2}")
   @MethodSource
-  void testWhatIsValid(
-      final String displayName, final BattleState battleState, final boolean expected) {
+  void stepOrder(final String displayName, final BattleState battleState, final boolean expected) {
     final AirAttackVsNonSubsStep airAttackVsNonSubsStep = new AirAttackVsNonSubsStep(battleState);
-    assertThat(airAttackVsNonSubsStep.valid(), is(expected));
-    if (expected) {
-      assertThat(airAttackVsNonSubsStep.getNames(), hasSize(1));
-    } else {
-      assertThat(airAttackVsNonSubsStep.getNames(), hasSize(0));
-    }
+    assertThat(
+        airAttackVsNonSubsStep.getOrder(),
+        is(expected ? Order.AIR_OFFENSIVE_NON_SUBS : Order.SKIP));
   }
 
-  static List<Arguments> testWhatIsValid() {
+  static List<Arguments> stepOrder() {
     return List.of(
         Arguments.of(
             "Attacker has air units and no destroyers vs Defender subs",

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirDefendVsNonSubsStepTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirDefendVsNonSubsStepTest.java
@@ -29,7 +29,7 @@ class AirDefendVsNonSubsStepTest {
     final AirDefendVsNonSubsStep airDefendVsNonSubsStep = new AirDefendVsNonSubsStep(battleState);
     assertThat(
         airDefendVsNonSubsStep.getOrder(),
-        is(expected ? Order.AIR_DEFENSIVE_NON_SUBS : Order.SKIP));
+        is(expected ? Order.AIR_DEFENSIVE_NON_SUBS : Order.NOT_APPLICABLE));
   }
 
   static List<Arguments> stepOrder() {

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirDefendVsNonSubsStepTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirDefendVsNonSubsStepTest.java
@@ -6,13 +6,13 @@ import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.given
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitDestroyer;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitIsAir;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.delegate.battle.BattleState;
+import games.strategy.triplea.delegate.battle.steps.BattleStep.Order;
 import java.util.List;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -25,18 +25,14 @@ class AirDefendVsNonSubsStepTest {
 
   @ParameterizedTest(name = "[{index}] {0} is {2}")
   @MethodSource
-  void testWhatIsValid(
-      final String displayName, final BattleState battleState, final boolean expected) {
+  void stepOrder(final String displayName, final BattleState battleState, final boolean expected) {
     final AirDefendVsNonSubsStep airDefendVsNonSubsStep = new AirDefendVsNonSubsStep(battleState);
-    assertThat(airDefendVsNonSubsStep.valid(), is(expected));
-    if (expected) {
-      assertThat(airDefendVsNonSubsStep.getNames(), hasSize(1));
-    } else {
-      assertThat(airDefendVsNonSubsStep.getNames(), hasSize(0));
-    }
+    assertThat(
+        airDefendVsNonSubsStep.getOrder(),
+        is(expected ? Order.AIR_DEFENSIVE_NON_SUBS : Order.SKIP));
   }
 
-  static List<Arguments> testWhatIsValid() {
+  static List<Arguments> stepOrder() {
     return List.of(
         Arguments.of(
             "Defender has air units and no destroyers vs Attacker subs",

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirDefendVsNonSubsStepTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirDefendVsNonSubsStepTest.java
@@ -6,13 +6,12 @@ import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.given
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitDestroyer;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitIsAir;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.mock;
 
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.delegate.battle.BattleState;
-import games.strategy.triplea.delegate.battle.steps.BattleStep.Order;
 import java.util.List;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -25,14 +24,12 @@ class AirDefendVsNonSubsStepTest {
 
   @ParameterizedTest(name = "[{index}] {0} is {2}")
   @MethodSource
-  void stepOrder(final String displayName, final BattleState battleState, final boolean expected) {
+  void stepName(final String displayName, final BattleState battleState, final boolean expected) {
     final AirDefendVsNonSubsStep airDefendVsNonSubsStep = new AirDefendVsNonSubsStep(battleState);
-    assertThat(
-        airDefendVsNonSubsStep.getOrder(),
-        is(expected ? Order.AIR_DEFENSIVE_NON_SUBS : Order.NOT_APPLICABLE));
+    assertThat(airDefendVsNonSubsStep.getNames(), hasSize(expected ? 1 : 0));
   }
 
-  static List<Arguments> stepOrder() {
+  static List<Arguments> stepName() {
     return List.of(
         Arguments.of(
             "Defender has air units and no destroyers vs Attacker subs",

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStepTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStepTest.java
@@ -5,7 +5,7 @@ import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.given
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitCanEvadeAndCanNotBeTargetedByRandomUnit;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitIsAir;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
@@ -14,7 +14,6 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
-import games.strategy.triplea.delegate.battle.steps.BattleStep.Order;
 import java.util.List;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -32,15 +31,13 @@ class SubmergeSubsVsOnlyAirStepTest {
 
   @ParameterizedTest(name = "[{index}] {0} is {2}")
   @MethodSource
-  void stepOrder(final String displayName, final BattleState battleState, final boolean expected) {
+  void stepName(final String displayName, final BattleState battleState, final boolean expected) {
     final SubmergeSubsVsOnlyAirStep submergeSubsVsOnlyAirStep =
         new SubmergeSubsVsOnlyAirStep(battleState, battleActions);
-    assertThat(
-        submergeSubsVsOnlyAirStep.getOrder(),
-        is(expected ? Order.SUBMERGE_SUBS_VS_ONLY_AIR : Order.NOT_APPLICABLE));
+    assertThat(submergeSubsVsOnlyAirStep.getNames(), hasSize(1));
   }
 
-  static List<Arguments> stepOrder() {
+  static List<Arguments> stepName() {
     return List.of(
         Arguments.of(
             "Attacking evaders vs NO air",

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStepTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStepTest.java
@@ -5,7 +5,6 @@ import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.given
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitCanEvadeAndCanNotBeTargetedByRandomUnit;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitIsAir;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -15,6 +14,7 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
+import games.strategy.triplea.delegate.battle.steps.BattleStep.Order;
 import java.util.List;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -32,19 +32,15 @@ class SubmergeSubsVsOnlyAirStepTest {
 
   @ParameterizedTest(name = "[{index}] {0} is {2}")
   @MethodSource
-  void testWhatIsValid(
-      final String displayName, final BattleState battleState, final boolean expected) {
+  void stepOrder(final String displayName, final BattleState battleState, final boolean expected) {
     final SubmergeSubsVsOnlyAirStep submergeSubsVsOnlyAirStep =
         new SubmergeSubsVsOnlyAirStep(battleState, battleActions);
-    assertThat(submergeSubsVsOnlyAirStep.valid(), is(expected));
-    if (expected) {
-      assertThat(submergeSubsVsOnlyAirStep.getNames(), hasSize(1));
-    } else {
-      assertThat(submergeSubsVsOnlyAirStep.getNames(), hasSize(0));
-    }
+    assertThat(
+        submergeSubsVsOnlyAirStep.getOrder(),
+        is(expected ? Order.SUBMERGE_SUBS_VS_ONLY_AIR : Order.SKIP));
   }
 
-  static List<Arguments> testWhatIsValid() {
+  static List<Arguments> stepOrder() {
     return List.of(
         Arguments.of(
             "Attacking evaders vs NO air",
@@ -96,7 +92,7 @@ class SubmergeSubsVsOnlyAirStepTest {
 
   @ParameterizedTest(name = "[{index}] {0}")
   @MethodSource
-  void testSubmerging(
+  void submergeUnits(
       final String displayName,
       final BattleState battleState,
       final List<Unit> expectedSubmergingSubs,
@@ -109,7 +105,7 @@ class SubmergeSubsVsOnlyAirStepTest {
     verify(battleActions).submergeUnits(expectedSubmergingSubs, expectedSide, delegateBridge);
   }
 
-  static List<Arguments> testSubmerging() {
+  static List<Arguments> submergeUnits() {
     final Unit sub = givenUnitCanEvadeAndCanNotBeTargetedByRandomUnit();
     return List.of(
         Arguments.of(

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStepTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStepTest.java
@@ -34,7 +34,7 @@ class SubmergeSubsVsOnlyAirStepTest {
   void stepName(final String displayName, final BattleState battleState, final boolean expected) {
     final SubmergeSubsVsOnlyAirStep submergeSubsVsOnlyAirStep =
         new SubmergeSubsVsOnlyAirStep(battleState, battleActions);
-    assertThat(submergeSubsVsOnlyAirStep.getNames(), hasSize(1));
+    assertThat(submergeSubsVsOnlyAirStep.getNames(), hasSize(expected ? 1 : 0));
   }
 
   static List<Arguments> stepName() {

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStepTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStepTest.java
@@ -37,7 +37,7 @@ class SubmergeSubsVsOnlyAirStepTest {
         new SubmergeSubsVsOnlyAirStep(battleState, battleActions);
     assertThat(
         submergeSubsVsOnlyAirStep.getOrder(),
-        is(expected ? Order.SUBMERGE_SUBS_VS_ONLY_AIR : Order.SKIP));
+        is(expected ? Order.SUBMERGE_SUBS_VS_ONLY_AIR : Order.NOT_APPLICABLE));
   }
 
   static List<Arguments> stepOrder() {


### PR DESCRIPTION
I discovered that some steps have different `valid` conditions depending on if it is called at the beginning of a round during `getNames` or later during `execute`.  An example is the offensive sub submerge/withdraw.  During `getNames`, it shouldn't care about the presence of a destroyer because the destroyer could be killed later.  But during `execute`, it must care about the presence of a destroyer.

So, this removes the `valid` method from the `BattleStep` interface.

But since I still need to know if a step should be visible or not, I've added a `getOrder` method.  If a step should be skipped, then it can return the enum `NOT_APPLICABLE`.  Otherwise, it should return the order it should be run in.  All of the existing steps that have been converted only return `SKIP` or one other enum.  But other steps will return different enums depending on their situation (eg. subs can submerge at the beginning of the round or at the end).

Once all the steps have been converted, then I should be able to get the step names with code like:
```
List<BattleStep> steps = new ArrayList<>();
steps.add(new OffensiveAaFire(this, battleActions));
steps.add(new DefensiveAaFire(this, battleActions));
steps.add(new ...);
steps.add(new ...);

List<String> stepNames = steps.stream()
        .filter(step -> step.getOrder() != BattleStep.Order.NOT_APPLICABLE)
        .sorted(Comparator.comparing(BattleStep::getOrder))
        .flatMap(step -> step.getNames().stream())
        .collect(Collectors.toList());
```

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

