### PR TITLE
Ansible.cfg default update

### DIFF
--- a/infrastructure/ansible.cfg
+++ b/infrastructure/ansible.cfg
@@ -1,11 +1,17 @@
+# For example with defaults:
+# https://raw.githubusercontent.com/ansible/ansible/devel/examples/ansible.cfg
+
 [defaults]
 host_key_checking = False
 forks = 10
 strategy = linear
 serial = 100%
-gathering = no
-poll_interval = 3
+gathering = implicit
+poll_interval = 1
 remote_user: root
+
+[privilege_escalation]
+become = True
 
 [ssh_connection]
 pipelining = True

--- a/infrastructure/ansible/roles/bot/tasks/main.yml
+++ b/infrastructure/ansible/roles/bot/tasks/main.yml
@@ -1,5 +1,4 @@
 - name: allow ports
-  become: true
   ufw:
     rule: allow
     port: "40{{ item }}"
@@ -7,14 +6,12 @@
   with_items: "{{ bot_numbers }}"
 
 - name: create service user to run the app
-  become: true
   user:
     name: "{{ bot_user }}"
     create_home: yes
     system: yes
 
 - name: deploy scripts to admin home
-  become: true
   template:
     src: "{{ item }}.j2"
     dest: "{{ admin_home }}/{{ item }}"
@@ -27,7 +24,6 @@
     - download-all-maps
 
 - name: create maps folder
-  become: true
   file:
     state: directory
     path: "{{ item }}"
@@ -39,12 +35,10 @@
     - "{{ bot_maps_folder }}"
 
 - name: download maps on bot server
-  become: true
   command: "{{ admin_home }}/download-all-maps"
 
 - name: deploy jar file if using latest
   when: using_latest
-  become: true
   copy:
     src: "triplea-game-headless-{{ version }}.jar"
     dest: "{{ bot_jar }}"
@@ -52,7 +46,6 @@
     group: "{{ bot_user }}"
 
 - name: create triplea-root touch file
-  become: true
   file:
     state: touch
     path: "{{ bot_install_home }}/.triplea-root"
@@ -62,7 +55,6 @@
 
 - name: download zip file if not using latest
   when: not using_latest
-  become: true
   get_url:
     url: "{{ zip_download }}"
     dest: "{{ bot_install_home }}/triplea-game-headless-{{ version }}.zip"
@@ -71,7 +63,6 @@
 
 - name: extract zip file if not using latest
   when: not using_latest
-  become: true
   unarchive:
     remote_src: yes
     src: "{{ bot_install_home }}/triplea-game-headless-{{ version }}.zip"
@@ -81,7 +72,6 @@
 
 - name: move jar file to expected location if not using latest
   when: not using_latest
-  become: true
   copy:
     remote_src: true
     src: "{{ bot_install_home }}/bin/triplea-game-headless-{{ version }}.jar"
@@ -90,7 +80,6 @@
     group: "{{ bot_user }}"
 
 - name: deploy run_server script
-  become: true
   template:
     src: run_server.j2
     dest: "{{ bot_folder }}/run_server"
@@ -99,20 +88,17 @@
     group: "{{ bot_user }}"
 
 - name: install systemd service script
-  become: true
   template:
     src: bot.service.j2
     dest: /lib/systemd/system/bot@.service
     mode: "644"
 
 - name: reload systemd
-  become: true
   systemd:
     daemon_reload: yes
 
 - name: restart bots if deploying latest
   when: using_latest
-  become: true
   service:
     name: "bot@{{ item }}"
     state: restarted
@@ -121,7 +107,6 @@
 
 - name: enable and ensure bots are started
   when: not using_latest
-  become: true
   service:
     name: "bot@{{ item }}"
     state: started

--- a/infrastructure/ansible/roles/certbot/tasks/main.yml
+++ b/infrastructure/ansible/roles/certbot/tasks/main.yml
@@ -1,11 +1,9 @@
 - name: install software properties common
-  become: true
   apt:
     state: present
     name: software-properties-common
 
 - name: install certbot and python for certbot on nginx
