### PR TITLE
If a unit is dead, don't categorize it

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/util/UnitSeparator.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/UnitSeparator.java
@@ -101,6 +101,10 @@ public class UnitSeparator {
       categories = new LinkedHashMap<>();
     }
     for (final Unit current : units) {
+      if (current.getUnitAttachment().getHitPoints() - current.getHits() == 0) {
+        continue;
+      }
+
       BigDecimal unitMovement = new BigDecimal(-1);
       if (categorizeMovement
           || (categorizeTrnMovement && Matches.unitIsTransport().test(current))) {

--- a/game-core/src/test/java/games/strategy/triplea/util/UnitSeparatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/util/UnitSeparatorTest.java
@@ -76,6 +76,26 @@ class UnitSeparatorTest {
     assertEquals(expected, categories);
   }
 
+  @Test
+  void ignoreKilledUnitsInSorting() {
+    final GameData data = TestMapGameData.TWW.getGameData();
+    final Territory northernGermany = territory("Northern Germany", data);
+    northernGermany.getUnitCollection().clear();
+    final GamePlayer italians = GameDataTestUtil.italy(data);
+    final List<Unit> units =
+        new ArrayList<>(GameDataTestUtil.italianInfantry(data).create(1, italians));
+    units.get(0).setHits(1);
+    final GamePlayer british = GameDataTestUtil.britain(data);
+    units.addAll(new ArrayList<>(GameDataTestUtil.britishInfantry(data).create(1, british)));
+    GameDataTestUtil.addTo(northernGermany, units);
+    when(mockMapData.shouldDrawUnit(ArgumentMatchers.anyString())).thenReturn(true);
+    final List<UnitCategory> categories =
+        UnitSeparator.getSortedUnitCategories(northernGermany, mockMapData);
+    final List<UnitCategory> expected = new ArrayList<>();
+    expected.add(newUnitCategory("britishInfantry", british, data));
+    assertEquals(expected, categories);
+  }
+
   private static UnitCategory newUnitCategory(
       final String unitName, final GamePlayer player, final GameData data) {
     return new UnitCategory(new UnitType(unitName, data), player);


### PR DESCRIPTION
Fixes #7117

This changes the UnitSeparator code to ignore dead units.  I don't see a reason for why UnitSeparator should worry about dead units since they are generally not in the territory.

The problem that it is fixing is that during a battle, when an attacker dies and a defender dies, if the defender will change into a new unit, a change request is made to set the hit points to 0 instead of just removing the unit.  I believe this change request is needed to trigger the unit to change into the other unit.

Because the change request sets the hit points to 0, the map will sort the units and include these dead units.  If a redraw is triggered (which I think always happens if there is a dead attacker unit, but I'm not sure), then it will try and draw these dead units.

By excluding the dead units during the categorizing/sorting, the map will not try and draw them.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->
I tested the save from the bug with a breakpoint at the `continue` line.  I verified that the line was reached and that the error didn't occur afterwards.

I also ran a all AI match in Warcraft War Heroes with a breakpoint on the `continue` line to see if things acted weirdly after it was triggered.  I didn't see anything obviously wrong.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->FIX|Missing unit image in Warcraft War Heroes for dead units shouldn't happen anymore<!--END_RELEASE_NOTE-->
