### PR TITLE
Lobby: Turn off rate-limiting for bots

### DIFF
--- a/http-server/src/main/java/org/triplea/modules/game/lobby/watcher/LobbyWatcherController.java
+++ b/http-server/src/main/java/org/triplea/modules/game/lobby/watcher/LobbyWatcherController.java
@@ -66,6 +66,7 @@ public class LobbyWatcherController extends HttpController {
    * duplicate posts, the same gameId will be returned.
    */
   @RateLimited(
+      reportOnly = true,
       keys = {KeyPart.IP},
       rates = {@Rate(limit = 20, duration = 4, timeUnit = TimeUnit.MINUTES)})
   @POST
@@ -104,6 +105,7 @@ public class LobbyWatcherController extends HttpController {
 
   /** Explicit remove of a game from the lobby. */
   @RateLimited(
+      reportOnly = true,
       keys = {KeyPart.IP},
       rates = {@Rate(limit = 5, duration = 1, timeUnit = TimeUnit.SECONDS)})
   @POST
@@ -120,6 +122,7 @@ public class LobbyWatcherController extends HttpController {
    * kept alive, or false indicates the game was already removed and the client should re-post.
    */
   @RateLimited(
+      reportOnly = true,
       keys = {KeyPart.IP},
       rates = {@Rate(limit = 5, duration = 1, timeUnit = TimeUnit.SECONDS)})
   @POST
@@ -130,6 +133,7 @@ public class LobbyWatcherController extends HttpController {
 
   /** Replaces an existing game with new game data details. */
   @RateLimited(
+      reportOnly = true,
       keys = {KeyPart.IP},
       rates = {@Rate(limit = 10, duration = 1, timeUnit = TimeUnit.SECONDS)})
   @POST
@@ -146,6 +150,7 @@ public class LobbyWatcherController extends HttpController {
   @POST
   @Path(LobbyWatcherClient.UPLOAD_CHAT_PATH)
   @RateLimited(
+      reportOnly = true,
       keys = {KeyPart.IP},
       rates = {@Rate(limit = 10, duration = 1, timeUnit = TimeUnit.SECONDS)})
   @RolesAllowed(UserRole.HOST)
@@ -173,6 +178,7 @@ public class LobbyWatcherController extends HttpController {
   @POST
   @Path(LobbyWatcherClient.PLAYER_JOINED_PATH)
   @RateLimited(
+      reportOnly = true,
       keys = {KeyPart.IP},
       rates = {@Rate(limit = 20, duration = 1, timeUnit = TimeUnit.MINUTES)})
   @RolesAllowed(UserRole.HOST)
@@ -190,6 +196,7 @@ public class LobbyWatcherController extends HttpController {
   @POST
   @Path(LobbyWatcherClient.PLAYER_LEFT_PATH)
   @RateLimited(
+      reportOnly = true,
       keys = {KeyPart.IP},
       rates = {@Rate(limit = 20, duration = 1, timeUnit = TimeUnit.MINUTES)})
   @RolesAllowed(UserRole.HOST)


### PR DESCRIPTION
Set the endpoints used by bots to 'report-only' for rate limiting.
This will prevent any 429 (rate limit) errors from being thrown
and instead the server will just log when the rate-limit has
been breached but will still service the request.

The bots are not currently set up to handle arbitrary communication
failures and we need to audit them to ensure that they handle
such failures well and do not result in a poison-pill scenario.

This update will let us know where and what breaches rate limits
so we can adjust limits and the code accordingly and gives us
time to harden the bot communication with the lobby.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
