### PR TITLE
Fix: main screen not displaying loaded save game name

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -246,7 +246,7 @@ public class ServerModel extends Observable implements IConnectionChangeListener
                 bytes,
                 is -> {
                   try (InputStream inputStream = new BufferedInputStream(is)) {
-                    headless.loadGameSave(inputStream, fileName);
+                    headless.loadGameSave(inputStream);
                   }
                 });
           } catch (final Exception e) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
@@ -86,15 +86,8 @@ public class GameSelectorModel extends Observable implements GameSelector {
       // try to load it as a saved game whatever the extension
       final GameData newData = GameDataManager.loadGame(file);
       newData.setSaveGameFileName(file.getName());
+      this.fileName = file.getName();
       setGameData(newData);
-    }
-  }
-
-  public void load(final @Nullable GameData data, final @Nullable String fileName) {
-    setGameData(data);
-    this.fileName = fileName;
-    if (data != null) {
-      log.info("Loaded game: " + data.getGameName() + ", in file: " + fileName);
     }
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
@@ -18,13 +18,11 @@ import java.util.function.Function;
 import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.extern.java.Log;
 
 /**
  * Model class that tracks the currently 'selected' game. This is the info that appears in the game
  * selector panel on the staging screens, eg: map, round, filename.
  */
-@Log
 public class GameSelectorModel extends Observable implements GameSelector {
 
   private final Function<URI, Optional<GameData>> gameParser;

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -129,15 +129,13 @@ public class HeadlessGameServer {
    * Loads a save game from the specified stream.
    *
    * @param input The stream containing the save game.
-   * @param fileName The label used to identify the save game in the UI. Typically the file name of
-   *     the save game on the remote client that requested the save game to be loaded.
    */
-  public synchronized void loadGameSave(final InputStream input, final String fileName) {
+  public synchronized void loadGameSave(final InputStream input) {
     // don't change mid-game
     if (setupPanelModel.getPanel() != null && game == null) {
       getGameData(input)
           .filter(this::checkGameIsAvailableOnServer)
-          .ifPresent(data -> gameSelectorModel.load(data, fileName));
+          .ifPresent(gameSelectorModel::setGameData);
     }
   }
 

--- a/game-core/src/test/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModelTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModelTest.java
@@ -2,10 +2,8 @@ package games.strategy.engine.framework.startup.ui.panels.main.game.selector;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -32,7 +30,6 @@ class GameSelectorModelTest extends AbstractClientSettingTestCase {
   private static final String fakeGameVersion = "12.34.56";
   private static final String fakeGameRound = "3";
   private static final String fakeGameName = "_fakeGameName_";
-  private static final String fakeFileName = "/hack/and/slash";
 
   private GameSelectorModel testObj;
 
@@ -137,30 +134,6 @@ class GameSelectorModelTest extends AbstractClientSettingTestCase {
   }
 
   @Test
-  void saveGameNameGetsResetWhenLoadingOtherMap() throws Exception {
-    final String testFileName = "someFileName";
-    testObj = new GameSelectorModel(uri -> Optional.of(mockGameData));
-    when(mockGameData.getSequence()).thenReturn(mock(GameSequence.class));
-    when(mockGameData.getGameVersion()).thenReturn(new Version(0, 0, 0));
-    when(mockGameData.getGameName()).thenReturn("Dummy name");
-    testObj.load(mockGameData, testFileName);
-    assertThat(testObj.getFileName(), is(testFileName));
-
-    testObj.load(new URI("abc"));
-    assertThat(testObj.getFileName(), is(not(testFileName)));
-  }
-
-  @Test
-  void testLoadFromGameDataFileNamePair() {
-    assertHasEmptyData(testObj);
-
-    prepareMockGameDataExpectations();
-    testObj.load(mockGameData, fakeFileName);
-    assertThat(testObj.getGameData(), sameInstance(mockGameData));
-    assertThat(testObj.getFileName(), is(fakeFileName));
-  }
-
-  @Test
   void testGetGameData() {
     assertThat(testObj.getGameData(), nullValue());
     prepareMockGameDataExpectations();
@@ -184,14 +157,6 @@ class GameSelectorModelTest extends AbstractClientSettingTestCase {
     assertThat(testObj.getClientModelForHostBots(), sameInstance(mockClientModel));
     testObj.setClientModelForHostBots(null);
     assertThat(testObj.getClientModelForHostBots(), nullValue());
-  }
-
-  @Test
-  void testGetFileName() {
-    assertThat(testObj.getFileName(), is("-"));
-    prepareMockGameDataExpectations();
-    testObj.load(mockGameData, fakeFileName);
-    assertThat(testObj.getFileName(), is(fakeFileName));
   }
 
   @Test


### PR DESCRIPTION
1) Main screen will now set the file name of a loaded save game

2) Cleanup: delete load method was only called by bot and
  was setting the filename. Bots do not have a use
  for the filename display variable and do not need
  use a load method that sets it.

Side-note: it appears that the 'loaded savegame' text did
not update previously, that seems to have broken at some point.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
- Fixes: https://github.com/triplea-game/triplea/issues/7673

<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
