### PR TITLE
Add WWII Pacific back to map compatiblity list, those maps remain

### DIFF
--- a/smoke-testing/map-list.txt
+++ b/smoke-testing/map-list.txt
@@ -224,6 +224,9 @@ https://raw.githubusercontent.com/triplea-maps/world_war_ii_global/master/map/ga
 https://raw.githubusercontent.com/triplea-maps/world_war_ii_global/master/map/games/ww2global40_balanced_move1st.xml
 https://raw.githubusercontent.com/triplea-maps/world_war_ii_global/master/map/games/ww2global40.xml
 https://raw.githubusercontent.com/triplea-maps/world_war_ii_global/master/map/games/ww2global42_2nd_edition.xml
+https://raw.githubusercontent.com/triplea-maps/world_war_ii_pacific/master/map/games/ww2pac40_2nd_edition.xml
+https://raw.githubusercontent.com/triplea-maps/world_war_ii_pacific/master/map/games/ww2pac40_balanced_veqryn.xml
+https://raw.githubusercontent.com/triplea-maps/world_war_ii_pacific/master/map/games/ww2pac40.xml
 https://raw.githubusercontent.com/triplea-maps/world_war_ii_revised/master/map/games/lhtr.xml
 https://raw.githubusercontent.com/triplea-maps/world_war_ii_revised/master/map/games/ww2v2.xml
 https://raw.githubusercontent.com/triplea-maps/world_war_ii_revised_variations/master/map/games/barbarossa.xml


### PR DESCRIPTION
Removed in: https://github.com/triplea-game/triplea/pull/7424, but repo was not deleted, could have been kept in the map compat check list.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
