### PR TITLE
Couple Simplifications to 'MyFormatter'

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/formatter/MyFormatter.java
+++ b/game-core/src/main/java/games/strategy/triplea/formatter/MyFormatter.java
@@ -117,10 +117,11 @@ public class MyFormatter {
     return pluralize(in);
   }
 
-  public static String pluralize(final String in) {
+  private static String pluralize(final String in) {
     if (plural.containsKey(in)) {
       return plural.get(in);
     }
+
     if (in.endsWith("man")) {
       return in.substring(0, in.lastIndexOf("man")) + "men";
     }
@@ -216,6 +217,7 @@ public class MyFormatter {
     if (roll == null || roll.isEmpty()) {
       return "none";
     }
+
     final StringBuilder buf = new StringBuilder();
     for (int i = 0; i < roll.size(); i++) {
       buf.append(roll.getDie(i).getValue() + 1);
@@ -235,14 +237,10 @@ public class MyFormatter {
     if (rolls == null || rolls.length == 0) {
       return "none";
     }
-    final StringBuilder buf = new StringBuilder(rolls.length * 2);
-    for (int i = 0; i < rolls.length; i++) {
-      buf.append(rolls[i] + 1);
-      if (i + 1 < rolls.length) {
-        buf.append(",");
-      }
-    }
-    return buf.toString();
+    return Arrays.stream(rolls)
+        .map(roll -> roll + 1)
+        .mapToObj(String::valueOf)
+        .collect(Collectors.joining(","));
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -9,7 +9,6 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.Matches;
-import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.image.MapImage;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.UiContext;
@@ -324,15 +323,5 @@ public class UnitsDrawer extends AbstractDrawable {
   @Override
   public DrawLevel getLevel() {
     return DrawLevel.UNITS_LEVEL;
-  }
-
-  @Override
-  public String toString() {
-    return "UnitsDrawer for "
-        + count
-        + " "
-        + MyFormatter.pluralize(unitType)
-        + " in  "
-        + territoryName;
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/formatter/MyFormatterTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/formatter/MyFormatterTest.java
@@ -13,6 +13,28 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 final class MyFormatterTest {
+
+  @Nested
+  final class AsDiceTest {
+    @Test
+    void empty() {
+      final String result = MyFormatter.asDice(new int[] {});
+      assertThat(result, is("none"));
+    }
+
+    @Test
+    void singleton() {
+      final String result = MyFormatter.asDice(new int[] {1});
+      assertThat(result, is("2"));
+    }
+
+    @Test
+    void multiple() {
+      final String result = MyFormatter.asDice(new int[] {1, 2, 3, 10});
+      assertThat(result, is("2,3,4,11"));
+    }
+  }
+
   @Nested
   final class UnitsToTextTest {
     private final GameData gameData = new GameData();


### PR DESCRIPTION
1) Remove unnecessary toString on 'UnitsDrawer'. The history of such
methods is that they were useful in older debuggers. It could be
that the toString is used somewhere for display text, though that
does not look to be the case.

2) Simplify some dice roll formatting logic.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
