### PR TITLE
Use BattleStep.getAll instead of creating each one individually

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
@@ -8,6 +8,7 @@ import games.strategy.engine.data.Unit;
 import java.util.Collection;
 import java.util.UUID;
 import lombok.Value;
+import org.triplea.java.RemoveOnNextMajorRelease;
 
 /** Exposes the battle state and allows updates to it */
 public interface BattleState {
@@ -41,6 +42,7 @@ public interface BattleState {
 
   Collection<TerritoryEffect> getTerritoryEffects();
 
+  @RemoveOnNextMajorRelease("Use a BattleId class instead of UUID")
   UUID getBattleId();
 
   Collection<Unit> getUnits(Side... sides);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
@@ -8,7 +8,7 @@ import games.strategy.engine.data.Unit;
 import java.util.Collection;
 import java.util.UUID;
 import lombok.Value;
-import org.triplea.java.RemoveOnNextMajorRelease;
+import org.triplea.java.ChangeOnNextMajorRelease;
 
 /** Exposes the battle state and allows updates to it */
 public interface BattleState {
@@ -42,7 +42,7 @@ public interface BattleState {
 
   Collection<TerritoryEffect> getTerritoryEffects();
 
-  @RemoveOnNextMajorRelease("Use a BattleId class instead of UUID")
+  @ChangeOnNextMajorRelease("Use a BattleId class instead of UUID")
   UUID getBattleId();
 
   Collection<Unit> getUnits(Side... sides);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleStep.java
@@ -3,12 +3,17 @@ package games.strategy.triplea.delegate.battle.steps;
 import games.strategy.triplea.delegate.IExecutable;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
+import games.strategy.triplea.delegate.battle.steps.change.CheckGeneralBattleEnd;
+import games.strategy.triplea.delegate.battle.steps.change.CheckStalemateBattleEnd;
 import games.strategy.triplea.delegate.battle.steps.change.ClearAaCasualties;
+import games.strategy.triplea.delegate.battle.steps.change.ClearGeneralCasualties;
 import games.strategy.triplea.delegate.battle.steps.change.LandParatroopers;
 import games.strategy.triplea.delegate.battle.steps.change.MarkNoMovementLeft;
 import games.strategy.triplea.delegate.battle.steps.change.RemoveNonCombatants;
 import games.strategy.triplea.delegate.battle.steps.change.RemoveUnprotectedUnits;
+import games.strategy.triplea.delegate.battle.steps.change.RemoveUnprotectedUnitsGeneral;
 import games.strategy.triplea.delegate.battle.steps.change.suicide.RemoveFirstStrikeSuicide;
+import games.strategy.triplea.delegate.battle.steps.change.suicide.RemoveGeneralSuicide;
 import games.strategy.triplea.delegate.battle.steps.fire.NavalBombardment;
 import games.strategy.triplea.delegate.battle.steps.fire.aa.DefensiveAaFire;
 import games.strategy.triplea.delegate.battle.steps.fire.aa.OffensiveAaFire;
@@ -20,6 +25,7 @@ import games.strategy.triplea.delegate.battle.steps.fire.firststrike.OffensiveFi
 import games.strategy.triplea.delegate.battle.steps.fire.general.DefensiveGeneral;
 import games.strategy.triplea.delegate.battle.steps.fire.general.OffensiveGeneral;
 import games.strategy.triplea.delegate.battle.steps.retreat.DefensiveSubsRetreat;
+import games.strategy.triplea.delegate.battle.steps.retreat.OffensiveGeneralRetreat;
 import games.strategy.triplea.delegate.battle.steps.retreat.OffensiveSubsRetreat;
 import games.strategy.triplea.delegate.battle.steps.retreat.sub.SubmergeSubsVsOnlyAirStep;
 import java.util.List;
@@ -97,6 +103,12 @@ public interface BattleStep extends IExecutable {
         new ClearAaCasualties(battleState, battleActions),
         new RemoveNonCombatants(battleActions),
         new MarkNoMovementLeft(battleState, battleActions),
-        new RemoveFirstStrikeSuicide(battleState, battleActions));
+        new RemoveFirstStrikeSuicide(battleState, battleActions),
+        new RemoveGeneralSuicide(battleState, battleActions),
+        new OffensiveGeneralRetreat(battleState, battleActions),
+        new ClearGeneralCasualties(battleState, battleActions),
+        new RemoveUnprotectedUnitsGeneral(battleState, battleActions),
+        new CheckGeneralBattleEnd(battleState, battleActions),
+        new CheckStalemateBattleEnd(battleState, battleActions));
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleSteps.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleSteps.java
@@ -1,36 +1,11 @@
 package games.strategy.triplea.delegate.battle.steps;
 
-import static games.strategy.triplea.delegate.battle.steps.BattleStep.Order.FIRST_STRIKE_DEFENSIVE;
-import static games.strategy.triplea.delegate.battle.steps.BattleStep.Order.FIRST_STRIKE_DEFENSIVE_REGULAR;
-import static games.strategy.triplea.delegate.battle.steps.BattleStep.Order.FIRST_STRIKE_OFFENSIVE;
-import static games.strategy.triplea.delegate.battle.steps.BattleStep.Order.FIRST_STRIKE_OFFENSIVE_REGULAR;
-import static games.strategy.triplea.delegate.battle.steps.BattleStep.Order.SUB_DEFENSIVE_RETREAT_AFTER_BATTLE;
-import static games.strategy.triplea.delegate.battle.steps.BattleStep.Order.SUB_DEFENSIVE_RETREAT_BEFORE_BATTLE;
-import static games.strategy.triplea.delegate.battle.steps.BattleStep.Order.SUB_OFFENSIVE_RETREAT_AFTER_BATTLE;
-import static games.strategy.triplea.delegate.battle.steps.BattleStep.Order.SUB_OFFENSIVE_RETREAT_BEFORE_BATTLE;
-
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.BattleStepStrings;
-import games.strategy.triplea.delegate.battle.steps.change.ClearGeneralCasualties;
-import games.strategy.triplea.delegate.battle.steps.change.LandParatroopers;
-import games.strategy.triplea.delegate.battle.steps.change.RemoveUnprotectedUnits;
-import games.strategy.triplea.delegate.battle.steps.fire.NavalBombardment;
-import games.strategy.triplea.delegate.battle.steps.fire.aa.DefensiveAaFire;
-import games.strategy.triplea.delegate.battle.steps.fire.aa.OffensiveAaFire;
-import games.strategy.triplea.delegate.battle.steps.fire.air.AirAttackVsNonSubsStep;
-import games.strategy.triplea.delegate.battle.steps.fire.air.AirDefendVsNonSubsStep;
-import games.strategy.triplea.delegate.battle.steps.fire.firststrike.ClearFirstStrikeCasualties;
-import games.strategy.triplea.delegate.battle.steps.fire.firststrike.DefensiveFirstStrike;
-import games.strategy.triplea.delegate.battle.steps.fire.firststrike.OffensiveFirstStrike;
-import games.strategy.triplea.delegate.battle.steps.fire.general.DefensiveGeneral;
-import games.strategy.triplea.delegate.battle.steps.fire.general.OffensiveGeneral;
-import games.strategy.triplea.delegate.battle.steps.retreat.DefensiveSubsRetreat;
-import games.strategy.triplea.delegate.battle.steps.retreat.OffensiveGeneralRetreat;
-import games.strategy.triplea.delegate.battle.steps.retreat.OffensiveSubsRetreat;
-import games.strategy.triplea.delegate.battle.steps.retreat.sub.SubmergeSubsVsOnlyAirStep;
-import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.Builder;
 
 /** Get the steps that will occur in the battle */
@@ -41,73 +16,9 @@ public class BattleSteps implements BattleStepStrings {
   final BattleActions battleActions;
 
   public List<String> get() {
-    final BattleStep offensiveAaStep = new OffensiveAaFire(battleState, battleActions);
-    final BattleStep defensiveAaStep = new DefensiveAaFire(battleState, battleActions);
-    final BattleStep submergeSubsVsOnlyAir =
-        new SubmergeSubsVsOnlyAirStep(battleState, battleActions);
-    final BattleStep removeUnprotectedUnits =
-        new RemoveUnprotectedUnits(battleState, battleActions);
-    final BattleStep airAttackVsNonSubs = new AirAttackVsNonSubsStep(battleState);
-    final BattleStep airDefendVsNonSubs = new AirDefendVsNonSubsStep(battleState);
-    final BattleStep navalBombardment = new NavalBombardment(battleState, battleActions);
-    final BattleStep landParatroopers = new LandParatroopers(battleState, battleActions);
-    final BattleStep offensiveSubsSubmerge = new OffensiveSubsRetreat(battleState, battleActions);
-    final BattleStep defensiveSubsSubmerge = new DefensiveSubsRetreat(battleState, battleActions);
-    final BattleStep offensiveFirstStrike = new OffensiveFirstStrike(battleState, battleActions);
-    final BattleStep defensiveFirstStrike = new DefensiveFirstStrike(battleState, battleActions);
-    final BattleStep firstStrikeCasualties =
-        new ClearFirstStrikeCasualties(battleState, battleActions);
-    final BattleStep offensiveStandard = new OffensiveGeneral(battleState, battleActions);
-    final BattleStep defensiveStandard = new DefensiveGeneral(battleState, battleActions);
-    final BattleStep offensiveGeneralRetreat =
-        new OffensiveGeneralRetreat(battleState, battleActions);
-    final BattleStep clearGeneralCasualties =
-        new ClearGeneralCasualties(battleState, battleActions);
-
-    final List<String> steps = new ArrayList<>();
-    steps.addAll(offensiveAaStep.getNames());
-    steps.addAll(defensiveAaStep.getNames());
-
-    steps.addAll(navalBombardment.getNames());
-    steps.addAll(landParatroopers.getNames());
-
-    if (offensiveSubsSubmerge.getOrder() == SUB_OFFENSIVE_RETREAT_BEFORE_BATTLE) {
-      steps.addAll(offensiveSubsSubmerge.getNames());
-    }
-    if (defensiveSubsSubmerge.getOrder() == SUB_DEFENSIVE_RETREAT_BEFORE_BATTLE) {
-      steps.addAll(defensiveSubsSubmerge.getNames());
-    }
-    steps.addAll(removeUnprotectedUnits.getNames());
-    steps.addAll(submergeSubsVsOnlyAir.getNames());
-
-    if (offensiveFirstStrike.getOrder() == FIRST_STRIKE_OFFENSIVE) {
-      steps.addAll(offensiveFirstStrike.getNames());
-    }
-    if (defensiveFirstStrike.getOrder() == FIRST_STRIKE_DEFENSIVE) {
-      steps.addAll(defensiveFirstStrike.getNames());
-    }
-    steps.addAll(firstStrikeCasualties.getNames());
-
-    if (offensiveFirstStrike.getOrder() == FIRST_STRIKE_OFFENSIVE_REGULAR) {
-      steps.addAll(offensiveFirstStrike.getNames());
-    }
-    steps.addAll(airAttackVsNonSubs.getNames());
-    steps.addAll(offensiveStandard.getNames());
-
-    if (defensiveFirstStrike.getOrder() == FIRST_STRIKE_DEFENSIVE_REGULAR) {
-      steps.addAll(defensiveFirstStrike.getNames());
-    }
-    steps.addAll(airDefendVsNonSubs.getNames());
-    steps.addAll(defensiveStandard.getNames());
-
-    steps.addAll(clearGeneralCasualties.getNames());
-    if (offensiveSubsSubmerge.getOrder() == SUB_OFFENSIVE_RETREAT_AFTER_BATTLE) {
-      steps.addAll(offensiveSubsSubmerge.getNames());
-    }
-    steps.addAll(offensiveGeneralRetreat.getNames());
-    if (defensiveSubsSubmerge.getOrder() == SUB_DEFENSIVE_RETREAT_AFTER_BATTLE) {
-      steps.addAll(defensiveSubsSubmerge.getNames());
-    }
-    return steps;
+    return BattleStep.getAll(battleState, battleActions).stream()
+        .sorted(Comparator.comparing(BattleStep::getOrder))
+        .flatMap(step -> step.getNames().stream())
+        .collect(Collectors.toList());
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckStalemateBattleEnd.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckStalemateBattleEnd.java
@@ -5,10 +5,10 @@ import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.List;
-import org.triplea.java.RemoveOnNextMajorRelease;
+import org.triplea.java.ChangeOnNextMajorRelease;
 
-@RemoveOnNextMajorRelease(
-    "CheckStalemateBattleEnd should be worked so that it doesn't inherit from CheckGeneralBattleEnd")
+@ChangeOnNextMajorRelease(
+    "This should be reworked so that it doesn't inherit from CheckGeneralBattleEnd")
 public class CheckStalemateBattleEnd extends CheckGeneralBattleEnd {
   public CheckStalemateBattleEnd(final BattleState battleState, final BattleActions battleActions) {
     super(battleState, battleActions);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckStalemateBattleEnd.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckStalemateBattleEnd.java
@@ -5,7 +5,10 @@ import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.List;
+import org.triplea.java.RemoveOnNextMajorRelease;
 
+@RemoveOnNextMajorRelease(
+    "CheckStalemateBattleEnd should be worked so that it doesn't inherit from CheckGeneralBattleEnd")
 public class CheckStalemateBattleEnd extends CheckGeneralBattleEnd {
   public CheckStalemateBattleEnd(final BattleState battleState, final BattleActions battleActions) {
     super(battleState, battleActions);

--- a/java-extras/src/main/java/org/triplea/java/ChangeOnNextMajorRelease.java
+++ b/java-extras/src/main/java/org/triplea/java/ChangeOnNextMajorRelease.java
@@ -1,7 +1,7 @@
 package org.triplea.java;
 
-    import java.lang.annotation.Retention;
-    import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 
 /**
  * Annotation indicating an unused element may be deleted on the next major release when we are okay

--- a/java-extras/src/main/java/org/triplea/java/ChangeOnNextMajorRelease.java
+++ b/java-extras/src/main/java/org/triplea/java/ChangeOnNextMajorRelease.java
@@ -1,0 +1,13 @@
+package org.triplea.java;
+
+    import java.lang.annotation.Retention;
+    import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Annotation indicating an unused element may be deleted on the next major release when we are okay
+ * breaking save game compatibility.
+ */
+@Retention(RetentionPolicy.SOURCE)
+public @interface ChangeOnNextMajorRelease {
+  String value() default "";
+}


### PR DESCRIPTION
All of the steps except for the final "re-loop" step is done.  So I've changed everything to just use `BattleStep.getAll()` and no longer construct the steps individually.

I also added some `@RemoveOnNextMajorRelease` comments to indicate changes that should be done later.  Maybe there should be a `@ChangeOnNextMajorRelease` annotation?

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
