### PR TITLE
Fix: Ensure ProTerritory returns a unique set of units

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -785,7 +785,7 @@ class ProNonCombatMoveAi {
         }
         final TreeMap<Double, Territory> estimatesMap = new TreeMap<>();
         for (final Territory t : sortedUnitMoveOptions.get(unit)) {
-          List<Unit> defendingUnits =
+          Collection<Unit> defendingUnits =
               CollectionUtils.getMatches(
                   moveMap.get(t).getAllDefenders(),
                   ProMatches.unitIsAlliedNotOwnedAir(player, data).negate());
@@ -814,7 +814,7 @@ class ProNonCombatMoveAi {
         Territory maxWinTerritory = null;
         double maxWinPercentage = -1;
         for (final Territory t : sortedUnitMoveOptions.get(unit)) {
-          List<Unit> defendingUnits =
+          Collection<Unit> defendingUnits =
               CollectionUtils.getMatches(
                   moveMap.get(t).getAllDefenders(),
                   ProMatches.unitIsAlliedNotOwnedAir(player, data).negate());
@@ -881,7 +881,7 @@ class ProNonCombatMoveAi {
               && !ProMatches.territoryHasInfraFactoryAndIsLand().test(t)) {
             continue; // skip moving air units to allied land without a factory
           }
-          List<Unit> defendingUnits =
+          Collection<Unit> defendingUnits =
               CollectionUtils.getMatches(
                   moveMap.get(t).getAllDefenders(),
                   ProMatches.unitIsAlliedNotOwnedAir(player, data).negate());
@@ -943,7 +943,7 @@ class ProNonCombatMoveAi {
           // Find current naval defense that needs transport if it isn't transporting units
           for (final Territory t : transportDefendOptions.get(transport)) {
             if (!TransportTracker.isTransporting(transport)) {
-              final List<Unit> defendingUnits = moveMap.get(t).getAllDefenders();
+              final Collection<Unit> defendingUnits = moveMap.get(t).getAllDefenders();
               if (moveMap.get(t).getBattleResult() == null) {
                 moveMap
                     .get(t)
@@ -994,7 +994,7 @@ class ProNonCombatMoveAi {
 
         // Find current land defense results for territories that unit can amphib move
         for (final Territory t : amphibMoveOptions.get(transport)) {
-          final List<Unit> defendingUnits = moveMap.get(t).getAllDefenders();
+          final Collection<Unit> defendingUnits = moveMap.get(t).getAllDefenders();
           if (moveMap.get(t).getBattleResult() == null) {
             moveMap
                 .get(t)
@@ -1055,7 +1055,7 @@ class ProNonCombatMoveAi {
                       && (moveMap.get(territoryToMoveTransport).isCanHold() || hasFactory)) {
                     final List<Unit> attackers =
                         moveMap.get(territoryToMoveTransport).getMaxEnemyUnits();
-                    final List<Unit> defenders =
+                    final Collection<Unit> defenders =
                         moveMap.get(territoryToMoveTransport).getAllDefenders();
                     defenders.add(transport);
                     final double strengthDifference =
@@ -1121,7 +1121,7 @@ class ProNonCombatMoveAi {
         final Territory t = patd.getTerritory();
 
         // Find defense result and hold value based on used defenders TUV
-        final List<Unit> defendingUnits = moveMap.get(t).getAllDefenders();
+        final Collection<Unit> defendingUnits = moveMap.get(t).getAllDefenders();
         moveMap
             .get(t)
             .setBattleResult(
@@ -1954,7 +1954,7 @@ class ProNonCombatMoveAi {
       for (final Territory t : territoriesToDefend) {
 
         // Find result with temp units
-        final List<Unit> defendingUnits = moveMap.get(t).getAllDefenders();
+        final Collection<Unit> defendingUnits = moveMap.get(t).getAllDefenders();
         moveMap
             .get(t)
             .setBattleResult(
@@ -2258,7 +2258,7 @@ class ProNonCombatMoveAi {
         }
 
         // Check to see if the territory is safe
-        final List<Unit> defendingUnits = moveMap.get(t).getAllDefenders();
+        final Collection<Unit> defendingUnits = moveMap.get(t).getAllDefenders();
         defendingUnits.add(u);
         if (moveMap.get(t).getBattleResult() == null) {
           moveMap
@@ -2392,7 +2392,7 @@ class ProNonCombatMoveAi {
           continue;
         }
         final List<Unit> attackers = moveMap.get(t).getMaxEnemyUnits();
-        final List<Unit> defenders = moveMap.get(t).getAllDefenders();
+        final Collection<Unit> defenders = moveMap.get(t).getAllDefenders();
         defenders.add(u);
         final double strengthDifference =
             ProBattleUtils.estimateStrengthDifference(proData, t, attackers, defenders);
@@ -2445,7 +2445,7 @@ class ProNonCombatMoveAi {
 
             // Check if territory is safe after all current moves
             if (moveMap.get(t).getBattleResult() == null) {
-              final List<Unit> defendingUnits = moveMap.get(t).getAllDefenders();
+              final Collection<Unit> defendingUnits = moveMap.get(t).getAllDefenders();
               moveMap
                   .get(t)
                   .setBattleResult(

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritory.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritory.java
@@ -143,13 +143,16 @@ public class ProTerritory {
     return defenders;
   }
 
-  public Collection<Unit> getAllDefendersForCarrierCalcs(final GameData data, final GamePlayer player) {
+  public Collection<Unit> getAllDefendersForCarrierCalcs(
+      final GameData data, final GamePlayer player) {
     if (Properties.getProduceNewFightersOnOldCarriers(data)) {
       return getAllDefenders();
     }
 
     final Set<Unit> defenders =
-        new HashSet<>(CollectionUtils.getMatches(cantMoveUnits, ProMatches.unitIsOwnedCarrier(player).negate()));
+        new HashSet<>(
+            CollectionUtils.getMatches(
+                cantMoveUnits, ProMatches.unitIsOwnedCarrier(player).negate()));
     defenders.addAll(units);
     // tempUnits can already be in the units/cantMoveUnits collection
     defenders.addAll(tempUnits);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritory.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritory.java
@@ -11,6 +11,7 @@ import games.strategy.triplea.ai.pro.util.ProOddsCalculator;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TransportTracker;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -134,21 +135,23 @@ public class ProTerritory {
     maxScrambleUnits = new ArrayList<>(patd.getMaxScrambleUnits());
   }
 
-  public List<Unit> getAllDefenders() {
-    final List<Unit> defenders = new ArrayList<>(units);
+  public Collection<Unit> getAllDefenders() {
+    final Set<Unit> defenders = new HashSet<>(units);
     defenders.addAll(cantMoveUnits);
+    // tempUnits can already be in the units/cantMoveUnits collection
     defenders.addAll(tempUnits);
     return defenders;
   }
 
-  public List<Unit> getAllDefendersForCarrierCalcs(final GameData data, final GamePlayer player) {
+  public Collection<Unit> getAllDefendersForCarrierCalcs(final GameData data, final GamePlayer player) {
     if (Properties.getProduceNewFightersOnOldCarriers(data)) {
       return getAllDefenders();
     }
 
-    final List<Unit> defenders =
-        CollectionUtils.getMatches(cantMoveUnits, ProMatches.unitIsOwnedCarrier(player).negate());
+    final Set<Unit> defenders =
+        new HashSet<>(CollectionUtils.getMatches(cantMoveUnits, ProMatches.unitIsOwnedCarrier(player).negate()));
     defenders.addAll(units);
+    // tempUnits can already be in the units/cantMoveUnits collection
     defenders.addAll(tempUnits);
     return defenders;
   }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTransportUtils.java
@@ -314,7 +314,7 @@ public final class ProTransportUtils {
   public static boolean validateCarrierCapacity(
       final GamePlayer player,
       final Territory t,
-      final List<Unit> existingUnits,
+      final Collection<Unit> existingUnits,
       final Unit newUnit) {
     final GameData data = player.getData();
 


### PR DESCRIPTION
During non-combat ai, the ai sometimes will try an amphibious move from
the same sea location of the transport. It will add the transported
units to the tempUnit collection of the location but those same units are
already in the cantMoveUnits collection. So duplicate units will show
up.

Fixes #7370

<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->
I ran the saved game in the linked bug for multiple rounds with the AI.  I couldn't get any more errors.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->FIX|Duplicate key errors when the AI tries certain non-combat amphibious moves<!--END_RELEASE_NOTE-->
