### PR TITLE
Remove CSS formatting from spotless apply

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,10 +45,6 @@ allprojects {
             indentWithSpaces()
             trimTrailingWhitespace()
         }
-        format 'styling', {
-            target '**/*.css'
-            prettier().config(['parser': 'postcss'])
-        }
     }
 }
 


### PR DESCRIPTION
Remove 'postcss' formatter, it keeps running into 501 errors when
spotlessApply is run locally:

```
Execution failed for task ':spotlessStyling'.
> Unexpected response status code at /prettier/format [HTTP 501] -- (Error while formatting: Error: Couldn't resolve parser "postcss")
```


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
