### PR TITLE
Correct & simplify ansible/vagrant inventory file [skip ci]

### DIFF
--- a/infrastructure/ansible/inventory/vagrant
+++ b/infrastructure/ansible/inventory/vagrant
@@ -1,13 +1,12 @@
-[postgresHosts]
-127.0.0.1 ansible_port=2010 ansible_ssh_private_key_file=./.vagrant/machines/vagrantHost/virtualbox/private_key
+[vagrant]
+vagrant ansible_host=127.0.0.1 ansible_port=2010 ansible_ssh_private_key_file=./.vagrant/machines/vagrantHost/virtualbox/private_key
 
-[dropwizardHosts]
-127.0.0.1 ansible_port=2010 ansible_ssh_private_key_file=./.vagrant/machines/vagrantHost/virtualbox/private_key
+[postgresHosts:children]
+vagrant
 
-[botHosts]
-127.0.0.1 ansible_port=2010 ansible_ssh_private_key_file=./.vagrant/machines/vagrantHost/virtualbox/private_key
+[dropwizardHosts:children]
+vagrant
 
-[vagrant:children]
-postgresHosts
-dropwizardHosts
-botHosts
+[botHosts:children]
+vagrant
+


### PR DESCRIPTION
- Correction: Host groups containing other host groups need a ':children' suffix
- Simplify: instead of redundantly listing the vagrant host, we only need to specify
  it once and then reference that hostgroup under the other hostgroups


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