-  become: true
   apt:
     update_cache: yes
     name:
@@ -13,13 +11,11 @@
       - python3-certbot-nginx
 
 - name: look for certbot generated key file
-  become: true
   stat:
     path: /etc/letsencrypt/live/{{ inventory_hostname }}/cert.pem
   register: has_certbot_pem
 
 - name: run certbot
-  become: true
   command: |
      certbot --nginx -n \
          -m tripleabuilderbot@gmail.com \

--- a/infrastructure/ansible/roles/database/flyway/tasks/main.yml
+++ b/infrastructure/ansible/roles/database/flyway/tasks/main.yml
@@ -1,12 +1,10 @@
 - name: create service user to run flyway
-  become: true
   user:
     name: flyway
     create_home: yes
     system: yes
 
 - name: Download flyway CLI
-  become: true
   get_url:
     url: "{{ flyway_download_location }}"
     dest: "/home/flyway/flyway-cli.tar.gz"
@@ -16,7 +14,6 @@
     group: flyway
 
 - name: extract flyway CLI
-  become: true
   unarchive:
     copy: no
     src: "/home/flyway/flyway-cli.tar.gz"
@@ -26,7 +23,6 @@
     group: flyway
 
 - name: copy flyway migrations zip if deploying latest
-  become: true
   when: using_latest == "true"
   copy:
     src: "migrations.zip"
@@ -36,7 +32,6 @@
     group: flyway
 
 - name: download flyway migrations if deploying a specific version
-  become: true
   when: using_latest == "false"
   get_url:
     url: "{{ migrations_url }}"
@@ -45,7 +40,6 @@
     group: flyway
 
 - name: create migration folders
-  become: true
   file:
     state: directory
     mode: "0755"
@@ -54,7 +48,6 @@
     path : "{{ flyway_extracted_location }}/migrations"
 
 - name: extract migrations
-  become: true
   unarchive:
      src: "/home/flyway/migrations.zip"
      remote_src: true
@@ -64,7 +57,6 @@
      group: flyway
 
 - name: run flyway
-  become: true
   become_user: flyway
   command: "{{ flyway_extracted_location }}/flyway -user={{ item.user }} -password={{ item.password }} -url={{ item.url }} -locations={{ item.migration_dir }} migrate"
   register: flyway

--- a/infrastructure/ansible/roles/database/postgres/tasks/main.yml
+++ b/infrastructure/ansible/roles/database/postgres/tasks/main.yml
@@ -1,5 +1,4 @@
 - name: Ensure latest bash and ssl
-  become: true
   apt:
     state: latest
     name:
@@ -9,7 +8,6 @@
       - libssl-doc
 
 - name: Install PostgreSQL
-  become: true
   apt:
     state: present
     name:
@@ -25,7 +23,6 @@
     enabled: yes
 
 - name: Set postgres user password
-  become: true
   become_user: postgres
   no_log: true
   postgresql_user:
@@ -35,7 +32,6 @@
     encrypted: yes
 
 - name: Create application database users
-  become: true
   become_user: postgres
   postgresql_user:
     name: "{{ item.user }}"
@@ -49,7 +45,6 @@
   no_log: true
 
 - name: Create application databases
-  become: true
   become_user: postgres
   postgresql_db:
     name: "{{ item.name }}"
@@ -59,7 +54,6 @@
     label: "{{ item.name }}"
 
 - name: Ensure user has access to the database
-  become: true
   become_user: postgres
   postgresql_user:
     db: "{{ item.name }}"

--- a/infrastructure/ansible/roles/java/tasks/main.yml
+++ b/infrastructure/ansible/roles/java/tasks/main.yml
@@ -1,5 +1,4 @@
 - name: install java
-  become: true
   apt:
     state: present
     update_cache: true

--- a/infrastructure/ansible/roles/lobby_server/tasks/main.yml
+++ b/infrastructure/ansible/roles/lobby_server/tasks/main.yml
@@ -1,5 +1,4 @@
 - name: create service user
-  become: true
   user:
     name: "{{ lobby_server_user }}"
     create_home: yes
