### PR TITLE
De dupe error uploads & Add Map Name to Error Uploads

### DIFF
--- a/game-core/src/main/java/org/triplea/debug/ErrorMessage.java
+++ b/game-core/src/main/java/org/triplea/debug/ErrorMessage.java
@@ -13,7 +13,7 @@ import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.SwingUtilities;
-import org.triplea.debug.error.reporting.StackTraceReportView;
+import org.triplea.debug.error.reporting.UploadDecisionModule;
 import org.triplea.http.client.error.report.ErrorReportClient;
 import org.triplea.live.servers.LiveServersFetcher;
 import org.triplea.swing.JButtonBuilder;
@@ -141,7 +141,7 @@ public enum ErrorMessage {
     INSTANCE.uploadButton.addActionListener(
         e -> {
           hide();
-          StackTraceReportView.showWindow(windowReference, errorReportClient, logRecord);
+          UploadDecisionModule.processUploadDecision(windowReference, errorReportClient, logRecord);
         });
   }
 

--- a/game-core/src/main/java/org/triplea/debug/error/reporting/CanNotUploadSwingView.java
+++ b/game-core/src/main/java/org/triplea/debug/error/reporting/CanNotUploadSwingView.java
@@ -1,0 +1,42 @@
+package org.triplea.debug.error.reporting;
+
+import java.util.Optional;
+import javax.swing.JFrame;
+import javax.swing.JOptionPane;
+import lombok.experimental.UtilityClass;
+import org.triplea.http.client.error.report.CanUploadErrorReportResponse;
+import org.triplea.swing.JEditorPaneWithClickableLinks;
+import org.triplea.swing.jpanel.JPanelBuilder;
+
+/**
+ * Shows a dialog that gives a message to user about why they cannot report an error (usually
+ * because it already exists). If a link to an error report is provided in the server response, this
+ * dialog renders a clickable link the user can click to open the bug report.
+ */
+@UtilityClass
+class CanNotUploadSwingView {
+
+  static void showView(
+      final JFrame parent, final CanUploadErrorReportResponse canUploadErrorReportResponse) {
+
+    JOptionPane.showMessageDialog(
+        parent,
+        new JPanelBuilder()
+            .border(10)
+            .add(
+                new JEditorPaneWithClickableLinks(
+                    createWindowTextContents(canUploadErrorReportResponse)))
+            .build(),
+        "",
+        JOptionPane.INFORMATION_MESSAGE);
+  }
+
+  private static String createWindowTextContents(
+      final CanUploadErrorReportResponse reportResponse) {
+    return reportResponse.getResponseDetails()
+        + "<br>"
+        + Optional.ofNullable(reportResponse.getExistingBugReportUrl())
+            .map(url -> JEditorPaneWithClickableLinks.toLink(url, url))
+            .orElse("");
+  }
+}

--- a/game-core/src/main/java/org/triplea/debug/error/reporting/ErrorReportRequestParams.java
+++ b/game-core/src/main/java/org/triplea/debug/error/reporting/ErrorReportRequestParams.java
@@ -1,0 +1,15 @@
+package org.triplea.debug.error.reporting;
+
+import java.util.logging.LogRecord;
+import javax.annotation.Nonnull;
+import lombok.Builder;
+import lombok.Value;
+
+/** Value object representing data gathered from user and an underlying error. */
+@Value
+@Builder
+class ErrorReportRequestParams {
+  @Nonnull private final String userDescription;
+  @Nonnull private final String mapName;
+  @Nonnull private final LogRecord logRecord;
+}

--- a/game-core/src/main/java/org/triplea/debug/error/reporting/ReportPreviewSwingView.java
+++ b/game-core/src/main/java/org/triplea/debug/error/reporting/ReportPreviewSwingView.java
@@ -21,7 +21,12 @@ class ReportPreviewSwingView implements Consumer<ErrorReportRequest> {
                 .columns(45)
                 .rows(12)
                 .readOnly()
-                .text(errorReport.getTitle() + "\n\n" + errorReport.getBody())
+                .text(
+                    errorReport.getGameVersion()
+                        + ": "
+                        + errorReport.getTitle()
+                        + "\n\n"
+                        + errorReport.getBody())
                 .build()),
         "Preview - The Following Data Will Be Uploaded",
         JOptionPane.INFORMATION_MESSAGE);

--- a/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceErrorReportFormatter.java
+++ b/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceErrorReportFormatter.java
@@ -170,11 +170,6 @@ class StackTraceErrorReportFormatter
     try (PrintWriter printWriter = new PrintWriter(outputStream, false, StandardCharsets.UTF_8)) {
       e.printStackTrace(printWriter);
     }
-    return "## Exception \n"
-        + e.getClass().getName()
-        + Optional.ofNullable(e.getMessage()).map(msg -> ": " + msg).orElse("")
-        + "\n\n## Stack Trace\n```\n"
-        + outputStream.toString(StandardCharsets.UTF_8)
-        + "\n```\n\n";
+    return "## Stack Trace\n```\n" + outputStream.toString(StandardCharsets.UTF_8) + "\n```\n\n";
   }
 }

--- a/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceErrorReportFormatter.java
+++ b/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceErrorReportFormatter.java
@@ -33,8 +33,9 @@ class StackTraceErrorReportFormatter implements BiFunction<String, LogRecord, Er
   @Override
   public ErrorReportRequest apply(final String userDescription, final LogRecord logRecord) {
     return ErrorReportRequest.builder()
-        .title(versionSupplier.get() + ": " + createTitle(logRecord))
+        .title(createTitle(logRecord))
         .body(buildBody(userDescription, logRecord))
+        .gameVersion(versionSupplier.get())
         .build();
   }
 
@@ -44,7 +45,7 @@ class StackTraceErrorReportFormatter implements BiFunction<String, LogRecord, Er
    * logging or exception, and we expect for there to always either be at least a log message or an
    * exception.
    */
