### PR TITLE
Change dead units after they've been removed from the battle site

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -568,6 +568,15 @@ public class MustFightBattle extends DependentBattle
     }
     final Collection<Unit> killed = getUnitsWithDependents(killedUnits);
 
+    // Remove units
+    final Change killedChange = ChangeFactory.removeUnits(battleSite, killed);
+    this.killed.addAll(killed);
+    killedDuringCurrentRound.addAll(killed);
+    final String transcriptText =
+        MyFormatter.unitsToText(killed) + " lost in " + battleSite.getName();
+    bridge.getHistoryWriter().addChildToEvent(transcriptText, new ArrayList<>(killed));
+    bridge.addChange(killedChange);
+
     // Set max damage for any units that will change into another unit
     final IntegerMap<Unit> lethallyDamagedMap = new IntegerMap<>();
     for (final Unit unit :
@@ -578,16 +587,7 @@ public class MustFightBattle extends DependentBattle
         ChangeFactory.unitsHit(lethallyDamagedMap, List.of(battleSite));
     bridge.addChange(lethallyDamagedChange);
 
-    // Remove units
-    final Change killedChange = ChangeFactory.removeUnits(battleSite, killed);
-    this.killed.addAll(killed);
-    killedDuringCurrentRound.addAll(killed);
-    final String transcriptText =
-        MyFormatter.unitsToText(killed) + " lost in " + battleSite.getName();
-    bridge.getHistoryWriter().addChildToEvent(transcriptText, new ArrayList<>(killed));
-    bridge.addChange(killedChange);
     final Collection<IBattle> dependentBattles = battleTracker.getBlocked(this);
-
     // If there are NO dependent battles, check for unloads in allied territories
     if (dependentBattles.isEmpty()) {
       removeFromNonCombatLandings(killed, bridge);


### PR DESCRIPTION
Fixes #7117

This moves the code that changes dead units after the code that removes the dead units.

The bug is that the map is redrawing with the units before they've been changed.  By clearing out the dead units first, the map won't redraw them.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[X] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->
I played the save game in the referenced issue.  I verified that the history of the game still has the same order.  I also used break points to make sure things were changing as expected.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->FIX|Missing unit error message for Warcraft War Heroes when a unit dies and is turned into XP should no longer occur.<!--END_RELEASE_NOTE-->
