### PR TITLE
Pass correct variables into DiceRoll.getAaUnitPowerAndRollsForNormalBattles

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelector.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelector.java
@@ -328,7 +328,7 @@ public class AaCasualtySelector {
         (allowMultipleHitsPerUnit ? CasualtyUtil.getTotalHitpointsLeft(planes) : planes.size());
     final Map<Unit, TotalPowerAndTotalRolls> unitPowerAndRollsMap =
         DiceRoll.getAaUnitPowerAndRollsForNormalBattles(
-            defendingAa, allEnemyUnits, allFriendlyUnits, defending, bridge.getData());
+            defendingAa, allFriendlyUnits, allEnemyUnits, defending, bridge.getData());
     if (DiceRoll.getTotalAaAttacks(unitPowerAndRollsMap, planes) != planeHitPoints) {
       return randomAaCasualties(planes, dice, bridge, allowMultipleHitsPerUnit);
     }


### PR DESCRIPTION
Fixes #6745 and #6485

This only affects maps that have AA support attachments and only during casualty selection.  The actual dice rolls are being correctly calculated.  I've only seen AA support attachments in warcraft war heroes.

The friendlyUnits and enemyUnits in AaCasualtySelector are oriented to the attacked player.  But DiceRoll.getAaUnitPowerAndRollsForNormalBattles orients friendlyUnits and enemyUnits to the attacker player.

This makes it a little confusing and I first thought that AaCasualtySelector had their variables flipped.  But after more debugging, I realized that AaCasualtySelector uses friendlyUnits/enemyUnits consistently from the attacked player point of view and I felt it would be too risky to try and swap the variables.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix
[] Other:   <!-- Please specify -->

## Testing
I loaded a saved game from #6745 and used breakpoints and debugger to ensure that the data was being calculated correctly.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->FIX|Correctly calculate AAroll and AAstrength during battle.<!--END_RELEASE_NOTE-->
