### PR TITLE
Conditional coverage report upload based on env variable presence

### DIFF
--- a/.travis/stages/verify/unit-testing/run
+++ b/.travis/stages/verify/unit-testing/run
@@ -69,12 +69,12 @@ function uploadCoverageReports() {
   # ID tokens will be defined for branches that are part of the triplea-game repo,
   # will not be available to branches present on forks.
   # Travis will have these values defined in the build setting environment variables.
-  if [ ! -z "${CODACY_PROJECT_TOKEN-}" ]; then
+  if [ -n "${CODACY_PROJECT_TOKEN-}" ]; then
     # upload coverage report to codacy
     bash <(curl -Ls https://coverage.codacy.com/get.sh)
   fi
   
-  if [ ! -z "${CC_TEST_REPORTER_ID-}" ]; then
+  if [ -n "${CC_TEST_REPORTER_ID-}" ]; then
    # upload coverage report to codeclimate
     ./cc-test-reporter upload-coverage
   fi

--- a/.travis/stages/verify/unit-testing/run
+++ b/.travis/stages/verify/unit-testing/run
@@ -2,8 +2,6 @@
 
 set -ux
 
-export CC_TEST_REPORTER_ID="$CODE_CLIMATE_TEST_COVERAGE_ID"
-
 function main() {
   downloadCodeClimateReporter
   runTests
@@ -68,12 +66,18 @@ function uploadCoverageReports() {
   # upload coverage report to codecov - https://github.com/codecov/example-gradle
   bash <(curl -s https://codecov.io/bash)
 
-  # upload coverage report to codacy
-   bash <(curl -Ls https://coverage.codacy.com/get.sh)
-
-  # upload coverage report to codeclimate
-  ./cc-test-reporter upload-coverage
-
+  # ID tokens will be defined for branches that are part of the triplea-game repo,
+  # will not be available to branches present on forks.
+  # Travis will have these values defined in the build setting environment variables.
+  if [ ! -z "${CODACY_PROJECT_TOKEN-}" ]; then
+    # upload coverage report to codacy
+    bash <(curl -Ls https://coverage.codacy.com/get.sh)
+  fi
+  
+  if [ ! -z "${CC_TEST_REPORTER_ID-}" ]; then
+   # upload coverage report to codeclimate
+    ./cc-test-reporter upload-coverage
+  fi
 }
 
 main


### PR DESCRIPTION
Travis environment variables are only present for branch builds from
the main repo, not forks. This update makes coverage uploads conditional
on whether these variables are not present. Otherwise we get an error
for variable not defined when building from forks.

Second, the 'CC_TEST_REPORTER_ID' env variable can be defined directly
in Travis so we do not need to re-assign, this has been made implicit.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

