### PR TITLE
Ensure getRemainingAttackingUnits doesn't return duplicate units

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -328,7 +328,7 @@ public class MustFightBattle extends DependentBattle
    */
   @Override
   public List<Unit> getRemainingAttackingUnits() {
-    final List<Unit> remaining = new ArrayList<>(attackingUnitsRetreated);
+    final Set<Unit> remaining = new HashSet<>(attackingUnitsRetreated);
     final Collection<Unit> unitsLeftInTerritory = new ArrayList<>(battleSite.getUnits());
     unitsLeftInTerritory.removeAll(killed);
     remaining.addAll(
@@ -339,7 +339,7 @@ public class MustFightBattle extends DependentBattle
                 : Matches.unitOwnedBy(attacker)
                     .and(Matches.unitIsAir())
                     .and(Matches.unitIsNotInfrastructure())));
-    return remaining;
+    return new ArrayList<>(remaining);
   }
 
   /**


### PR DESCRIPTION
A submerged sub is in the retreated list as well as in the territory
list and so will be included twice.

Fixes #7017 

This will probably also affect the AI since previously, the submerged subs were counted twice in `determineTerritoriesThatCanBeHeld`.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix
[] Other:   <!-- Please specify -->

## Testing
I ran a game where the attackers had a sub and it was submerged before the attackers won.  Then using a breakpoint, I checked what `getRemainingAttackingUnits` returned and verified that it had duplicate values and that this fixed it.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->FIX|AI no longer crashes when determining if a territory with a submerged sub can be held.<!--END_RELEASE_NOTE-->
