### PR TITLE
Add conversion logic for 'XOR' conditionType to be translated to '1'

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/gameparser/LegacyPropertyMapper.java
+++ b/game-core/src/main/java/games/strategy/engine/data/gameparser/LegacyPropertyMapper.java
@@ -36,6 +36,9 @@ class LegacyPropertyMapper {
       } else {
         return optionValue;
       }
+    } else if (optionName.equalsIgnoreCase("conditionType")
+        && optionValue.equalsIgnoreCase("XOR")) {
+      return "1";
     }
     return optionValue;
   }

--- a/game-core/src/test/resources/v1_8_map__270BC.xml
+++ b/game-core/src/test/resources/v1_8_map__270BC.xml
@@ -2303,6 +2303,7 @@
       <option name="gameProperty" value="8 Capital Victory"/>
       <option name="alliedOwnershipTerritories" value="Sparta:Thessalonica:Alexandria:Roma:Antioch:Carthago:Cirta:Persepolis" count="8"/>
       <option name="rounds" value="1:2"/>
+      <option name="conditionType" value="XOR"/>
     </attatchment>
     <attatchment name="conditionAttachmentRomanVictory8" attatchTo="RomanRepublic" javaClass="games.strategy.triplea.attatchments.RulesAttachment" type="player">
       <option name="gameProperty" value="8 Capital Victory"/>


### PR DESCRIPTION
The XOR condition type crashes, the 1.8 pacific challenge map has
this value.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
