### PR TITLE
Allow travis to publish patch releases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,7 @@ jobs:
 
     - stage: DeployPrerelease
       name: "Build Installer Downloads & Upload to Github Releases"
-      if: (branch = master) and (repo = 'triplea-game/triplea') and (type != 'pull_request')
+      if: ((branch = master) or (branch =~ /^release\//)) and (repo = 'triplea-game/triplea') and (type != 'pull_request')
       script: [ $DEPLOY_PRERELEASE_STAGE/push-to-github-releases/run || $REPORT_FAIL "build installers" ]
       deploy:
         on: { tags: false, repo: triplea-game/triplea, branch: master }


### PR DESCRIPTION
If we cut release branches called "release/<version>", eg: "release/2.2",
then any merges to that branch we would want Travis to tag and create
installers pushed to github releasese.

This updates adds a regex (hopefully) that would match any such "release/" branch


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
