### PR TITLE
Fix: check if translucency is supported before invoking setOpacity

### DIFF
--- a/swing-lib/src/main/java/org/triplea/swing/Toast.java
+++ b/swing-lib/src/main/java/org/triplea/swing/Toast.java
@@ -2,6 +2,8 @@ package org.triplea.swing;
 
 import java.awt.Color;
 import java.awt.Graphics;
+import java.awt.GraphicsDevice;
+import java.awt.Window;
 import java.time.Duration;
 import javax.annotation.Nonnull;
 import javax.swing.JFrame;
@@ -62,7 +64,9 @@ public class Toast {
     window.add(panel);
     window.setSize(windowWidth, windowHeight);
 
-    window.setOpacity(1);
+    if (supportsTranslucency(window)) {
+      window.setOpacity(1);
+    }
     window.setVisible(true);
 
     new Thread(
@@ -82,12 +86,20 @@ public class Toast {
                   Thread.currentThread().interrupt();
                   return;
                 }
-                final float newOpacity = (float) d;
-                SwingUtilities.invokeLater(() -> window.setOpacity(newOpacity));
+                if (supportsTranslucency(window)) {
+                  final float newOpacity = (float) d;
+                  SwingUtilities.invokeLater(() -> window.setOpacity(newOpacity));
+                }
               }
-
               SwingUtilities.invokeLater(window::dispose);
             })
         .start();
+  }
+
+  private static boolean supportsTranslucency(final Window window) {
+    return window
+        .getGraphicsConfiguration()
+        .getDevice()
+        .isWindowTranslucencySupported(GraphicsDevice.WindowTranslucency.TRANSLUCENT);
   }
 }


### PR DESCRIPTION
Fixes a potential UnsupportedOperationException that can be thrown
otherwise: https://github.com/triplea-game/triplea/issues/7681


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
