### PR TITLE
warcraft air transport issue

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
@@ -48,16 +48,6 @@ public class TransportTracker {
     return transport.getTransporting();
   }
 
-  /**
-   * @return Unmodifiable collection of units that the given transport is transporting.
-   * @deprecated Invoke unit.getTransporting(Collection) directly
-   */
-  @Deprecated
-  public static List<Unit> transporting(
-      final Unit transport, final Collection<Unit> transportedUnitsPossible) {
-    return transport.getTransporting(transportedUnitsPossible);
-  }
-
   /** @return Unmodifiable map of transport -> collection of transported units. */
   public static Map<Unit, Collection<Unit>> transporting(final Collection<Unit> units) {
     return transporting(units, TransportTracker::transporting);
@@ -83,11 +73,11 @@ public class TransportTracker {
   /**
    * Returns a map of transport -> collection of transported units. This method is identical to
    * {@link #transporting(Collection)} except that it considers all elements in {@code units} as the
-   * possible units to transport (see {@link #transporting(Unit, Collection)}).
+   * possible units to transport
    */
   public static Map<Unit, Collection<Unit>> transportingWithAllPossibleUnits(
       final Collection<Unit> units) {
-    return transporting(units, transport -> transporting(transport, units));
+    return transporting(units, transport -> transport.getTransporting(units));
   }
 
   public static boolean isTransporting(final Unit transport) {
@@ -146,10 +136,7 @@ public class TransportTracker {
     change.add(ChangeFactory.unitPropertyChange(unit, territory, Unit.UNLOADED_TO));
     if (!GameStepPropertiesHelper.isNonCombatMove(unit.getData(), true)) {
       change.add(ChangeFactory.unitPropertyChange(unit, true, Unit.UNLOADED_IN_COMBAT_PHASE));
-      // change.add(ChangeFactory.unitPropertyChange(unit, true, TripleAUnit.UNLOADED_AMPHIBIOUS));
       change.add(ChangeFactory.unitPropertyChange(transport, true, Unit.UNLOADED_IN_COMBAT_PHASE));
-      // change.add(ChangeFactory.unitPropertyChange(transport, true,
-      // TripleAUnit.UNLOADED_AMPHIBIOUS));
     }
     if (!dependentBattle) {
       // TODO: this is causing issues with Scrambling. if the units were unloaded, then scrambling

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
@@ -129,10 +129,6 @@ public class TransportTracker {
       return change;
     }
     assertTransport(transport);
-    if (!transport.getTransporting().contains(unit)) {
-      throw new IllegalStateException(
-          "Not being carried, unit:" + unit + " transport:" + transport);
-    }
     change.add(ChangeFactory.unitPropertyChange(unit, territory, Unit.UNLOADED_TO));
     if (!GameStepPropertiesHelper.isNonCombatMove(unit.getData(), true)) {
       change.add(ChangeFactory.unitPropertyChange(unit, true, Unit.UNLOADED_IN_COMBAT_PHASE));

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/FireAa.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/FireAa.java
@@ -78,7 +78,9 @@ public class FireAa implements IExecutable {
       final List<Unit> allEnemyUnitsAliveOrWaitingToDie,
       final List<String> aaTypes) {
     this.attackableUnits =
-        CollectionUtils.getMatches(attackableUnits, Matches.unitIsNotInfrastructure());
+        CollectionUtils.getMatches(
+            attackableUnits,
+            Matches.unitIsNotInfrastructure().and(Matches.unitIsBeingTransported().negate()));
     this.firingUnits = firingUnits;
     this.battle = battle;
     this.hitPlayer = hitPlayer;


### PR DESCRIPTION
In the AA firing phase, it will now exclude any units that are currently being transported.

## Testing
<!-- Describe any manual testing performed below. -->
Ran a game with air transported units and ensured that they were not fired on until after they were landed.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->FIX|Air Transported units in no longer cause battle errors in Warcraft: War Heroes<!--END_RELEASE_NOTE-->
