### PR TITLE
Fix prerelease deployment of maps-db migration files

### DIFF
--- a/infrastructure/ansible/roles/database/flyway/defaults/main.yml
+++ b/infrastructure/ansible/roles/database/flyway/defaults/main.yml
@@ -16,7 +16,7 @@ flyway_args:
     password: "{{ maps_db_password }}"
     url: "{{ flyway_db_url }}/{{ maps_db_name }}"
     migration:
-      zip: map_migrations.zip
+      zip: maps_database__migrations.zip
       url: "https://github.com/triplea-game/triplea/releases/download/{{ version }}/map_migrations.zip"
       dir: "maps_sql"
 

--- a/infrastructure/ansible/roles/database/flyway/defaults/main.yml
+++ b/infrastructure/ansible/roles/database/flyway/defaults/main.yml
@@ -16,7 +16,7 @@ flyway_args:
     password: "{{ maps_db_password }}"
     url: "{{ flyway_db_url }}/{{ maps_db_name }}"
     migration:
-      zip: maps_database__migrations.zip
-      url: "https://github.com/triplea-game/triplea/releases/download/{{ version }}/map_migrations.zip"
+      zip: maps_database_migrations.zip
+      url: "https://github.com/triplea-game/triplea/releases/download/{{ version }}/maps_database_migrations.zip"
       dir: "maps_sql"
 

--- a/infrastructure/run_ansible_prerelease
+++ b/infrastructure/run_ansible_prerelease
@@ -38,9 +38,10 @@ function main() {
 function buildArtifacts() {
   (
     cd ..
-    ./gradlew :http-server:shadowJar :game-headless:shadowJar :lobby-db:release
+    ./gradlew :http-server:shadowJar :game-headless:shadowJar :lobby-db:release :maps-db:release
   )
   copyBuildArtifact "../lobby-db/build/artifacts/migrations.zip" "ansible/roles/database/flyway/files/"
+  copyBuildArtifact "../maps-db/build/artifacts/maps_database_migrations.zip" "ansible/roles/database/flyway/files/"
   copyBuildArtifact "../http-server/build/libs/triplea-http-server-$VERSION.jar" "ansible/roles/http_server/files/"
   copyBuildArtifact "../game-headless/build/libs/triplea-game-headless-$VERSION.jar" "ansible/roles/bot/files/"
 }

--- a/infrastructure/run_ansible_vagrant
+++ b/infrastructure/run_ansible_vagrant
@@ -54,7 +54,7 @@ function buildMigrations() {
     )
     mkdir -p $targetFolder
     cp ../lobby-db/build/distributions/migrations.zip $targetFolder
-    cp ../maps-db/build/distributions/map_migrations.zip $targetFolder
+    cp ../maps-db/build/distributions/maps_database_migrations.zip $targetFolder
   fi
 }
 

--- a/maps-db/build.gradle
+++ b/maps-db/build.gradle
@@ -21,7 +21,7 @@ flyway {
 task portableInstaller(type: Zip, group: 'release') {
     from 'src/main/resources/db/migration'
     include '*.sql'
-    archiveName 'map_migrations.zip'
+    archiveName 'maps_database_migrations.zip'
 }
 
 task release(group: 'release', dependsOn: portableInstaller) {


### PR DESCRIPTION
1. We were not copying the maps-db migration zip file for prerelease, this
update fixes that so that the zip file will be available to ansible.

2. Minor, update the name of the maps migration file for clarity:
'map_migration.zip' -> 'maps_database_migrations.zip'


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[x] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
