### PR TITLE
Fix unsupported operations in retain-all

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -287,17 +287,16 @@ public class MustFightBattle extends DependentBattle
         if (ua.getCarrierCapacity() == -1) {
           continue;
         }
-        final Collection<Unit> fighters = dependencies.get(carrier);
-        // Dependencies count both land and air units. Land units could be allied or owned, while
-        // air is just allied
-        // since owned already launched at beginning of turn
-        fighters.retainAll(CollectionUtils.getMatches(fighters, Matches.unitIsAir()));
-        for (final Unit fighter : fighters) {
-          // Set transportedBy for fighter
-          change.add(ChangeFactory.unitPropertyChange(fighter, carrier, Unit.TRANSPORTED_BY));
-        }
-        // remove transported fighters from battle display
-        this.attackingUnits.removeAll(fighters);
+
+        // set transported by on each figher and remove each one from battle display
+        dependencies.get(carrier).stream()
+            .filter(Matches.unitIsAir())
+            .forEach(
+                fighter -> {
+                  change.add(
+                      ChangeFactory.unitPropertyChange(fighter, carrier, Unit.TRANSPORTED_BY));
+                  this.attackingUnits.remove(fighter);
+                });
       }
     }
     addDependentUnits(dependencies);


### PR DESCRIPTION
Convert imperative code to functional style, avoids
a retain-all done on an unmodifiable set.

Addresses UnsupportedOperationException reported in:
https://github.com/triplea-game/triplea/issues/6788


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->FIX|Fix UnsupportedOperationException during battle phase possible when fighters are transported as cargo<!--END_RELEASE_NOTE-->
