### PR TITLE
Add missing null check to duplicated code

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -336,7 +336,7 @@ public final class ProMoveUtils {
 
         // Skip if unit is already in move to territory
         final Territory startTerritory = proData.getUnitTerritory(u);
-        if (startTerritory.equals(bombardFromTerritory)) {
+        if (startTerritory == null || startTerritory.equals(bombardFromTerritory)) {
           continue;
         }
 


### PR DESCRIPTION
'startTerritory' can be null. On line 392 there
is a null check for 'startTerritory' (copy/pasted
code), but we do not have the same on line 339 where
we can get a NPE.

Addresses NPE reported in:
https://github.com/triplea-game/triplea/issues/6789


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->FIX|Fix NPE possible when AI is evaluating naval bombardment<!--END_RELEASE_NOTE-->
