### PR TITLE
Fix null resourceLoader for bots

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -109,6 +109,10 @@ public class UiContext {
 
   UiContext() {}
 
+  public static void setResourceLoader(final GameData gameData) {
+    resourceLoader = ResourceLoader.getMapResourceLoader(getDefaultMapDir(gameData));
+  }
+
   protected void internalSetMapDir(final String dir, final GameData data) {
     if (resourceLoader != null) {
       resourceLoader.close();

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
@@ -10,6 +10,7 @@ import games.strategy.engine.framework.startup.launcher.LaunchAction;
 import games.strategy.engine.framework.startup.mc.ServerModel;
 import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorModel;
 import games.strategy.engine.player.Player;
+import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.ui.display.HeadlessDisplay;
 import java.io.File;
 import java.util.Set;
@@ -55,6 +56,7 @@ public class HeadlessLaunchAction implements LaunchAction {
       final IGame game,
       final Set<Player> players,
       final Chat chat) {
+    UiContext.setResourceLoader(game.getData());
     return new HeadlessDisplay();
   }
 


### PR DESCRIPTION
HeadlessUiContext was setting the static 'resourceLoader' variable,
not a local variable. This fix initializes the static
UIContext.resourceLoader variable that is then used in numerous
locations to load map reosurce files.

Resolves: https://github.com/triplea-game/triplea/issues/7137


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
