### PR TITLE
Log when a unit icon is missing in the SimpleUnitPanel

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
@@ -11,6 +11,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.UnitTypeComparator;
 import games.strategy.triplea.delegate.Matches;
+import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.util.UnitCategory;
 import java.util.Collection;
 import java.util.Comparator;
@@ -22,10 +23,12 @@ import javax.swing.BoxLayout;
 import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
+import lombok.extern.java.Log;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.swing.WrapLayout;
 
 /** A Simple panel that displays a list of units. */
+@Log
 public class SimpleUnitPanel extends JPanel {
   private static final long serialVersionUID = -3768796793775300770L;
   private final UiContext uiContext;
@@ -216,6 +219,18 @@ public class SimpleUnitPanel extends JPanel {
       final UnitType unitType = (UnitType) unit;
       final Optional<ImageIcon> icon =
           uiContext.getUnitImageFactory().getIcon(unitType, player, damaged, disabled);
+      if (icon.isEmpty() && !uiContext.isShutDown()) {
+        final String imageName =
+            UnitImageFactory.getBaseImageName(unitType, player, damaged, disabled);
+        log.severe(
+            "missing unit icon (won't be displayed): "
+                + unitType.getName()
+                + " ("
+                + imageName
+                + ")"
+                + " owned by "
+                + player.getName());
+      }
       icon.ifPresent(label::setIcon);
       MapUnitTooltipManager.setUnitTooltip(label, unitType, player, quantity);
     } else if (unit instanceof Resource) {


### PR DESCRIPTION
While testing #7217, I noticed that the history wasn't showing an image for the dead wraiths.  I assumed it was related to the missing image that #7217 is dealing with but it wasn't throwing any message.  This adds a log for the missing icon.

I went through the history of a game with Warcraft and I only got the error message when I had units that were dead but changed into other units.  But I think I've seen this missing icon happen other times in Warcraft.

I think it would be useful to log these situations since we log the missing units when rendering the map.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix
[x] Other:   Add a new log for missing icons

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note
I don't know how to add this to the release notes.  Any ideas?
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