-  private static String createTitle(final LogRecord logRecord) {
+  static String createTitle(final LogRecord logRecord) {
     // if we have a stack trace with a triplea class in it, use that for the title;
     // EG: org.triplea.TripleaClass.method:[lineNumber] - [exception]; Caused by: [exception cause]
     return extractTripleAClassAndLine(logRecord)

--- a/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceReportModel.java
+++ b/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceReportModel.java
@@ -1,7 +1,7 @@
 package org.triplea.debug.error.reporting;
 
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.logging.LogRecord;
 import javax.annotation.Nonnull;
@@ -13,7 +13,7 @@ class StackTraceReportModel {
 
   @Nonnull private final StackTraceReportView view;
   @Nonnull private final LogRecord stackTraceRecord;
-  @Nonnull private final BiFunction<String, LogRecord, ErrorReportRequest> formatter;
+  @Nonnull private final Function<ErrorReportRequestParams, ErrorReportRequest> formatter;
   @Nonnull private final Predicate<ErrorReportRequest> uploader;
   @Nonnull private final Consumer<ErrorReportRequest> preview;
 
@@ -24,7 +24,12 @@ class StackTraceReportModel {
   }
 
   private ErrorReportRequest readErrorReportFromUi() {
-    return formatter.apply(view.readUserDescription(), stackTraceRecord);
+    return formatter.apply(
+        ErrorReportRequestParams.builder()
+            .userDescription(view.readUserDescription())
+            .mapName(view.readMapName())
+            .logRecord(stackTraceRecord)
+            .build());
   }
 
   void previewAction() {

--- a/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceReportSwingView.java
+++ b/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceReportSwingView.java
@@ -5,14 +5,17 @@ import javax.annotation.Nullable;
 import javax.swing.Box;
 import javax.swing.JButton;
 import javax.swing.JFrame;
+import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JTextArea;
+import javax.swing.JTextField;
 import org.triplea.http.client.error.report.ErrorReportClient;
 import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.JFrameBuilder;
 import org.triplea.swing.JLabelBuilder;
 import org.triplea.swing.JTextAreaBuilder;
+import org.triplea.swing.JTextFieldBuilder;
 import org.triplea.swing.jpanel.JPanelBuilder;
 
 class StackTraceReportSwingView implements StackTraceReportView {
@@ -33,6 +36,11 @@ class StackTraceReportSwingView implements StackTraceReportView {
 
   private final JTextArea userDescriptionField =
       JTextAreaBuilder.builder().toolTip(HELP_TEXT).build();
+
+  private final JTextField mapNameField =
+      new JTextFieldBuilder()
+          .toolTip("If you are in-game, enter the name of the map you are playing")
+          .build();
 
   private final JButton submitButton =
       new JButtonBuilder()
@@ -78,7 +86,14 @@ class StackTraceReportSwingView implements StackTraceReportView {
                                 .build())
                         .build())
                 .addCenter(userDescriptionField)
-                .addSouth(buttonPanel())
+                .addSouth(
+                    new JPanelBuilder()
+                        .border(5)
+                        .borderLayout()
+                        .addNorth(new JLabel("If in-game, which map are you playing?"))
+                        .addCenter(mapNameField)
+                        .addSouth(buttonPanel())
+                        .build())
                 .build());
   }
 
@@ -125,5 +140,10 @@ class StackTraceReportSwingView implements StackTraceReportView {
   @Override
   public String readUserDescription() {
     return userDescriptionField.getText();
+  }
+
+  @Override
+  public String readMapName() {
+    return mapNameField.getText();
   }
 }

--- a/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceReportView.java
+++ b/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceReportView.java
@@ -10,6 +10,9 @@ public interface StackTraceReportView {
   /** Returns the data user has entered in the error description field. */
   String readUserDescription();
 
+  /** Returns the data user entered for map name. */
+  String readMapName();
+
   /** Method where UI components should bind components actions to model methods. */
   void bindActions(StackTraceReportModel viewModel);
 

--- a/game-core/src/main/java/org/triplea/debug/error/reporting/UploadDecisionModule.java
+++ b/game-core/src/main/java/org/triplea/debug/error/reporting/UploadDecisionModule.java
@@ -1,0 +1,36 @@
+package org.triplea.debug.error.reporting;
+
+import games.strategy.engine.ClientContext;
+import java.util.logging.LogRecord;
+import javax.swing.JFrame;
+import lombok.experimental.UtilityClass;
+import org.triplea.http.client.error.report.CanUploadRequest;
+import org.triplea.http.client.error.report.ErrorReportClient;
+
+/**
+ * Decision module to handle the case where a user wishes to report an error to TripleA. First we
+ * need to invoke the 'can-upload' API on the server which will tell us if there is an existing bug
+ * report. If so we render a window that will let them see the bug report, otherwise we show the bug
+ * upload report form.
+ */
+@UtilityClass
+public class UploadDecisionModule {
+
+  public static void processUploadDecision(
+      final JFrame parentWindow, final ErrorReportClient uploader, final LogRecord logRecord) {
+
+    final var canUploadRequest =
+        CanUploadRequest.builder()
+            .errorTitle(StackTraceErrorReportFormatter.createTitle(logRecord))
+            .gameVersion(ClientContext.engineVersion().toString())
+            .build();
+
+    final var canUploadErrorReportResponse = uploader.canUploadErrorReport(canUploadRequest);
+
+    if (canUploadErrorReportResponse.getCanUpload()) {
+      StackTraceReportView.showWindow(parentWindow, uploader, logRecord);
+    } else {
+      CanNotUploadSwingView.showView(parentWindow, canUploadErrorReportResponse);
+    }
+  }
+}

--- a/game-core/src/test/java/org/triplea/debug/error/reporting/StackTraceErrorReportFormatterTest.java
+++ b/game-core/src/test/java/org/triplea/debug/error/reporting/StackTraceErrorReportFormatterTest.java
@@ -36,6 +36,19 @@ class StackTraceErrorReportFormatterTest {
   @Mock private LogRecord logRecord;
 
   @Nested
+  final class VerifyVersion {
+    @Test
+    void verifyVersion() {
+      when(logRecord.getSourceClassName()).thenReturn("org.ClassName");
+
+      final ErrorReportRequest errorReportResult =
+          new StackTraceErrorReportFormatter(() -> "4.1").apply(SAMPLE_USER_DESCRIPTION, logRecord);
+
+      assertThat(errorReportResult.getGameVersion(), is("4.1"));
+    }
+  }
+
+  @Nested
   final class VerifyTitle {
     @Test
     void logMessageOnly() {
@@ -47,7 +60,7 @@ class StackTraceErrorReportFormatterTest {
           new StackTraceErrorReportFormatter(() -> "4.1").apply(SAMPLE_USER_DESCRIPTION, logRecord);
 
       assertThat(
-          errorReportResult.getTitle(), is("4.1: ClassName#" + METHOD_NAME + " - " + LOG_MESSAGE));
+          errorReportResult.getTitle(), is("ClassName#" + METHOD_NAME + " - " + LOG_MESSAGE));
     }
 
     @Test
@@ -60,7 +73,7 @@ class StackTraceErrorReportFormatterTest {
           new StackTraceErrorReportFormatter(() -> "4.1").apply(SAMPLE_USER_DESCRIPTION, logRecord);
 
       assertThat(
-          errorReportResult.getTitle(), is("4.1: ClassName#" + METHOD_NAME + " - " + LOG_MESSAGE));
+          errorReportResult.getTitle(), is("ClassName#" + METHOD_NAME + " - " + LOG_MESSAGE));
     }
 
     @Test
@@ -73,8 +86,7 @@ class StackTraceErrorReportFormatterTest {
       assertThat(
           errorReportResult.getTitle(),
           is(
-              "5.6: "
-                  + StackTraceErrorReportFormatterTest.class.getSimpleName()
+              StackTraceErrorReportFormatterTest.class.getSimpleName()
                   + "#<clinit>:"
                   + EXCEPTION_WITH_NO_MESSAGE.getStackTrace()[0].getLineNumber()
                   + " - "
@@ -102,8 +114,7 @@ class StackTraceErrorReportFormatterTest {
       assertThat(
           errorReportResult.getTitle(),
           is(
-              "5.6: "
-                  + StackTraceErrorReportFormatterTest.class.getSimpleName()
+              StackTraceErrorReportFormatterTest.class.getSimpleName()
                   + "#<clinit>:"
                   + EXCEPTION_WITH_CAUSE.getCause().getStackTrace()[0].getLineNumber()
                   + " - "

--- a/game-core/src/test/java/org/triplea/debug/error/reporting/StackTraceErrorReportFormatterTest.java
+++ b/game-core/src/test/java/org/triplea/debug/error/reporting/StackTraceErrorReportFormatterTest.java
@@ -42,7 +42,13 @@ class StackTraceErrorReportFormatterTest {
       when(logRecord.getSourceClassName()).thenReturn("org.ClassName");
 
       final ErrorReportRequest errorReportResult =
-          new StackTraceErrorReportFormatter(() -> "4.1").apply(SAMPLE_USER_DESCRIPTION, logRecord);
+          new StackTraceErrorReportFormatter(() -> "4.1")
+              .apply(
+                  ErrorReportRequestParams.builder()
+                      .userDescription(SAMPLE_USER_DESCRIPTION)
+                      .mapName("mapName")
+                      .logRecord(logRecord)
+                      .build());
 
       assertThat(errorReportResult.getGameVersion(), is("4.1"));
     }
@@ -57,7 +63,13 @@ class StackTraceErrorReportFormatterTest {
       when(logRecord.getMessage()).thenReturn(LOG_MESSAGE);
 
       final ErrorReportRequest errorReportResult =
-          new StackTraceErrorReportFormatter(() -> "4.1").apply(SAMPLE_USER_DESCRIPTION, logRecord);
+          new StackTraceErrorReportFormatter(() -> "4.1")
+              .apply(
+                  ErrorReportRequestParams.builder()
+                      .userDescription(SAMPLE_USER_DESCRIPTION)
+                      .mapName("mapName")
+                      .logRecord(logRecord)
+                      .build());
 
       assertThat(
           errorReportResult.getTitle(), is("ClassName#" + METHOD_NAME + " - " + LOG_MESSAGE));
@@ -70,7 +82,13 @@ class StackTraceErrorReportFormatterTest {
       when(logRecord.getMessage()).thenReturn(LOG_MESSAGE);
 
       final ErrorReportRequest errorReportResult =
-          new StackTraceErrorReportFormatter(() -> "4.1").apply(SAMPLE_USER_DESCRIPTION, logRecord);
+          new StackTraceErrorReportFormatter(() -> "4.1")
+              .apply(
+                  ErrorReportRequestParams.builder()
+                      .userDescription(SAMPLE_USER_DESCRIPTION)
+                      .mapName("mapName")
+                      .logRecord(logRecord)
+                      .build());
 
       assertThat(
           errorReportResult.getTitle(), is("ClassName#" + METHOD_NAME + " - " + LOG_MESSAGE));
@@ -81,7 +99,13 @@ class StackTraceErrorReportFormatterTest {
       when(logRecord.getThrown()).thenReturn(EXCEPTION_WITH_NO_MESSAGE);
 
       final ErrorReportRequest errorReportResult =
-          new StackTraceErrorReportFormatter(() -> "5.6").apply(SAMPLE_USER_DESCRIPTION, logRecord);
+          new StackTraceErrorReportFormatter(() -> "5.6")
+              .apply(
+                  ErrorReportRequestParams.builder()
+                      .userDescription(SAMPLE_USER_DESCRIPTION)
+                      .mapName("mapName")
+                      .logRecord(logRecord)
+                      .build());
 
       assertThat(
           errorReportResult.getTitle(),
@@ -99,7 +123,13 @@ class StackTraceErrorReportFormatterTest {
       when(logRecord.getSourceClassName()).thenReturn("ClassInDefaultPackage");
 
       final ErrorReportRequest errorReportResult =
-          new StackTraceErrorReportFormatter().apply(SAMPLE_USER_DESCRIPTION, logRecord);
+          new StackTraceErrorReportFormatter()
+              .apply(
+                  ErrorReportRequestParams.builder()
+                      .userDescription(SAMPLE_USER_DESCRIPTION)
+                      .mapName("mapName")
+                      .logRecord(logRecord)
+                      .build());
 
       assertDoesNotThrow(errorReportResult::getTitle);
     }
@@ -109,7 +139,13 @@ class StackTraceErrorReportFormatterTest {
       when(logRecord.getThrown()).thenReturn(EXCEPTION_WITH_CAUSE);
 
       final ErrorReportRequest errorReportResult =
-          new StackTraceErrorReportFormatter(() -> "5.6").apply(SAMPLE_USER_DESCRIPTION, logRecord);
+          new StackTraceErrorReportFormatter(() -> "5.6")
+              .apply(
+                  ErrorReportRequestParams.builder()
+                      .userDescription(SAMPLE_USER_DESCRIPTION)
+                      .mapName("mapName")
+                      .logRecord(logRecord)
+                      .build());
 
       assertThat(
           errorReportResult.getTitle(),
@@ -130,9 +166,32 @@ class StackTraceErrorReportFormatterTest {
       when(logRecord.getSourceMethodName()).thenReturn(METHOD_NAME);
 
       final ErrorReportRequest errorReportResult =
-          new StackTraceErrorReportFormatter().apply(SAMPLE_USER_DESCRIPTION, logRecord);
+          new StackTraceErrorReportFormatter()
+              .apply(
+                  ErrorReportRequestParams.builder()
+                      .userDescription(SAMPLE_USER_DESCRIPTION)
+                      .mapName("mapName")
+                      .logRecord(logRecord)
+                      .build());
 
       assertThat(errorReportResult.getBody(), containsString(SAMPLE_USER_DESCRIPTION));
+    }
+
+    @Test
+    void containsMapName() {
+      when(logRecord.getSourceClassName()).thenReturn(CLASS_NAME);
+      when(logRecord.getSourceMethodName()).thenReturn(METHOD_NAME);
+
+      final ErrorReportRequest errorReportResult =
+          new StackTraceErrorReportFormatter()
+              .apply(
+                  ErrorReportRequestParams.builder()
+                      .userDescription(SAMPLE_USER_DESCRIPTION)
+                      .mapName("mapName")
+                      .logRecord(logRecord)
+                      .build());
+
+      assertThat(errorReportResult.getBody(), containsString("mapName"));
     }
 
     @Test
@@ -141,7 +200,13 @@ class StackTraceErrorReportFormatterTest {
       when(logRecord.getSourceMethodName()).thenReturn(METHOD_NAME);
 
       final ErrorReportRequest errorReportResult =
-          new StackTraceErrorReportFormatter().apply(SAMPLE_USER_DESCRIPTION, logRecord);
+          new StackTraceErrorReportFormatter()
+              .apply(
+                  ErrorReportRequestParams.builder()
+                      .userDescription(SAMPLE_USER_DESCRIPTION)
+                      .mapName("mapName")
+                      .logRecord(logRecord)
+                      .build());
 
       assertThat(errorReportResult.getBody(), containsString(SAMPLE_USER_DESCRIPTION));
       assertThat(
@@ -155,7 +220,13 @@ class StackTraceErrorReportFormatterTest {
     void containsStackTraceData() {
       when(logRecord.getThrown()).thenReturn(EXCEPTION_WITH_CAUSE);
       final ErrorReportRequest errorReportResult =
-          new StackTraceErrorReportFormatter().apply(SAMPLE_USER_DESCRIPTION, logRecord);
+          new StackTraceErrorReportFormatter()
+              .apply(
+                  ErrorReportRequestParams.builder()
+                      .userDescription(SAMPLE_USER_DESCRIPTION)
+                      .mapName("mapName")
+                      .logRecord(logRecord)
+                      .build());
 
       Stream.of(EXCEPTION_WITH_CAUSE, EXCEPTION_WITH_MESSAGE)
           .map(Throwable::getStackTrace)
@@ -179,7 +250,13 @@ class StackTraceErrorReportFormatterTest {
       when(logRecord.getThrown()).thenReturn(EXCEPTION_WITH_MESSAGE);
 
       final ErrorReportRequest errorReportResult =
-          new StackTraceErrorReportFormatter().apply(SAMPLE_USER_DESCRIPTION, logRecord);
+          new StackTraceErrorReportFormatter()
+              .apply(
+                  ErrorReportRequestParams.builder()
+                      .userDescription(SAMPLE_USER_DESCRIPTION)
+                      .mapName("mapName")
+                      .logRecord(logRecord)
+                      .build());
 
       assertThat(
           errorReportResult.getBody(), containsString(EXCEPTION_WITH_MESSAGE.getClass().getName()));
@@ -194,7 +271,13 @@ class StackTraceErrorReportFormatterTest {
       when(logRecord.getThrown()).thenReturn(EXCEPTION_WITH_NO_MESSAGE);
 
       final ErrorReportRequest errorReportResult =
-          new StackTraceErrorReportFormatter().apply(SAMPLE_USER_DESCRIPTION, logRecord);
+          new StackTraceErrorReportFormatter()
+              .apply(
+                  ErrorReportRequestParams.builder()
+                      .userDescription(SAMPLE_USER_DESCRIPTION)
+                      .mapName("mapName")
+                      .logRecord(logRecord)
+                      .build());
 
       assertThat(
           errorReportResult.getBody(),

--- a/game-core/src/test/java/org/triplea/debug/error/reporting/StackTraceReportModelTest.java
+++ b/game-core/src/test/java/org/triplea/debug/error/reporting/StackTraceReportModelTest.java
@@ -1,11 +1,12 @@
 package org.triplea.debug.error.reporting;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.logging.LogRecord;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,7 +30,7 @@ class StackTraceReportModelTest {
 
   @Mock private Consumer<ErrorReportRequest> preview;
 
-  @Mock private BiFunction<String, LogRecord, ErrorReportRequest> formatter;
+  @Mock private Function<ErrorReportRequestParams, ErrorReportRequest> formatter;
 
   @Mock private ErrorReportRequest errorReport;
 
@@ -60,7 +61,8 @@ class StackTraceReportModelTest {
 
     private void givenUploadSuccessResult(final boolean result) {
       when(stackTraceReportView.readUserDescription()).thenReturn(STRING_VALUE);
-      when(formatter.apply(STRING_VALUE, logRecord)).thenReturn(errorReport);
+      when(stackTraceReportView.readMapName()).thenReturn("mapName");
+      when(formatter.apply(any())).thenReturn(errorReport);
       when(uploader.test(errorReport)).thenReturn(result);
     }
 
@@ -77,7 +79,8 @@ class StackTraceReportModelTest {
   @Test
   void preview() {
     when(stackTraceReportView.readUserDescription()).thenReturn(STRING_VALUE);
-    when(formatter.apply(STRING_VALUE, logRecord)).thenReturn(errorReport);
+    when(stackTraceReportView.readMapName()).thenReturn("mapName");
+    when(formatter.apply(any())).thenReturn(errorReport);
 
     viewModel.previewAction();
 

--- a/http-clients/src/main/java/org/triplea/http/client/error/report/CanUploadErrorReportResponse.java
+++ b/http-clients/src/main/java/org/triplea/http/client/error/report/CanUploadErrorReportResponse.java
@@ -1,0 +1,27 @@
+package org.triplea.http.client.error.report;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+@ToString
+@Builder
+@Getter
+@EqualsAndHashCode
+public class CanUploadErrorReportResponse {
+  /**
+   * True means a user can upload an error report. False means an error report is already uploaded.
+   * If true, then responseDetails and existingBugReportUrl will be null.
+   */
+  @Nonnull private final Boolean canUpload;
+  /**
+   * Contains any message details that should be displayed to the user. EG: "This error is already
+   * uploaded"
+   */
+  @Nullable private final String responseDetails;
+  /** Contains a link to any existing error report that matches the same error the user sees. */
+  @Nullable private final String existingBugReportUrl;
+}

--- a/http-clients/src/main/java/org/triplea/http/client/error/report/CanUploadRequest.java
+++ b/http-clients/src/main/java/org/triplea/http/client/error/report/CanUploadRequest.java
@@ -1,0 +1,19 @@
+package org.triplea.http.client.error.report;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+@ToString
+@EqualsAndHashCode
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class CanUploadRequest {
+  private String gameVersion;
+  private String errorTitle;
+}

--- a/http-clients/src/main/java/org/triplea/http/client/error/report/ErrorReportClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/error/report/ErrorReportClient.java
@@ -12,6 +12,7 @@ import org.triplea.http.client.SystemIdHeader;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ErrorReportClient {
   public static final String ERROR_REPORT_PATH = "/error-report";
+  public static final String CAN_UPLOAD_ERROR_REPORT_PATH = "/error-report-check";
   public static final int MAX_REPORTS_PER_DAY = 5;
 
   private final Map<String, Object> headers;
@@ -30,5 +31,14 @@ public class ErrorReportClient {
    */
   public ErrorReportResponse uploadErrorReport(final ErrorReportRequest request) {
     return errorReportFeignClient.uploadErrorReport(headers, request);
+  }
+
+  /**
+   * Checks if user can upload a request. A request can be uploaded if: - it has not yet been
+   * reported - reporting version is greater than fix version - user is not banned
+   */
+  public CanUploadErrorReportResponse canUploadErrorReport(
+      final CanUploadRequest canUploadRequest) {
+    return errorReportFeignClient.canUploadErrorReport(headers, canUploadRequest);
   }
 }

--- a/http-clients/src/main/java/org/triplea/http/client/error/report/ErrorReportFeignClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/error/report/ErrorReportFeignClient.java
@@ -1,6 +1,5 @@
 package org.triplea.http.client.error.report;
 
-import feign.FeignException;
 import feign.HeaderMap;
 import feign.Headers;
 import feign.RequestLine;
@@ -10,12 +9,11 @@ import org.triplea.http.client.HttpConstants;
 @SuppressWarnings("InterfaceNeverImplemented")
 @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
 interface ErrorReportFeignClient {
-  /**
-   * API to upload an exception error report from a TripleA client to TripleA server.
-   *
-   * @throws FeignException Thrown on non-2xx responses.
-   */
   @RequestLine("POST " + ErrorReportClient.ERROR_REPORT_PATH)
   ErrorReportResponse uploadErrorReport(
       @HeaderMap Map<String, Object> headers, ErrorReportRequest request);
+
+  @RequestLine("POST " + ErrorReportClient.CAN_UPLOAD_ERROR_REPORT_PATH)
+  CanUploadErrorReportResponse canUploadErrorReport(
+      @HeaderMap Map<String, Object> headers, CanUploadRequest canUploadRequest);
 }

--- a/http-clients/src/main/java/org/triplea/http/client/error/report/ErrorReportRequest.java
+++ b/http-clients/src/main/java/org/triplea/http/client/error/report/ErrorReportRequest.java
@@ -4,6 +4,7 @@ import com.google.common.base.Ascii;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.triplea.http.client.github.issues.GithubIssueClient;
@@ -17,6 +18,7 @@ import org.triplea.http.client.github.issues.GithubIssueClient;
 public class ErrorReportRequest {
   private String title;
   private String body;
+  @Getter private String gameVersion;
 
   public String getTitle() {
     return title == null ? null : Ascii.truncate(title, GithubIssueClient.TITLE_MAX_LENGTH, "...");

--- a/http-clients/src/main/java/org/triplea/http/client/github/issues/GithubIssueClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/github/issues/GithubIssueClient.java
@@ -69,7 +69,7 @@ public class GithubIssueClient {
         githubOrg,
         githubRepo,
         CreateIssueRequest.builder()
-            .title(uploadRequest.getTitle())
+            .title(uploadRequest.getGameVersion() + ": " + uploadRequest.getTitle())
             .body(uploadRequest.getBody())
             .labels(new String[] {"Error Report"})
             .build());

--- a/http-server/src/main/java/org/triplea/db/dao/error/reporting/ErrorReportingDao.java
+++ b/http-server/src/main/java/org/triplea/db/dao/error/reporting/ErrorReportingDao.java
@@ -1,19 +1,22 @@
 package org.triplea.db.dao.error.reporting;
 
 import java.time.Instant;
+import java.util.Optional;
 import org.jdbi.v3.sqlobject.customizer.Bind;
+import org.jdbi.v3.sqlobject.customizer.BindBean;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
 /** DAO class for error reporting functionality. */
 public interface ErrorReportingDao {
 
-  /**
-   * Inserts a new record indicating a user has submitted an error report at a given date.
-   *
-   * @param userIp Ip host address of the user submitting an error report.
-   */
-  @SqlUpdate("insert into error_report_history(user_ip) values(:ip)")
-  void insertHistoryRecord(@Bind("ip") String userIp);
+  /** Inserts a new record indicating a user has submitted an error report at a given date. */
+  @SqlUpdate(
+      "insert into error_report_history"
+          + "(user_ip, system_id, report_title, game_version, created_issue_link) "
+          + "values"
+          + "(:ip, :systemId, :title, :gameVersion, :githubIssueLink)")
+  void insertHistoryRecord(@BindBean InsertHistoryRecordParams insertHistoryRecordParams);
 
   /**
    * Method to clean up old records from the error report history table. This is to avoid the table
@@ -23,4 +26,12 @@ public interface ErrorReportingDao {
    */
   @SqlUpdate("delete from error_report_history where date_created < :purgeSinceDate")
   void purgeOld(@Bind("purgeSinceDate") Instant purgeSinceDate);
+
+  @SqlQuery(
+      "select created_issue_link"
+          + "  from error_report_history"
+          + "  where report_title = :reportTitle "
+          + "    and game_version = :gameVersion")
+  Optional<String> getErrorReportLink(
+      @Bind("reportTitle") String reportTitle, @Bind("gameVersion") String gameVersion);
 }

--- a/http-server/src/main/java/org/triplea/db/dao/error/reporting/InsertHistoryRecordParams.java
+++ b/http-server/src/main/java/org/triplea/db/dao/error/reporting/InsertHistoryRecordParams.java
@@ -1,0 +1,27 @@
+package org.triplea.db.dao.error.reporting;
+
+import lombok.Builder;
+import lombok.Value;
+
+/** Parameter object for inserting a record of an error report uploaded by a user. */
+@Value
+@Builder
+public class InsertHistoryRecordParams {
+  /** The IP address of the user reporting the error. */
+  String ip;
+
+  /** SystemId of the user uploading the error report. */
+  String systemId;
+
+  /** The engine version of the user at the time they uploaded the error report. */
+  String gameVersion;
+
+  /** The title of the error report, will be used for de-duping. */
+  String title;
+
+  /**
+   * Link to the github issue created by the error report. This is the issue that the user should
+   * have just uploaded.
+   */
+  String githubIssueLink;
+}

--- a/http-server/src/main/java/org/triplea/modules/error/reporting/CanUploadErrorReportStrategy.java
+++ b/http-server/src/main/java/org/triplea/modules/error/reporting/CanUploadErrorReportStrategy.java
@@ -1,0 +1,48 @@
+package org.triplea.modules.error.reporting;
+
+import java.util.function.Function;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import org.jdbi.v3.core.Jdbi;
+import org.triplea.db.dao.error.reporting.ErrorReportingDao;
+import org.triplea.http.client.error.report.CanUploadErrorReportResponse;
+import org.triplea.http.client.error.report.CanUploadRequest;
+
+/**
+ * Answers the question if a user can upload an error report. If the given title and version already
+ * exist, then a user cannot upload a (duplicate) error report.
+ */
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class CanUploadErrorReportStrategy
+    implements Function<CanUploadRequest, CanUploadErrorReportResponse> {
+
+  private final ErrorReportingDao errorReportingDao;
+
+  static CanUploadErrorReportStrategy build(final Jdbi jdbi) {
+    return new CanUploadErrorReportStrategy(jdbi.onDemand(ErrorReportingDao.class));
+  }
+
+  @Override
+  public CanUploadErrorReportResponse apply(final CanUploadRequest canUploadRequest) {
+    return errorReportingDao
+        .getErrorReportLink(canUploadRequest.getErrorTitle(), canUploadRequest.getGameVersion())
+        .map(CanUploadErrorReportStrategy::buildResponseFromExisting)
+        .orElseGet(
+            () ->
+                // no error report exists, user can upload
+                CanUploadErrorReportResponse.builder().canUpload(true).build());
+  }
+
+  private static CanUploadErrorReportResponse buildResponseFromExisting(
+      final String existingBugLink) {
+    return CanUploadErrorReportResponse.builder()
+        .canUpload(false)
+        .existingBugReportUrl(existingBugLink)
+        .responseDetails(
+            "A bug report already exists for this problem. <br><br>"
+                + "Please visit the bug report URL and add any details that could help.<br><br>"
+                + "We are always interested to know how a problem happened<br>"
+                + "and we may have questions you might be able to help answer.<br>")
+        .build();
+  }
+}

--- a/http-server/src/main/java/org/triplea/modules/error/reporting/CreateIssueParams.java
+++ b/http-server/src/main/java/org/triplea/modules/error/reporting/CreateIssueParams.java
@@ -1,0 +1,14 @@
+package org.triplea.modules.error.reporting;
+
+import javax.annotation.Nonnull;
+import lombok.Builder;
+import lombok.Value;
+import org.triplea.http.client.error.report.ErrorReportRequest;
+
+@Value
+@Builder
+class CreateIssueParams {
+  @Nonnull private final String ip;
+  @Nonnull private final String systemId;
+  @Nonnull private final ErrorReportRequest errorReportRequest;
+}

--- a/http-server/src/test/java/org/triplea/db/dao/error/reporting/ErrorReportingDaoTest.java
+++ b/http-server/src/test/java/org/triplea/db/dao/error/reporting/ErrorReportingDaoTest.java
@@ -1,10 +1,18 @@
 package org.triplea.db.dao.error.reporting;
 
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.npathai.hamcrestopt.OptionalMatchers;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.triplea.db.dao.DaoTest;
 
 final class ErrorReportingDaoTest extends DaoTest {
@@ -15,7 +23,14 @@ final class ErrorReportingDaoTest extends DaoTest {
   @ExpectedDataSet(value = "error_reporting/post-insert.yml")
   @Test
   void insertRow() {
-    errorReportingDao.insertHistoryRecord("second");
+    errorReportingDao.insertHistoryRecord(
+        InsertHistoryRecordParams.builder()
+            .ip("the_userIp")
+            .systemId("the_systemId")
+            .title("the_reportTitle")
+            .gameVersion("the_gameVersion")
+            .githubIssueLink("the_createdIssueLink")
+            .build());
   }
 
   @DataSet(cleanBefore = true, value = "error_reporting/pre-purge.yml")
@@ -23,5 +38,30 @@ final class ErrorReportingDaoTest extends DaoTest {
   @Test
   void purgeOld() {
     errorReportingDao.purgeOld(LocalDateTime.of(2016, 1, 3, 23, 0, 0).toInstant(ZoneOffset.UTC));
+  }
+
+  @DataSet(cleanBefore = true, value = "error_reporting/post-purge.yml")
+  @Test
+  void getErrorReportLinkFoundCase() {
+    assertThat(
+        errorReportingDao.getErrorReportLink("the_reportTitle2", "the_gameVersion2"),
+        isPresentAndIs("the_createdIssueLink2"));
+  }
+
+  @DataSet(cleanBefore = true, value = "error_reporting/post-purge.yml")
+  @ParameterizedTest
+  @MethodSource
+  void getErrorReportLinkNotFoundCases(final String title, final String version) {
+    assertThat(
+        errorReportingDao.getErrorReportLink(title, version), //
+        OptionalMatchers.isEmpty());
+  }
+
+  @SuppressWarnings("unused")
+  private static List<Arguments> getErrorReportLinkNotFoundCases() {
+    return List.of(
+        Arguments.of("title-not-found", "version-not-found"),
+        Arguments.of("title-not-found", "the_gameVersion2"),
+        Arguments.of("the_reportTitle2", "version-not-found"));
   }
 }

--- a/http-server/src/test/java/org/triplea/modules/error/reporting/CanUploadErrorReportStrategyTest.java
+++ b/http-server/src/test/java/org/triplea/modules/error/reporting/CanUploadErrorReportStrategyTest.java
@@ -1,0 +1,56 @@
+package org.triplea.modules.error.reporting;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.db.dao.error.reporting.ErrorReportingDao;
+import org.triplea.http.client.error.report.CanUploadErrorReportResponse;
+import org.triplea.http.client.error.report.CanUploadRequest;
+
+@ExtendWith(MockitoExtension.class)
+class CanUploadErrorReportStrategyTest {
+
+  @Mock private ErrorReportingDao errorReportingDao;
+
+  @InjectMocks private CanUploadErrorReportStrategy canUploadErrorReportStrategy;
+
+  @Test
+  @DisplayName("If we do not find an existing error report then the user can upload")
+  void errorReportDoesNotExist() {
+    when(errorReportingDao.getErrorReportLink("reportTitle", "version"))
+        .thenReturn(Optional.empty());
+
+    final CanUploadErrorReportResponse response =
+        canUploadErrorReportStrategy.apply(
+            CanUploadRequest.builder().errorTitle("reportTitle").gameVersion("version").build());
+
+    assertThat(response.getCanUpload(), is(true));
+    assertThat(response.getExistingBugReportUrl(), is(nullValue()));
+    assertThat(response.getResponseDetails(), is(nullValue()));
+  }
+
+  @Test
+  @DisplayName("If find an existing error report then the user can *not* upload")
+  void errorReportDoesExist() {
+    when(errorReportingDao.getErrorReportLink("reportTitle", "version"))
+        .thenReturn(Optional.of("link"));
+
+    final CanUploadErrorReportResponse response =
+        canUploadErrorReportStrategy.apply(
+            CanUploadRequest.builder().errorTitle("reportTitle").gameVersion("version").build());
+
+    assertThat(response.getCanUpload(), is(false));
+    assertThat(response.getExistingBugReportUrl(), is("link"));
+    assertThat(response.getResponseDetails(), is(notNullValue()));
+  }
+}

--- a/http-server/src/test/java/org/triplea/modules/error/reporting/ErrorReportControllerIntegrationTest.java
+++ b/http-server/src/test/java/org/triplea/modules/error/reporting/ErrorReportControllerIntegrationTest.java
@@ -1,6 +1,7 @@
 package org.triplea.modules.error.reporting;
 
 import org.junit.jupiter.api.Test;
+import org.triplea.http.client.error.report.CanUploadRequest;
 import org.triplea.http.client.error.report.ErrorReportClient;
 import org.triplea.http.client.error.report.ErrorReportRequest;
 import org.triplea.modules.http.BasicEndpointTest;
@@ -16,6 +17,18 @@ class ErrorReportControllerIntegrationTest extends BasicEndpointTest<ErrorReport
     verifyEndpointReturningObject(
         client ->
             client.uploadErrorReport(
-                ErrorReportRequest.builder().body("body").title("title").build()));
+                ErrorReportRequest.builder()
+                    .body("body")
+                    .title("title")
+                    .gameVersion("version")
+                    .build()));
+  }
+
+  @Test
+  void canUploadErrorReport() {
+    verifyEndpointReturningObject(
+        client ->
+            client.canUploadErrorReport(
+                CanUploadRequest.builder().gameVersion("2.0").errorTitle("title").build()));
   }
 }

--- a/http-server/src/test/resources/datasets/error_reporting/post-insert.yml
+++ b/http-server/src/test/resources/datasets/error_reporting/post-insert.yml
@@ -1,3 +1,7 @@
 error_report_history:
   - id:  "regex:\\d+" #any number
-    user_ip: second
+    user_ip: the_userIp
+    system_id: the_systemId
+    report_title: the_reportTitle
+    game_version: the_gameVersion
+    created_issue_link: the_createdIssueLink

--- a/http-server/src/test/resources/datasets/error_reporting/post-purge.yml
+++ b/http-server/src/test/resources/datasets/error_reporting/post-purge.yml
@@ -2,6 +2,14 @@ error_report_history:
   - id: 900002
     user_ip: first
     date_created: 2016-01-03 23:59:20.0
+    system_id: the_systemId
+    report_title: the_reportTitle2
+    game_version: the_gameVersion2
+    created_issue_link: the_createdIssueLink2
   - id: 900003
     user_ip: second
     date_created: 2016-01-03 23:59:20.0
+    system_id: the_systemId
+    report_title: the_reportTitle3
+    game_version: the_gameVersion3
+    created_issue_link: the_createdIssueLink3

--- a/http-server/src/test/resources/datasets/error_reporting/pre-purge.yml
+++ b/http-server/src/test/resources/datasets/error_reporting/pre-purge.yml
@@ -2,12 +2,28 @@ error_report_history:
   - id: 900000
     user_ip: first
     date_created: 2016-01-01 23:59:20.0
+    system_id: the_systemId
+    report_title: the_reportTitle0
+    game_version: the_gameVersion0
+    created_issue_link: the_createdIssueLink0
   - id: 900001
     user_ip: first
     date_created: 2016-01-02 23:59:20.0
+    system_id: the_systemId
+    report_title: the_reportTitle1
+    game_version: the_gameVersion1
+    created_issue_link: the_createdIssueLink1
   - id: 900002
     user_ip: first
     date_created: 2016-01-03 23:59:20.0
+    system_id: the_systemId
+    report_title: the_reportTitle2
+    game_version: the_gameVersion2
+    created_issue_link: the_createdIssueLink2
   - id: 900003
     user_ip: second
     date_created: 2016-01-03 23:59:20.0
+    system_id: the_systemId
+    report_title: the_reportTitle3
+    game_version: the_gameVersion3
+    created_issue_link: the_createdIssueLink3

--- a/lobby-db/src/main/resources/db/migration/V2.00.06__error_report_issue_and_title_column.sql
+++ b/lobby-db/src/main/resources/db/migration/V2.00.06__error_report_issue_and_title_column.sql
@@ -1,0 +1,30 @@
+alter table error_report_history
+    add column system_id varchar(36);
+alter table error_report_history
+    add column report_title varchar(125);
+alter table error_report_history
+    add column game_version varchar(16);
+alter table error_report_history
+    add column created_issue_link varchar(128);
+
+update error_report_history
+set system_id          = '---' || random(),
+    report_title       = '---' || random(),
+    game_version       = '2.0.20234',
+    created_issue_link = '----' || random();
+
+alter table error_report_history
+    alter column system_id set not null;
+alter table error_report_history
+    alter column report_title set not null;
+alter table error_report_history
+    alter column game_version set not null;
+alter table error_report_history
+    alter column created_issue_link set not null;
+
+-- the title and version pair should be unique, otherwise we are looking at a duplicate
+alter table error_report_history
+    add constraint error_report_history_unique_title_version unique (report_title, game_version);
+-- all links should be unique
+alter table error_report_history
+    add constraint error_report_history_unique_link unique (created_issue_link);


### PR DESCRIPTION
## Commits

commit 6af5f46092f247f9677cf879073f8e83c0b58919

    De-Dupe Error Report Uploads
    
    Prevent redundant error message uploads by first checking
    with the server if an error report already exists.
    If the error report exists, then we will show a prompt
    to the user and give them a link to the existing error report.
    
    Change Summary:
    - Add columns in error report history table to track the
      title of the error report, reporting game version,
      and the issue link that was created.
    - Add APIs to error reporting DAO to get the link of
      an existing error report by title and game version.
    - Add server API to check if an error report exists
    - Update client so that after clicking 'upload error report',
      we first query the server if an error report exists.
      If one exists, we show the link to the user, othewise
      we show the user the upload form.
    
    Note: we use both title and game version for de-duplication.
      This may lead to some duplication as version number
      changes, but in case we do not fix a problem or if
      the title matches but is actually different in a different
      version we will allow the error report upload.

commit 8ed128a76e98949e7e5b0e438fb43d2da6a5bc0f

    Add field to error report upload for map name

commit e9da7eb10e0e26e6fad48bc0539a0be5d09545ff

    Do not print Exception in its own block (redundant)
    
    Exception is always at the head of the stack trace which
    we already print in the issue body. This update removes
    the redundant 'exception' block.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix
[] Other:   <!-- Please specify -->

## Testing
Add an explicit throw exception at the end of gameRunner launch to test out against a local server. Created an error report and then reported and verified that there was a de-dupe message.

<!-- Describe any manual testing performed below. -->

## Screens Shots

### De-Dupe Sequence

Existing screen prompt to upload:
![Screenshot from 2020-07-01 00-32-23](https://user-images.githubusercontent.com/12397753/86220441-72fd7f80-bb38-11ea-9e9b-7439065dbbfc.png)

Clicking upload, get the de-dupe message:
![Screenshot from 2020-07-01 00-32-30](https://user-images.githubusercontent.com/12397753/86220445-73961600-bb38-11ea-80f4-66ed8eac7f89.png)

### New Map Name Field
Notice at the bottom of the dialog there is a 'map name' field:
![Screenshot from 2020-07-01 01-05-59](https://user-images.githubusercontent.com/12397753/86220495-83adf580-bb38-11ea-88da-59b9d61a7cd0.png)

Notice in the preview there is a 'map name' section:
![Screenshot from 2020-07-01 01-06-09](https://user-images.githubusercontent.com/12397753/86220496-84468c00-bb38-11ea-80d1-18217f43d259.png)


## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->UPDATE|Error uploads will now recognize duplicates and give you a link to an existing error upload if there is one. Added 'map-name' as an error upload field<!--END_RELEASE_NOTE-->
