### PR TITLE
Simplify: Use bulk unit owner change API

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/ChangeFactory.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/ChangeFactory.java
@@ -22,7 +22,6 @@ import games.strategy.triplea.delegate.data.BattleRecords;
 import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.List;
-import java.util.Set;
 import org.triplea.java.collections.IntegerMap;
 
 /**
@@ -70,11 +69,6 @@ public class ChangeFactory {
   public static Change changeOwner(
       final Collection<Unit> units, final GamePlayer owner, final Territory location) {
     return new PlayerOwnerChange(units, owner, location);
-  }
-
-  public static Change changeOwner(
-      final Unit unit, final GamePlayer owner, final Territory location) {
-    return new PlayerOwnerChange(Set.of(unit), owner, location);
   }
 
   public static Change addUnits(final Territory territory, final Collection<Unit> units) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -151,9 +151,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
       // change ownership of friendly factories
       final Collection<Unit> units =
           territory.getUnitCollection().getMatches(Matches.unitIsInfrastructure());
-      for (final Unit unit : units) {
-        bridge.addChange(ChangeFactory.changeOwner(unit, player, territory));
-      }
+      bridge.addChange(ChangeFactory.changeOwner(units, player, territory));
     } else {
       final Predicate<Unit> enemyNonCom =
           Matches.unitIsInfrastructure().and(Matches.enemyUnit(player, data));
@@ -161,9 +159,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
       // mark no movement for enemy units
       bridge.addChange(ChangeFactory.markNoMovementChange(units));
       // change ownership of enemy AA and factories
-      for (final Unit unit : units) {
-        bridge.addChange(ChangeFactory.changeOwner(unit, player, territory));
-      }
+      bridge.addChange(ChangeFactory.changeOwner(units, player, territory));
     }
     // change ownership of territory
     bridge.addChange(ChangeFactory.changeOwner(territory, player));


### PR DESCRIPTION
Instead of iterating over a loop of units to create a series of change
objects, there is a bulk unit change API that we can use directly.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer

- After this update the API:

```
  public static Change changeOwner(
      final Unit unit, final GamePlayer owner, final Territory location) {
```
Is no longer used and is removed.

<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
