### PR TITLE
Fix lobby chat line breaking words

### DIFF
--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/messages/envelopes/chat/ChatReceivedMessage.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/messages/envelopes/chat/ChatReceivedMessage.java
@@ -1,9 +1,6 @@
 package org.triplea.http.client.web.socket.messages.envelopes.chat;
 
 import com.google.common.base.Ascii;
-import com.google.common.base.Joiner;
-import com.google.common.base.Splitter;
-import java.util.Optional;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.triplea.domain.data.UserName;
@@ -21,7 +18,6 @@ public class ChatReceivedMessage implements WebSocketMessage {
       MessageType.of(ChatReceivedMessage.class);
   public static final int MAX_MESSAGE_LENGTH = 240;
   public static final String ELLIPSES = "...";
-  static final int MAX_LINE_LENGTH = 80;
 
   private final String sender;
   @Getter private final String message;
@@ -29,15 +25,7 @@ public class ChatReceivedMessage implements WebSocketMessage {
   public ChatReceivedMessage(final UserName sender, final String message) {
     this.sender = sender.getValue();
 
-    this.message = insertLineBreaks(truncateToMaxLength(Optional.ofNullable(message).orElse("")));
-  }
-
-  private static String insertLineBreaks(final String message) {
-    return Joiner.on("\n").join(Splitter.fixedLength(MAX_LINE_LENGTH).splitToList(message));
-  }
-
-  private static String truncateToMaxLength(final String message) {
-    return Ascii.truncate(message, MAX_MESSAGE_LENGTH, ELLIPSES);
+    this.message = message == null ? "" : Ascii.truncate(message, MAX_MESSAGE_LENGTH, ELLIPSES);
   }
 
   public UserName getSender() {

--- a/http-clients/src/test/java/org/triplea/http/client/web/socket/messages/envelopes/chat/ChatReceivedMessageTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/web/socket/messages/envelopes/chat/ChatReceivedMessageTest.java
@@ -13,49 +13,13 @@ import org.triplea.domain.data.UserName;
 class ChatReceivedMessageTest {
 
   @Test
-  @DisplayName("Verify a message under max line length is left untouched")
-  void messageUnderMaxLineLength() {
-    final String testString = createStringWithLength(ChatReceivedMessage.MAX_LINE_LENGTH - 1);
-
-    final String result = chatMessage(testString);
-
-    assertThat("expecting no difference, string is under the length limit", result, is(testString));
-  }
-
-  @Test
-  @DisplayName("Verify a message at max line length is left untouched")
-  void messageAtMaxLineLength() {
-    final String testString = createStringWithLength(ChatReceivedMessage.MAX_LINE_LENGTH);
-
-    final String result = chatMessage(testString);
-
-    assertThat("expecting no difference, string is at the limit", result, is(testString));
-  }
-
-  @Test
-  @DisplayName("Verify a message over max line length is split untouched")
-  void messageOverMaxLineLength() {
-    final String testString = createStringWithLength(ChatReceivedMessage.MAX_LINE_LENGTH + 1);
-
-    final String result = chatMessage(testString);
-
-    assertThat(
-        "String is expected to be split, should see a newline at the max line length",
-        String.valueOf(result.charAt(ChatReceivedMessage.MAX_LINE_LENGTH)),
-        is("\n"));
-    assertThat(
-        "Expecting a single new line to have been inserted",
-        result.length(),
-        is(testString.length() + "\n".length()));
-  }
-
-  @Test
   @DisplayName("Verify message at max length is not truncated")
   void messageAtMaxLimit() {
     final String testString = createStringWithLength(ChatReceivedMessage.MAX_MESSAGE_LENGTH);
 
     final String result = chatMessage(testString);
 
+    assertThat(result, is(testString));
     assertThat(result, not(endsWith(ChatReceivedMessage.ELLIPSES)));
   }
 
@@ -66,6 +30,7 @@ class ChatReceivedMessageTest {
 
     final String result = chatMessage(testString);
 
+    assertThat(result.length(), is(ChatReceivedMessage.MAX_MESSAGE_LENGTH));
     assertThat(result, endsWith(ChatReceivedMessage.ELLIPSES));
   }
 


### PR DESCRIPTION
Line breaking in words is caused by auto-insert of new lines
at a max line width. This does not account for word boundaries.
We can instead have long lines and rely on JTextArea to do the
line breaking at word boundaries. Longer lines is better than
breaks at odd locations.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix
[] Other:   <!-- Please specify -->

## Testing
Checked rendering of long lines in a local lobby

<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->FIX|Fix lobby chat to break on word boundaries<!--END_RELEASE_NOTE-->
