### PR TITLE
Use Objects.hashCode to generate the key instead of summing the hashCodes

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLosses.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLosses.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea.delegate.battle.casualty;
 
+import com.google.common.base.Objects;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
@@ -68,28 +69,7 @@ class CasualtyOrderOfLosses {
       amphibTypes.add(u.getType());
     }
     // Calculate hashes and cache key
-    int targetsHashCode = 1;
-    for (final UnitType ut : targetTypes) {
-      targetsHashCode += ut.hashCode();
-    }
-    targetsHashCode *= 31;
-    int amphibHashCode = 1;
-    for (final UnitType ut : amphibTypes) {
-      amphibHashCode += ut.hashCode();
-    }
-    amphibHashCode *= 31;
-    String key =
-        parameters.player.getName()
-            + "|"
-            + parameters.battlesite.getName()
-            + "|"
-            + parameters.combatModifiers.isDefending()
-            + "|"
-            + parameters.combatModifiers.isAmphibious()
-            + "|"
-            + targetsHashCode
-            + "|"
-            + amphibHashCode;
+    String key = computeOolCacheKey(parameters, targetTypes, amphibTypes);
     // Check OOL cache
     final List<UnitType> stored = oolCache.get(key);
     if (stored != null) {
@@ -278,30 +258,26 @@ class CasualtyOrderOfLosses {
           < Collections.frequency(amphibTypes, unitTypeToRemove)) {
         amphibTypes.remove(unitTypeToRemove);
       }
-      targetsHashCode = 1;
-      for (final UnitType ut : targetTypes) {
-        targetsHashCode += ut.hashCode();
-      }
-      targetsHashCode *= 31;
-      amphibHashCode = 1;
-      for (final UnitType ut : amphibTypes) {
-        amphibHashCode += ut.hashCode();
-      }
-      amphibHashCode *= 31;
-      key =
-          parameters.player.getName()
-              + "|"
-              + parameters.battlesite.getName()
-              + "|"
-              + parameters.combatModifiers.isDefending()
-              + "|"
-              + parameters.combatModifiers.isAmphibious()
-              + "|"
-              + targetsHashCode
-              + "|"
-              + amphibHashCode;
+      key = computeOolCacheKey(parameters, targetTypes, amphibTypes);
       it.remove();
     }
     return sortedWellEnoughUnitsList;
+  }
+
+  static String computeOolCacheKey(
+      final Parameters parameters,
+      final List<UnitType> targetTypes,
+      final List<UnitType> amphibTypes) {
+    return parameters.player.getName()
+        + "|"
+        + parameters.battlesite.getName()
+        + "|"
+        + parameters.combatModifiers.isDefending()
+        + "|"
+        + parameters.combatModifiers.isAmphibious()
+        + "|"
+        + Objects.hashCode(targetTypes)
+        + "|"
+        + Objects.hashCode(amphibTypes);
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTest.java
@@ -1,0 +1,72 @@
+package games.strategy.triplea.delegate.battle.casualty;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.delegate.battle.UnitBattleComparator;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.java.collections.IntegerMap;
+
+@ExtendWith(MockitoExtension.class)
+class CasualtyOrderOfLossesTest {
+
+  @Mock GameData gameData;
+
+  @BeforeEach
+  void clearCache() {
+    CasualtyOrderOfLosses.clearOolCache();
+  }
+
+  @Test
+  void oolCacheKeyIsUniqueWhenUnitTypeHashCodesHaveSameSum() {
+    final UnitType typePikemen = new UnitType("Pikemen", gameData);
+    final UnitType typeFootmen = new UnitType("Footmen", gameData);
+    final UnitType typeVeteranPikemen = new UnitType("Veteran-Pikemen", gameData);
+    final UnitType typeVeteranFootmen = new UnitType("Veteran-Footmen", gameData);
+
+    final String key1 =
+        CasualtyOrderOfLosses.computeOolCacheKey(
+            withFakeParameters(), List.of(typePikemen, typeVeteranFootmen), List.of());
+
+    final String key2 =
+        CasualtyOrderOfLosses.computeOolCacheKey(
+            withFakeParameters(), List.of(typeFootmen, typeVeteranPikemen), List.of());
+
+    assertThat(key1, is(not(key2)));
+  }
+
+  private CasualtyOrderOfLosses.Parameters withFakeParameters() {
+    final GamePlayer player = mock(GamePlayer.class);
+    when(player.getName()).thenReturn("player");
+    final Territory territory = mock(Territory.class);
+    when(territory.getName()).thenReturn("territory");
+    return CasualtyOrderOfLosses.Parameters.builder()
+        .targetsToPickFrom(List.of())
+        .combatModifiers(
+            UnitBattleComparator.CombatModifiers.builder()
+                .defending(false)
+                .amphibious(false)
+                .territoryEffects(List.of())
+                .build())
+        .player(player)
+        .enemyUnits(List.of())
+        .amphibiousLandAttackers(List.of())
+        .battlesite(territory)
+        .costs(IntegerMap.of(Map.of()))
+        .data(gameData)
+        .build();
+  }
+}


### PR DESCRIPTION
Fixes #7020

I moved the code to generate the key into a helper method, added tests, and changed it to use Objects.hashCode.

<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->
Played the save game from the issue and verified that it didn't show the error anymore.
## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->FIX|Warcraft War Heroes no longer errors with "sortedTargetsToPickFrom must have the same size as targetsToPickFrom list"<!--END_RELEASE_NOTE-->
