### PR TITLE
Structure lobby login window so that it can be re-used

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/lobby/client/LobbyClient.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/LobbyClient.java
@@ -1,10 +1,13 @@
 package games.strategy.engine.lobby.client;
 
+import games.strategy.engine.lobby.client.login.LoginResult;
+import java.net.URI;
 import javax.annotation.Nonnull;
 import lombok.Builder;
 import lombok.Getter;
 import org.triplea.domain.data.UserName;
 import org.triplea.http.client.web.socket.client.connections.PlayerToLobbyConnection;
+import org.triplea.swing.SwingComponents;
 
 /** Provides information about a client connection to a lobby server. */
 @Getter
@@ -15,4 +18,17 @@ public class LobbyClient {
   private final boolean anonymousLogin;
   private final boolean moderator;
   private final boolean passwordChangeRequired;
+
+  public static LobbyClient newLobbyClient(final URI lobbyUri, final LoginResult loginResult) {
+    return LobbyClient.builder()
+        .playerToLobbyConnection(
+            new PlayerToLobbyConnection(
+                lobbyUri,
+                loginResult.getApiKey(),
+                error -> SwingComponents.showError(null, "Error communicating with lobby", error)))
+        .anonymousLogin(loginResult.isAnonymousLogin())
+        .moderator(loginResult.isModerator())
+        .userName(loginResult.getUsername())
+        .build();
+  }
 }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/ChangePasswordPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/ChangePasswordPanel.java
@@ -6,6 +6,7 @@ import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.GridBagLayout;
 import java.awt.Window;
+import java.net.URI;
 import java.util.Arrays;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -18,6 +19,9 @@ import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPasswordField;
+import org.triplea.domain.data.ApiKey;
+import org.triplea.http.client.lobby.HttpLobbyClient;
+import org.triplea.http.client.lobby.user.account.UserAccountClient;
 import org.triplea.http.client.web.socket.client.connections.PlayerToLobbyConnection;
 import org.triplea.java.Sha512Hasher;
 import org.triplea.swing.DocumentListenerBuilder;
