### PR TITLE
Suppress error-prone java.lang clash warning for XML types

### DIFF
--- a/map-data/src/main/java/org/triplea/map/data/elements/PropertyList.java
+++ b/map-data/src/main/java/org/triplea/map/data/elements/PropertyList.java
@@ -33,11 +33,14 @@ public class PropertyList {
       @BodyText private java.lang.String data;
     }
 
+    @SuppressWarnings("JavaLangClash")
     public static class Boolean {}
 
+    @SuppressWarnings("JavaLangClash")
     public static class String {}
 
     @Getter
+    @SuppressWarnings("JavaLangClash")
     public static class Number {
       @Attribute private int min;
       @Attribute private int max;


### PR DESCRIPTION
Regrettably we have XML tags named "String" and "Number", we cannot
change the tag name. This update suppresses the error prone warning
to avoid compilation warning messages that we cannot readily fixed.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
