### PR TITLE
Remove codeclimate linting of markdown files

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -27,14 +27,6 @@ plugins:
   # https://docs.codeclimate.com/docs/codenarc
   codenarc:
     enabled: true
-  # https://docs.codeclimate.com/docs/markdownlint
-  markdownlint:
-    enabled: true
-    checks:
-      MD006:
-        # Disable "Consider starting bulleted lists at the beginning of the line"
-        enabled: false
-
   # https://docs.codeclimate.com/docs/shellcheck
   shellcheck:
     enabled: true


### PR DESCRIPTION
Markdown (documentation) formatting is not terribly important.
Without an automatic formatter, it is largely noise. This update
removes codeclimate analysis of markdown (documentation) files
so we can more focus on the content and less on the formatting.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
