### PR TITLE
Add missing serialVersionUID in battle steps

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/AaFireAndCasualtyStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/AaFireAndCasualtyStep.java
@@ -18,6 +18,7 @@ import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
 public abstract class AaFireAndCasualtyStep implements BattleStep {
+  private static final long serialVersionUID = -3195299749378932928L;
 
   protected final BattleState battleState;
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirAttackVsNonSubsStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirAttackVsNonSubsStep.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 /** Air can not attack subs unless a destroyer is present */
 public class AirAttackVsNonSubsStep extends AirVsNonSubsStep {
+  private static final long serialVersionUID = 4273449622231941896L;
+
   public AirAttackVsNonSubsStep(final BattleState battleState) {
     super(battleState);
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirDefendVsNonSubsStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirDefendVsNonSubsStep.java
@@ -7,6 +7,8 @@ import java.util.List;
 
 /** Air can not attack subs unless a destroyer is present */
 public class AirDefendVsNonSubsStep extends AirVsNonSubsStep {
+  private static final long serialVersionUID = -7965786276905309057L;
+
   public AirDefendVsNonSubsStep(final BattleState battleState) {
     super(battleState);
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirVsNonSubsStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/air/AirVsNonSubsStep.java
@@ -12,6 +12,7 @@ import lombok.AllArgsConstructor;
 /** Air can not attack subs unless a destroyer is present */
 @AllArgsConstructor
 public abstract class AirVsNonSubsStep implements BattleStep {
+  private static final long serialVersionUID = 4641526323094044712L;
 
   protected final BattleState battleState;
 


### PR DESCRIPTION
I noticed that some of the battle steps and parent classes didn't have an explicit serialVersionUID.  This is something I missed when I created the classes.  This adds an explicit serialVersionUID.

The `AaFireAndCasualtyStep` class is the only one that is currently being stored as part of a saved game.  I worked out what its serialVersionUID is and explicitly set it to that.  I tested it by saving a game with an `AaFireAndCasualtyStep` in the stack and then loading that with this branch.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->
Saved a game during the AA phases in the battle and then loaded that game in this branch.  The game loaded without issues.  The other step classes aren't currently part of the saved game.

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

