### PR TITLE
Config change: Increase code climate method argument threshold to 6 arguments or more

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,6 +4,9 @@ version: "2"
 # https://docs.codeclimate.com/docs/maintainability#section-checks
 # https://docs.codeclimate.com/docs/advanced-configuration
 checks:
+  argument-count:
+    config:
+      threshold: 5
   method-complexity:
     config:
       threshold: 7


### PR DESCRIPTION
Generally, 4 or 5 arguments are too many and we should strongly
consider using a paramter object or other techniques to reduce arg count.
5 arguments seems to be a threshold between when it's bad idea compared
to really beyond the pale. 6 arguments or more probably should always
be behind a parameter object.

This update sets code climate to not generate a warning until
method arguments hit 6 or more, a point where generally we will
want something to be done (reduces false positives)


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