@@ -7,7 +6,6 @@
 
 - name: create bin folder for jar file
   when: using_latest
-  become: true
   file:
     state: directory
     path: "{{ lobby_server_home_folder }}/bin/"
@@ -17,7 +15,6 @@
 
 - name: deploy jar file
   when: using_latest
-  become: true
   register: deploy_jar_file
   copy:
     src: "{{ lobby_server_jar }}"
@@ -28,7 +25,6 @@
 
 - name: download zip file if not using latest
   when: not using_latest
-  become: true
   register: deploy_jar_file
   get_url:
     url: "{{ lobby_server_zip_download }}"
@@ -38,7 +34,6 @@
 
 - name: extract zip file if not using latest
   when: not using_latest
-  become: true
   unarchive:
     remote_src: yes
     src: "{{ lobby_server_home_folder }}/triplea-lobby-server-{{ version }}.zip"
@@ -47,7 +42,6 @@
     group: "{{ lobby_server_user }}"
 
 - name: deploy run_server script
-  become: true
   template:
     src: run_server.j2
     dest: "{{ lobby_server_run_file }}"
@@ -56,7 +50,6 @@
     group: "{{ lobby_server_user }}"
 
 - name: deploy server config file
-  become: true
   register: deploy_config_file
   template:
     src: configuration.yml.j2
@@ -66,20 +59,17 @@
     group: "{{ lobby_server_user }}"
 
 - name: install systemd service script
-  become: true
   template:
     src: lobby_server.service.j2
     dest: /lib/systemd/system/lobby_server.service
     mode: "644"
 
 - name: reload systemd
-  become: true
   systemd:
     daemon_reload: yes
 
 - name: enable and start service
   when: (deploy_jar_file.changed == false) and (deploy_config_file.changed == false)
-  become: true
   service:
     name: lobby_server
     state: started
@@ -87,14 +77,12 @@
 
 - name: restart service if new jar file deployed
   when: (deploy_jar_file.changed) or (deploy_config_file.changed)
-  become: true
   service:
     name: lobby_server
     state: restarted
     enabled: yes
 
 - name: deploy admin scripts to facilite server operations, EG. check logs, start, stop
-  become: true
   copy:
     src: "{{ item }}"
     dest: /home/admin/

--- a/infrastructure/ansible/roles/nginx/tasks/main.yml
+++ b/infrastructure/ansible/roles/nginx/tasks/main.yml
@@ -1,18 +1,15 @@
 - name: apt install nginx
-  become: true
   apt:
     name: nginx
     state: present
 
 
 - name: generate dhparam.pem
-  become: true
   shell:
     cmd: openssl dhparam -out {{ dhparams_pem_file }} 4096
     creates: "{{ dhparams_pem_file }}"
 
 - name: set permissions of dhparam.pem
-  become: true
   file:
     dest: "{{ dhparams_pem_file }}"
     mode: 600
@@ -31,7 +28,6 @@
   changed_when: false
 
 - name: create SSL keys if needed
-  become: true
   when: (has_cert_key.stat.exists == false) or (has_cert.stat.exists == false)
   command: |
        openssl req -x509 -nodes -days 365 \
@@ -78,14 +74,12 @@
 
 
 - name: deploy nginx sites_enabled configuation
-  become: true
   template:
     src: etc_nginx_sites_enabled_default.j2
     dest: /etc/nginx/sites-enabled/default
   register: nginx_config_changed
 
 - name: allow ports
-  become: true
   tags: firewall
   ufw:
     rule: allow
@@ -98,13 +92,11 @@
     (nginx_config_changed.changed) 
       or (has_cert_key.stat.exists == false) 
       or (has_cert.stat.exists == false)
-  become: true
   systemd:
     name: nginx
     state: restarted
 
 - name: ensure nginx is started
-  become: true
   systemd:
     name: nginx
     state: started

--- a/infrastructure/ansible/roles/postfix/tasks/main.yml
+++ b/infrastructure/ansible/roles/postfix/tasks/main.yml
@@ -1,11 +1,9 @@
 - name: Install postfix
