### PR TITLE
Don't retreat submerged units

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -2032,7 +2032,8 @@ public class MustFightBattle extends DependentBattle
     Collection<Unit> units = defender ? defendingUnits : attackingUnits;
     if (!defender) {
       units = new HashSet<>(units);
-      units.addAll(battleSite.getUnitCollection().getMatches(Matches.unitIsOwnedBy(attacker)));
+      units.addAll(battleSite.getUnitCollection().getMatches(
+          Matches.unitIsOwnedBy(attacker).and(Matches.unitIsSubmerged().negate())));
       units.removeAll(killed);
     }
     if (subs) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -2032,8 +2032,10 @@ public class MustFightBattle extends DependentBattle
     Collection<Unit> units = defender ? defendingUnits : attackingUnits;
     if (!defender) {
       units = new HashSet<>(units);
-      units.addAll(battleSite.getUnitCollection().getMatches(
-          Matches.unitIsOwnedBy(attacker).and(Matches.unitIsSubmerged().negate())));
+      units.addAll(
+          battleSite
+              .getUnitCollection()
+              .getMatches(Matches.unitIsOwnedBy(attacker).and(Matches.unitIsSubmerged().negate())));
       units.removeAll(killed);
     }
     if (subs) {


### PR DESCRIPTION
This fixes the second issue listed in #4821 as well as the issue in #6504 where it asks you to retreat if you've already submerged all of your subs and you don't have any other units.

It doesn't change the dialogs that pop up.  I was just trying to fix the second issue in #4821 where the sub was retreated with the rest of the units even though it has been submerged. During testing, I noticed that it partially "fixed" #6504 because the engine doesn't see any units to retreat, so it doesn't ask to retreat.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix
[] Other:   <!-- Please specify -->

## Testing
Played with sub only battles and sub with other units.  I submerged and retreated the units to see where things ended up.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->FIX|Submerged subs don't retreat when other units retreat<!--END_RELEASE_NOTE-->
