### PR TITLE
Suppress build output warnings for issues that cannot be fixed

### DIFF
--- a/java-extras/src/main/java/org/triplea/java/Retryable.java
+++ b/java-extras/src/main/java/org/triplea/java/Retryable.java
@@ -17,6 +17,7 @@ import lombok.AllArgsConstructor;
  */
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class Retryable<T> {
+  @SuppressWarnings("UnnecessaryLambda")
   private static final Consumer<Duration> DEFAULT_THREAD_SLEEP =
       duration -> Interruptibles.sleep(duration.toMillis());
 

--- a/java-extras/src/main/java/org/triplea/performance/PerfTimer.java
+++ b/java-extras/src/main/java/org/triplea/performance/PerfTimer.java
@@ -66,6 +66,7 @@ public class PerfTimer implements Closeable {
     return time(title, 1);
   }
 
+  @SuppressWarnings("try")
   public static <T> T time(final String title, final ThrowingSupplier<T, ?> functionToTime) {
     final T value;
     try (PerfTimer timer = time(title)) {
@@ -77,6 +78,7 @@ public class PerfTimer implements Closeable {
     return value;
   }
 
+  @SuppressWarnings("try")
   public static void time(final String title, final ThrowingRunnable<?> functionToTime) {
     try (PerfTimer timer = time(title)) {
       try {


### PR DESCRIPTION
1. Suppress 'try' block resource not used in body. The try-with-resources
  is used so we can take advantage of an automatic close method that
  does our perf timing logging.

2. Remove unnecessary lambda. The lambda is so we can inject functionality
  and seemingly cannot be replaced with a method reference.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
