### PR TITLE
Fix handling properties with no name (skip rather than stop)

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
@@ -465,7 +465,7 @@ public final class GameParser {
 
     for (final PropertyList.Property current : propertyList.getProperties()) {
       if (current.getName() == null) {
-        return;
+        continue;
       }
       final String propertyName = LegacyPropertyMapper.mapPropertyName(current.getName());
 


### PR DESCRIPTION
Instead of 'returning' when we see a a property with no name,
we should instead skip (continue). If we return then we stop parsing
remaining properties.

This was noticed starting a game on 'a song of fire and ice'
which has a few properties without a name set.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->
This problem was introduced relatively recently, within the last week or two.

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
