### PR TITLE
Convert defensive sub withdraw

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleActions.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleActions.java
@@ -22,4 +22,8 @@ public interface BattleActions {
       Collection<Territory> initialAvailableTerritories);
 
   void fireNavalBombardment(IDelegateBridge bridge);
+
+  void endBattle(IDelegateBridge bridge);
+
+  void attackerWins(IDelegateBridge bridge);
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
@@ -15,6 +15,8 @@ public interface BattleState {
 
   Collection<Unit> getAttackingUnits();
 
+  Collection<Unit> getAttackingWaitingToDie();
+
   Collection<Unit> getDefendingUnits();
 
   Collection<Unit> getDefendingWaitingToDie();
@@ -36,4 +38,6 @@ public interface BattleState {
   boolean isOver();
 
   Collection<Territory> getAttackerRetreatTerritories();
+
+  Collection<Territory> getEmptyOrFriendlySeaNeighbors(Collection<Unit> units);
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -1579,25 +1579,6 @@ public class MustFightBattle extends DependentBattle
         });
   }
 
-  private void defenderRetreatSubs(final IDelegateBridge bridge) {
-    if (!RetreatChecks.canDefenderRetreatSubs(
-        attackingUnits,
-        attackingWaitingToDie,
-        defendingUnits,
-        gameData,
-        this::getEmptyOrFriendlySeaNeighbors)) {
-      return;
-    }
-    if (!isOver && defendingUnits.stream().anyMatch(Matches.unitCanEvade())) {
-      queryRetreat(
-          true,
-          RetreatType.SUBS,
-          bridge,
-          getEmptyOrFriendlySeaNeighbors(
-              CollectionUtils.getMatches(defendingUnits, Matches.unitCanEvade())));
-    }
-  }
-
   /** Check for unescorted transports and kill them immediately. */
   private void checkUndefendedTransports(final IDelegateBridge bridge, final GamePlayer player) {
     // if we are the attacker, we can retreat instead of dying

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -156,6 +156,7 @@ public class MustFightBattle extends DependentBattle
 
   private static final long serialVersionUID = 5879502298361231540L;
 
+  @Getter(onMethod = @__({@Override}))
   private final Collection<Unit> attackingWaitingToDie = new ArrayList<>();
 
   @Getter(onMethod = @__({@Override}))
@@ -433,7 +434,8 @@ public class MustFightBattle extends DependentBattle
     endBattle(bridge);
   }
 
