### PR TITLE
Fix: Convert DB test cleanup from afterEach to beforeEach

### DIFF
--- a/dropwizard-common-test/src/main/java/org/triplea/dropwizard/test/DropwizardServerExtension.java
+++ b/dropwizard-common-test/src/main/java/org/triplea/dropwizard/test/DropwizardServerExtension.java
@@ -13,8 +13,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.jdbi.v3.core.Jdbi;
 import org.jdbi.v3.core.mapper.RowMapperFactory;
 import org.jdbi.v3.sqlobject.SqlObjectPlugin;
-import org.junit.jupiter.api.extension.AfterEachCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.junit.jupiter.api.extension.ParameterContext;
 import org.junit.jupiter.api.extension.ParameterResolutionException;
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.extension.ParameterResolver;
  */
 @Slf4j
 public abstract class DropwizardServerExtension<C extends Configuration>
-    implements BeforeAllCallback, AfterEachCallback, ParameterResolver {
+    implements BeforeAllCallback, BeforeEachCallback, ParameterResolver {
 
   private static Jdbi jdbi;
   private static URI serverUri;
@@ -77,7 +77,7 @@ public abstract class DropwizardServerExtension<C extends Configuration>
   }
 
   @Override
-  public void afterEach(final ExtensionContext context) throws Exception {
+  public void beforeEach(final ExtensionContext context) throws Exception {
     final URL cleanupFileUrl = getClass().getClassLoader().getResource("db-cleanup.sql");
     if (cleanupFileUrl != null) {
       final String cleanupSql = Files.readString(Path.of(cleanupFileUrl.toURI()));


### PR DESCRIPTION
When starting database, sample data is inserted. When we then run tests,
DbRider clears out target tables and then inserts data. If the sample
data has a FK to any of the cleared out data then we'll get an error.

To fix this, instead of cleaning database data *after* tests, we
can clean database data *before* running tests.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
