### PR TITLE
Add more NPE fixes to game selector model

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
@@ -60,7 +60,10 @@ public class GameSelectorModel extends Observable implements GameSelector {
 
   public void load(final GameChooserEntry entry) {
     fileName = null;
-    if (entry == null || entry.getGameData().getGameName() == null || entry.getUri() == null) {
+    if (entry == null
+        || entry.getGameData() == null
+        || entry.getGameData().getGameName() == null
+        || entry.getUri() == null) {
       ClientSetting.defaultGameName.resetValue();
       ClientSetting.defaultGameUri.resetValue();
     } else {


### PR DESCRIPTION
It appears gameData must be nullable in some cases, was able
to trigger a NPE after selecting a map, quitting, deleting
that map, then reloading.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

