### PR TITLE
Fix error prone warnings in xml-reader:test

### DIFF
--- a/xml-reader/src/test/java/org/triplea/generic/xml/reader/ExtendedLibraryExampleTest.java
+++ b/xml-reader/src/test/java/org/triplea/generic/xml/reader/ExtendedLibraryExampleTest.java
@@ -32,7 +32,7 @@ public class ExtendedLibraryExampleTest extends AbstractXmlMapperTest {
     }
 
     static class MostRead {
-      @Tag private Book book;
+      @Tag private MostRead.Book book;
       @Tag private Magazine magazine;
 
       static class Book {
@@ -47,7 +47,7 @@ public class ExtendedLibraryExampleTest extends AbstractXmlMapperTest {
     }
 
     static class Inventory {
-      @TagList private List<Book> books;
+      @TagList private List<Inventory.Book> books;
 
       @Tag private CdRom cdrom;
       @Tag private Gaming gaming;

--- a/xml-reader/src/test/java/org/triplea/generic/xml/reader/XmlDataErrorTest.java
+++ b/xml-reader/src/test/java/org/triplea/generic/xml/reader/XmlDataErrorTest.java
@@ -16,7 +16,7 @@ public class XmlDataErrorTest extends AbstractXmlMapperTest {
   }
 
   public static class BadNumber {
-    @Tag private SingleChild singleChild;
+    @Tag private BadNumber.SingleChild singleChild;
 
     public static class SingleChild {
       // this has a 'string' value in the XML
@@ -25,7 +25,7 @@ public class XmlDataErrorTest extends AbstractXmlMapperTest {
   }
 
   public static class BadDouble {
-    @Tag private SingleChild singleChild;
+    @Tag private BadDouble.SingleChild singleChild;
 
     public static class SingleChild {
       // this has a 'string' value in the XML
@@ -34,7 +34,7 @@ public class XmlDataErrorTest extends AbstractXmlMapperTest {
   }
 
   public static class BadBoolean {
-    @Tag private SingleChild singleChild;
+    @Tag private BadBoolean.SingleChild singleChild;
 
     public static class SingleChild {
       // this has a 'string' value in the XML


### PR DESCRIPTION
Warnings were to fully qualify class names that appeared in multiple
places but were distinct. The full qualification is to make it
explicit which one is being referenced where.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
