### PR TITLE
Fix NPE when shallow parsing a game that has a null property

### DIFF
--- a/map-data/src/main/java/org/triplea/map/data/elements/ShallowParsedGame.java
+++ b/map-data/src/main/java/org/triplea/map/data/elements/ShallowParsedGame.java
@@ -13,6 +13,7 @@ public class ShallowParsedGame {
 
   public Optional<PropertyList.Property> getProperty(final String propertyName) {
     return propertyList.getProperties().stream()
+        .filter(property -> property.getName() != null)
         .filter(property -> property.getName().equalsIgnoreCase(propertyName))
         .findAny();
   }


### PR DESCRIPTION
"A Song of Ice and Fire" has a property with an empty property name
that then gets converted to a null. This update fixes handling
of that to avoid the NPE when processing this property (simply
skip it).


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
