### PR TITLE
Add SLF4J logger

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,7 @@ subprojects {
         jlayerVersion = '1.0.1.4'
         junitJupiterVersion = '5.7.0'
         junitPlatformLauncherVersion = '1.7.0'
+        logbackClassicVersion = '1.2.3'
         mockitoVersion = '3.5.13'
         openFeignVersion = '10.5.1'
         postgresqlVersion = '42.2.16'
@@ -117,6 +118,7 @@ subprojects {
 
     dependencies {
         errorprone "com.google.errorprone:error_prone_core:$errorProneVersion"
+        implementation "ch.qos.logback:logback-classic:$logbackClassicVersion"
         implementation "com.google.guava:guava:$guavaVersion"
         testImplementation "com.github.npathai:hamcrest-optional:$hamcrestOptionalVersion"
         testImplementation "nl.jqno.equalsverifier:equalsverifier:$equalsVerifierVersion"

--- a/game-core/src/main/java/org/triplea/debug/ErrorMessage.java
+++ b/game-core/src/main/java/org/triplea/debug/ErrorMessage.java
@@ -7,9 +7,7 @@ import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.net.URI;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.logging.Level;
 import java.util.logging.LogManager;
-import java.util.logging.LogRecord;
 import javax.swing.JButton;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
@@ -109,7 +107,7 @@ public enum ErrorMessage {
    * Note, we hide and reveal the error message dialog instead of creating and disposing it to avoid
    * swing component creation threading issues.
    */
-  public static void show(final LogRecord record) {
+  public static void show(final LoggerRecord record) {
     if (INSTANCE.enableErrorPopup && INSTANCE.isVisible.compareAndSet(false, true)) {
       INSTANCE.setUploadRecord(record);
 
@@ -123,7 +121,7 @@ public enum ErrorMessage {
     }
   }
 
-  private void setUploadRecord(final LogRecord logRecord) {
+  private void setUploadRecord(final LoggerRecord logRecord) {
     new LiveServersFetcher()
         .lobbyUriForCurrentVersion()
         .ifPresentOrElse(
@@ -132,13 +130,13 @@ public enum ErrorMessage {
             () -> INSTANCE.uploadButton.setVisible(false));
   }
 
-  private void activateUploadErrorReportButton(final URI lobbyUri, final LogRecord logRecord) {
+  private void activateUploadErrorReportButton(final URI lobbyUri, final LoggerRecord logRecord) {
     // Set upload button to be visible only if the logging is greater than a 'warning'.
     // Warning logging should tell a user how to correct the error and it should be something
     // that is 'normal' (but maybe not happy, like no internet) and something they can fix
     // (or perhaps something that we simply can never fix). Hence, for warning we want to inform
     // the user that the problem happened, how to fix it, and let them create a bug report manually.
-    INSTANCE.uploadButton.setVisible(logRecord.getLevel().intValue() > Level.WARNING.intValue());
+    INSTANCE.uploadButton.setVisible(logRecord.isError());
 
     final ErrorReportClient errorReportClient = ErrorReportClient.newClient(lobbyUri);
 

--- a/game-core/src/main/java/org/triplea/debug/ErrorMessageFormatter.java
+++ b/game-core/src/main/java/org/triplea/debug/ErrorMessageFormatter.java
@@ -1,27 +1,19 @@
 package org.triplea.debug;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import games.strategy.triplea.UrlConstants;
 import java.util.function.Function;
-import java.util.logging.Level;
-import java.util.logging.LogRecord;
 import org.triplea.swing.JEditorPaneWithClickableLinks;
 
 /** Converts a 'LogRecord' to the text that we display to a user in an alert pop-up. */
-class ErrorMessageFormatter implements Function<LogRecord, String> {
+class ErrorMessageFormatter implements Function<LoggerRecord, String> {
   private static final String BREAK = "\n\n";
 
   @Override
-  public String apply(final LogRecord logRecord) {
-    checkArgument(
-        logRecord.getThrown() != null || logRecord.getMessage() != null,
-        "LogRecord should have one or both, a message or exception: " + logRecord);
-
+  public String apply(final LoggerRecord logRecord) {
     final String baseMessage = format(logRecord);
 
     final String additionalMessageForWarnings =
-        (logRecord.getLevel().intValue() == Level.WARNING.intValue())
+        logRecord.isWarning()
             ? "<br><br>If this problem happens frequently and is something you cannot fix,<br>"
                 + JEditorPaneWithClickableLinks.toLink(
                     "please report it to TripleA ", UrlConstants.GITHUB_ISSUES)
@@ -30,132 +22,51 @@ class ErrorMessageFormatter implements Function<LogRecord, String> {
   }
 
   /**
-   * Five ways we will hit our logging handler.:<br>
-   * (1) uncaught exception with no message {@code throw new NullPointerException() =>
-   * LogRecord.getMessage() == null && LogRecord.getThrown().getMessage() == null } Return: *
-   * {exception simple name} <br>
-   * (2) uncaught exception with a message {@code throw new NullPointerException("message") => //
-   * log record message will be populated with the exception message
-   * LogRecord.getMessage().equals(LogRecord.getThrown().getMessage())} } <br>
-   * Return: * {exception simple name} - {exception message} <br>
-   * (3) logging an error message {@code log.severe("message") => LogRecord.getMessage() != null &&
-   * LogRecord.getThrown() == null } <br>
-   * Return: * {log message} <br>
-   * (4) logging an error message with exception that has no message {@code log.log(Level.SEVERE,
-   * "message", new NullPointerException()) => LogRecord.getMessage() != null &&
-   * LogRecord.getThrown().getMessage() == null } Return: * * {log message} * * * * {exception
-   * simple name} <br>
-   * (5) logging an error message with exception that has a message {@code log.log(Level.SEVERE,
-   * "log-message", new NullPointerException("exception message")) => LogRecord.getMessage() != null
-   * && LogRecord.getThrown() != null &&
-   * !LogRecord.getMessage().equals(LogRecord.getThrown().getMessage()) } <br>
-   * Return: * {log message} * * {exception simple name} - {exception message}
-   */
-  private static String format(final LogRecord logRecord) {
-    if (logRecord.getThrown() == null) {
-      return logMessageOnly(logRecord);
-    }
-
-    if (logRecord.getMessage() != null
-        && logRecord.getThrown() != null
-        && logRecord.getThrown().getMessage() != null
-        && !logRecord.getMessage().equals(logRecord.getThrown().getMessage())) {
-      return logMessageAndExceptionMessage(logRecord);
-    }
-
-    if (logRecord.getMessage() != null
-        && logRecord.getThrown() != null
-        && logRecord.getThrown().getMessage() == null) {
-      return logMessageAndExceptionWithoutMessage(logRecord);
-    }
-
-    if (logRecord.getMessage() == null
-        && logRecord.getThrown() != null
-        && logRecord.getThrown().getMessage() == null) {
-      return exceptionOnlyWithOutMessage(logRecord);
-    }
-
-    if (logRecord.getMessage() != null
-        && logRecord.getThrown() != null
-        && logRecord.getThrown().getMessage() != null
-        && logRecord.getMessage().equals(logRecord.getThrown().getMessage())) {
-      return exceptionOnlyWithMessage(logRecord);
-    }
-
-    throw new IllegalStateException(
-        "Unhandled: " + logRecord.getMessage() + ", exception: " + logRecord.getThrown());
-  }
-
-  /*
-   * <pre>
-   * Error: {log message}
-   * </pre>
-   */
-  private static String logMessageOnly(final LogRecord logRecord) {
-    checkArgument(logRecord.getMessage() != null);
-    checkArgument(logRecord.getThrown() == null);
-
-    return logRecord.getMessage();
-  }
-
-  /*
-   * <pre>
-   * Error: {exception simple name} - {exception message}
-   * </pre>
-   */
-  private static String exceptionOnlyWithMessage(final LogRecord logRecord) {
-    checkArgument(logRecord.getThrown().getMessage() != null);
-    checkArgument(logRecord.getMessage() != null);
-    checkArgument(logRecord.getThrown().getMessage().equals(logRecord.getMessage()));
-    return simpleName(logRecord) + " - " + logRecord.getThrown().getMessage();
-  }
-
-  private static String simpleName(final LogRecord logRecord) {
-    return logRecord.getThrown().getClass().getSimpleName();
-  }
-
-  /*
-   * <pre>
-   * Error: {exception simple name}
-   * </pre>
-   */
-  private static String exceptionOnlyWithOutMessage(final LogRecord logRecord) {
-    checkArgument(logRecord.getThrown().getMessage() == null);
-    checkArgument(logRecord.getMessage() == null);
-
-    return simpleName(logRecord);
-  }
-
-  /*
-   * <pre>
-   * Error: {log message}
+   * Five ways we will hit our logging handler:
    *
-   * Details: {exception simple name} - {exception message}
-   * </pre>
-   */
-  private static String logMessageAndExceptionMessage(final LogRecord logRecord) {
-    checkArgument(logRecord.getThrown().getMessage() != null);
-    checkArgument(logRecord.getMessage() != null);
-    checkArgument(!logRecord.getThrown().getMessage().equals(logRecord.getMessage()));
-
-    return logRecord.getMessage()
-        + BREAK
-        + simpleName(logRecord)
-        + ": "
-        + logRecord.getThrown().getMessage();
-  }
-
-  /*
    * <pre>
-   * Error: {log message}
-   *
-   * Details: {exception simple name}
+   * (1) uncaught exception with no message, eg: {@code throw new NullPointerException()}
+   * (2) uncaught exception with a message, eg:  {@code throw new NullPointerException("message")}
+   * (3) logging an error message, eg: {@code log.severe("message")}
+   * (4) logging an error message with exception that has no message, eg:
+   * {@code log.log(Level.SEVERE, "message", new NullPointerException())}
+   * (5) logging an error message with exception that has a message, eg:
+   * {@code log.log(Level.SEVERE, "log-message", new NullPointerException("exception message"))}
    * </pre>
    */
-  private static String logMessageAndExceptionWithoutMessage(final LogRecord logRecord) {
-    checkArgument(logRecord.getThrown().getMessage() == null);
-    checkArgument(logRecord.getMessage() != null);
+  private static String format(final LoggerRecord logRecord) {
+    if (logRecord.getLogMessage() == null) {
+      final LoggerRecord.ExceptionDetails exceptionDetails =
+          logRecord.getExceptions().size() > 1
+              ? logRecord.getExceptions().get(1)
+              : logRecord.getExceptions().get(0);
 
-    return logRecord.getMessage() + BREAK + simpleName(logRecord);
+      if (exceptionDetails.getExceptionMessage() != null) {
+        return exceptionDetails.getExceptionClassName()
+            + " - "
+            + exceptionDetails.getExceptionMessage();
+      } else {
+        return exceptionDetails.getExceptionClassName();
+      }
+    } else {
+      if (logRecord.getExceptions().isEmpty()) {
+        return logRecord.getLogMessage();
+      } else {
+        final LoggerRecord.ExceptionDetails exceptionDetails =
+            logRecord.getExceptions().size() > 1
+                ? logRecord.getExceptions().get(1)
+                : logRecord.getExceptions().get(0);
+
+        if (exceptionDetails.getExceptionMessage() != null) {
+          return logRecord.getLogMessage()
+              + BREAK
+              + exceptionDetails.getExceptionClassName()
+              + ": "
+              + exceptionDetails.getExceptionMessage();
+        } else {
+          return logRecord.getLogMessage() + BREAK + exceptionDetails.getExceptionClassName();
+        }
+      }
+    }
   }
 }

--- a/game-core/src/main/java/org/triplea/debug/ErrorMessageHandler.java
+++ b/game-core/src/main/java/org/triplea/debug/ErrorMessageHandler.java
@@ -32,7 +32,8 @@ public final class ErrorMessageHandler extends Handler {
 
   @Override
   public synchronized void publish(final LogRecord record) {
-    publish(record, logRecord -> ErrorMessage.show(LoggerRecordAdapter.fromJavaUtilLogRecord(record)));
+    publish(
+        record, logRecord -> ErrorMessage.show(LoggerRecordAdapter.fromJavaUtilLogRecord(record)));
   }
 
   @VisibleForTesting

--- a/game-core/src/main/java/org/triplea/debug/ErrorMessageHandler.java
+++ b/game-core/src/main/java/org/triplea/debug/ErrorMessageHandler.java
@@ -32,7 +32,7 @@ public final class ErrorMessageHandler extends Handler {
 
   @Override
   public synchronized void publish(final LogRecord record) {
-    publish(record, ErrorMessage::show);
+    publish(record, logRecord -> ErrorMessage.show(LoggerRecordAdapter.fromJavaUtilLogRecord(record)));
   }
 
   @VisibleForTesting

--- a/game-core/src/main/java/org/triplea/debug/LoggerRecord.java
+++ b/game-core/src/main/java/org/triplea/debug/LoggerRecord.java
@@ -1,0 +1,36 @@
+package org.triplea.debug;
+
+import java.util.List;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import lombok.Builder;
+import lombok.Getter;
+
+/**
+ * Unified interface for data needed to upload error reports.
+ *
+ * @see LoggerRecordAdapter
+ */
+public interface LoggerRecord {
+  String getLoggerClassName();
+
+  String getLogMessage();
+
+  boolean isError();
+
+  boolean isWarning();
+
+  /**
+   * Return the stack trace of each exception, each successive element should be the next 'caused
+   * by' exception'.
+   */
+  List<ExceptionDetails> getExceptions();
+
+  @Builder
+  @Getter
+  class ExceptionDetails {
+    @Nonnull private final String exceptionClassName;
+    @Nullable private final String exceptionMessage;
+    @Nullable private final StackTraceElement[] stackTraceElements;
+  }
+}

--- a/game-core/src/main/java/org/triplea/debug/LoggerRecordAdapter.java
+++ b/game-core/src/main/java/org/triplea/debug/LoggerRecordAdapter.java
@@ -1,0 +1,122 @@
+package org.triplea.debug;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.classic.spi.StackTraceElementProxy;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.logging.LogRecord;
+import lombok.experimental.UtilityClass;
+
+/**
+ * Contains adapter methods to convert log events from either java.util.logger or logback to a
+ * unified @{code LoggerRecord}. The unified data is then used to create error reports that can be
+ * uploaded.
+ */
+@UtilityClass
+class LoggerRecordAdapter {
+
+  static LoggerRecord fromLogbackEvent(final ILoggingEvent eventObject) {
+    return new LoggerRecord() {
+      @Override
+      public String getLoggerClassName() {
+        return eventObject.getLoggerName();
+      }
+
+      @Override
+      public String getLogMessage() {
+        return eventObject.getFormattedMessage();
+      }
+
+      @Override
+      public boolean isError() {
+        return eventObject.getLevel().isGreaterOrEqual(Level.ERROR);
+      }
+
+      @Override
+      public boolean isWarning() {
+        return eventObject.getLevel() == Level.WARN;
+      }
+
+      @Override
+      public List<ExceptionDetails> getExceptions() {
+        final List<ExceptionDetails> details = new ArrayList<>();
+        IThrowableProxy throwableProxy = eventObject.getThrowableProxy();
+        // get up 20 exceptions via 'caused by' and convert each to exception details
+        for (int i = 0; i < 20 && throwableProxy != null; i++) {
+          details.add(toExceptionDetails(throwableProxy));
+          throwableProxy = throwableProxy.getCause();
+        }
+        return details;
+      }
+
+      private ExceptionDetails toExceptionDetails(final IThrowableProxy throwableProxy) {
+        return ExceptionDetails.builder()
+            .exceptionClassName(throwableProxy.getClassName())
+            .exceptionMessage(throwableProxy.getMessage())
+            .stackTraceElements(mapThrowableProxyToStackTrace(throwableProxy))
+            .build();
+      }
+
+      private StackTraceElement[] mapThrowableProxyToStackTrace(final IThrowableProxy proxy) {
+        return Optional.ofNullable(proxy)
+            .map(IThrowableProxy::getStackTraceElementProxyArray)
+            .map(this::mapProxyArrayToStackTraceArray)
+            .orElse(null);
+      }
+
+      private StackTraceElement[] mapProxyArrayToStackTraceArray(
+          final StackTraceElementProxy[] proxies) {
+        return Arrays.stream(proxies)
+            .map(StackTraceElementProxy::getStackTraceElement)
+            .toArray(StackTraceElement[]::new);
+      }
+    };
+  }
+
+  static LoggerRecord fromJavaUtilLogRecord(final LogRecord record) {
+    return new LoggerRecord() {
+      @Override
+      public String getLoggerClassName() {
+        return record.getLoggerName();
+      }
+
+      @Override
+      public String getLogMessage() {
+        return record.getMessage();
+      }
+
+      @Override
+      public boolean isError() {
+        return record.getLevel().intValue() >= java.util.logging.Level.SEVERE.intValue();
+      }
+
+      @Override
+      public boolean isWarning() {
+        return record.getLevel().intValue() == java.util.logging.Level.WARNING.intValue();
+      }
+
+      @Override
+      public List<ExceptionDetails> getExceptions() {
+        final List<ExceptionDetails> exceptionDetails = new ArrayList<>();
+        Throwable throwable = record.getThrown();
+        for (int i = 0; i < 20 && throwable != null; i++) {
+          exceptionDetails.add(mapToExceptionDetails(throwable));
+          throwable = throwable.getCause();
+        }
+        return exceptionDetails;
+      }
+
+      private ExceptionDetails mapToExceptionDetails(final Throwable throwable) {
+        return ExceptionDetails.builder()
+            .exceptionClassName(throwable.getClass().getName())
+            .exceptionMessage(throwable.getMessage())
+            .stackTraceElements(throwable.getStackTrace())
+            .build();
+      }
+    };
+  }
+}

--- a/game-core/src/main/java/org/triplea/debug/Slf4jLogMessageUploader.java
+++ b/game-core/src/main/java/org/triplea/debug/Slf4jLogMessageUploader.java
@@ -1,0 +1,16 @@
+package org.triplea.debug;
+
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.AppenderBase;
+
+/**
+ * This appender is activated via logback.xml and can accept SLF4J logger messages. Log messages are
+ * displayed as an error dialog to users with an option for 'error' logs to be uploaded
+ * automatically to github issues.
+ */
+public class Slf4jLogMessageUploader extends AppenderBase<ILoggingEvent> {
+  @Override
+  protected void append(final ILoggingEvent eventObject) {
+    ErrorMessage.show(LoggerRecordAdapter.fromLogbackEvent(eventObject));
+  }
+}

--- a/game-core/src/main/java/org/triplea/debug/error/reporting/ErrorReportRequestParams.java
+++ b/game-core/src/main/java/org/triplea/debug/error/reporting/ErrorReportRequestParams.java
@@ -1,9 +1,9 @@
 package org.triplea.debug.error.reporting;
 
-import java.util.logging.LogRecord;
 import javax.annotation.Nonnull;
 import lombok.Builder;
 import lombok.Value;
+import org.triplea.debug.LoggerRecord;
 import org.triplea.debug.console.window.DebugUtils;
 
 /** Value object representing data gathered from user and an underlying error. */
@@ -13,5 +13,5 @@ class ErrorReportRequestParams {
   @Nonnull private final String userDescription;
   private final String mapName;
   @Builder.Default @Nonnull private final String memoryStatistics = DebugUtils.getMemory();
-  @Nonnull private final LogRecord logRecord;
+  @Nonnull private final LoggerRecord logRecord;
 }

--- a/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceReportModel.java
+++ b/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceReportModel.java
@@ -6,16 +6,16 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.logging.LogRecord;
 import javax.annotation.Nonnull;
 import lombok.Builder;
+import org.triplea.debug.LoggerRecord;
 import org.triplea.http.client.error.report.ErrorReportRequest;
 
 @Builder
 class StackTraceReportModel {
 
   @Nonnull private final StackTraceReportView view;
-  @Nonnull private final LogRecord stackTraceRecord;
+  @Nonnull private final LoggerRecord stackTraceRecord;
   @Nonnull private final Function<ErrorReportRequestParams, ErrorReportRequest> formatter;
   @Nonnull private final Predicate<ErrorReportRequest> uploader;
   @Nonnull private final Consumer<ErrorReportRequest> preview;

--- a/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceReportView.java
+++ b/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceReportView.java
@@ -1,7 +1,7 @@
 package org.triplea.debug.error.reporting;
 
 import java.awt.Component;
-import java.util.logging.LogRecord;
+import org.triplea.debug.LoggerRecord;
 import org.triplea.http.client.error.report.ErrorReportClient;
 
 /** Interface for interactions with the stack trace user-reporting window UI. */
@@ -27,7 +27,9 @@ public interface StackTraceReportView {
    * information around the circumstances of an error.
    */
   static void showWindow(
-      final Component parentWindow, final ErrorReportClient uploader, final LogRecord logRecord) {
+      final Component parentWindow,
+      final ErrorReportClient uploader,
+      final LoggerRecord logRecord) {
 
     final StackTraceReportView window = new StackTraceReportSwingView(parentWindow);
 

--- a/game-core/src/main/java/org/triplea/debug/error/reporting/UploadDecisionModule.java
+++ b/game-core/src/main/java/org/triplea/debug/error/reporting/UploadDecisionModule.java
@@ -1,9 +1,9 @@
 package org.triplea.debug.error.reporting;
 
 import games.strategy.engine.ClientContext;
-import java.util.logging.LogRecord;
 import javax.swing.JFrame;
 import lombok.experimental.UtilityClass;
+import org.triplea.debug.LoggerRecord;
 import org.triplea.http.client.error.report.CanUploadRequest;
 import org.triplea.http.client.error.report.ErrorReportClient;
 
@@ -17,7 +17,7 @@ import org.triplea.http.client.error.report.ErrorReportClient;
 public class UploadDecisionModule {
 
   public static void processUploadDecision(
-      final JFrame parentWindow, final ErrorReportClient uploader, final LogRecord logRecord) {
+      final JFrame parentWindow, final ErrorReportClient uploader, final LoggerRecord logRecord) {
 
     final var canUploadRequest =
         CanUploadRequest.builder()

--- a/game-core/src/test/java/org/triplea/debug/ErrorMessageFormatterTest.java
+++ b/game-core/src/test/java/org/triplea/debug/ErrorMessageFormatterTest.java
@@ -3,12 +3,11 @@ package org.triplea.debug;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.StringContains.containsString;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.lenient;
 
 import games.strategy.triplea.UrlConstants;
+import java.util.List;
 import java.util.function.Function;
-import java.util.logging.Level;
-import java.util.logging.LogRecord;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -18,21 +17,16 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class ErrorMessageFormatterTest {
 
   private static final String LOG_MESSAGE = "Pants travel with power at the stormy madagascar!";
-  private static final String EXCEPTION_MESSAGE = "Jolly, yer not trading me without a life!";
 
-  private static final Exception EXCEPTION_WITHOUT_MESSAGE = new NullPointerException();
-  private static final Exception EXCEPTION_WITH_MESSAGE =
-      new NullPointerException(EXCEPTION_MESSAGE);
+  @Mock private LoggerRecord logRecord;
 
-  @Mock private LogRecord logRecord;
-
-  private final Function<LogRecord, String> errorMessageFormatter = new ErrorMessageFormatter();
+  private final Function<LoggerRecord, String> errorMessageFormatter = new ErrorMessageFormatter();
 
   @Test
   void logMessageOnly() {
-    when(logRecord.getMessage()).thenReturn(LOG_MESSAGE);
-    when(logRecord.getLevel()).thenReturn(Level.SEVERE);
-    when(logRecord.getThrown()).thenReturn(null);
+    lenient().when(logRecord.getLogMessage()).thenReturn(LOG_MESSAGE);
+    lenient().when(logRecord.isError()).thenReturn(true);
+    lenient().when(logRecord.getExceptions()).thenReturn(List.of());
 
     final String result = errorMessageFormatter.apply(logRecord);
 
@@ -41,42 +35,52 @@ class ErrorMessageFormatterTest {
 
   @Test
   void exceptionOnlyWithMessage() {
-    givenLogRecordWithNoMessageOnlyAnException(logRecord, EXCEPTION_WITH_MESSAGE);
+    lenient().when(logRecord.getLogMessage()).thenReturn(null);
+    lenient().when(logRecord.isError()).thenReturn(true);
+    lenient()
+        .when(logRecord.getExceptions())
+        .thenReturn(
+            List.of(
+                LoggerRecord.ExceptionDetails.builder()
+                    .exceptionMessage("message from exception111")
+                    .exceptionClassName("NullPointerException111")
+                    .build()));
 
     final String result = errorMessageFormatter.apply(logRecord);
 
     assertThat(
-        result,
-        is(
-            "<html>"
-                + EXCEPTION_WITH_MESSAGE.getClass().getSimpleName()
-                + " - "
-                + EXCEPTION_WITH_MESSAGE.getMessage()
-                + "</html>"));
-  }
-
-  private static void givenLogRecordWithNoMessageOnlyAnException(
-      final LogRecord logRecord, final Exception exception) {
-    when(logRecord.getMessage()).thenReturn(exception.getMessage());
-    when(logRecord.getLevel()).thenReturn(Level.SEVERE);
-    when(logRecord.getThrown()).thenReturn(exception);
+        result, is("<html>" + "NullPointerException111" + " - message from exception111</html>"));
   }
 
   @Test
   void exceptionOnlyWithNoMessage() {
-    givenLogRecordWithNoMessageOnlyAnException(logRecord, EXCEPTION_WITHOUT_MESSAGE);
+    lenient().when(logRecord.getLogMessage()).thenReturn(null);
+    lenient().when(logRecord.isError()).thenReturn(true);
+    lenient()
+        .when(logRecord.getExceptions())
+        .thenReturn(
+            List.of(
+                LoggerRecord.ExceptionDetails.builder()
+                    .exceptionClassName("NullPointerException")
+                    .build()));
 
     final String result = errorMessageFormatter.apply(logRecord);
 
-    assertThat(
-        result, is("<html>" + EXCEPTION_WITHOUT_MESSAGE.getClass().getSimpleName() + "</html>"));
+    assertThat(result, is("<html>NullPointerException</html>"));
   }
 
   @Test
   void bothMessageAndExceptionWithExceptionMessage() {
-    when(logRecord.getMessage()).thenReturn(LOG_MESSAGE);
-    when(logRecord.getLevel()).thenReturn(Level.SEVERE);
-    when(logRecord.getThrown()).thenReturn(EXCEPTION_WITH_MESSAGE);
+    lenient().when(logRecord.getLogMessage()).thenReturn(LOG_MESSAGE);
+    lenient().when(logRecord.isError()).thenReturn(true);
+    lenient()
+        .when(logRecord.getExceptions())
+        .thenReturn(
+            List.of(
+                LoggerRecord.ExceptionDetails.builder()
+                    .exceptionMessage("message from exception222")
+                    .exceptionClassName("NullPointerException222")
+                    .build()));
 
     final String result = errorMessageFormatter.apply(logRecord);
 
@@ -85,36 +89,38 @@ class ErrorMessageFormatterTest {
         is(
             "<html>"
                 + LOG_MESSAGE
-                + "<br/><br/>"
-                + EXCEPTION_WITH_MESSAGE.getClass().getSimpleName()
-                + ": "
-                + EXCEPTION_WITH_MESSAGE.getMessage()
-                + "</html>"));
+                + "<br/><br/>NullPointerException222: message from exception222</html>"));
   }
 
   @Test
   void messageAndExceptionWithoutExceptionMessage() {
-    when(logRecord.getMessage()).thenReturn(LOG_MESSAGE);
-    when(logRecord.getLevel()).thenReturn(Level.SEVERE);
-    when(logRecord.getThrown()).thenReturn(EXCEPTION_WITHOUT_MESSAGE);
+    lenient().when(logRecord.getLogMessage()).thenReturn(LOG_MESSAGE);
+    lenient().when(logRecord.isError()).thenReturn(true);
+    lenient()
+        .when(logRecord.getExceptions())
+        .thenReturn(
+            List.of(
+                LoggerRecord.ExceptionDetails.builder()
+                    .exceptionClassName("NullPointerException4444")
+                    .build()));
 
     final String result = errorMessageFormatter.apply(logRecord);
 
-    assertThat(
-        result,
-        is(
-            "<html>"
-                + LOG_MESSAGE
-                + "<br/><br/>"
-                + EXCEPTION_WITHOUT_MESSAGE.getClass().getSimpleName()
-                + "</html>"));
+    assertThat(result, is("<html>" + LOG_MESSAGE + "<br/><br/>NullPointerException4444</html>"));
   }
 
   @Test
   void warningLevelAppendsBugReportLink() {
-    when(logRecord.getMessage()).thenReturn(LOG_MESSAGE);
-    when(logRecord.getLevel()).thenReturn(Level.WARNING);
-    when(logRecord.getThrown()).thenReturn(EXCEPTION_WITHOUT_MESSAGE);
+    lenient().when(logRecord.getLogMessage()).thenReturn(LOG_MESSAGE);
+    lenient().when(logRecord.isError()).thenReturn(false);
+    lenient().when(logRecord.isWarning()).thenReturn(true);
+    lenient()
+        .when(logRecord.getExceptions())
+        .thenReturn(
+            List.of(
+                LoggerRecord.ExceptionDetails.builder()
+                    .exceptionClassName("NullPointerException6")
+                    .build()));
 
     final String result = errorMessageFormatter.apply(logRecord);
 

--- a/game-core/src/test/java/org/triplea/debug/error/reporting/StackTraceErrorReportFormatterTest.java
+++ b/game-core/src/test/java/org/triplea/debug/error/reporting/StackTraceErrorReportFormatterTest.java
@@ -96,8 +96,7 @@ class StackTraceErrorReportFormatterTest {
           .thenReturn(
               List.of(
                   LoggerRecord.ExceptionDetails.builder()
-                      .exceptionClassName(
-                          EXCEPTION_WITH_NO_MESSAGE.getClass().getSimpleName())
+                      .exceptionClassName(EXCEPTION_WITH_NO_MESSAGE.getClass().getSimpleName())
                       .stackTraceElements(EXCEPTION_WITH_NO_MESSAGE.getStackTrace())
                       .build()));
 
@@ -294,13 +293,13 @@ class StackTraceErrorReportFormatterTest {
     void containsExceptionMessageAndLogMessageWhenBothArePresent() {
       when(logRecord.getLoggerClassName()).thenReturn(CLASS_NAME);
       when(logRecord.getLogMessage()).thenReturn(LOG_MESSAGE);
-      when(logRecord.getExceptions()).thenReturn(
-          List.of(LoggerRecord.ExceptionDetails.builder()
-              .exceptionClassName(EXCEPTION_WITH_MESSAGE.getClass().getName())
-              .exceptionMessage(EXCEPTION_WITH_MESSAGE.getMessage())
-              .build())
-
-      );
+      when(logRecord.getExceptions())
+          .thenReturn(
+              List.of(
+                  LoggerRecord.ExceptionDetails.builder()
+                      .exceptionClassName(EXCEPTION_WITH_MESSAGE.getClass().getName())
+                      .exceptionMessage(EXCEPTION_WITH_MESSAGE.getMessage())
+                      .build()));
 
       final ErrorReportRequest errorReportResult =
           new StackTraceErrorReportFormatter()
@@ -346,9 +345,7 @@ class StackTraceErrorReportFormatterTest {
             @Override
             public List<ExceptionDetails> getExceptions() {
               return List.of(
-                  ExceptionDetails.builder()
-                      .exceptionClassName("NullPointerException")
-                      .build());
+                  ExceptionDetails.builder().exceptionClassName("NullPointerException").build());
             }
           };
 

--- a/game-core/src/test/java/org/triplea/debug/error/reporting/StackTraceReportModelTest.java
+++ b/game-core/src/test/java/org/triplea/debug/error/reporting/StackTraceReportModelTest.java
@@ -8,13 +8,13 @@ import static org.mockito.Mockito.when;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
-import java.util.logging.LogRecord;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.debug.LoggerRecord;
 import org.triplea.http.client.error.report.ErrorReportRequest;
 
 @ExtendWith(MockitoExtension.class)
@@ -22,7 +22,7 @@ class StackTraceReportModelTest {
 
   private static final String STRING_VALUE = "Dominas studere, tanquam brevis canis.";
 
-  @Mock private LogRecord logRecord;
+  @Mock private LoggerRecord logRecord;
 
   @Mock private StackTraceReportView stackTraceReportView;
 

--- a/game-headed/src/main/resources/logback.xml
+++ b/game-headed/src/main/resources/logback.xml
@@ -1,0 +1,6 @@
+<configuration>
+    <appender name="swingMessage" class="org.triplea.debug.Slf4jLogMessageUploader"/>
+    <root level="info">
+        <appender-ref ref="swingMessage"/>
+    </root>
+</configuration>


### PR DESCRIPTION
1) Adds logback dependency to all projects, which by default brings in SLF4J

2) Add logback.xml config to headed game runner to register a custom adapter
   to be used for sending error reports. A SLF4J adapter is equivalent
   to a java.util.logger Handler

3) Update ErrorFormatter to accept a generic "LoggerRecord" interface,
   this is used to send error report uploads. We also add an adapter
   class to convert either java.util.logging or logback records
   to a LoggerRecord.

4) Update error report uploads to no longer have method name, it is not
   available from logback logs.

Notes:
- uncaught exceptions are still handled by java.util
- java.util logging and SLF4J logging live side-by-side well, just should
  not be mixed within the same class


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing

Manually tested the various permutations of uncaught exception and logging messages with info, warning, error for both java.util and slf4j logging.

<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
