### PR TITLE
Move NavalBombardment to individual BattleStep classes

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/AbstractBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/AbstractBattle.java
@@ -39,7 +39,7 @@ abstract class AbstractBattle implements IBattle {
    */
   boolean headless = false;
 
-  final Territory battleSite;
+  @Getter final Territory battleSite;
   final GamePlayer attacker;
   GamePlayer defender;
   final BattleTracker battleTracker;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleActions.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleActions.java
@@ -20,4 +20,6 @@ public interface BattleActions {
       RetreatType retreatType,
       IDelegateBridge bridge,
       Collection<Territory> initialAvailableTerritories);
+
+  void fireNavalBombardment(IDelegateBridge bridge);
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
@@ -9,6 +9,10 @@ import java.util.Collection;
 /** Exposes the battle state and allows updates to it */
 public interface BattleState {
 
+  int getBattleRound();
+
+  Territory getBattleSite();
+
   Collection<Unit> getAttackingUnits();
 
   Collection<Unit> getDefendingUnits();
@@ -18,6 +22,8 @@ public interface BattleState {
   Collection<Unit> getOffensiveAa();
 
   Collection<Unit> getDefendingAa();
+
+  Collection<Unit> getBombardingUnits();
 
   GamePlayer getAttacker();
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -33,6 +33,7 @@ import games.strategy.triplea.delegate.battle.steps.BattleStep;
 import games.strategy.triplea.delegate.battle.steps.BattleSteps;
 import games.strategy.triplea.delegate.battle.steps.RetreatChecks;
 import games.strategy.triplea.delegate.battle.steps.SubsChecks;
+import games.strategy.triplea.delegate.battle.steps.fire.NavalBombardment;
 import games.strategy.triplea.delegate.battle.steps.fire.aa.DefensiveAaFire;
 import games.strategy.triplea.delegate.battle.steps.fire.aa.OffensiveAaFire;
 import games.strategy.triplea.delegate.battle.steps.retreat.OffensiveSubsRetreat;
@@ -91,16 +92,6 @@ public class MustFightBattle extends DependentBattle
    */
   public abstract static class ClearAaWaitingToDieAndDamagedChangesInto implements IExecutable {
     private static final long serialVersionUID = -3223166334485741752L;
-  }
-
-  /**
-   * An action representing naval bombardment during a battle.
-   *
-   * <p>NOTE: This type exists solely for tests to interrogate the execution stack looking for an
-   * action of this type.
-   */
-  public abstract static class FireNavalBombardment implements IExecutable {
-    private static final long serialVersionUID = -4807027908694648211L;
   }
 
   /**
@@ -881,7 +872,7 @@ public class MustFightBattle extends DependentBattle
       updateDefendingAaUnits();
     }
     return BattleSteps.builder()
-        .showFirstRun(showFirstRun)
+        .battleRound(round)
         .attacker(attacker)
         .defender(defender)
         .offensiveAa(getOffensiveAa())
@@ -894,7 +885,6 @@ public class MustFightBattle extends DependentBattle
         .gameData(gameData)
         .bombardingUnits(bombardingUnits)
         .getDependentUnits(this::getDependentUnits)
-        .isBattleSiteWater(battleSite.isWater())
         .isAmphibious(isAmphibious)
         .getAttackerRetreatTerritories(this::getAttackerRetreatTerritories)
         .getEmptyOrFriendlySeaNeighbors(this::getEmptyOrFriendlySeaNeighbors)
@@ -1099,6 +1089,7 @@ public class MustFightBattle extends DependentBattle
     if (defendingAa == null) {
       updateDefendingAaUnits();
     }
+    final BattleStep navalBombardment = new NavalBombardment(this, this);
     final boolean offensiveAa = canFireOffensiveAa();
     final boolean defendingAa = canFireDefendingAa();
     final BattleStep offensiveAaStep = new OffensiveAaFire(this, this);
@@ -1147,16 +1138,18 @@ public class MustFightBattle extends DependentBattle
             }
           });
     }
-    if (firstRun) {
-      steps.add(
-          new FireNavalBombardment() {
-            private static final long serialVersionUID = -2255284529092427441L;
+    steps.add(navalBombardment);
+    new IExecutable() {
+      private static final long serialVersionUID = -2255284529092427441L;
 
-            @Override
-            public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-              fireNavalBombardment(bridge);
-            }
-          });
+      @Override
+      public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+        final BattleStep navalBombardment =
+            new NavalBombardment(MustFightBattle.this, MustFightBattle.this);
+        navalBombardment.execute(stack, bridge);
+      }
+    };
+    if (firstRun) {
       steps.add(
           new IExecutable() {
             private static final long serialVersionUID = 3389635558184415797L;
@@ -1233,21 +1226,20 @@ public class MustFightBattle extends DependentBattle
             defendingAaTypes));
   }
 
-  private void fireNavalBombardment(final IDelegateBridge bridge) {
+  @Override
+  public void fireNavalBombardment(final IDelegateBridge bridge) {
     final Collection<Unit> bombard = getBombardingUnits();
     final Collection<Unit> attacked =
         CollectionUtils.getMatches(
             defendingUnits,
             Matches.unitIsNotInfrastructureAndNotCapturedOnEntering(
                 attacker, battleSite, gameData));
-    // bombarding units can't move after bombarding
-    if (!headless) {
-      // TODO: StepRefactor: Why is a change always added even if there are no units?
-      //       Shouldn't this be moved inside of the if (!bombard.isEmpty() ...) check?
+
+    if (!headless && !bombard.isEmpty()) {
+      // bombarding units can't move after bombarding even if there are no units to bombard
       final Change change = ChangeFactory.markNoMovementChange(bombard);
       bridge.addChange(change);
     }
-    final boolean canReturnFire = Properties.getNavalBombardCasualtiesReturnFire(gameData);
     if (!bombard.isEmpty() && !attacked.isEmpty()) {
       if (!headless) {
         bridge
@@ -1256,6 +1248,7 @@ public class MustFightBattle extends DependentBattle
       }
       final List<Unit> allEnemyUnitsAliveOrWaitingToDie = new ArrayList<>(defendingUnits);
       allEnemyUnitsAliveOrWaitingToDie.addAll(defendingWaitingToDie);
+      final boolean canReturnFire = Properties.getNavalBombardCasualtiesReturnFire(gameData);
       fire(
           SELECT_NAVAL_BOMBARDMENT_CASUALTIES,
           bombard,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleStep.java
@@ -20,6 +20,7 @@ public interface BattleStep extends IExecutable {
   enum Order {
     AA_OFFENSIVE,
     AA_DEFENSIVE,
+    NAVAL_BOMBARDMENT,
     SUB_OFFENSIVE_RETREAT_BEFORE_BATTLE,
     SUBMERGE_SUBS_VS_ONLY_AIR,
     AIR_OFFENSIVE_NON_SUBS,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/NavalBombardment.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/NavalBombardment.java
@@ -1,0 +1,52 @@
+package games.strategy.triplea.delegate.battle.steps.fire;
+
+import static games.strategy.triplea.delegate.battle.BattleStepStrings.NAVAL_BOMBARDMENT;
+import static games.strategy.triplea.delegate.battle.BattleStepStrings.SELECT_NAVAL_BOMBARDMENT_CASUALTIES;
+
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.delegate.ExecutionStack;
+import games.strategy.triplea.delegate.battle.BattleActions;
+import games.strategy.triplea.delegate.battle.BattleState;
+import games.strategy.triplea.delegate.battle.steps.BattleStep;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public class NavalBombardment implements BattleStep {
+
+  private static final long serialVersionUID = 3338296388191048761L;
+
+  protected final BattleState battleState;
+
+  protected final BattleActions battleActions;
+
+  @Override
+  public List<String> getNames() {
+    final List<String> steps = new ArrayList<>();
+    if (!valid()) {
+      return steps;
+    }
+    steps.add(NAVAL_BOMBARDMENT);
+    steps.add(SELECT_NAVAL_BOMBARDMENT_CASUALTIES);
+    return steps;
+  }
+
+  @Override
+  public Order getOrder() {
+    return Order.NAVAL_BOMBARDMENT;
+  }
+
+  @Override
+  public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+    if (valid()) {
+      battleActions.fireNavalBombardment(bridge);
+    }
+  }
+
+  private boolean valid() {
+    return battleState.getBattleRound() == 1
+        && !battleState.getBombardingUnits().isEmpty()
+        && !battleState.getBattleSite().isWater();
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/FakeBattleState.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/FakeBattleState.java
@@ -22,6 +22,12 @@ import lombok.NonNull;
 public class FakeBattleState implements BattleState {
 
   @Getter(onMethod = @__({@Override}))
+  final int battleRound;
+
+  @Getter(onMethod = @__({@Override}))
+  final @NonNull Territory battleSite;
+
+  @Getter(onMethod = @__({@Override}))
   final @NonNull GamePlayer attacker;
 
   @Getter(onMethod = @__({@Override}))
@@ -54,8 +60,13 @@ public class FakeBattleState implements BattleState {
   @Getter(onMethod = @__({@Override}))
   final Collection<Territory> attackerRetreatTerritories;
 
+  @Getter(onMethod = @__({@Override}))
+  final @NonNull Collection<Unit> bombardingUnits;
+
   public static FakeBattleState.FakeBattleStateBuilder givenBattleStateBuilder() {
     return FakeBattleState.builder()
+        .battleRound(2)
+        .battleSite(mock(Territory.class))
         .attackingUnits(List.of())
         .defendingUnits(List.of())
         .defendingWaitingToDie(List.of())
@@ -63,6 +74,7 @@ public class FakeBattleState implements BattleState {
         .defender(mock(GamePlayer.class))
         .offensiveAa(List.of())
         .defendingAa(List.of())
+        .bombardingUnits(List.of())
         .gameData(mock(GameData.class))
         .amphibious(false)
         .over(false)

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleExecutablesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleExecutablesTest.java
@@ -26,7 +26,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
@@ -37,7 +36,6 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.MutableProperty;
@@ -46,7 +44,6 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitCollection;
 import games.strategy.engine.data.UnitType;
-import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Constants;
@@ -66,7 +63,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.java.collections.IntegerMap;
-import org.triplea.sound.ISound;
 
 @ExtendWith(MockitoExtension.class)
 @SuppressWarnings("UnmatchedTest")
@@ -140,79 +136,6 @@ class MustFightBattleExecutablesTest {
         stepClass.getName() + " is missing from the steps",
         getIndex(execs, stepClass),
         greaterThanOrEqualTo(0));
-  }
-
-  @Test
-  @DisplayName("Verify basic land battle with bombard on first run")
-  void bombardOnFirstRun() {
-    final MustFightBattle battle = newBattle(LAND);
-
-    battle.setUnits(List.of(), List.of(), List.of(), List.of(), defender, List.of());
-    final List<IExecutable> execs = battle.getBattleExecutables(true);
-
-    assertThatStepExists(execs, MustFightBattle.FireNavalBombardment.class);
-  }
-
-  @Test
-  @DisplayName("Verify basic land battle with bombard on subsequent run")
-  void bombardOnSubsequentRun() {
-    final MustFightBattle battle = newBattle(LAND);
-
-    battle.setUnits(List.of(), List.of(), List.of(), List.of(), defender, List.of());
-    final List<IExecutable> execs = battle.getBattleExecutables(false);
-
-    assertThatStepIsMissing(execs, MustFightBattle.FireNavalBombardment.class);
-  }
-
-  @Test
-  @DisplayName("Verify Bombard step is added but no bombardment happens if bombard units are empty")
-  void bombardStepAddedButNoBombardUnits() {
-    final MustFightBattle battle = spy(newBattle(LAND));
-
-    battle.setUnits(List.of(), List.of(), List.of(), List.of(), defender, List.of());
-    final List<IExecutable> execs = battle.getBattleExecutables(true);
-
-    final int index = getIndex(execs, MustFightBattle.FireNavalBombardment.class);
-    final IExecutable step = execs.get(index);
-
-    final IDelegateBridge delegateBridge = mock(IDelegateBridge.class);
-
-    step.execute(null, delegateBridge);
-
-    verify(delegateBridge).addChange(ChangeFactory.EMPTY_CHANGE);
-    verify(battle, never())
-        .fire(anyString(), any(), any(), any(), any(), anyBoolean(), any(), anyString());
-  }
-
-  @Test
-  @DisplayName("Verify Bombard step is added and bombardment happens if bombard units exist")
-  void bombardStepAddedAndBombardHappens() {
-    final MustFightBattle battle = spy(newBattle(LAND));
-
-    final Unit unit1 = mock(Unit.class);
-    when(unit1.getMovementLeft()).thenReturn(BigDecimal.ZERO);
-    final MutableProperty<Boolean> alreadyMovedProperty = MutableProperty.ofReadOnly(() -> true);
-    doReturn(alreadyMovedProperty).when(unit1).getPropertyOrThrow(ALREADY_MOVED);
-
-    final Unit unit2 = givenAnyUnit();
-    when(unit2.getOwner()).thenReturn(defender);
-
-    battle.setUnits(List.of(unit2), List.of(), List.of(unit1), List.of(), defender, List.of());
-    final List<IExecutable> execs = battle.getBattleExecutables(true);
-
-    final int index = getIndex(execs, MustFightBattle.FireNavalBombardment.class);
-    final IExecutable step = execs.get(index);
-
-    final IDelegateBridge delegateBridge = mock(IDelegateBridge.class);
-    when(delegateBridge.getSoundChannelBroadcaster()).thenReturn(mock(ISound.class));
-    doNothing()
-        .when(battle)
-        .fire(anyString(), any(), any(), any(), any(), anyBoolean(), any(), anyString());
-
-    step.execute(null, delegateBridge);
-
-    verify(delegateBridge).addChange(argThat((Change change) -> !change.isEmpty()));
-    verify(battle).fire(anyString(), any(), any(), any(), any(), anyBoolean(), any(), anyString());
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
@@ -105,6 +105,12 @@ public class BattleStepsTest {
     when(getEmptyOrFriendlySeaNeighbors.apply(any())).thenReturn(Arrays.asList(territories));
   }
 
+  public static Territory givenSeaBattleSite() {
+    final Territory battleSite = mock(Territory.class);
+    when(battleSite.isWater()).thenReturn(true);
+    return battleSite;
+  }
+
   @Value
   public static class UnitAndAttachment {
     private Unit unit;
@@ -231,7 +237,7 @@ public class BattleStepsTest {
 
   private BattleSteps.BattleStepsBuilder newStepBuilder() {
     return BattleSteps.builder()
-        .showFirstRun(true)
+        .battleRound(1)
         .attacker(attacker)
         .defender(defender)
         .offensiveAa(List.of())
@@ -244,7 +250,6 @@ public class BattleStepsTest {
         .gameData(gameData)
         .bombardingUnits(List.of())
         .getDependentUnits(getDependentUnits)
-        .isBattleSiteWater(true)
         .getAttackerRetreatTerritories(getAttackerRetreatTerritories)
         .getEmptyOrFriendlySeaNeighbors(getEmptyOrFriendlySeaNeighbors)
         .battleActions(battleActions)
@@ -275,7 +280,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
-            .isBattleSiteWater(false)
+            .battleSite(battleSite)
             .build()
             .get();
 
@@ -296,7 +301,8 @@ public class BattleStepsTest {
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
             .bombardingUnits(List.of(mock(Unit.class)))
-            .isBattleSiteWater(false)
+            .battleSite(battleSite)
+            .battleRound(1)
             .build()
             .get();
 
@@ -319,10 +325,10 @@ public class BattleStepsTest {
     final Unit unit2 = givenAnyUnit();
     final List<String> steps =
         newStepBuilder()
-            .showFirstRun(false)
+            .battleRound(2)
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
-            .isBattleSiteWater(false)
+            .battleSite(battleSite)
             .build()
             .get();
 
@@ -343,6 +349,7 @@ public class BattleStepsTest {
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
             .bombardingUnits(List.of(mock(Unit.class)))
+            .battleSite(givenSeaBattleSite())
             .build()
             .get();
 
@@ -372,7 +379,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1, unit3))
             .defendingUnits(List.of(unit2))
-            .isBattleSiteWater(false)
+            .battleSite(battleSite)
             .build()
             .get();
 
@@ -395,7 +402,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1, unit3))
             .defendingUnits(List.of(unit2))
-            .isBattleSiteWater(false)
+            .battleSite(battleSite)
             .build()
             .get();
 
@@ -413,10 +420,10 @@ public class BattleStepsTest {
     final Unit unit2 = givenAnyUnit();
     final List<String> steps =
         newStepBuilder()
-            .showFirstRun(false)
+            .battleRound(2)
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
-            .isBattleSiteWater(false)
+            .battleSite(battleSite)
             .build()
             .get();
 
@@ -446,7 +453,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1, unit3))
             .defendingUnits(List.of(unit2))
-            .isBattleSiteWater(false)
+            .battleSite(battleSite)
             .build()
             .get();
 
@@ -467,6 +474,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
+            .battleSite(givenSeaBattleSite())
             .build()
             .get();
 
@@ -489,7 +497,7 @@ public class BattleStepsTest {
             .offensiveAa(List.of(unit1))
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
-            .isBattleSiteWater(false)
+            .battleSite(battleSite)
             .build()
             .get();
 
@@ -520,7 +528,7 @@ public class BattleStepsTest {
             .defendingAa(List.of(unit2))
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
-            .isBattleSiteWater(false)
+            .battleSite(battleSite)
             .build()
             .get();
 
@@ -552,7 +560,7 @@ public class BattleStepsTest {
             .defendingAa(List.of(unit2))
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
-            .isBattleSiteWater(false)
+            .battleSite(battleSite)
             .build()
             .get();
 
@@ -690,6 +698,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
+            .battleSite(givenSeaBattleSite())
             .build()
             .get();
 
@@ -712,6 +721,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
+            .battleSite(givenSeaBattleSite())
             .build()
             .get();
 
@@ -732,6 +742,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
+            .battleSite(givenSeaBattleSite())
             .build()
             .get();
 
@@ -754,6 +765,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
+            .battleSite(givenSeaBattleSite())
             .build()
             .get();
 
@@ -1021,6 +1033,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
+            .battleSite(givenSeaBattleSite())
             .build()
             .get();
 
@@ -1058,6 +1071,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1, unit3))
             .defendingUnits(List.of(unit2, unit4))
+            .battleSite(givenSeaBattleSite())
             .build()
             .get();
 
@@ -1093,6 +1107,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
+            .battleSite(givenSeaBattleSite())
             .build()
             .get();
 
@@ -1128,6 +1143,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1, unit3))
             .defendingUnits(List.of(unit2, unit4))
+            .battleSite(givenSeaBattleSite())
             .build()
             .get();
 
@@ -1167,6 +1183,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2, unit3))
+            .battleSite(givenSeaBattleSite())
             .build()
             .get();
 
@@ -1204,6 +1221,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1, unit3))
             .defendingUnits(List.of(unit2))
+            .battleSite(givenSeaBattleSite())
             .build()
             .get();
 
@@ -1239,6 +1257,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2, unit3))
+            .battleSite(givenSeaBattleSite())
             .build()
             .get();
 
@@ -1273,6 +1292,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1, unit3))
             .defendingUnits(List.of(unit2))
+            .battleSite(givenSeaBattleSite())
             .build()
             .get();
 
@@ -1306,6 +1326,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
+            .battleSite(givenSeaBattleSite())
             .build()
             .get();
 
@@ -1340,6 +1361,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2, unit3))
+            .battleSite(givenSeaBattleSite())
             .build()
             .get();
 
@@ -1372,6 +1394,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
+            .battleSite(givenSeaBattleSite())
             .build()
             .get();
 
@@ -1407,6 +1430,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1, unit3))
             .defendingUnits(List.of(unit2))
+            .battleSite(givenSeaBattleSite())
             .build()
             .get();
 
@@ -1630,6 +1654,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
+            .battleSite(givenSeaBattleSite())
             .build()
             .get();
 
@@ -1775,6 +1800,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
+            .battleSite(givenSeaBattleSite())
             .build()
             .get();
 
@@ -1800,7 +1826,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1, unit3))
             .defendingUnits(List.of(unit2))
-            .isBattleSiteWater(false)
+            .battleSite(battleSite)
             .isAmphibious(true)
             .build()
             .get();
@@ -1827,7 +1853,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1, unit3))
             .defendingUnits(List.of(unit2))
-            .isBattleSiteWater(false)
+            .battleSite(battleSite)
             .isAmphibious(true)
             .build()
             .get();
@@ -1848,7 +1874,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1, unit3))
             .defendingUnits(List.of(unit2))
-            .isBattleSiteWater(false)
+            .battleSite(battleSite)
             .isAmphibious(true)
             .build()
             .get();
@@ -1876,7 +1902,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1, unit3))
             .defendingUnits(List.of(unit2))
-            .isBattleSiteWater(false)
+            .battleSite(battleSite)
             .isAmphibious(false)
             .build()
             .get();
@@ -1897,7 +1923,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
-            .isBattleSiteWater(false)
+            .battleSite(battleSite)
             .isAmphibious(true)
             .build()
             .get();
@@ -1926,7 +1952,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1, unit3))
             .defendingUnits(List.of(unit2))
-            .isBattleSiteWater(false)
+            .battleSite(battleSite)
             .isAmphibious(true)
             .build()
             .get();
@@ -1952,7 +1978,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
-            .isBattleSiteWater(false)
+            .battleSite(battleSite)
             .isAmphibious(true)
             .build()
             .get();
@@ -1975,7 +2001,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
-            .isBattleSiteWater(false)
+            .battleSite(battleSite)
             .isAmphibious(false)
             .build()
             .get();
@@ -2004,7 +2030,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1, unit3))
             .defendingUnits(List.of(unit2))
-            .isBattleSiteWater(false)
+            .battleSite(battleSite)
             .isAmphibious(false)
             .build()
             .get();
@@ -2030,7 +2056,7 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
-            .isBattleSiteWater(false)
+            .battleSite(battleSite)
             .isAmphibious(false)
             .build()
             .get();

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/NavalBombardmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/NavalBombardmentTest.java
@@ -1,0 +1,74 @@
+package games.strategy.triplea.delegate.battle.steps.fire;
+
+import static games.strategy.triplea.delegate.battle.FakeBattleState.givenBattleStateBuilder;
+import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenSeaBattleSite;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.delegate.ExecutionStack;
+import games.strategy.triplea.delegate.battle.BattleActions;
+import games.strategy.triplea.delegate.battle.BattleState;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class NavalBombardmentTest {
+
+  @Mock ExecutionStack executionStack;
+  @Mock IDelegateBridge delegateBridge;
+  @Mock BattleActions battleActions;
+
+  @Test
+  @DisplayName("Has bombardment units and first round")
+  void bombardmentHappensIfHasBombardmentUnitsAndIsFirstRound() {
+    final BattleState battleState =
+        givenBattleStateBuilder().bombardingUnits(List.of(mock(Unit.class))).battleRound(1).build();
+    final NavalBombardment navalBombardment = new NavalBombardment(battleState, battleActions);
+    assertThat(navalBombardment.getNames(), hasSize(2));
+    navalBombardment.execute(executionStack, delegateBridge);
+    verify(battleActions).fireNavalBombardment(delegateBridge);
+  }
+
+  @Test
+  void bombardmentDoesNotHappenIfNotFirstRound() {
+    final BattleState battleState =
+        givenBattleStateBuilder().bombardingUnits(List.of(mock(Unit.class))).battleRound(2).build();
+    final NavalBombardment navalBombardment = new NavalBombardment(battleState, battleActions);
+    assertThat(navalBombardment.getNames(), hasSize(0));
+    navalBombardment.execute(executionStack, delegateBridge);
+    verify(battleActions, never()).fireNavalBombardment(delegateBridge);
+  }
+
+  @Test
+  void bombardmentDoesNotHappenIfNoBombardmentUnitsAndFirstRound() {
+    final BattleState battleState =
+        givenBattleStateBuilder().bombardingUnits(List.of()).battleRound(1).build();
+    final NavalBombardment navalBombardment = new NavalBombardment(battleState, battleActions);
+    assertThat(navalBombardment.getNames(), hasSize(0));
+    navalBombardment.execute(executionStack, delegateBridge);
+    verify(battleActions, never()).fireNavalBombardment(delegateBridge);
+  }
+
+  @Test
+  void bombardmentDoesNotHappenIfSeaBattle() {
+    final BattleState battleState =
+        givenBattleStateBuilder()
+            .bombardingUnits(List.of(mock(Unit.class)))
+            .battleRound(1)
+            .battleSite(givenSeaBattleSite())
+            .build();
+    final NavalBombardment navalBombardment = new NavalBombardment(battleState, battleActions);
+    assertThat(navalBombardment.getNames(), hasSize(0));
+    navalBombardment.execute(executionStack, delegateBridge);
+    verify(battleActions, never()).fireNavalBombardment(delegateBridge);
+  }
+}


### PR DESCRIPTION
Converts the NavalBombardment step.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
Created a save before a bombardment battle (that included an AA round), during aa casualty selection, during bombardment casualty selection, and after the battle.

I ensured that there were AA casualties so that the save would have an old bombardment step to deserialize and execute.

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->


## Additional Review Notes
This is a redo of https://github.com/triplea-game/triplea/pull/6653 that has been updated with the latest changes to BattleStep.