@@ -184,13 +188,34 @@ public final class ChangePasswordPanel extends JPanel {
 
   public static boolean doPasswordChange(
       final Window lobbyFrame,
+      final URI lobbyUri,
+      final ApiKey apiKey,
+      final AllowCancelMode allowCancelMode) {
+    return doPasswordChange(
+        lobbyFrame, new HttpLobbyClient(lobbyUri, apiKey).getUserAccountClient(), allowCancelMode);
+  }
+
+  public static boolean doPasswordChange(
+      final Window lobbyFrame,
       final PlayerToLobbyConnection playerToLobbyConnection,
       final AllowCancelMode allowCancelMode) {
+
+    return doPasswordChange(
+        lobbyFrame,
+        playerToLobbyConnection.getHttpLobbyClient().getUserAccountClient(),
+        allowCancelMode);
+  }
+
+  private static boolean doPasswordChange(
+      final Window lobbyFrame,
+      final UserAccountClient userAccountClient,
+      final AllowCancelMode allowCancelMode) {
+
     return new ChangePasswordPanel(allowCancelMode)
         .show(lobbyFrame)
         .map(
             pass -> {
-              playerToLobbyConnection.changePassword(pass);
+              userAccountClient.changePassword(pass);
               return true;
             })
         .orElse(false);

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LoginMode.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LoginMode.java
@@ -1,0 +1,6 @@
+package games.strategy.engine.lobby.client.login;
+
+public enum LoginMode {
+  REGISTRATION_REQUIRED,
+  REGISTRATION_NOT_REQUIRED
+}

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LoginPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LoginPanel.java
@@ -54,20 +54,11 @@ final class LoginPanel extends JPanel {
   private final JButton cancel = new JButton("Cancel");
   private final JLabel passwordLabel = new JLabel("Password:");
 
-  LoginPanel() {
-    initializeComponents();
-    layoutComponents();
-    setupListeners();
-    updateComponents();
-  }
-
-  private void initializeComponents() {
+  LoginPanel(final LoginMode loginMode) {
     username.setText(String.valueOf(ClientSetting.lobbyLoginName.getValue().orElse(new char[0])));
     password.setText(
         String.valueOf(ClientSetting.lobbySavedPassword.getValue().orElse(new char[0])));
-  }
 
-  private void layoutComponents() {
     setLayout(new BorderLayout());
 
     final JLabel label = new JLabel(new ImageIcon(Util.getBanner("Login")));
@@ -161,34 +152,38 @@ final class LoginPanel extends JPanel {
             new Insets(5, 5, 0, 0),
             0,
             0));
-    main.add(
-        new JLabel(),
-        new GridBagConstraints(
-            0,
-            3,
-            1,
-            1,
-            0.0,
-            0.0,
-            GridBagConstraints.WEST,
-            GridBagConstraints.NONE,
-            new Insets(5, 0, 0, 0),
-            0,
-            0));
-    main.add(
-        anonymousLogin,
-        new GridBagConstraints(
-            1,
-            3,
-            1,
-            1,
-            0.0,
-            0.0,
-            GridBagConstraints.WEST,
-            GridBagConstraints.NONE,
-            new Insets(5, 5, 0, 0),
-            0,
-            0));
+    if (loginMode == LoginMode.REGISTRATION_NOT_REQUIRED) {
+      main.add(
+          new JLabel(),
+          new GridBagConstraints(
+              0,
+              3,
+              1,
+              1,
+              0.0,
+              0.0,
+              GridBagConstraints.WEST,
+              GridBagConstraints.NONE,
+              new Insets(5, 0, 0, 0),
+              0,
+              0));
+      main.add(
+          anonymousLogin,
+          new GridBagConstraints(
+              1,
+              3,
+              1,
+              1,
+              0.0,
+              0.0,
+              GridBagConstraints.WEST,
+              GridBagConstraints.NONE,
+              new Insets(5, 5, 0, 0),
+              0,
+              0));
+    } else {
+      anonymousLogin.setSelected(false);
+    }
 
     final JPanel buttons = new JPanel();
     add(buttons, BorderLayout.SOUTH);
@@ -198,9 +193,7 @@ final class LoginPanel extends JPanel {
     buttons.add(createAccount);
     buttons.add(forgotPassword);
     buttons.add(cancel);
-  }
 
-  private void setupListeners() {
     logon.addActionListener(e -> logonPressed());
     createAccount.addActionListener(
         e -> {
@@ -215,6 +208,7 @@ final class LoginPanel extends JPanel {
           close();
         });
     SwingKeyBinding.addKeyBinding(this, KeyCode.ENTER, this::logonPressed);
+    updateComponents();
   }
 
   private void close() {

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/login/LoginResult.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/login/LoginResult.java
@@ -1,0 +1,36 @@
+package games.strategy.engine.lobby.client.login;
+
+import lombok.Builder;
+import lombok.Getter;
+import org.triplea.domain.data.ApiKey;
+import org.triplea.domain.data.UserName;
+
+/**
+ * Data object representing a successful login to lobby and the data we received back from the lobby
+ * after logging in.
+ */
+@Builder
+@Getter
+public class LoginResult {
+  /**
+   * After a successful login the lobby generates and returns an API-Key. On subsequent transactions
+   * with the lobby we can send this API-Key instead of logging in again.
+   */
+  private final ApiKey apiKey;
+  /** The name of the user that has logged in. */
+  private final UserName username;
+  /**
+   * Anonymous login is a login without an account, an unregistered login. No password is required.
+   */
+  private final boolean anonymousLogin;
+  /**
+   * Moderator flag indicates if the user is a moderator, this comes from a lookup on the lobby side
+   * and the lobby tells us if this user is a moderator.
+   */
+  private final boolean moderator;
+  /**
+   * If the user is using a temporary password, the lobby will set the password change required flag
+   * in its response to indicate the user should be prompted with a password change prompt.
+   */
+  private final boolean passwordChangeRequired;
+}

--- a/game-core/src/main/java/org/triplea/live/servers/LiveServersFetcher.java
+++ b/game-core/src/main/java/org/triplea/live/servers/LiveServersFetcher.java
@@ -12,6 +12,7 @@ import java.util.logging.Level;
 import lombok.AllArgsConstructor;
 import lombok.extern.java.Log;
 import org.triplea.java.function.ThrowingSupplier;
+import org.triplea.swing.SwingComponents;
 import org.triplea.util.Version;
 
 /**
@@ -37,6 +38,29 @@ public class LiveServersFetcher {
             .contentDownloader(networkFetcher)
             .yamlParser(new ServerYamlParser())
             .build());
+  }
+
+  /**
+   * Fetches from online configuration server properties. The online configuration is a fixed
+   * configuration file at a known URI. The server properties lists which lobbies are available for
+   * which game versions.
+   */
+  public static Optional<ServerProperties> fetch() {
+    final ServerProperties serverProperties = new LiveServersFetcher().serverForCurrentVersion();
+    if (serverProperties.isInactive()) {
+      SwingComponents.showDialogWithLinks(
+          SwingComponents.DialogWithLinksParams.builder()
+              .title("Lobby Not Available")
+              .dialogText(
+                  String.format(
+                      "Your version of TripleA is out of date, please download the latest:"
+                          + "<br><a href=\"%s\">%s</a>",
+                      UrlConstants.DOWNLOAD_WEBSITE, UrlConstants.DOWNLOAD_WEBSITE))
+              .dialogType(SwingComponents.DialogWithLinksTypes.ERROR)
+              .build());
+      return Optional.empty();
+    }
+    return Optional.of(serverProperties);
   }
 
   public Optional<Version> latestVersion() {

--- a/http-clients/src/main/java/org/triplea/http/client/lobby/HttpLobbyClient.java
+++ b/http-clients/src/main/java/org/triplea/http/client/lobby/HttpLobbyClient.java
@@ -22,7 +22,7 @@ public class HttpLobbyClient {
   private final RemoteActionsClient remoteActionsClient;
   private final PlayerLobbyActionsClient playerLobbyActionsClient;
 
-  private HttpLobbyClient(final URI lobbyUri, final ApiKey apiKey) {
+  public HttpLobbyClient(final URI lobbyUri, final ApiKey apiKey) {
     this.lobbyUri = lobbyUri;
     this.apiKey = apiKey;
 

--- a/http-clients/src/main/java/org/triplea/http/client/web/socket/client/connections/PlayerToLobbyConnection.java
+++ b/http-clients/src/main/java/org/triplea/http/client/web/socket/client/connections/PlayerToLobbyConnection.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 import lombok.Builder;
+import lombok.Getter;
 import org.triplea.domain.data.ApiKey;
 import org.triplea.domain.data.PlayerChatId;
 import org.triplea.domain.data.UserName;
@@ -32,7 +33,7 @@ import org.triplea.http.client.web.socket.messages.envelopes.chat.PlayerStatusUp
  * like chat messages, slap notifications, ban notifications.
  */
 public class PlayerToLobbyConnection {
-  private final HttpLobbyClient httpLobbyClient;
+  @Getter private final HttpLobbyClient httpLobbyClient;
   private GameListingClient gameListingClient;
   private WebSocket webSocket;
 


### PR DESCRIPTION
To be able to do a lobby login prompt from other screens,
we need to decouple the successful login action from the
login screen.

This update restructures responsibilities so that the
caller of the login screen can inject the successful
login behavior.

Additionally, this update adds a flag that can disable
unregistered login. The reasoning is if we are requiring
a login to enable a functionality, then we need
the user to have or to create an account.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
- Did some smoke testing to make sure the lobby login window still looked good and worked.
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
