### PR TITLE
Change minimap rendering hint parameters from quality to speed

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/SmallMapImageManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/SmallMapImageManager.java
@@ -61,6 +61,8 @@ public class SmallMapImageManager {
     final Image largeImage = Util.newImage(bounds.width, bounds.height, true);
     // make it transparent
     // http://www-106.ibm.com/developerworks/library/j-begjava/
+    // Once the image is transparent, we will be drawing the territory shape and filling
+    // the territory polygon. Any remaining edges will be transparent.
     {
       final Graphics2D g = (Graphics2D) largeImage.getGraphics();
       g.setComposite(AlphaComposite.getInstance(AlphaComposite.CLEAR, 0.0f));
@@ -71,15 +73,16 @@ public class SmallMapImageManager {
     // draw the territory
     {
       final Graphics2D g = (Graphics2D) largeImage.getGraphics();
-      g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_QUALITY);
+      g.setRenderingHint(RenderingHints.KEY_RENDERING, RenderingHints.VALUE_RENDER_SPEED);
       g.setRenderingHint(
-          RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_QUALITY);
+          RenderingHints.KEY_ALPHA_INTERPOLATION, RenderingHints.VALUE_ALPHA_INTERPOLATION_SPEED);
       g.setRenderingHint(
-          RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_BICUBIC);
+          RenderingHints.KEY_INTERPOLATION, RenderingHints.VALUE_INTERPOLATION_NEAREST_NEIGHBOR);
       final LandTerritoryDrawable drawable = new LandTerritoryDrawable(t.getName());
       drawable.draw(bounds, data, g, mapData, mapData.getSmallMapTerritorySaturation());
       g.dispose();
     }
+
     // scale it down
     int thumbWidth = (int) (bounds.width * view.getRatioX());
     int thumbHeight = (int) (bounds.height * view.getRatioY());


### PR DESCRIPTION
If we will be shrinking (drastically) the rendered mini-map image
anyways, we do not need to do a quality initial rendering.

This update changes drawing parameters for minimap images from essentially
the best quality to 'speed'. The minimap image is first rendered
at full scale (eg: 250x200), rendered, then shrunk down to be placed
in the minimap (EG: 12x8).

The initial image allocation of a full scale image consumes a significant
amount of memory, ideally we would draw the image directly in a first
pass at its final scale. Failing that, this update tunes the rendering
parameters down to conserve CPU (and maybe memory) resources.

We have had bug reports that the initial image allocation has generated
OOM exceptions. While observing a heap memory sampler during
World-of-Warcraft map which starts a game by assigning territory ownership
to each territory (which causes redraws in the mini-map), this update
reduces memory pressure.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix
[] Other:   <!-- Please specify -->

## Testing
- Loaded World of Warcraft map and watched memory usage in VisualVM

<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->UPDATE|Improve minimap rendering performance to be faster and use less memory<!--END_RELEASE_NOTE-->
