### PR TITLE
Fix validation error messaging (if validation were to fail, we'd get a NPE)

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParsingValidation.java
+++ b/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParsingValidation.java
@@ -56,8 +56,7 @@ class GameParsingValidation {
       // in relation to every player
       for (final GamePlayer player2 : data.getPlayerList()) {
         // See if there is a relationship between them
-        if ((data.getRelationshipTracker().getRelationshipType(player, player2) == null)) {
-          // or else throw an exception!
+        if (data.getRelationshipTracker().getRelationship(player, player2) == null) {
           throw new GameParseException(
               "No relation set for: " + player.getName() + " and " + player2.getName());
         }


### PR DESCRIPTION



<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

If a relation does not exist between two players it is null. The call to 'getRelationshipType' of a null relation will result in a NPE. Hence, this validation will never print a useful message, it will NPE instead.
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
