### PR TITLE
Update headless game logging when cannot load a map

### DIFF
--- a/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -129,12 +129,16 @@ public class HeadlessGameServer {
       }
       final GameData data = gameSelectorModel.getGameData(input);
       if (data == null) {
-        log.info("Loading GameData failed for: " + fileName);
+        log.severe("Loading GameData failed for: " + fileName);
         return;
       }
       final String mapNameProperty = data.getProperties().get(Constants.MAP_NAME, "");
       if (!availableGames.containsMapName(mapNameProperty)) {
-        log.info("Game mapName not in available games listing: " + mapNameProperty);
+        log.warning(
+            "Game mapName not in available games listing: "
+                + mapNameProperty
+                + ", available maps = "
+                + availableGames.getGameNames());
         return;
       }
       gameSelectorModel.load(data, fileName);


### PR DESCRIPTION
Print the list of available maps when a map cannot be loaded.
Useful to debug why a deployed production bot cannot load
from save game while local running bots with the same version
and same base map zip have no problem.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

