### PR TITLE
Improve unable to bind exception message

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -42,6 +42,7 @@ import games.strategy.triplea.settings.ClientSetting;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.BindException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -479,8 +480,16 @@ public class ServerModel extends Observable implements IConnectionChangeListener
       serverMessenger.setAcceptNewConnections(true);
       gameDataChanged();
       serverSetupModel.onServerMessengerCreated(this, gameHostingResponse);
-    } catch (final IOException ioe) {
-      log.log(Level.SEVERE, "Unable to create server socket", ioe);
+    } catch (final BindException e) {
+      log.log(
+          Level.WARNING,
+          "Could not open network port, please close any other TripleA games you are\n"
+              + "hosting or choose a different network port. If that is not the problem\n"
+              + "then check your firewall rules.",
+          e);
+      cancel();
+    } catch (final IOException e) {
+      log.log(Level.SEVERE, "Unable to create server socket.", e);
       cancel();
     }
   }


### PR DESCRIPTION
Instead of presenting a crash report to a user if they 'double' host
on the same port, change the log level to warning to make the
problem non-reportable and add details to the error message giving
some instructions on how the user can fix the problem.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
