### PR TITLE
Remove 'isBombing' boolean, instead infer it from BattleType

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
@@ -441,7 +441,7 @@ public abstract class AbstractProAi extends AbstractAi {
     final GamePlayer player = this.getGamePlayer();
     final BattleDelegate delegate = DelegateFinder.battleDelegate(data);
     final IBattle battle =
-        delegate.getBattleTracker().getPendingBattle(scrambleTo, false, BattleType.NORMAL);
+        delegate.getBattleTracker().getPendingBattle(scrambleTo, BattleType.NORMAL);
 
     // If battle is null then don't scramble
     if (battle == null) {
@@ -472,7 +472,7 @@ public abstract class AbstractProAi extends AbstractAi {
     final GamePlayer player = this.getGamePlayer();
     final BattleDelegate delegate = DelegateFinder.battleDelegate(data);
     final IBattle battle =
-        delegate.getBattleTracker().getPendingBattle(unitTerritory, false, BattleType.NORMAL);
+        delegate.getBattleTracker().getPendingBattle(unitTerritory, BattleType.NORMAL);
 
     // If battle is null then don't attack
     if (battle == null) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProScrambleAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProScrambleAi.java
@@ -45,7 +45,7 @@ class ProScrambleAi {
     final GamePlayer player = proData.getPlayer();
     final BattleDelegate delegate = DelegateFinder.battleDelegate(data);
     final IBattle battle =
-        delegate.getBattleTracker().getPendingBattle(scrambleTo, false, BattleType.NORMAL);
+        delegate.getBattleTracker().getPendingBattle(scrambleTo, BattleType.NORMAL);
 
     // Check if defense already wins
     final Collection<Unit> attackers = battle.getAttackingUnits();
@@ -105,9 +105,7 @@ class ProScrambleAi {
       final Set<Territory> battleTerritories = new HashSet<>();
       for (final Territory possibleTerritory : possibleTerritories) {
         final IBattle possibleBattle =
-            delegate
-                .getBattleTracker()
-                .getPendingBattle(possibleTerritory, false, BattleType.NORMAL);
+            delegate.getBattleTracker().getPendingBattle(possibleTerritory, BattleType.NORMAL);
         if (possibleBattle != null) {
           battleTerritories.add(possibleTerritory);
         }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
@@ -55,9 +55,7 @@ public final class ProSimulateTurnUtils {
     for (final Entry<BattleType, Collection<Territory>> entry : battleTerritories.entrySet()) {
       for (final Territory t : entry.getValue()) {
         final IBattle battle =
-            battleDelegate
-                .getBattleTracker()
-                .getPendingBattle(t, entry.getKey().isBombingRun(), entry.getKey());
+            battleDelegate.getBattleTracker().getPendingBattle(t, entry.getKey());
         final Collection<Unit> attackers = new ArrayList<>(battle.getAttackingUnits());
         attackers.retainAll(t.getUnits());
         final Collection<Unit> defenders = new ArrayList<>(battle.getDefendingUnits());

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -472,7 +472,7 @@ public class MovePerformer implements Serializable {
       // any pending battles in the unloading zone?
       final BattleTracker tracker = getBattleTracker();
       final boolean pendingBattles =
-          tracker.getPendingBattle(route.getStart(), false, BattleType.NORMAL) != null;
+          tracker.getPendingBattle(route.getStart(), BattleType.NORMAL) != null;
       for (final Unit unit : units) {
         if (Matches.unitIsAir().test(unit)) {
           continue;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -286,7 +286,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
     }
     if (onlyWhereUnderAttackAlready) {
       if (!battleTracker.getConquered().contains(end)) {
-        final IBattle battle = battleTracker.getPendingBattle(end, false, BattleType.NORMAL);
+        final IBattle battle = battleTracker.getPendingBattle(end, BattleType.NORMAL);
         if (battle == null) {
           return result.setErrorReturnResult(
               "Airborne May Only Attack Territories Already Under Assault");

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/AbstractBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/AbstractBattle.java
@@ -71,14 +71,13 @@ abstract class AbstractBattle implements IBattle {
       final Territory battleSite,
       final GamePlayer attacker,
       final BattleTracker battleTracker,
-      final boolean isBombingRun,
       final BattleType battleType,
       final GameData data) {
     this.battleTracker = battleTracker;
     this.attacker = attacker;
     this.battleSite = battleSite;
     territoryEffects = TerritoryEffectHelper.getEffects(battleSite);
-    this.isBombingRun = isBombingRun;
+    this.isBombingRun = battleType.isBombingRun();
     this.battleType = battleType;
     gameData = data;
     defender = findDefender(battleSite, attacker, data);
@@ -214,7 +213,7 @@ abstract class AbstractBattle implements IBattle {
 
   @Override
   public boolean isBombingRun() {
-    return isBombingRun;
+    return battleType.isBombingRun();
   }
 
   @Override
@@ -274,7 +273,6 @@ abstract class AbstractBattle implements IBattle {
     }
     final IBattle other = (IBattle) o;
     return other.getTerritory().equals(this.battleSite)
-        && other.isBombingRun() == this.isBombingRun()
         && other.getBattleType() == this.getBattleType();
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
@@ -63,17 +63,11 @@ public class AirBattle extends AbstractBattle {
 
   AirBattle(
       final Territory battleSite,
-      final boolean bombingRaid,
+      final BattleType battleType,
       final GameData data,
       final GamePlayer attacker,
       final BattleTracker battleTracker) {
-    super(
-        battleSite,
-        attacker,
-        battleTracker,
-        bombingRaid,
-        (bombingRaid ? BattleType.AIR_RAID : BattleType.AIR_BATTLE),
-        data);
+    super(battleSite, attacker, battleTracker, battleType, data);
     isAmphibious = false;
     maxRounds = Properties.getAirBattleRounds(data);
     updateDefendingUnits();
@@ -388,13 +382,12 @@ public class AirBattle extends AbstractBattle {
           }
         }
         final IBattle battle = battleTracker.getPendingBombingBattle(battleSite);
-        final IBattle dependent =
-            battleTracker.getPendingBattle(battleSite, false, BattleType.NORMAL);
+        final IBattle dependent = battleTracker.getPendingBattle(battleSite, BattleType.NORMAL);
         if (dependent != null) {
           battleTracker.addDependency(dependent, battle);
         }
         final IBattle dependentAirBattle =
-            battleTracker.getPendingBattle(battleSite, false, BattleType.AIR_BATTLE);
+            battleTracker.getPendingBattle(battleSite, BattleType.AIR_BATTLE);
         if (dependentAirBattle != null) {
           battleTracker.addDependency(dependentAirBattle, battle);
         }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -1320,7 +1320,6 @@ public class BattleTracker implements Serializable {
    * other combat.
    */
   void fightAirRaidsAndStrategicBombing(final IDelegateBridge delegateBridge) {
-    final boolean bombing = true;
     fightAirRaidsAndStrategicBombing(
         delegateBridge, () -> getPendingBattleSites(true), this::getPendingBattle);
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/DependentBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/DependentBattle.java
@@ -23,7 +23,7 @@ public abstract class DependentBattle extends AbstractBattle {
       final GamePlayer attacker,
       final BattleTracker battleTracker,
       final GameData data) {
-    super(battleSite, attacker, battleTracker, false, BattleType.NORMAL, data);
+    super(battleSite, attacker, battleTracker, BattleType.NORMAL, data);
     attackingFromMap = new HashMap<>();
     attackingFrom = new HashSet<>();
     amphibiousAttackFrom = new ArrayList<>();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/FinishedBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/FinishedBattle.java
@@ -37,12 +37,11 @@ public class FinishedBattle extends AbstractBattle {
       final Territory battleSite,
       final GamePlayer attacker,
       final BattleTracker battleTracker,
-      final boolean isBombingRun,
       final BattleType battleType,
       final GameData data,
       final BattleResultDescription battleResultDescription,
       final WhoWon whoWon) {
-    super(battleSite, attacker, battleTracker, isBombingRun, battleType, data);
+    super(battleSite, attacker, battleTracker, battleType, data);
     this.battleResultDescription = battleResultDescription;
     this.whoWon = whoWon;
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/IBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/IBattle.java
@@ -50,6 +50,10 @@ public interface IBattle extends Serializable {
     public static Collection<BattleType> bombingBattleTypes() {
       return Arrays.stream(values()).filter(BattleType::isBombingRun).collect(Collectors.toSet());
     }
+
+    public String toDisplayText() {
+      return type;
+    }
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/IBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/IBattle.java
@@ -7,10 +7,16 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
 import java.io.Serializable;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
 
 /** Represents a battle. */
 public interface IBattle extends Serializable {
@@ -23,31 +29,26 @@ public interface IBattle extends Serializable {
   }
 
   /** The type of a battle. */
+  @AllArgsConstructor
+  @ToString(of = "type")
   enum BattleType {
-    NORMAL("Battle"),
-    AIR_BATTLE("Air Battle"),
-    AIR_RAID("Air Raid"),
-    BOMBING_RAID("Bombing Raid");
+    NORMAL("Battle", false, false),
+    AIR_BATTLE("Air Battle", false, true),
+    AIR_RAID("Air Raid", true, true),
+    BOMBING_RAID("Bombing Raid", true, false);
 
     private final String type;
+    @Getter private final boolean bombingRun;
+    @Getter private final boolean airBattle;
 
-    BattleType(final String type) {
-      this.type = type;
+    public static Collection<BattleType> nonBombingBattleTypes() {
+      return Arrays.stream(values())
+          .filter(Predicate.not(BattleType::isBombingRun))
+          .collect(Collectors.toSet());
     }
 
-    @Override
-    public String toString() {
-      return type;
-    }
-
-    // if it has the word "Raid" in it, then it is a bombing battle
-    public boolean isBombingRun() {
-      return type.contains("Raid");
-    }
-
-    // if it has the word "Air" in it, then it is an air battle
-    public boolean isAirPreBattleOrPreRaid() {
-      return type.contains("Air");
+    public static Collection<BattleType> bombingBattleTypes() {
+      return Arrays.stream(values()).filter(BattleType::isBombingRun).collect(Collectors.toSet());
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/ScrambleLogic.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/ScrambleLogic.java
@@ -139,7 +139,7 @@ public class ScrambleLogic {
           scrambleTerrs.put(battleTerr, new HashSet<>(canScrambleFrom));
         }
       }
-      final IBattle battle = battleTracker.getPendingBattle(battleTerr, false, BattleType.NORMAL);
+      final IBattle battle = battleTracker.getPendingBattle(battleTerr, BattleType.NORMAL);
       // do not forget we may already have the territory in the list, so we need to add to the
       // collection, not overwrite it.
       if (battle != null && battle.isAmphibious() && battle instanceof DependentBattle) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
@@ -70,7 +70,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
       final GameData data,
       final GamePlayer attacker,
       final BattleTracker battleTracker) {
-    super(battleSite, attacker, battleTracker, true, BattleType.BOMBING_RAID, data);
+    super(battleSite, attacker, battleTracker, BattleType.BOMBING_RAID, data);
     isAmphibious = false;
     updateDefendingUnits();
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
@@ -134,7 +134,7 @@ public class MoveValidator {
 
     // Don't let the user move out of a battle zone, the exception is air units and unloading units
     // into a battle zone
-    if (AbstractMoveDelegate.getBattleTracker(data).hasPendingBattle(route.getStart(), false)
+    if (AbstractMoveDelegate.getBattleTracker(data).hasPendingNonBombingBattle(route.getStart())
         && units.stream().anyMatch(Matches.unitIsNotAir())) {
       // if the units did not move into the territory, then they can move out this will happen if
       // there is a submerged

--- a/game-core/src/main/java/games/strategy/triplea/delegate/remote/IBattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/remote/IBattleDelegate.java
@@ -9,6 +9,7 @@ import games.strategy.triplea.delegate.battle.IBattle;
 import games.strategy.triplea.delegate.battle.IBattle.BattleType;
 import games.strategy.triplea.delegate.data.BattleListing;
 import java.io.Serializable;
+import org.triplea.java.RemoveOnNextMajorRelease;
 
 /** Logic for querying and fighting pending battles. */
 public interface IBattleDelegate extends IRemote, IDelegate {
@@ -23,6 +24,7 @@ public interface IBattleDelegate extends IRemote, IDelegate {
    * @param bombing - fight a bombing raid
    * @return an error string if the battle could not be fought or an error occurred, null otherwise
    */
+  @RemoveOnNextMajorRelease("Remove 'boolean bombing' parameter")
   @RemoteActionCode(2)
   String fightBattle(Territory where, boolean bombing, BattleType type);
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -888,7 +888,7 @@ public class BattleDisplay extends JPanel {
       final List<Unit> units = new ArrayList<>(this.units);
       DiceRoll.sortByStrength(units, !attack);
       final Map<Unit, TotalPowerAndTotalRolls> unitPowerAndRollsMap;
-      final boolean isAirPreBattleOrPreRaid = battleType.isAirPreBattleOrPreRaid();
+      final boolean isAirPreBattleOrPreRaid = battleType.isAirBattle();
       if (isAirPreBattleOrPreRaid) {
         unitPowerAndRollsMap = Map.of();
       } else {

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -116,7 +116,7 @@ public final class BattlePanel extends ActionPanel {
             .addCenter(
                 new JButton(
                     SwingAction.of(
-                        battleType.toString() + " in " + territory.getName() + "...",
+                        battleType.toDisplayText() + " in " + territory.getName() + "...",
                         () -> fightBattleAction(territory, bomb, battleType))))
             .addEast(
                 new JButtonBuilder()

--- a/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -69,6 +69,7 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.battle.BattleDelegate;
 import games.strategy.triplea.delegate.battle.BattleTracker;
 import games.strategy.triplea.delegate.battle.IBattle;
+import games.strategy.triplea.delegate.battle.IBattle.BattleType;
 import games.strategy.triplea.delegate.battle.MustFightBattle;
 import games.strategy.triplea.delegate.battle.StrategicBombingRaidBattle;
 import games.strategy.triplea.delegate.battle.steps.fire.firststrike.DefensiveFirstStrike;
@@ -284,8 +285,8 @@ class RevisedTest {
     battle.start();
     final BattleTracker tracker = AbstractMoveDelegate.getBattleTracker(gameData);
     // The battle should NOT be empty
-    assertTrue(tracker.hasPendingBattle(sz5, false));
-    assertFalse(tracker.getPendingBattle(sz5).isEmpty());
+    assertTrue(tracker.hasPendingNonBombingBattle(sz5));
+    assertFalse(tracker.getPendingBattle(sz5, BattleType.NORMAL).isEmpty());
     battle.end();
   }
 
@@ -799,7 +800,9 @@ class RevisedTest {
     moveDelegate(gameData).end();
     // Set up battle
     MustFightBattle battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(fic);
+        (MustFightBattle)
+            AbstractMoveDelegate.getBattleTracker(gameData)
+                .getPendingBattle(fic, BattleType.NORMAL);
     // fight
     whenGetRandom(delegateBridge).thenAnswer(withValues(0)).thenAnswer(withValues(5));
     battle.fight(delegateBridge);
@@ -820,7 +823,9 @@ class RevisedTest {
     assertValid(validResults);
     moveDelegate(gameData).end();
     battle =
-        (MustFightBattle) AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(fic);
+        (MustFightBattle)
+            AbstractMoveDelegate.getBattleTracker(gameData)
+                .getPendingBattle(fic, BattleType.NORMAL);
     // fight
     whenGetRandom(delegateBridge).thenAnswer(withValues(0)).thenAnswer(withValues(5));
     battle.fight(delegateBridge);

--- a/java-extras/src/main/java/org/triplea/java/RemoveOnNextMajorRelease.java
+++ b/java-extras/src/main/java/org/triplea/java/RemoveOnNextMajorRelease.java
@@ -8,4 +8,6 @@ import java.lang.annotation.RetentionPolicy;
  * breaking save game compatibility.
  */
 @Retention(RetentionPolicy.SOURCE)
-public @interface RemoveOnNextMajorRelease {}
+public @interface RemoveOnNextMajorRelease {
+  String value() default "";
+}


### PR DESCRIPTION
This update adds flags to 'BattleType' that can be used to directly
infer if a battle type is bombing or an air battle. This has a
relation to the 'isBombing' flag that is passed around into methods,
so rather than using methods like "boolean isBombing, BattleType type",
we can replace that with "type.isBombing, type".


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
