### PR TITLE
Handle trigger attachments that still use deprecated isSuicide

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -1517,7 +1517,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
               + ": Unable to get the value for "
               + propertyName
               + " from "
-              + propertyAttachmentName, e);
+              + propertyAttachmentName,
+          e);
     }
 
     if (!isValueTheSame) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -1517,7 +1517,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
               + ": Unable to get the value for "
               + propertyName
               + " from "
-              + propertyAttachmentName);
+              + propertyAttachmentName, e);
     }
 
     if (!isValueTheSame) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -1508,8 +1508,17 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     final boolean clearFirst = clearFirstNewValue.getFirst();
     final String newValue = clearFirstNewValue.getSecond();
 
-    final boolean isValueTheSame =
-        newValue.equals(propertyAttachment.getRawPropertyString(propertyName));
+    final boolean isValueTheSame;
+    try {
+      isValueTheSame = newValue.equals(propertyAttachment.getRawPropertyString(propertyName));
+    } catch (final UnsupportedOperationException e) {
+      throw new UnsupportedOperationException(
+          triggerAttachment.getName()
+              + ": Unable to get the value for "
+              + propertyName
+              + " from "
+              + propertyAttachmentName);
+    }
 
     if (!isValueTheSame) {
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -1781,6 +1781,11 @@ public class UnitAttachment extends DefaultAttachment {
     }
   }
 
+  @Deprecated
+  public boolean getIsSuicide() {
+    return isSuicideOnAttack || isSuicideOnDefense;
+  }
+
   private void setIsSuicideOnAttack(final Boolean s) {
     isSuicideOnAttack = s;
   }
@@ -3841,7 +3846,8 @@ public class UnitAttachment extends DefaultAttachment {
                 this::setIsMarine, this::setIsMarine, this::getIsMarine, this::resetIsMarine))
         .put(
             "isSuicide",
-            MutableProperty.<Boolean>ofWriteOnly(this::setIsSuicide, this::setIsSuicide))
+            MutableProperty.ofMapper(
+                DefaultAttachment::getBool, this::setIsSuicide, this::getIsSuicide, () -> false))
         .put(
             "isSuicideOnAttack",
             MutableProperty.ofMapper(


### PR DESCRIPTION
This adds `getIsSuicide` back so that the trigger attachments in TWW will still work.

I've also wrapped the exception inside a new exception that has the name of the trigger, the property, and what type of attachment it is on.  This should help in finding and fixing similar issues.

Fixes #6961

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix
[] Other:   <!-- Please specify -->

## Testing
Loaded a TWW save that triggered it, verified that the unit attachment had suicide turned off before non-combat and then had it turned back on after non-combat.  And then I let the UI play for several more rounds to see if anything else might happen.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->FIX|TWW will no longer crash before Germany's non-combat phase.<!--END_RELEASE_NOTE-->
