### PR TITLE
Ignore failure when retreiving download lengths

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadLengthReader.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadLengthReader.java
@@ -56,7 +56,8 @@ final class DownloadLengthReader {
     try (CloseableHttpClient client = httpClientFactory.get()) {
       return getDownloadLengthFromHost(uri, client);
     } catch (final IOException e) {
-      log.log(Level.SEVERE, String.format("failed to get download length for '%s'", uri), e);
+      log.log(
+          Level.INFO, String.format("(Ignoring) Failed to get download length for '%s'", uri), e);
       return Optional.empty();
     }
   }


### PR DESCRIPTION
We have a fallback for download progress bars to count up the number
of downloaded bytes if we can't print a percentage. If we can't
get the download length, then we can ignore the problem since the progress
bar still works and very notably the download is still in-progress.

This update simply suppresses any errors when requesting the download
length (of map files when downloading them).

Resolves error-report: https://github.com/triplea-game/triplea/issues/7024


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
