### PR TITLE
Better fix for leaked DB password, use loop-control

### DIFF
--- a/infrastructure/ansible/roles/database/postgres/tasks/main.yml
+++ b/infrastructure/ansible/roles/database/postgres/tasks/main.yml
@@ -27,6 +27,7 @@
 - name: Set postgres user password
   become: true
   become_user: postgres
+  no_log: true
   postgresql_user:
     name: postgres
     login_password: "{{ postgres_user_db_password }}"
@@ -42,7 +43,9 @@
     login_password: "{{ item.password }}"
     encrypted: yes
     state: "present"
-  with_items: "{{ databases }}"
+  loop: "{{ databases }}"
+  loop_control:
+    label: "{{ item.user }}"
 
 - name: Create application databases
   become: true
@@ -50,7 +53,9 @@
   postgresql_db:
     name: "{{ item.name }}"
     owner: "{{ item.user }}"
-  with_items: "{{ databases }}"
+  loop: "{{ databases }}"
+  loop_control:
+    label: "{{ item.name }}"
 
 - name: Ensure user has access to the database
   become: true
@@ -64,7 +69,9 @@
     priv: "ALL"
     role_attr_flags: NOSUPERUSER,NOCREATEDB
     state: "present"
-  with_items: "{{ databases }}"
+  loop: "{{ databases }}"
+  loop_control:
+    label: "{{ item.name }} {{ item.user }}"
 
 # This is a hack because the previous tasks were supposed to set
 # the DB level password for our DB user, but it typically does not.
@@ -77,4 +84,7 @@
   environment:
     PGPASSWORD: "{{ item.password }}"
   changed_when: false
-  with_items: "{{ databases }}"
+  loop: "{{ databases }}"
+  loop_control:
+    label: "{{ item.user }}"
+

--- a/infrastructure/run_ansible_prerelease
+++ b/infrastructure/run_ansible_prerelease
@@ -65,7 +65,6 @@ function addPrivateSshKeyToAgent() {
 
 function runDeployment() {
   ansible-playbook \
-    --skip-tags database \
     --vault-password-file "$VAULT_PASSWORD_FILE" \
     -i ansible/inventory/prerelease \
    "$@" \

--- a/infrastructure/run_ansible_production
+++ b/infrastructure/run_ansible_production
@@ -23,7 +23,6 @@ ansible-vault view \
 
 # Run deployment
 ansible-playbook \
-    --skip-tags database \
     --vault-password-file vault_password \
     "$@" \
     -i ansible/inventory/prod2 \


### PR DESCRIPTION
Loop_control can be used to control how the loop iteration label is printed.
When ansible runs a loop, it prints the value of the loop variable.
This is bad for us if the loop variable is a map and contains a password.
This fix removes the skip-tags command that skipped over DB tasks to prevent
password leakage and simply makes explicit which parts of the loop
variable is to be printed (omitting passwords).


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix
[] Other:   <!-- Please specify -->

## Testing
- ran deployment against prerelease to verify that the output was clean
```
triplea/infrastructure$ ./run_ansible_prerelease 2.1.0 -t database
```
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
