### PR TITLE
Remove custom check for legacy API usage

### DIFF
--- a/.travis/stages/verify/code-convention-checks/check-custom-style
+++ b/.travis/stages/verify/code-convention-checks/check-custom-style
@@ -28,7 +28,6 @@ status=0
 function main() {
   favorJava9CollectionsApi
   #referToCollectionsByInterfaceType
-  avoidLegacyApi
   removeUnusedLogAnnotations
   databaseNamesAreLowerSnakeCase
   databaseTablesAreSingular
@@ -76,17 +75,6 @@ function referToCollectionsByInterfaceType() {
 
   while read -r file; do
     grep --color=auto -EHn -f "$script_dir/style.include/concrete-collection-types" "$file" && status=1 && found=1
-  done <<< "$(cat "$javaFiles")"
-  
-  displayResult "$found"
-}
-
-function avoidLegacyApi() {
-  title "Do not use legacy API tools like Vector"
-  local found=0
-
-  while read -r file; do
-    grep --color=auto -Hn -f "$script_dir/style.include/legacy-api" "$file" && status=1 && found=1
   done <<< "$(cat "$javaFiles")"
   
   displayResult "$found"

--- a/.travis/stages/verify/code-convention-checks/style.include/legacy-api
+++ b/.travis/stages/verify/code-convention-checks/style.include/legacy-api
@@ -1,2 +1,0 @@
-java.util.Hashtable
-java.util.Vector


### PR DESCRIPTION
Most developers are not going to use Vector or the old Hashtable,
we can save a small amount of build time by not checking for this.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
