### PR TITLE
Compute maps folder location rather than storing as client setting

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
+++ b/game-core/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
@@ -105,7 +105,7 @@ public final class ClientFileSystemHelper {
    *     installations. Users can override this location in settings.
    */
   public static File getUserMapsFolder() {
-    return getUserMapsFolder(ClientFileSystemHelper::getRootFolder);
+    return getUserMapsFolder(ClientFileSystemHelper::getUserRootFolder);
   }
 
   @VisibleForTesting

--- a/game-core/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
+++ b/game-core/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
@@ -3,12 +3,12 @@ package games.strategy.engine;
 import com.google.common.annotations.VisibleForTesting;
 import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.triplea.settings.ClientSetting;
-import games.strategy.triplea.settings.GameSetting;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.security.CodeSource;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import lombok.extern.java.Log;
 import org.triplea.game.ApplicationContext;
@@ -105,25 +105,22 @@ public final class ClientFileSystemHelper {
    *     installations. Users can override this location in settings.
    */
   public static File getUserMapsFolder() {
-    final File mapsFolder =
-        getUserMapsFolder(ClientSetting.userMapsFolderPath, ClientSetting.mapFolderOverride)
-            .toFile();
-    if (!mapsFolder.exists()) {
-      mapsFolder.mkdirs();
-    }
-    if (!mapsFolder.exists()) {
-      log.severe("Error, downloaded maps folder does not exist: " + mapsFolder.getAbsolutePath());
-    }
-    return mapsFolder;
+    return getUserMapsFolder(ClientFileSystemHelper::getRootFolder);
   }
 
   @VisibleForTesting
-  static Path getUserMapsFolder(
-      final GameSetting<Path> currentUserMapsFolderSetting,
-      final GameSetting<Path> overrideUserMapsFolderSetting) {
-    return overrideUserMapsFolderSetting.isSet()
-        ? overrideUserMapsFolderSetting.getValueOrThrow()
-        : currentUserMapsFolderSetting.getValueOrThrow();
+  static File getUserMapsFolder(final Supplier<File> userHomeRootFolderSupplier) {
+    final File mapsFolder =
+        ClientSetting.mapFolderOverride
+            .getValue()
+            .map(Path::toFile)
+            .orElseGet(
+                () -> userHomeRootFolderSupplier.get().toPath().resolve("downloadedMaps").toFile());
+
+    if (!mapsFolder.exists() && !mapsFolder.mkdirs()) {
+      log.severe("Error, could not create map download folder: " + mapsFolder.getAbsolutePath());
+    }
+    return mapsFolder;
   }
 
   /** Create a temporary file, checked exceptions are re-thrown as unchecked. */

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -287,7 +287,7 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
       "The folder where game engine will download and find map files.") {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
-      return folderPath(ClientSetting.userMapsFolderPath);
+      return folderPath(ClientSetting.mapFolderOverride);
     }
   },
 

--- a/game-core/src/test/java/games/strategy/engine/ClientFileSystemHelperTest.java
+++ b/game-core/src/test/java/games/strategy/engine/ClientFileSystemHelperTest.java
@@ -5,10 +5,10 @@ import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
-import games.strategy.triplea.settings.GameSetting;
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
+import games.strategy.triplea.settings.ClientSetting;
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+@SuppressWarnings("InnerClassMayBeStatic")
 final class ClientFileSystemHelperTest {
   @ExtendWith(MockitoExtension.class)
   @Nested
@@ -64,32 +65,24 @@ final class ClientFileSystemHelperTest {
     }
   }
 
-  @ExtendWith(MockitoExtension.class)
   @Nested
-  final class GetUserMapsFolderTest {
-    @Mock private GameSetting<Path> currentSetting;
-    @Mock private GameSetting<Path> overrideSetting;
-
-    private Path getUserMapsFolder() {
-      return ClientFileSystemHelper.getUserMapsFolder(currentSetting, overrideSetting);
-    }
-
+  final class GetUserMapsFolderTest extends AbstractClientSettingTestCase {
     @Test
     void shouldReturnCurrentFolderWhenOverrideFolderNotSet() {
-      when(overrideSetting.isSet()).thenReturn(false);
-      final Path currentFolder = Paths.get("/path", "to", "current");
-      when(currentSetting.getValueOrThrow()).thenReturn(currentFolder);
+      final File result =
+          ClientFileSystemHelper.getUserMapsFolder(() -> new File("/path/to/current"));
 
-      assertThat(getUserMapsFolder(), is(currentFolder));
+      assertThat(result, is(Paths.get("/path", "to", "current", "downloadedMaps").toFile()));
     }
 
     @Test
     void shouldReturnOverrideFolderWhenOverrideFolderSet() {
-      when(overrideSetting.isSet()).thenReturn(true);
-      final Path overrideFolder = Paths.get("/path", "to", "override");
-      when(overrideSetting.getValueOrThrow()).thenReturn(overrideFolder);
+      ClientSetting.mapFolderOverride.setValue(Paths.get("/path", "to", "override"));
 
-      assertThat(getUserMapsFolder(), is(overrideFolder));
+      final File result =
+          ClientFileSystemHelper.getUserMapsFolder(() -> new File("/path/to/current"));
+
+      assertThat(result, is(Paths.get("/path", "to", "override").toFile()));
     }
   }
 }

--- a/game-headed-javafx/src/main/java/org/triplea/game/client/ui/javafx/util/ClientSettingJavaFxUiBinding.java
+++ b/game-headed-javafx/src/main/java/org/triplea/game/client/ui/javafx/util/ClientSettingJavaFxUiBinding.java
@@ -162,13 +162,6 @@ public enum ClientSettingJavaFxUiBinding implements GameSettingUiBinding<Region>
     }
   },
 
-  USER_MAPS_FOLDER_PATH_BINDING(SettingType.FOLDER_LOCATIONS) {
-    @Override
-    public SelectionComponent<Region> newSelectionComponent() {
-      return folderPath(ClientSetting.userMapsFolderPath);
-    }
-  },
-
   WHEEL_SCROLL_AMOUNT_BINDING(SettingType.MAP_SCROLLING) {
     @Override
     public SelectionComponent<Region> newSelectionComponent() {


### PR DESCRIPTION
This update removes client setting storage of default maps folder
and instead computes the location when it is not overriden.
The default maps folder location is not a value the user would configure
and hence is not appropriate to be in client settings.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->
It seems possible that storing the map folder as a client setting could cause problems if we have users install TripleA to a new location and delete their old. I'll do some follow-up testing to see if this is also a problem fix. In the meantime the update to not store map folder is IMO correct. The client settings should generally not be so aware of implementation details of like how to find a default folder path and should generally try to have primitive values.

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
