### PR TITLE
Simplify map loading responsibility

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
@@ -104,24 +104,19 @@ public final class GameParser {
    * @return A complete {@link GameData} instance that can be used to play the game.
    */
   public static Optional<GameData> parse(final URI mapUri) {
-
-    final Optional<InputStream> inputStream = UrlStreams.openStream(mapUri);
-    if (inputStream.isEmpty()) {
-      return Optional.empty();
-    }
-
-    try (InputStream input = inputStream.get()) {
-      return Optional.of(parse(mapUri.toString(), input, new XmlGameElementMapper()));
-    } catch (final EngineVersionException e) {
-      log.log(Level.WARNING, "Game engine not compatible with: " + mapUri, e);
-      return Optional.empty();
-    } catch (final GameParseException e) {
-      log.log(Level.WARNING, "Could not parse:" + mapUri, e);
-      return Optional.empty();
-    } catch (final IOException e) {
-      log.log(Level.SEVERE, "Error opening file: " + mapUri + ", " + e.getMessage(), e);
-      return Optional.empty();
-    }
+    return UrlStreams.openStream(
+        mapUri,
+        inputStream -> {
+          try {
+            return parse(mapUri.toString(), inputStream, new XmlGameElementMapper());
+          } catch (final EngineVersionException e) {
+            log.log(Level.WARNING, "Game engine not compatible with: " + mapUri, e);
+            return null;
+          } catch (final GameParseException e) {
+            log.log(Level.WARNING, "Could not parse:" + mapUri, e);
+            return null;
+          }
+        });
   }
 
   @Nonnull

--- a/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
@@ -44,7 +44,6 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.GenericTechAdvance;
 import games.strategy.triplea.delegate.TechAdvance;
 import games.strategy.triplea.formatter.MyFormatter;
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;

--- a/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
@@ -44,7 +44,9 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.GenericTechAdvance;
 import games.strategy.triplea.delegate.TechAdvance;
 import games.strategy.triplea.formatter.MyFormatter;
+import java.io.IOException;
 import java.io.InputStream;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -52,6 +54,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.function.Function;
@@ -61,6 +64,7 @@ import java.util.stream.IntStream;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import lombok.extern.java.Log;
+import org.triplea.java.UrlStreams;
 import org.triplea.util.Tuple;
 import org.triplea.util.Version;
 import org.w3c.dom.Element;
@@ -99,10 +103,25 @@ public final class GameParser {
    *
    * @return A complete {@link GameData} instance that can be used to play the game.
    */
-  @Nonnull
-  public static GameData parse(final String mapName, final InputStream stream)
-      throws GameParseException, EngineVersionException {
-    return parse(mapName, stream, new XmlGameElementMapper());
+  public static Optional<GameData> parse(final URI mapUri) {
+
+    final Optional<InputStream> inputStream = UrlStreams.openStream(mapUri);
+    if (inputStream.isEmpty()) {
+      return Optional.empty();
+    }
+
+    try (InputStream input = inputStream.get()) {
+      return Optional.of(parse(mapUri.toString(), input, new XmlGameElementMapper()));
+    } catch (final EngineVersionException e) {
+      log.log(Level.WARNING, "Game engine not compatible with: " + mapUri, e);
+      return Optional.empty();
+    } catch (final GameParseException e) {
+      log.log(Level.WARNING, "Could not parse:" + mapUri, e);
+      return Optional.empty();
+    } catch (final IOException e) {
+      log.log(Level.SEVERE, "Error opening file: " + mapUri + ", " + e.getMessage(), e);
+      return Optional.empty();
+    }
   }
 
   @Nonnull

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -5,7 +5,6 @@ import static org.triplea.swing.SwingComponents.DialogWithLinksTypes;
 
 import games.strategy.engine.ClientContext;
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.GameParseException;
 import games.strategy.engine.data.properties.IEditableProperty;
 import games.strategy.engine.data.properties.PropertiesUi;
 import games.strategy.engine.framework.HeadlessAutoSaveType;
@@ -365,16 +364,7 @@ public final class GameSelectorPanel extends JPanel implements Observer {
           GameChooser.chooseGame(
               JOptionPane.getFrameForComponent(this), gameChooserModel, model.getGameName());
       if (entry != null) {
-
-        BackgroundTaskRunner.runInBackground(
-            "Loading map...",
-            () -> {
-              try {
-                model.load(entry.getUri(), entry.fullyParseGameData());
-              } catch (final GameParseException e) {
-                model.load(entry.getUri(), null);
-              }
-            });
+        BackgroundTaskRunner.runInBackground("Loading map...", () -> model.load(entry.getUri()));
         // warning: NPE check is not to protect against concurrency, another thread could still null
         // out game data.
         // The NPE check is to protect against the case where there are errors loading game, in

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/DefaultGameChooserEntry.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/DefaultGameChooserEntry.java
@@ -8,10 +8,8 @@ import java.net.URI;
 import java.util.Optional;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.extern.java.Log;
 import org.triplea.java.UrlStreams;
 
-@Log
 @EqualsAndHashCode(of = "uri")
 @Getter
 public class DefaultGameChooserEntry implements Comparable<DefaultGameChooserEntry> {

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/DefaultGameChooserEntry.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/DefaultGameChooserEntry.java
@@ -1,15 +1,11 @@
 package games.strategy.engine.framework.ui;
 
-import games.strategy.engine.data.EngineVersionException;
-import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParseException;
-import games.strategy.engine.data.gameparser.GameParser;
 import games.strategy.engine.data.gameparser.ShallowGameParser;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.Optional;
-import java.util.logging.Level;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.extern.java.Log;
@@ -23,8 +19,7 @@ public class DefaultGameChooserEntry implements Comparable<DefaultGameChooserEnt
   private final URI uri;
   private String gameName;
 
-  public DefaultGameChooserEntry(final URI uri)
-      throws IOException, GameParseException, EngineVersionException {
+  public DefaultGameChooserEntry(final URI uri) throws IOException, GameParseException {
     this.uri = uri;
 
     final Optional<InputStream> inputStream = UrlStreams.openStream(uri);
@@ -35,26 +30,6 @@ public class DefaultGameChooserEntry implements Comparable<DefaultGameChooserEnt
 
     try (InputStream input = inputStream.get()) {
       gameName = ShallowGameParser.readGameName(uri.toString(), input);
-    }
-  }
-
-  public GameData fullyParseGameData() throws GameParseException {
-    final Optional<InputStream> inputStream = UrlStreams.openStream(uri);
-    if (inputStream.isEmpty()) {
-      return null;
-    }
-
-    try (InputStream input = inputStream.get()) {
-      return GameParser.parse(uri.toString(), input);
-    } catch (final EngineVersionException e) {
-      log.log(Level.WARNING, "Game engine not compatible with: " + uri, e);
-      throw new GameParseException(e);
-    } catch (final GameParseException e) {
-      log.log(Level.WARNING, "Could not parse:" + uri, e);
-      throw e;
-    } catch (final Exception e) {
-      log.log(Level.WARNING, "Could not parse:" + uri, e);
-      throw new GameParseException(e);
     }
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
@@ -1,7 +1,7 @@
 package games.strategy.engine.framework.ui;
 
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.GameParseException;
+import games.strategy.engine.data.gameparser.GameParser;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -158,11 +158,9 @@ public class GameChooser extends JDialog {
       return "";
     }
 
-    final GameData data;
-    try {
-      data = gameChooserEntry.fullyParseGameData();
-    } catch (final GameParseException e) {
-      return "Error reading file: " + e.getMessage();
+    final GameData data = GameParser.parse(gameChooserEntry.getUri()).orElse(null);
+    if (data == null) {
+      return "Error reading file.. ";
     }
 
     final StringBuilder notes = new StringBuilder();

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
@@ -89,11 +89,7 @@ public class GameChooser extends JDialog {
     notesPanel.setEditable(false);
     notesPanel.setContentType("text/html");
     notesPanel.setForeground(Color.BLACK);
-    try {
-      notesPanel.setText(buildGameNotesText(gameList.getSelectedValue()));
-    } catch (final GameParseException e) {
-      notesPanel.setText("Error reading file: " + e.getMessage());
-    }
+    notesPanel.setText(buildGameNotesText(gameList.getSelectedValue()));
 
     final JPanel infoPanel = new JPanel();
     infoPanel.setLayout(new BorderLayout());
@@ -124,12 +120,7 @@ public class GameChooser extends JDialog {
     gameList.addListSelectionListener(
         e -> {
           if (!e.getValueIsAdjusting()) {
-
-            try {
-              notesPanel.setText(buildGameNotesText(gameList.getSelectedValue()));
-            } catch (final GameParseException gameParseException) {
-              notesPanel.setText("Error reading game file: " + gameParseException.getMessage());
-            }
+            notesPanel.setText(buildGameNotesText(gameList.getSelectedValue()));
             // scroll to the top of the notes screen
             SwingUtilities.invokeLater(
                 () -> notesPanel.scrollRectToVisible(new Rectangle(0, 0, 0, 0)));
@@ -162,12 +153,18 @@ public class GameChooser extends JDialog {
     return chooser.chosen;
   }
 
-  private static String buildGameNotesText(final DefaultGameChooserEntry gameChooserEntry)
-      throws GameParseException {
+  private static String buildGameNotesText(final DefaultGameChooserEntry gameChooserEntry) {
     if (gameChooserEntry == null) {
       return "";
     }
-    final GameData data = gameChooserEntry.fullyParseGameData();
+
+    final GameData data;
+    try {
+      data = gameChooserEntry.fullyParseGameData();
+    } catch (final GameParseException e) {
+      return "Error reading file: " + e.getMessage();
+    }
+
     final StringBuilder notes = new StringBuilder();
     notes.append("<h1>").append(data.getGameName()).append("</h1>");
     final String mapNameDir = data.getProperties().get("mapName", "");
@@ -178,10 +175,6 @@ public class GameChooser extends JDialog {
     notes.append("<p></p>");
     final String trimmedNotes = data.getProperties().get("notes", "").trim();
     if (!trimmedNotes.isEmpty()) {
-      // UiContext resource loader should be null (or potentially is still the last game
-      // we played's loader),
-      // so we send the map dir name so that our localizing of image links can get a new resource
-      // loader if needed
       notes.append(LocalizeHtml.localizeImgLinksInHtml(trimmedNotes, mapNameDir));
     }
     return notes.toString();

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.framework.ui;
 
 import games.strategy.engine.ClientFileSystemHelper;
-import games.strategy.engine.data.EngineVersionException;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -143,13 +142,8 @@ public final class GameChooserModel extends DefaultListModel<DefaultGameChooserE
   private static Optional<DefaultGameChooserEntry> newGameChooserEntry(final URI uri) {
     try {
       return Optional.of(new DefaultGameChooserEntry(uri));
-    } catch (final EngineVersionException e) {
-      // suppress any maps that have version problems (map requires a min version
-      // not compatible with current version). Returning empty here should
-      // remove such maps from the map selection list.
-      return Optional.empty();
     } catch (final Exception e) {
-      log.log(Level.SEVERE, "Could not parse: " + uri, e);
+      log.log(Level.INFO, "Invalid map: " + uri + ", " + e.getMessage(), e);
     }
     return Optional.empty();
   }

--- a/game-core/src/main/java/org/triplea/game/server/AvailableGames.java
+++ b/game-core/src/main/java/org/triplea/game/server/AvailableGames.java
@@ -1,10 +1,7 @@
 package org.triplea.game.server;
 
 import games.strategy.engine.ClientFileSystemHelper;
-import games.strategy.engine.data.EngineVersionException;
-import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameParseException;
-import games.strategy.engine.data.gameparser.GameParser;
 import games.strategy.engine.data.gameparser.ShallowGameParser;
 import java.io.File;
 import java.net.URI;
@@ -73,7 +70,7 @@ final class AvailableGames {
         inputStream -> {
           try {
             return ShallowGameParser.readGameName(uri.toString(), inputStream);
-          } catch (final GameParseException | EngineVersionException e) {
+          } catch (final GameParseException e) {
             log.log(Level.SEVERE, "Exception while parsing: " + uri, e);
             return null;
           }

--- a/game-core/src/main/java/org/triplea/game/server/AvailableGames.java
+++ b/game-core/src/main/java/org/triplea/game/server/AvailableGames.java
@@ -1,8 +1,6 @@
 package org.triplea.game.server;
 
 import games.strategy.engine.ClientFileSystemHelper;
-import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.gameparser.GameParser;
 import games.strategy.engine.data.gameparser.ShallowGameParser;
 import java.io.File;
 import java.io.FileInputStream;
@@ -136,26 +134,7 @@ final class AvailableGames {
    * @param gameName The name of the game whose file path is to be retrieved; may be {@code null}.
    * @return The path to the game file; or {@code null} if the game is not available.
    */
-  String getGameFilePath(final String gameName) {
-    return Optional.ofNullable(availableGames.get(gameName)).map(Object::toString).orElse(null);
-  }
-
-  /** Can return null. */
-  GameData getGameData(final String gameName) {
-    return Optional.ofNullable(availableGames.get(gameName))
-        .flatMap(AvailableGames::parse)
-        .orElse(null);
-  }
-
-  private static Optional<GameData> parse(final URI uri) {
-    final Optional<InputStream> inputStream = UrlStreams.openStream(uri);
-    if (inputStream.isPresent()) {
-      try (InputStream input = inputStream.get()) {
-        return Optional.of(GameParser.parse(uri.toString(), input));
-      } catch (final Exception e) {
-        log.log(Level.SEVERE, "Exception while parsing: " + uri.toString(), e);
-      }
-    }
-    return Optional.empty();
+  URI getGameFilePath(final String gameName) {
+    return availableGames.get(gameName);
   }
 }

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -93,8 +93,7 @@ public class HeadlessGameServer {
     log.info("Requested to change map to: " + gameName);
     // don't change mid-game and only if we have the game
     if (setupPanelModel.getPanel() != null && game == null && availableGames.hasGame(gameName)) {
-      gameSelectorModel.load(
-          availableGames.getGameData(gameName), availableGames.getGameFilePath(gameName));
+      gameSelectorModel.load(availableGames.getGameFilePath(gameName));
       log.info("Changed to game map: " + gameName);
     } else {
       log.info(

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
@@ -34,8 +34,7 @@ public class HeadlessLaunchAction implements LaunchAction {
         gameSelectorModel.load(autoSaveFile);
       }
     } catch (final Exception e1) {
-      log.log(Level.SEVERE, "Failed to load game", e1);
-      gameSelectorModel.resetGameDataToNull();
+      log.log(Level.SEVERE, "Failed to load game: " + e1.getMessage(), e1);
     }
   }
 

--- a/game-core/src/test/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModelTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModelTest.java
@@ -17,6 +17,7 @@ import games.strategy.engine.framework.startup.mc.ClientModel;
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import java.net.URI;
 import java.util.Observer;
+import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -99,15 +100,6 @@ class GameSelectorModelTest extends AbstractClientSettingTestCase {
   }
 
   @Test
-  void testResetGameDataToNull() {
-    assertHasEmptyData(testObj);
-    this.testObjectSetMockGameData();
-
-    testObj.resetGameDataToNull();
-    assertHasEmptyData(testObj);
-  }
-
-  @Test
   void testCanSelect() {
     assertThat(testObj.isCanSelect(), is(true));
     testObj.setCanSelect(false);
@@ -135,8 +127,9 @@ class GameSelectorModelTest extends AbstractClientSettingTestCase {
   @Test
   void testLoadFromNewGameChooserEntry() throws Exception {
     prepareMockGameDataExpectations();
+    testObj = new GameSelectorModel(uri -> Optional.of(mockGameData));
 
-    testObj.load(new URI("abc"), mockGameData);
+    testObj.load(new URI("abc"));
 
     assertThat(testObj.getFileName(), is("-"));
     assertThat(testObj.getGameData(), sameInstance(mockGameData));
@@ -146,13 +139,14 @@ class GameSelectorModelTest extends AbstractClientSettingTestCase {
   @Test
   void saveGameNameGetsResetWhenLoadingOtherMap() throws Exception {
     final String testFileName = "someFileName";
+    testObj = new GameSelectorModel(uri -> Optional.of(mockGameData));
     when(mockGameData.getSequence()).thenReturn(mock(GameSequence.class));
     when(mockGameData.getGameVersion()).thenReturn(new Version(0, 0, 0));
     when(mockGameData.getGameName()).thenReturn("Dummy name");
     testObj.load(mockGameData, testFileName);
     assertThat(testObj.getFileName(), is(testFileName));
 
-    testObj.load(new URI("abc"), mockGameData);
+    testObj.load(new URI("abc"));
     assertThat(testObj.getFileName(), is(not(testFileName)));
   }
 
@@ -198,8 +192,6 @@ class GameSelectorModelTest extends AbstractClientSettingTestCase {
     prepareMockGameDataExpectations();
     testObj.load(mockGameData, fakeFileName);
     assertThat(testObj.getFileName(), is(fakeFileName));
-    testObj.resetGameDataToNull();
-    assertThat(testObj.getFileName(), is("-"));
   }
 
   @Test

--- a/smoke-testing/src/test/java/games/strategy/engine/data/ParseGameXmlsTest.java
+++ b/smoke-testing/src/test/java/games/strategy/engine/data/ParseGameXmlsTest.java
@@ -1,26 +1,27 @@
 package games.strategy.engine.data;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import com.github.npathai.hamcrestopt.OptionalMatchers;
 import games.strategy.engine.data.gameparser.GameParser;
 import java.io.File;
-import java.io.FileInputStream;
-import java.io.InputStream;
 import java.util.Collection;
+import java.util.Optional;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.triplea.test.common.Integration;
 
-@SuppressWarnings("unused")
 @Integration
 class ParseGameXmlsTest {
 
   @ParameterizedTest
   @MethodSource
-  void parseGameFiles(final File xmlFile) throws Exception {
-    try (InputStream inputStream = new FileInputStream(xmlFile)) {
-      GameParser.parse(xmlFile.getAbsolutePath(), inputStream);
-    }
+  void parseGameFiles(final File xmlFile) {
+    final Optional<GameData> result = GameParser.parse(xmlFile.toURI());
+    assertThat(result, OptionalMatchers.isPresent());
   }
 
+  @SuppressWarnings("unused")
   static Collection<File> parseGameFiles() {
     return TestDataFileLister.listFilesInTestResourcesDirectory("map-xmls");
   }


### PR DESCRIPTION
commit 76b918d0a5bdcca8bef3c07f02bafd436df01db5

    Simplify, consolidate error handling for game parse exception when
    building game notes (for select map window)

commit a1d7e935697675e4331b7f60da88720b51970d92

    Simplify, push map parsing error handling to GameParser and game loading to GameChooserModel
    
    The push of responsibility offloads responsibility and simplifies clients.
    We also relax the error handling to not do things like reset the default game


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
