### PR TITLE
Add scrollbars to error message popups

### DIFF
--- a/game-core/src/main/java/org/triplea/debug/ErrorMessage.java
+++ b/game-core/src/main/java/org/triplea/debug/ErrorMessage.java
@@ -19,6 +19,7 @@ import org.triplea.http.client.error.report.ErrorReportClient;
 import org.triplea.live.servers.LiveServersFetcher;
 import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.JEditorPaneWithClickableLinks;
+import org.triplea.swing.SwingComponents;
 import org.triplea.swing.jpanel.JPanelBuilder;
 
 /**
@@ -68,7 +69,7 @@ public enum ErrorMessage {
                 new JPanelBuilder()
                     .boxLayoutHorizontal()
                     .addHorizontalGlue()
-                    .add(errorMessage)
+                    .add(SwingComponents.newJScrollPane(errorMessage))
                     .addHorizontalGlue()
                     .build())
             .addSouth(


### PR DESCRIPTION
In case an error message is very long, this prevents truncation and
awkward resizing.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. Commit comments should include an overview of
  the updates and the goal and reasoning behind the update.
  Code standards and PR guidelines can be found at:
  - https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines
  - https://github.com/triplea-game/triplea/wiki/Code-Reviews
-->

## Functional Changes
<!-- Put an X next any that apply -->
[] New map or map update
[] New Feature
[x] Feature update or enhancement
[] Feature Removal
[] Code Cleanup or refactor
[] Configuration Change
[] Problem fix
[] Other:   <!-- Please specify -->

## Testing
<!-- Describe any manual testing performed below. -->
- warlords FFA as part of red sun over china is generating a long error message on launch

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

After this update, we get scrollbars (before content was truncated):
![Screenshot from 2020-08-01 13-50-20](https://user-images.githubusercontent.com/12397753/89110299-3d310c80-d3fe-11ea-8738-897c1ed94473.png)


## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
