### PR TITLE
Fix invalid URI error for forum username that can contain a space

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/posted/game/pbf/NodeBbForumPoster.java
+++ b/game-core/src/main/java/games/strategy/engine/posted/game/pbf/NodeBbForumPoster.java
@@ -30,6 +30,7 @@ import org.apache.http.message.BasicNameValuePair;
 import org.apache.http.util.EntityUtils;
 import org.snakeyaml.engine.v2.api.Load;
 import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.snakeyaml.engine.v2.common.UriEncoder;
 import org.triplea.awt.OpenFileUtility;
 import org.triplea.util.Arrays;
 
@@ -217,7 +218,8 @@ public class NodeBbForumPoster {
   }
 
   private Map<?, ?> queryUserInfo(final CloseableHttpClient client) throws IOException {
-    final HttpGet post = new HttpGet(forumUrl + "/api/user/username/" + username);
+    final String getUserInfoUri = forumUrl + "/api/user/username/" + UriEncoder.encode(username);
+    final HttpGet post = new HttpGet(getUserInfoUri);
     HttpProxy.addProxy(post);
     try (CloseableHttpResponse response = client.execute(post)) {
       return (Map<?, ?>) load.loadFromString(EntityUtils.toString(response.getEntity()));


### PR DESCRIPTION
This fix URI encodes a forums username to avoid a URI encoding
error, EG: user name contains a space.

Fixes: https://github.com/triplea-game/triplea/issues/6737


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix
[] Other:   <!-- Please specify -->

## Testing
- none, blind fix.

<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->
Based on the fix presented in: #6487 by @RoiEXLab 

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->FIX|Fix URI syntax error triggered in PBF when a forum username contains a space<!--END_RELEASE_NOTE-->
