### PR TITLE
Update: leniency for trailing colon in attachment names

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
+++ b/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
@@ -95,7 +95,7 @@ public abstract class DefaultAttachment extends GameDataComponent implements IAt
   }
 
   protected String thisErrorMsg() {
-    return "   for: " + toString();
+    return ",   for: " + toString();
   }
 
   /** Returns null or the toString() of the field value. */

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -64,7 +64,7 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
     }
     final Collection<GamePlayer> gamePlayers = getData().getPlayerList().getPlayers();
     for (final String subString : splitOnColon(conditions)) {
-      if(subString.isBlank()) {
+      if (subString.isBlank()) {
         continue;
       }
       this.conditions.add(

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractConditionsAttachment.java
@@ -64,6 +64,9 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
     }
     final Collection<GamePlayer> gamePlayers = getData().getPlayerList().getPlayers();
     for (final String subString : splitOnColon(conditions)) {
+      if(subString.isBlank()) {
+        continue;
+      }
       this.conditions.add(
           gamePlayers.stream()
               .map(p -> p.getAttachment(subString))
@@ -73,7 +76,11 @@ public abstract class AbstractConditionsAttachment extends DefaultAttachment imp
               .orElseThrow(
                   () ->
                       new GameParseException(
-                          "Could not find rule. name:" + subString + thisErrorMsg())));
+                          "Could not find rule. From conditions value: "
+                              + conditions
+                              + ", expected name: "
+                              + subString
+                              + thisErrorMsg())));
     }
   }
 


### PR DESCRIPTION
(1) When splitting for multiple attachment names, allow a trailing colon to
be ignored.

For example: (Pacific Challenge, 1.8 version)
```
<option name="conditions" value="conditionAttachmentUsaBomberUpgrade:"/>
```

(2) Improve error messaging


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
