### PR TITLE
Fix: Don't create the owner map in readObject as the owner might not yet be deserialized

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AddUnits.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AddUnits.java
@@ -25,7 +25,7 @@ public class AddUnits extends Change {
    * performed. To ensure that the newly created units have the correct ownership, their original
    * owners are stored in this separate map.
    */
-  private Map<UUID, String> unitOwnerMap;
+  private final Map<UUID, String> unitOwnerMap;
 
   AddUnits(final UnitCollection collection, final Collection<Unit> units) {
     this.units = units;
@@ -62,7 +62,11 @@ public class AddUnits extends Change {
   @Override
   protected void perform(final GameData data) {
     final UnitHolder holder = data.getUnitHolder(name, type);
-    final Collection<Unit> unitsWithCorrectOwner = buildUnitsWithOwner(data);
+    final Collection<Unit> unitsWithCorrectOwner =
+        // old saved games will have a null unitOwnerMap
+        unitOwnerMap == null
+        ? units
+        : buildUnitsWithOwner(data);
     holder.getUnitCollection().addAll(unitsWithCorrectOwner);
   }
 
@@ -88,12 +92,5 @@ public class AddUnits extends Change {
   @Override
   public String toString() {
     return "Add unit change.  Add to:" + name + " units:" + units;
-  }
-
-  private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
-    in.defaultReadObject();
-    if (unitOwnerMap == null) {
-      unitOwnerMap = buildUnitOwnerMap(units);
-    }
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/AddUnits.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/AddUnits.java
@@ -6,8 +6,6 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitCollection;
 import games.strategy.engine.data.UnitHolder;
-import java.io.IOException;
-import java.io.ObjectInputStream;
 import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
@@ -64,9 +62,7 @@ public class AddUnits extends Change {
     final UnitHolder holder = data.getUnitHolder(name, type);
     final Collection<Unit> unitsWithCorrectOwner =
         // old saved games will have a null unitOwnerMap
-        unitOwnerMap == null
-        ? units
-        : buildUnitsWithOwner(data);
+        unitOwnerMap == null ? units : buildUnitsWithOwner(data);
     holder.getUnitCollection().addAll(unitsWithCorrectOwner);
   }
 


### PR DESCRIPTION
I think this is a better fix for #7226

I went through the code trying to understand why the owner wasn't available during deserialization and I realized that there can be a deserialization chain that goes Unit -> Owner -> ... -> AddUnits -> Unit.  In this situation, the Owner nor the Unit have been fully deserialized so during the `readObject` call in AddUnits, Unit will have a null owner.

And in the case where `unitOwnerMap` is null, the value of `buildUnitOwnerMap` was identical to `units`.  So instead of having a `readObject` to check for the the null case, I just moved that check inside of the code path.

As far as I can tell, the unit will never have a null owner while the game is actually running.  It can only have a null owner during deserialization.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
Played several games, loaded several saved games, stepped through the code with breakpoints
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
