### PR TITLE
Remove logging message when custom DBRider delete table data cleanup is executed

### DIFF
--- a/dropwizard-common-test/src/main/java/org/triplea/dropwizard/test/DropwizardServerExtension.java
+++ b/dropwizard-common-test/src/main/java/org/triplea/dropwizard/test/DropwizardServerExtension.java
@@ -80,11 +80,8 @@ public abstract class DropwizardServerExtension<C extends Configuration>
   public void afterEach(final ExtensionContext context) throws Exception {
     final URL cleanupFileUrl = getClass().getClassLoader().getResource("db-cleanup.sql");
     if (cleanupFileUrl != null) {
-      log.info("Running database cleanup..");
       final String cleanupSql = Files.readString(Path.of(cleanupFileUrl.toURI()));
       jdbi.withHandle(handle -> handle.execute(cleanupSql));
-    } else {
-      log.debug("No cleanup file 'db-cleanup' found");
     }
   }
 


### PR DESCRIPTION
This logging causes every DbRider unit test to print to console which
creates a lot of noise when running tests. This update removes that logging.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above. 
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
