### PR TITLE
Update PR template with release note block

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -37,4 +37,3 @@ https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
 -->
 
 <!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
-

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,27 +16,25 @@
 [] Feature Removal
 [] Code Cleanup or refactor
 [] Configuration Change
-[] Problem fix:  <!-- Link to bug issue or forum post here -->
+[] Problem fix
 [] Other:   <!-- Please specify -->
 
 ## Testing
-<!--
-  Describe any manual testing performed below.
--->
+<!-- Describe any manual testing performed below. -->
 
-<!-- If there are UI updates, uncomment and include screenshots below -->
-<!--
 ## Screens Shots
+<!-- If there are UI updates, include screenshots below -->
 
-### Before
+## Additional Notes to Reviewer
+<!-- Add any additional details that would be helpful to reviewers -->
 
-### After
--->
+## Release Note
 
 <!--
-  Uncomment the below and add any additional details that would be helpful for reviewers.
+Include a release note if there is a bug fix or a visible change for players.
+For format & syntax help, see:
+https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
 -->
-<!--
-## Additional Review Notes
--->
+
+<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
 


### PR DESCRIPTION
The format & syntax for release note is documented in wiki.
The release comment goes in between the special release
note comment block, eg:
`UPDATE|Add release note magic block to PR template`

Also in this update, uncomment sections so they are always include and
its okay if they are left blank. This makes the documentation and
manual steps slightly less when submitting a PR.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix:  <!-- Link to bug issue or forum post here -->
[] Other:   <!-- Please specify -->

## Testing
Scraped the github API URL, placed into a text file, ran the release note scraper script now in wiki and verified that got an expected table format.
<!--
  Describe any manual testing performed below.
-->

<!-- If there are UI updates, uncomment and include screenshots below -->
<!--
## Screens Shots

### Before

### After
-->

<!--
  Uncomment the below and add any additional details that would be helpful for reviewers.
-->
<!--
## Additional Review Notes
-->

