### PR TITLE
Remove comment that was attached to code long deleted

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -2174,8 +2174,6 @@ public class MustFightBattle extends DependentBattle
     if (retreatTo != null) {
       // if attacker retreating non subs then its all over
       if (!defender && !subs && !planes && !partialAmphib) {
-        // this is illegal in ww2v2 revised and beyond (the fighters should die). still checking if
-        // illegal in classic.
         isOver = true;
       }
       if (!headless) {


### PR DESCRIPTION
This comment was added when a method was commented out that is now deleted

The method was ensureAttackingAirCanRetreat(bridge); and it was
commented out and the comment added back in 2012 in commit
https://github.com/triplea-game/triplea/commit/5e08943f6a766e04e9675b55f2c191210836d762#diff-895095e078e7763b8b467774750abc45R1449.

The commented out call to ensureAttackingAirCanRetreat(bridge); was
removed in 2017 in commit https://github.com/triplea-game/triplea/commit/5b5db78177dcb75c9ac4189623695fc053344dcb#diff-0ebfd4b6aefa1709451d2b0f04a323ffL1465. But
this related comment was not removed with it.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

