### PR TITLE
Check for null owner in AddUnits

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AddUnits.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AddUnits.java
@@ -42,7 +42,16 @@ public class AddUnits extends Change {
   }
 
   private Map<UUID, String> buildUnitOwnerMap(final Collection<Unit> units) {
-    return units.stream().collect(Collectors.toMap(Unit::getId, unit -> unit.getOwner().getName()));
+    return units.stream()
+        .collect(
+            Collectors.toMap(
+                Unit::getId,
+                unit -> {
+                  if (unit.getOwner() == null || unit.getOwner().getName() == null) {
+                    return null;
+                  }
+                  return unit.getOwner().getName();
+                }));
   }
 
   @Override
@@ -67,8 +76,10 @@ public class AddUnits extends Change {
               if (unit == null) {
                 unit = uuidToUnits.get(entry.getKey());
               }
-              final GamePlayer player = data.getPlayerList().getPlayerId(entry.getValue());
-              unit.setOwner(player);
+              if (entry.getValue() != null) {
+                final GamePlayer player = data.getPlayerList().getPlayerId(entry.getValue());
+                unit.setOwner(player);
+              }
               return unit;
             })
         .collect(Collectors.toList());


### PR DESCRIPTION
Fixes #7226

I don't know the null owner occurred.  But there exists code that already checks for the null owner case so this adds similar code to the AddUnits class.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->
I don't know how to duplicate the null owner case so I just ensured that things continued to work as expected.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->FIX|Fix null error in AddUnits#buildUnitOwnerMap when loading a saved game<!--END_RELEASE_NOTE-->
