### PR TITLE
Update: Improve map parsing time - more efficient player attachment lookup

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractTriggerAttachment.java
@@ -51,16 +51,11 @@ public abstract class AbstractTriggerAttachment extends AbstractConditionsAttach
    */
   public static CompositeChange triggerSetUsedForThisRound(final GamePlayer player) {
     final CompositeChange change = new CompositeChange();
-    for (final TriggerAttachment ta : TriggerAttachment.getTriggers(player, null)) {
-      if (ta.getUsedThisRound()) {
-        final int currentUses = ta.getUses();
-        if (currentUses > 0) {
-          change.add(
-              ChangeFactory.attachmentPropertyChange(
-                  ta, Integer.toString(currentUses - 1), "uses"));
-          change.add(ChangeFactory.attachmentPropertyChange(ta, false, "usedThisRound"));
-        }
-      }
+    for (final TriggerAttachment ta :
+        TriggerAttachment.getTriggers(player, ta -> ta.getUsedThisRound() && ta.getUses() > 0)) {
+      change.add(
+          ChangeFactory.attachmentPropertyChange(ta, Integer.toString(ta.getUses() - 1), "uses"));
+      change.add(ChangeFactory.attachmentPropertyChange(ta, false, "usedThisRound"));
     }
     return change;
   }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -353,13 +353,9 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
     }
     TriggerAttachment trigger = null;
     for (final GamePlayer player : getData().getPlayerList().getPlayers()) {
-      for (final TriggerAttachment ta : getTriggers(player, null)) {
-        if (ta.getName().equals(s[0])) {
-          trigger = ta;
-          break;
-        }
-      }
-      if (trigger != null) {
+      final TriggerAttachment triggerAttachment = (TriggerAttachment) player.getAttachment(s[0]);
+      if (triggerAttachment != null) {
+        trigger = triggerAttachment;
         break;
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -1,6 +1,7 @@
 package games.strategy.triplea.attachments;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.Change;
@@ -51,6 +52,7 @@ import java.util.function.Predicate;
 import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import lombok.extern.java.Log;
 import org.triplea.java.ObjectUtils;
 import org.triplea.java.PredicateBuilder;
@@ -180,9 +182,10 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
    */
   static Set<TriggerAttachment> getTriggers(
       final GamePlayer player, final Predicate<TriggerAttachment> cond) {
+    Preconditions.checkNotNull(cond);
     final Set<TriggerAttachment> trigs = new HashSet<>();
     for (final IAttachment a : player.getAttachments().values()) {
-      if (a instanceof TriggerAttachment && (cond == null || cond.test((TriggerAttachment) a))) {
+      if (a instanceof TriggerAttachment && cond.test((TriggerAttachment) a)) {
         trigs.add((TriggerAttachment) a);
       }
     }
@@ -222,11 +225,12 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
 
   public static Set<TriggerAttachment> collectForAllTriggersMatching(
       final Set<GamePlayer> players, final Predicate<TriggerAttachment> triggerMatch) {
-    final Set<TriggerAttachment> toFirePossible = new HashSet<>();
-    for (final GamePlayer player : players) {
-      toFirePossible.addAll(TriggerAttachment.getTriggers(player, triggerMatch));
-    }
-    return toFirePossible;
+    Preconditions.checkNotNull(triggerMatch);
+
+    return players.stream()
+        .map(player -> TriggerAttachment.getTriggers(player, triggerMatch))
+        .flatMap(Collection::stream)
+        .collect(Collectors.toSet());
   }
 
   public static Map<ICondition, Boolean> collectTestsForAllTriggers(
@@ -2470,13 +2474,9 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
         // numberOfTimes:useUses:testUses:testConditions:testChance
         TriggerAttachment toFire = null;
         for (final GamePlayer player : data.getPlayerList().getPlayers()) {
-          for (final TriggerAttachment ta : TriggerAttachment.getTriggers(player, null)) {
-            if (ta.getName().equals(tuple.getFirst())) {
-              toFire = ta;
-              break;
-            }
-          }
-          if (toFire != null) {
+          final TriggerAttachment ta = (TriggerAttachment) player.getAttachment(tuple.getFirst());
+          if (ta != null) {
+            toFire = ta;
             break;
           }
         }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -58,13 +58,9 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
     }
     TriggerAttachment trigger = null;
     for (final GamePlayer player : getData().getPlayerList().getPlayers()) {
-      for (final TriggerAttachment ta : TriggerAttachment.getTriggers(player, null)) {
-        if (ta.getName().equals(s[0])) {
-          trigger = ta;
-          break;
-        }
-      }
-      if (trigger != null) {
+      final TriggerAttachment ta = (TriggerAttachment) player.getAttachment(s[0]);
+      if(ta != null) {
+        trigger = ta;
         break;
       }
     }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -59,7 +59,7 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
     TriggerAttachment trigger = null;
     for (final GamePlayer player : getData().getPlayerList().getPlayers()) {
       final TriggerAttachment ta = (TriggerAttachment) player.getAttachment(s[0]);
-      if(ta != null) {
+      if (ta != null) {
         trigger = ta;
         break;
       }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UserActionAttachment.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -108,9 +109,8 @@ public class UserActionAttachment extends AbstractUserActionAttachment {
       // numberOfTimes:useUses:testUses:testConditions:testChance
       final Optional<TriggerAttachment> optionalTrigger =
           data.getPlayerList().getPlayers().stream()
-              .map(player -> TriggerAttachment.getTriggers(player, null))
-              .flatMap(Collection::stream)
-              .filter(ta -> ta.getName().equals(tuple.getFirst()))
+              .map(player -> (TriggerAttachment) player.getAttachment(tuple.getFirst()))
+              .filter(Objects::nonNull)
               .findAny();
       if (optionalTrigger.isEmpty()) {
         continue;

--- a/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/TriggerAttachmentTest.java
@@ -608,7 +608,8 @@ class TriggerAttachmentTest {
 
         triggerToBeFiredTriggerAttachment =
             new TriggerAttachment("triggerToBeFired", gamePlayer, gameData);
-        gamePlayer.addAttachment("somekey", triggerToBeFiredTriggerAttachment);
+        gamePlayer.addAttachment(
+            triggerToBeFiredTriggerAttachment.getName(), triggerToBeFiredTriggerAttachment);
 
         final TechnologyFrontier gameTechnologyFrontier = gameData.getTechnologyFrontier();
         gameTechnologyFrontier.addAdvance(


### PR DESCRIPTION
This update improves game parsing speed by increasing the efficiency of
attachment processing. This update converts the attachment processing algorithm,
used on full-game-parse, from a runtime of O(p * a), where p is number of players
and 'a' is the number of attachments per player to O(p).

The core of this update is taking advantage that we map attachments by their
name and we can do a O(1) lookup by name. The previous algorithm iterated over
every attachment looking an attachment with a given name.

For full map parsing, here are some example performance numbers before
and after this update:
- War of the Relics: 4751 ms -> 1569.8 ms
- World at war:      3200 ms -> 1102.7 ms
- World of Warcraft: 2783 ms -> 1147.1 ms


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing

- manual tested while getting performance numbers
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->UPDATE|Improved map loading performance (about 3x times faster)<!--END_RELEASE_NOTE-->
