### PR TITLE
Remove bot05, SSH connectivity to it is not working

### DIFF
--- a/infrastructure/ansible/inventory/prod2
+++ b/infrastructure/ansible/inventory/prod2
@@ -14,7 +14,6 @@ dropwizardHosts
 support01.triplea-game.org
 
 [botHosts]
-prod2-bot05.triplea-game.org  bot_prefix=5 bot_name=Texas
 prod2-bot06.triplea-game.org  bot_prefix=6 bot_name=California
 prod2-bot07.triplea-game.org  bot_prefix=7 bot_name=Jersey
 prod2-bot08.triplea-game.org  bot_prefix=8 bot_name=London


### PR DESCRIPTION
The bot apparently is still serving games, but SSH to it fails.
To remedy, the bot has been deleted in linode, it now no longer
exists.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
