### PR TITLE
Improve PerfTimer utility.

### DIFF
--- a/game-core/src/main/java/org/triplea/performance/PerfTimer.java
+++ b/game-core/src/main/java/org/triplea/performance/PerfTimer.java
@@ -3,7 +3,6 @@ package org.triplea.performance;
 import java.io.Closeable;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import lombok.extern.java.Log;

--- a/game-core/src/main/java/org/triplea/performance/PerfTimer.java
+++ b/game-core/src/main/java/org/triplea/performance/PerfTimer.java
@@ -33,12 +33,12 @@ public class PerfTimer implements Closeable {
   private PerfTimer(final String title, final int reportingFrequency) {
     this.title = title;
     this.reportingFrequency = reportingFrequency;
-	// If reporting frequency is 0, avoid the overhead of querying the time.
-	if ( this.reportingFrequency > 0) {
-		this.startNanos = Optional.of(System.nanoTime());
-	} else {
-		this.startNanos = Optional.empty();
-	}
+    // If reporting frequency is 0, avoid the overhead of querying the time.
+    if (this.reportingFrequency > 0) {
+      this.startNanos = Optional.of(System.nanoTime());
+    } else {
+      this.startNanos = Optional.empty();
+    }
   }
 
   private long stopTimer() {
@@ -57,15 +57,16 @@ public class PerfTimer implements Closeable {
     return startTimer(title, 1);
   }
 
-  /** Creates a perf timer with a reporting frequency.
-   * The reporting frequency specifies N specifies that performance information
-   * should be printed every N executions of the timer. If 0, no information is
-   * printed (and no timings are taken), which can be useful to have some places
-   * in the code to be always instrumented, but not always enabled.
+  /**
+   * Creates a perf timer with a reporting frequency. The reporting frequency specifies N specifies
+   * that performance information should be printed every N executions of the timer. If 0, no
+   * information is printed (and no timings are taken), which can be useful to have some places in
+   * the code to be always instrumented, but not always enabled.
+   *
    * @param title The name of the timer
    * @param reportingFrequency The reporting frequency.
    * @return the perf timer object
-	*/
+   */
   @SuppressWarnings("unused")
   public static PerfTimer startTimer(final String title, final int reportingFrequency) {
     return new PerfTimer(title, reportingFrequency);

--- a/game-core/src/main/java/org/triplea/performance/PerfTimer.java
+++ b/game-core/src/main/java/org/triplea/performance/PerfTimer.java
@@ -33,12 +33,12 @@ public class PerfTimer implements Closeable {
   private PerfTimer(final String title, final int reportingFrequency) {
     this.title = title;
     this.reportingFrequency = reportingFrequency;
-    // If reporting frequency is 0, avoid the overhead of querying the time.
-    if (this.reportingFrequency > 0) {
-      this.startNanos = Optional.of(System.nanoTime());
-    } else {
-      this.startNanos = Optional.empty();
-    }
+	// If reporting frequency is 0, avoid the overhead of querying the time.
+	if ( this.reportingFrequency > 0) {
+		this.startNanos = Optional.of(System.nanoTime());
+	} else {
+		this.startNanos = Optional.empty();
+	}
   }
 
   private long stopTimer() {
@@ -57,16 +57,15 @@ public class PerfTimer implements Closeable {
     return startTimer(title, 1);
   }
 
-  /**
-   * Creates a perf timer with a reporting frequency. The reporting frequency specifies N specifies
-   * that performance information should be printed every N executions of the timer. If 0, no
-   * information is printed (and no timings are taken), which can be useful to have some places in
-   * the code to be always instrumented, but not always enabled.
-   *
+  /** Creates a perf timer with a reporting frequency.
+   * The reporting frequency specifies N specifies that performance information
+   * should be printed every N executions of the timer. If 0, no information is
+   * printed (and no timings are taken), which can be useful to have some places
+   * in the code to be always instrumented, but not always enabled.
    * @param title The name of the timer
-   * @param title The reporting frequency.
+   * @param reportingFrequency The reporting frequency.
    * @return the perf timer object
-   */
+	*/
   @SuppressWarnings("unused")
   public static PerfTimer startTimer(final String title, final int reportingFrequency) {
     return new PerfTimer(title, reportingFrequency);

--- a/game-core/src/main/java/org/triplea/performance/PerfTimer.java
+++ b/game-core/src/main/java/org/triplea/performance/PerfTimer.java
@@ -27,22 +27,17 @@ public class PerfTimer implements Closeable {
   private static final Map<String, AtomicLong> runningTotal = new HashMap<>();
   private static final Map<String, AtomicLong> runningCount = new HashMap<>();
   private final String title;
-  private final Optional<Long> startNanos;
   private final int reportingFrequency;
+  private final long startNanos;
 
   private PerfTimer(final String title, final int reportingFrequency) {
     this.title = title;
     this.reportingFrequency = reportingFrequency;
-    // If reporting frequency is 0, avoid the overhead of querying the time.
-    if (this.reportingFrequency > 0) {
-      this.startNanos = Optional.of(System.nanoTime());
-    } else {
-      this.startNanos = Optional.empty();
-    }
+    this.startNanos = System.nanoTime();
   }
 
   private long stopTimer() {
-    return System.nanoTime() - startNanos.get();
+    return System.nanoTime() - startNanos;
   }
 
   @Override
@@ -60,8 +55,7 @@ public class PerfTimer implements Closeable {
   /**
    * Creates a perf timer with a reporting frequency. The reporting frequency specifies N specifies
    * that performance information should be printed every N executions of the timer. If 0, no
-   * information is printed (and no timings are taken), which can be useful to have some places in
-   * the code to be always instrumented, but not always enabled.
+   * information is printed.
    *
    * @param title The name of the timer
    * @param reportingFrequency The reporting frequency.

--- a/game-core/src/main/java/org/triplea/performance/PerfTimer.java
+++ b/game-core/src/main/java/org/triplea/performance/PerfTimer.java
@@ -3,6 +3,7 @@ package org.triplea.performance;
 import java.io.Closeable;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import lombok.extern.java.Log;
@@ -26,17 +27,22 @@ public class PerfTimer implements Closeable {
   private static final Map<String, AtomicLong> runningTotal = new HashMap<>();
   private static final Map<String, AtomicLong> runningCount = new HashMap<>();
   private final String title;
-  private final long startMillis;
+  private final Optional<Long> startNanos;
   private final int reportingFrequency;
 
   private PerfTimer(final String title, final int reportingFrequency) {
     this.title = title;
     this.reportingFrequency = reportingFrequency;
-    this.startMillis = this.reportingFrequency > 0 ? System.nanoTime() : 0;
+    // If reporting frequency is 0, avoid the overhead of querying the time.
+    if (this.reportingFrequency > 0) {
+      this.startNanos = Optional.of(System.nanoTime());
+    } else {
+      this.startNanos = Optional.empty();
+    }
   }
 
   private long stopTimer() {
-    return System.nanoTime() - startMillis;
+    return System.nanoTime() - startNanos.get();
   }
 
   @Override
@@ -51,6 +57,17 @@ public class PerfTimer implements Closeable {
     return startTimer(title, 1);
   }
 
+  /**
+   * Creates a perf timer with a reporting frequency. The reporting frequency specifies N specifies
+   * that performance information should be printed every N executions of the timer. If 0, no
+   * information is printed (and no timings are taken), which can be useful to have some places in
+   * the code to be always instrumented, but not always enabled.
+   *
+   * @param title The name of the timer
+   * @param title The reporting frequency.
+   * @return the perf timer object
+   */
+  @SuppressWarnings("unused")
   public static PerfTimer startTimer(final String title, final int reportingFrequency) {
     return new PerfTimer(title, reportingFrequency);
   }

--- a/game-core/src/main/java/org/triplea/performance/PerfTimer.java
+++ b/game-core/src/main/java/org/triplea/performance/PerfTimer.java
@@ -23,14 +23,16 @@ import lombok.extern.java.Log;
 @Log
 public class PerfTimer implements Closeable {
 
-  private static final PerfTimer DISABLED_TIMER = new PerfTimer("disabled");
   private static final Map<String, AtomicLong> runningTotal = new HashMap<>();
-  final String title;
+  private static final Map<String, AtomicLong> runningCount = new HashMap<>();
+  private final String title;
   private final long startMillis;
+  private final int reportingFrequency;
 
-  private PerfTimer(final String title) {
+  private PerfTimer(final String title, final int reportingFrequency) {
     this.title = title;
-    this.startMillis = System.nanoTime();
+    this.reportingFrequency = reportingFrequency;
+    this.startMillis = this.reportingFrequency > 0 ? System.nanoTime() : 0;
   }
 
   private long stopTimer() {
@@ -39,36 +41,54 @@ public class PerfTimer implements Closeable {
 
   @Override
   public void close() {
-    processResult(stopTimer(), this);
+    if (this.reportingFrequency > 0) {
+      processResult(stopTimer(), this);
+    }
   }
 
   @SuppressWarnings("unused")
   public static PerfTimer startTimer(final String title) {
-    return new PerfTimer(title);
+    return startTimer(title, 1);
+  }
+
+  public static PerfTimer startTimer(final String title, final int reportingFrequency) {
+    return new PerfTimer(title, reportingFrequency);
   }
 
   private static synchronized void processResult(final long stopNanos, final PerfTimer perfTimer) {
-    final long stopMicros = stopNanos / 1000;
-
-    final long milliFraction = (stopMicros % 1000) / 100;
-    final long millis = (stopMicros / 1000);
-
     final AtomicLong totalNanos =
         runningTotal.computeIfAbsent(perfTimer.title, key -> new AtomicLong(0));
-    totalNanos.set(totalNanos.get() + stopNanos);
+    final long totalNano = totalNanos.get() + stopNanos;
+    totalNanos.set(totalNano);
 
-    final long totalNano = totalNanos.get();
+    final AtomicLong totalCount =
+        runningCount.computeIfAbsent(perfTimer.title, key -> new AtomicLong(0));
+    final long newCount = totalCount.get() + 1;
+    totalCount.set(newCount);
+
+    if ((newCount % perfTimer.reportingFrequency) == 0) {
+      return;
+    }
+
     final long totalMillis = (totalNano / (1000 * 1000));
+    final long avgNanos = totalNano / newCount;
 
     log.info(
         String.format(
-            "%s: %s.%s ms; %s total ms;   %s ns; %s total ns",
-            perfTimer.title, //
-            millis,
-            milliFraction,
+            "%s: %s ms; %s total ms;   %s ns; %s total ns;   running avg %s ms",
+            perfTimer.title,
+            toMilllisString(stopNanos),
             totalMillis,
             stopNanos,
-            totalNano));
+            totalNano,
+            toMilllisString(avgNanos)));
+  }
+
+  private static String toMilllisString(final long nanos) {
+    final long micros = nanos / 1000;
+    final long millis = (micros / 1000);
+    final long milliFraction = (micros % 1000) / 100;
+    return String.format("%s.%s", millis, milliFraction);
   }
 
   public static <T> T time(final String title, final Supplier<T> functionToTime) {


### PR DESCRIPTION
Improve PerfTimer utility.

- Showing running average.
- Passing a frequency param to print stats every N calls
- If frequency is 0, no work is done. This allows adding
  the perf timer permanently to some code locations and
  having a pref setting to set the frequency / enable.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[X] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
