### PR TITLE
Fix: Restore leniency for mismatching territory names

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -537,6 +537,20 @@ public class MapData {
       final GameData data, final Set<String> keys, final String dataTypeForErrorMessage) {
     final StringBuilder errors = new StringBuilder();
 
+    // This block ignores mismatched territory data and the result of removing
+    // from the iterator is we will wind up using the correct territory name.
+    // Without this the engine becomes extremely strict about territory naming.
+    // See: https://github.com/triplea-game/triplea/issues/7386
+    final Iterator<String> iter = keys.iterator();
+    while (iter.hasNext()) {
+      final String name = iter.next();
+      final Territory terr = data.getMap().getTerritory(name);
+      // allow loading saved games with missing territories; just ignore them
+      if (terr == null) {
+        iter.remove();
+      }
+    }
+
     for (final Territory terr : data.getMap().getTerritories()) {
       if (!keys.contains(terr.getName())) {
         errors


### PR DESCRIPTION
Allows for new territory naming to be ignored in favor of "old"
territory. This allows territory naming to line up with polygons.txt
and centers.txt, without the matching is strict and territory names
can appear as 'none' which disallows movements into those territories.

Partial revert of: https://github.com/triplea-game/triplea/pull/7233
Fixes: https://github.com/triplea-game/triplea/issues/7386


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
Double check WaW 1940 map movement into renamed territories.

<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->FIX|Movement incorrectly disallowed into certain territories on WaW <!--END_RELEASE_NOTE-->
