### PR TITLE
Fix empty map selection rendering bug

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
@@ -40,11 +40,11 @@ public class GameChooser extends JDialog {
     final JList<GameChooserEntry> gameList = new JList<>(gameChooserModel);
     if (gameName == null || gameName.equals("-")) {
       gameList.setSelectedIndex(0);
-      return;
+    } else {
+      gameChooserModel
+          .findByName(gameName)
+          .ifPresent(entry -> gameList.setSelectedValue(entry, true));
     }
-    gameChooserModel
-        .findByName(gameName)
-        .ifPresent(entry -> gameList.setSelectedValue(entry, true));
     setLayout(new BorderLayout());
 
     final JSplitPane mainSplit = new JSplitPane();


### PR DESCRIPTION
Fixes a problem where map selection screen renders blank.
This is caused by bad handling of no-map selected case
where an early return statement was introduced. Instead
the code should go on to render the map selection screen,
this update fixes that.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

