### PR TITLE
Bump latest and lobby version to 20026

### DIFF
--- a/servers.yml
+++ b/servers.yml
@@ -1,6 +1,6 @@
-latest: 2.0.19800
+latest: 2.0.20026
 servers:
-  - version: "2.0.19800"
+  - version: "2.0.20026"
     lobby_uri: https://prod2-lobby.triplea-game.org
     message: |
       Welcome to the TripleA 2.0 lobby!


### PR DESCRIPTION
Picks up change where we drop the password column and
hash passwords on client side. sets latest to 20026 to
notify users of a new version.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[x] Other:  Deployment & version change <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

