### PR TITLE
Add BattleState to RemoveNonCombatants

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -1043,7 +1043,8 @@ public class MustFightBattle extends DependentBattle
       @Override
       @RemoveOnNextMajorRelease
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-        final BattleStep removeNonCombatants = new RemoveNonCombatants(MustFightBattle.this);
+        final BattleStep removeNonCombatants =
+            new RemoveNonCombatants(MustFightBattle.this, MustFightBattle.this);
         removeNonCombatants.execute(stack, bridge);
       }
     };
@@ -1066,7 +1067,8 @@ public class MustFightBattle extends DependentBattle
       @Override
       @RemoveOnNextMajorRelease
       public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-        final BattleStep removeNonCombatants = new RemoveNonCombatants(MustFightBattle.this);
+        final BattleStep removeNonCombatants =
+            new RemoveNonCombatants(MustFightBattle.this, MustFightBattle.this);
         removeNonCombatants.execute(stack, bridge);
       }
     };

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleStep.java
@@ -101,7 +101,7 @@ public interface BattleStep extends IExecutable {
         new OffensiveGeneral(battleState, battleActions),
         new DefensiveGeneral(battleState, battleActions),
         new ClearAaCasualties(battleState, battleActions),
-        new RemoveNonCombatants(battleActions),
+        new RemoveNonCombatants(battleState, battleActions),
         new MarkNoMovementLeft(battleState, battleActions),
         new RemoveFirstStrikeSuicide(battleState, battleActions),
         new RemoveGeneralSuicide(battleState, battleActions),

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/RemoveNonCombatants.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/RemoveNonCombatants.java
@@ -3,16 +3,27 @@ package games.strategy.triplea.delegate.battle.steps.change;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleActions;
+import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.steps.BattleStep;
+import java.io.IOException;
+import java.io.ObjectInputStream;
 import java.util.List;
-import lombok.AllArgsConstructor;
+import org.triplea.java.ChangeOnNextMajorRelease;
+import org.triplea.java.RemoveOnNextMajorRelease;
 
-@AllArgsConstructor
 public class RemoveNonCombatants implements BattleStep {
 
   private static final long serialVersionUID = 7629566123535773501L;
 
   protected final BattleActions battleActions;
+
+  @ChangeOnNextMajorRelease("Change order of members so that @AllArgsConstructor can be used")
+  protected BattleState battleState;
+
+  public RemoveNonCombatants(final BattleState battleState, final BattleActions battleActions) {
+    this.battleState = battleState;
+    this.battleActions = battleActions;
+  }
 
   @Override
   public List<String> getNames() {
@@ -27,5 +38,15 @@ public class RemoveNonCombatants implements BattleStep {
   @Override
   public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
     battleActions.removeNonCombatants(bridge);
+  }
+
+  @RemoveOnNextMajorRelease("battleState will not need to be converted from battleActions")
+  private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
+    in.defaultReadObject();
+
+    if (battleState == null && battleActions instanceof BattleState) {
+      // this works because the only BattleActions implementor also implements BattleState
+      battleState = (BattleState) battleActions;
+    }
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/RemoveNonCombatantsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/RemoveNonCombatantsTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.verify;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleActions;
+import games.strategy.triplea.delegate.battle.BattleState;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -16,11 +17,13 @@ class RemoveNonCombatantsTest {
 
   @Mock ExecutionStack executionStack;
   @Mock IDelegateBridge delegateBridge;
+  @Mock BattleState battleState;
   @Mock BattleActions battleActions;
 
   @Test
   void runs() {
-    final RemoveNonCombatants removeNonCombatants = new RemoveNonCombatants(battleActions);
+    final RemoveNonCombatants removeNonCombatants =
+        new RemoveNonCombatants(battleState, battleActions);
 
     removeNonCombatants.execute(executionStack, delegateBridge);
 


### PR DESCRIPTION
I noticed that when I converted RemoveNonCombatants, I only gave it `BattleActions`.  But the `battleActions.removeNonCombatants()` actually interacts with the battle state so when I refactor it, I'll need the battle state.

Since this step can be saved, I came up with a work around to get the `battleState` from the existing `battleActions`.

## Testing
<!-- Describe any manual testing performed below. -->
Loaded a game on a "select AA casualty" step that was saved in master to verify that the `battleState` was correctly populated.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
