### PR TITLE
Make warnings non-reportable

### DIFF
--- a/game-core/src/main/java/org/triplea/debug/ErrorMessageFormatter.java
+++ b/game-core/src/main/java/org/triplea/debug/ErrorMessageFormatter.java
@@ -2,8 +2,11 @@ package org.triplea.debug;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
+import games.strategy.triplea.UrlConstants;
 import java.util.function.Function;
+import java.util.logging.Level;
 import java.util.logging.LogRecord;
+import org.triplea.swing.JEditorPaneWithClickableLinks;
 
 /** Converts a 'LogRecord' to the text that we display to a user in an alert pop-up. */
 class ErrorMessageFormatter implements Function<LogRecord, String> {
@@ -15,7 +18,15 @@ class ErrorMessageFormatter implements Function<LogRecord, String> {
         logRecord.getThrown() != null || logRecord.getMessage() != null,
         "LogRecord should have one or both, a message or exception: " + logRecord);
 
-    return TextUtils.textToHtml(format(logRecord));
+    final String baseMessage = format(logRecord);
+
+    final String additionalMessageForWarnings =
+        (logRecord.getLevel().intValue() == Level.WARNING.intValue())
+            ? "<br><br>If this problem happens frequently and is something you cannot fix,<br>"
+                + JEditorPaneWithClickableLinks.toLink(
+                    "please report it to TripleA ", UrlConstants.GITHUB_ISSUES)
+            : "";
+    return TextUtils.textToHtml(baseMessage + additionalMessageForWarnings);
   }
 
   /**

--- a/game-core/src/test/java/org/triplea/debug/ErrorMessageFormatterTest.java
+++ b/game-core/src/test/java/org/triplea/debug/ErrorMessageFormatterTest.java
@@ -2,9 +2,12 @@ package org.triplea.debug;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.StringContains.containsString;
 import static org.mockito.Mockito.when;
 
+import games.strategy.triplea.UrlConstants;
 import java.util.function.Function;
+import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -28,6 +31,7 @@ class ErrorMessageFormatterTest {
   @Test
   void logMessageOnly() {
     when(logRecord.getMessage()).thenReturn(LOG_MESSAGE);
+    when(logRecord.getLevel()).thenReturn(Level.SEVERE);
     when(logRecord.getThrown()).thenReturn(null);
 
     final String result = errorMessageFormatter.apply(logRecord);
@@ -54,6 +58,7 @@ class ErrorMessageFormatterTest {
   private static void givenLogRecordWithNoMessageOnlyAnException(
       final LogRecord logRecord, final Exception exception) {
     when(logRecord.getMessage()).thenReturn(exception.getMessage());
+    when(logRecord.getLevel()).thenReturn(Level.SEVERE);
     when(logRecord.getThrown()).thenReturn(exception);
   }
 
@@ -70,6 +75,7 @@ class ErrorMessageFormatterTest {
   @Test
   void bothMessageAndExceptionWithExceptionMessage() {
     when(logRecord.getMessage()).thenReturn(LOG_MESSAGE);
+    when(logRecord.getLevel()).thenReturn(Level.SEVERE);
     when(logRecord.getThrown()).thenReturn(EXCEPTION_WITH_MESSAGE);
 
     final String result = errorMessageFormatter.apply(logRecord);
@@ -89,6 +95,7 @@ class ErrorMessageFormatterTest {
   @Test
   void messageAndExceptionWithoutExceptionMessage() {
     when(logRecord.getMessage()).thenReturn(LOG_MESSAGE);
+    when(logRecord.getLevel()).thenReturn(Level.SEVERE);
     when(logRecord.getThrown()).thenReturn(EXCEPTION_WITHOUT_MESSAGE);
 
     final String result = errorMessageFormatter.apply(logRecord);
@@ -101,5 +108,16 @@ class ErrorMessageFormatterTest {
                 + "<br/><br/>"
                 + EXCEPTION_WITHOUT_MESSAGE.getClass().getSimpleName()
                 + "</html>"));
+  }
+
+  @Test
+  void warningLevelAppendsBugReportLink() {
+    when(logRecord.getMessage()).thenReturn(LOG_MESSAGE);
+    when(logRecord.getLevel()).thenReturn(Level.WARNING);
+    when(logRecord.getThrown()).thenReturn(EXCEPTION_WITHOUT_MESSAGE);
+
+    final String result = errorMessageFormatter.apply(logRecord);
+
+    assertThat(result, containsString(UrlConstants.GITHUB_ISSUES));
   }
 }


### PR DESCRIPTION
Add a check for logging level in our global logging handler. If the log
level is warning then disable the 'upload button'. Same, if the level
is a warning also add a generic statement giving the user a link to
report the problem.

This update allows us to notify users of general errors that have happened
that are outside of TripleA's control and are something that we can
tell the user how to fix in the warning message. This way we can
use a 'warning' logging to report this to the user without
constructing a full swing dialog with the same text.

Events logged at a 'severe' level will continue to have an 'upload' button
enabled and there is no change to the 'severe' logging behavior.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix
[] Other:   <!-- Please specify -->

## Testing
Injected a logging statement into GameRunner main method to verify dialog behavior for warning and severe levels.

<!-- Describe any manual testing performed below. -->

## Screens Shots

**Before**
![Screenshot from 2020-07-07 21-02-46](https://user-images.githubusercontent.com/12397753/86874495-55c73480-c095-11ea-86c5-4d62b85045c4.png)


**After**
![Screenshot from 2020-07-07 20-59-32](https://user-images.githubusercontent.com/12397753/86874506-595abb80-c095-11ea-8462-670c32767646.png)


## Additional Notes to Reviewer

Of note, this fix is not for us to blindly convert severe logging into warning to make it non-reportable. We should be careful that any warning logging actually tells a user how to fix the problem (eg: "unavailable, try again", "you are a probably already hosting a game on this port, please choose another port")

<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
