### PR TITLE
Improve available game loading speed

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/AvailableGamesFileSystemReader.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/AvailableGamesFileSystemReader.java
@@ -42,6 +42,10 @@ public class AvailableGamesFileSystemReader {
     return availableGamesListCache;
   }
 
+  public static void populateAvailableMapFilesCache() {
+    parseMapFiles();
+  }
+
   private Collection<DefaultGameChooserEntry> mapXmlsGameNamesByUri(
       final Collection<URI> fileList) {
     return fileList.stream()

--- a/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/MapZipReaderUtil.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/MapZipReaderUtil.java
@@ -8,11 +8,12 @@ import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.ArrayList;
+import java.util.Enumeration;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Level;
 import java.util.zip.ZipEntry;
-import java.util.zip.ZipInputStream;
+import java.util.zip.ZipFile;
 import lombok.experimental.UtilityClass;
 import lombok.extern.java.Log;
 
@@ -24,25 +25,24 @@ class MapZipReaderUtil {
    * Finds all game XMLs in a zip file. More specifically, given a zip file, finds all '*.xml' files
    * that have a 'games/' folder on the zip file path.
    */
-  List<URI> findGameXmlFilesInZip(final File zipFile) {
+  List<URI> findGameXmlFilesInZip(final File zip) {
     final List<URI> zipFiles = new ArrayList<>();
 
-    try (InputStream fis = new FileInputStream(zipFile);
-        ZipInputStream zis = new ZipInputStream(fis);
-        URLClassLoader loader = new URLClassLoader(new URL[] {zipFile.toURI().toURL()})) {
-      ZipEntry entry = zis.getNextEntry();
-      while (entry != null) {
+    try (ZipFile zipFile = new ZipFile(zip);
+         URLClassLoader loader = new URLClassLoader(new URL[] {zip.toURI().toURL()})) {
+
+      final Enumeration<? extends ZipEntry> entries = zipFile.entries();
+      while (entries.hasMoreElements()) {
+        final ZipEntry entry = entries.nextElement();
+
         if (entry.getName().toLowerCase().endsWith(".xml")) {
           Optional.ofNullable(loader.getResource(entry.getName()))
               .map(url -> URI.create(url.toString().replace(" ", "%20")))
               .ifPresent(zipFiles::add);
         }
-        // we have to close the loader to allow files to be deleted on windows
-        zis.closeEntry();
-        entry = zis.getNextEntry();
       }
     } catch (final IOException e) {
-      log.log(Level.SEVERE, "Error reading zip file in: " + zipFile.getAbsolutePath(), e);
+      log.log(Level.SEVERE, "Error reading zip file in: " + zip.getAbsolutePath(), e);
     }
     return zipFiles;
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/MapZipReaderUtil.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/MapZipReaderUtil.java
@@ -1,9 +1,7 @@
 package games.strategy.engine.framework.map.file.system.loader;
 
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLClassLoader;
@@ -29,7 +27,7 @@ class MapZipReaderUtil {
     final List<URI> zipFiles = new ArrayList<>();
 
     try (ZipFile zipFile = new ZipFile(zip);
-         URLClassLoader loader = new URLClassLoader(new URL[] {zip.toURI().toURL()})) {
+        URLClassLoader loader = new URLClassLoader(new URL[] {zip.toURI().toURL()})) {
 
       final Enumeration<? extends ZipEntry> entries = zipFile.entries();
       while (entries.hasMoreElements()) {

--- a/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
+++ b/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
@@ -8,6 +8,7 @@ import games.strategy.engine.framework.CliProperties;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.lookandfeel.LookAndFeel;
 import games.strategy.engine.framework.map.download.DownloadMapsWindow;
+import games.strategy.engine.framework.map.file.system.loader.AvailableGamesFileSystemReader;
 import games.strategy.engine.framework.system.HttpProxy;
 import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.triplea.settings.ClientSetting;
@@ -91,5 +92,6 @@ public final class HeadedGameRunner {
     SwingUtilities.invokeLater(ConsoleConfiguration::initialize);
     SwingUtilities.invokeLater(ErrorMessage::initialize);
     GameRunner.start();
+    new Thread(AvailableGamesFileSystemReader::populateAvailableMapFilesCache).start();
   }
 }


### PR DESCRIPTION
- Speeds up the button "select maps"
- Speeds up bot startup time

(1) We swap ZipInputStream (slow) for ZipFile (fast) when
    searching for XML files within zip files. This is
    the majority of the performance improvement and is
    a magnitude faster.

(2) Preload available games at game launch. By the time a
    user has clicked the 'Select Maps' button, chances
    are really good we'll have pre-cached the list of
    available games and the list would then open without
    delay.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer

Addresses the performance problem noted in: https://github.com/triplea-game/triplea/issues/7656

<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->UPDATE|Improve performance of the 'available maps' button and startup time for bot servers<!--END_RELEASE_NOTE-->
