### PR TITLE
Fix error reporting HTML formatting

### DIFF
--- a/game-core/src/main/java/org/triplea/debug/ErrorMessageFormatter.java
+++ b/game-core/src/main/java/org/triplea/debug/ErrorMessageFormatter.java
@@ -26,7 +26,7 @@ class ErrorMessageFormatter implements Function<LogRecord, String> {
                 + JEditorPaneWithClickableLinks.toLink(
                     "please report it to TripleA ", UrlConstants.GITHUB_ISSUES)
             : "";
-    return TextUtils.textToHtml(baseMessage + additionalMessageForWarnings);
+    return "<html>" + TextUtils.textToHtml(baseMessage) + additionalMessageForWarnings + "</html>";
   }
 
   /**

--- a/game-core/src/main/java/org/triplea/debug/TextUtils.java
+++ b/game-core/src/main/java/org/triplea/debug/TextUtils.java
@@ -1,13 +1,12 @@
 package org.triplea.debug;
 
 import com.google.common.html.HtmlEscapers;
+import lombok.experimental.UtilityClass;
 
+@UtilityClass
 final class TextUtils {
-  private TextUtils() {}
 
   static String textToHtml(final String text) {
-    return "<html>"
-        + HtmlEscapers.htmlEscaper().escape(text).replaceAll("\r?\n", "<br/>")
-        + "</html>";
+    return HtmlEscapers.htmlEscaper().escape(text).replaceAll("\r?\n", "<br/>");
   }
 }

--- a/game-core/src/test/java/org/triplea/debug/TextUtilsTest.java
+++ b/game-core/src/test/java/org/triplea/debug/TextUtilsTest.java
@@ -12,19 +12,19 @@ final class TextUtilsTest {
   final class TextToHtmlTest {
     @Test
     void shouldEmbedTextInHtmlElement() {
-      assertThat(textToHtml("test"), is("<html>test</html>"));
+      assertThat(textToHtml("test"), is("test"));
     }
 
     @Test
     void shouldEscapeHtmlMetacharacters() {
-      assertThat(textToHtml("abc<>&\"'123"), is("<html>abc&lt;&gt;&amp;&quot;&#39;123</html>"));
+      assertThat(textToHtml("abc<>&\"'123"), is("abc&lt;&gt;&amp;&quot;&#39;123"));
     }
 
     @Test
     void shouldReplaceLineSeparatorsWithBreakElement() {
       assertThat(
           textToHtml("a" + System.lineSeparator() + "b" + System.lineSeparator() + "c"),
-          is("<html>a<br/>b<br/>c</html>"));
+          is("a<br/>b<br/>c"));
     }
   }
 }


### PR DESCRIPTION
Passing HTML to HTML escaper will HTML escape the HTML markup.
This fix passes plaintext to be converted to HTML and then
passes HTML unescpated to the error message output to be rendered
as HTML.

Before this update the error upload dialog renders as "plaintext"
with all the HTML escaped and displayed as HTML text rather than
as rendered (IE: displays "<a href..." instead of showing a link)


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots

After this fix, error dialogs render HTML once again:
![Screenshot from 2020-07-12 20-50-35](https://user-images.githubusercontent.com/12397753/87269315-a8339700-c481-11ea-9e07-22ce50abed4f.png)

<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
