### PR TITLE
Update: Automatically infer game XML property 'types'

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/gameparser/PropertyValueTypeInference.java
+++ b/game-core/src/main/java/games/strategy/engine/data/gameparser/PropertyValueTypeInference.java
@@ -1,0 +1,43 @@
+package games.strategy.engine.data.gameparser;
+
+import com.google.common.primitives.Ints;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+class PropertyValueTypeInference {
+
+  @SuppressWarnings("UnstableApiUsage")
+  public Class<?> inferType(final String value) {
+    if (value == null) {
+      return String.class;
+    } else if (value.equalsIgnoreCase("true") || value.equalsIgnoreCase("false")) {
+      return Boolean.class;
+    } else if (Ints.tryParse(value) != null) {
+      return Integer.class;
+    } else {
+      return String.class;
+    }
+  }
+
+  /**
+   * Given an input, infers the type of value that is provided and returns casted object of
+   * equivalent value cast to an appropriate type.
+   *
+   * @return
+   *     <ul>
+   *       <li>An 'int' type if the value is a number.
+   *       <li>Boolean (case) insensitive if string is 'true' or 'false'
+   *       <li>Otherwise returns the parameter value (string)
+   *     </ul>
+   */
+  public Object castToInferredType(final String value) {
+    final Class<?> inferredType = inferType(value);
+    if (inferredType == Boolean.class) {
+      return Boolean.parseBoolean(value);
+    } else if (inferredType == Integer.class) {
+      return Integer.parseInt(value);
+    } else {
+      return value;
+    }
+  }
+}

--- a/game-core/src/test/java/games/strategy/engine/data/gameparser/PropertyValueTypeInferenceTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/gameparser/PropertyValueTypeInferenceTest.java
@@ -1,0 +1,62 @@
+package games.strategy.engine.data.gameparser;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+class PropertyValueTypeInferenceTest {
+
+  @Test
+  void inferNullType() {
+    assertThat(PropertyValueTypeInference.inferType(null), is(String.class));
+  }
+
+  @Test
+  void inferString() {
+    assertThat(PropertyValueTypeInference.inferType(""), is(String.class));
+  }
+
+  @Test
+  void inferNumber() {
+    assertThat(PropertyValueTypeInference.inferType("2"), is(Integer.class));
+  }
+
+  @Test
+  void inferBoolean() {
+    assertThat(PropertyValueTypeInference.inferType("false"), is(Boolean.class));
+  }
+
+  @Test
+  void nullInputIsReturnedAsNull() {
+    assertThat(PropertyValueTypeInference.castToInferredType(null), is(nullValue()));
+  }
+
+  @ParameterizedTest
+  @ValueSource(ints = {-1, 0, 1, 100})
+  void inferNumberValues(final int value) {
+    final Object result = PropertyValueTypeInference.castToInferredType(String.valueOf(value));
+
+    assertThat(result, is(value));
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void inferNumberValues(final boolean value) {
+    assertThat(
+        PropertyValueTypeInference.castToInferredType(String.valueOf(value).toLowerCase()),
+        is(value));
+    assertThat(
+        PropertyValueTypeInference.castToInferredType(String.valueOf(value).toUpperCase()),
+        is(value));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"", "string"})
+  void inferStringValue(final String value) {
+    assertThat(PropertyValueTypeInference.castToInferredType(value), is(value));
+  }
+}

--- a/map-data/src/main/java/org/triplea/map/data/elements/PropertyList.java
+++ b/map-data/src/main/java/org/triplea/map/data/elements/PropertyList.java
@@ -4,6 +4,7 @@ import java.util.List;
 import lombok.Getter;
 import org.triplea.generic.xml.reader.annotations.Attribute;
 import org.triplea.generic.xml.reader.annotations.BodyText;
+import org.triplea.generic.xml.reader.annotations.LegacyXml;
 import org.triplea.generic.xml.reader.annotations.Tag;
 import org.triplea.generic.xml.reader.annotations.TagList;
 
