### PR TITLE
Add a band-aid fix to avoid a ConcurrentModificationException

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameDataEventListeners.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameDataEventListeners.java
@@ -2,6 +2,7 @@ package games.strategy.engine.data;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
+import java.util.List;
 import java.util.function.Consumer;
 
 /**
@@ -14,7 +15,9 @@ class GameDataEventListeners implements Consumer<GameDataEvent> {
 
   @Override
   public void accept(final GameDataEvent gameDataEvent) {
-    listeners.get(gameDataEvent).forEach(Runnable::run);
+    // Create a list copy to avoid a ConcurrentModificationException
+    // The list copy is a band-aid fix for: https://github.com/triplea-game/triplea/issues/7588
+    List.copyOf(listeners.get(gameDataEvent)).forEach(Runnable::run);
   }
 
   void addListener(final GameDataEvent event, final Runnable runnable) {


### PR DESCRIPTION
Likely a better fix would be to ensure that any UI models
that need to 'hear' events have finished registering before
we could fire any. It appears that during a game load such
a sequence occurred where an event was fired while something
was still registering a listener resulting in an error.

This fix is a band-aid as doing a list copy is not ideal
long term. It is better though than errors and it might be
some time before the game startup sequencing is clear enough
that we can avoid the noted scenario.

Related to: https://github.com/triplea-game/triplea/issues/7588


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->FIX|Fix rare ConcurrentModificationException game crash when loading save games<!--END_RELEASE_NOTE-->
