### PR TITLE
Install JDK instead of a JRE on headless bots [skip ci]

### DIFF
--- a/infrastructure/ansible/roles/java/defaults/main.yml
+++ b/infrastructure/ansible/roles/java/defaults/main.yml
@@ -1,1 +1,1 @@
-java_version: "openjdk-11-jre-headless"
+java_version: "openjdk-11-jdk-headless"


### PR DESCRIPTION
A JDK gives us tools like 'jstack' which can be used to get thread-dumps.
EG:
```
ps -ef | grep java
jstack <PID> > thread-dump-file
```


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
