### PR TITLE
Fix deprecated gradle properties

### DIFF
--- a/database/build.gradle
+++ b/database/build.gradle
@@ -31,7 +31,7 @@ task flywayMigrateAll(dependsOn: [flywayMigrateLobbyDb, flywayMigrateMapsDb])
 
 task portableInstaller(type: Zip, group: 'release') {
     from 'src/main/resources/db/migration/'
-    archiveName 'migrations.zip'
+    archiveFileName = 'migrations.zip'
 }
 
 task release(group: 'release', dependsOn: portableInstaller) {

--- a/game-headless/build.gradle
+++ b/game-headless/build.gradle
@@ -25,7 +25,7 @@ task portableInstaller(type: Zip, group: 'release', dependsOn: shadowJar) {
     from file('.triplea-root')
     from file('scripts/run_bot')
     from(file('scripts/run_bot.bat')) {
-        filter ReplaceTokens, tokens: [version: version]
+        filter ReplaceTokens, tokens: [version: project.version]
         filter FixCrLfFilter, eol: FixCrLfFilter.CrLf.newInstance('crlf') // workaround for https://github.com/gradle/gradle/issues/1151
     }
     from(shadowJar.outputs) {

--- a/map-data/build.gradle
+++ b/map-data/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     implementation "com.sun.xml.bind:jaxb-impl:$jaxbImplVersion"
     implementation project(":xml-reader")
-    testCompile "org.xmlunit:xmlunit-core:$xmlUnitCore"
-    testCompile "org.xmlunit:xmlunit-matchers:$xmlUnitMatchers"
+    testImplementation "org.xmlunit:xmlunit-core:$xmlUnitCore"
+    testImplementation "org.xmlunit:xmlunit-matchers:$xmlUnitMatchers"
 }


### PR DESCRIPTION
The deprecations can be seen with './gradlew compileJava --warning-mode all'

Fixes:
- Replace deprecated 'testCompile' with 'testImplementation'
- Use project.version instead of deprecated property 'version'
- Use 'getArchiveFileName' method instead of 'setArchiveName'


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing

Verified task:  ./gradlew :game-headless:release, will still correctly replace the version number in the zipped bot file, 'run_bot.bat'

<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
