### PR TITLE
Remove unused XML tag from DTD: 'remove-connection'

### DIFF
--- a/game-core/src/main/resources/games/strategy/engine/xml/game.dtd
+++ b/game-core/src/main/resources/games/strategy/engine/xml/game.dtd
@@ -37,7 +37,7 @@
 			name CDATA #REQUIRED
 		>
 
-<!ELEMENT map (territory+, connection*, remove-connection*)>
+<!ELEMENT map (territory+, connection*)>
 	<!ELEMENT territory EMPTY>
 	<!ATTLIST territory
 		name CDATA #REQUIRED
@@ -46,12 +46,6 @@
 	<!-- connections are two way -->
 	<!ELEMENT connection EMPTY>
 	<!ATTLIST connection
-		t1 CDATA #REQUIRED 
-		t2 CDATA #REQUIRED
-	>
-
-	<!ELEMENT remove-connection EMPTY>
-	<!ATTLIST remove-connection
 		t1 CDATA #REQUIRED 
 		t2 CDATA #REQUIRED
 	>


### PR DESCRIPTION
It looks like the tag is only defined in game.dtd
- Could not find any code to handle the tag
- Could not find any maps using the tag


<!--RELEASE_NOTE-->REMOVE|Remove unused and unsupported game XML tag 'removeConnection'<!--END_RELEASE_NOTE-->
