### PR TITLE
Remove Bot Loading of Maps from Directories & Simplify Bot Map Zip Loading

### DIFF
--- a/game-core/src/main/java/org/triplea/game/server/AvailableGames.java
+++ b/game-core/src/main/java/org/triplea/game/server/AvailableGames.java
@@ -1,24 +1,21 @@
 package org.triplea.game.server;
 
 import games.strategy.engine.ClientFileSystemHelper;
+import games.strategy.engine.data.EngineVersionException;
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.data.gameparser.GameParser;
 import games.strategy.engine.data.gameparser.ShallowGameParser;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
-import java.net.URL;
-import java.net.URLClassLoader;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.logging.Level;
-import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
+import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.concurrent.Immutable;
 import lombok.extern.java.Log;
@@ -36,87 +33,51 @@ final class AvailableGames {
   private final Map<String, URI> availableGames;
 
   AvailableGames() {
+
     availableGames = new HashMap<>();
-    FileUtils.listFiles(ClientFileSystemHelper.getUserMapsFolder()).stream()
-        .map(AvailableGames::getGames)
-        .map(Map::entrySet)
-        .flatMap(Collection::stream)
+    findAllXmlFiles()
         .forEach(
-            gameEntry -> {
-              if (!availableGames.containsKey(gameEntry.getKey())) {
-                availableGames.put(gameEntry.getKey(), gameEntry.getValue());
-              } else {
-                log.warning(
-                    String.format(
-                        "DUPLICATE GAME ENTRY! Ignoring game entry: %s, " + "existing value is: %s",
-                        gameEntry, availableGames.get(gameEntry.getKey())));
-              }
-            });
+            xmlInZipUri ->
+                readGameName(xmlInZipUri)
+                    .ifPresent(
+                        gameName -> {
+                          if (!availableGames.containsKey(gameName)) {
+                            availableGames.put(gameName, xmlInZipUri);
+                          } else {
+                            log.warning(
+                                String.format(
+                                    "DUPLICATE GAME ENTRY! Ignoring game name: %s, "
+                                        + "at path entry: %s, existing value is: %s",
+                                    gameName, xmlInZipUri, availableGames.get(gameName)));
+                          }
+                        }));
     log.info(
         String.format(
             "Done loading maps, " + "availableGames count: %s, contents: %s",
             availableGames.keySet().size(), availableGames.keySet()));
   }
 
