### PR TITLE
Remove custom command to set DB passwords - use exclusively postgres_user to set DB password

### DIFF
--- a/infrastructure/ansible/roles/database/postgres/tasks/main.yml
+++ b/infrastructure/ansible/roles/database/postgres/tasks/main.yml
@@ -46,6 +46,7 @@
   loop: "{{ databases }}"
   loop_control:
     label: "{{ item.user }}"
+  no_log: true
 
 - name: Create application databases
   become: true
@@ -72,19 +73,5 @@
   loop: "{{ databases }}"
   loop_control:
     label: "{{ item.name }} {{ item.user }}"
-
-# This is a hack because the previous tasks were supposed to set
-# the DB level password for our DB user, but it typically does not.
-# To achieve this, we'll run the native SQL commands to set the
-# user DB password.
-- name: check if password is valid
-  shell: >
-      echo "select 1" |  psql -h localhost -U {{ lobby_db_user }} {{ lobby_db_name }}
-      || echo "alter role {{ item.user }} with password '{{ item.password }}';"  | sudo -u postgres psql
-  environment:
-    PGPASSWORD: "{{ postgres_user_db_password }}"
-  changed_when: false
-  loop: "{{ databases }}"
-  loop_control:
-    label: "{{ item.user }}"
+  no_log: true
 


### PR DESCRIPTION
Testing against prerelease from local, it appears the postgres
DB password set task is working properly. Build is currently
failing due to bad passwords, using the postgres_user task
to set it has succeeded to reset it when running a prerelease
deployment from a developer machine.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
- ran prerelease deployment script (run_ansible_prerelease) from local, a developer machine.
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
