### PR TITLE
Add: Parameterize maps server DB port

### DIFF
--- a/maps-server/configuration.yml
+++ b/maps-server/configuration.yml
@@ -9,7 +9,7 @@ database:
   driverClass: org.postgresql.Driver
   user: maps_user
   password: postgres
-  url: jdbc:postgresql://localhost:5433/maps_db
+  url: jdbc:postgresql://localhost:${MAPS_SERVER_DB_PORT:-5433}/maps_db
   properties:
     charSet: UTF-8
   validationQuery: select 1


### PR DESCRIPTION
On travis the maps-db will be on the same port as the lobby-db.
To point the maps-server to the right DB port, this update
parameterize the port so that we can set an environment vaiable
with the correct port number.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
