### PR TITLE
Documentation: document map parsing design

### DIFF
--- a/docs/development/design/map-loading-design.md
+++ b/docs/development/design/map-loading-design.md
@@ -1,0 +1,30 @@
+# Map Loading Design
+
+Document describes the design behind game parsing and how games are transformed
+from XML to Java Code
+
+
+## Parsing
+
+XML parsing is done in the 'xml-reader' sub-project. This has the responsibility of just
+reading the data in the XML and converting it to a POJO.
+
+The 'map-data' sub-project stores the POJOs that model the data in XML. These POJOs
+should have no semantic information about the information read, just model what
+was in the XML. For example instead of creating java game objects around properties
+and options, the POJOs will simply record property and options field values without
+knowing what they mean, just model what was in the XML.
+
+
+## Assembly
+
+Assembly is the process of transforming 'map-data' POJOs into a game object. This is where
+we add semantic meaning to the data that was read. This creates a two step process and allows
+flexibility for there to be a variety of XMLs formats that can all be assembled in the same
+way.
+
+
+To illustrate the data transformation, it looks something like this:
+![map-data-flow](https://user-images.githubusercontent.com/12397753/91668327-d0726600-eac0-11ea-98b5-d10054337c60.png)
+
+


### PR DESCRIPTION
Documents the discussion started in: https://github.com/triplea-game/triplea/issues/7498,
covers the terms parsing and game data assembly and describes the design
philosophy that map-reading should just read the contents of XML and assembly
converts the XML model objects into actual java game objects.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
