### PR TITLE
Move getEmptyOrFriendlySeaNeighbors to its only caller: DefensiveSubsRetreat

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/AbstractBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/AbstractBattle.java
@@ -38,7 +38,7 @@ abstract class AbstractBattle implements IBattle {
    * In headless mode we should NOT access any Delegates. In headless mode we are just being used to
    * calculate results for an odds calculator so we can skip some steps for efficiency.
    */
-  boolean headless = false;
+  @Getter boolean headless = false;
 
   @Getter final Territory battleSite;
   final GamePlayer attacker;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
@@ -45,9 +45,9 @@ public interface BattleState {
 
   boolean isOver();
 
-  Collection<Territory> getAttackerRetreatTerritories();
+  boolean isHeadless();
 
-  Collection<Territory> getEmptyOrFriendlySeaNeighbors(Collection<Unit> units);
+  Collection<Territory> getAttackerRetreatTerritories();
 
   Collection<Unit> getDependentUnits(Collection<Unit> units);
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -983,27 +983,6 @@ public class MustFightBattle extends DependentBattle
     return possible;
   }
 
-  @Override
-  public Collection<Territory> getEmptyOrFriendlySeaNeighbors(
-      final Collection<Unit> unitsToRetreat) {
-    Collection<Territory> possible = gameData.getMap().getNeighbors(battleSite);
-    if (headless) {
-      return possible;
-    }
-    // make sure we can move through the any canals
-    final Predicate<Territory> canalMatch =
-        t -> {
-          final Route r = new Route(battleSite, t);
-          return new MoveValidator(gameData).validateCanal(r, unitsToRetreat, defender) == null;
-        };
-    final Predicate<Territory> match =
-        Matches.territoryIsWater()
-            .and(Matches.territoryHasNoEnemyUnits(defender, gameData))
-            .and(canalMatch);
-    possible = CollectionUtils.getMatches(possible, match);
-    return possible;
-  }
-
   private void pushFightLoopOnStack() {
     if (isOver) {
       return;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreat.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreat.java
@@ -5,6 +5,9 @@ import static games.strategy.triplea.delegate.battle.BattleStepStrings.SUBS_WITH
 import static games.strategy.triplea.delegate.battle.steps.BattleStep.Order.SUB_DEFENSIVE_RETREAT_AFTER_BATTLE;
 import static games.strategy.triplea.delegate.battle.steps.BattleStep.Order.SUB_DEFENSIVE_RETREAT_BEFORE_BATTLE;
 
+import games.strategy.engine.data.Route;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.ExecutionStack;
@@ -13,7 +16,10 @@ import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.MustFightBattle.RetreatType;
 import games.strategy.triplea.delegate.battle.steps.BattleStep;
+import games.strategy.triplea.delegate.move.validation.MoveValidator;
+import java.util.Collection;
 import java.util.List;
+import java.util.function.Predicate;
 import lombok.AllArgsConstructor;
 import org.triplea.java.collections.CollectionUtils;
 
@@ -64,13 +70,7 @@ public class DefensiveSubsRetreat implements BattleStep {
       return;
     }
 
-    battleActions.queryRetreat(
-        true,
-        RetreatType.SUBS,
-        bridge,
-        battleState.getEmptyOrFriendlySeaNeighbors(
-            CollectionUtils.getMatches(
-                battleState.getUnits(BattleState.Side.DEFENSE), Matches.unitCanEvade())));
+    battleActions.queryRetreat(true, RetreatType.SUBS, bridge, getEmptyOrFriendlySeaNeighbors());
 
     // If no defenders left, then battle is over. The reason we test a "second" time here,
     // is because otherwise the battle will try and do one more round and nothing will
@@ -95,10 +95,33 @@ public class DefensiveSubsRetreat implements BattleStep {
 
   private boolean isRetreatPossible() {
     return Properties.getSubmersibleSubs(battleState.getGameData())
-        || !battleState
-            .getEmptyOrFriendlySeaNeighbors(
-                CollectionUtils.getMatches(
-                    battleState.getUnits(BattleState.Side.DEFENSE), Matches.unitCanEvade()))
-            .isEmpty();
+        || !getEmptyOrFriendlySeaNeighbors().isEmpty();
+  }
+
+  public Collection<Territory> getEmptyOrFriendlySeaNeighbors() {
+    final Collection<Territory> possible =
+        battleState.getGameData().getMap().getNeighbors(battleState.getBattleSite());
+    if (battleState.isHeadless()) {
+      return possible;
+    }
+    final Collection<Unit> unitsToRetreat =
+        CollectionUtils.getMatches(
+            battleState.getUnits(BattleState.Side.DEFENSE), Matches.unitCanEvade());
+
+    // make sure we can move through the any canals
+    final Predicate<Territory> canalMatch =
+        t -> {
+          final Route r = new Route(battleState.getBattleSite(), t);
+          return new MoveValidator(battleState.getGameData())
+                  .validateCanal(r, unitsToRetreat, battleState.getDefender())
+              == null;
+        };
+    final Predicate<Territory> match =
+        Matches.territoryIsWater()
+            .and(
+                Matches.territoryHasNoEnemyUnits(
+                    battleState.getDefender(), battleState.getGameData()))
+            .and(canalMatch);
+    return CollectionUtils.getMatches(possible, match);
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/FakeBattleState.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/FakeBattleState.java
@@ -60,19 +60,15 @@ public class FakeBattleState implements BattleState {
   final boolean over;
 
   @Getter(onMethod = @__({@Override}))
-  final Collection<Territory> attackerRetreatTerritories;
+  final boolean headless;
 
-  final Collection<Territory> emptyOrFriendlySeaNeighbors;
+  @Getter(onMethod = @__({@Override}))
+  final Collection<Territory> attackerRetreatTerritories;
 
   final Collection<Unit> dependentUnits;
 
   @Getter(onMethod = @__({@Override}))
   final @NonNull Collection<Unit> bombardingUnits;
-
-  @Override
-  public Collection<Territory> getEmptyOrFriendlySeaNeighbors(final Collection<Unit> units) {
-    return emptyOrFriendlySeaNeighbors;
-  }
 
   @Override
   public Collection<Unit> getDependentUnits(final Collection<Unit> units) {
@@ -166,7 +162,6 @@ public class FakeBattleState implements BattleState {
         .gameData(mock(GameData.class))
         .amphibious(false)
         .over(false)
-        .attackerRetreatTerritories(List.of())
-        .emptyOrFriendlySeaNeighbors(List.of());
+        .attackerRetreatTerritories(List.of());
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
@@ -40,9 +40,11 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GameMap;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitCollection;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.triplea.Constants;
@@ -68,6 +70,7 @@ public class BattleStepsTest {
 
   @Mock GameData gameData;
   @Mock GameProperties gameProperties;
+  @Mock GameMap gameMap;
   @Mock BattleActions battleActions;
 
   @Mock Territory battleSite;
@@ -78,6 +81,7 @@ public class BattleStepsTest {
   @BeforeEach
   void setupMocks() {
     when(gameData.getProperties()).thenReturn(gameProperties);
+    lenient().when(gameData.getMap()).thenReturn(gameMap);
   }
 
   private void givenPlayers() {
@@ -1662,6 +1666,14 @@ public class BattleStepsTest {
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
+    final Territory retreatTerritory = mock(Territory.class);
+    when(retreatTerritory.isWater()).thenReturn(true);
+    when(retreatTerritory.getUnitCollection()).thenReturn(mock(UnitCollection.class));
+
+    final GameMap gameMap = mock(GameMap.class);
+    lenient().when(gameData.getMap()).thenReturn(gameMap);
+    when(gameMap.getNeighbors(battleSite)).thenReturn(Set.of(retreatTerritory));
+
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
@@ -1670,7 +1682,6 @@ public class BattleStepsTest {
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
                 .defendingUnits(List.of(unit2))
-                .emptyOrFriendlySeaNeighbors(List.of(battleSite))
                 .battleSite(battleSite)
                 .build());
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/MockGameData.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/MockGameData.java
@@ -13,18 +13,23 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GameMap;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.RelationshipTracker;
+import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.properties.GameProperties;
+import java.util.Set;
 
 public class MockGameData {
   private final GameData gameData = mock(GameData.class);
   private final GameProperties gameProperties = mock(GameProperties.class);
   private final RelationshipTracker relationshipTracker = mock(RelationshipTracker.class);
+  private final GameMap gameMap = mock(GameMap.class);
 
   private MockGameData() {
     lenient().when(gameData.getProperties()).thenReturn(gameProperties);
     lenient().when(gameData.getRelationshipTracker()).thenReturn(relationshipTracker);
+    lenient().when(gameData.getMap()).thenReturn(gameMap);
   }
 
   public static MockGameData givenGameData() {
@@ -86,6 +91,12 @@ public class MockGameData {
 
   public MockGameData withAttackerRetreatPlanes(final boolean value) {
     when(gameProperties.get(ATTACKER_RETREAT_PLANES, false)).thenReturn(value);
+    return this;
+  }
+
+  public MockGameData withTerritoryHasNeighbors(
+      final Territory territory, final Set<Territory> neighbors) {
+    when(gameMap.getNeighbors(territory)).thenReturn(neighbors);
     return this;
   }
 }


### PR DESCRIPTION
I'm going through the battlestate/battleaction methods to refactor them and I saw that this method is only used by one of the battle steps.  So this PR removes the method from `BattleState` and makes it a private method of `DefensiveSubsRetreat`.

The majority of the code change is to handle the changes to tests.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
