### PR TITLE
Cleanup unused game parser methods (follow up to (#7552))

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
@@ -139,29 +139,6 @@ public final class GameParser {
         String.format("map name: '%s', game name: '%s', %s", mapName, gameName, message), cause);
   }
 
-  /**
-   * Performs a shallow parse of the game definition contained in the specified stream.
-   *
-   * @return A partial {@link GameData} instance that can be used to display metadata about the game
-   *     (e.g. when displaying all available maps); it cannot be used to play the game.
-   */
-  @Nonnull
-  public static GameData parseShallow(final String mapName, final InputStream stream)
-      throws GameParseException, EngineVersionException {
-    checkNotNull(mapName);
-    checkNotNull(stream);
-
-    return new GameParser(new GameData(), mapName).parseShallow(stream);
-  }
-
-  @Nonnull
-  GameData parseShallow(final InputStream stream)
-      throws GameParseException, EngineVersionException {
-    final Element root = XmlReader.parseDom(mapName, stream, errorsSax);
-    parseMapProperties(root);
-    return data;
-  }
-
   private void parseMapProperties(final Element root)
       throws GameParseException, EngineVersionException {
     // mandatory fields


### PR DESCRIPTION
After applying a strangle to 'parseShallow', the strangled methods in
GameParser were not removed. They can be removed now as nothing
calls them.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
