### PR TITLE
NPE fix for 2.1.20365: ResourceLoader#loadImage:311 - NullPointerException #7039

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -309,11 +309,11 @@ public class ResourceLoader implements Closeable {
       return Optional.empty();
     }
     try {
-      BufferedImage bi = ImageIO.read(url);
-      if(bi == null) {
+      final BufferedImage bufferedImage = ImageIO.read(url);
+      if(bufferedImage == null) {
         log.severe("Unsupported Image Format: " + url);
       }
-      return Optional.ofNullable(bi);
+      return Optional.ofNullable(bufferedImage);
     } catch (final IOException e) {
       log.log(Level.SEVERE, "Image loading failed: " + imageName, e);
       return Optional.empty();

--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -8,6 +8,7 @@ import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.map.download.DownloadMapsWindow;
 import games.strategy.engine.framework.startup.launcher.MapNotFoundException;
 import java.awt.Image;
+import java.awt.image.BufferedImage;
 import java.io.ByteArrayInputStream;
 import java.io.Closeable;
 import java.io.File;

--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -308,7 +308,11 @@ public class ResourceLoader implements Closeable {
       return Optional.empty();
     }
     try {
-      return Optional.ofNullable(ImageIO.read(url));
+      BufferedImage bi = ImageIO.read(url);
+      if(bi == null) {
+        log.severe("Unsupported Image Format: " + url);
+      }
+      return Optional.ofNullable(bi);
     } catch (final IOException e) {
       log.log(Level.SEVERE, "Image loading failed: " + imageName, e);
       return Optional.empty();

--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -310,7 +310,7 @@ public class ResourceLoader implements Closeable {
     }
     try {
       final BufferedImage bufferedImage = ImageIO.read(url);
-      if(bufferedImage == null) {
+      if (bufferedImage == null) {
         log.severe("Unsupported Image Format: " + url);
       }
       return Optional.ofNullable(bufferedImage);


### PR DESCRIPTION
<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
