### PR TITLE
Simplify last map update check parsing and set threshold for last check to 7 days

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -137,8 +137,8 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
       new BooleanClientSetting("TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY", true);
   public static final ClientSetting<String> lastCheckForEngineUpdate =
       new StringClientSetting("TRIPLEA_LAST_CHECK_FOR_ENGINE_UPDATE");
-  public static final ClientSetting<String> lastCheckForMapUpdates =
-      new StringClientSetting("TRIPLEA_LAST_CHECK_FOR_MAP_UPDATES");
+  public static final ClientSetting<Long> lastCheckForMapUpdates =
+      new LongClientSetting("TRIPLEA_LAST_CHECK_FOR_MAP_UPDATES_EPOCH_MILLI", 0);
   public static final ClientSetting<Boolean> promptToDownloadTutorialMap =
       new BooleanClientSetting("TRIPLEA_PROMPT_TO_DOWNLOAD_TUTORIAL_MAP", true);
   public static final ClientSetting<UnitsDrawer.UnitFlagDrawMode> unitFlagDrawMode =

--- a/game-core/src/main/java/games/strategy/triplea/settings/LongClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/LongClientSetting.java
@@ -1,0 +1,31 @@
+package games.strategy.triplea.settings;
+
+import javax.annotation.Nullable;
+
+final class LongClientSetting extends ClientSetting<Long> {
+  LongClientSetting(final String name) {
+    super(Long.class, name);
+  }
+
+  LongClientSetting(final String name, final long defaultValue) {
+    super(Long.class, name, defaultValue);
+  }
+
+  @Override
+  protected String encodeValue(final Long value) {
+    return value.toString();
+  }
+
+  @Override
+  @Nullable
+  protected Long decodeValue(final String encodedValue) throws ValueEncodingException {
+    try {
+      if (encodedValue.isEmpty()) {
+        return null;
+      }
+      return Long.valueOf(encodedValue);
+    } catch (final NumberFormatException e) {
+      throw new ValueEncodingException(e);
+    }
+  }
+}


### PR DESCRIPTION

1. Simplify: Rather than storing a formatted string for the last time we checked for
map updates, just store the equivalent epoch milli timestamp.

2. Adjust threshold for checking for maps to be every 7 days rather than once
a month. The once a month made more sense when the map list was hosted on source
forge and the download time was very slow, with a fast download of the map
list we can check more often and thereby get better responsiveness to map
version updates.

Fixes last map-date-check parsing error reported in:
https://github.com/triplea-game/triplea/issues/7014


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[x] Configuration Change
[x] Problem fix
[] Other:   <!-- Please specify -->

## Testing
- Did a smoke test, launched the game, verified saw 'maps out of date' message & launched a second time and verified that no such message was present.

<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->FIX|Rare date parser error on game launch when checking for out-of-date maps<!--END_RELEASE_NOTE-->
