### PR TITLE
_ss image should be restricted to first strike and evaders

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -272,6 +272,7 @@ public class UnitImageFactory {
         }
       }
       if (UnitAttachment.get(type).getIsFirstStrike()
+          && UnitAttachment.get(type).getCanEvade()
           && (UnitAttachment.get(type).getAttack(gamePlayer) > 0
               || UnitAttachment.get(type).getDefense(gamePlayer) > 0)
           && TechTracker.hasSuperSubs(gamePlayer)) {


### PR DESCRIPTION
Fixes #6771

When isSub was split into isFirstStrike, canEvade, etc, the check for the _ss (super sub) image was limited to just isFirstStrike.  And then when isSuicide was split into isFirstStrike, isSuicideOnAttack, etc, all isSuicide units required the _ss images.

The _ss check now includes canEvade.  I thought of checking for isSuicideOnAttack == false, but thought that someone might want a super sub unit with suicide on attack.  I also thought of checking the values of canNotTarget and canNotBeTargetedBy but those could be overridden.

The pos2 should also be updated and say that when isFirstStrike and canEvade are true, then the _ss image is required.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->
Loaded the save in #6771 and verified that it is fixed.  You have to move the map to show Japan waters to get the error.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->FIX|MISSING UNIT IMAGE error for kamikaze units will no longer show up<!--END_RELEASE_NOTE-->
