### PR TITLE
Test & Documentation Update: Document missing attribute and missing list behavior

### DIFF
--- a/xml-reader/README.md
+++ b/xml-reader/README.md
@@ -75,3 +75,10 @@ Library library = mapper.mapXmlToObject(mapper);
 - Model POJO objects must have a no-arg constructor.
 - Variables annotated with `@BodyText` can have any name
 - List parsing maintains XML ordering..
+
+
+### Missing XML element behavior
+
+- If a `@Tag` is not present in XML it is null.
+- If a `@TagList` element is not present in XML the list is initialized to empty.
+- If an `@Attribute` is not present in XML the value is initialized.

--- a/xml-reader/src/test/java/org/triplea/generic/xml/reader/SimpleLibraryExampleTest.java
+++ b/xml-reader/src/test/java/org/triplea/generic/xml/reader/SimpleLibraryExampleTest.java
@@ -2,6 +2,7 @@ package org.triplea.generic.xml.reader;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 
@@ -27,14 +28,20 @@ public class SimpleLibraryExampleTest extends AbstractXmlMapperTest {
     @Tag private MostRead mostReadExample;
     @Tag private Inventory libraryInventory;
 
+    @TagList private List<NotPresentListElement> exampleOfListThatIsNotPresent;
+
     @Getter
     public static class MostRead {
       @Attribute private String updated;
       @BodyText private String bodyText;
     }
 
+    public static class NotPresentListElement {}
+
     @Getter
     public static class Inventory {
+      @Attribute private String attributeThatDoesNotExist;
+
       @Attribute private String type;
 
       @TagList private List<Book> books;
@@ -59,8 +66,10 @@ public class SimpleLibraryExampleTest extends AbstractXmlMapperTest {
 
     assertThat(library, is(notNullValue()));
     assertThat(library.mostReadExample, is(notNullValue()));
+    assertThat(library.exampleOfListThatIsNotPresent, is(empty()));
 
     assertThat(library.libraryInventory, is(notNullValue()));
+    assertThat(library.libraryInventory.attributeThatDoesNotExist, is(""));
     assertThat(library.libraryInventory.type, is("available"));
     assertThat(library.libraryInventory.books, hasSize(2));
     assertThat(library.libraryInventory.books.get(0), is(notNullValue()));


### PR DESCRIPTION
Document and test the following expectations:
- If a @TagList element is not present in XML the list is initialized to empty.
- If an @Attribute is not present in XML the value is initialized.
- If a @Tag is not present in XML it is null.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
