### PR TITLE
Throttle code climate similar code threshold to 80, avoid warnings on imports

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -10,6 +10,9 @@ checks:
   method-lines:
     config:
       threshold: 30
+  similar-code:
+    config:
+      threshold: 80
 plugins:
   # https://docs.codeclimate.com/docs/git-legal
   git-legal:


### PR DESCRIPTION
Code climate is detecting similar code warnings in imports with masses ranging
from 55 to 75. Generally, 4 to 5 lines of similar imports is not something
we want to change. This update throttles the similar code threshold to be
less sensitive, to a value that will omit these false positives (a value of 80)


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

