### PR TITLE
Simplify download file properties

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
@@ -87,9 +87,10 @@ final class DownloadFile {
             return;
           }
 
-          final DownloadFileProperties props = new DownloadFileProperties();
-          props.setFrom(download);
-          props.saveForZip(download.getInstallLocation());
+          if (download.getVersion() != null) {
+            new DownloadFileProperties(download.getVersion())
+                .saveForZip(download.getInstallLocation());
+          }
 
           downloadListener.downloadStopped(download);
         });

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
@@ -89,7 +89,7 @@ final class DownloadFile {
 
           final DownloadFileProperties props = new DownloadFileProperties();
           props.setFrom(download);
-          DownloadFileProperties.saveForZip(download.getInstallLocation(), props);
+          props.saveForZip(download.getInstallLocation());
 
           downloadListener.downloadStopped(download);
         });

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileProperties.java
@@ -9,14 +9,20 @@ import java.io.OutputStream;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.logging.Level;
+import lombok.NoArgsConstructor;
 import lombok.extern.java.Log;
 import org.triplea.util.Version;
 
 /** Properties file used to know which map versions have been installed. */
 @Log
+@NoArgsConstructor
 class DownloadFileProperties {
   static final String VERSION_PROPERTY = "map.version";
   private final Properties props = new Properties();
+
+  DownloadFileProperties(final Version mapVersion) {
+    props.put(VERSION_PROPERTY, mapVersion.toString());
+  }
 
   static DownloadFileProperties loadForZip(final File zipFile) {
     if (!fromZip(zipFile).exists()) {
@@ -49,11 +55,5 @@ class DownloadFileProperties {
 
   Optional<Version> getVersion() {
     return Optional.ofNullable(props.getProperty(VERSION_PROPERTY)).map(Version::new);
-  }
-
-  void setFrom(final DownloadFileDescription selected) {
-    if (selected.getVersion() != null) {
-      props.put(VERSION_PROPERTY, selected.getVersion().toString());
-    }
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileProperties.java
@@ -9,6 +9,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.logging.Level;
 import lombok.extern.java.Log;
@@ -35,9 +36,9 @@ class DownloadFileProperties {
     return downloadFileProperties;
   }
 
-  static void saveForZip(final File zipFile, final DownloadFileProperties props) {
+  void saveForZip(final File zipFile) {
     try (OutputStream fos = new FileOutputStream(fromZip(zipFile))) {
-      props.props.store(fos, null);
+      props.store(fos, null);
     } catch (final IOException e) {
       log.log(
           Level.SEVERE,
@@ -50,21 +51,15 @@ class DownloadFileProperties {
     return new File(zipFile.getAbsolutePath() + ".properties");
   }
 
-  Version getVersion() {
-    if (!props.containsKey(VERSION_PROPERTY)) {
-      return null;
-    }
-    return new Version(props.getProperty(VERSION_PROPERTY));
-  }
-
-  private void setVersion(final Version v) {
-    if (v != null) {
-      props.put(VERSION_PROPERTY, v.toString());
-    }
+  Optional<Version> getVersion() {
+    return Optional.ofNullable(props.getProperty(VERSION_PROPERTY))
+        .map(Version::new);
   }
 
   void setFrom(final DownloadFileDescription selected) {
-    setVersion(selected.getVersion());
+    if (selected.getVersion() != null) {
+      props.put(VERSION_PROPERTY, selected.getVersion().toString());
+    }
     props.setProperty("map.url", selected.getUrl());
     props.setProperty(
         "download.time",

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileProperties.java
@@ -1,19 +1,15 @@
 package games.strategy.engine.framework.map.download;
 
-import games.strategy.engine.ClientContext;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.logging.Level;
 import lombok.extern.java.Log;
-import org.triplea.java.DateTimeFormatterUtil;
 import org.triplea.util.Version;
 
 /** Properties file used to know which map versions have been installed. */
@@ -52,18 +48,12 @@ class DownloadFileProperties {
   }
 
   Optional<Version> getVersion() {
-    return Optional.ofNullable(props.getProperty(VERSION_PROPERTY))
-        .map(Version::new);
+    return Optional.ofNullable(props.getProperty(VERSION_PROPERTY)).map(Version::new);
   }
 
   void setFrom(final DownloadFileDescription selected) {
     if (selected.getVersion() != null) {
       props.put(VERSION_PROPERTY, selected.getVersion().toString());
     }
-    props.setProperty("map.url", selected.getUrl());
-    props.setProperty(
-        "download.time",
-        DateTimeFormatterUtil.toDateString(LocalDateTime.now(ZoneId.systemDefault())));
-    props.setProperty("engine.version", ClientContext.engineVersion().toString());
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
@@ -24,8 +24,7 @@ class FileSystemAccessStrategy {
       return Optional.empty();
     }
 
-    final DownloadFileProperties props = DownloadFileProperties.loadForZip(potentialFile);
-    return (props.getVersion() == null) ? Optional.empty() : Optional.of(props.getVersion());
+    return DownloadFileProperties.loadForZip(potentialFile).getVersion();
   }
 
   static void remove(

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadController.java
@@ -96,7 +96,7 @@ public final class MapDownloadController {
     return new DownloadedMaps() {
       @Override
       public Optional<Version> getVersionForZipFile(final File mapZipFile) {
-        return Optional.ofNullable(DownloadFileProperties.loadForZip(mapZipFile).getVersion());
+        return DownloadFileProperties.loadForZip(mapZipFile).getVersion();
       }
 
       @Override


### PR DESCRIPTION
Simplifies the '*.properties' files that we create after downloading a map zip. Largely we store extraneous data in them like the engine version and time of download, we only use the map version from those files.

commit 78927f16a0fa42c70367b03850102854af48a954

    Remove unused properties in map '*.properties' files, we only use the map version
    
    The map url, time of download, engine version are unused, we only
    need the map version in a '.properties' map suffix file.

commit 0c39898c5d89b72616da85cfb8c74ccde9d08517

    Simplify DownloadFileProperties construction
    
    Rather than construct via no-arg and then inject
    a version value, we can accept the version value
    as a constructor argument.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