-  private void endBattle(final IDelegateBridge bridge) {
+  @Override
+  public void endBattle(final IDelegateBridge bridge) {
     clearWaitingToDieAndDamagedChangesInto(bridge);
     isOver = true;
     battleTracker.removeBattle(this, bridge.getData());
@@ -1012,8 +1014,8 @@ public class MustFightBattle extends DependentBattle
     return possible;
   }
 
-  @VisibleForTesting
-  protected Collection<Territory> getEmptyOrFriendlySeaNeighbors(
+  @Override
+  public Collection<Territory> getEmptyOrFriendlySeaNeighbors(
       final Collection<Unit> unitsToRetreat) {
     Collection<Territory> possible = gameData.getMap().getNeighbors(battleSite);
     if (headless) {
@@ -2433,7 +2435,8 @@ public class MustFightBattle extends DependentBattle
     checkDefendingPlanesCanLand();
   }
 
-  private void attackerWins(final IDelegateBridge bridge) {
+  @Override
+  public void attackerWins(final IDelegateBridge bridge) {
     whoWon = WhoWon.ATTACKER;
     bridge.getDisplayChannelBroadcaster().battleEnd(battleId, attacker.getName() + " win");
     if (headless) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleStep.java
@@ -22,10 +22,12 @@ public interface BattleStep extends IExecutable {
     AA_DEFENSIVE,
     NAVAL_BOMBARDMENT,
     SUB_OFFENSIVE_RETREAT_BEFORE_BATTLE,
+    SUB_DEFENSIVE_RETREAT_BEFORE_BATTLE,
     SUBMERGE_SUBS_VS_ONLY_AIR,
     AIR_OFFENSIVE_NON_SUBS,
     AIR_DEFENSIVE_NON_SUBS,
     SUB_OFFENSIVE_RETREAT_AFTER_BATTLE,
+    SUB_DEFENSIVE_RETREAT_AFTER_BATTLE,
   }
 
   /** @return a list of names that will be shown in {@link games.strategy.triplea.ui.BattlePanel} */

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleSteps.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleSteps.java
@@ -56,6 +56,7 @@ public class BattleSteps implements BattleStepStrings, BattleState {
   @Getter(onMethod = @__({@Override}))
   final @NonNull Collection<Unit> defendingUnits;
 
+  @Getter(onMethod = @__({@Override}))
   final @NonNull Collection<Unit> attackingWaitingToDie;
 
   @Getter(onMethod = @__({@Override}))
@@ -81,6 +82,11 @@ public class BattleSteps implements BattleStepStrings, BattleState {
   @Override
   public Collection<Territory> getAttackerRetreatTerritories() {
     return getAttackerRetreatTerritories.get();
+  }
+
+  @Override
+  public Collection<Territory> getEmptyOrFriendlySeaNeighbors(final Collection<Unit> units) {
+    return getEmptyOrFriendlySeaNeighbors.apply(units);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/RetreatChecks.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/RetreatChecks.java
@@ -7,7 +7,6 @@ import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.Matches;
 import java.util.Collection;
 import java.util.List;
-import java.util.function.Function;
 import java.util.function.Supplier;
 import lombok.NonNull;
 import lombok.experimental.UtilityClass;
@@ -15,24 +14,6 @@ import org.triplea.java.collections.CollectionUtils;
 
 @UtilityClass
 public class RetreatChecks {
-
-  public static boolean canDefenderRetreatSubs(
-      final @NonNull Collection<Unit> attackingUnits,
-      final @NonNull Collection<Unit> attackingWaitingToDie,
-      final @NonNull Collection<Unit> defendingUnits,
-      final @NonNull GameData gameData,
-      final @NonNull Function<Collection<Unit>, Collection<Territory>>
-              getEmptyOrFriendlySeaNeighbors) {
-    if (attackingUnits.stream().anyMatch(Matches.unitIsDestroyer())) {
-      return false;
-    }
-    return attackingWaitingToDie.stream().noneMatch(Matches.unitIsDestroyer())
-        && (getEmptyOrFriendlySeaNeighbors
-                    .apply(CollectionUtils.getMatches(defendingUnits, Matches.unitCanEvade()))
-                    .size()
-                != 0
-            || Properties.getSubmersibleSubs(gameData));
-  }
 
   public static boolean canAttackerRetreatPartialAmphib(
       final @NonNull Collection<Unit> attackingUnits,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreat.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreat.java
@@ -74,7 +74,8 @@ public class DefensiveSubsRetreat implements BattleStep {
     // If no defenders left, then battle is over. The reason we test a "second" time here,
     // is because otherwise the battle will try and do one more round and nothing will
     // happen in that round.
-    if (getOrder() == SUB_DEFENSIVE_RETREAT_AFTER_BATTLE && battleState.getDefendingUnits().isEmpty()) {
+    if (getOrder() == SUB_DEFENSIVE_RETREAT_AFTER_BATTLE
+        && battleState.getDefendingUnits().isEmpty()) {
       battleActions.endBattle(bridge);
       battleActions.attackerWins(bridge);
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreat.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreat.java
@@ -71,14 +71,12 @@ public class DefensiveSubsRetreat implements BattleStep {
         battleState.getEmptyOrFriendlySeaNeighbors(
             CollectionUtils.getMatches(battleState.getDefendingUnits(), Matches.unitCanEvade())));
 
-    if (getOrder() == SUB_DEFENSIVE_RETREAT_AFTER_BATTLE) {
-      // If no defenders left, then battle is over. The reason we test a "second" time here,
-      // is because otherwise the battle will try and do one more round and nothing will
-      // happen in that round.
-      if (battleState.getDefendingUnits().isEmpty()) {
-        battleActions.endBattle(bridge);
-        battleActions.attackerWins(bridge);
-      }
+    // If no defenders left, then battle is over. The reason we test a "second" time here,
+    // is because otherwise the battle will try and do one more round and nothing will
+    // happen in that round.
+    if (getOrder() == SUB_DEFENSIVE_RETREAT_AFTER_BATTLE && battleState.getDefendingUnits().isEmpty()) {
+      battleActions.endBattle(bridge);
+      battleActions.attackerWins(bridge);
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreat.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreat.java
@@ -1,0 +1,108 @@
+package games.strategy.triplea.delegate.battle.steps.retreat;
+
+import static games.strategy.triplea.delegate.battle.BattleStepStrings.SUBS_SUBMERGE;
+import static games.strategy.triplea.delegate.battle.BattleStepStrings.SUBS_WITHDRAW;
+import static games.strategy.triplea.delegate.battle.steps.BattleStep.Order.SUB_DEFENSIVE_RETREAT_AFTER_BATTLE;
+import static games.strategy.triplea.delegate.battle.steps.BattleStep.Order.SUB_DEFENSIVE_RETREAT_BEFORE_BATTLE;
+import static games.strategy.triplea.delegate.battle.steps.BattleStep.Order.SUB_OFFENSIVE_RETREAT_AFTER_BATTLE;
+import static games.strategy.triplea.delegate.battle.steps.BattleStep.Order.SUB_OFFENSIVE_RETREAT_BEFORE_BATTLE;
+
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.Properties;
+import games.strategy.triplea.delegate.ExecutionStack;
+import games.strategy.triplea.delegate.Matches;
+import games.strategy.triplea.delegate.battle.BattleActions;
+import games.strategy.triplea.delegate.battle.BattleState;
+import games.strategy.triplea.delegate.battle.MustFightBattle.RetreatType;
+import games.strategy.triplea.delegate.battle.steps.BattleStep;
+import games.strategy.triplea.delegate.battle.steps.RetreatChecks;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.triplea.java.collections.CollectionUtils;
+
+@AllArgsConstructor
+public class DefensiveSubsRetreat implements BattleStep {
+
+  private static final long serialVersionUID = 1249467218938096244L;
+
+  protected final BattleState battleState;
+
+  protected final BattleActions battleActions;
+
+  @Override
+  public List<String> getNames() {
+    // Check if defending subs can submerge before battle
+    if (Properties.getSubRetreatBeforeBattle(battleState.getGameData())) {
+      if (battleState.getAttackingUnits().stream().noneMatch(Matches.unitIsDestroyer())
+          && battleState.getDefendingUnits().stream().anyMatch(Matches.unitCanEvade())) {
+        return List.of(battleState.getDefender().getName() + SUBS_SUBMERGE);
+      }
+    }
+
+    // retreat defending subs
+    if (battleState.getDefendingUnits().stream().anyMatch(Matches.unitCanEvade())) {
+      if (Properties.getSubmersibleSubs(battleState.getGameData())) {
+        // TODO: BUG? Should the presence of destroyers be checked?
+        if (!Properties.getSubRetreatBeforeBattle(battleState.getGameData())) {
+          return List.of(battleState.getDefender().getName() + SUBS_SUBMERGE);
+        }
+      } else {
+        if (RetreatChecks.canDefenderRetreatSubs(
+            battleState.getAttackingUnits(),
+            battleState.getAttackingWaitingToDie(),
+            battleState.getDefendingUnits(),
+            battleState.getGameData(),
+            battleState::getEmptyOrFriendlySeaNeighbors)) {
+          return List.of(battleState.getDefender().getName() + SUBS_WITHDRAW);
+        }
+      }
+    }
+
+    return List.of();
+  }
+
+  @Override
+  public Order getOrder() {
+    if (Properties.getSubRetreatBeforeBattle(battleState.getGameData())) {
+      return SUB_DEFENSIVE_RETREAT_BEFORE_BATTLE;
+    } else {
+      return SUB_DEFENSIVE_RETREAT_AFTER_BATTLE;
+    }
+  }
+
+  @Override
+  public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+    if (battleState.isOver()) {
+      return;
+    }
+    defenderRetreatSubs(bridge);
+
+    if (getOrder() == SUB_DEFENSIVE_RETREAT_AFTER_BATTLE) {
+      // If no defenders left, then battle is over. The reason we test a "second" time here,
+      // is because otherwise the attackers can retreat even though the battle is over (illegal).
+      if (battleState.getDefendingUnits().isEmpty()) {
+        battleActions.endBattle(bridge);
+        battleActions.attackerWins(bridge);
+      }
+    }
+  }
+
+  private void defenderRetreatSubs(final IDelegateBridge bridge) {
+    if (!RetreatChecks.canDefenderRetreatSubs(
+        battleState.getAttackingUnits(),
+        battleState.getAttackingWaitingToDie(),
+        battleState.getDefendingUnits(),
+        battleState.getGameData(),
+        battleState::getEmptyOrFriendlySeaNeighbors)) {
+      return;
+    }
+    if (!battleState.isOver() && battleState.getDefendingUnits().stream().anyMatch(Matches.unitCanEvade())) {
+      battleActions.queryRetreat(
+          true,
+          RetreatType.SUBS,
+          bridge,
+          battleState.getEmptyOrFriendlySeaNeighbors(
+              CollectionUtils.getMatches(battleState.getDefendingUnits(), Matches.unitCanEvade())));
+    }
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/FakeBattleState.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/FakeBattleState.java
@@ -37,6 +37,9 @@ public class FakeBattleState implements BattleState {
   final @NonNull Collection<Unit> attackingUnits;
 
   @Getter(onMethod = @__({@Override}))
+  final @NonNull Collection<Unit> attackingWaitingToDie;
+
+  @Getter(onMethod = @__({@Override}))
   final @NonNull Collection<Unit> defendingUnits;
 
   @Getter(onMethod = @__({@Override}))
@@ -60,8 +63,15 @@ public class FakeBattleState implements BattleState {
   @Getter(onMethod = @__({@Override}))
   final Collection<Territory> attackerRetreatTerritories;
 
+  final Collection<Territory> emptyOrFriendlySeaNeighbors;
+
   @Getter(onMethod = @__({@Override}))
   final @NonNull Collection<Unit> bombardingUnits;
+
+  @Override
+  public Collection<Territory> getEmptyOrFriendlySeaNeighbors(final Collection<Unit> units) {
+    return emptyOrFriendlySeaNeighbors;
+  }
 
   public static FakeBattleState.FakeBattleStateBuilder givenBattleStateBuilder() {
     return FakeBattleState.builder()
@@ -69,6 +79,7 @@ public class FakeBattleState implements BattleState {
         .battleSite(mock(Territory.class))
         .attackingUnits(List.of())
         .defendingUnits(List.of())
+        .attackingWaitingToDie(List.of())
         .defendingWaitingToDie(List.of())
         .attacker(mock(GamePlayer.class))
         .defender(mock(GamePlayer.class))
@@ -78,6 +89,7 @@ public class FakeBattleState implements BattleState {
         .gameData(mock(GameData.class))
         .amphibious(false)
         .over(false)
-        .attackerRetreatTerritories(List.of());
+        .attackerRetreatTerritories(List.of())
+        .emptyOrFriendlySeaNeighbors(List.of());
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleExecutablesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/MustFightBattleExecutablesTest.java
@@ -52,6 +52,7 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.IExecutable;
 import games.strategy.triplea.delegate.battle.steps.fire.aa.DefensiveAaFire;
 import games.strategy.triplea.delegate.battle.steps.fire.aa.OffensiveAaFire;
+import games.strategy.triplea.delegate.battle.steps.retreat.DefensiveSubsRetreat;
 import java.math.BigDecimal;
 import java.util.EnumMap;
 import java.util.List;
@@ -383,7 +384,7 @@ class MustFightBattleExecutablesTest {
     battle.setUnits(List.of(canEvadeUnit), List.of(), List.of(), List.of(), defender, List.of());
     final List<IExecutable> execs = battle.getBattleExecutables(true);
 
-    final int index = getIndex(execs, MustFightBattle.DefenderRetreatSubsBeforeBattle.class);
+    final int index = getIndex(execs, DefensiveSubsRetreat.class);
     final IExecutable step = execs.get(index);
 
     final IDelegateBridge delegateBridge = mock(IDelegateBridge.class);
@@ -409,7 +410,7 @@ class MustFightBattleExecutablesTest {
         List.of(canEvadeUnit), List.of(destroyer), List.of(), List.of(), defender, List.of());
     final List<IExecutable> execs = battle.getBattleExecutables(true);
 
-    final int index = getIndex(execs, MustFightBattle.DefenderRetreatSubsBeforeBattle.class);
+    final int index = getIndex(execs, DefensiveSubsRetreat.class);
     final IExecutable step = execs.get(index);
 
     final IDelegateBridge delegateBridge = mock(IDelegateBridge.class);
@@ -439,38 +440,13 @@ class MustFightBattleExecutablesTest {
     battle.setUnits(List.of(), List.of(unit), List.of(), List.of(), defender, List.of());
     final List<IExecutable> execs = battle.getBattleExecutables(true);
 
-    final int index = getIndex(execs, MustFightBattle.DefenderRetreatSubsBeforeBattle.class);
+    final int index = getIndex(execs, DefensiveSubsRetreat.class);
     final IExecutable step = execs.get(index);
 
     final IDelegateBridge delegateBridge = mock(IDelegateBridge.class);
     step.execute(null, delegateBridge);
 
     verify(battle, never()).queryRetreat(anyBoolean(), any(), any(), any());
-  }
-
-  @Test
-  @DisplayName("Verify defending canEvade units can retreat if SUB_RETREAT_BEFORE_BATTLE")
-  void defenderSubsRetreatBeforeBattleIsAdded() {
-    final MustFightBattle battle = newBattle(WATER);
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(true);
-
-    battle.setUnits(List.of(), List.of(), List.of(), List.of(), defender, List.of());
-    final List<IExecutable> execs = battle.getBattleExecutables(true);
-
-    assertThatStepExists(execs, MustFightBattle.DefenderRetreatSubsBeforeBattle.class);
-  }
-
-  @Test
-  @DisplayName(
-      "Verify defending canEvade units can not retreat if SUB_RETREAT_BEFORE_BATTLE is false")
-  void defendingSubsRetreatIfCanNotRetreatBeforeBattle() {
-    final MustFightBattle battle = newBattle(WATER);
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-
-    battle.setUnits(List.of(), List.of(), List.of(), List.of(), defender, List.of());
-    final List<IExecutable> execs = battle.getBattleExecutables(true);
-
-    assertThatStepIsMissing(execs, MustFightBattle.DefenderRetreatSubsBeforeBattle.class);
   }
 
   @Test
@@ -494,7 +470,7 @@ class MustFightBattleExecutablesTest {
     battle.setUnits(List.of(canEvadeUnit), List.of(), List.of(), List.of(), defender, List.of());
     final List<IExecutable> execs = battle.getBattleExecutables(true);
 
-    final int index = getIndex(execs, MustFightBattle.DefenderRetreatSubsBeforeBattle.class);
+    final int index = getIndex(execs, DefensiveSubsRetreat.class);
     final IExecutable step = execs.get(index);
 
     final IDelegateBridge delegateBridge = mock(IDelegateBridge.class);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
@@ -587,7 +587,6 @@ public class BattleStepsTest {
   void defendingSubsRetreatIfNoDestroyersAndCanRetreatBeforeBattle() {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
-    givenDefenderNoRetreatTerritories();
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenUnitCanEvade();
 
@@ -661,9 +660,6 @@ public class BattleStepsTest {
     when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
     when(gameProperties.get(WW2V2, false)).thenReturn(false);
     when(gameProperties.get(DEFENDING_SUBS_SNEAK_ATTACK, false)).thenReturn(true);
-    when(gameProperties.get(ATTACKER_RETREAT_PLANES, false)).thenReturn(false);
-    when(gameProperties.get(PARTIAL_AMPHIBIOUS_RETREAT, false)).thenReturn(false);
-    when(gameProperties.get(SUBMERSIBLE_SUBS, false)).thenReturn(true);
     final List<String> steps =
         newStepBuilder()
             .attackingUnits(List.of(unit1))

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
@@ -591,6 +591,7 @@ public class BattleStepsTest {
     final Unit unit2 = givenUnitCanEvade();
 
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(true);
+    when(gameProperties.get(SUBMERSIBLE_SUBS, false)).thenReturn(true);
 
     final List<String> steps =
         newStepBuilder()
@@ -609,6 +610,7 @@ public class BattleStepsTest {
   void defendingSubsNotRetreatIfDestroyersAndCanRetreatBeforeBattle() {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
+    givenDefenderNoRetreatTerritories();
     final Unit unit1 = givenUnitDestroyer();
     final Unit unit2 = givenUnitCanEvade();
 
@@ -657,7 +659,7 @@ public class BattleStepsTest {
     final Unit unit2 = givenUnitDefenderFirstStrike();
 
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(true);
-    when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
+    when(gameProperties.get(SUBMERSIBLE_SUBS, false)).thenReturn(true);
     when(gameProperties.get(WW2V2, false)).thenReturn(false);
     when(gameProperties.get(DEFENDING_SUBS_SNEAK_ATTACK, false)).thenReturn(true);
     final List<String> steps =
@@ -892,6 +894,7 @@ public class BattleStepsTest {
   void defendingFirstStrikeWithSneakAttackAllowedAndDestroyers() {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
+    givenDefenderNoRetreatTerritories();
     final Unit unit1 = givenUnitDestroyer();
     final Unit unit2 = givenUnitDefenderFirstStrike();
 
@@ -955,6 +958,7 @@ public class BattleStepsTest {
   void defendingFirstStrikeWithWW2v2AndDestroyers() {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
+    givenDefenderNoRetreatTerritories();
     final Unit unit1 = givenUnitDestroyer();
     final Unit unit2 = givenUnitDefenderFirstStrike();
 
@@ -1053,6 +1057,7 @@ public class BattleStepsTest {
   void attackingDefendingFirstStrikeWithSneakAttackAllowedAndDestroyers() {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
+    givenDefenderNoRetreatTerritories();
     final Unit unit1 = givenUnitFirstStrike();
     final Unit unit2 = givenUnitDefenderFirstStrike();
     final Unit unit3 = givenUnitDestroyer();
@@ -1126,6 +1131,7 @@ public class BattleStepsTest {
   void attackingDefendingFirstStrikeWithWW2v2AndDestroyers() {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
+    givenDefenderNoRetreatTerritories();
     final Unit unit1 = givenUnitFirstStrike();
     final Unit unit2 = givenUnitDefenderFirstStrike();
     final Unit unit3 = givenUnitDestroyer();
@@ -1204,6 +1210,7 @@ public class BattleStepsTest {
   void attackingDefendingFirstStrikeWithSneakAttackAllowedAndAttackingDestroyers() {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
+    givenDefenderNoRetreatTerritories();
     final Unit unit1 = givenUnitAttackerFirstStrike();
     final Unit unit2 = givenUnitDefenderFirstStrike();
     final Unit unit3 = givenUnitDestroyer();
@@ -1276,6 +1283,7 @@ public class BattleStepsTest {
   void attackingDefendingFirstStrikeWithWW2v2AndAttackingDestroyers() {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
+    givenDefenderNoRetreatTerritories();
     final Unit unit1 = givenUnitAttackerFirstStrike();
     final Unit unit2 = givenUnitDefenderFirstStrike();
     final Unit unit3 = givenUnitDestroyer();
@@ -1414,6 +1422,7 @@ public class BattleStepsTest {
   void defendingFirstStrikeVsAirAndDestroyer() {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
+    givenDefenderNoRetreatTerritories();
     final Unit unit1 = givenUnitIsAir();
     final Unit unit2 = givenUnitDefenderFirstStrike();
     final Unit unit3 = givenUnitDestroyer();
@@ -1733,6 +1742,7 @@ public class BattleStepsTest {
   void defendingFirstStrikeNoWithdrawIfDestroyers() {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
+    givenDefenderNoRetreatTerritories();
     final Unit unit1 = givenUnitDestroyer();
     final Unit unit2 = givenUnitDefenderFirstStrike();
 
@@ -1740,36 +1750,6 @@ public class BattleStepsTest {
         newStepBuilder()
             .attackingUnits(List.of(unit1))
             .defendingUnits(List.of(unit2))
-            .build()
-            .get();
-
-    assertThat(
-        steps,
-        is(
-            List.of(
-                attacker.getName() + FIRE,
-                defender.getName() + SELECT_CASUALTIES,
-                defender.getName() + FIRST_STRIKE_UNITS_FIRE,
-                attacker.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_CASUALTIES)));
-  }
-
-  @Test
-  @DisplayName(
-      "Verify defending firstStrike can't withdraw when "
-          + "SUBMERSIBLE_SUBS is false and destroyers waiting to die")
-  void defendingFirstStrikeNoWithdrawIfDestroyersWaitingToDie() {
-    givenPlayers();
-    givenAttackerNoRetreatTerritories();
-    final Unit unit1 = givenAnyUnit();
-    final Unit unit2 = givenUnitDefenderFirstStrike();
-    final Unit unit3 = givenUnitDestroyer();
-
-    final List<String> steps =
-        newStepBuilder()
-            .attackingUnits(List.of(unit1))
-            .defendingUnits(List.of(unit2))
-            .attackingWaitingToDie(List.of(unit3))
             .build()
             .get();
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreatTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreatTest.java
@@ -1,0 +1,303 @@
+package games.strategy.triplea.delegate.battle.steps.retreat;
+
+import static games.strategy.triplea.delegate.battle.FakeBattleState.givenBattleStateBuilder;
+import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenAnyUnit;
+import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitCanEvade;
+import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitDestroyer;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.delegate.ExecutionStack;
+import games.strategy.triplea.delegate.battle.BattleActions;
+import games.strategy.triplea.delegate.battle.BattleState;
+import games.strategy.triplea.delegate.battle.MustFightBattle;
+import games.strategy.triplea.delegate.battle.steps.retreat.OffensiveSubsRetreatTest.MockGameData;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class DefensiveSubsRetreatTest {
+
+  @Mock ExecutionStack executionStack;
+  @Mock IDelegateBridge delegateBridge;
+  @Mock BattleActions battleActions;
+
+  @Test
+  void hasNamesWhenNotSubmersibleButHasRetreatTerritories() {
+    final BattleState battleState =
+        givenBattleStateBuilder()
+            .defendingUnits(List.of(givenUnitCanEvade()))
+            .gameData(MockGameData.givenGameData().build())
+            .emptyOrFriendlySeaNeighbors(List.of(mock(Territory.class)))
+            .build();
+    final DefensiveSubsRetreat defensiveSubsRetreat =
+        new DefensiveSubsRetreat(battleState, battleActions);
+
+    assertThat(defensiveSubsRetreat.getNames(), hasSize(1));
+  }
+
+  @Test
+  void hasNamesWhenHasNoRetreatTerritoriesButIsSubmersible() {
+    final BattleState battleState =
+        givenBattleStateBuilder()
+            .defendingUnits(List.of(givenUnitCanEvade()))
+            .gameData(
+                MockGameData.givenGameData()
+                    .withSubRetreatBeforeBattle(false)
+                    .withSubmersibleSubs(true)
+                    .build())
+            .emptyOrFriendlySeaNeighbors(List.of())
+            .build();
+    final DefensiveSubsRetreat defensiveSubsRetreat =
+        new DefensiveSubsRetreat(battleState, battleActions);
+
+    assertThat(defensiveSubsRetreat.getNames(), hasSize(1));
+  }
+
+  @Test
+  void hasNameWhenDestroyerIsOnOffenseAndWithdrawIsAfterBattle() {
+    final BattleState battleState =
+        givenBattleStateBuilder()
+            // it shouldn't even care if the attacking unit is a destroyer
+            .attackingUnits(List.of(mock(Unit.class)))
+            .defendingUnits(List.of(givenUnitCanEvade()))
+            .gameData(
+                MockGameData.givenGameData()
+                    .withSubRetreatBeforeBattle(false)
+                    .withSubmersibleSubs(true)
+                    .build())
+            .build();
+    final DefensiveSubsRetreat defensiveSubsRetreat =
+        new DefensiveSubsRetreat(battleState, battleActions);
+
+    assertThat(defensiveSubsRetreat.getNames(), hasSize(1));
+  }
+
+  @Test
+  void hasNoNamesWhenDestroyerIsOnOffenseAndWithdrawIsBeforeBattle() {
+    final BattleState battleState =
+        givenBattleStateBuilder()
+            .attackingUnits(List.of(givenUnitDestroyer()))
+            .defendingUnits(List.of(givenUnitCanEvade()))
+            .gameData(
+                MockGameData.givenGameData()
+                    .withSubmersibleSubs(true)
+                    .withSubRetreatBeforeBattle(true)
+                    .build())
+            .build();
+    final DefensiveSubsRetreat defensiveSubsRetreat =
+        new DefensiveSubsRetreat(battleState, battleActions);
+
+    assertThat(defensiveSubsRetreat.getNames(), hasSize(0));
+  }
+
+  @Test
+  void hasNoNamesWhenCanNotSubmergeAndNoRetreatTerritories() {
+    final BattleState battleState =
+        givenBattleStateBuilder()
+            .gameData(MockGameData.givenGameData().build())
+            .emptyOrFriendlySeaNeighbors(List.of())
+            .build();
+    final DefensiveSubsRetreat defensiveSubsRetreat =
+        new DefensiveSubsRetreat(battleState, battleActions);
+
+    assertThat(defensiveSubsRetreat.getNames(), hasSize(0));
+  }
+
+  @Test
+  void retreatHappensWhenNotSubmersibleButHasRetreatTerritories() {
+    final BattleState battleState =
+        givenBattleStateBuilder()
+            .defendingUnits(List.of(givenUnitCanEvade()))
+            .gameData(MockGameData.givenGameData().build())
+            .emptyOrFriendlySeaNeighbors(List.of(mock(Territory.class)))
+            .build();
+    final DefensiveSubsRetreat defensiveSubsRetreat =
+        new DefensiveSubsRetreat(battleState, battleActions);
+
+    assertThat(defensiveSubsRetreat.getNames(), hasSize(1));
+  }
+
+  @Test
+  void retreatHappensWhenHasNoRetreatTerritoriesButIsSubmersible() {
+    final BattleState battleState =
+        givenBattleStateBuilder()
+            .defendingUnits(List.of(givenUnitCanEvade()))
+            .gameData(MockGameData.givenGameData().withSubmersibleSubs(true).build())
+            .emptyOrFriendlySeaNeighbors(List.of())
+            .build();
+    final DefensiveSubsRetreat defensiveSubsRetreat =
+        new DefensiveSubsRetreat(battleState, battleActions);
+
+    defensiveSubsRetreat.execute(executionStack, delegateBridge);
+
+    verify(battleActions)
+        .queryRetreat(eq(true), eq(MustFightBattle.RetreatType.SUBS), eq(delegateBridge), any());
+  }
+
+  @Test
+  void retreatDoesNotHappenWhenBattleIsOver() {
+    final BattleState battleState =
+        givenBattleStateBuilder().defendingUnits(List.of(mock(Unit.class))).over(true).build();
+    final DefensiveSubsRetreat defensiveSubsRetreat =
+        new DefensiveSubsRetreat(battleState, battleActions);
+
+    defensiveSubsRetreat.execute(executionStack, delegateBridge);
+
+    verify(battleActions, never()).queryRetreat(anyBoolean(), any(), any(), any());
+  }
+
+  @Test
+  void retreatDoesNotHappenWhenDestroyerIsOnOffense() {
+    final BattleState battleState =
+        givenBattleStateBuilder()
+            .defendingUnits(List.of(mock(Unit.class)))
+            .attackingUnits(List.of(givenUnitDestroyer()))
+            .build();
+    final DefensiveSubsRetreat defensiveSubsRetreat =
+        new DefensiveSubsRetreat(battleState, battleActions);
+
+    defensiveSubsRetreat.execute(executionStack, delegateBridge);
+
+    verify(battleActions, never()).queryRetreat(anyBoolean(), any(), any(), any());
+  }
+
+  @Test
+  void retreatDoesNotHappenWhenWaitingToDieDestroyerIsOnOffense() {
+    final BattleState battleState =
+        givenBattleStateBuilder()
+            .defendingUnits(List.of(mock(Unit.class)))
+            .attackingWaitingToDie(List.of(givenUnitDestroyer()))
+            .build();
+    final DefensiveSubsRetreat defensiveSubsRetreat =
+        new DefensiveSubsRetreat(battleState, battleActions);
+
+    defensiveSubsRetreat.execute(executionStack, delegateBridge);
+
+    verify(battleActions, never()).queryRetreat(anyBoolean(), any(), any(), any());
+  }
+
+  @Test
+  void retreatDoesNotHappenWhenCanNotSubmergeAndNoRetreatTerritories() {
+    final BattleState battleState =
+        givenBattleStateBuilder()
+            .gameData(MockGameData.givenGameData().build())
+            .emptyOrFriendlySeaNeighbors(List.of())
+            .build();
+    final DefensiveSubsRetreat defensiveSubsRetreat =
+        new DefensiveSubsRetreat(battleState, battleActions);
+
+    defensiveSubsRetreat.execute(executionStack, delegateBridge);
+
+    verify(battleActions, never()).queryRetreat(anyBoolean(), any(), any(), any());
+  }
+
+  @Test
+  void gameIsOverIfAfterRegularBattleAndAllDefendingUnitsAreEvadersAndWithdraw() {
+
+    final BattleState battleState =
+        spy(
+            givenBattleStateBuilder()
+                .gameData(
+                    MockGameData.givenGameData()
+                        .withSubmersibleSubs(true)
+                        .withSubRetreatBeforeBattle(false)
+                        .build())
+                .emptyOrFriendlySeaNeighbors(List.of())
+                .build());
+
+    // first return an evader so it can retreat it
+    // then return nothing to indicate that the evader retreated during the queryRetreat call
+    doReturn(List.of(givenUnitCanEvade()), List.of()).when(battleState).getDefendingUnits();
+
+    final DefensiveSubsRetreat defensiveSubsRetreat =
+        new DefensiveSubsRetreat(battleState, battleActions);
+
+    defensiveSubsRetreat.execute(executionStack, delegateBridge);
+
+    verify(battleActions)
+        .queryRetreat(eq(true), eq(MustFightBattle.RetreatType.SUBS), eq(delegateBridge), any());
+
+    verify(battleActions).endBattle(eq(delegateBridge));
+    verify(battleActions).attackerWins(eq(delegateBridge));
+  }
+
+  @Test
+  void gameIsNotOverIfAfterRegularBattleAndNotAllDefendingUnitsAreEvadersAndWithdraw() {
+
+    final BattleState battleState =
+        spy(
+            givenBattleStateBuilder()
+                .gameData(
+                    MockGameData.givenGameData()
+                        .withSubmersibleSubs(true)
+                        .withSubRetreatBeforeBattle(false)
+                        .build())
+                .emptyOrFriendlySeaNeighbors(List.of())
+                .build());
+
+    // first return an evader so it can retreat it
+    // then return nothing to indicate that the evader retreated during the queryRetreat call
+    doReturn(List.of(givenUnitCanEvade(), mock(Unit.class)), List.of(givenAnyUnit()))
+        .when(battleState)
+        .getDefendingUnits();
+
+    final DefensiveSubsRetreat defensiveSubsRetreat =
+        new DefensiveSubsRetreat(battleState, battleActions);
+
+    defensiveSubsRetreat.execute(executionStack, delegateBridge);
+
+    verify(battleActions)
+        .queryRetreat(eq(true), eq(MustFightBattle.RetreatType.SUBS), eq(delegateBridge), any());
+
+    verify(battleActions, never()).endBattle(eq(delegateBridge));
+    verify(battleActions, never()).attackerWins(eq(delegateBridge));
+  }
+
+  @Test
+  void gameIsNotOverIfBeforeRegularBattleAndAllDefendingUnitsAreEvadersAndWithdraw() {
+
+    final BattleState battleState =
+        spy(
+            givenBattleStateBuilder()
+                .gameData(
+                    MockGameData.givenGameData()
+                        .withSubmersibleSubs(true)
+                        .withSubRetreatBeforeBattle(true)
+                        .build())
+                .emptyOrFriendlySeaNeighbors(List.of())
+                .build());
+
+    // first return an evader so it can retreat it
+    doReturn(List.of(givenUnitCanEvade()))
+        // then return nothing to indicate that the evader retreated during the queryRetreat call
+        .doReturn(List.of())
+        .when(battleState)
+        .getDefendingUnits();
+
+    final DefensiveSubsRetreat defensiveSubsRetreat =
+        new DefensiveSubsRetreat(battleState, battleActions);
+
+    defensiveSubsRetreat.execute(executionStack, delegateBridge);
+
+    verify(battleActions)
+        .queryRetreat(eq(true), eq(MustFightBattle.RetreatType.SUBS), eq(delegateBridge), any());
+
+    verify(battleActions, never()).endBattle(eq(delegateBridge));
+    verify(battleActions, never()).attackerWins(eq(delegateBridge));
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveSubsRetreatTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveSubsRetreatTest.java
@@ -80,10 +80,7 @@ class OffensiveSubsRetreatTest {
             .attackingUnits(List.of(givenUnitCanEvade()))
             // it shouldn't even care if the defending unit is a destroyer
             .defendingUnits(List.of(mock(Unit.class)))
-            .gameData(
-                MockGameData.givenGameData()
-                    .withSubmersibleSubs(true)
-                    .build())
+            .gameData(MockGameData.givenGameData().withSubmersibleSubs(true).build())
             .build();
     final OffensiveSubsRetreat offensiveSubsRetreat =
         new OffensiveSubsRetreat(battleState, battleActions);
@@ -97,9 +94,11 @@ class OffensiveSubsRetreatTest {
         givenBattleStateBuilder()
             .attackingUnits(List.of(givenUnitCanEvade()))
             .defendingUnits(List.of(givenUnitDestroyer()))
-            .gameData(MockGameData.givenGameData()
-                .withSubmersibleSubs(true)
-                .withSubRetreatBeforeBattle(true).build())
+            .gameData(
+                MockGameData.givenGameData()
+                    .withSubmersibleSubs(true)
+                    .withSubRetreatBeforeBattle(true)
+                    .build())
             .build();
     final OffensiveSubsRetreat offensiveSubsRetreat =
         new OffensiveSubsRetreat(battleState, battleActions);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveSubsRetreatTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveSubsRetreatTest.java
@@ -1,12 +1,15 @@
 package games.strategy.triplea.delegate.battle.steps.retreat;
 
 import static games.strategy.triplea.Constants.SUBMERSIBLE_SUBS;
+import static games.strategy.triplea.Constants.SUB_RETREAT_BEFORE_BATTLE;
 import static games.strategy.triplea.Constants.TRANSPORT_CASUALTIES_RESTRICTED;
 import static games.strategy.triplea.delegate.battle.FakeBattleState.givenBattleStateBuilder;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenAnyUnit;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitCanEvade;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitDestroyer;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitTransport;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.eq;
@@ -39,6 +42,118 @@ class OffensiveSubsRetreatTest {
   @Mock BattleActions battleActions;
 
   @Test
+  void hasNamesWhenNotSubmersibleButHasRetreatTerritories() {
+    final BattleState battleState =
+        givenBattleStateBuilder()
+            .attackingUnits(List.of(givenUnitCanEvade()))
+            .gameData(MockGameData.givenGameData().build())
+            .attackerRetreatTerritories(List.of(mock(Territory.class)))
+            .build();
+    final OffensiveSubsRetreat offensiveSubsRetreat =
+        new OffensiveSubsRetreat(battleState, battleActions);
+
+    assertThat(offensiveSubsRetreat.getNames(), hasSize(1));
+  }
+
+  @Test
+  void hasNamesWhenHasNoRetreatTerritoriesButIsSubmersible() {
+    final BattleState battleState =
+        givenBattleStateBuilder()
+            .attackingUnits(List.of(givenUnitCanEvade()))
+            .gameData(
+                MockGameData.givenGameData()
+                    .withSubRetreatBeforeBattle(false)
+                    .withSubmersibleSubs(true)
+                    .build())
+            .attackerRetreatTerritories(List.of())
+            .build();
+    final OffensiveSubsRetreat offensiveSubsRetreat =
+        new OffensiveSubsRetreat(battleState, battleActions);
+
+    assertThat(offensiveSubsRetreat.getNames(), hasSize(1));
+  }
+
+  @Test
+  void hasNameWhenDestroyerIsOnDefenseAndWithdrawIsAfterBattle() {
+    final BattleState battleState =
+        givenBattleStateBuilder()
+            .attackingUnits(List.of(givenUnitCanEvade()))
+            // it shouldn't even care if the defending unit is a destroyer
+            .defendingUnits(List.of(mock(Unit.class)))
+            .gameData(
+                MockGameData.givenGameData()
+                    .withSubmersibleSubs(true)
+                    .build())
+            .build();
+    final OffensiveSubsRetreat offensiveSubsRetreat =
+        new OffensiveSubsRetreat(battleState, battleActions);
+
+    assertThat(offensiveSubsRetreat.getNames(), hasSize(1));
+  }
+
+  @Test
+  void hasNoNamesWhenDestroyerIsOnDefenseAndWithdrawIsBeforeBattle() {
+    final BattleState battleState =
+        givenBattleStateBuilder()
+            .attackingUnits(List.of(givenUnitCanEvade()))
+            .defendingUnits(List.of(givenUnitDestroyer()))
+            .gameData(MockGameData.givenGameData()
+                .withSubmersibleSubs(true)
+                .withSubRetreatBeforeBattle(true).build())
+            .build();
+    final OffensiveSubsRetreat offensiveSubsRetreat =
+        new OffensiveSubsRetreat(battleState, battleActions);
+
+    assertThat(offensiveSubsRetreat.getNames(), hasSize(0));
+  }
+
+  @Test
+  void hasNoNamesWhenAmphibiousAssault() {
+    final BattleState battleState =
+        givenBattleStateBuilder()
+            .attackingUnits(List.of(givenUnitCanEvade()))
+            .gameData(MockGameData.givenGameData().build())
+            .amphibious(true)
+            .build();
+    final OffensiveSubsRetreat offensiveSubsRetreat =
+        new OffensiveSubsRetreat(battleState, battleActions);
+
+    assertThat(offensiveSubsRetreat.getNames(), hasSize(0));
+  }
+
+  @Test
+  void hasNoNamesWhenDefenselessTransportsEvenIfCanWithdraw() {
+    final BattleState battleState =
+        givenBattleStateBuilder()
+            .attackingUnits(List.of(givenUnitCanEvade()))
+            .gameData(
+                MockGameData.givenGameData()
+                    .withTransportCasualtiesRestricted(true)
+                    .withSubmersibleSubs(false)
+                    .build())
+            .defendingUnits(List.of(givenUnitTransport()))
+            .attackerRetreatTerritories(List.of(mock(Territory.class)))
+            .build();
+    final OffensiveSubsRetreat offensiveSubsRetreat =
+        new OffensiveSubsRetreat(battleState, battleActions);
+
+    assertThat(offensiveSubsRetreat.getNames(), hasSize(0));
+  }
+
+  @Test
+  void hasNoNamesWhenCanNotSubmergeAndNoRetreatTerritories() {
+    final BattleState battleState =
+        givenBattleStateBuilder()
+            .gameData(MockGameData.givenGameData().build())
+            .attackerRetreatTerritories(List.of())
+            .build();
+    final OffensiveSubsRetreat offensiveSubsRetreat =
+        new OffensiveSubsRetreat(battleState, battleActions);
+
+    assertThat(offensiveSubsRetreat.getNames(), hasSize(0));
+  }
+
+  @Test
   void retreatHappensWhenNotSubmersibleButHasRetreatTerritories() {
     final BattleState battleState =
         givenBattleStateBuilder()
@@ -49,10 +164,7 @@ class OffensiveSubsRetreatTest {
     final OffensiveSubsRetreat offensiveSubsRetreat =
         new OffensiveSubsRetreat(battleState, battleActions);
 
-    offensiveSubsRetreat.execute(executionStack, delegateBridge);
-
-    verify(battleActions)
-        .queryRetreat(eq(false), eq(MustFightBattle.RetreatType.SUBS), eq(delegateBridge), any());
+    assertThat(offensiveSubsRetreat.getNames(), hasSize(1));
   }
 
   @Test
@@ -235,6 +347,11 @@ class OffensiveSubsRetreatTest {
 
     MockGameData withSubmersibleSubs(final boolean value) {
       when(gameProperties.get(SUBMERSIBLE_SUBS, false)).thenReturn(value);
+      return this;
+    }
+
+    MockGameData withSubRetreatBeforeBattle(final boolean value) {
+      when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(value);
       return this;
     }
   }


### PR DESCRIPTION
This converts the defensive sub withdraw step.

It is very similar to the offensive sub withdraw step.  The only difference is the offensive one checks for undefended subs and prevents the retreat while the defensive one checks to see if everything has been retreated and marks the game over.  I think both of that can be reworked in separate steps but that is for a later refactoring.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix
[] Other:   <!-- Please specify -->

## Testing
Create a saved game with defensive sub retreat and verified that it loads.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
This also unifies the logic for the step names and the executable just like with the offensive sub retreat step (#6719).  See the notes there on what was unified.

I also noticed that I had no tests for the step names in the offensive sub retreat test file.  I added those tests as part of this PR.

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
