### PR TITLE
Documentation map changelog

### DIFF
--- a/docs/map-making/how-to-upgrade-legacy-map-features.md
+++ b/docs/map-making/how-to-upgrade-legacy-map-features.md
@@ -28,8 +28,8 @@ Caution, this list might not be complete, please let us know if there is anythin
 - `="victoryCity" count="-reset-true"` >> `="victoryCity" count="-reset-1"`
 - `="victoryCity" count="false"` >> `="victoryCity" count="0"`
 - `="victoryCity" count="true"` >> `="victoryCity" count="1"`
-- `="victoryCity" value="false"` >> `="victoryCity" count="0"`
-- `="victoryCity" value="true"` >> `="victoryCity" count="1"`
+- `="victoryCity" value="false"` >> `="victoryCity" value="0"`
+- `="victoryCity" value="true"` >> `="victoryCity" value="1"`
 - `attatchment` >> `attachment`
 - `Attatchment` >> `Attachment`
 - `attatchTo=` >> `attachTo=`

--- a/docs/map-making/how-to-upgrade-legacy-map-features.md
+++ b/docs/map-making/how-to-upgrade-legacy-map-features.md
@@ -47,12 +47,6 @@ Caution, this list might not be complete, please let us know if there is anythin
 
 ### XML Deletions
 
-Delete these options entirely:
-
-- `<option name="takeUnitControl"`
-- `<option name="giveUnitControl"`
-
-
 Delete these tags (found under `<property>`)
 
 - `<boolean/>`

--- a/docs/map-making/how-to-upgrade-legacy-map-features.md
+++ b/docs/map-making/how-to-upgrade-legacy-map-features.md
@@ -1,26 +1,10 @@
-# How To Upgrade Legacy Map Features
+# Map Change Log
 
-A list of changes to upgrade legacy TripleA Game XML properties and options to the most recent.
+A list of changes to map files that have occurred over time.
+Caution, this list might not be complete, please let us know if there is anything missing.
  
-Note: Before applying the changes below (assuming you do it with a simple replace), you should make
-sure to not have unnecessary spaces inside angle brackets (chevrons).
-
-Note: Some items are not validated. Thus, if the game plays without errors using a latest,
-this doesn't necessarily mean that you correctly upgraded it (for more information, see the "warning"
-section).
-
 
 ## XML Changes
-
-These changes need to happen in your game XML files.
-
-### New game (XML) file settings:
-
-`<triplea minimumVersion="*"/>`:`<triplea minimumVersion="1.9.0.0"/>`
-
-### Changes:
-
-All occurrences of the code before the `>>` must be substituted with the code after the `>>`.
 
 - `attatchment` >> `attachment`
 - `Attatchment` >> `Attachment`
@@ -35,70 +19,36 @@ All occurrences of the code before the `>>` must be substituted with the code af
 - `="conditionType" count="XOR"` >> `="conditionType" count="1"`
 - `="conditionType" count="-reset-XOR"` >> `="conditionType" count="-reset-1"`
 - `="isTwoHit" count="true"` >> `="hitPoints" count="2"`
-- `="isTwoHit" value="false"` >> `="hitPoints" value="1"`
-- `="isTwoHit" count="-reset-true"` >> `="hitPoints" count="-reset-2"`
 - `="isTwoHit" count="false"` >> `="hitPoints" count="1"`
+- `="isTwoHit" value="true"` >> `="hitPoints" value="2"`
+- `="isTwoHit" value="false"` >> `="hitPoints" count="1"`
+- `="isTwoHit" count="-reset-true"` >> `="hitPoints" count="-reset-2"`
 - `="isTwoHit" count="-reset-false"` >> `="hitPoints" count="-reset-1"`
 - `="occupiedTerrOf"` >> `="originalOwner"`
 - `="victoryCity" count="true"` >> `="victoryCity" count="1"`
-- `="victoryCity" count="-reset-true"` >> `="victoryCity" count="-reset-1"`
 - `="victoryCity" count="false"` >> `="victoryCity" count="0"`
+- `="victoryCity" value="true"` >> `="victoryCity" count="1"`
+- `="victoryCity" value="false"` >> `="victoryCity" count="0"`
+- `="victoryCity" count="-reset-true"` >> `="victoryCity" count="-reset-1"`
 - `="victoryCity" count="-reset-false"` >> `="victoryCity" count="-reset-0"`
