### PR TITLE
Fix loading of deleted maps

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
@@ -169,6 +169,7 @@ public class GameSelectorModel extends Observable implements GameSelector {
         .filter(
             defaultGame ->
                 defaultGame.contains(ClientFileSystemHelper.getUserRootFolder().toURI().toString()))
+        .filter(defaultGame -> new File(defaultGame).exists())
         .map(URI::create)
         .ifPresent(this::load);
   }


### PR DESCRIPTION
If you load a map and it then becomes the 'default game', if you
then close the game and delete the map and then launch the game,
there are errors trying to load the 'default game'. This update
fixes that such that if a default game does not exist on disk
then we do not try to load it.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->FIX|Fix errors on game start when the last played map is deleted on disk.<!--END_RELEASE_NOTE-->
