### PR TITLE
Find a location to use for BattleCalculatorPanel even if one isn't selected

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -1194,17 +1194,7 @@ class BattleCalculatorPanel extends JPanel {
             () -> {
               try {
                 // find a territory to fight in
-                Territory location = null;
-                if (this.location == null || this.location.isWater() == isLand()) {
-                  for (final Territory t : data.getMap()) {
-                    if (t.isWater() == !isLand()) {
-                      location = t;
-                      break;
-                    }
-                  }
-                } else {
-                  location = this.location;
-                }
+                final Territory location = findPotentialBattleSite();
                 if (location == null) {
                   throw new IllegalStateException("No territory found that is land:" + isLand());
                 }
@@ -1310,6 +1300,21 @@ class BattleCalculatorPanel extends JPanel {
     }
   }
 
+  private Territory findPotentialBattleSite() {
+    Territory location = null;
+    if (this.location == null || this.location.isWater() == isLand()) {
+      for (final Territory t : data.getMap()) {
+        if (t.isWater() == !isLand()) {
+          location = t;
+          break;
+        }
+      }
+    } else {
+      location = this.location;
+    }
+    return location;
+  }
+
   private static String formatPercentage(final double percentage) {
     return new DecimalFormat("#%").format(percentage);
   }
@@ -1413,6 +1418,7 @@ class BattleCalculatorPanel extends JPanel {
       final Collection<TerritoryEffect> territoryEffects = getTerritoryEffects();
       final IntegerMap<UnitType> costs = TuvUtils.getCostsForTuv(getAttacker(), data);
       attackers.sort(new UnitBattleComparator(false, costs, territoryEffects, data).reversed());
+      final Territory location = findPotentialBattleSite();
       final int attackPower =
           DiceRoll.getTotalPower(
               DiceRoll.getUnitPowerAndRollsForNormalBattles(


### PR DESCRIPTION
Fixes #6769 

There was already code that would find a potential battle site.  This moves that code into a helper function and uses it during the setWidgetActivation call.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix
[] Other:   <!-- Please specify -->

## Testing
I was able to duplicate the issue in the battle calculator.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->Fix|Game crash when calculating a sea battle with units that can bombard<!--END_RELEASE_NOTE-->
