### PR TITLE
Build unit owner map defensive code

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AddUnits.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AddUnits.java
@@ -48,7 +48,7 @@ public class AddUnits extends Change {
                 Unit::getId,
                 unit -> {
                   if (unit.getOwner() == null || unit.getOwner().getName() == null) {
-                    return null;
+                    return GamePlayer.NULL_PLAYERID.getName();
                   }
                   return unit.getOwner().getName();
                 }));


### PR DESCRIPTION
Fixes #7226 again based on feedback from #7269

I had set the owner to null manually in the code.  This broke a ton of things.  So the old fix would make the save game unplayable.  So this sets the owner to be the null player which should allow things to run.

I still don't know where the null owner comes from.

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[X] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