-
-
-### **Procedural alternatives:**
-
-For a more defined change, instead of the aforementioned:
-
-- `attatchment` >> `attachment`
-
-you can change:
-
-- `attatchmentList` >> `attachmentList`
-- `<attatchment` >> `<attachment`
-- `attatchment>` >> `attachment>`
-- `="games.strategy.triplea.attatchments` >> `="games.strategy.triplea.attachments`
-
-- `="techAttatchment` >> `="techAttachment`
-- `="unitAttatchment` >> `="unitAttachment`
-- `="territoryAttatchment` >> `="territoryAttachment`
-- `="canalAttatchment` >> `="canalAttachment`
-- `="rulesAttatchment` >> `="rulesAttachment`
-- `="playerAttatchment` >> `="playerAttachment`
+- `<option name="isParatroop"` >> `<option name="isAirTransportable"`
+- `<option name="isMechanized"` >> `<optiona name="isLandTransportable"`
 
 
 ### XML Deletions
 
-_(these items were already deprecated and did nothing)_
+Delete these options entirely:
 
-- `<option name="isParatroop"*/>`
-- `<option name="isMechanized"*/>`
-- `<option name="takeUnitControl"*/>`
-- `<option name="giveUnitControl" value="true"/>`
-- `<option name="giveUnitControl" value="false"/>`
+- `<option name="takeUnitControl"`
+- `<option name="giveUnitControl"`
 
-## map.properties Changes
-
-Within every "map" properties file, inside the main folder of the map, change:
+## map.properties changes
 
 - `color.Impassible=` >> `color.Impassable=`
 
-## Sound file changes
+## sound.properties and sound file changes
 
-Change all sounds inside the "sounds" main folder of the map from "wav" to "mp3" format.
-128Kbps and 168Kbps are the preferred bit rates.
+- .wav files need to be re-encoded as mp3 (128 or 168Kbps are preferred bit rates)
+- all file names in sound.properties need to be updated to match the new '.mp3' suffix
+  on sound files.
 
-
-## Warnings
-
-The following xml codes, as being properties, are not validated (if you leave them, the game will play,
-but they will set nothing in the engine) (it is suggested you double check you don't have them within
-any game files, after upgrading the map):
-
-- `="Battleships repair at end of round"`
-- `="Battleships repair at beginning of round"`
-- `="Naval Bombard Casualties Return Fire Restricted"`
-- `="SBR Affects Unit Production"`
-
-While all options named "takeUnitControl" must be deleted, any option named "giveUnitControl" must be
-deleted only if its value is "true" or "false".

--- a/docs/map-making/how-to-upgrade-legacy-map-features.md
+++ b/docs/map-making/how-to-upgrade-legacy-map-features.md
@@ -6,7 +6,7 @@ Caution, this list might not be complete, please let us know if there is anythin
 
 ## XML Changes
 
-- `<option name="isMechanized"` >> `<optiona name="isLandTransportable"`
+- `<option name="isMechanized"` >> `<option name="isLandTransportable"`
 - `<option name="isParatroop"` >> `<option name="isAirTransportable"`
 - `="Battleships repair at beginning of round"` >> `="Units Repair Hits Start Turn"`
 - `="Battleships repair at end of round"` >> `="Units Repair Hits End Turn"`

--- a/docs/map-making/how-to-upgrade-legacy-map-features.md
+++ b/docs/map-making/how-to-upgrade-legacy-map-features.md
@@ -1,4 +1,4 @@
-# Map Change Log
+# Map Features Change Log
 
 A list of changes to map files that have occurred over time.
 Caution, this list might not be complete, please let us know if there is anything missing.
@@ -35,12 +35,30 @@ Caution, this list might not be complete, please let us know if there is anythin
 - `<option name="isMechanized"` >> `<optiona name="isLandTransportable"`
 
 
+```
+<property name="..." value="...">
+   <number min="..." max="..."/>
+</property>
+
+>>
+
+<property name="..." value="..." min="..." max="..."/>
+```
+
 ### XML Deletions
 
 Delete these options entirely:
 
 - `<option name="takeUnitControl"`
 - `<option name="giveUnitControl"`
+
+
+Delete these tags (found under `<property>`)
+
+- `<boolean/>`
+- `<string/>`
+
+
 
 ## map.properties changes
 

--- a/docs/map-making/how-to-upgrade-legacy-map-features.md
+++ b/docs/map-making/how-to-upgrade-legacy-map-features.md
@@ -6,33 +6,33 @@ Caution, this list might not be complete, please let us know if there is anythin
 
 ## XML Changes
 
