### PR TITLE
Add Jaxb for writing 'Game' (XML Model Object) to XML

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,8 @@ subprojects {
         wireMockJunit5Version = '1.3.1'
         wireMockVersion = '2.21.0'
         xchartVersion = '3.6.5'
+        xmlUnitCore = '2.7.0'
+        xmlUnitMatchers = '2.2.1'
     }
 
     repositories {

--- a/map-data/build.gradle
+++ b/map-data/build.gradle
@@ -1,3 +1,6 @@
 dependencies {
+    implementation "com.sun.xml.bind:jaxb-impl:$jaxbImplVersion"
     implementation project(":xml-reader")
+    testCompile "org.xmlunit:xmlunit-core:$xmlUnitCore"
+    testCompile "org.xmlunit:xmlunit-matchers:$xmlUnitMatchers"
 }

--- a/map-data/src/main/java/org/triplea/map/data/elements/AttachmentList.java
+++ b/map-data/src/main/java/org/triplea/map/data/elements/AttachmentList.java
@@ -1,37 +1,53 @@
 package org.triplea.map.data.elements;
 
 import java.util.List;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.triplea.generic.xml.reader.annotations.Attribute;
 import org.triplea.generic.xml.reader.annotations.TagList;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class AttachmentList {
   @TagList(names = {"Attachment", "Attatchment"})
+  @XmlElement(name = "attachment")
   private List<Attachment> attachments;
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class Attachment {
-    @Attribute private String foreach;
-    @Attribute private String name;
+    @XmlAttribute @Attribute private String foreach;
+    @XmlAttribute @Attribute private String name;
 
     @Attribute(names = {"attachTo", "attatchTo"})
+    @XmlAttribute
     private String attachTo;
 
-    @Attribute private String javaClass;
+    @XmlAttribute @Attribute private String javaClass;
 
-    @Attribute(defaultValue = "unitType")
-    private String type;
+    @XmlAttribute @Attribute private String type;
 
-    @TagList private List<Option> options;
+    @XmlElement(name = "option")
+    @TagList
+    private List<Option> options;
 
     @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Option {
-      @Attribute private String name;
-      @Attribute private String value;
+      @XmlAttribute @Attribute private String name;
+      @XmlAttribute @Attribute private String value;
 
-      @Attribute(defaultValue = "")
-      private String count;
+      @XmlAttribute @Attribute private String count;
     }
   }
 }

--- a/map-data/src/main/java/org/triplea/map/data/elements/DiceSides.java
+++ b/map-data/src/main/java/org/triplea/map/data/elements/DiceSides.java
@@ -1,10 +1,16 @@
 package org.triplea.map.data.elements;
 
+import javax.xml.bind.annotation.XmlAttribute;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.triplea.generic.xml.reader.annotations.Attribute;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class DiceSides {
-  @Attribute(defaultInt = 6)
-  private int value;
+  @XmlAttribute @Attribute private Integer value;
 }

--- a/map-data/src/main/java/org/triplea/map/data/elements/Game.java
+++ b/map-data/src/main/java/org/triplea/map/data/elements/Game.java
@@ -1,6 +1,11 @@
 package org.triplea.map.data.elements;
 
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.triplea.generic.xml.reader.annotations.Tag;
 
 /**
@@ -9,24 +14,29 @@ import org.triplea.generic.xml.reader.annotations.Tag;
  * without semantic meaning.
  */
 @Getter
+@XmlRootElement(name = "game")
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Game {
-  @Tag private Info info;
-  @Tag private Triplea triplea;
+  @XmlElement @Tag private Info info;
+  @XmlElement @Tag private Triplea triplea;
 
+  @XmlElement(name = "attachmentList")
   @Tag(names = {"attachmentList", "attatchmentList"})
   private AttachmentList attachmentList;
 
-  @Tag private DiceSides diceSides;
-  @Tag private GamePlay gamePlay;
-  @Tag private Initialize initialize;
-  @Tag private Map map;
-  @Tag private ResourceList resourceList;
-  @Tag private PlayerList playerList;
-  @Tag private UnitList unitList;
-  @Tag private RelationshipTypes relationshipTypes;
-  @Tag private TerritoryEffectList territoryEffectList;
-  @Tag private Production production;
-  @Tag private Technology technology;
-  @Tag private PropertyList propertyList;
-  @Tag private VariableList variableList;
+  @XmlElement @Tag private DiceSides diceSides;
+  @XmlElement @Tag private GamePlay gamePlay;
+  @XmlElement @Tag private Initialize initialize;
+  @XmlElement @Tag private Map map;
+  @XmlElement @Tag private ResourceList resourceList;
+  @XmlElement @Tag private PlayerList playerList;
+  @XmlElement @Tag private UnitList unitList;
+  @XmlElement @Tag private RelationshipTypes relationshipTypes;
+  @XmlElement @Tag private TerritoryEffectList territoryEffectList;
+  @XmlElement @Tag private Production production;
+  @XmlElement @Tag private Technology technology;
+  @XmlElement @Tag private PropertyList propertyList;
+  @XmlElement @Tag private VariableList variableList;
 }

--- a/map-data/src/main/java/org/triplea/map/data/elements/GamePlay.java
+++ b/map-data/src/main/java/org/triplea/map/data/elements/GamePlay.java
@@ -1,50 +1,73 @@
 package org.triplea.map.data.elements;
 
 import java.util.List;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.triplea.generic.xml.reader.annotations.Attribute;
 import org.triplea.generic.xml.reader.annotations.Tag;
 import org.triplea.generic.xml.reader.annotations.TagList;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class GamePlay {
 
-  @TagList private List<Delegate> delegates;
+  @XmlElement(name = "delegate")
+  @TagList
+  private List<Delegate> delegates;
 
-  @Tag private Sequence sequence;
-  @Tag private Offset offset;
+  @XmlElement @Tag private Sequence sequence;
+  @XmlElement @Tag private Offset offset;
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class Delegate {
-    @Attribute private String name;
-    @Attribute private String javaClass;
-    @Attribute private String display;
+    @XmlAttribute @Attribute private String name;
+    @XmlAttribute @Attribute private String javaClass;
+    @XmlAttribute @Attribute private String display;
   }
 
   @Getter
   public static class Sequence {
-    @TagList private List<Step> steps;
+    @XmlElement(name = "step")
+    @TagList
+    private List<Step> steps;
 
     @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Step {
-      @Attribute private String name;
-      @Attribute private String delegate;
-      @Attribute private String player;
-      @Attribute private int maxRunCount;
-      @Attribute private String display;
+      @XmlAttribute @Attribute private String name;
+      @XmlAttribute @Attribute private String delegate;
+      @XmlAttribute @Attribute private String player;
+      @XmlAttribute @Attribute private Integer maxRunCount;
+      @XmlAttribute @Attribute private String display;
 
-      @TagList private List<StepProperty> stepProperties;
+      @XmlElement(name = "stepProperty")
+      @TagList
+      private List<StepProperty> stepProperties;
 
       @Getter
+      @Builder
+      @NoArgsConstructor
+      @AllArgsConstructor
       public static class StepProperty {
-        @Attribute private String name;
-        @Attribute private String value;
+        @XmlAttribute @Attribute private String name;
+        @XmlAttribute @Attribute private String value;
       }
     }
   }
 
   @Getter
   public static class Offset {
-    @Attribute private int round;
+    @XmlAttribute @Attribute private Integer round;
   }
 }

--- a/map-data/src/main/java/org/triplea/map/data/elements/Info.java
+++ b/map-data/src/main/java/org/triplea/map/data/elements/Info.java
@@ -1,10 +1,17 @@
 package org.triplea.map.data.elements;
 
+import javax.xml.bind.annotation.XmlAttribute;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.triplea.generic.xml.reader.annotations.Attribute;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Info {
-  @Attribute private String name;
-  @Attribute private String version;
+  @XmlAttribute @Attribute private String name;
+  @XmlAttribute @Attribute private String version;
 }

--- a/map-data/src/main/java/org/triplea/map/data/elements/Initialize.java
+++ b/map-data/src/main/java/org/triplea/map/data/elements/Initialize.java
@@ -1,77 +1,117 @@
 package org.triplea.map.data.elements;
 
 import java.util.List;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.ToString;
 import org.triplea.generic.xml.reader.annotations.Attribute;
 import org.triplea.generic.xml.reader.annotations.Tag;
 import org.triplea.generic.xml.reader.annotations.TagList;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Initialize {
-  @Tag private OwnerInitialize ownerInitialize;
-  @Tag private UnitInitialize unitInitialize;
-  @Tag private ResourceInitialize resourceInitialize;
-  @Tag private RelationshipInitialize relationshipInitialize;
+  @XmlElement @Tag private OwnerInitialize ownerInitialize;
+  @XmlElement @Tag private UnitInitialize unitInitialize;
+  @XmlElement @Tag private ResourceInitialize resourceInitialize;
+  @XmlElement @Tag private RelationshipInitialize relationshipInitialize;
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class OwnerInitialize {
-    @TagList private List<TerritoryOwner> territoryOwners;
+    @XmlElement(name = "territoryOwner")
+    @TagList
+    private List<TerritoryOwner> territoryOwners;
 
     @Getter
     public static class TerritoryOwner {
-      @Attribute private String territory;
-      @Attribute private String owner;
+      @XmlAttribute @Attribute private String territory;
+      @XmlAttribute @Attribute private String owner;
     }
   }
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class UnitInitialize {
-    @TagList private List<UnitPlacement> unitPlacements;
+    @XmlElement(name = "unitPlacement")
+    @TagList
+    private List<UnitPlacement> unitPlacements;
 
-    @TagList private List<HeldUnits> heldUnits;
+    @XmlElement @TagList private List<HeldUnits> heldUnits;
 
     @Getter
     @ToString
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class UnitPlacement {
-      @Attribute private String unitType;
-      @Attribute private String territory;
-      @Attribute private int quantity;
-      @Attribute private String owner;
-      @Attribute private int hitsTaken;
-      @Attribute private int unitDamage;
+      @XmlAttribute @Attribute private String unitType;
+      @XmlAttribute @Attribute private String territory;
+      @XmlAttribute @Attribute private int quantity;
+      @XmlAttribute @Attribute private String owner;
+      @XmlAttribute @Attribute private Integer hitsTaken;
+      @XmlAttribute @Attribute private Integer unitDamage;
     }
 
     @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class HeldUnits {
-      @Attribute private String unitType;
-      @Attribute private String player;
-      @Attribute private int quantity;
+      @XmlAttribute @Attribute private String unitType;
+      @XmlAttribute @Attribute private String player;
+      @XmlAttribute @Attribute private int quantity;
     }
   }
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class ResourceInitialize {
-    @TagList private List<ResourceGiven> resourcesGiven;
+    @XmlElement(name = "resourceGiven")
+    @TagList
+    private List<ResourceGiven> resourcesGiven;
 
     @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class ResourceGiven {
-      @Attribute private String player;
-      @Attribute private String resource;
-      @Attribute private int quantity;
+      @XmlAttribute @Attribute private String player;
+      @XmlAttribute @Attribute private String resource;
+      @XmlAttribute @Attribute private int quantity;
     }
   }
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class RelationshipInitialize {
-    @TagList private List<Relationship> relationships;
+    @XmlElement(name = "relationship")
+    @TagList
+    private List<Relationship> relationships;
 
     @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Relationship {
-      @Attribute private String type;
-      @Attribute private int roundValue;
-      @Attribute private String player1;
-      @Attribute private String player2;
+      @XmlAttribute @Attribute private String type;
+      @XmlAttribute @Attribute private int roundValue;
+      @XmlAttribute @Attribute private String player1;
+      @XmlAttribute @Attribute private String player2;
     }
   }
 }

--- a/map-data/src/main/java/org/triplea/map/data/elements/Map.java
+++ b/map-data/src/main/java/org/triplea/map/data/elements/Map.java
@@ -1,27 +1,45 @@
 package org.triplea.map.data.elements;
 
 import java.util.List;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.triplea.generic.xml.reader.annotations.Attribute;
 import org.triplea.generic.xml.reader.annotations.TagList;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Map {
 
-  @TagList private List<Territory> territories;
+  @XmlElement(name = "territory")
+  @TagList
+  private List<Territory> territories;
 
-  @TagList private List<Connection> connections;
+  @XmlElement(name = "connection")
+  @TagList
+  private List<Connection> connections;
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class Territory {
-    @Attribute private String name;
+    @XmlAttribute @Attribute private String name;
 
-    @Attribute private boolean water;
+    @XmlAttribute @Attribute private Boolean water;
   }
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class Connection {
-    @Attribute private String t1;
-    @Attribute private String t2;
+    @XmlAttribute @Attribute private String t1;
+    @XmlAttribute @Attribute private String t2;
   }
 }

--- a/map-data/src/main/java/org/triplea/map/data/elements/PlayerList.java
+++ b/map-data/src/main/java/org/triplea/map/data/elements/PlayerList.java
@@ -1,34 +1,51 @@
 package org.triplea.map.data.elements;
 
 import java.util.List;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.triplea.generic.xml.reader.annotations.Attribute;
 import org.triplea.generic.xml.reader.annotations.TagList;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class PlayerList {
 
-  @TagList private List<Player> players;
+  @XmlElement(name = "player")
+  @TagList
+  private List<Player> players;
 
-  @TagList private List<Alliance> alliances;
+  @XmlElement(name = "alliance")
+  @TagList
+  private List<Alliance> alliances;
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class Player {
-    @Attribute private String name;
+    @XmlAttribute @Attribute private String name;
 
-    @Attribute private boolean optional;
+    @XmlAttribute @Attribute private Boolean optional;
 
-    @Attribute private boolean canBeDisabled;
+    @XmlAttribute @Attribute private Boolean canBeDisabled;
 
-    @Attribute(defaultValue = "Human")
-    private String defaultType;
+    @XmlAttribute @Attribute private String defaultType;
 
-    @Attribute private boolean isHidden;
+    @XmlAttribute @Attribute private Boolean isHidden;
   }
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class Alliance {
-    @Attribute private String player;
-    @Attribute private String alliance;
+    @XmlAttribute @Attribute private String player;
+    @XmlAttribute @Attribute private String alliance;
   }
 }

--- a/map-data/src/main/java/org/triplea/map/data/elements/Production.java
+++ b/map-data/src/main/java/org/triplea/map/data/elements/Production.java
@@ -1,100 +1,164 @@
 package org.triplea.map.data.elements;
 
 import java.util.List;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.triplea.generic.xml.reader.annotations.Attribute;
 import org.triplea.generic.xml.reader.annotations.TagList;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Production {
 
-  @TagList private List<ProductionRule> productionRules;
+  @XmlElement(name = "productionRule")
+  @TagList
+  private List<ProductionRule> productionRules;
 
-  @TagList private List<RepairRule> repairRules;
+  @XmlElement(name = "repairRule")
+  @TagList
+  private List<RepairRule> repairRules;
 
-  @TagList private List<RepairFrontier> repairFrontiers;
+  @XmlElement(name = "repairFrontier")
+  @TagList
+  private List<RepairFrontier> repairFrontiers;
 
-  @TagList private List<ProductionFrontier> productionFrontiers;
+  @XmlElement(name = "productionFrontier")
+  @TagList
+  private List<ProductionFrontier> productionFrontiers;
 
-  @TagList private List<PlayerProduction> playerProductions;
+  @XmlElement(name = "playerProduction")
+  @TagList
+  private List<PlayerProduction> playerProductions;
 
-  @TagList private List<PlayerRepair> playerRepairs;
+  @XmlElement(name = "playerRepair")
+  @TagList
+  private List<PlayerRepair> playerRepairs;
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class ProductionRule {
-    @Attribute private String name;
+    @XmlAttribute @Attribute private String name;
 
-    @TagList private List<Cost> costs;
+    @XmlElement(name = "cost")
+    @TagList
+    private List<Cost> costs;
 
-    @TagList private List<Result> results;
+    @XmlElement(name = "result")
+    @TagList
+    private List<Result> results;
 
     @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Cost {
-      @Attribute private String resource;
-      @Attribute private int quantity;
+      @XmlAttribute @Attribute private String resource;
+      @XmlAttribute @Attribute private Integer quantity;
     }
 
     @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Result {
-      @Attribute private String resourceOrUnit;
-      @Attribute private int quantity;
+      @XmlAttribute @Attribute private String resourceOrUnit;
+      @XmlAttribute @Attribute private Integer quantity;
     }
   }
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class RepairRule {
-    @Attribute private String name;
+    @XmlAttribute @Attribute private String name;
 
-    @TagList private List<ProductionRule.Cost> costs;
+    @XmlElement(name = "cost")
+    @TagList
+    private List<ProductionRule.Cost> costs;
 
-    @TagList private List<ProductionRule.Result> results;
+    @XmlElement(name = "result")
+    @TagList
+    private List<ProductionRule.Result> results;
 
     @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Cost {
-      @Attribute private String resource;
-      @Attribute private String quantity;
+      @XmlAttribute @Attribute private String resource;
+      @XmlAttribute @Attribute private String quantity;
     }
 
     @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Result {
-      @Attribute private String resourceOrUnit;
-      @Attribute private String quantity;
+      @XmlAttribute @Attribute private String resourceOrUnit;
+      @XmlAttribute @Attribute private String quantity;
     }
   }
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class RepairFrontier {
-    @Attribute private String name;
+    @XmlAttribute @Attribute private String name;
 
-    @TagList private List<RepairRules> repairRules;
+    @XmlElement @TagList private List<RepairRules> repairRules;
 
     @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class RepairRules {
-      @Attribute private String name;
+      @XmlAttribute @Attribute private String name;
     }
   }
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class ProductionFrontier {
-    @Attribute private String name;
+    @XmlAttribute @Attribute private String name;
 
-    @TagList private List<FrontierRules> frontierRules;
+    @XmlElement @TagList private List<FrontierRules> frontierRules;
 
     @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class FrontierRules {
-      @Attribute private String name;
+      @XmlAttribute @Attribute private String name;
     }
   }
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class PlayerProduction {
-    @Attribute private String player;
-    @Attribute private String frontier;
+    @XmlAttribute @Attribute private String player;
+    @XmlAttribute @Attribute private String frontier;
   }
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class PlayerRepair {
-    @Attribute private String player;
-    @Attribute private String frontier;
+    @XmlAttribute @Attribute private String player;
+    @XmlAttribute @Attribute private String frontier;
   }
 }

--- a/map-data/src/main/java/org/triplea/map/data/elements/PropertyList.java
+++ b/map-data/src/main/java/org/triplea/map/data/elements/PropertyList.java
@@ -1,7 +1,13 @@
 package org.triplea.map.data.elements;
 
 import java.util.List;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlValue;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.triplea.generic.xml.reader.annotations.Attribute;
 import org.triplea.generic.xml.reader.annotations.BodyText;
 import org.triplea.generic.xml.reader.annotations.LegacyXml;
@@ -9,34 +15,48 @@ import org.triplea.generic.xml.reader.annotations.Tag;
 import org.triplea.generic.xml.reader.annotations.TagList;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class PropertyList {
 
-  @TagList private List<Property> properties;
+  @XmlElement(name = "property")
+  @TagList
+  private List<Property> properties;
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class Property {
-    @Attribute private String name;
-    @Attribute private boolean editable;
-    @Attribute private String player;
-    @Attribute private String value;
-    @Attribute private Integer min;
-    @Attribute private Integer max;
+    @XmlAttribute @Attribute private String name;
+    @XmlAttribute @Attribute private Boolean editable;
+    @XmlAttribute @Attribute private String player;
+    @XmlAttribute @Attribute private String value;
+    @XmlAttribute @Attribute private Integer min;
+    @XmlAttribute @Attribute private Integer max;
 
-    @Tag private Property.Value valueProperty;
+    @XmlElement(name = "value")
+    @Tag
+    private Property.Value valueProperty;
 
-    @Tag(names = "Number")
+    @XmlElement(name = "number")
+    @Tag(names = "number")
     private XmlNumberTag numberProperty;
 
     @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Value {
-      @BodyText private String data;
+      @XmlValue @BodyText private String data;
     }
 
     @LegacyXml
     @Getter
     public static class XmlNumberTag {
-      @Attribute private int min;
-      @Attribute private int max;
+      @XmlAttribute @Attribute private Integer min;
+      @XmlAttribute @Attribute private Integer max;
     }
   }
 }

--- a/map-data/src/main/java/org/triplea/map/data/elements/RelationshipTypes.java
+++ b/map-data/src/main/java/org/triplea/map/data/elements/RelationshipTypes.java
@@ -1,17 +1,30 @@
 package org.triplea.map.data.elements;
 
 import java.util.List;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.triplea.generic.xml.reader.annotations.Attribute;
 import org.triplea.generic.xml.reader.annotations.TagList;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class RelationshipTypes {
 
-  @TagList private List<RelationshipType> relationshipTypes;
+  @XmlElement(name = "relationshipType")
+  @TagList
+  private List<RelationshipType> relationshipTypes;
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class RelationshipType {
-    @Attribute private String name;
+    @XmlAttribute @Attribute private String name;
   }
 }

--- a/map-data/src/main/java/org/triplea/map/data/elements/ResourceList.java
+++ b/map-data/src/main/java/org/triplea/map/data/elements/ResourceList.java
@@ -1,18 +1,31 @@
 package org.triplea.map.data.elements;
 
 import java.util.List;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.triplea.generic.xml.reader.annotations.Attribute;
 import org.triplea.generic.xml.reader.annotations.TagList;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class ResourceList {
 
-  @TagList private List<Resource> resources;
+  @XmlElement(name = "resource")
+  @TagList
+  private List<Resource> resources;
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class Resource {
-    @Attribute private String name;
-    @Attribute private String isDisplayedFor;
+    @XmlAttribute @Attribute private String name;
+    @XmlAttribute @Attribute private String isDisplayedFor;
   }
 }

--- a/map-data/src/main/java/org/triplea/map/data/elements/Technology.java
+++ b/map-data/src/main/java/org/triplea/map/data/elements/Technology.java
@@ -1,46 +1,75 @@
 package org.triplea.map.data.elements;
 
 import java.util.List;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.triplea.generic.xml.reader.annotations.Attribute;
 import org.triplea.generic.xml.reader.annotations.Tag;
 import org.triplea.generic.xml.reader.annotations.TagList;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Technology {
 
-  @Tag private Technologies technologies;
+  @XmlElement @Tag private Technologies technologies;
 
-  @TagList private List<PlayerTech> playerTechs;
+  @XmlElement(name = "playerTech")
+  @TagList
+  private List<PlayerTech> playerTechs;
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class Technologies {
-    @TagList private List<TechName> techNames;
+    @XmlElement(name = "techname")
+    @TagList
+    private List<TechName> techNames;
 
     @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class TechName {
-      @Attribute String name;
-
-      @Attribute(defaultValue = "")
-      String tech;
+      @XmlAttribute @Attribute String name;
+      @XmlAttribute @Attribute String tech;
     }
   }
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class PlayerTech {
-    @Attribute private String player;
+    @XmlAttribute @Attribute private String player;
 
-    @TagList private List<Category> categories;
+    @XmlElement(name = "category")
+    @TagList
+    private List<Category> categories;
 
     @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Category {
-      @Attribute private String name;
+      @XmlAttribute @Attribute private String name;
 
-      @TagList private List<Tech> techs;
+      @XmlElement(name = "tech")
+      @TagList
+      private List<Tech> techs;
 
       @Getter
+      @Builder
+      @NoArgsConstructor
+      @AllArgsConstructor
       public static class Tech {
-        @Attribute private String name;
+        @XmlAttribute @Attribute private String name;
       }
     }
   }

--- a/map-data/src/main/java/org/triplea/map/data/elements/TerritoryEffectList.java
+++ b/map-data/src/main/java/org/triplea/map/data/elements/TerritoryEffectList.java
@@ -1,17 +1,30 @@
 package org.triplea.map.data.elements;
 
 import java.util.List;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.triplea.generic.xml.reader.annotations.Attribute;
 import org.triplea.generic.xml.reader.annotations.TagList;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class TerritoryEffectList {
 
-  @TagList private List<TerritoryEffect> territoryEffects;
+  @XmlElement(name = "territoryEffect")
+  @TagList
+  private List<TerritoryEffect> territoryEffects;
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class TerritoryEffect {
-    @Attribute private String name;
+    @XmlAttribute @Attribute private String name;
   }
 }

--- a/map-data/src/main/java/org/triplea/map/data/elements/Triplea.java
+++ b/map-data/src/main/java/org/triplea/map/data/elements/Triplea.java
@@ -1,9 +1,16 @@
 package org.triplea.map.data.elements;
 
+import javax.xml.bind.annotation.XmlAttribute;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.triplea.generic.xml.reader.annotations.Attribute;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class Triplea {
-  @Attribute private String minimumVersion;
+  @XmlAttribute @Attribute private String minimumVersion;
 }

--- a/map-data/src/main/java/org/triplea/map/data/elements/UnitList.java
+++ b/map-data/src/main/java/org/triplea/map/data/elements/UnitList.java
@@ -1,16 +1,29 @@
 package org.triplea.map.data.elements;
 
 import java.util.List;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.triplea.generic.xml.reader.annotations.Attribute;
 import org.triplea.generic.xml.reader.annotations.TagList;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class UnitList {
-  @TagList private List<Unit> units;
+  @XmlElement(name = "unit")
+  @TagList
+  private List<Unit> units;
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class Unit {
-    @Attribute private String name;
+    @XmlAttribute @Attribute private String name;
   }
 }

--- a/map-data/src/main/java/org/triplea/map/data/elements/VariableList.java
+++ b/map-data/src/main/java/org/triplea/map/data/elements/VariableList.java
@@ -1,24 +1,46 @@
 package org.triplea.map.data.elements;
 
 import java.util.List;
+import java.util.Optional;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.triplea.generic.xml.reader.annotations.Attribute;
 import org.triplea.generic.xml.reader.annotations.TagList;
 
 @Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
 public class VariableList {
 
-  @TagList private List<Variable> variables;
+  @XmlElement(name = "variable")
+  @TagList
+  private List<Variable> variables;
 
   @Getter
+  @Builder
+  @NoArgsConstructor
+  @AllArgsConstructor
   public static class Variable {
-    @Attribute private String name;
+    @XmlAttribute @Attribute private String name;
 
-    @TagList private List<Element> elements;
+    @XmlElement(name = "element")
+    @TagList
+    private List<Element> elements;
 
-    @Getter
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
     public static class Element {
-      @Attribute private String name;
+      @XmlAttribute @Attribute private String name;
+
+      public String getName() {
+        return Optional.ofNullable(name).orElse("");
+      }
     }
   }
 }

--- a/map-data/src/main/java/org/triplea/map/xml/writer/GameXmlWriter.java
+++ b/map-data/src/main/java/org/triplea/map/xml/writer/GameXmlWriter.java
@@ -1,0 +1,25 @@
+package org.triplea.map.xml.writer;
+
+import java.nio.file.Path;
+import java.util.logging.Level;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import lombok.experimental.UtilityClass;
+import lombok.extern.java.Log;
+import org.triplea.map.data.elements.Game;
+
+@Log
+@UtilityClass
+public class GameXmlWriter {
+  public void exportXml(final Game game, final Path toPath) {
+    try {
+      final JAXBContext context = JAXBContext.newInstance(Game.class);
+      final Marshaller marshaller = context.createMarshaller();
+      marshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, Boolean.TRUE);
+      marshaller.marshal(game, toPath.toFile());
+    } catch (final JAXBException e) {
+      log.log(Level.SEVERE, "Error writing game data to XML: " + e.getMessage(), e);
+    }
+  }
+}

--- a/map-data/src/test/java/org/triplea/map/data/elements/AttachmentListTest.java
+++ b/map-data/src/test/java/org/triplea/map/data/elements/AttachmentListTest.java
@@ -3,6 +3,7 @@ package org.triplea.map.data.elements;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.triplea.map.data.elements.XmlReaderTestUtils.parseMapXml;
 
 import java.util.List;
@@ -23,13 +24,13 @@ public class AttachmentListTest {
     assertThat(attachments.get(0).getName(), is("name-value"));
     assertThat(attachments.get(0).getAttachTo(), is("attachTo-value"));
     assertThat(attachments.get(0).getJavaClass(), is("javaClass-value"));
-    assertThat(attachments.get(0).getType(), is("unitType"));
+    assertThat(attachments.get(0).getType(), is(nullValue()));
 
     List<Option> options = attachments.get(0).getOptions();
     assertThat(options, hasSize(2));
     assertThat(options.get(0).getName(), is("default-option"));
     assertThat(options.get(0).getValue(), is("some-value"));
-    assertThat(options.get(0).getCount(), is(""));
+    assertThat(options.get(0).getCount(), is(nullValue()));
 
     assertThat(options.get(1).getName(), is("default-option2"));
     assertThat(options.get(1).getValue(), is("some-value2"));

--- a/map-data/src/test/java/org/triplea/map/data/elements/MapTest.java
+++ b/map-data/src/test/java/org/triplea/map/data/elements/MapTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.triplea.map.data.elements.XmlReaderTestUtils.parseMapXml;
 
 import org.junit.jupiter.api.Test;
@@ -18,11 +19,11 @@ public class MapTest {
 
     assertThat(map.getTerritories().get(0), is(notNullValue()));
     assertThat(map.getTerritories().get(0).getName(), is("Belgium"));
-    assertThat(map.getTerritories().get(0).isWater(), is(false));
+    assertThat(map.getTerritories().get(0).getWater(), is(nullValue()));
 
     assertThat(map.getTerritories().get(1), is(notNullValue()));
     assertThat(map.getTerritories().get(1).getName(), is("Sea"));
-    assertThat(map.getTerritories().get(1).isWater(), is(true));
+    assertThat(map.getTerritories().get(1).getWater(), is(true));
 
     assertThat(map.getConnections(), is(notNullValue()));
     assertThat(map.getTerritories(), hasSize(2));

--- a/map-data/src/test/java/org/triplea/map/data/elements/PlayerListTest.java
+++ b/map-data/src/test/java/org/triplea/map/data/elements/PlayerListTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
 import static org.triplea.map.data.elements.XmlReaderTestUtils.parseMapXml;
 
 import org.junit.jupiter.api.Test;
@@ -19,17 +20,17 @@ class PlayerListTest {
 
     assertThat(playerList.getPlayers().get(0), is(notNullValue()));
     assertThat(playerList.getPlayers().get(0).getName(), is("player1"));
-    assertThat(playerList.getPlayers().get(0).isOptional(), is(false));
-    assertThat(playerList.getPlayers().get(0).isCanBeDisabled(), is(false));
-    assertThat(playerList.getPlayers().get(0).getDefaultType(), is("Human"));
-    assertThat(playerList.getPlayers().get(0).isHidden(), is(false));
+    assertThat(playerList.getPlayers().get(0).getOptional(), is(nullValue()));
+    assertThat(playerList.getPlayers().get(0).getCanBeDisabled(), is(nullValue()));
+    assertThat(playerList.getPlayers().get(0).getDefaultType(), is(nullValue()));
+    assertThat(playerList.getPlayers().get(0).getIsHidden(), is(nullValue()));
 
     assertThat(playerList.getPlayers().get(1), is(notNullValue()));
     assertThat(playerList.getPlayers().get(1).getName(), is("player2"));
-    assertThat(playerList.getPlayers().get(1).isOptional(), is(true));
-    assertThat(playerList.getPlayers().get(1).isCanBeDisabled(), is(true));
+    assertThat(playerList.getPlayers().get(1).getOptional(), is(true));
+    assertThat(playerList.getPlayers().get(1).getCanBeDisabled(), is(true));
     assertThat(playerList.getPlayers().get(1).getDefaultType(), is("AI"));
-    assertThat(playerList.getPlayers().get(1).isHidden(), is(true));
+    assertThat(playerList.getPlayers().get(1).getIsHidden(), is(true));
 
     assertThat(playerList.getAlliances(), is(notNullValue()));
     assertThat(playerList.getAlliances(), hasSize(1));

--- a/map-data/src/test/java/org/triplea/map/data/elements/PropertyListTest.java
+++ b/map-data/src/test/java/org/triplea/map/data/elements/PropertyListTest.java
@@ -19,7 +19,7 @@ class PropertyListTest {
 
     assertThat(propertyList.getProperties().get(0).getValue(), is("propValue"));
     assertThat(propertyList.getProperties().get(0).getName(), is("propName"));
-    assertThat(propertyList.getProperties().get(0).isEditable(), is(true));
+    assertThat(propertyList.getProperties().get(0).getEditable(), is(true));
     assertThat(propertyList.getProperties().get(0).getPlayer(), is("player1"));
     assertThat(propertyList.getProperties().get(0).getMin(), is(nullValue()));
     assertThat(propertyList.getProperties().get(0).getMax(), is(nullValue()));
@@ -29,22 +29,22 @@ class PropertyListTest {
     assertThat(propertyList.getProperties().get(1).getMin(), is(1));
     assertThat(propertyList.getProperties().get(1).getMax(), is(1000));
 
-    assertThat(propertyList.getProperties().get(2).getValue(), is(""));
+    assertThat(propertyList.getProperties().get(2).getValue(), is(nullValue()));
     assertThat(propertyList.getProperties().get(2).getName(), is("notes"));
-    assertThat(propertyList.getProperties().get(2).isEditable(), is(false));
-    assertThat(propertyList.getProperties().get(2).getPlayer(), is(""));
+    assertThat(propertyList.getProperties().get(2).getEditable(), is(nullValue()));
+    assertThat(propertyList.getProperties().get(2).getPlayer(), is(nullValue()));
     assertThat(propertyList.getProperties().get(2).getValueProperty(), is(notNullValue()));
     assertThat(propertyList.getProperties().get(2).getValueProperty().getData(), is("Notes here"));
 
-    assertThat(propertyList.getProperties().get(3).getValue(), is(""));
+    assertThat(propertyList.getProperties().get(3).getValue(), is(nullValue()));
     assertThat(propertyList.getProperties().get(3).getName(), is("stringProperty"));
-    assertThat(propertyList.getProperties().get(3).isEditable(), is(false));
-    assertThat(propertyList.getProperties().get(3).getPlayer(), is(""));
+    assertThat(propertyList.getProperties().get(3).getEditable(), is(nullValue()));
+    assertThat(propertyList.getProperties().get(3).getPlayer(), is(nullValue()));
 
-    assertThat(propertyList.getProperties().get(4).getValue(), is(""));
+    assertThat(propertyList.getProperties().get(4).getValue(), is(nullValue()));
     assertThat(propertyList.getProperties().get(4).getName(), is("numberProperty"));
-    assertThat(propertyList.getProperties().get(4).isEditable(), is(false));
-    assertThat(propertyList.getProperties().get(4).getPlayer(), is(""));
+    assertThat(propertyList.getProperties().get(4).getEditable(), is(nullValue()));
+    assertThat(propertyList.getProperties().get(4).getPlayer(), is(nullValue()));
     assertThat(propertyList.getProperties().get(4).getNumberProperty(), is(notNullValue()));
     assertThat(propertyList.getProperties().get(4).getNumberProperty().getMin(), is(123));
     assertThat(propertyList.getProperties().get(4).getNumberProperty().getMax(), is(999));

--- a/map-data/src/test/java/org/triplea/map/xml/writer/GameXmlWriterTest.java
+++ b/map-data/src/test/java/org/triplea/map/xml/writer/GameXmlWriterTest.java
@@ -1,0 +1,58 @@
+package org.triplea.map.xml.writer;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.triplea.generic.xml.reader.XmlMapper;
+import org.triplea.map.data.elements.Game;
+import org.xmlunit.matchers.CompareMatcher;
+
+class GameXmlWriterTest {
+
+  /**
+   * In this test we'll assume 'XmlMapper' is correct and load a 'Game' object from XML. We'll then
+   * write that same Game object back to another XML file and then verify that the read and written
+   * XML files are equivalent.
+   */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "attachment-list.xml",
+        "dice-sides.xml",
+        "game.xml",
+        "game-play.xml",
+        "info.xml",
+        "initialize.xml",
+        "map.xml",
+        "player-list.xml",
+        "production.xml",
+        "property-list.xml",
+        "relationship-types.xml",
+        "resource-list.xml",
+        "technology.xml",
+        "territory-effect-list.xml",
+        "triplea.xml",
+        "unit-list.xml",
+        "variable-list.xml"
+      })
+  void verifyXmlOutput(final String gameXmlFileName) throws Exception {
+    final URI uri = this.getClass().getClassLoader().getResource(gameXmlFileName).toURI();
+
+    final XmlMapper mapper =
+        new XmlMapper(this.getClass().getClassLoader().getResourceAsStream(gameXmlFileName));
+    final Game game = mapper.mapXmlToObject(Game.class);
+
+    final Path outputPath = Path.of("output" + gameXmlFileName);
+    GameXmlWriter.exportXml(game, outputPath);
+    outputPath.toFile().deleteOnExit();
+
+    final String input = Files.readString(Path.of(uri));
+    final String output = Files.readString(outputPath);
+
+    assertThat(output, CompareMatcher.isSimilarTo(input));
+  }
+}

--- a/map-data/src/test/resources/attachment-list.xml
+++ b/map-data/src/test/resources/attachment-list.xml
@@ -1,21 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <game>
     <attachmentList>
-        <attachment
-                foreach="foreach-value"
-                name="name-value"
-                attachTo="attachTo-value"
-                javaClass="javaClass-value">
-            <!-- type = default:"unitType" -->
+        <attachment foreach="foreach-value" name="name-value" attachTo="attachTo-value" javaClass="javaClass-value">
             <option name="default-option" value="some-value"/>
             <option name="default-option2" value="some-value2" count="2"/>
         </attachment>
-
-        <attachment
-                foreach="foreach-value2"
-                name="name-value2"
-                attachTo="attachTo-value2"
-                javaClass="javaClass-value2"
-                type="resource">
+        <attachment foreach="foreach-value2" name="name-value2" attachTo="attachTo-value2" javaClass="javaClass-value2" type="resource">
             <option name="option-name" value="option-value" count="option-count"/>
         </attachment>
     </attachmentList>

--- a/map-data/src/test/resources/dice-sides.xml
+++ b/map-data/src/test/resources/dice-sides.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <game>
     <diceSides value="20"/>
 </game>

--- a/map-data/src/test/resources/game-play.xml
+++ b/map-data/src/test/resources/game-play.xml
@@ -1,10 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <game>
     <gamePlay>
         <delegate name="delegate1" javaClass="javaDelegate1" display="display1"/>
         <delegate name="delegate2" javaClass="javaDelegate2"/>
-
-        <offset round="3"/>
-
         <sequence>
             <step name="step1" delegate="stepDelegate1" player="player1" maxRunCount="1" display="stepDisplay"/>
             <step name="step2" delegate="stepDelegate2"/>
@@ -13,6 +11,6 @@
                 <stepProperty name="stepProp2" value="stepValue2"/>
             </step>
         </sequence>
-
+        <offset round="3"/>
     </gamePlay>
 </game>

--- a/map-data/src/test/resources/game.xml
+++ b/map-data/src/test/resources/game.xml
@@ -1,21 +1,20 @@
-<?xml version="1.0" ?>
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!DOCTYPE game SYSTEM "game.dtd">
-
 <game>
     <info/>
     <triplea/>
+    <attachmentList/>
     <diceSides/>
-    <variableList/>
+    <gamePlay/>
+    <initialize/>
     <map/>
     <resourceList/>
     <playerList/>
     <unitList/>
     <relationshipTypes/>
     <territoryEffectList/>
-    <gamePlay/>
     <production/>
     <technology/>
-    <attachmentList/>
-    <initialize/>
     <propertyList/>
+    <variableList/>
 </game>

--- a/map-data/src/test/resources/info.xml
+++ b/map-data/src/test/resources/info.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <game>
     <info name="info-tag-test" version="123.xyz"/>
 </game>

--- a/map-data/src/test/resources/initialize.xml
+++ b/map-data/src/test/resources/initialize.xml
@@ -1,8 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <game>
     <initialize>
         <ownerInitialize>
-            <territoryOwner territory="Poland" owner="Polish" />
-            <territoryOwner territory="France" owner="French" />
+            <territoryOwner territory="Poland" owner="Polish"/>
+            <territoryOwner territory="France" owner="French"/>
         </ownerInitialize>
         <unitInitialize>
             <unitPlacement unitType="Infantry" territory="Poland" quantity="1" owner="Polish" hitsTaken="1" unitDamage="2"/>
@@ -11,8 +12,8 @@
             <heldUnits unitType="Delkon" player="AI" quantity="1"/>
         </unitInitialize>
         <resourceInitialize>
-            <resourceGiven player="Anzac" resource="PUs" quantity="20" />
-            <resourceGiven player="Dutch" resource="PUs" quantity="0" />
+            <resourceGiven player="Anzac" resource="PUs" quantity="20"/>
+            <resourceGiven player="Dutch" resource="PUs" quantity="0"/>
         </resourceInitialize>
         <relationshipInitialize>
             <relationship type="Neutrality" roundValue="1" player1="Western" player2="Southern"/>

--- a/map-data/src/test/resources/map.xml
+++ b/map-data/src/test/resources/map.xml
@@ -1,8 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <game>
     <map>
-        <territory name="Belgium" />
-        <territory name="Sea" water = "true" />
-        <connection t1="start1" t2="end1" />
-        <connection t1="start2" t2="end2" />
+        <territory name="Belgium"/>
+        <territory name="Sea" water="true"/>
+        <connection t1="start1" t2="end1"/>
+        <connection t1="start2" t2="end2"/>
     </map>
 </game>

--- a/map-data/src/test/resources/player-list.xml
+++ b/map-data/src/test/resources/player-list.xml
@@ -1,13 +1,8 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <game>
     <playerList>
         <player name="player1"/>
-        <player
-                name="player2"
-                optional="true"
-                canBeDisabled="true"
-                defaultType="AI"
-                isHidden="true"/>
-
+        <player name="player2" optional="true" canBeDisabled="true" defaultType="AI" isHidden="true"/>
         <alliance player="player1" alliance="alliance1"/>
     </playerList>
 </game>

--- a/map-data/src/test/resources/production.xml
+++ b/map-data/src/test/resources/production.xml
@@ -1,5 +1,5 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <game>
-
     <production>
         <productionRule name="buyInfantry">
             <cost resource="PUs" quantity="2"/>
@@ -11,24 +11,19 @@
             <cost resource="PUs" quantity="5"/>
             <result resourceOrUnit="Tank" quantity="1"/>
         </productionRule>
-
         <repairRule name="repairFactoryIndustrialTechnology">
             <cost resource="PUs" quantity="1"/>
             <result resourceOrUnit="factory" quantity="2"/>
         </repairRule>
-
         <repairFrontier name="repair">
             <repairRules name="repairFactory"/>
         </repairFrontier>
-
         <productionFrontier name="NeutralFrontier">
             <frontierRules name="buyInfantry"/>
             <frontierRules name="buyArtillery"/>
         </productionFrontier>
-
         <playerProduction player="Russians" frontier="RussiansFrontier"/>
         <playerProduction player="Italians" frontier="ItaliansFrontier"/>
-
         <playerRepair player="France" frontier="repair"/>
         <playerRepair player="Russia" frontier="repair"/>
     </production>

--- a/map-data/src/test/resources/property-list.xml
+++ b/map-data/src/test/resources/property-list.xml
@@ -1,15 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <game>
     <propertyList>
         <property value="propValue" name="propName" editable="true" player="player1"/>
-
         <property value="100" name="number" min="1" max="1000"/>
-
         <property name="notes">
             <value>Notes here</value>
         </property>
-
         <property name="stringProperty"/>
-
         <property name="numberProperty">
             <number min="123" max="999"/>
         </property>

--- a/map-data/src/test/resources/relationship-types.xml
+++ b/map-data/src/test/resources/relationship-types.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <game>
     <relationshipTypes>
-        <relationshipType name="war" />
-        <relationshipType name="peace" />
+        <relationshipType name="war"/>
+        <relationshipType name="peace"/>
     </relationshipTypes>
 </game>

--- a/map-data/src/test/resources/resource-list.xml
+++ b/map-data/src/test/resources/resource-list.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <game>
     <resourceList>
-        <resource name="PUs" />
+        <resource name="PUs"/>
         <resource name="Gold" isDisplayedFor="player1"/>
     </resourceList>
 </game>

--- a/map-data/src/test/resources/technology.xml
+++ b/map-data/src/test/resources/technology.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <game>
     <technology>
         <technologies>
@@ -5,7 +6,6 @@
             <techname name="tracer_rounds"/>
             <techname name="creeping_barrage" tech="improvedArtillerySupport"/>
         </technologies>
-
         <playerTech player="USA">
             <category name="Land">
                 <tech name="counter_battery_fire"/>
@@ -19,7 +19,6 @@
                 <tech name="radio"/>
             </category>
         </playerTech>
-
         <playerTech player="UK">
             <category name="Land">
                 <tech name="mobile_warfare"/>

--- a/map-data/src/test/resources/territory-effect-list.xml
+++ b/map-data/src/test/resources/territory-effect-list.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <game>
     <territoryEffectList>
         <territoryEffect name="city"/>
@@ -5,4 +6,3 @@
         <territoryEffect name="sea"/>
     </territoryEffectList>
 </game>
-

--- a/map-data/src/test/resources/triplea.xml
+++ b/map-data/src/test/resources/triplea.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <game>
     <triplea minimumVersion="min-version"/>
 </game>

--- a/map-data/src/test/resources/unit-list.xml
+++ b/map-data/src/test/resources/unit-list.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <game>
     <unitList>
-        <unit name="Infantry" />
+        <unit name="Infantry"/>
         <unit name="Militia"/>
         <unit name="Helicopter"/>
     </unitList>

--- a/map-data/src/test/resources/variable-list.xml
+++ b/map-data/src/test/resources/variable-list.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <game>
     <variableList>
         <variable name="AllHeroUnits">
@@ -6,7 +7,6 @@
             <element name="Sevis"/>
             <element name="Sian-tsu"/>
         </variable>
-
         <variable name="AllAllianceHeroUnits">
             <element name="Arthur"/>
             <element name="Khorman"/>

--- a/xml-reader/src/main/java/org/triplea/generic/xml/reader/AttributeValueCasting.java
+++ b/xml-reader/src/main/java/org/triplea/generic/xml/reader/AttributeValueCasting.java
@@ -1,6 +1,7 @@
 package org.triplea.generic.xml.reader;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import java.lang.reflect.Field;
 import java.util.Optional;
 import org.triplea.generic.xml.reader.annotations.Attribute;
@@ -25,7 +26,8 @@ class AttributeValueCasting {
       return castToBoolean(attributeValue);
     } else {
       // type is a String
-      return Optional.ofNullable(attributeValue).orElseGet(attributeAnnotation::defaultValue);
+      return Strings.emptyToNull(
+          Optional.ofNullable(attributeValue).orElseGet(attributeAnnotation::defaultValue));
     }
   }
 

--- a/xml-reader/src/test/java/org/triplea/generic/xml/reader/ExtendedLibraryExampleTest.java
+++ b/xml-reader/src/test/java/org/triplea/generic/xml/reader/ExtendedLibraryExampleTest.java
@@ -28,6 +28,7 @@ public class ExtendedLibraryExampleTest extends AbstractXmlMapperTest {
 
     static class Name {
       @Attribute private String libraryName;
+      @Attribute private String notInTheXml;
     }
 
     static class MostRead {
@@ -77,7 +78,6 @@ public class ExtendedLibraryExampleTest extends AbstractXmlMapperTest {
 
   @Test
   void verifyExtendedExample() throws Exception {
-
     final Library library = xmlMapper.mapXmlToObject(Library.class);
     assertThat(library, is(notNullValue()));
 

--- a/xml-reader/src/test/java/org/triplea/generic/xml/reader/SimpleLibraryExampleTest.java
+++ b/xml-reader/src/test/java/org/triplea/generic/xml/reader/SimpleLibraryExampleTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.IsNull.nullValue;
 
 import java.util.List;
 import lombok.Getter;
@@ -61,6 +62,13 @@ public class SimpleLibraryExampleTest extends AbstractXmlMapperTest {
   }
 
   @Test
+  void attributesNotPresentInXmlAreNull() throws Exception {
+    final Library library = xmlMapper.mapXmlToObject(Library.class);
+
+    assertThat(library.libraryInventory.attributeThatDoesNotExist, is(nullValue()));
+  }
+
+  @Test
   void verifySimpleExample() throws Exception {
     final Library library = xmlMapper.mapXmlToObject(Library.class);
 
@@ -69,7 +77,6 @@ public class SimpleLibraryExampleTest extends AbstractXmlMapperTest {
     assertThat(library.exampleOfListThatIsNotPresent, is(empty()));
 
     assertThat(library.libraryInventory, is(notNullValue()));
-    assertThat(library.libraryInventory.attributeThatDoesNotExist, is(""));
     assertThat(library.libraryInventory.type, is("available"));
     assertThat(library.libraryInventory.books, hasSize(2));
     assertThat(library.libraryInventory.books.get(0), is(notNullValue()));


### PR DESCRIPTION
This update enables writing of 'Game' data to XML using Jaxb.
Later, following this update, if we can convert a 'GameData'
to a 'Game' object, then we'll be able to write a 'GameData'
to XML.

Notable changes and summary:
- (read path update) when parsing XML attributes, missing attribute
  are now set to null rather than an empty string

- (write path) Jaxb annotations are added to 'Game' objects
  and children to enable those objects to be unmarshalled into XML.

- (write path) builder annotations are added to the 'Game' object and
  children in anticipation of later creating those objects when
  we marshal a 'GameData' object into a 'Game' object

- A write test is added where we we re-use the test data and testing
  of XMLMapper, we use XMLMapper to read a 'Game' object using
  each test-XML created and we then write that 'Game' object back
  to XML and then compare the before and after XML.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer

(1) XML model object defaults are removed. This is so that the reading from XML and writing to XML can write back the same XML .This is a bit of a design/architecture choice which I think makes sense. The XML model objects are really meant to be strict POJO representations of what's in the XML file and not have any semantic knowledge about the data. In this sense, having defaults does mean those objects do know something about game concepts. We might be able to strip the XML default value logic pretty soon, for now I'd like to see how things play out before removing it.

(2) Fixes: https://github.com/triplea-game/triplea/issues/7656

By converting missing attributes to null, this enables the fallback logic for parsing game notes that looks for null's to work correctly.
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
