### PR TITLE
A NonCombatMovementBonus Tech

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -235,7 +235,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return nonCombatMovementBonus;
   }
 
-  static int getNonCombatMovementBonus(final UnitType ut, final GamePlayer player, final GameData data) {
+  static int getNonCombatMovementBonus(
+      final UnitType ut, final GamePlayer player, final GameData data) {
     return sumIntegerMap(TechAbilityAttachment::getNonCombatMovementBonus, ut, player, data);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -48,6 +48,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
   private IntegerMap<UnitType> attackBonus = new IntegerMap<>();
   private IntegerMap<UnitType> defenseBonus = new IntegerMap<>();
   private IntegerMap<UnitType> movementBonus = new IntegerMap<>();
+  private IntegerMap<UnitType> nonCombatMovementBonus = new IntegerMap<>();
   private IntegerMap<UnitType> radarBonus = new IntegerMap<>();
   private IntegerMap<UnitType> airAttackBonus = new IntegerMap<>();
   private IntegerMap<UnitType> airDefenseBonus = new IntegerMap<>();
@@ -220,6 +221,26 @@ public class TechAbilityAttachment extends DefaultAttachment {
 
   private void resetMovementBonus() {
     movementBonus = new IntegerMap<>();
+  }
+
+  private void setNonCombatMovementBonus(final String value) throws GameParseException {
+    applyCheckedValue("nonCombatMovementBonus", value, nonCombatMovementBonus::put);
+  }
+
+  private void setNonCombatMovementBonus(final IntegerMap<UnitType> value) {
+    nonCombatMovementBonus = value;
+  }
+
+  private IntegerMap<UnitType> getNonCombatMovementBonus() {
+    return nonCombatMovementBonus;
+  }
+
+  static int getNonCombatMovementBonus(final UnitType ut, final GamePlayer player, final GameData data) {
+    return sumIntegerMap(TechAbilityAttachment::getNonCombatMovementBonus, ut, player, data);
+  }
+
+  private void resetNonCombatMovementBonus() {
+    nonCombatMovementBonus = new IntegerMap<>();
   }
 
   private void setRadarBonus(final String value) throws GameParseException {
@@ -999,6 +1020,13 @@ public class TechAbilityAttachment extends DefaultAttachment {
                 this::setMovementBonus,
                 this::getMovementBonus,
                 this::resetMovementBonus))
+        .put(
+            "nonCombatMovementBonus",
+            MutableProperty.of(
+                this::setNonCombatMovementBonus,
+                this::setNonCombatMovementBonus,
+                this::getNonCombatMovementBonus,
+                this::resetNonCombatMovementBonus))
         .put(
             "radarBonus",
             MutableProperty.of(

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -16,6 +16,7 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.Properties;
+import games.strategy.triplea.delegate.GameStepPropertiesHelper;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TechTracker;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
@@ -1479,9 +1480,13 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public int getMovement(final GamePlayer player) {
+    final int nonCombatMoveBonus = GameStepPropertiesHelper.isNonCombatMove(getData(),true) ?
+          TechAbilityAttachment.getNonCombatMovementBonus(
+              (UnitType) this.getAttachedTo(), player, getData()) : 0;
     return Math.max(
         0,
         movement
+            + nonCombatMoveBonus
             + TechAbilityAttachment.getMovementBonus(
                 (UnitType) this.getAttachedTo(), player, getData()));
   }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -1480,9 +1480,11 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public int getMovement(final GamePlayer player) {
-    final int nonCombatMoveBonus = GameStepPropertiesHelper.isNonCombatMove(getData(),true) ?
-          TechAbilityAttachment.getNonCombatMovementBonus(
-              (UnitType) this.getAttachedTo(), player, getData()) : 0;
+    final int nonCombatMoveBonus =
+        GameStepPropertiesHelper.isNonCombatMove(getData(), true)
+            ? TechAbilityAttachment.getNonCombatMovementBonus(
+                (UnitType) this.getAttachedTo(), player, getData())
+            : 0;
     return Math.max(
         0,
         movement


### PR DESCRIPTION
This is a NonCombatMovementBonus Tech that uses TechAbilityAttachment to give bonus movement to units that move during the non-combat movement phase. The bonus can be positive or negative, and goes through the UnitAttachment Movement check to insure the effected units do not receive less then 0 movement. 
<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->
Have tested with land units and works as desired. Wondering if it should only be limited to land and sea units?

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
