### PR TITLE
Use thread-safe chatters list

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/Chat.java
@@ -1,6 +1,7 @@
 package games.strategy.engine.chat;
 
 import com.google.common.collect.EvictingQueue;
+import com.google.common.collect.Sets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -31,7 +32,7 @@ public class Chat implements ChatClient {
   @Getter(AccessLevel.PACKAGE)
   private final SentMessagesHistory sentMessagesHistory;
 
-  private final Collection<ChatParticipant> chatters = new HashSet<>();
+  private final Collection<ChatParticipant> chatters = Sets.newConcurrentHashSet();
 
   /**
    * ChatHistory is used to copy chat contents from a game staging screen to an actual game once it

--- a/game-core/src/main/java/games/strategy/engine/chat/Chat.java
+++ b/game-core/src/main/java/games/strategy/engine/chat/Chat.java
@@ -6,7 +6,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.function.BiConsumer;


### PR DESCRIPTION
Avoids a possible concurrent modification exception. For example, if
a user leaves and is removed from the list then we could see a modification
in one thread not accounted for in the current.


To address: https://github.com/triplea-game/triplea/issues/6914 "Chat#getStatus:133 - ConcurrentModificationException"

<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix
[] Other:   <!-- Please specify -->

## Testing
- none, fixed based on stack trace
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
