### PR TITLE
Grab the base image name for the unit missing error message

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -221,7 +221,7 @@ public class UnitImageFactory {
     return Optional.of(icon);
   }
 
-  private static String getBaseImageName(
+  public static String getBaseImageName(
       final UnitType type,
       final GamePlayer gamePlayer,
       final boolean damaged,

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -9,6 +9,7 @@ import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.image.MapImage;
+import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.mapdata.MapData;
@@ -115,18 +116,14 @@ public class UnitsDrawer extends AbstractDrawable {
         uiContext.getUnitImageFactory().getImage(type, owner, damagedImage, disabled);
 
     if (img.isEmpty() && !uiContext.isShutDown()) {
-      final String imageQualifier;
-      if (disabled) {
-        imageQualifier = "disabled ";
-      } else if (damagedImage) {
-        imageQualifier = "damaged ";
-      } else {
-        imageQualifier = "";
-      }
+      final String imageName =
+          UnitImageFactory.getBaseImageName(type, owner, damagedImage, disabled);
       log.severe(
           "MISSING UNIT IMAGE (won't be displayed): "
-              + imageQualifier
               + type.getName()
+              + " ("
+              + imageName
+              + ")"
               + " owned by "
               + owner.getName()
               + " in "


### PR DESCRIPTION
This improves the unit missing error message by including the actual image name that it is looking for.  This should help map makers actually know what is missing.

This change is because of the last discussions in #6771

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->
I loaded the save in #6771 without its fix and verified that the error message was generated correctly.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->CHANGE|Unit Missing error will now indicate which image is actually missing<!--END_RELEASE_NOTE-->
