### PR TITLE
Simplify Meta setup panel

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -28,40 +28,49 @@ public class MetaSetupPanel extends SetupPanel {
 
   public MetaSetupPanel(final SetupPanelModel model) {
 
-    final JButton connectToLobby = new JButton("Play Online");
-    final Font bigButtonFont =
-        new Font(
-            connectToLobby.getFont().getName(),
-            connectToLobby.getFont().getStyle(),
-            connectToLobby.getFont().getSize() + 3);
-    connectToLobby.setFont(bigButtonFont);
-    connectToLobby.setToolTipText(
-        "<html>Find Games Online on the Lobby Server. <br>"
-            + "TripleA is MEANT to be played Online against other humans. <br>"
-            + "Any other way is not as fun!</html>");
-    final JButton startLocal = new JButton("Start Local Game");
-    startLocal.setToolTipText(
-        "<html>Start a game on this computer. <br>"
-            + "You can play against a friend sitting besides you (hotseat mode), <br>"
-            + "or against one of the AIs.</html>");
-    final JButton startPbf = new JButton("Play By Forum");
-    startPbf.setToolTipText(
-        "<html>Starts a game which will be posted to an online forum or message board.</html>");
-    final JButton startPbem = new JButton("Play By Email");
-    startPbem.setToolTipText(
-        "<html>Starts a game which will be emailed back and forth between all players.</html>");
-    final JButton hostGame = new JButton("Host Networked Game");
-    hostGame.setToolTipText(
-        "<html>Hosts a network game, which people can connect to. <br>"
-            + "Anyone on a LAN will be able to connect. <br>"
-            + "Anyone from the internet can connect as well, but only if the host has "
-            + "configured port forwarding correctly.</html>");
-    final JButton connectToHostedGame = new JButton("Connect to Networked Game");
-    connectToHostedGame.setToolTipText(
-        "<html>Connects to someone's hosted game, <br>"
-            + "so long as you know their IP address.</html>");
-    final JButton enginePreferences = new JButton("Engine Preferences");
-    enginePreferences.setToolTipText("<html>Configure certain options related to the engine.");
+    final JButton connectToLobby =
+        new JButtonBuilder("Play Online")
+            .biggerFont()
+            .toolTipText(
+                "<html>Find Games Online on the Lobby Server. <br>"
+                    + "TripleA is MEANT to be played Online against other humans. <br>"
+                    + "Any other way is not as fun!</html>")
+            .build();
+    final JButton startLocal =
+        new JButtonBuilder("Start Local Game")
+            .toolTipText(
+                "<html>Start a game on this computer. <br>"
+                    + "You can play against a friend sitting besides you (hotseat mode), <br>"
+                    + "or against one of the AIs.</html>")
+            .build();
+    final JButton startPbf =
+        new JButtonBuilder("Play By Forum")
+            .toolTipText(
+                "<html>Starts a game which will be posted to an online forum or message board.</html>")
+            .build();
+    final JButton startPbem =
+        new JButtonBuilder("Play By Email")
+            .toolTipText(
+                "<html>Starts a game which will be emailed back and forth between all players.</html>")
+            .build();
+    final JButton hostGame =
+        new JButtonBuilder("Host Networked Game")
+            .toolTipText(
+                "<html>Hosts a network game, which people can connect to. <br>"
+                    + "Anyone on a LAN will be able to connect. <br>"
+                    + "Anyone from the internet can connect as well, but only if the host has "
+                    + "configured port forwarding correctly.</html>")
+            .build();
+    final JButton connectToHostedGame =
+        new JButtonBuilder("Connect to Networked Game")
+            .toolTipText(
+                "<html>Connects to someone's hosted game, <br>"
+                    + "so long as you know their IP address.</html>")
+            .build();
+    final JButton enginePreferences =
+        new JButtonBuilder("Engine Preferences")
+            .toolTipText("<html>Configure certain options related to the engine.")
+            .build();
     final JButton userGuideButton = new JButton("User Guide & Help");
 
     setLayout(new GridBagLayout());

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -5,7 +5,6 @@ import games.strategy.engine.framework.startup.mc.SetupPanelModel;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.triplea.settings.ClientSetting;
 import java.awt.BorderLayout;
-import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
@@ -31,7 +30,6 @@ public class MetaSetupPanel extends SetupPanel {
   private static final long serialVersionUID = 3926503672972937677L;
 
   public MetaSetupPanel(final SetupPanelModel model) {
-
     final JButton connectToLobby =
         new JButtonBuilder("Play Online")
             .biggerFont()
@@ -39,6 +37,7 @@ public class MetaSetupPanel extends SetupPanel {
                 "<html>Find Games Online on the Lobby Server. <br>"
                     + "TripleA is MEANT to be played Online against other humans. <br>"
                     + "Any other way is not as fun!</html>")
+            .actionListener(model::login)
             .build();
     final JButton startLocal =
         new JButtonBuilder("Start Local Game")
@@ -46,16 +45,24 @@ public class MetaSetupPanel extends SetupPanel {
                 "<html>Start a game on this computer. <br>"
                     + "You can play against a friend sitting besides you (hotseat mode), <br>"
                     + "or against one of the AIs.</html>")
+            .actionListener(model::showLocal)
             .build();
+
     final JButton startPbf =
         new JButtonBuilder("Play By Forum")
             .toolTipText(
-                "<html>Starts a game which will be posted to an online forum or message board.</html>")
+                "<html>"
+                    + "Starts a game which will be posted to an online forum or message board."
+                    + "</html>")
+            .actionListener(model::showPbf)
             .build();
     final JButton startPbem =
         new JButtonBuilder("Play By Email")
             .toolTipText(
-                "<html>Starts a game which will be emailed back and forth between all players.</html>")
+                "<html>"
+                    + "Starts a game which will be emailed back and forth between all players."
+                    + "</html>")
+            .actionListener(model::showPbem)
             .build();
     final JButton hostGame =
         new JButtonBuilder("Host Networked Game")
@@ -64,18 +71,31 @@ public class MetaSetupPanel extends SetupPanel {
                     + "Anyone on a LAN will be able to connect. <br>"
                     + "Anyone from the internet can connect as well, but only if the host has "
                     + "configured port forwarding correctly.</html>")
+            .actionListener(() -> new Thread(model::showServer).start())
             .build();
     final JButton connectToHostedGame =
         new JButtonBuilder("Connect to Networked Game")
             .toolTipText(
                 "<html>Connects to someone's hosted game, <br>"
                     + "so long as you know their IP address.</html>")
+            .actionListener(() -> new Thread(model::showClient).start())
             .build();
     final JButton enginePreferences =
         new JButtonBuilder("Engine Preferences")
             .toolTipText("<html>Configure certain options related to the engine.")
+            .actionListener(
+                () -> ClientSetting.showSettingsWindow(JOptionPane.getFrameForComponent(this)))
             .build();
-    final JButton userGuideButton = new JButton("User Guide & Help");
+    final JButton userGuideButton =
+        new JButtonBuilder("User Guide & Help")
+            .actionListener(
+                () -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.USER_GUIDE))
+            .build();
+    final JButton mapCreator =
+        new JButtonBuilder()
+            .title("Run the Map Creator")
+            .actionListener(MapCreator::openMapCreatorWindow)
+            .build();
 
     setLayout(new BorderLayout());
     final JPanel mainContents = new JPanel();
@@ -89,44 +109,24 @@ public class MetaSetupPanel extends SetupPanel {
     mainContents.add(startPbf, buildConstraintForRow(row));
     row++;
     mainContents.add(startPbem, buildConstraintForRow(row));
-
     row++;
     mainContents.add(hostGame, buildConstraintForRow(row));
     row++;
     mainContents.add(connectToHostedGame, buildConstraintForRow(row));
     row++;
     mainContents.add(enginePreferences, buildConstraintForRow(row));
-
-    final JButton mapCreator =
-        new JButtonBuilder()
-            .title("Run the Map Creator")
-            .actionListener(MapCreator::openMapCreatorWindow)
-            .build();
-
     row++;
     mainContents.add(mapCreator, buildConstraintForRow(row));
-
-    startLocal.addActionListener(e -> model.showLocal());
-    startPbf.addActionListener(e -> model.showPbf());
-    startPbem.addActionListener(e -> model.showPbem());
-    hostGame.addActionListener(e -> new Thread(model::showServer).start());
-    connectToHostedGame.addActionListener(e -> new Thread(model::showClient).start());
-    connectToLobby.addActionListener(e -> model.login());
-    enginePreferences.addActionListener(
-        e -> ClientSetting.showSettingsWindow(JOptionPane.getFrameForComponent(this)));
-    userGuideButton.addActionListener(e -> userGuidePage());
+    row++;
+    mainContents.add(userGuideButton, buildConstraintForRow(row));
   }
 
-  private GridBagConstraints buildConstraintForRow(int rowNumber) {
+  private GridBagConstraints buildConstraintForRow(final int rowNumber) {
     return new GridBagConstraintsBuilder(0, rowNumber)
         .anchor(GridBagConstraintsAnchor.CENTER)
         .fill(GridBagConstraintsFill.NONE)
         .insets(new Insets(10, 0, 0, 0))
         .build();
-  }
-
-  private static void userGuidePage() {
-    SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.USER_GUIDE);
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -39,12 +39,6 @@ public class MetaSetupPanel extends SetupPanel {
   public MetaSetupPanel(final SetupPanelModel model) {
     this.model = model;
 
-    createComponents();
-    layoutComponents();
-    setupListeners();
-  }
-
-  private void createComponents() {
     connectToLobby = new JButton("Play Online");
     final Font bigButtonFont =
         new Font(
@@ -80,9 +74,7 @@ public class MetaSetupPanel extends SetupPanel {
     enginePreferences = new JButton("Engine Preferences");
     enginePreferences.setToolTipText("<html>Configure certain options related to the engine.");
     userGuideButton = new JButton("User Guide & Help");
-  }
 
-  private void layoutComponents() {
     setLayout(new GridBagLayout());
     // top space
     int row = 0;
@@ -259,9 +251,7 @@ public class MetaSetupPanel extends SetupPanel {
             new Insets(0, 0, 0, 0),
             0,
             0));
-  }
 
-  private void setupListeners() {
     startLocal.addActionListener(e -> model.showLocal());
     startPbf.addActionListener(e -> model.showPbf());
     startPbem.addActionListener(e -> model.showPbem());

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -4,6 +4,7 @@ import games.strategy.engine.framework.startup.launcher.ILauncher;
 import games.strategy.engine.framework.startup.mc.SetupPanelModel;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.triplea.settings.ClientSetting;
+import java.awt.BorderLayout;
 import java.awt.Font;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
@@ -76,32 +77,25 @@ public class MetaSetupPanel extends SetupPanel {
             .build();
     final JButton userGuideButton = new JButton("User Guide & Help");
 
-    setLayout(new GridBagLayout());
-    // top space
+    setLayout(new BorderLayout());
+    final JPanel mainContents = new JPanel();
+    add(mainContents);
+    mainContents.setLayout(new GridBagLayout());
     int row = 0;
-    add(
-        new JPanel(),
-        new GridBagConstraintsBuilder(0, row)
-            .weightX(1.0)
-            .weightY(1.0)
-            .anchor(GridBagConstraintsAnchor.CENTER)
-            .insets(new Insets(0, 0, 0, 0))
-            .build());
+    mainContents.add(connectToLobby, buildConstraintForRow(row));
     row++;
-    add(connectToLobby, buildConstraintForRow(row));
+    mainContents.add(startLocal, buildConstraintForRow(row));
     row++;
-    add(startLocal, buildConstraintForRow(row));
+    mainContents.add(startPbf, buildConstraintForRow(row));
     row++;
-    add(startPbf, buildConstraintForRow(row));
-    row++;
-    add(startPbem, buildConstraintForRow(row));
+    mainContents.add(startPbem, buildConstraintForRow(row));
 
     row++;
-    add(hostGame, buildConstraintForRow(row));
+    mainContents.add(hostGame, buildConstraintForRow(row));
     row++;
-    add(connectToHostedGame, buildConstraintForRow(row));
+    mainContents.add(connectToHostedGame, buildConstraintForRow(row));
     row++;
-    add(enginePreferences, buildConstraintForRow(row));
+    mainContents.add(enginePreferences, buildConstraintForRow(row));
 
     final JButton mapCreator =
         new JButtonBuilder()
@@ -110,52 +104,7 @@ public class MetaSetupPanel extends SetupPanel {
             .build();
 
     row++;
-    add(
-        mapCreator,
-        new GridBagConstraints(
-            0,
-            row,
-            1,
-            1,
-            0,
-            0,
-            GridBagConstraints.CENTER,
-            GridBagConstraints.NONE,
-            new Insets(10, 0, 0, 0),
-            0,
-            0));
-
-    row++;
-    add(
-        userGuideButton,
-        new GridBagConstraints(
-            0,
-            row,
-            1,
-            1,
-            0,
-            0,
-            GridBagConstraints.CENTER,
-            GridBagConstraints.NONE,
-            new Insets(10, 0, 0, 0),
-            0,
-            0));
-
-    // bottom space
-    add(
-        new JPanel(),
-        new GridBagConstraints(
-            0,
-            100,
-            1,
-            1,
-            1,
-            1,
-            GridBagConstraints.CENTER,
-            GridBagConstraints.BOTH,
-            new Insets(0, 0, 0, 0),
-            0,
-            0));
+    mainContents.add(mapCreator, buildConstraintForRow(row));
 
     startLocal.addActionListener(e -> model.showLocal());
     startPbf.addActionListener(e -> model.showPbf());

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -25,21 +25,10 @@ import tools.map.making.MapCreator;
 public class MetaSetupPanel extends SetupPanel {
 
   private static final long serialVersionUID = 3926503672972937677L;
-  private JButton startLocal;
-  private JButton startPbf;
-  private JButton startPbem;
-  private JButton hostGame;
-  private JButton connectToHostedGame;
-  private JButton connectToLobby;
-  private JButton enginePreferences;
-  private JButton userGuideButton;
-
-  private final SetupPanelModel model;
 
   public MetaSetupPanel(final SetupPanelModel model) {
-    this.model = model;
 
-    connectToLobby = new JButton("Play Online");
+    final JButton connectToLobby = new JButton("Play Online");
     final Font bigButtonFont =
         new Font(
             connectToLobby.getFont().getName(),
@@ -50,30 +39,30 @@ public class MetaSetupPanel extends SetupPanel {
         "<html>Find Games Online on the Lobby Server. <br>"
             + "TripleA is MEANT to be played Online against other humans. <br>"
             + "Any other way is not as fun!</html>");
-    startLocal = new JButton("Start Local Game");
+    final JButton startLocal = new JButton("Start Local Game");
     startLocal.setToolTipText(
         "<html>Start a game on this computer. <br>"
             + "You can play against a friend sitting besides you (hotseat mode), <br>"
             + "or against one of the AIs.</html>");
-    startPbf = new JButton("Play By Forum");
+    final JButton startPbf = new JButton("Play By Forum");
     startPbf.setToolTipText(
         "<html>Starts a game which will be posted to an online forum or message board.</html>");
-    startPbem = new JButton("Play By Email");
+    final JButton startPbem = new JButton("Play By Email");
     startPbem.setToolTipText(
         "<html>Starts a game which will be emailed back and forth between all players.</html>");
-    hostGame = new JButton("Host Networked Game");
+    final JButton hostGame = new JButton("Host Networked Game");
     hostGame.setToolTipText(
         "<html>Hosts a network game, which people can connect to. <br>"
             + "Anyone on a LAN will be able to connect. <br>"
             + "Anyone from the internet can connect as well, but only if the host has "
             + "configured port forwarding correctly.</html>");
-    connectToHostedGame = new JButton("Connect to Networked Game");
+    final JButton connectToHostedGame = new JButton("Connect to Networked Game");
     connectToHostedGame.setToolTipText(
         "<html>Connects to someone's hosted game, <br>"
             + "so long as you know their IP address.</html>");
-    enginePreferences = new JButton("Engine Preferences");
+    final JButton enginePreferences = new JButton("Engine Preferences");
     enginePreferences.setToolTipText("<html>Configure certain options related to the engine.");
-    userGuideButton = new JButton("User Guide & Help");
+    final JButton userGuideButton = new JButton("User Guide & Help");
 
     setLayout(new GridBagLayout());
     // top space

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/MetaSetupPanel.java
@@ -16,6 +16,9 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.SwingComponents;
+import org.triplea.swing.jpanel.GridBagConstraintsAnchor;
+import org.triplea.swing.jpanel.GridBagConstraintsBuilder;
+import org.triplea.swing.jpanel.GridBagConstraintsFill;
 import tools.map.making.MapCreator;
 
 /**
@@ -78,123 +81,27 @@ public class MetaSetupPanel extends SetupPanel {
     int row = 0;
     add(
         new JPanel(),
-        new GridBagConstraints(
-            0,
-            row,
-            1,
-            1,
-            1,
-            1,
-            GridBagConstraints.CENTER,
-            GridBagConstraints.BOTH,
-            new Insets(0, 0, 0, 0),
-            0,
-            0));
+        new GridBagConstraintsBuilder(0, row)
+            .weightX(1.0)
+            .weightY(1.0)
+            .anchor(GridBagConstraintsAnchor.CENTER)
+            .insets(new Insets(0, 0, 0, 0))
+            .build());
     row++;
-    add(
-        connectToLobby,
-        new GridBagConstraints(
-            0,
-            row,
-            1,
-            1,
-            0,
-            0,
-            GridBagConstraints.CENTER,
-            GridBagConstraints.NONE,
-            new Insets(10, 0, 0, 0),
-            0,
-            0));
+    add(connectToLobby, buildConstraintForRow(row));
     row++;
-    add(
-        startLocal,
-        new GridBagConstraints(
-            0,
-            row,
-            1,
-            1,
-            0,
-            0,
-            GridBagConstraints.CENTER,
-            GridBagConstraints.NONE,
-            new Insets(10, 0, 0, 0),
-            0,
-            0));
+    add(startLocal, buildConstraintForRow(row));
     row++;
-    add(
-        startPbf,
-        new GridBagConstraints(
-            0,
-            row,
-            1,
-            1,
-            0,
-            0,
-            GridBagConstraints.CENTER,
-            GridBagConstraints.NONE,
-            new Insets(10, 0, 0, 0),
-            0,
-            0));
+    add(startPbf, buildConstraintForRow(row));
     row++;
-    add(
-        startPbem,
-        new GridBagConstraints(
-            0,
-            row,
-            1,
-            1,
-            0,
-            0,
-            GridBagConstraints.CENTER,
-            GridBagConstraints.NONE,
-            new Insets(10, 0, 0, 0),
-            0,
-            0));
+    add(startPbem, buildConstraintForRow(row));
+
     row++;
-    add(
-        hostGame,
-        new GridBagConstraints(
-            0,
-            row,
-            1,
-            1,
-            0,
-            0,
-            GridBagConstraints.CENTER,
-            GridBagConstraints.NONE,
-            new Insets(10, 0, 0, 0),
-            0,
-            0));
+    add(hostGame, buildConstraintForRow(row));
     row++;
-    add(
-        connectToHostedGame,
-        new GridBagConstraints(
-            0,
-            row,
-            1,
-            1,
-            0,
-            0,
-            GridBagConstraints.CENTER,
-            GridBagConstraints.NONE,
-            new Insets(10, 0, 0, 0),
-            0,
-            0));
+    add(connectToHostedGame, buildConstraintForRow(row));
     row++;
-    add(
-        enginePreferences,
-        new GridBagConstraints(
-            0,
-            row,
-            1,
-            1,
-            0,
-            0,
-            GridBagConstraints.CENTER,
-            GridBagConstraints.NONE,
-            new Insets(10, 0, 0, 0),
-            0,
-            0));
+    add(enginePreferences, buildConstraintForRow(row));
 
     final JButton mapCreator =
         new JButtonBuilder()
@@ -234,7 +141,7 @@ public class MetaSetupPanel extends SetupPanel {
             0,
             0));
 
-    // top space
+    // bottom space
     add(
         new JPanel(),
         new GridBagConstraints(
@@ -259,6 +166,14 @@ public class MetaSetupPanel extends SetupPanel {
     enginePreferences.addActionListener(
         e -> ClientSetting.showSettingsWindow(JOptionPane.getFrameForComponent(this)));
     userGuideButton.addActionListener(e -> userGuidePage());
+  }
+
+  private GridBagConstraints buildConstraintForRow(int rowNumber) {
+    return new GridBagConstraintsBuilder(0, rowNumber)
+        .anchor(GridBagConstraintsAnchor.CENTER)
+        .fill(GridBagConstraintsFill.NONE)
+        .insets(new Insets(10, 0, 0, 0))
+        .build();
   }
 
   private static void userGuidePage() {

--- a/swing-lib/src/main/java/org/triplea/swing/JButtonBuilder.java
+++ b/swing-lib/src/main/java/org/triplea/swing/JButtonBuilder.java
@@ -109,6 +109,11 @@ public class JButtonBuilder {
     return this;
   }
 
+  /** An alias for toolTip */
+  public JButtonBuilder toolTipText(final String toolTip) {
+    return toolTip(toolTip);
+  }
+
   /** Sets the event that occurs when the button is clicked. SIDE EFFECT: Enables the button */
   public JButtonBuilder actionListener(final Runnable actionListener) {
     checkNotNull(actionListener);


### PR DESCRIPTION
Various simplifications to UI components of meta setup panel to reduce redundancy.

It would be nice to find a nice pattern to decouple the swing component creation vs their layout, though I'm not quite sure what that would be. This update in the mean time just progresses through a variety of cleanups to group component construction (improve class cohesion) and simplify.

<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
- Did a quick smoke test that the main launch screen looks the same and components still move in the same way when the screen is resized.

<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
