### PR TITLE
Only check for FirstStrike when deciding to show the FirstStrike step

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleSteps.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleSteps.java
@@ -201,8 +201,7 @@ public class BattleSteps implements BattleStepStrings, BattleState {
     // also, ww2v3/global rules, defending subs without sneak attack fire with all defenders
     final Collection<Unit> defendingUnitsAliveAndDamaged = new ArrayList<>(defendingUnits);
     defendingUnitsAliveAndDamaged.addAll(defendingWaitingToDie);
-    // TODO: BUG? why is unitCanNotTargetAll used instead of unitIsFirstStrike?
-    if (defendingUnitsAliveAndDamaged.stream().anyMatch(Matches.unitCanNotTargetAll())
+    if (defendingUnitsAliveAndDamaged.stream().anyMatch(Matches.unitIsFirstStrike())
         && !defenderSubsFireFirst
         && (defendingSubsFireWithAllDefenders || defendingSubsFireWithAllDefendersAlways)) {
       steps.add(defender.getName() + FIRST_STRIKE_UNITS_FIRE);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
@@ -142,14 +142,14 @@ public class BattleStepsTest {
     return unitAndAttachment.unit;
   }
 
-  public static Unit givenUnitAttackerFirstStrike() {
+  public static Unit givenUnitFirstStrikeAndEvade() {
     final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
     when(unitAndAttachment.unitAttachment.getIsFirstStrike()).thenReturn(true);
     when(unitAndAttachment.unitAttachment.getCanEvade()).thenReturn(true);
     return unitAndAttachment.unit;
   }
 
-  public static Unit givenUnitAttackerFirstStrikeCanNotBeTargetedBy(final UnitType otherType) {
+  public static Unit givenUnitFirstStrikeAndEvadeAndCanNotBeTargetedBy(final UnitType otherType) {
     final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
     when(unitAndAttachment.unitAttachment.getIsFirstStrike()).thenReturn(true);
     when(unitAndAttachment.unitAttachment.getCanEvade()).thenReturn(true);
@@ -167,25 +167,6 @@ public class BattleStepsTest {
 
   public static Unit givenUnitCanNotBeTargetedBy(final UnitType otherType) {
     final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
-    when(unitAndAttachment.unitAttachment.getCanNotBeTargetedBy()).thenReturn(Set.of(otherType));
-    return unitAndAttachment.unit;
-  }
-
-  public static Unit givenUnitDefenderFirstStrike() {
-    final UnitType canNotTargetType = mock(UnitType.class);
-    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
-    when(unitAndAttachment.unitAttachment.getIsFirstStrike()).thenReturn(true);
-    when(unitAndAttachment.unitAttachment.getCanEvade()).thenReturn(true);
-    when(unitAndAttachment.unitAttachment.getCanNotTarget()).thenReturn(Set.of(canNotTargetType));
-    return unitAndAttachment.unit;
-  }
-
-  public static Unit givenUnitDefenderFirstStrikeCanNotBeTargetedBy(final UnitType otherType) {
-    final UnitType canNotTargetType = mock(UnitType.class);
-    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
-    when(unitAndAttachment.unitAttachment.getIsFirstStrike()).thenReturn(true);
-    when(unitAndAttachment.unitAttachment.getCanEvade()).thenReturn(true);
-    when(unitAndAttachment.unitAttachment.getCanNotTarget()).thenReturn(Set.of(canNotTargetType));
     when(unitAndAttachment.unitAttachment.getCanNotBeTargetedBy()).thenReturn(Set.of(otherType));
     return unitAndAttachment.unit;
   }
@@ -655,7 +636,7 @@ public class BattleStepsTest {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
     final Unit unit1 = givenAnyUnit();
-    final Unit unit2 = givenUnitDefenderFirstStrike();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(true);
     when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
@@ -780,7 +761,7 @@ public class BattleStepsTest {
   void attackingFirstStrikeBasic() {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
-    final Unit unit1 = givenUnitAttackerFirstStrike();
+    final Unit unit1 = givenUnitFirstStrikeAndEvade();
     final Unit unit2 = givenAnyUnit();
 
     final List<String> steps =
@@ -837,7 +818,7 @@ public class BattleStepsTest {
     givenAttackerNoRetreatTerritories();
     givenDefenderNoRetreatTerritories();
     final Unit unit1 = givenAnyUnit();
-    final Unit unit2 = givenUnitDefenderFirstStrike();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         newStepBuilder()
@@ -864,7 +845,7 @@ public class BattleStepsTest {
     givenAttackerNoRetreatTerritories();
     givenDefenderNoRetreatTerritories();
     final Unit unit1 = givenAnyUnit();
-    final Unit unit2 = givenUnitDefenderFirstStrike();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
     when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
@@ -897,7 +878,7 @@ public class BattleStepsTest {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
     final Unit unit1 = givenUnitDestroyer();
-    final Unit unit2 = givenUnitDefenderFirstStrike();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
     when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
@@ -929,7 +910,7 @@ public class BattleStepsTest {
     givenAttackerNoRetreatTerritories();
     givenDefenderNoRetreatTerritories();
     final Unit unit1 = givenAnyUnit();
-    final Unit unit2 = givenUnitDefenderFirstStrike();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
     when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
@@ -960,7 +941,7 @@ public class BattleStepsTest {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
     final Unit unit1 = givenUnitDestroyer();
-    final Unit unit2 = givenUnitDefenderFirstStrike();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
     when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
@@ -993,8 +974,8 @@ public class BattleStepsTest {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
     givenDefenderNoRetreatTerritories();
-    final Unit unit1 = givenUnitAttackerFirstStrike();
-    final Unit unit2 = givenUnitDefenderFirstStrike();
+    final Unit unit1 = givenUnitFirstStrikeAndEvade();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         newStepBuilder()
@@ -1021,8 +1002,8 @@ public class BattleStepsTest {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
     givenDefenderNoRetreatTerritories();
-    final Unit unit1 = givenUnitAttackerFirstStrike();
-    final Unit unit2 = givenUnitDefenderFirstStrike();
+    final Unit unit1 = givenUnitFirstStrikeAndEvade();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
     when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
@@ -1058,7 +1039,7 @@ public class BattleStepsTest {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
     final Unit unit1 = givenUnitFirstStrike();
-    final Unit unit2 = givenUnitDefenderFirstStrike();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
     final Unit unit3 = givenUnitDestroyer();
     final Unit unit4 = givenUnitDestroyer();
 
@@ -1096,8 +1077,8 @@ public class BattleStepsTest {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
     givenDefenderNoRetreatTerritories();
-    final Unit unit1 = givenUnitAttackerFirstStrike();
-    final Unit unit2 = givenUnitDefenderFirstStrike();
+    final Unit unit1 = givenUnitFirstStrikeAndEvade();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
     when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
@@ -1131,7 +1112,7 @@ public class BattleStepsTest {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
     final Unit unit1 = givenUnitFirstStrike();
-    final Unit unit2 = givenUnitDefenderFirstStrike();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
     final Unit unit3 = givenUnitDestroyer();
     final Unit unit4 = givenUnitDestroyer();
 
@@ -1171,7 +1152,7 @@ public class BattleStepsTest {
     givenAttackerNoRetreatTerritories();
     givenDefenderNoRetreatTerritories();
     final Unit unit1 = givenUnitFirstStrike();
-    final Unit unit2 = givenUnitDefenderFirstStrike();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
     final Unit unit3 = givenUnitDestroyer();
 
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
@@ -1208,8 +1189,8 @@ public class BattleStepsTest {
   void attackingDefendingFirstStrikeWithSneakAttackAllowedAndAttackingDestroyers() {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
-    final Unit unit1 = givenUnitAttackerFirstStrike();
-    final Unit unit2 = givenUnitDefenderFirstStrike();
+    final Unit unit1 = givenUnitFirstStrikeAndEvade();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
     final Unit unit3 = givenUnitDestroyer();
 
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
@@ -1246,7 +1227,7 @@ public class BattleStepsTest {
     givenAttackerNoRetreatTerritories();
     givenDefenderNoRetreatTerritories();
     final Unit unit1 = givenUnitFirstStrike();
-    final Unit unit2 = givenUnitDefenderFirstStrike();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
     final Unit unit3 = givenUnitDestroyer();
 
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
@@ -1280,8 +1261,8 @@ public class BattleStepsTest {
   void attackingDefendingFirstStrikeWithWW2v2AndAttackingDestroyers() {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
-    final Unit unit1 = givenUnitAttackerFirstStrike();
-    final Unit unit2 = givenUnitDefenderFirstStrike();
+    final Unit unit1 = givenUnitFirstStrikeAndEvade();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
     final Unit unit3 = givenUnitDestroyer();
 
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
@@ -1316,7 +1297,7 @@ public class BattleStepsTest {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
     final Unit unit2 = givenUnitIsAir();
-    final Unit unit1 = givenUnitAttackerFirstStrikeCanNotBeTargetedBy(unit2.getType());
+    final Unit unit1 = givenUnitFirstStrikeAndEvadeAndCanNotBeTargetedBy(unit2.getType());
 
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
     when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
@@ -1384,7 +1365,7 @@ public class BattleStepsTest {
     givenAttackerNoRetreatTerritories();
     givenDefenderNoRetreatTerritories();
     final Unit unit1 = givenUnitIsAir();
-    final Unit unit2 = givenUnitDefenderFirstStrikeCanNotBeTargetedBy(mock(UnitType.class));
+    final Unit unit2 = givenUnitFirstStrikeAndEvadeAndCanNotBeTargetedBy(mock(UnitType.class));
 
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
     when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
@@ -1419,7 +1400,7 @@ public class BattleStepsTest {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
     final Unit unit1 = givenUnitIsAir();
-    final Unit unit2 = givenUnitDefenderFirstStrike();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
     final Unit unit3 = givenUnitDestroyer();
 
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
@@ -1452,7 +1433,7 @@ public class BattleStepsTest {
   void attackingFirstStrikeCanSubmergeIfSubmersibleSubs() {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
-    final Unit unit1 = givenUnitAttackerFirstStrike();
+    final Unit unit1 = givenUnitFirstStrikeAndEvade();
     final Unit unit2 = givenAnyUnit();
 
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
@@ -1486,7 +1467,7 @@ public class BattleStepsTest {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
     final Unit unit1 = givenAnyUnit();
-    final Unit unit2 = givenUnitDefenderFirstStrike();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
     when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
@@ -1522,7 +1503,7 @@ public class BattleStepsTest {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
     final Unit unit1 = givenUnitDestroyer();
-    final Unit unit2 = givenUnitDefenderFirstStrike();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
     when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
     when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
@@ -1555,7 +1536,7 @@ public class BattleStepsTest {
   void attackingFirstStrikeWithdrawIfAble() {
     givenPlayers();
     givenAttackerRetreatTerritories(battleSite);
-    final Unit unit1 = givenUnitAttackerFirstStrike();
+    final Unit unit1 = givenUnitFirstStrikeAndEvade();
     final Unit unit2 = givenAnyUnit();
 
     final List<String> steps =
@@ -1586,7 +1567,7 @@ public class BattleStepsTest {
   void attackingFirstStrikeNoWithdrawIfEmptyTerritories() {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
-    final Unit unit1 = givenUnitAttackerFirstStrike();
+    final Unit unit1 = givenUnitFirstStrikeAndEvade();
     final Unit unit2 = givenAnyUnit();
 
     final List<String> steps =
@@ -1644,7 +1625,7 @@ public class BattleStepsTest {
   void attackingFirstStrikeWithdrawIfNonRestrictedDefenselessTransports() {
     givenPlayers();
     givenAttackerRetreatTerritories(battleSite);
-    final Unit unit1 = givenUnitAttackerFirstStrike();
+    final Unit unit1 = givenUnitFirstStrikeAndEvade();
     final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
     final Unit unit2 = unitAndAttachment.unit;
 
@@ -1680,7 +1661,7 @@ public class BattleStepsTest {
     givenAttackerNoRetreatTerritories();
     givenDefenderRetreatTerritories(battleSite);
     final Unit unit1 = givenAnyUnit();
-    final Unit unit2 = givenUnitDefenderFirstStrike();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         newStepBuilder()
@@ -1710,7 +1691,7 @@ public class BattleStepsTest {
     givenAttackerNoRetreatTerritories();
     givenDefenderNoRetreatTerritories();
     final Unit unit1 = givenAnyUnit();
-    final Unit unit2 = givenUnitDefenderFirstStrike();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         newStepBuilder()
@@ -1738,7 +1719,7 @@ public class BattleStepsTest {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
     final Unit unit1 = givenUnitDestroyer();
-    final Unit unit2 = givenUnitDefenderFirstStrike();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         newStepBuilder()
@@ -1766,7 +1747,7 @@ public class BattleStepsTest {
     givenPlayers();
     givenAttackerNoRetreatTerritories();
     final Unit unit1 = givenAnyUnit();
-    final Unit unit2 = givenUnitDefenderFirstStrike();
+    final Unit unit2 = givenUnitFirstStrikeAndEvade();
     final Unit unit3 = givenUnitDestroyer();
 
     final List<String> steps =


### PR DESCRIPTION
Fixes #6878

To duplicate, you need a map that has an `isSub` unit but no air units.  Then you attack the `isSub` unit with an `isDestroyer` unit.  The `Carribbean Trade War` map has this scenario.  Attack a Sloop with a Battleship and this error will occur.

You can also duplicate it by having an `isFirstStrike` unit that has an empty `canNotTarget`.  I don't know of any maps like that, though.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix
[] Other:   <!-- Please specify -->

## Testing
Attacked a Sloop with a Battleship in the Caribbean Trade War.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->FIX|Attacking a sub unit with a destroyer unit in a map with no air units will no longer throw an error.<!--END_RELEASE_NOTE-->
