### PR TITLE
Remove travis gradle cache

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ dist: xenial
 sudo: false
 language: java
 jdk: openjdk11
-cache: { directories: [ ".gradle", "~/.gradle/caches" ] }
 install: skip
 
 env:


### PR DESCRIPTION
- The cache is caching too much and when we run tests gradle is doing
  an incremental build rather than a complete build. We could add
  'clean' and 'cleanTest' to our gradle tasks though it seems that
  would not be the right answer. The CI system really ought to
  be running all tests by default.

We will need to watch the CI system for build system, previously we
saw issues downloading the gradle binaries and had frequent errors
around this. We may need to add the cache back with a more targetted
rule.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer

Noticed that we were not actually running all tests when examining test output. I do trust gradle was running
the right tests on the right changes, however it is expected for CI to do clean and full builds.
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