-  become: true
   apt:
     state: present
     name: postfix
 
 - name: Deploy postfix config
-  become: true
   template:
     src: main.cf.j2
     dest: /etc/postfix/main.cf
@@ -15,14 +13,12 @@
   register: postfix_config
 
 - name: Restart postfix if config changes
-  become: true
   when: postfix_config.changed
   systemd:
     name: postfix
     state: restarted
 
 - name: Ensure postfix is started
-  become: true
   systemd:
     name: postfix
     state: started

--- a/infrastructure/ansible/roles/support/log_aggregation_sender/tasks/main.yml
+++ b/infrastructure/ansible/roles/support/log_aggregation_sender/tasks/main.yml
@@ -1,5 +1,4 @@
 - name: deploy send logs script
-  become: true
   copy:
     src: send_logs
     dest: /home/admin/send_logs
@@ -8,7 +7,6 @@
     group: admin
 
 - name: install cronjob to send logs
-  become: true
   cron:
     user: admin
     name: "send logs {{ item }}"
@@ -18,7 +16,6 @@
 
 - name: deploy private logs-user ssh key to admin user
   # This is the SSH key that will be needed when sending log files to the aggregation server
-  become: true
   copy:
    src: log_aggregation_ed25519
    dest: "{{ log_sending_private_key_file }}"
@@ -28,7 +25,6 @@
 
 
 - name: deploy ssh config to admin user to disable strict host key checking
-  become: true
   template:
     src: ssh_config.j2
     dest: /home/admin/.ssh/config

--- a/infrastructure/ansible/roles/support/log_aggregation_server/tasks/main.yml
+++ b/infrastructure/ansible/roles/support/log_aggregation_server/tasks/main.yml
@@ -1,5 +1,4 @@
 - name: install cronjob to compress any log files older than 2 hours
-  become: true
   cron:
     user: admin
     name: "log compression"
@@ -7,7 +6,6 @@
     job: "find /home/admin/logs/ -name \"*.log\" -type f -mmin +120 | xargs gzip"
 
 - name: install cronjob to delete any log files older than 3 months
-  become: true
   cron:
     user: admin
     name: "old log deletion"
@@ -15,7 +13,6 @@
     job: "find /home/admin/logs/ -name \"*.log.gz\" -type f -mmin +129600 | xargs rm"
 
 - name: install cronjob to delete empty log folders
-  become: true
   cron:
     user: admin
     name: "empty log folder cleanup"
@@ -23,13 +20,11 @@
     job: "find /home/admin/logs/ -mindepth 1 -type d -empty | xargs -r rmdir"
 
 - name: create logs group
-  become: true
   group:
     name: logs
     state: present
 
 - name: create a logs server user, a user dedicated to receiving log files
-  become: true
   user:
     name: logs
     shell: /bin/bash
@@ -39,14 +34,12 @@
 
 
 - name: add the admin user to the logs group
-  become: true
   user:
     name: admin
     append: yes
     groups: logs
 
 - name: create and share /home/admin/logs with the log server user
-  become: true
   file:
     state: directory
     path: /home/admin/logs
@@ -55,7 +48,6 @@
     group: logs
 
 - name: create ssh folder for logs user
-  become: true
   file:
     state: directory
     path: /home/logs/.ssh
@@ -64,7 +56,6 @@
     group: logs
 
 - name: deploy public key to logs user
-  become: true
   copy:
     src: logs_user_authorized_keys
     dest: /home/logs/.ssh/authorized_keys

--- a/infrastructure/ansible/roles/system/admin_user/tasks/main.yml
+++ b/infrastructure/ansible/roles/system/admin_user/tasks/main.yml
@@ -1,11 +1,9 @@
 - name: create admin group
-  become: true
   group:
     name: admin
     state: present
 
 - name: create the admin user (triplea) for maintainers to SSH to the system
-  become: true
   user:
     name: "{{ admin_user }}"
     shell: /bin/bash
@@ -14,7 +12,6 @@
     groups: admin,adm
 
 - name: Allow the admin user to have passwordless sudo
