### PR TITLE
Use DropwizardServerExtension to clean up data after test execution

### DIFF
--- a/lobby-server/src/test/java/org/triplea/db/dao/access/log/AccessLogDaoTest.java
+++ b/lobby-server/src/test/java/org/triplea/db/dao/access/log/AccessLogDaoTest.java
@@ -27,7 +27,7 @@ class AccessLogDaoTest extends LobbyServerTest {
    * are as expected
    */
   @Test
-  @DataSet(cleanBefore = true, value = "access_log/two_rows.yml")
+  @DataSet("access_log/two_rows.yml")
   void fetchTwoRows() {
     List<AccessLogRecord> data = accessLogDao.fetchAccessLogRows(0, 1, "%", "%", "%");
     assertThat(data, hasSize(1));
@@ -57,7 +57,7 @@ class AccessLogDaoTest extends LobbyServerTest {
   }
 
   @Test
-  @DataSet(cleanBefore = true, value = "access_log/two_rows.yml")
+  @DataSet("access_log/two_rows.yml")
   void searchForAllIdentifiesWithExactMatch() {
     final List<AccessLogRecord> data =
         accessLogDao.fetchAccessLogRows(0, 2, "first", "127.0.0.1", "system-id1");
@@ -67,7 +67,7 @@ class AccessLogDaoTest extends LobbyServerTest {
   }
 
   @Test
-  @DataSet(cleanBefore = true, value = "access_log/two_rows.yml")
+  @DataSet("access_log/two_rows.yml")
   void searchForSystemId() {
     final List<AccessLogRecord> data =
         accessLogDao.fetchAccessLogRows(0, 2, "%", "%", "system-id1");
@@ -77,7 +77,7 @@ class AccessLogDaoTest extends LobbyServerTest {
   }
 
   @Test
-  @DataSet(cleanBefore = true, value = "access_log/two_rows.yml")
+  @DataSet("access_log/two_rows.yml")
   void searchForUserName() {
     final List<AccessLogRecord> data = accessLogDao.fetchAccessLogRows(0, 2, "first", "%", "%");
 
@@ -86,7 +86,7 @@ class AccessLogDaoTest extends LobbyServerTest {
   }
 
   @Test
-  @DataSet(cleanBefore = true, value = "access_log/two_rows.yml")
+  @DataSet("access_log/two_rows.yml")
   void searchForIp() {
     final List<AccessLogRecord> data = accessLogDao.fetchAccessLogRows(0, 2, "%", "127.0.0.1", "%");
 
@@ -96,7 +96,7 @@ class AccessLogDaoTest extends LobbyServerTest {
 
   /** There are only 2 rows, requesting a row offset of '2' should yield no data. */
   @Test
-  @DataSet(cleanBefore = true, value = "access_log/two_rows.yml")
+  @DataSet("access_log/two_rows.yml")
   void requestingRowsOffDataSetReturnsNothing() {
     assertThat(accessLogDao.fetchAccessLogRows(2, 1, "%", "%", "%"), hasSize(0));
   }

--- a/lobby-server/src/test/java/org/triplea/db/dao/api/key/GameHostingApiKeyDaoTest.java
+++ b/lobby-server/src/test/java/org/triplea/db/dao/api/key/GameHostingApiKeyDaoTest.java
@@ -15,19 +15,19 @@ class GameHostingApiKeyDaoTest extends LobbyServerTest {
   private final GameHostingApiKeyDao gameHostApiKeyDao;
 
   @Test
-  @DataSet(cleanBefore = true, value = "game_hosting_api_key/key_exists.yml")
+  @DataSet("game_hosting_api_key/key_exists.yml")
   void keyExists() {
     assertThat(gameHostApiKeyDao.keyExists("game-hosting-key"), is(true));
   }
 
   @Test
-  @DataSet(cleanBefore = true, value = "game_hosting_api_key/key_exists.yml")
+  @DataSet("game_hosting_api_key/key_exists.yml")
   void keyDoesNotExist() {
     assertThat(gameHostApiKeyDao.keyExists("DNE"), is(false));
   }
 
   @Test
-  @DataSet(cleanBefore = true, value = "game_hosting_api_key/insert_key_before.yml")
+  @DataSet("game_hosting_api_key/insert_key_before.yml")
   @ExpectedDataSet("game_hosting_api_key/insert_key_after.yml")
   void insertKey() {
     gameHostApiKeyDao.insertKey("game-hosting-api-key", "127.0.0.2");

--- a/lobby-server/src/test/java/org/triplea/db/dao/api/key/PlayerApiKeyDaoTest.java
+++ b/lobby-server/src/test/java/org/triplea/db/dao/api/key/PlayerApiKeyDaoTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Test;
 import org.triplea.db.dao.user.role.UserRole;
 import org.triplea.modules.http.LobbyServerTest;
 
-@DataSet(cleanBefore = true, value = "lobby_api_key/initial.yml")
+@DataSet("lobby_api_key/initial.yml")
 @RequiredArgsConstructor
 class PlayerApiKeyDaoTest extends LobbyServerTest {
 
@@ -79,7 +79,7 @@ class PlayerApiKeyDaoTest extends LobbyServerTest {
   }
 
   @Test
-  @DataSet(cleanBefore = true, value = "lobby_api_key/delete_old_keys_before.yml")
+  @DataSet("lobby_api_key/delete_old_keys_before.yml")
   @ExpectedDataSet(value = "lobby_api_key/delete_old_keys_after.yml", orderBy = "key")
   void deleteOldKeys() {
     playerApiKeyDao.deleteOldKeys();
@@ -101,7 +101,7 @@ class PlayerApiKeyDaoTest extends LobbyServerTest {
   }
 
   @Test
-  //    @DataSet(cleanBefore = true, value = "lobby_api_key/initial.yml")
+  //    @DataSet("lobby_api_key/initial.yml")
   void foundCase() {
     final Optional<Integer> result = playerApiKeyDao.lookupPlayerIdByPlayerChatId("chat-id0");
 

--- a/lobby-server/src/test/java/org/triplea/db/dao/chat/history/LobbyChatHistoryDaoTest.java
+++ b/lobby-server/src/test/java/org/triplea/db/dao/chat/history/LobbyChatHistoryDaoTest.java
@@ -12,7 +12,7 @@ class LobbyChatHistoryDaoTest extends LobbyServerTest {
   private final LobbyChatHistoryDao lobbyChatHistoryDao;
 
   @Test
-  @DataSet(cleanBefore = true, value = "chat_history/insert_into_lobby_chat_history_before.yml")
+  @DataSet("chat_history/insert_into_lobby_chat_history_before.yml")
   @ExpectedDataSet("chat_history/insert_into_lobby_chat_history_after.yml")
   void insertChatMessage() {
     lobbyChatHistoryDao.insertMessage("username", 3000, "message");

--- a/lobby-server/src/test/java/org/triplea/db/dao/error/reporting/ErrorReportingDaoTest.java
+++ b/lobby-server/src/test/java/org/triplea/db/dao/error/reporting/ErrorReportingDaoTest.java
@@ -21,7 +21,7 @@ final class ErrorReportingDaoTest extends LobbyServerTest {
   private final ErrorReportingDao errorReportingDao;
 
   /** Simple check that if we insert a record we'll get a new record in the expected dataset. */
-  @DataSet(cleanBefore = true, value = "error_reporting/pre-insert.yml")
+  @DataSet("error_reporting/pre-insert.yml")
   @ExpectedDataSet(value = "error_reporting/post-insert.yml")
   @Test
   void insertRow() {
@@ -35,14 +35,14 @@ final class ErrorReportingDaoTest extends LobbyServerTest {
             .build());
   }
 
-  @DataSet(cleanBefore = true, value = "error_reporting/pre-purge.yml")
+  @DataSet("error_reporting/pre-purge.yml")
   @ExpectedDataSet(value = "error_reporting/post-purge.yml")
   @Test
   void purgeOld() {
     errorReportingDao.purgeOld(LocalDateTime.of(2016, 1, 3, 23, 0, 0).toInstant(ZoneOffset.UTC));
   }
 
-  @DataSet(cleanBefore = true, value = "error_reporting/post-purge.yml")
+  @DataSet("error_reporting/post-purge.yml")
   @Test
   void getErrorReportLinkFoundCase() {
     assertThat(
@@ -50,7 +50,7 @@ final class ErrorReportingDaoTest extends LobbyServerTest {
         isPresentAndIs("the_createdIssueLink2"));
   }
 
-  @DataSet(cleanBefore = true, value = "error_reporting/post-purge.yml")
+  @DataSet("error_reporting/post-purge.yml")
   @ParameterizedTest
   @MethodSource
   void getErrorReportLinkNotFoundCases(final String title, final String version) {

--- a/lobby-server/src/test/java/org/triplea/db/dao/lobby/games/LobbyGameDaoTest.java
+++ b/lobby-server/src/test/java/org/triplea/db/dao/lobby/games/LobbyGameDaoTest.java
@@ -15,7 +15,7 @@ class LobbyGameDaoTest extends LobbyServerTest {
   private final LobbyGameDao lobbyGameDao;
 
   @Test
-  @DataSet(cleanBefore = true, value = "lobby_games/lobby_game_insert_before.yml")
+  @DataSet("lobby_games/lobby_game_insert_before.yml")
   @ExpectedDataSet("lobby_games/lobby_game_insert_after.yml")
   void insertLobbyGame() {
     lobbyGameDao.insertLobbyGame(
@@ -27,7 +27,7 @@ class LobbyGameDaoTest extends LobbyServerTest {
   }
 
   @Test
-  @DataSet(cleanBefore = true, value = "lobby_games/game_chat_history_insert_before.yml")
+  @DataSet("lobby_games/game_chat_history_insert_before.yml")
   @ExpectedDataSet("lobby_games/game_chat_history_insert_after.yml")
   void insertChatMessage() {
     lobbyGameDao.recordChat(

--- a/lobby-server/src/test/java/org/triplea/db/dao/moderator/BadWordsDaoTest.java
+++ b/lobby-server/src/test/java/org/triplea/db/dao/moderator/BadWordsDaoTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.triplea.modules.http.LobbyServerTest;
 
-@DataSet(cleanBefore = true, value = "bad_words/select.yml")
+@DataSet("bad_words/select.yml")
 @RequiredArgsConstructor
 class BadWordsDaoTest extends LobbyServerTest {
   private static final List<String> expectedBadWords = List.of("aaa", "one", "two", "zzz");

--- a/lobby-server/src/test/java/org/triplea/db/dao/moderator/ModeratorAuditHistoryDaoTest.java
+++ b/lobby-server/src/test/java/org/triplea/db/dao/moderator/ModeratorAuditHistoryDaoTest.java
@@ -23,7 +23,7 @@ class ModeratorAuditHistoryDaoTest extends LobbyServerTest {
   private final ModeratorAuditHistoryDao moderatorAuditHistoryDao;
 
   @Test
-  @DataSet(cleanBefore = true, value = "moderator_audit/pre_insert.yml")
+  @DataSet("moderator_audit/pre_insert.yml")
   void addAuditRecordThrowsIfModeratorNameNotFound() {
     assertThrows(
         UnableToExecuteStatementException.class,
@@ -37,7 +37,7 @@ class ModeratorAuditHistoryDaoTest extends LobbyServerTest {
   }
 
   @Test
-  @DataSet(cleanBefore = true, value = "moderator_audit/pre_insert.yml")
+  @DataSet("moderator_audit/pre_insert.yml")
   @ExpectedDataSet("moderator_audit/post_insert.yml")
   void addAuditRecord() {
     moderatorAuditHistoryDao.addAuditRecord(
@@ -49,7 +49,7 @@ class ModeratorAuditHistoryDaoTest extends LobbyServerTest {
   }
 
   @Test
-  @DataSet(cleanBefore = true, value = "moderator_audit/history_select.yml")
+  @DataSet("moderator_audit/history_select.yml")
   void selectHistory() {
     List<ModeratorAuditHistoryRecord> results = moderatorAuditHistoryDao.lookupHistoryItems(0, 3);
 

--- a/lobby-server/src/test/java/org/triplea/db/dao/moderator/ModeratorsDaoTest.java
+++ b/lobby-server/src/test/java/org/triplea/db/dao/moderator/ModeratorsDaoTest.java
@@ -14,7 +14,7 @@ import org.junit.jupiter.api.Test;
 import org.triplea.db.dao.user.role.UserRole;
 import org.triplea.modules.http.LobbyServerTest;
 
-@DataSet(cleanBefore = true, value = "moderators/select.yml")
+@DataSet("moderators/select.yml")
 @RequiredArgsConstructor
 class ModeratorsDaoTest extends LobbyServerTest {
 

--- a/lobby-server/src/test/java/org/triplea/db/dao/moderator/player/info/PlayerInfoForModeratorDaoTest.java
+++ b/lobby-server/src/test/java/org/triplea/db/dao/moderator/player/info/PlayerInfoForModeratorDaoTest.java
@@ -19,9 +19,7 @@ class PlayerInfoForModeratorDaoTest extends LobbyServerTest {
   private final PlayerInfoForModeratorDao playerInfoForModeratorDao;
 
   @Nested
-  @DataSet(
-      cleanBefore = true,
-      value = "moderator_player_lookup/lookup_player_aliases_select_data.yml")
+  @DataSet("moderator_player_lookup/lookup_player_aliases_select_data.yml")
   class LookupPlayerAliases {
     @Test
     void lookupEmptyCase() {
@@ -88,7 +86,7 @@ class PlayerInfoForModeratorDaoTest extends LobbyServerTest {
   }
 
   @Nested
-  @DataSet(cleanBefore = true, value = "moderator_player_lookup/lookup_player_bans_select_data.yml")
+  @DataSet("moderator_player_lookup/lookup_player_bans_select_data.yml")
   class LookupPlayerBans {
     @Test
     void emptyLookupCase() {

--- a/lobby-server/src/test/java/org/triplea/db/dao/temp/password/TempPasswordDaoTest.java
+++ b/lobby-server/src/test/java/org/triplea/db/dao/temp/password/TempPasswordDaoTest.java
@@ -10,7 +10,7 @@ import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.triplea.modules.http.LobbyServerTest;
 
-@DataSet(cleanBefore = true, value = "temp_password/sample.yml")
+@DataSet("temp_password/sample.yml")
 @RequiredArgsConstructor
 class TempPasswordDaoTest extends LobbyServerTest {
 
@@ -55,7 +55,7 @@ class TempPasswordDaoTest extends LobbyServerTest {
     assertThat(tempPasswordDao.fetchTempPassword(USERNAME), isPresentAndIs(NEW_PASSWORD));
   }
 
-  @DataSet(cleanBefore = true, value = "temp_password/invalidate_password.yml")
+  @DataSet("temp_password/invalidate_password.yml")
   @Test
   void invalidateTempPasswordsForMissingNameDoesNothing() {
     // verify that before we do any invalidation that indeed our known user has a temp password
@@ -68,7 +68,7 @@ class TempPasswordDaoTest extends LobbyServerTest {
     assertThat(tempPasswordDao.fetchTempPassword(USERNAME), isPresentAndIs(PASSWORD));
   }
 
-  @DataSet(cleanBefore = true, value = "temp_password/invalidate_password.yml")
+  @DataSet("temp_password/invalidate_password.yml")
   @Test
   void invalidatePassword() {
     tempPasswordDao.invalidateTempPasswords(USERNAME);

--- a/lobby-server/src/test/java/org/triplea/db/dao/user/UserJdbiDaoTest.java
+++ b/lobby-server/src/test/java/org/triplea/db/dao/user/UserJdbiDaoTest.java
@@ -13,7 +13,7 @@ import org.triplea.db.dao.user.role.UserRole;
 import org.triplea.db.dao.user.role.UserRoleLookup;
 import org.triplea.modules.http.LobbyServerTest;
 
-@DataSet(cleanBefore = true, value = "user/initial.yml")
+@DataSet("user/initial.yml")
 @RequiredArgsConstructor
 class UserJdbiDaoTest extends LobbyServerTest {
 
@@ -41,7 +41,7 @@ class UserJdbiDaoTest extends LobbyServerTest {
     assertThat(userDao.getPassword("DNE"), isEmpty());
   }
 
-  @DataSet(cleanBefore = true, value = "user/change_password_before.yml")
+  @DataSet("user/change_password_before.yml")
   @ExpectedDataSet("user/change_password_after.yml")
   @Test
   void updatePassword() {

--- a/lobby-server/src/test/java/org/triplea/db/dao/user/ban/UserBanDaoTest.java
+++ b/lobby-server/src/test/java/org/triplea/db/dao/user/ban/UserBanDaoTest.java
@@ -23,7 +23,7 @@ class UserBanDaoTest extends LobbyServerTest {
   private final UserBanDao userBanDao;
 
   @Nested
-  @DataSet(cleanBefore = true, value = "user_ban/banned_by_ip.yml")
+  @DataSet("user_ban/banned_by_ip.yml")
   class IsBannedByIp {
     @Test
     void isBannedByIpPositiveCase() {
@@ -42,7 +42,7 @@ class UserBanDaoTest extends LobbyServerTest {
   }
 
   @Nested
-  @DataSet(cleanBefore = true, value = "user_ban/lookup_bans.yml")
+  @DataSet("user_ban/lookup_bans.yml")
   class BanLookups {
     @Test
     @DisplayName("Verify retrieval of all current bans")
@@ -101,7 +101,7 @@ class UserBanDaoTest extends LobbyServerTest {
   }
 
   @Nested
-  @DataSet(cleanBefore = true, value = "user_ban/lookup_username_by_ban_id.yml")
+  @DataSet("user_ban/lookup_username_by_ban_id.yml")
   class LookupUsernameByBanId {
     @Test
     void banIdFound() {
@@ -117,14 +117,14 @@ class UserBanDaoTest extends LobbyServerTest {
   @Nested
   class AddAndRemoveBan {
     @Test
-    @DataSet(cleanBefore = true, value = "user_ban/remove_ban_before.yml")
+    @DataSet("user_ban/remove_ban_before.yml")
     @ExpectedDataSet("user_ban/remove_ban_after.yml")
     void removeBan() {
       userBanDao.removeBan("public-id");
     }
 
     @Test
-    @DataSet(cleanBefore = true, value = "user_ban/add_ban_before.yml")
+    @DataSet("user_ban/add_ban_before.yml")
     @ExpectedDataSet("user_ban/add_ban_after.yml")
     void addBan() {
       userBanDao.addBan("public-id", "username", "system-id", "127.0.0.3", 5);

--- a/lobby-server/src/test/java/org/triplea/db/dao/user/role/UserRoleDaoTest.java
+++ b/lobby-server/src/test/java/org/triplea/db/dao/user/role/UserRoleDaoTest.java
@@ -8,7 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.Test;
 import org.triplea.modules.http.LobbyServerTest;
 
-@DataSet(cleanBefore = true, value = "user_role/initial.yml")
+@DataSet("user_role/initial.yml")
 @RequiredArgsConstructor
 class UserRoleDaoTest extends LobbyServerTest {
 

--- a/lobby-server/src/test/java/org/triplea/db/dao/username/ban/UsernameBanDaoTest.java
+++ b/lobby-server/src/test/java/org/triplea/db/dao/username/ban/UsernameBanDaoTest.java
@@ -20,7 +20,7 @@ class UsernameBanDaoTest extends LobbyServerTest {
 
   @Test
   @DisplayName("Verify retrieving username bans")
-  @DataSet(cleanBefore = true, value = "username_ban/get_banned_usernames.yml")
+  @DataSet("username_ban/get_banned_usernames.yml")
   void getBannedUserNames() {
     final List<UsernameBanRecord> result = usernameBanDao.getBannedUserNames();
     assertThat(result, hasSize(2));
@@ -34,7 +34,7 @@ class UsernameBanDaoTest extends LobbyServerTest {
 
   @Test
   @DisplayName("Verify name matching")
-  @DataSet(cleanBefore = true, value = "username_ban/get_banned_usernames.yml")
+  @DataSet("username_ban/get_banned_usernames.yml")
   void nameIsBanned() {
     assertThat(
         "Exact match should return true",
@@ -54,7 +54,7 @@ class UsernameBanDaoTest extends LobbyServerTest {
 
   @Test
   @DisplayName("Verify adding a username ban")
-  @DataSet(cleanBefore = true, value = "username_ban/add_banned_username_before.yml")
+  @DataSet("username_ban/add_banned_username_before.yml")
   @ExpectedDataSet("username_ban/add_banned_username_after.yml")
   void addBannedUserName() {
     usernameBanDao.addBannedUserName("username");
@@ -62,7 +62,7 @@ class UsernameBanDaoTest extends LobbyServerTest {
 
   @Test
   @DisplayName("Verify removing a username ban")
-  @DataSet(cleanBefore = true, value = "username_ban/remove_banned_username_before.yml")
+  @DataSet("username_ban/remove_banned_username_before.yml")
   @ExpectedDataSet("username_ban/remove_banned_username_after.yml")
   void removeBannedUserName() {
     final int result = usernameBanDao.removeBannedUserName("username");
@@ -72,7 +72,7 @@ class UsernameBanDaoTest extends LobbyServerTest {
 
   @Test
   @DisplayName("Verify when removing a username that DNE, that nothing changes")
-  @DataSet(cleanBefore = true, value = "username_ban/remove_banned_username_before.yml")
+  @DataSet("username_ban/remove_banned_username_before.yml")
   @ExpectedDataSet("username_ban/remove_banned_username_before.yml")
   void removeBannedUserNameNameDoesNotExist() {
     final int result = usernameBanDao.removeBannedUserName("DNE");

--- a/lobby-server/src/test/resources/datasets/access_log/empty_data.yml
+++ b/lobby-server/src/test/resources/datasets/access_log/empty_data.yml
@@ -1,5 +1,3 @@
-lobby_api_key:
-
 user_role:
   - id: 9898
     name: PLAYER
@@ -10,5 +8,3 @@ lobby_user:
     username: registered
     bcrypt_password: $2a$56789_123456789_123456789_123456789_123456789_123456789_
     email: email@
-
-access_log:

--- a/lobby-server/src/test/resources/datasets/access_log/two_rows.yml
+++ b/lobby-server/src/test/resources/datasets/access_log/two_rows.yml
@@ -1,5 +1,3 @@
-lobby_api_key:
-
 user_role:
   - id: 9111
     name: PLAYER

--- a/lobby-server/src/test/resources/datasets/lobby_api_key/delete_old_keys_before.yml
+++ b/lobby-server/src/test/resources/datasets/lobby_api_key/delete_old_keys_before.yml
@@ -1,5 +1,3 @@
-lobby_user:
-
 user_role:
   - id: 1
     name: ANONYMOUS

--- a/lobby-server/src/test/resources/datasets/moderators/select.yml
+++ b/lobby-server/src/test/resources/datasets/moderators/select.yml
@@ -1,5 +1,3 @@
-lobby_api_key:
-
 user_role:
   - id: 1
     name: PLAYER

--- a/lobby-server/src/test/resources/datasets/user/initial.yml
+++ b/lobby-server/src/test/resources/datasets/user/initial.yml
@@ -1,4 +1,3 @@
-lobby_api_key:
 user_role:
   - id: 1
     name: PLAYER

--- a/lobby-server/src/test/resources/datasets/user_role/initial.yml
+++ b/lobby-server/src/test/resources/datasets/user_role/initial.yml
@@ -3,7 +3,3 @@ user_role:
     name: ANONYMOUS
   - id: 2
     name: HOST
-
-lobby_chat_history:
-lobby_api_key:
-lobby_user:

--- a/lobby-server/src/test/resources/db-cleanup.sql
+++ b/lobby-server/src/test/resources/db-cleanup.sql
@@ -1,0 +1,17 @@
+-- Deletes table data in proper order
+
+delete from access_log;
+delete from bad_word;
+delete from banned_user;
+delete from banned_username;
+delete from error_report_history;
+delete from game_chat_history;
+delete from lobby_game;
+delete from game_hosting_api_key;
+delete from lobby_chat_history;
+delete from lobby_api_key;
+delete from moderator_action_history;
+delete from temp_password_request;
+delete from temp_password_request_history;
+delete from lobby_user;
+delete from user_role;


### PR DESCRIPTION
This update adds functionality to the extensions 'afterAll' block
to execute the SQL statements in a test/resources/db-cleanup.sql
file if it exists.

This update allows for most 'cleanBefore' tags to be removed and
removes non-determinism of DbRider tests where certain test
execution orderings can result in a FK constraint violation error.

Motivation & Benefit: DBRider tests will clear tables before inserting
data. One problem is that the table clearing logic is only aware of
the tables in that test. If other tables have a FK to one of these
cleared tables, there will be a constraint violation error. Worse yet,
this situation depends on the ordering of when tests are executed.

By deleting data using SQL from a file that is aware of all tables
and the correct order to delete data, we can execute this to ensure
that when any new tests run that there won't be any foreign key
reference violations when setting up new data.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
