### PR TITLE
Keep http-server name for download artifact of 2.1.20777

### DIFF
--- a/infrastructure/ansible/roles/lobby_server/defaults/main.yml
+++ b/infrastructure/ansible/roles/lobby_server/defaults/main.yml
@@ -16,4 +16,4 @@ lobby_server_db_user: "{{ lobby_db_user }}"
 
 create_issues_github_api_token: test
 
-lobby_server_zip_download: "https://github.com/triplea-game/triplea/releases/download/{{ version }}/triplea-lobby-server-{{ version }}.zip"
+lobby_server_zip_download: "https://github.com/triplea-game/triplea/releases/download/{{ version }}/triplea-http-server-{{ version }}.zip"


### PR DESCRIPTION
The artifact deployed to releases is still named 'http-server',
this update reverts back to the name 'http-server' so it matches
to fix prod2 deployment.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
