### PR TITLE
Remove junit-platform.properties

### DIFF
--- a/java-extras/src/test/resources/junit-platform.properties
+++ b/java-extras/src/test/resources/junit-platform.properties
@@ -1,8 +1,0 @@
-# documentation on parallelism config: https://junit.org/junit5/docs/snapshot/user-guide/#writing-tests-parallel-execution
-# Runs all top-level classes in parallel, methods in order
-junit.jupiter.execution.parallel.enabled = true
-junit.jupiter.execution.parallel.mode.default = same_thread
-junit.jupiter.execution.parallel.mode.classes.default = concurrent
-
-# chooses number of threads based on available cores
-junit.jupiter.execution.parallel.config.strategy=dynamic

--- a/swing-lib/src/test/resources/junit-platform.properties
+++ b/swing-lib/src/test/resources/junit-platform.properties
@@ -1,8 +1,0 @@
-# documentation on parallelism config: https://junit.org/junit5/docs/snapshot/user-guide/#writing-tests-parallel-execution
-# Runs all top-level classes in parallel, methods in order
-junit.jupiter.execution.parallel.enabled = true
-junit.jupiter.execution.parallel.mode.default = same_thread
-junit.jupiter.execution.parallel.mode.classes.default = concurrent
-
-# chooses number of threads based on available cores
-junit.jupiter.execution.parallel.config.strategy=dynamic

--- a/test-common/src/test/resources/junit-platform.properties
+++ b/test-common/src/test/resources/junit-platform.properties
@@ -1,8 +1,0 @@
-# documentation on parallelism config: https://junit.org/junit5/docs/snapshot/user-guide/#writing-tests-parallel-execution
-# Runs all top-level classes in parallel, methods in order
-junit.jupiter.execution.parallel.enabled = true
-junit.jupiter.execution.parallel.mode.default = same_thread
-junit.jupiter.execution.parallel.mode.classes.default = concurrent
-
-# chooses number of threads based on available cores
-junit.jupiter.execution.parallel.config.strategy=dynamic


### PR DESCRIPTION
The files are used to execute tests within a sub-project in parallel.
They are being removed for a few reasons:
- junit5 produces logging output when it reads these files. Removing
  the files reduces output during test.
- the performance gains of running in parallel a single project
  is generally always less than 20%, in total less than a second
- the performance gains of running tests within a subproject in
  parallel are not very significant as we run all subprojects in
  parallel which distributes test load already across multiple
  CPU cores, giving us most of the benefit of parallel tests.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
