### PR TITLE
Fix setting of database password, use postgres password

### DIFF
--- a/infrastructure/ansible/roles/database/postgres/tasks/main.yml
+++ b/infrastructure/ansible/roles/database/postgres/tasks/main.yml
@@ -82,7 +82,7 @@
       echo "select 1" |  psql -h localhost -U {{ lobby_db_user }} {{ lobby_db_name }}
       || echo "alter role {{ item.user }} with password '{{ item.password }}';"  | sudo -u postgres psql
   environment:
-    PGPASSWORD: "{{ item.password }}"
+    PGPASSWORD: "{{ postgres_user_db_password }}"
   changed_when: false
   loop: "{{ databases }}"
   loop_control:


### PR DESCRIPTION
We need to use the postgres user password when setting
passwords and logging in as the postgres user.

Using 'item.password' would be the database (application)
user and would be incorrect. The task appears to fail
silently when the password is incorrect, the task
was previously not updating passwords as expected.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