+- `<option name="isMechanized"` >> `<optiona name="isLandTransportable"`
+- `<option name="isParatroop"` >> `<option name="isAirTransportable"`
+- `="Battleships repair at beginning of round"` >> `="Units Repair Hits Start Turn"`
+- `="Battleships repair at end of round"` >> `="Units Repair Hits End Turn"`
+- `="conditionType" count="-reset-XOR"` >> `="conditionType" count="-reset-1"`
+- `="conditionType" count="XOR"` >> `="conditionType" count="1"`
+- `="conditionType" value="XOR"` >> `="conditionType" value="1"`
+- `="isImpassible"` >> `="isImpassable"`
+- `="isTwoHit" count="-reset-false"` >> `="hitPoints" count="-reset-1"`
+- `="isTwoHit" count="-reset-true"` >> `="hitPoints" count="-reset-2"`
+- `="isTwoHit" count="false"` >> `="hitPoints" count="1"`
+- `="isTwoHit" count="true"` >> `="hitPoints" count="2"`
+- `="isTwoHit" value="false"` >> `="hitPoints" count="1"`
+- `="isTwoHit" value="true"` >> `="hitPoints" value="2"`
+- `="Naval Bombard Casualties Return Fire Restricted"` >> `="Naval Bombard Casualties Return Fire"`
+- `="occupiedTerrOf"` >> `="originalOwner"`
+- `="SBR Affects Unit Production"` >> `="Damage From Bombing Done To Units Instead Of Territories"`
+- `="turns"` >> `="rounds"`
+- `="victoryCity" count="-reset-false"` >> `="victoryCity" count="-reset-0"`
+- `="victoryCity" count="-reset-true"` >> `="victoryCity" count="-reset-1"`
+- `="victoryCity" count="false"` >> `="victoryCity" count="0"`
+- `="victoryCity" count="true"` >> `="victoryCity" count="1"`
+- `="victoryCity" value="false"` >> `="victoryCity" count="0"`
+- `="victoryCity" value="true"` >> `="victoryCity" count="1"`
 - `attatchment` >> `attachment`
 - `Attatchment` >> `Attachment`
 - `attatchTo=` >> `attachTo=`
-- `="isImpassible"` >> `="isImpassable"`
-- `="conditionType" value="XOR"` >> `="conditionType" value="1"`
-- `="turns"` >> `="rounds"`
-- `="Battleships repair at end of round"` >> `="Units Repair Hits End Turn"`
-- `="Battleships repair at beginning of round"` >> `="Units Repair Hits Start Turn"`
-- `="Naval Bombard Casualties Return Fire Restricted"` >> `="Naval Bombard Casualties Return Fire"`
-- `="SBR Affects Unit Production"` >> `="Damage From Bombing Done To Units Instead Of Territories"`
-- `="conditionType" count="XOR"` >> `="conditionType" count="1"`
-- `="conditionType" count="-reset-XOR"` >> `="conditionType" count="-reset-1"`
-- `="isTwoHit" count="true"` >> `="hitPoints" count="2"`
-- `="isTwoHit" count="false"` >> `="hitPoints" count="1"`
-- `="isTwoHit" value="true"` >> `="hitPoints" value="2"`
-- `="isTwoHit" value="false"` >> `="hitPoints" count="1"`
-- `="isTwoHit" count="-reset-true"` >> `="hitPoints" count="-reset-2"`
-- `="isTwoHit" count="-reset-false"` >> `="hitPoints" count="-reset-1"`
-- `="occupiedTerrOf"` >> `="originalOwner"`
-- `="victoryCity" count="true"` >> `="victoryCity" count="1"`
-- `="victoryCity" count="false"` >> `="victoryCity" count="0"`
-- `="victoryCity" value="true"` >> `="victoryCity" count="1"`
-- `="victoryCity" value="false"` >> `="victoryCity" count="0"`
-- `="victoryCity" count="-reset-true"` >> `="victoryCity" count="-reset-1"`
-- `="victoryCity" count="-reset-false"` >> `="victoryCity" count="-reset-0"`
-- `<option name="isParatroop"` >> `<option name="isAirTransportable"`
-- `<option name="isMechanized"` >> `<optiona name="isLandTransportable"`
 
 
 ```


### PR DESCRIPTION
commit 01d83a1a9e604026d230ea17bf60559f389b1800

    Documentation: legacy map upgrade edits
    
    - Re-title the page, prep for the page to be named "map-change-log.md"
    - Clarify that changes need to be done in sound.properties
    - Remove warnings section, all the properties mentioned are already in
      the change list
    - Add missing variations of 'victoryCity' and 'isTwoHit' options

commit 7f6a2fc538ec1553fbd713fb6e242cccc2c6c64c

    Add notes to delete property children: boolean, string, and how to change 'number' property



<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer

- I'm planning to rename the document shortly to 'map-features-change-log.md'. For now keeping the original name to keep the diff intact. I'm thinking the name change will be desirable as the actual 'how to upgrade' will soon evolve. Specifically instead of changing a lot of text in XML, players can simply load a 1.8 map in 2.3 and then re-export the XML. Hence this document is now more geared as a change log (and hence why the the mention about minimum version is completely removed).
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
