### PR TITLE
Increase code climate method length threshold from 30 to 50 lines

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -12,7 +12,7 @@ checks:
       threshold: 7
   method-lines:
     config:
-      threshold: 30
+      threshold: 50
   similar-code:
     config:
       threshold: 80


### PR DESCRIPTION
30 lines is quite short methods. This update increases the threshold
to 50 lines to reduce false positives and flag the things that we
probably really should fix.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