@@ -14,33 +15,26 @@ public class PropertyList {
 
   @Getter
   public static class Property {
-    @Attribute private java.lang.String name;
-
+    @Attribute private String name;
     @Attribute private boolean editable;
-
-    @Attribute private java.lang.String player;
-
-    @Attribute private java.lang.String value;
+    @Attribute private String player;
+    @Attribute private String value;
+    @Attribute private Integer min;
+    @Attribute private Integer max;
 
     @Tag private Property.Value valueProperty;
-    @Tag private Property.Boolean booleanProperty;
-    @Tag private Property.String stringProperty;
-    @Tag private Property.Number numberProperty;
+
+    @Tag(names = "Number")
+    private XmlNumberTag numberProperty;
 
     @Getter
     public static class Value {
-      @BodyText private java.lang.String data;
+      @BodyText private String data;
     }
 
-    @SuppressWarnings("JavaLangClash")
-    public static class Boolean {}
-
-    @SuppressWarnings("JavaLangClash")
-    public static class String {}
-
+    @LegacyXml
     @Getter
-    @SuppressWarnings("JavaLangClash")
-    public static class Number {
+    public static class XmlNumberTag {
       @Attribute private int min;
       @Attribute private int max;
     }

--- a/map-data/src/test/java/org/triplea/map/data/elements/PropertyListTest.java
+++ b/map-data/src/test/java/org/triplea/map/data/elements/PropertyListTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.triplea.map.data.elements.XmlReaderTestUtils.parseMapXml;
 
 import org.junit.jupiter.api.Test;
@@ -14,17 +15,19 @@ class PropertyListTest {
   void propertyParsing() {
     final PropertyList propertyList = parseMapXml("property-list.xml").getPropertyList();
     assertThat(propertyList, is(notNullValue()));
-    assertThat(propertyList.getProperties(), hasSize(6));
+    assertThat(propertyList.getProperties(), hasSize(5));
 
     assertThat(propertyList.getProperties().get(0).getValue(), is("propValue"));
     assertThat(propertyList.getProperties().get(0).getName(), is("propName"));
     assertThat(propertyList.getProperties().get(0).isEditable(), is(true));
     assertThat(propertyList.getProperties().get(0).getPlayer(), is("player1"));
+    assertThat(propertyList.getProperties().get(0).getMin(), is(nullValue()));
+    assertThat(propertyList.getProperties().get(0).getMax(), is(nullValue()));
 
-    assertThat(propertyList.getProperties().get(1).getValue(), is(""));
-    assertThat(propertyList.getProperties().get(1).getName(), is("propName1"));
-    assertThat(propertyList.getProperties().get(1).isEditable(), is(false));
-    assertThat(propertyList.getProperties().get(1).getPlayer(), is(""));
+    assertThat(propertyList.getProperties().get(1).getValue(), is("100"));
+    assertThat(propertyList.getProperties().get(1).getName(), is("number"));
+    assertThat(propertyList.getProperties().get(1).getMin(), is(1));
+    assertThat(propertyList.getProperties().get(1).getMax(), is(1000));
 
     assertThat(propertyList.getProperties().get(2).getValue(), is(""));
     assertThat(propertyList.getProperties().get(2).getName(), is("notes"));
@@ -34,23 +37,16 @@ class PropertyListTest {
     assertThat(propertyList.getProperties().get(2).getValueProperty().getData(), is("Notes here"));
 
     assertThat(propertyList.getProperties().get(3).getValue(), is(""));
-    assertThat(propertyList.getProperties().get(3).getName(), is("booleanProperty"));
+    assertThat(propertyList.getProperties().get(3).getName(), is("stringProperty"));
     assertThat(propertyList.getProperties().get(3).isEditable(), is(false));
     assertThat(propertyList.getProperties().get(3).getPlayer(), is(""));
-    assertThat(propertyList.getProperties().get(3).getBooleanProperty(), is(notNullValue()));
 
     assertThat(propertyList.getProperties().get(4).getValue(), is(""));
-    assertThat(propertyList.getProperties().get(4).getName(), is("stringProperty"));
+    assertThat(propertyList.getProperties().get(4).getName(), is("numberProperty"));
     assertThat(propertyList.getProperties().get(4).isEditable(), is(false));
     assertThat(propertyList.getProperties().get(4).getPlayer(), is(""));
-    assertThat(propertyList.getProperties().get(4).getStringProperty(), is(notNullValue()));
-
-    assertThat(propertyList.getProperties().get(5).getValue(), is(""));
-    assertThat(propertyList.getProperties().get(5).getName(), is("numberProperty"));
-    assertThat(propertyList.getProperties().get(5).isEditable(), is(false));
-    assertThat(propertyList.getProperties().get(5).getPlayer(), is(""));
-    assertThat(propertyList.getProperties().get(5).getNumberProperty(), is(notNullValue()));
-    assertThat(propertyList.getProperties().get(5).getNumberProperty().getMin(), is(123));
-    assertThat(propertyList.getProperties().get(5).getNumberProperty().getMax(), is(999));
+    assertThat(propertyList.getProperties().get(4).getNumberProperty(), is(notNullValue()));
+    assertThat(propertyList.getProperties().get(4).getNumberProperty().getMin(), is(123));
+    assertThat(propertyList.getProperties().get(4).getNumberProperty().getMax(), is(999));
   }
 }

--- a/map-data/src/test/resources/property-list.xml
+++ b/map-data/src/test/resources/property-list.xml
@@ -1,19 +1,14 @@
 <game>
     <propertyList>
         <property value="propValue" name="propName" editable="true" player="player1"/>
-        <property name="propName1"/>
+
+        <property value="100" name="number" min="1" max="1000"/>
 
         <property name="notes">
             <value>Notes here</value>
         </property>
 
-        <property name="booleanProperty">
-            <boolean/>
-        </property>
-
-        <property name="stringProperty">
-            <string/>
-        </property>
+        <property name="stringProperty"/>
 
         <property name="numberProperty">
             <number min="123" max="999"/>

--- a/xml-reader/src/main/java/org/triplea/generic/xml/reader/annotations/LegacyXml.java
+++ b/xml-reader/src/main/java/org/triplea/generic/xml/reader/annotations/LegacyXml.java
@@ -1,0 +1,7 @@
+package org.triplea.generic.xml.reader.annotations;
+
+/**
+ * Marker annotation to indicate that an item is legacy, we keep it around so old XMLs will continue
+ * to work, but the annotated entity is not "the preferred way to do it."
+ */
+public @interface LegacyXml {}


### PR DESCRIPTION
This update makes the `<String/>` and `<Boolean/>` child
nodes of `<Property>` to no longer be read. Instead we now
always infer the value type from the property value attribute
(eg: `<property value=...>`).

For legacy purposes we keep the `<Number min="..." max="..."/>` tag
as a fallback so existing maps would continue to work.

Forum discussion:
https://forums.triplea-game.org/topic/2265/proposal-automatic-property-type-discovery-based-on-value


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
