### PR TITLE
Cache Images in UnitImageFactory & not ImageIcon; Simplify using ImageLoader over Toolkit

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/UnitType.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitType.java
@@ -144,7 +144,7 @@ public class UnitType extends NamedAttachable {
           try {
             final UnitImageFactory imageFactory = uiContext.getUnitImageFactory();
             if (imageFactory != null) {
-              final Optional<Image> unitImage = imageFactory.getImage(ut, player, false, false);
+              final Optional<Image> unitImage = imageFactory.getScaledImage(ut, player, false, false);
               if (unitImage.isPresent() && !unitTypes.contains(ut)) {
                 unitTypes.add(ut);
               }

--- a/game-core/src/main/java/games/strategy/engine/data/UnitType.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitType.java
@@ -144,7 +144,8 @@ public class UnitType extends NamedAttachable {
           try {
             final UnitImageFactory imageFactory = uiContext.getUnitImageFactory();
             if (imageFactory != null) {
-              final Optional<Image> unitImage = imageFactory.getScaledImage(ut, player, false, false);
+              final Optional<Image> unitImage =
+                  imageFactory.getScaledImage(ut, player, false, false);
               if (unitImage.isPresent() && !unitTypes.contains(ut)) {
                 unitTypes.add(ut);
               }

--- a/game-core/src/main/java/games/strategy/triplea/image/ImageLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/ImageLoader.java
@@ -2,7 +2,6 @@ package games.strategy.triplea.image;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import java.awt.Image;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;

--- a/game-core/src/main/java/games/strategy/triplea/image/ImageLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/ImageLoader.java
@@ -3,8 +3,10 @@ package games.strategy.triplea.image;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.awt.Image;
+import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
 import javax.imageio.ImageIO;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -17,13 +19,21 @@ public final class ImageLoader {
    *
    * @param path Location of the file to be read as an image.
    */
-  public static Image getImage(final File path) {
+  public static BufferedImage getImage(final File path) {
     checkArgument(path.exists(), "File must exist at path: " + path.getAbsolutePath());
     checkArgument(path.isFile(), "Must be a file: " + path.getAbsolutePath());
     try {
       return ImageIO.read(path);
     } catch (final IOException e) {
       throw new RuntimeException("Unable to load image at path: " + path.getAbsolutePath(), e);
+    }
+  }
+
+  public static BufferedImage getImage(final URL url) {
+    try {
+      return ImageIO.read(url);
+    } catch (final IOException e) {
+      throw new RuntimeException("Unable to load image at path: " + url, e);
     }
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -149,8 +149,7 @@ public class UnitImageFactory {
                 unscaledImages.computeIfAbsent(
                     imageLocation,
                     path -> {
-                      Image image = Toolkit.getDefaultToolkit().getImage(path);
-                      Util.ensureImageLoaded(image);
+                      Image image = ImageLoader.getImage(path);
                       if (needToTransformImage(gamePlayer, type, mapData)) {
                         image = transformImage(image, gamePlayer);
                       }

--- a/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -41,10 +41,10 @@ public class UnitImageFactory {
 
   private final int unitCounterOffsetWidth;
   private final int unitCounterOffsetHeight;
-  // maps Point -> image
-  private final Map<String, Image> images = new HashMap<>();
-  // maps Point -> Icon
-  private final Map<String, ImageIcon> icons = new HashMap<>();
+  // maps Path -> scaled image
+  private final Map<String, Image> scaledImages = new HashMap<>();
+  // maps Path -> unscaled Icon
+  private final Map<String, ImageIcon> unscaledIcons = new HashMap<>();
   // Scaling factor for unit images
   private final double scaleFactor;
   private final ResourceLoader resourceLoader;
@@ -91,19 +91,19 @@ public class UnitImageFactory {
     return (int) (scaleFactor * unitCounterOffsetHeight);
   }
 
-  public Image getImage(final UnitCategory unit) {
-    return getImage(unit.getType(), unit.getOwner(), (unit.getDamaged() > 0), unit.getDisabled())
+  public Image getScaledImage(final UnitCategory unit) {
+    return getScaledImage(unit.getType(), unit.getOwner(), (unit.getDamaged() > 0), unit.getDisabled())
         .orElseThrow(() -> new RuntimeException("No unit image for: " + unit));
   }
 
   /** Return the appropriate unit image. */
-  public Optional<Image> getImage(
+  public Optional<Image> getScaledImage(
       final UnitType type, final GamePlayer player, final boolean damaged, final boolean disabled) {
     final String baseName = getBaseImageName(type, player, damaged, disabled);
     final String fullName = baseName + player.getName();
 
     return Optional.ofNullable(
-        images.computeIfAbsent(
+        scaledImages.computeIfAbsent(
             fullName,
             pathName ->
                 getTransformedImage(baseName, player, type) //
@@ -185,7 +185,7 @@ public class UnitImageFactory {
    */
   public Optional<Image> getHighlightImage(
       final UnitType type, final GamePlayer player, final boolean damaged, final boolean disabled) {
-    return getImage(type, player, damaged, disabled).map(UnitImageFactory::highlightImage);
+    return getScaledImage(type, player, damaged, disabled).map(UnitImageFactory::highlightImage);
   }
 
   private static Image highlightImage(final Image image) {
@@ -203,12 +203,12 @@ public class UnitImageFactory {
   }
 
   /** Return a icon image for a unit. */
-  public Optional<ImageIcon> getIcon(
+  public Optional<ImageIcon> getUnscaledIcon(
       final UnitType type, final GamePlayer player, final boolean damaged, final boolean disabled) {
     final String baseName = getBaseImageName(type, player, damaged, disabled);
     final String fullName = baseName + player.getName();
-    if (icons.containsKey(fullName)) {
-      return Optional.of(icons.get(fullName));
+    if (unscaledIcons.containsKey(fullName)) {
+      return Optional.of(unscaledIcons.get(fullName));
     }
     final Optional<Image> image = getTransformedImage(baseName, player, type);
     if (image.isEmpty()) {
@@ -216,7 +216,7 @@ public class UnitImageFactory {
     }
 
     final ImageIcon icon = new ImageIcon(image.get());
-    icons.put(fullName, icon);
+    unscaledIcons.put(fullName, icon);
     return Optional.of(icon);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -108,22 +108,25 @@ public class UnitImageFactory {
                 getTransformedImage(baseName, player, type)
                     .map(
                         baseImage -> {
-                          // We want to scale units according to the given scale factor.
-                          // We use smooth scaling since the images are cached to allow to take our
-                          // time in
-                          // doing the
-                          // scaling.
-                          // Image observer is null, since the image should have been guaranteed to
-                          // be loaded.
-                          final int width = (int) (baseImage.getWidth(null) * scaleFactor);
-                          final int height = (int) (baseImage.getHeight(null) * scaleFactor);
-                          final Image scaledImage =
-                              baseImage.getScaledInstance(width, height, Image.SCALE_SMOOTH);
-                          // Ensure the scaling is completed.
-                          Util.ensureImageLoaded(scaledImage);
+                          final Image scaledImage = scaleImage(baseImage);
                           images.put(fullName, scaledImage);
                           return scaledImage;
                         }));
+  }
+
+  private Image scaleImage(final Image baseImage) {
+    // We want to scale units according to the given scale factor.
+    // We use smooth scaling since the images are cached to allow to take our
+    // time in doing the scaling.
+    // Image observer is null, since the image should have been guaranteed to
+    // be loaded.
+    final int width = (int) (baseImage.getWidth(null) * scaleFactor);
+    final int height = (int) (baseImage.getHeight(null) * scaleFactor);
+    final Image scaledImage =
+        baseImage.getScaledInstance(width, height, Image.SCALE_SMOOTH);
+    // Ensure the scaling is completed.
+    Util.ensureImageLoaded(scaledImage);
+    return scaledImage;
   }
 
   public Optional<URL> getBaseImageUrl(final String baseImageName, final GamePlayer gamePlayer) {

--- a/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -102,16 +102,13 @@ public class UnitImageFactory {
     final String baseName = getBaseImageName(type, player, damaged, disabled);
     final String fullName = baseName + player.getName();
 
-    return Optional.ofNullable(images.get(fullName))
-        .or(
-            () ->
-                getTransformedImage(baseName, player, type)
-                    .map(
-                        baseImage -> {
-                          final Image scaledImage = scaleImage(baseImage);
-                          images.put(fullName, scaledImage);
-                          return scaledImage;
-                        }));
+    return Optional.ofNullable(
+        images.computeIfAbsent(
+            fullName,
+            pathName ->
+                getTransformedImage(baseName, player, type) //
+                    .map(this::scaleImage)
+                    .orElse(null)));
   }
 
   private Image scaleImage(final Image baseImage) {
@@ -122,8 +119,7 @@ public class UnitImageFactory {
     // be loaded.
     final int width = (int) (baseImage.getWidth(null) * scaleFactor);
     final int height = (int) (baseImage.getHeight(null) * scaleFactor);
-    final Image scaledImage =
-        baseImage.getScaledInstance(width, height, Image.SCALE_SMOOTH);
+    final Image scaledImage = baseImage.getScaledInstance(width, height, Image.SCALE_SMOOTH);
     // Ensure the scaling is completed.
     Util.ensureImageLoaded(scaledImage);
     return scaledImage;

--- a/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -146,7 +146,7 @@ public class UnitImageFactory {
       final GamePlayer gamePlayer, final UnitType type, final MapData mapData) {
     return !mapData.ignoreTransformingUnit(type.getName())
         && (mapData.getUnitColor(gamePlayer.getName()).isPresent()
-        || mapData.shouldFlipUnit(gamePlayer.getName()));
+            || mapData.shouldFlipUnit(gamePlayer.getName()));
   }
 
   private BufferedImage transformImage(final BufferedImage rawImage, final GamePlayer gamePlayer) {

--- a/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -154,19 +154,23 @@ public class UnitImageFactory {
       image = Toolkit.getDefaultToolkit().getImage(imageLocation.get());
       Util.ensureImageLoaded(image);
       if (needToTransformImage(gamePlayer, type, mapData)) {
-        image = convertToBufferedImage(image);
-        final Optional<Color> unitColor = mapData.getUnitColor(gamePlayer.getName());
-        if (unitColor.isPresent()) {
-          final int brightness = mapData.getUnitBrightness(gamePlayer.getName());
-          ImageTransformer.colorize(unitColor.get(), brightness, (BufferedImage) image);
-        }
-        if (mapData.shouldFlipUnit(gamePlayer.getName())) {
-          image = ImageTransformer.flipHorizontally((BufferedImage) image);
-        }
+        image = transformImage(image, gamePlayer);
       }
       unscaledImages.put(imageLocation.get(), image);
     }
     return Optional.ofNullable(image);
+  }
+
+  private Image transformImage(final Image rawImage, final GamePlayer gamePlayer) {
+    Image image = convertToBufferedImage(rawImage);
+    final Optional<Color> unitColor = mapData.getUnitColor(gamePlayer.getName());
+    if (unitColor.isPresent()) {
+      final int brightness = mapData.getUnitBrightness(gamePlayer.getName());
+      ImageTransformer.colorize(unitColor.get(), brightness, (BufferedImage) image);
+    }
+    if (mapData.shouldFlipUnit(gamePlayer.getName())) {
+      image = ImageTransformer.flipHorizontally((BufferedImage) image);
+    }
   }
 
   private static boolean needToTransformImage(

--- a/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -15,7 +15,6 @@ import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
 import java.awt.Image;
-import java.awt.Toolkit;
 import java.awt.image.BufferedImage;
 import java.net.URL;
 import java.util.HashMap;
@@ -149,7 +148,7 @@ public class UnitImageFactory {
                 unscaledImages.computeIfAbsent(
                     imageLocation,
                     path -> {
-                      Image image = ImageLoader.getImage(path);
+                      BufferedImage image = ImageLoader.getImage(path);
                       if (needToTransformImage(gamePlayer, type, mapData)) {
                         image = transformImage(image, gamePlayer);
                       }
@@ -157,15 +156,15 @@ public class UnitImageFactory {
                     }));
   }
 
-  private Image transformImage(final Image rawImage, final GamePlayer gamePlayer) {
-    Image image = convertToBufferedImage(rawImage);
+  private BufferedImage transformImage(final BufferedImage rawImage, final GamePlayer gamePlayer) {
+    BufferedImage image = rawImage;
     final Optional<Color> unitColor = mapData.getUnitColor(gamePlayer.getName());
     if (unitColor.isPresent()) {
       final int brightness = mapData.getUnitBrightness(gamePlayer.getName());
-      ImageTransformer.colorize(unitColor.get(), brightness, (BufferedImage) image);
+      ImageTransformer.colorize(unitColor.get(), brightness, image);
     }
     if (mapData.shouldFlipUnit(gamePlayer.getName())) {
-      image = ImageTransformer.flipHorizontally((BufferedImage) image);
+      image = ImageTransformer.flipHorizontally(image);
     }
     return image;
   }
@@ -175,15 +174,6 @@ public class UnitImageFactory {
     return !mapData.ignoreTransformingUnit(type.getName())
         && (mapData.getUnitColor(gamePlayer.getName()).isPresent()
             || mapData.shouldFlipUnit(gamePlayer.getName()));
-  }
-
-  private static BufferedImage convertToBufferedImage(final Image image) {
-    final BufferedImage newImage =
-        new BufferedImage(image.getWidth(null), image.getHeight(null), BufferedImage.TYPE_INT_ARGB);
-    final Graphics2D g = newImage.createGraphics();
-    g.drawImage(image, 0, 0, null);
-    g.dispose();
-    return newImage;
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -145,19 +145,17 @@ public class UnitImageFactory {
       final String baseImageName, final GamePlayer gamePlayer, final UnitType type) {
     return getBaseImageUrl(baseImageName, gamePlayer)
         .map(
-            imageLocation -> {
-              if (unscaledImages.containsKey(imageLocation)) {
-                return unscaledImages.get(imageLocation);
-              }
-
-              Image image = Toolkit.getDefaultToolkit().getImage(imageLocation);
-              Util.ensureImageLoaded(image);
-              if (needToTransformImage(gamePlayer, type, mapData)) {
-                image = transformImage(image, gamePlayer);
-                unscaledImages.put(imageLocation, image);
-              }
-              return image;
-            });
+            imageLocation ->
+                unscaledImages.computeIfAbsent(
+                    imageLocation,
+                    path -> {
+                      Image image = Toolkit.getDefaultToolkit().getImage(path);
+                      Util.ensureImageLoaded(image);
+                      if (needToTransformImage(gamePlayer, type, mapData)) {
+                        image = transformImage(image, gamePlayer);
+                      }
+                      return image;
+                    }));
   }
 
   private Image transformImage(final Image rawImage, final GamePlayer gamePlayer) {

--- a/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -143,22 +143,21 @@ public class UnitImageFactory {
 
   private Optional<Image> getTransformedImage(
       final String baseImageName, final GamePlayer gamePlayer, final UnitType type) {
-    final Optional<URL> imageLocation = getBaseImageUrl(baseImageName, gamePlayer);
+    return getBaseImageUrl(baseImageName, gamePlayer)
+        .map(
+            imageLocation -> {
+              if (unscaledImages.containsKey(imageLocation)) {
+                return unscaledImages.get(imageLocation);
+              }
 
-    if (imageLocation.isPresent() && unscaledImages.containsKey(imageLocation.get())) {
-      return Optional.of(unscaledImages.get(imageLocation.get()));
-    }
-
-    Image image = null;
-    if (imageLocation.isPresent()) {
-      image = Toolkit.getDefaultToolkit().getImage(imageLocation.get());
-      Util.ensureImageLoaded(image);
-      if (needToTransformImage(gamePlayer, type, mapData)) {
-        image = transformImage(image, gamePlayer);
-      }
-      unscaledImages.put(imageLocation.get(), image);
-    }
-    return Optional.ofNullable(image);
+              Image image = Toolkit.getDefaultToolkit().getImage(imageLocation);
+              Util.ensureImageLoaded(image);
+              if (needToTransformImage(gamePlayer, type, mapData)) {
+                image = transformImage(image, gamePlayer);
+                unscaledImages.put(imageLocation, image);
+              }
+              return image;
+            });
   }
 
   private Image transformImage(final Image rawImage, final GamePlayer gamePlayer) {
@@ -171,6 +170,7 @@ public class UnitImageFactory {
     if (mapData.shouldFlipUnit(gamePlayer.getName())) {
       image = ImageTransformer.flipHorizontally((BufferedImage) image);
     }
+    return image;
   }
 
   private static boolean needToTransformImage(

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/OrderOfLossesInputPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/OrderOfLossesInputPanel.java
@@ -280,7 +280,7 @@ class OrderOfLossesInputPanel extends JPanel {
         final Optional<Image> img =
             uiContext
                 .getUnitImageFactory()
-                .getImage(
+                .getScaledImage(
                     category.getType(),
                     category.getOwner(),
                     category.hasDamageOrBombingUnitDamage(),

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/UnitPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/UnitPanel.java
@@ -48,7 +48,7 @@ public class UnitPanel extends JPanel {
     final Optional<Image> img =
         uiContext
             .getUnitImageFactory()
-            .getImage(
+            .getScaledImage(
                 category.getType(),
                 category.getOwner(),
                 category.hasDamageOrBombingUnitDamage(),

--- a/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
@@ -130,7 +130,7 @@ public abstract class AbstractUndoableMovesPanel extends JPanel {
               .getMap()
               .getUiContext()
               .getUnitImageFactory()
-              .getIcon(
+              .getUnscaledIcon(
                   category.getType(),
                   category.getOwner(),
                   category.hasDamageOrBombingUnitDamage(),

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -1004,7 +1004,7 @@ public class BattleDisplay extends JPanel {
       this.player = player;
       this.count = count;
       this.unitType = type;
-      icon = uiContext.getUnitImageFactory().getIcon(type, player, damaged, disabled);
+      icon = uiContext.getUnitImageFactory().getUnscaledIcon(type, player, damaged, disabled);
     }
 
     void updateStamp(final JLabel stamp) {
@@ -1077,7 +1077,7 @@ public class BattleDisplay extends JPanel {
         final Optional<ImageIcon> unitImage =
             uiContext
                 .getUnitImageFactory()
-                .getIcon(
+                .getUnscaledIcon(
                     category.getType(),
                     category.getOwner(),
                     damaged && category.hasDamageOrBombingUnitDamage(),

--- a/game-core/src/main/java/games/strategy/triplea/ui/EditProductionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EditProductionPanel.java
@@ -91,7 +91,7 @@ class EditProductionPanel extends ProductionPanel {
           try {
             final UnitImageFactory imageFactory = uiContext.getUnitImageFactory();
             if (imageFactory != null) {
-              final Optional<Image> unitImage = imageFactory.getImage(ut, player, false, false);
+              final Optional<Image> unitImage = imageFactory.getScaledImage(ut, player, false, false);
               if (unitImage.isPresent()) {
                 unitsAllowed.add(ut);
                 final IntegerMap<NamedAttachable> result = new IntegerMap<>();

--- a/game-core/src/main/java/games/strategy/triplea/ui/EditProductionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EditProductionPanel.java
@@ -91,7 +91,8 @@ class EditProductionPanel extends ProductionPanel {
           try {
             final UnitImageFactory imageFactory = uiContext.getUnitImageFactory();
             if (imageFactory != null) {
-              final Optional<Image> unitImage = imageFactory.getScaledImage(ut, player, false, false);
+              final Optional<Image> unitImage =
+                  imageFactory.getScaledImage(ut, player, false, false);
               if (unitImage.isPresent()) {
                 unitsAllowed.add(ut);
                 final IntegerMap<NamedAttachable> result = new IntegerMap<>();

--- a/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
@@ -125,7 +125,7 @@ public class HeadedUiContext extends AbstractUiContext {
       final UnitEnable disabled) {
     final Optional<ImageIcon> image =
         getUnitImageFactory()
-            .getIcon(type, player, damaged == UnitDamage.DAMAGED, disabled == UnitEnable.DISABLED);
+            .getUnscaledIcon(type, player, damaged == UnitDamage.DAMAGED, disabled == UnitEnable.DISABLED);
     final JLabel label = image.map(JLabel::new).orElseGet(JLabel::new);
     MapUnitTooltipManager.setUnitTooltip(label, type, player, 1);
     return label;

--- a/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/HeadedUiContext.java
@@ -125,7 +125,8 @@ public class HeadedUiContext extends AbstractUiContext {
       final UnitEnable disabled) {
     final Optional<ImageIcon> image =
         getUnitImageFactory()
-            .getUnscaledIcon(type, player, damaged == UnitDamage.DAMAGED, disabled == UnitEnable.DISABLED);
+            .getUnscaledIcon(
+                type, player, damaged == UnitDamage.DAMAGED, disabled == UnitEnable.DISABLED);
     final JLabel label = image.map(JLabel::new).orElseGet(JLabel::new);
     MapUnitTooltipManager.setUnitTooltip(label, type, player, 1);
     return label;

--- a/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
@@ -348,7 +348,7 @@ class ProductionPanel extends JPanel {
         final NamedAttachable resourceOrUnit = iter.next();
         if (resourceOrUnit instanceof UnitType) {
           final UnitType type = (UnitType) resourceOrUnit;
-          icon = uiContext.getUnitImageFactory().getIcon(type, player, false, false);
+          icon = uiContext.getUnitImageFactory().getUnscaledIcon(type, player, false, false);
           final UnitAttachment attach = UnitAttachment.get(type);
           final int attack = attach.getAttack(player);
           final int movement = attach.getMovement(player);

--- a/game-core/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
@@ -309,7 +309,7 @@ class ProductionRepairPanel extends JPanel {
       final Optional<ImageIcon> icon =
           uiContext
               .getUnitImageFactory()
-              .getIcon(
+              .getUnscaledIcon(
                   type,
                   gamePlayer,
                   Matches.unitHasTakenSomeBombingUnitDamage().test(repairUnit),

--- a/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
@@ -215,7 +215,7 @@ public class SimpleUnitPanel extends JPanel {
     if (unit instanceof UnitType) {
       final UnitType unitType = (UnitType) unit;
       final Optional<ImageIcon> icon =
-          uiContext.getUnitImageFactory().getIcon(unitType, player, damaged, disabled);
+          uiContext.getUnitImageFactory().getUnscaledIcon(unitType, player, damaged, disabled);
       icon.ifPresent(label::setIcon);
       MapUnitTooltipManager.setUnitTooltip(label, unitType, player, quantity);
     } else if (unit instanceof Resource) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -147,7 +147,7 @@ class TerritoryDetailPanel extends AbstractStatPanel {
       final Optional<ImageIcon> unitIcon =
           uiContext
               .getUnitImageFactory()
-              .getIcon(
+              .getUnscaledIcon(
                   item.getType(),
                   item.getOwner(),
                   item.hasDamageOrBombingUnitDamage(),

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1240,7 +1240,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
       final Optional<ImageIcon> icon =
           uiContext
               .getUnitImageFactory()
-              .getIcon(
+              .getUnscaledIcon(
                   unit.getType(),
                   unit.getOwner(),
                   Matches.unitHasTakenSomeBombingUnitDamage().test(unit),

--- a/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -617,7 +617,7 @@ public final class UnitChooser extends JPanel {
         final Optional<Image> image =
             uiContext
                 .getUnitImageFactory()
-                .getImage(
+                .getScaledImage(
                     category.getType(),
                     category.getOwner(),
                     forceDamaged || category.hasDamageOrBombingUnitDamage(),
@@ -630,7 +630,7 @@ public final class UnitChooser extends JPanel {
           final Optional<Image> unitImg =
               uiContext
                   .getUnitImageFactory()
-                  .getImage(holder.getType(), holder.getOwner(), false, false);
+                  .getScaledImage(holder.getType(), holder.getOwner(), false, false);
           unitImg.ifPresent(image1 -> g.drawImage(image1, x, 0, this));
           index++;
         }

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -113,7 +113,7 @@ public class UnitsDrawer extends AbstractDrawable {
     final GamePlayer owner = data.getPlayerList().getPlayerId(playerName);
     final boolean damagedImage = damaged > 0 || bombingUnitDamage > 0;
     final Optional<Image> img =
-        uiContext.getUnitImageFactory().getImage(type, owner, damagedImage, disabled);
+        uiContext.getUnitImageFactory().getScaledImage(type, owner, damagedImage, disabled);
 
     if (img.isEmpty() && !uiContext.isShutDown()) {
       final String imageName =

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/AvatarPanelFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/AvatarPanelFactory.java
@@ -134,7 +134,7 @@ class AvatarPanelFactory {
 
     unitsToDraw.sort(unitRenderingOrder(player));
     for (int i = 0; i < drawLocations.size(); i++) {
-      final var imageToDraw = unitImageFactory.getImage(unitsToDraw.get(i));
+      final var imageToDraw = unitImageFactory.getScaledImage(unitsToDraw.get(i));
       final Point drawLocation = drawLocations.get(i);
 
       graphics.drawImage(


### PR DESCRIPTION
Number of commits to simplify the code in UnitImageFactory.

ImageIcon cache is there to cache unscaled images. The converstion to an ImageIcon incurs a blocking call in MediaTracker and takes about 1 micro-second. This update clarifies the cache names and converts the unscaled ImageIcon cache to cache Images.

Second, if we use ImageIO we get a blocking operation (no longer requires MediaTracker) and we get a BufferedImage back. This simplifies further and avoids converting an Image to BufferedImage.

<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[x] Code Cleanup or refactor
[] Configuration Change
[] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
