### PR TITLE
Disable non-deterministic integ test: LobbyWebsocketClientIntegrationTest.java

### DIFF
--- a/lobby-server/src/test/java/org/triplea/http/server/LobbyWebsocketClientIntegrationTest.java
+++ b/lobby-server/src/test/java/org/triplea/http/server/LobbyWebsocketClientIntegrationTest.java
@@ -9,11 +9,45 @@ import java.net.URI;
 import java.time.Duration;
 import org.java_websocket.client.WebSocketClient;
 import org.java_websocket.handshake.ServerHandshake;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.triplea.http.client.web.socket.WebsocketPaths;
 import org.triplea.modules.http.LobbyServerTest;
 
+@Disabled // Disabled until this can be made more reliable, seeing failure listed below
+/*
+   ERROR [2020-09-06 01:52:03,515] org.triplea.web.socket.WebSocketMessagingBus: Error-id processing
+      websocket message, returning an error message to user. Error id:
+      fc66dc4b-61d8-4f87-9444-a00ba418c008
+   ! java.nio.channels.ClosedChannelException: null
+   ! at org.eclipse.jetty.io.WriteFlusher.onClose(WriteFlusher.java:492)
+   ! at org.eclipse.jetty.io.AbstractEndPoint.onClose(AbstractEndPoint.java:353)
+   ! at org.eclipse.jetty.io.ChannelEndPoint.onClose(ChannelEndPoint.java:215)
+   ! at org.eclipse.jetty.io.AbstractEndPoint.doOnClose(AbstractEndPoint.java:225)
+   ! at org.eclipse.jetty.io.AbstractEndPoint.shutdownOutput(AbstractEndPoint.java:157)
+   ! at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.disconnect
+      (AbstractWebSocketConnection.java:327)
+   ! at org.eclipse.jetty.websocket.common.io.DisconnectCallback.failed(DisconnectCallback.java:36)
+   ! at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.close
+      (AbstractWebSocketConnection.java:200)
+   ! at org.eclipse.jetty.websocket.common.io.AbstractWebSocketConnection.onFillable
+     (AbstractWebSocketConnection.java:452)
+   ! at org.eclipse.jetty.io.AbstractConnection$ReadCallback.succeeded(AbstractConnection.java:305)
+   ! at org.eclipse.jetty.io.FillInterest.fillable(FillInterest.java:103)
+   ! at org.eclipse.jetty.io.ChannelEndPoint$2.run(ChannelEndPoint.java:117)
+   ! at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.runTask(EatWhatYouKill.java:333)
+   ! at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.doProduce(EatWhatYouKill.java:310)
+   ! at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.tryProduce(EatWhatYouKill.java:168)
+   ! at org.eclipse.jetty.util.thread.strategy.EatWhatYouKill.run(EatWhatYouKill.java:126)
+   ! at org.eclipse.jetty.util.thread.ReservedThreadExecutor$ReservedThread.run
+      (ReservedThreadExecutor.java:366)
+   ! at org.eclipse.jetty.util.thread.QueuedThreadPool.runJob(QueuedThreadPool.java:698)
+   ! at org.eclipse.jetty.util.thread.QueuedThreadPool$Runner.run(QueuedThreadPool.java:804)
+   ! at java.base/java.lang.Thread.run(Thread.java:834)
+   INFO  [2020-09-06 01:52:03,521] org.triplea.dropwizard.test.DropwizardServerExtension:
+       Running database cleanup..
+*/
 @DataSet(value = LobbyServerTest.LOBBY_USER_DATASET, useSequenceFiltering = false)
 class LobbyWebsocketClientIntegrationTest extends LobbyServerTest {
 

--- a/lobby-server/src/test/java/org/triplea/modules/game/GameListingWebsocketIntegrationTest.java
+++ b/lobby-server/src/test/java/org/triplea/modules/game/GameListingWebsocketIntegrationTest.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.function.Consumer;
 import lombok.RequiredArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -34,6 +35,23 @@ import org.triplea.modules.game.lobby.watcher.LobbyWatcherController;
 import org.triplea.modules.http.AllowedUserRole;
 import org.triplea.modules.http.LobbyServerTest;
 
+
+/*
+GameListingWebsocketIntegrationTest > Post a game, verify listener is notified FAILED
+    Wanted but not invoked:
+    gameUpdatedListener.accept(
+        LobbyGameListing(gameId=690deee5-8cf7-4815-82b3-d0cc9424fa53,
+        lobbyGame=LobbyGame(hostAddress=127.0.0.1, hostPort=12, hostName=name,
+         mapName=map, playerCount=3, gameRound=1, epochMilliTimeStarted=1599358874438,
+         mapVersion=1, passworded=false, status=Waiting For Players, comments=comments))
+    );
+    -> at org.triplea.modules.game.GameListingWebsocketIntegrationTest.verifyPostGame(
+       GameListingWebsocketIntegrationTest.java:94)
+    Actually, there were zero interactions with this mock.
+        at org.triplea.modules.game.GameListingWebsocketIntegrationTest.verifyPostGame(
+        GameListingWebsocketIntegrationTest.java:94)
+ */
+@Disabled // Disabled due to flakiness, the above error is frequenlty seen and needs to be resolved.
 @ExtendWith(MockitoExtension.class)
 @DataSet(value = "integration/game_hosting_api_key.yml,", useSequenceFiltering = false)
 @RequiredArgsConstructor

--- a/lobby-server/src/test/java/org/triplea/modules/game/GameListingWebsocketIntegrationTest.java
+++ b/lobby-server/src/test/java/org/triplea/modules/game/GameListingWebsocketIntegrationTest.java
@@ -35,7 +35,6 @@ import org.triplea.modules.game.lobby.watcher.LobbyWatcherController;
 import org.triplea.modules.http.AllowedUserRole;
 import org.triplea.modules.http.LobbyServerTest;
 
-
 /*
 GameListingWebsocketIntegrationTest > Post a game, verify listener is notified FAILED
     Wanted but not invoked:


### PR DESCRIPTION
This test started failing frequently after we made the http server integration tests
much faster. Presumably what is happening is the server is shutting down much faster
now which leaves websocket communication still in flight. This is likely an interplay
with websocket communication happening on background threads and then getting
closed now quickly as the server shuts down. (That is a theory, what is known
though is thesse tests are failing quite frequently in CI, around 1 or 2 times out of 3)


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
