### PR TITLE
Fix missing game notes in 'select game' window

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
@@ -198,20 +198,31 @@ public class GameChooser extends JDialog {
         "Number Of Players", shallowParsedGame.getPlayerList().getPlayers().size() + "", notes);
     appendListItem("Version", shallowParsedGame.getInfo().getVersion() + "", notes);
     notes.append("<p></p>");
-    final String gameNotes =
-        shallowParsedGame
-            .getProperty("notes")
-            .map(PropertyList.Property::getValueProperty)
-            .map(PropertyList.Property.Value::getData)
-            .orElse("");
-    if (!gameNotes.isEmpty()) {
-      shallowParsedGame
-          .getProperty("mapName")
-          .map(PropertyList.Property::getValue)
-          .ifPresent(
-              mapName -> notes.append(LocalizeHtml.localizeImgLinksInHtml(gameNotes, mapName)));
-    }
+
+    extractGameNotes(shallowParsedGame)
+        .ifPresent(
+            gameNotes ->
+                shallowParsedGame
+                    .getProperty("mapName")
+                    .map(PropertyList.Property::getValue)
+                    .ifPresent(
+                        mapName ->
+                            notes.append(LocalizeHtml.localizeImgLinksInHtml(gameNotes, mapName))));
     return notes.toString();
+  }
+
+  private static Optional<String> extractGameNotes(final ShallowParsedGame shallowParsedGame) {
+    return shallowParsedGame
+        // get 'value' attribute of 'notes' property
+        .getProperty("notes")
+        .map(PropertyList.Property::getValue)
+        // otherwise look for 'value' child node of 'notes' property
+        .or(
+            () ->
+                shallowParsedGame
+                    .getProperty("notes")
+                    .map(PropertyList.Property::getValueProperty)
+                    .map(PropertyList.Property.Value::getData));
   }
 
   private static void appendListItem(


### PR DESCRIPTION
Add fallback code to look for game notes in an alternative location.
Game notes can be in either:
```
  <property name="notes" value="...game notes here..." />
```

Or:
```
  <property name="notes">
     <value>
           ... game notes here ...
     </value>
  </property>
```

Fixes bug report: https://github.com/triplea-game/triplea/issues/7656


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