-  become: true
   lineinfile:
     dest: /etc/sudoers
     state: present
@@ -23,7 +20,6 @@
     validate: 'visudo -cf %s'
 
 - name: create ssh directory
-  become: true
   file:
     path: "{{ admin_home }}/.ssh/"
     state: directory
@@ -32,7 +28,6 @@
     group: "{{ admin_user }}"
 
 - name: copy authorized keys file
-  become: true
   copy:
     src: authorized_keys
     dest: "{{ admin_home }}/.ssh/authorized_keys"

--- a/infrastructure/ansible/roles/system/apt_common_tools/tasks/main.yml
+++ b/infrastructure/ansible/roles/system/apt_common_tools/tasks/main.yml
@@ -1,5 +1,4 @@
 - name: apt install standard utilities and packages
-  become: true
   apt:
     state: present
     update_cache: true

--- a/infrastructure/ansible/roles/system/apt_update/tasks/main.yml
+++ b/infrastructure/ansible/roles/system/apt_update/tasks/main.yml
@@ -1,5 +1,4 @@
 - name: Update and upgrade apt packages
-  become: true
   apt:
     upgrade: yes
     cache_valid_time: 86400 # One day, only updates if caches are older than this.

--- a/infrastructure/ansible/roles/system/firewall/tasks/main.yml
+++ b/infrastructure/ansible/roles/system/firewall/tasks/main.yml
@@ -1,28 +1,23 @@
 - name: UFW allow SSH
-  become: true
   ufw:
     rule: allow
     name: OpenSSH
 
 - name: Turn on firewall
-  become: true
   ufw:
     state: enabled
 
 - name: UFW deny incoming by default
-  become: true
   ufw:
     default: deny
     direction: incoming
 
 - name: UFW allow outgoing by default
-  become: true
   ufw:
     default: allow
     direction: outgoing
 
 - name: turn on ssh rate limiting
-  become: true
   ufw:
     rule: limit
     port: ssh

--- a/infrastructure/ansible/roles/system/hostname/tasks/main.yml
+++ b/infrastructure/ansible/roles/system/hostname/tasks/main.yml
@@ -1,11 +1,9 @@
 - name: set hostname of system
-  become: true
   hostname: 
     name: "{{ inventory_hostname }}"
   register: hostname_result
 
 - name: deploy /etc/hosts file with hostname in it
-  become: true
   template:
     src: etc_hosts.j2
     dest: /etc/hosts
@@ -15,7 +13,6 @@
 
 - name: reboot machine for hostname to take effect
   when: hostname_result.changed
-  become: true
   reboot:
 
 

--- a/infrastructure/ansible/roles/system/journald/tasks/main.yml
+++ b/infrastructure/ansible/roles/system/journald/tasks/main.yml
@@ -1,5 +1,4 @@
 - name: deploy journald config
-  become: true
   register: journal_conf
   copy:
     src: journald.conf
@@ -9,7 +8,6 @@
     group: root
 
 - name: restart journald if config was changed
-  become: true
   when: journal_conf.changed
   service:
     state: restarted

--- a/infrastructure/ansible/roles/system/security/tasks/main.yml
+++ b/infrastructure/ansible/roles/system/security/tasks/main.yml
@@ -1,5 +1,4 @@
 - name: install security related apt packages
-  become: true
   apt:
     state: present
     name:


### PR DESCRIPTION
commit 957de0871dd51dabe859d0465ad499d6936adcec

    Update ansible.cfg
    
    - Lower polling interval for better deployment responsiveness
    - set gathering to be 'implicit', it appears 'no' is a legacy value
      for the same thing (turns off fact gathering, we do not use
      any of the host-vars facts and can skip the gather phase)
    - set default to run commands with 'sudo'. We run prerelease
      and prod commands as root, this helps vagrant deployments
      and would allow us to remove 'become: true' from all other commands.

commit f02a669657d41aa76d7e68d9ee6621731fc7fa7a

    Drop 'become: true', we by default escalate privilege now.

<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
