### PR TITLE
Remove unused method getBattleResultDescription

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/AbstractBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/AbstractBattle.java
@@ -233,11 +233,6 @@ abstract class AbstractBattle implements IBattle {
   }
 
   @Override
-  public BattleResultDescription getBattleResultDescription() {
-    return battleResultDescription;
-  }
-
-  @Override
   public UUID getBattleId() {
     return battleId;
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/IBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/IBattle.java
@@ -6,7 +6,6 @@ import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
-import games.strategy.triplea.delegate.data.BattleRecord.BattleResultDescription;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.Map;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/IBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/IBattle.java
@@ -146,8 +146,6 @@ public interface IBattle extends Serializable {
 
   WhoWon getWhoWon();
 
-  BattleResultDescription getBattleResultDescription();
-
   GamePlayer getAttacker();
 
   GamePlayer getDefender();


### PR DESCRIPTION
This method isn't used.  Looking in the git history, it appears to have never been used.  The commit that added it had a commented out line where it was used.  But that line was then deleted in a later commit.

I'd get rid of the member variable `battleResultDescription` but that would break save compatibility.  Should I put a comment on the variable and change all usage of it to local variables?

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->
Played an AI game just in case there was something using it through reflection.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
