### PR TITLE
Small code clean ups to tiling code.

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
@@ -630,10 +630,7 @@ public class MapPanel extends ImageScrollerLargeView {
       final Collection<Tile> tileList = tileManager.getTiles(bounds);
       for (final Tile tile : tileList) {
         tile.drawImage(gameData, uiContext.getMapData());
-        g2d.drawImage(
-            tile.getImage(),
-            AffineTransform.getTranslateInstance(tile.getBounds().x, tile.getBounds().y),
-            this);
+        g2d.drawImage(tile.getImage(), tile.getBounds().x, tile.getBounds().y, this);
       }
     } finally {
       gameData.releaseReadLock();
@@ -808,10 +805,7 @@ public class MapPanel extends ImageScrollerLargeView {
       } else {
         images.add(tile);
       }
-      g.drawImage(
-          tile.getImage(),
-          AffineTransform.getTranslateInstance(tile.getBounds().x, tile.getBounds().y),
-          this);
+      g.drawImage(tile.getImage(), tile.getBounds().x, tile.getBounds().y, this);
     }
     g.translate(bounds.getX(), bounds.getY());
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/Tile.java
@@ -20,13 +20,11 @@ import lombok.Getter;
 
 /** Responsible for rendering a single map tile. */
 public class Tile {
-  public static final int TILE_SIZE = 256;
-
   private volatile boolean isDirty = true;
   private AtomicBoolean isDrawing = new AtomicBoolean(false);
 
   /** Current de facto immutable state of this tile. */
-  @Getter private Image image = Util.newImage(TILE_SIZE, TILE_SIZE, true);
+  @Getter private Image image;
 
   private final Rectangle bounds;
   private final Object mutex = new Object();
@@ -34,6 +32,7 @@ public class Tile {
 
   Tile(final Rectangle bounds) {
     this.bounds = bounds;
+    this.image = Util.newImage(bounds.width, bounds.height, true);
   }
 
   public boolean needsRedraw() {
@@ -43,7 +42,7 @@ public class Tile {
   /** Returns the image representing this tile, re-rendering it first if the tile is dirty. */
   public void drawImage(final GameData data, final MapData mapData) {
     if (isDirty && !isDrawing.getAndSet(true)) {
-      final Image backImage = Util.newImage(TILE_SIZE, TILE_SIZE, true);
+      final Image backImage = Util.newImage(bounds.width, bounds.height, true);
       final Graphics2D g = (Graphics2D) backImage.getGraphics();
       g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
       g.setRenderingHint(
@@ -63,7 +62,7 @@ public class Tile {
     final AffineTransform original = g.getTransform();
     // clear
     g.setColor(Color.BLACK);
-    g.fill(new Rectangle(0, 0, TILE_SIZE, TILE_SIZE));
+    g.fill(new Rectangle(0, 0, bounds.width, bounds.height));
     synchronized (mutex) {
       final Queue<IDrawable> queue = new PriorityQueue<>(contents);
       while (!queue.isEmpty()) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/TileManager.java
@@ -1,7 +1,5 @@
 package games.strategy.triplea.ui.screen;
 
-import static games.strategy.triplea.ui.screen.Tile.TILE_SIZE;
-
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
@@ -53,6 +51,10 @@ import org.triplea.util.Tuple;
 
 /** Orchestrates the rendering of all map tiles. */
 public class TileManager {
+
+  // Note: This value cannot currently change as map images are stored in tile files of this size.
+  public static final int TILE_SIZE = 256;
+
   private List<Tile> tiles = new ArrayList<>();
   private final Object mutex = new Object();
   private final Map<String, IDrawable> territoryOverlays = new HashMap<>();
@@ -122,7 +124,7 @@ public class TileManager {
       final List<Tile> tilesInBounds = new ArrayList<>();
       for (final Tile tile : tiles) {
         final Rectangle tileBounds = tile.getBounds();
-        if (bounds.contains(tileBounds) || tileBounds.intersects(bounds)) {
+        if (tileBounds.intersects(bounds)) {
           tilesInBounds.add(tile);
         }
       }

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/MapTileDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/MapTileDrawable.java
@@ -1,9 +1,10 @@
 package games.strategy.triplea.ui.screen.drawable;
 
+import static games.strategy.triplea.ui.screen.TileManager.TILE_SIZE;
+
 import games.strategy.engine.data.GameData;
 import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.mapdata.MapData;
-import games.strategy.triplea.ui.screen.Tile;
 import java.awt.Graphics2D;
 import java.awt.Image;
 import java.awt.Rectangle;
@@ -49,7 +50,7 @@ public abstract class MapTileDrawable extends AbstractDrawable {
     graphics.setRenderingHint(
         RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
 
-    graphics.drawImage(img, x * Tile.TILE_SIZE - bounds.x, y * Tile.TILE_SIZE - bounds.y, null);
+    graphics.drawImage(img, x * TILE_SIZE - bounds.x, y * TILE_SIZE - bounds.y, null);
     if (oldAlphaValue == null) {
       graphics.setRenderingHint(
           RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_DEFAULT);

--- a/game-core/src/main/java/tools/image/TileImageBreaker.java
+++ b/game-core/src/main/java/tools/image/TileImageBreaker.java
@@ -1,7 +1,7 @@
 package tools.image;
 
 import static com.google.common.base.Preconditions.checkState;
-import static games.strategy.triplea.ui.screen.Tile.TILE_SIZE;
+import static games.strategy.triplea.ui.screen.TileManager.TILE_SIZE;
 
 import java.awt.GraphicsConfiguration;
 import java.awt.GraphicsEnvironment;

--- a/game-core/src/main/java/tools/image/TileImageReconstructor.java
+++ b/game-core/src/main/java/tools/image/TileImageReconstructor.java
@@ -1,8 +1,8 @@
 package tools.image;
 
 import static com.google.common.base.Preconditions.checkState;
+import static games.strategy.triplea.ui.screen.TileManager.TILE_SIZE;
 
-import games.strategy.triplea.ui.screen.Tile;
 import games.strategy.ui.Util;
 import java.awt.Color;
 import java.awt.Graphics;
@@ -170,8 +170,8 @@ public final class TileImageReconstructor {
     final BufferedImage mapImage =
         localGraphicSystem.createCompatibleImage(sizeX, sizeY, Transparency.TRANSLUCENT);
     final Graphics graphics = mapImage.getGraphics();
-    for (int x = 0; x * Tile.TILE_SIZE < sizeX; x++) {
-      for (int y = 0; y * Tile.TILE_SIZE < sizeY; y++) {
+    for (int x = 0; x * TILE_SIZE < sizeX; x++) {
+      for (int y = 0; y * TILE_SIZE < sizeY; y++) {
         final String tileName = x + "_" + y + ".png";
         final File tileFile = new File(baseTileLocation, tileName);
         if (!tileFile.exists()) {
@@ -181,10 +181,10 @@ public final class TileImageReconstructor {
         Util.ensureImageLoaded(tile);
         final Rectangle tileBounds =
             new Rectangle(
-                x * Tile.TILE_SIZE,
-                y * Tile.TILE_SIZE,
-                Math.min((x * Tile.TILE_SIZE) + Tile.TILE_SIZE, sizeX),
-                Math.min((y * Tile.TILE_SIZE) + Tile.TILE_SIZE, sizeY));
+                x * TILE_SIZE,
+                y * TILE_SIZE,
+                Math.min((x * TILE_SIZE) + TILE_SIZE, sizeX),
+                Math.min((y * TILE_SIZE) + TILE_SIZE, sizeY));
         graphics.drawImage(
             tile,
             tileBounds.x,


### PR DESCRIPTION
Small code clean ups to tiling code.

- Simplifies drawImage() by passing x/y directly instead of via
  AffineTransform.
- Moves TILE_SIZE to TileManager class. This way, the Tile object
  does not depend on the assumption of the tile size (it uses the
  size from its bounds).
- Removes an unnecessary contains() check before an intersect()
  check since the intersect check should cover this case already.
- Adds a comment about TILE_SIZE documenting that it can't
  currently change.

No functional changes.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[X] Code Cleanup or refactor
[] Configuration Change
[] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->
Basic smoke test to load a map and check that it looks fine.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
