### PR TITLE
Return the screen size in logical pixels, not screen pixels.

### DIFF
--- a/game-core/src/main/java/games/strategy/ui/Util.java
+++ b/game-core/src/main/java/games/strategy/ui/Util.java
@@ -79,14 +79,18 @@ public final class Util {
     w.setLocation(x, y);
   }
 
-  /** Returns the size of the screen associated with the passed window. */
+  /**
+   * Returns the size of the screen associated with the passed window. Note: The returned size is in
+   * logical pixels, rather than screen pixels - which is the same unit Swing UI sizes are in.
+   */
   public static Dimension getScreenSize(final Window window) {
     final var graphicsConfiguration = window.getGraphicsConfiguration();
     if (graphicsConfiguration == null) {
       return Toolkit.getDefaultToolkit().getScreenSize();
     }
-    final var displayMode = graphicsConfiguration.getDevice().getDisplayMode();
-    return new Dimension(displayMode.getWidth(), displayMode.getHeight());
+    // Note: The bounds of the graphic config is in logical pixels, which
+    // is what we want, unlike gc.getDevice().getDisplayMode().getWidth().
+    return graphicsConfiguration.getBounds().getSize();
   }
 
   /**


### PR DESCRIPTION
Return the screen size in logical pixels, not screen pixels.

This way, if the user has magnification turned on in Windows, the returned size is correspondingly scaled down. This is the
behavior that we want, as we use this size to compare against Swing UI sizes, which is in logical pixels (gets scaled by the system setting).


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[X] Problem fix: https://github.com/triplea-game/triplea/issues/6825
[] Other:   <!-- Please specify -->

## Testing
Tested on Windows 10 by changing the magnification setting and verifying the new method returns the scaled size (different from the previous implementation which was the unscaled size).
<!-- Describe any manual testing performed below. -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->Fixes combat window sizing with Windows 10 magnification<!--END_RELEASE_NOTE-->
