### PR TITLE
Update: Change the data structure of map-listing JSON response to account for map skins

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.triplea.http.client.maps.listing.MapDownloadListing;
+import org.triplea.http.client.maps.listing.MapSkinListing;
 import org.triplea.util.Version;
 
 /**
@@ -32,16 +33,6 @@ public final class DownloadFileDescription {
     MAP,
     MAP_SKIN,
     MAP_TOOL;
-
-    private static DownloadType fromString(final String type) {
-      if (type.equalsIgnoreCase(MAP_SKIN.name())) {
-        return MAP_SKIN;
-      } else if (type.equalsIgnoreCase(MAP_TOOL.name())) {
-        return MAP_TOOL;
-      } else {
-        return MAP;
-      }
-    }
   }
 
   enum MapCategory {
@@ -79,9 +70,22 @@ public final class DownloadFileDescription {
         .description(mapDownloadListing.getDescription())
         .mapName(mapDownloadListing.getMapName())
         .version(new Version(mapDownloadListing.getVersion()))
-        .downloadType(DownloadType.fromString(mapDownloadListing.getDownloadType()))
+        .downloadType(DownloadType.MAP)
         .mapCategory(MapCategory.fromString(mapDownloadListing.getMapCategory()))
-        .img(mapDownloadListing.getImg())
+        .img(mapDownloadListing.getPreviewImage())
+        .build();
+  }
+
+  public static DownloadFileDescription ofMapSkinListing(
+      final MapSkinListing skin, final String mapCategory) {
+    return DownloadFileDescription.builder()
+        .url(skin.getUrl())
+        .description(skin.getDescription())
+        .mapName(skin.getSkinName())
+        .version(new Version(skin.getVersion()))
+        .downloadType(DownloadType.MAP_SKIN)
+        .mapCategory(MapCategory.fromString(mapCategory))
+        .img(skin.getPreviewImageUrl())
         .build();
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/map/listing/MapListingFetcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/listing/MapListingFetcher.java
@@ -5,6 +5,7 @@ import games.strategy.engine.framework.map.download.DownloadRunnable;
 import games.strategy.engine.framework.system.DevOverrides;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.triplea.settings.ClientSetting;
+import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
@@ -36,8 +37,29 @@ public class MapListingFetcher {
 
   private static List<DownloadFileDescription> convertDownloadListings(
       final List<MapDownloadListing> downloadListings) {
-    return downloadListings.stream()
-        .map(DownloadFileDescription::ofMapDownloadListing)
+
+    final List<DownloadFileDescription> mapDownloads =
+        downloadListings.stream()
+            .map(DownloadFileDescription::ofMapDownloadListing)
+            .collect(Collectors.toList());
+
+    final List<DownloadFileDescription> mapSkins =
+        downloadListings.stream()
+            .map(MapListingFetcher::convertMapSkinListingsToDownloadFileDescriptions)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
+
+    mapDownloads.addAll(mapSkins);
+    return mapDownloads;
+  }
+
+  private static List<DownloadFileDescription> convertMapSkinListingsToDownloadFileDescriptions(
+      final MapDownloadListing mapDownloadListing) {
+    // convert each map skin in the map download listing into its own DownloadFileDescription
+    return mapDownloadListing.getMapsSkins().stream()
+        .map(
+            skin ->
+                DownloadFileDescription.ofMapSkinListing(skin, mapDownloadListing.getMapCategory()))
         .collect(Collectors.toList());
   }
 }

--- a/http-clients/src/main/java/org/triplea/http/client/maps/listing/MapDownloadListing.java
+++ b/http-clients/src/main/java/org/triplea/http/client/maps/listing/MapDownloadListing.java
@@ -1,5 +1,7 @@
 package org.triplea.http.client.maps.listing;
 
+import java.util.Set;
+import javax.annotation.Nonnull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -8,11 +10,12 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class MapDownloadListing {
-  private final String url;
-  private final String description;
-  private final String mapName;
-  private final String version;
-  private final String downloadType;
-  private final String mapCategory;
-  private final String img;
+  @Nonnull private final String url;
+  @Nonnull private final String mapName;
+  @Nonnull private final String description;
+  @Nonnull private final String version;
+  @Nonnull private final String mapCategory;
+  private final String previewImage;
+
+  private final Set<MapSkinListing> mapsSkins;
 }

--- a/http-clients/src/main/java/org/triplea/http/client/maps/listing/MapSkinListing.java
+++ b/http-clients/src/main/java/org/triplea/http/client/maps/listing/MapSkinListing.java
@@ -1,0 +1,14 @@
+package org.triplea.http.client.maps.listing;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class MapSkinListing {
+  private final String url;
+  private final String skinName;
+  private final String description;
+  private final String version;
+  private final String previewImageUrl;
+}


### PR DESCRIPTION
This update mostly makes map skins be children of the map element in the map listing JSON
response. Currently we need map downloads (skins included) to be a flat list, so we then
need some client logic to combine map downloads and their map skins into a flat list.

As part of this, we can remove the 'download type' attribute from the JSON response. The
download type is evident from the response structure. One implication is that in the
future we'll remove the 'tool' category and fold that into the 'map' category or
make the 'tool' download availabe via some other means.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
