### PR TITLE
Fix bots not loading by ensuring we reset the game before doing network communications

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -206,10 +206,10 @@ public class ServerLauncher extends AbstractLauncher<Void> {
     launchAction.handleGameInterruption(gameSelectorModel, serverModel);
     serverModel.setServerLauncher(null);
     serverModel.newGame();
+    launchAction.onGameInterrupt();
     if (inGameLobbyWatcher != null) {
       inGameLobbyWatcher.setGameStatus(GameDescription.GameStatus.WAITING_FOR_PLAYERS, null);
     }
-    launchAction.onGameInterrupt();
     log.info("Game Status: Waiting For Players");
   }
 


### PR DESCRIPTION


A call to 'setGameStatus' goes over network and can fail with exception.
If that happens then we will not invoke 'onGameInterrupt' which is
needed for a bot server to be able to start new games or load save games.
Specifically 'onGameInterrupt' will null out a game data which allows
for a game save to be changed and it will re-spawn the thread that
waits for a game to fill up to then start a game. If either of these
do not happen then maps won't change and a bot won't start games.

By re-odering these two calls, we ensure that we'll reset the bot before
any network communication happens.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix: https://github.com/triplea-game/triplea/issues/6909
[] Other:   <!-- Please specify -->

## Testing

- artificially injected an 'http interaction error'  when setting lobby status, see: https://github.com/triplea-game/triplea/issues/6909#issuecomment-651537251
- started a game on a bot, observed it crash due to a second 'GameOverException' injected error
- verified post-fix bot can change maps and start games


<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
