### PR TITLE
Add a serialVersionUID to OffensiveGeneralRetreat

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveGeneralRetreat.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveGeneralRetreat.java
@@ -25,6 +25,8 @@ import lombok.Value;
 @AllArgsConstructor
 public class OffensiveGeneralRetreat implements BattleStep {
 
+  private static final long serialVersionUID = -9192684621899682418L;
+
   private final BattleState battleState;
 
   private final BattleActions battleActions;


### PR DESCRIPTION
I noticed I had forgotten to hardcode the serialVersionUID.  I calculated the auto-generated value and this hardcodes it.

## Testing
<!-- Describe any manual testing performed below. -->
Save a battle with master and then loaded it in this branch to make sure it unserializes the object.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
