### PR TITLE
Reduce integ test time on controllers (minor)

### DIFF
--- a/lobby-server/src/test/java/org/triplea/modules/http/AllowedUserRole.java
+++ b/lobby-server/src/test/java/org/triplea/modules/http/AllowedUserRole.java
@@ -13,11 +13,11 @@ import org.triplea.domain.data.ApiKey;
 @SuppressWarnings("ImmutableEnumChecker")
 public enum AllowedUserRole {
   // caution: api-key values must match database (integration.yml)
-  ADMIN(KeyValues.ADMIN, KeyValues.MODERATOR, KeyValues.HOST),
-  MODERATOR(KeyValues.MODERATOR, KeyValues.PLAYER, KeyValues.HOST),
-  PLAYER(KeyValues.PLAYER, KeyValues.ANONYMOUS, KeyValues.HOST),
-  ANONYMOUS(KeyValues.ANONYMOUS, KeyValues.HOST),
-  HOST(KeyValues.HOST, KeyValues.ADMIN, KeyValues.ANONYMOUS);
+  ADMIN(KeyValues.ADMIN, KeyValues.MODERATOR),
+  MODERATOR(KeyValues.MODERATOR, KeyValues.PLAYER),
+  PLAYER(KeyValues.PLAYER, KeyValues.ANONYMOUS),
+  ANONYMOUS(KeyValues.ANONYMOUS),
+  HOST(KeyValues.HOST, KeyValues.ADMIN);
 
   /** Returns a set of keys that should be allowed access given a target role. */
   @Getter private ApiKey allowedKey;


### PR DESCRIPTION
Minor speed improvement by reducing number of negative cases for authentication checks.
Essentially instead of checking multiple 'bad' roles that can access an endpoint, we
will only verify just one (speeds up testing slightly).


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
Running all of the lobby-server tests before this change took 1m 29s, after 1m 22s. 
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
