### PR TITLE
Increase the stack size for IntelliJ's HeadedGameRunner configuration

### DIFF
--- a/.idea/runConfigurations/HeadedGameRunner.xml
+++ b/.idea/runConfigurations/HeadedGameRunner.xml
@@ -2,6 +2,7 @@
   <configuration default="false" name="HeadedGameRunner" type="Application" factoryName="Application" singleton="false" nameIsGenerated="true">
     <option name="MAIN_CLASS_NAME" value="org.triplea.game.client.HeadedGameRunner" />
     <module name="triplea.game-headed.main" />
+    <option name="VM_PARAMETERS" value="-Xss1250K" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/game-headed" />
     <extension name="coverage">
       <pattern>


### PR DESCRIPTION
For debugging the Warcraft map, I need to constantly increase the stack size.  This commits the change.

This only affects development when using IntelliJ.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
