### PR TITLE
Restore deprecated map property costPu

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -9,6 +9,7 @@ import games.strategy.engine.data.MutableProperty;
 import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.Constants;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -25,6 +26,13 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
   // a key referring to politicaltexts.properties or other .properties for all the UI messages
   // belonging to this action.
   protected String text = "";
+  /**
+   * The cost in PUs to attempt this action.
+   *
+   * @deprecated Replaced by costResources. The value is here only for backward compatibility with
+   *     possibly old map downloads that still have this value.
+   */
+  @Deprecated protected int costPu = 0;
   // cost in any resources to attempt this action
   protected IntegerMap<Resource> costResources = new IntegerMap<>();
   // how many times can you perform this action each round?
@@ -62,6 +70,27 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
 
   private void resetText() {
     text = "";
+  }
+
+  @Deprecated
+  private void setCostPu(final String s) {
+    setCostPu(getInt(s));
+  }
+
+  @Deprecated
+  public void setCostPu(final Integer s) {
+    final Resource r = getData().getResourceList().getResource(Constants.PUS);
+    costResources.put(r, s);
+  }
+
+  @Deprecated
+  public int getCostPu() {
+    return costPu;
+  }
+
+  @Deprecated
+  private void resetCostPu() {
+    costPu = 0;
   }
 
   private void setCostResources(final String value) throws GameParseException {
@@ -186,6 +215,12 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
         .put("text", MutableProperty.ofString(this::setText, this::getText, this::resetText))
+        .put("costPU",
+            MutableProperty.of(
+                this::setCostPu,
+                this::setCostPu,
+                this::getCostPu,
+                this::resetCostPu))
         .put(
             "costResources",
             MutableProperty.of(

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractUserActionAttachment.java
@@ -215,12 +215,10 @@ public abstract class AbstractUserActionAttachment extends AbstractConditionsAtt
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .putAll(super.getPropertyMap())
         .put("text", MutableProperty.ofString(this::setText, this::getText, this::resetText))
-        .put("costPU",
+        .put(
+            "costPU",
             MutableProperty.of(
-                this::setCostPu,
-                this::setCostPu,
-                this::getCostPu,
-                this::resetCostPu))
+                this::setCostPu, this::setCostPu, this::getCostPu, this::resetCostPu))
         .put(
             "costResources",
             MutableProperty.of(


### PR DESCRIPTION
Some players might have ancient maps, the error from the missing property
is non-obvious to recover from. Furthermore, there is misleading error
messaging that the map is not present and a prompt to download, which
might not even result in a fix and then another error when the
game becomes the default selection.

This problem speaks to being able to version maps for when they are
not forward compatible and to be able to download engine specific versions.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