-  private static Map<String, URI> getGames(final File map) {
-    log.info("Loading map: " + map);
-    if (map.isDirectory()) {
-      return getGamesFromDirectory(map);
-    } else if (map.isFile() && map.getName().toLowerCase().endsWith(ZIP_EXTENSION)) {
-      return getGamesFromZip(map);
-    }
-    return Map.of();
+  private static List<URI> findAllXmlFiles() {
+    return FileUtils.listFiles(ClientFileSystemHelper.getUserMapsFolder()).stream()
+        .filter(File::isFile)
+        .filter(file -> file.getName().toLowerCase().endsWith(ZIP_EXTENSION))
+        .map(MapZipReaderUtil::findGameXmlFilesInZip)
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
   }
 
-  private static Map<String, URI> getGamesFromDirectory(final File mapDir) {
-    final Map<String, URI> availableGames = new HashMap<>();
-    final File games = new File(mapDir, "games");
-    for (final File game : FileUtils.listFiles(games)) {
-      if (game.isFile() && game.getName().toLowerCase().endsWith("xml")) {
-        availableGames.putAll(getAvailableGames(game.toURI()));
-      }
-    }
-    return availableGames;
-  }
-
-  private static Map<String, URI> getGamesFromZip(final File map) {
-    final Map<String, URI> availableGames = new HashMap<>();
-
-    try (InputStream fis = new FileInputStream(map);
-        ZipInputStream zis = new ZipInputStream(fis);
-        URLClassLoader loader = new URLClassLoader(new URL[] {map.toURI().toURL()})) {
-      ZipEntry entry = zis.getNextEntry();
-      while (entry != null) {
-        if (entry.getName().contains("games/") && entry.getName().toLowerCase().endsWith(".xml")) {
-          final URL url = loader.getResource(entry.getName());
-          if (url != null) {
-            availableGames.putAll(
-                getAvailableGames(URI.create(url.toString().replace(" ", "%20"))));
+  private static Optional<String> readGameName(@Nonnull final URI uri) {
+    log.info("Loading XML: " + uri);
+    return UrlStreams.openStream(
+        uri,
+        inputStream -> {
+          try {
+            return ShallowGameParser.readGameName(uri.toString(), inputStream);
+          } catch (final GameParseException | EngineVersionException e) {
+            log.log(Level.SEVERE, "Exception while parsing: " + uri, e);
+            return null;
           }
-        }
-        // we have to close the loader to allow files to be deleted on windows
-        zis.closeEntry();
-        entry = zis.getNextEntry();
-      }
-    } catch (final IOException e) {
-      log.log(Level.SEVERE, "Error reading zip file in: " + map.getAbsolutePath(), e);
-    }
-    return availableGames;
-  }
-
-  private static Map<String, URI> getAvailableGames(@Nonnull final URI uri) {
-    final Map<String, URI> availableGames = new HashMap<>();
-
-    final Optional<InputStream> inputStream = UrlStreams.openStream(uri);
-    if (inputStream.isPresent()) {
-      try (InputStream input = inputStream.get()) {
-        final String name = ShallowGameParser.readGameName(uri.toString(), input);
-        availableGames.put(name, uri);
-      } catch (final Exception e) {
-        log.log(Level.SEVERE, "Exception while parsing: " + uri.toString(), e);
-      }
-    }
-    return availableGames;
+        });
   }
 
   boolean hasGame(final String gameName) {
@@ -140,22 +101,20 @@ final class AvailableGames {
     return Optional.ofNullable(availableGames.get(gameName)).map(Object::toString).orElse(null);
   }
 
-  /** Can return null. */
-  GameData getGameData(final String gameName) {
-    return Optional.ofNullable(availableGames.get(gameName))
-        .flatMap(AvailableGames::parse)
-        .orElse(null);
+  Optional<GameData> parseGameData(final String gameName) {
+    return Optional.ofNullable(availableGames.get(gameName)).flatMap(AvailableGames::parse);
   }
 
   private static Optional<GameData> parse(final URI uri) {
-    final Optional<InputStream> inputStream = UrlStreams.openStream(uri);
-    if (inputStream.isPresent()) {
-      try (InputStream input = inputStream.get()) {
-        return Optional.of(GameParser.parse(uri.toString(), input));
-      } catch (final Exception e) {
-        log.log(Level.SEVERE, "Exception while parsing: " + uri.toString(), e);
-      }
-    }
-    return Optional.empty();
+    return UrlStreams.openStream(
+        uri,
+        input -> {
+          try {
+            return GameParser.parse(uri.toString(), input);
+          } catch (final Exception e) {
+            log.log(Level.SEVERE, "Exception while parsing: " + uri, e);
+            return null;
+          }
+        });
   }
 }

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -93,9 +93,13 @@ public class HeadlessGameServer {
     log.info("Requested to change map to: " + gameName);
     // don't change mid-game and only if we have the game
     if (setupPanelModel.getPanel() != null && game == null && availableGames.hasGame(gameName)) {
-      gameSelectorModel.load(
-          availableGames.getGameData(gameName), availableGames.getGameFilePath(gameName));
-      log.info("Changed to game map: " + gameName);
+      availableGames
+          .parseGameData(gameName)
+          .ifPresent(
+              gameData -> {
+                gameSelectorModel.load(gameData, availableGames.getGameFilePath(gameName));
+                log.info("Changed to game map: " + gameName);
+              });
     } else {
       log.info(
           String.format(

--- a/game-core/src/main/java/org/triplea/game/server/MapZipReaderUtil.java
+++ b/game-core/src/main/java/org/triplea/game/server/MapZipReaderUtil.java
@@ -1,0 +1,49 @@
+package org.triplea.game.server;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URL;
+import java.net.URLClassLoader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import lombok.experimental.UtilityClass;
+import lombok.extern.java.Log;
+
+@UtilityClass
+@Log
+class MapZipReaderUtil {
+
+  /**
+   * Finds all game XMLs in a zip file. More specifically, given a zip file, finds all '*.xml' files
+   * that have a 'games/' folder on the zip file path.
+   */
+  List<URI> findGameXmlFilesInZip(final File zipFile) {
+    final List<URI> zipFiles = new ArrayList<>();
+
+    try (InputStream fis = new FileInputStream(zipFile);
+        ZipInputStream zis = new ZipInputStream(fis);
+        URLClassLoader loader = new URLClassLoader(new URL[] {zipFile.toURI().toURL()})) {
+      ZipEntry entry = zis.getNextEntry();
+      while (entry != null) {
+        if (entry.getName().contains("games/") && entry.getName().toLowerCase().endsWith(".xml")) {
+          Optional.ofNullable(loader.getResource(entry.getName()))
+              .map(url -> URI.create(url.toString().replace(" ", "%20")))
+              .ifPresent(zipFiles::add);
+        }
+        // we have to close the loader to allow files to be deleted on windows
+        zis.closeEntry();
+        entry = zis.getNextEntry();
+      }
+    } catch (final IOException e) {
+      log.log(Level.SEVERE, "Error reading zip file in: " + zipFile.getAbsolutePath(), e);
+    }
+    return zipFiles;
+  }
+}


### PR DESCRIPTION
This update simplifies how bots read the list of available maps and
drops code where bots would read maps from directories. We only deploy
zip files to bots, they do not need to read maps from directories.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
Launched a bot locally and verified map loading output
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
