### PR TITLE
Fix run-ansible-vagrant script to be in one directory above when invoking gradlew

### DIFF
--- a/infrastructure/run_ansible_vagrant
+++ b/infrastructure/run_ansible_vagrant
@@ -49,7 +49,10 @@ function buildMigrations() {
   local zipFile=migrations.zip
   if [ ! -e $targetFolder/$zipFile ]; then
     if [ ! -e ../lobby-db/build/distributions/$zipFile ]; then
-       ./gradlew :lobby-db:release
+      (
+        cd ..
+        ./gradlew :lobby-db:release
+      )
     fi
     mkdir -p $targetFolder
     cp ../lobby-db/build/distributions/$zipFile $targetFolder


### PR DESCRIPTION

<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
