### PR TITLE
Revert "Update: Bump bundled java version from 11.0.6+10 to 11.0.8+10"

### DIFF
--- a/game-headed/build.install4j
+++ b/game-headed/build.install4j
@@ -2,7 +2,7 @@
 <install4j version="8.0.7" transformSequenceNumber="8">
   <directoryPresets config=".triplea-root" />
   <application name="TripleA" applicationId="5251-3669-9623-1649" mediaDir="build/releases" mediaFilePattern="${compiler:sys.fullName}_${compiler:sys.version}_${compiler:sys.platform}" compression="9" lzmaCompression="true" pack200Compression="true" createChecksums="false" shortName="TripleA" publisher="TripleA Developer Team" publisherWeb="https://triplea-game.org" version="${compiler:sys.version}" allPathsRelative="true" autoSave="true" convertDotsToUnderscores="false" macVolumeId="af9346379363d40e" javaMinVersion="11" jdkMode="jdk">
-    <jreBundles jdkProviderId="AdoptOpenJDK" release="openjdk11/jdk-11.0.8+10_openj9-0.21.0" />
+    <jreBundles jdkProviderId="AdoptOpenJDK" release="openjdk11/jdk-11.0.6+10" />
   </application>
   <files>
     <mountPoints>


### PR DESCRIPTION
Reverts triplea-game/triplea#7610


Something more needs to be done, seeing failure in build:
```
Creating media file 'Windows 64 bit':

  Collecting files:

  Creating JRE bundle:

    Finding JDK release openjdk11/jdk-11.0.8+10_openj9-0.21.0 [windows-amd64]

install4j: compilation failed. Reason: Platform windows-amd64 not found in JDK release


```