### PR TITLE
Indicate if the missing image is for a damaged or disabled unit

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -112,21 +112,21 @@ public class UnitsDrawer extends AbstractDrawable {
     }
     final GamePlayer owner = data.getPlayerList().getPlayerId(playerName);
     final boolean damagedImage = damaged > 0 || bombingUnitDamage > 0;
-    final boolean disabledImage = disabled;
     final Optional<Image> img =
-        uiContext.getUnitImageFactory().getImage(type, owner, damagedImage, disabledImage);
+        uiContext.getUnitImageFactory().getImage(type, owner, damagedImage, disabled);
 
     if (img.isEmpty() && !uiContext.isShutDown()) {
-      final List<String> imageQualifiers = new ArrayList<>();
-      if (damagedImage) {
-        imageQualifiers.add("damaged ");
-      }
-      if (disabledImage) {
-        imageQualifiers.add("disabled ");
+      final String imageQualifier;
+      if (disabled) {
+        imageQualifier = "disabled ";
+      } else if (damagedImage) {
+        imageQualifier = "damaged ";
+      } else {
+        imageQualifier = "";
       }
       log.severe(
           "MISSING UNIT IMAGE (won't be displayed): "
-              + String.join("and ", imageQualifiers)
+              + imageQualifier
               + type.getName()
               + " owned by "
               + owner.getName()

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -19,6 +19,7 @@ import java.awt.Image;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;
@@ -116,19 +117,16 @@ public class UnitsDrawer extends AbstractDrawable {
         uiContext.getUnitImageFactory().getImage(type, owner, damagedImage, disabledImage);
 
     if (img.isEmpty() && !uiContext.isShutDown()) {
-      final StringBuilder prefix = new StringBuilder();
+      final List<String> imageQualifiers = new ArrayList<>();
       if (damagedImage) {
-        prefix.append("damaged ");
+        imageQualifiers.add("damaged ");
       }
       if (disabledImage) {
-        if (damagedImage) {
-          prefix.append("and ");
-        }
-        prefix.append("disabled ");
+        imageQualifiers.add("disabled ");
       }
       log.severe(
           "MISSING UNIT IMAGE (won't be displayed): "
-              + prefix.toString()
+              + String.join("and ", imageQualifiers)
               + type.getName()
               + " owned by "
               + owner.getName()

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -19,7 +19,6 @@ import java.awt.Image;
 import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.function.Predicate;

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -110,14 +110,25 @@ public class UnitsDrawer extends AbstractDrawable {
       throw new IllegalStateException("Type not found:" + unitType);
     }
     final GamePlayer owner = data.getPlayerList().getPlayerId(playerName);
+    final boolean damagedImage = damaged > 0 || bombingUnitDamage > 0;
+    final boolean disabledImage = disabled;
     final Optional<Image> img =
-        uiContext
-            .getUnitImageFactory()
-            .getImage(type, owner, damaged > 0 || bombingUnitDamage > 0, disabled);
+        uiContext.getUnitImageFactory().getImage(type, owner, damagedImage, disabledImage);
 
     if (img.isEmpty() && !uiContext.isShutDown()) {
+      final StringBuilder prefix = new StringBuilder();
+      if (damagedImage) {
+        prefix.append("damaged ");
+      }
+      if (disabledImage) {
+        if (damagedImage) {
+          prefix.append("and ");
+        }
+        prefix.append("disabled ");
+      }
       log.severe(
           "MISSING UNIT IMAGE (won't be displayed): "
+              + prefix.toString()
               + type.getName()
               + " owned by "
               + owner.getName()


### PR DESCRIPTION
This adds some additional text to the 'MISSING UNIT IMAGE' error message to indicate if the image should be a damaged and/or disabled image.  That should help in figuring out what image is actually missing.  It also might help in figuring out if the game is requesting these images more in 2.0 vs 1.9.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->CHANGE|Missing Unit Image error now indicates if image should be a damaged and/or disabled image<!--END_RELEASE_NOTE-->
