### PR TITLE
Remove alliedTransport check in end of battle situation

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -1830,30 +1830,8 @@ public class MustFightBattle extends DependentBattle
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             if (CollectionUtils.getMatches(attackingUnits, Matches.unitIsNotInfrastructure()).size()
                 == 0) {
-              if (!Properties.getTransportCasualtiesRestricted(gameData)) {
-                endBattle(bridge);
-                defenderWins(bridge);
-              } else {
-                // Get all allied transports in the territory
-                final Predicate<Unit> matchAllied =
-                    Matches.unitIsTransport()
-                        .and(Matches.unitIsNotCombatTransport())
-                        .and(Matches.isUnitAllied(attacker, gameData));
-                final List<Unit> alliedTransports =
-                    CollectionUtils.getMatches(battleSite.getUnits(), matchAllied);
-                // If no transports, just end the battle
-                if (alliedTransports.isEmpty()) {
-                  endBattle(bridge);
-                  defenderWins(bridge);
-                } else if (round <= 1) {
-                  attackingUnits =
-                      CollectionUtils.getMatches(
-                          battleSite.getUnits(), Matches.unitIsOwnedBy(attacker));
-                } else {
-                  endBattle(bridge);
-                  defenderWins(bridge);
-                }
-              }
+              endBattle(bridge);
+              defenderWins(bridge);
             } else if (CollectionUtils.getMatches(defendingUnits, Matches.unitIsNotInfrastructure())
                     .size()
                 == 0) {


### PR DESCRIPTION
This is pulling out a change that I had done as part of the "Shared code for Battle Tree Estimator" PR (https://github.com/triplea-game/triplea/pull/6520).  I'm reproducing here what I commented there (https://github.com/triplea-game/triplea/pull/6520#discussion_r430489294):


I've gone through the git history and I think the alliedTransport check is a bug. The code used to also do the undefended transport check and when that was refactored, this alliedTransport part forgotten.

I came up with a situation where this would happen in a game and played it out and got a weird state in the game. The situation is where your ally has a transport that has your land units in it and is next to a country that has an enemy factory. On the enemies turn, a ship is produced in the same sea zone. When the production is after combat, the two ships (enemy ship and allied transport) stay around. On your turn, you move a ship into the zone and initiate a combat. If your ship dies in the first round, you get an option to retreat because this code added your transported land units to the attacking units and they aren't dead. If you retreat, your transported land units are moved by themselves. I believe that is a bug.

I think the alliedTransport check should be removed.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

