### PR TITLE
Fix perftimer 'log every n' calculation

### DIFF
--- a/game-core/src/main/java/org/triplea/performance/PerfTimer.java
+++ b/game-core/src/main/java/org/triplea/performance/PerfTimer.java
@@ -76,7 +76,7 @@ public class PerfTimer implements Closeable {
     final long newCount = totalCount.get() + 1;
     totalCount.set(newCount);
 
-    if ((newCount % perfTimer.reportingFrequency) == 0) {
+    if ((newCount % perfTimer.reportingFrequency) != 0) {
       return;
     }
 


### PR DESCRIPTION
Instead of skipping if the iteration count modulus is 0,
we want to skip if the modulus is non-zero. This way
we log every 'n' requests instead of logging every time
except the "n'th' requests. This was noticed when
'n=1', in which case we skip every time (N mod 1 = 0).


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
