### PR TITLE
Bump bot version to 2.1.20765

### DIFF
--- a/infrastructure/ansible/group_vars/prod2_bot.yml
+++ b/infrastructure/ansible/group_vars/prod2_bot.yml
@@ -1,2 +1,2 @@
-version: "2.1.20567"
+version: "2.1.20765"
 journalctl_applications: ["bot@01", "bot@02", "bot@03", "bot@04", "bot@05"]


### PR DESCRIPTION
As usual, changes would take effect after a bot restart.
This latest version has a bug fix for the "host is already launching"
that is impacting numerous bots.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
