### PR TITLE
Move the LandParatrooper and MarkNoMovement logic to their steps

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/ObjectPropertyChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/ObjectPropertyChange.java
@@ -6,6 +6,7 @@ import games.strategy.engine.data.MutableProperty;
 import games.strategy.engine.data.Unit;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import lombok.AccessLevel;
 import lombok.Getter;
 
 /** A game data change that captures a change to an object property value. */
@@ -14,7 +15,11 @@ public class ObjectPropertyChange extends Change {
 
   private final Unit object;
   @Getter private String property;
+
+  @Getter(AccessLevel.PACKAGE)
   private final Object newValue;
+
+  @Getter(AccessLevel.PACKAGE)
   private final Object oldValue;
 
   ObjectPropertyChange(final Unit object, final String property, final Object newValue) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleActions.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleActions.java
@@ -17,12 +17,7 @@ public interface BattleActions {
 
   void fireNavalBombardment(IDelegateBridge bridge);
 
-  void landParatroopers(
-      IDelegateBridge bridge, Collection<Unit> airTransports, Collection<Unit> dependents);
-
   void removeNonCombatants(IDelegateBridge bridge);
-
-  void markNoMovementLeft(IDelegateBridge bridge);
 
   void clearWaitingToDieAndDamagedChangesInto(IDelegateBridge bridge);
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
@@ -102,6 +102,8 @@ public interface BattleState {
 
   Collection<Unit> getDependentUnits(Collection<Unit> units);
 
+  void removeDependentUnits(Collection<Unit> units);
+
   Collection<Unit> getTransportDependents(Collection<Unit> units);
 
   Collection<IBattle> getDependentBattles();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -448,6 +448,13 @@ public class MustFightBattle extends DependentBattle
   }
 
   @Override
+  public void removeDependentUnits(final Collection<Unit> unitsWithDependents) {
+    for (final Unit unit : unitsWithDependents) {
+      dependentUnits.remove(unit);
+    }
+  }
+
+  @Override
   public Collection<Unit> getAa(final Side... sides) {
     final Collection<Unit> units = new ArrayList<>();
     for (final Side side : sides) {
@@ -1624,36 +1631,6 @@ public class MustFightBattle extends DependentBattle
     // remove any units that were in air combat (veqryn)
     unitList.removeAll(CollectionUtils.getMatches(unitList, Matches.unitWasInAirBattle()));
     return unitList;
-  }
-
-  @Override
-  public void landParatroopers(
-      final IDelegateBridge bridge,
-      final Collection<Unit> airTransports,
-      final Collection<Unit> dependents) {
-    final CompositeChange change = new CompositeChange();
-    // remove dependency from paratroopers by unloading the air transports
-    for (final Unit unit : dependents) {
-      change.add(TransportTracker.unloadAirTransportChange(unit, battleSite, false));
-    }
-    bridge.addChange(change);
-    // remove bombers from dependentUnits
-    for (final Unit unit : airTransports) {
-      dependentUnits.remove(unit);
-    }
-  }
-
-  @Override
-  public void markNoMovementLeft(final IDelegateBridge bridge) {
-    if (headless) {
-      return;
-    }
-    final Collection<Unit> attackingNonAir =
-        CollectionUtils.getMatches(attackingUnits, Matches.unitIsAir().negate());
-    final Change noMovementChange = ChangeFactory.markNoMovementChange(attackingNonAir);
-    if (!noMovementChange.isEmpty()) {
-      bridge.addChange(noMovementChange);
-    }
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/LandParatroopers.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/LandParatroopers.java
@@ -3,11 +3,13 @@ package games.strategy.triplea.delegate.battle.steps.change;
 import static games.strategy.triplea.delegate.battle.BattleState.Side.OFFENSE;
 import static games.strategy.triplea.delegate.battle.BattleStepStrings.LAND_PARATROOPS;
 
+import games.strategy.engine.data.CompositeChange;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.Matches;
+import games.strategy.triplea.delegate.TransportTracker;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.steps.BattleStep;
@@ -41,29 +43,30 @@ public class LandParatroopers implements BattleStep {
     final TransportsAndParatroopers transportsAndParatroopers = new TransportsAndParatroopers();
 
     if (transportsAndParatroopers.hasParatroopers()) {
-      battleActions.landParatroopers(
-          bridge, transportsAndParatroopers.airTransports, transportsAndParatroopers.paratroopers);
+      final CompositeChange change = new CompositeChange();
+      // remove dependency from paratroopers by unloading the air transports
+      for (final Unit unit : transportsAndParatroopers.paratroopers) {
+        change.add(
+            TransportTracker.unloadAirTransportChange(unit, battleState.getBattleSite(), false));
+      }
+      bridge.addChange(change);
+
+      battleState.removeDependentUnits(transportsAndParatroopers.airTransports);
     }
   }
 
   private class TransportsAndParatroopers {
-    private Collection<Unit> airTransports = new ArrayList<>();
-    private Collection<Unit> paratroopers = new ArrayList<>();
+    private final Collection<Unit> airTransports = new ArrayList<>();
+    private final Collection<Unit> paratroopers = new ArrayList<>();
 
     private TransportsAndParatroopers() {
       if (battleState.getStatus().isFirstRound()
           && !battleState.getBattleSite().isWater()
           && TechAttachment.isAirTransportable(battleState.getPlayer(OFFENSE))) {
-        final Collection<Unit> airTransports =
+        this.airTransports.addAll(
             CollectionUtils.getMatches(
-                battleState.getBattleSite().getUnits(), Matches.unitIsAirTransport());
-        if (!airTransports.isEmpty()) {
-          final Collection<Unit> paratroopers = battleState.getDependentUnits(airTransports);
-          if (!paratroopers.isEmpty()) {
-            this.airTransports = airTransports;
-            this.paratroopers = paratroopers;
-          }
-        }
+                battleState.getBattleSite().getUnits(), Matches.unitIsAirTransport()));
+        this.paratroopers.addAll(battleState.getDependentUnits(airTransports));
       }
     }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/MarkNoMovementLeft.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/MarkNoMovementLeft.java
@@ -1,12 +1,21 @@
 package games.strategy.triplea.delegate.battle.steps.change;
 
+import static games.strategy.triplea.delegate.battle.BattleState.Side.OFFENSE;
+import static games.strategy.triplea.delegate.battle.BattleState.UnitBattleFilter.ALIVE;
+
+import games.strategy.engine.data.Change;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.delegate.ExecutionStack;
+import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.steps.BattleStep;
+import java.util.Collection;
 import java.util.List;
 import lombok.AllArgsConstructor;
+import org.triplea.java.collections.CollectionUtils;
 
 @AllArgsConstructor
 public class MarkNoMovementLeft implements BattleStep {
@@ -29,8 +38,14 @@ public class MarkNoMovementLeft implements BattleStep {
 
   @Override
   public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-    if (battleState.getStatus().isFirstRound()) {
-      battleActions.markNoMovementLeft(bridge);
+    if (battleState.getStatus().isFirstRound() && !battleState.getStatus().isHeadless()) {
+      final Collection<Unit> attackingNonAir =
+          CollectionUtils.getMatches(
+              battleState.filterUnits(ALIVE, OFFENSE), Matches.unitIsAir().negate());
+      final Change noMovementChange = ChangeFactory.markNoMovementChange(attackingNonAir);
+      if (!noMovementChange.isEmpty()) {
+        bridge.addChange(noMovementChange);
+      }
     }
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/data/ChangeMatcher.java
+++ b/game-core/src/test/java/games/strategy/engine/data/ChangeMatcher.java
@@ -2,4 +2,5 @@ package games.strategy.engine.data;
 
 import org.hamcrest.TypeSafeMatcher;
 
-public abstract class ChangeMatcher<T extends Change> extends TypeSafeMatcher<T> {}
+/** Parent class for all matchers for {@link Change} objects */
+public abstract class ChangeMatcher<T> extends TypeSafeMatcher<T> {}

--- a/game-core/src/test/java/games/strategy/engine/data/ChangeMatcher.java
+++ b/game-core/src/test/java/games/strategy/engine/data/ChangeMatcher.java
@@ -1,0 +1,5 @@
+package games.strategy.engine.data;
+
+import org.hamcrest.TypeSafeMatcher;
+
+public abstract class ChangeMatcher<T extends Change> extends TypeSafeMatcher<T> {}

--- a/game-core/src/test/java/games/strategy/engine/data/ChangeMatcher.java
+++ b/game-core/src/test/java/games/strategy/engine/data/ChangeMatcher.java
@@ -2,5 +2,9 @@ package games.strategy.engine.data;
 
 import org.hamcrest.TypeSafeMatcher;
 
-/** Parent class for all matchers for {@link Change} objects */
+/**
+ * Parent class for all matchers for {@link Change} objects
+ *
+ * @param <T> The change object to match
+ */
 public abstract class ChangeMatcher<T> extends TypeSafeMatcher<T> {}

--- a/game-core/src/test/java/games/strategy/engine/data/CompositeChangeMatcher.java
+++ b/game-core/src/test/java/games/strategy/engine/data/CompositeChangeMatcher.java
@@ -1,0 +1,42 @@
+package games.strategy.engine.data;
+
+import java.util.Arrays;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+
+@AllArgsConstructor
+public class CompositeChangeMatcher extends ChangeMatcher<CompositeChange> {
+
+  private final List<ChangeMatcher<?>> changeMatchers;
+
+  @Override
+  protected boolean matchesSafely(final CompositeChange compositeChange) {
+    final List<Change> changes = compositeChange.getChanges();
+
+    if (changes.size() != changeMatchers.size()) {
+      return false;
+    }
+
+    for (int i = 0; i < changeMatchers.size(); i++) {
+      if (!changeMatchers.get(i).matches(changes.get(i))) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @Override
+  public void describeTo(final Description description) {
+    description.appendText("CompositeChange <[");
+    changeMatchers.forEach(change -> change.describeTo(description));
+    description.appendText("]>");
+  }
+
+  public static Matcher<CompositeChange> compositeChangeContains(
+      final ChangeMatcher<?>... changes) {
+    return new CompositeChangeMatcher(Arrays.asList(changes));
+  }
+}

--- a/game-core/src/test/java/games/strategy/engine/data/CompositeChangeMatcher.java
+++ b/game-core/src/test/java/games/strategy/engine/data/CompositeChangeMatcher.java
@@ -6,6 +6,15 @@ import lombok.AllArgsConstructor;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 
+/**
+ * Matches all changes of a {@link CompositeChange} object
+ *
+ * <p>Each of the changes are matched against the requested matchers in the same order and will fail
+ * if the changes are not the same size or in the same order.
+ *
+ * <p>Example usage: assertThat(change, compositeChangeContains(propertyChange(property, newValue,
+ * oldValue)));
+ */
 @AllArgsConstructor
 public class CompositeChangeMatcher extends ChangeMatcher<CompositeChange> {
 

--- a/game-core/src/test/java/games/strategy/engine/data/changefactory/ObjectPropertyChangeMatcher.java
+++ b/game-core/src/test/java/games/strategy/engine/data/changefactory/ObjectPropertyChangeMatcher.java
@@ -1,0 +1,34 @@
+package games.strategy.engine.data.changefactory;
+
+import games.strategy.engine.data.ChangeMatcher;
+import lombok.AllArgsConstructor;
+import org.hamcrest.Description;
+
+@AllArgsConstructor
+public class ObjectPropertyChangeMatcher extends ChangeMatcher<ObjectPropertyChange> {
+
+  private final String property;
+
+  private final Object newValue;
+
+  private final Object oldValue;
+
+  @Override
+  protected boolean matchesSafely(final ObjectPropertyChange item) {
+    return item.getProperty().equals(property)
+        && item.getNewValue().equals(newValue)
+        && item.getOldValue().equals(oldValue);
+  }
+
+  @Override
+  public void describeTo(final Description description) {
+    description.appendText("property:" + property);
+    description.appendText(" newValue:" + newValue);
+    description.appendText(" oldValue:" + oldValue);
+  }
+
+  public static ChangeMatcher<ObjectPropertyChange> propertyChange(
+      final String property, final Object newValue, final Object oldValue) {
+    return new ObjectPropertyChangeMatcher(property, newValue, oldValue);
+  }
+}

--- a/game-core/src/test/java/games/strategy/engine/data/changefactory/ObjectPropertyChangeMatcher.java
+++ b/game-core/src/test/java/games/strategy/engine/data/changefactory/ObjectPropertyChangeMatcher.java
@@ -1,11 +1,19 @@
 package games.strategy.engine.data.changefactory;
 
+import static org.hamcrest.Matchers.equalTo;
+
+import games.strategy.engine.data.Change;
 import games.strategy.engine.data.ChangeMatcher;
 import lombok.AllArgsConstructor;
 import org.hamcrest.Description;
 
+/**
+ * Matches {@link ObjectPropertyChange} objects with the requested property, newValue, and oldValue
+ *
+ * <p>Example usage: assertThat(change, propertyChange(property, newValue, oldValue));
+ */
 @AllArgsConstructor
-public class ObjectPropertyChangeMatcher extends ChangeMatcher<ObjectPropertyChange> {
+public class ObjectPropertyChangeMatcher extends ChangeMatcher<Change> {
 
   private final String property;
 
@@ -14,10 +22,15 @@ public class ObjectPropertyChangeMatcher extends ChangeMatcher<ObjectPropertyCha
   private final Object oldValue;
 
   @Override
-  protected boolean matchesSafely(final ObjectPropertyChange item) {
-    return item.getProperty().equals(property)
-        && item.getNewValue().equals(newValue)
-        && item.getOldValue().equals(oldValue);
+  protected boolean matchesSafely(final Change change) {
+    if (!(change instanceof ObjectPropertyChange)) {
+      return false;
+    }
+
+    final ObjectPropertyChange objectPropertyChange = (ObjectPropertyChange) change;
+    return equalTo(objectPropertyChange.getProperty()).matches(property)
+        && equalTo(objectPropertyChange.getNewValue()).matches(newValue)
+        && equalTo(objectPropertyChange.getOldValue()).matches(oldValue);
   }
 
   @Override
@@ -27,7 +40,7 @@ public class ObjectPropertyChangeMatcher extends ChangeMatcher<ObjectPropertyCha
     description.appendText(" oldValue:" + oldValue);
   }
 
-  public static ChangeMatcher<ObjectPropertyChange> propertyChange(
+  public static ChangeMatcher<Change> propertyChange(
       final String property, final Object newValue, final Object oldValue) {
     return new ObjectPropertyChangeMatcher(property, newValue, oldValue);
   }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/FakeBattleState.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/FakeBattleState.java
@@ -88,6 +88,11 @@ public class FakeBattleState implements BattleState {
   }
 
   @Override
+  public void removeDependentUnits(final Collection<Unit> units) {
+    // use verify() to check if this method is called
+  }
+
+  @Override
   public Collection<IBattle> getDependentBattles() {
     return new ArrayList<>();
   }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/LandParatroopersTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/LandParatroopersTest.java
@@ -15,6 +15,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
@@ -139,7 +140,7 @@ class LandParatroopersTest {
     assertThat(landParatroopers.getNames(), hasSize(1));
 
     landParatroopers.execute(executionStack, delegateBridge);
-    verify(delegateBridge).addChange(any());
+    verify(delegateBridge).addChange(any(Change.class));
     verify(battleState).removeDependentUnits(airTransports);
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/LandParatroopersTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/LandParatroopersTest.java
@@ -7,8 +7,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.core.Is.is;
-import static org.mockito.ArgumentMatchers.anyList;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -40,25 +40,25 @@ class LandParatroopersTest {
 
   @Test
   void secondRoundDoesNothing() {
-    final BattleState battleState = givenBattleStateBuilder().battleRound(2).build();
+    final BattleState battleState = spy(givenBattleStateBuilder().battleRound(2).build());
     final LandParatroopers landParatroopers = new LandParatroopers(battleState, battleActions);
 
     assertThat(landParatroopers.getNames(), is(empty()));
 
     landParatroopers.execute(executionStack, delegateBridge);
-    verify(battleActions, never()).landParatroopers(eq(delegateBridge), anyList(), anyList());
+    verify(battleState, never()).removeDependentUnits(anyCollection());
   }
 
   @Test
   void waterBattleDoesNothing() {
     final BattleState battleState =
-        givenBattleStateBuilder().battleRound(1).battleSite(givenSeaBattleSite()).build();
+        spy(givenBattleStateBuilder().battleRound(1).battleSite(givenSeaBattleSite()).build());
     final LandParatroopers landParatroopers = new LandParatroopers(battleState, battleActions);
 
     assertThat(landParatroopers.getNames(), is(empty()));
 
     landParatroopers.execute(executionStack, delegateBridge);
-    verify(battleActions, never()).landParatroopers(eq(delegateBridge), anyList(), anyList());
+    verify(battleState, never()).removeDependentUnits(anyCollection());
   }
 
   @Test
@@ -68,13 +68,13 @@ class LandParatroopersTest {
     when(attacker.getAttachment(Constants.TECH_ATTACHMENT_NAME)).thenReturn(techAttachment);
     when(techAttachment.getParatroopers()).thenReturn(false);
     final BattleState battleState =
-        givenBattleStateBuilder().battleRound(1).attacker(attacker).build();
+        spy(givenBattleStateBuilder().battleRound(1).attacker(attacker).build());
     final LandParatroopers landParatroopers = new LandParatroopers(battleState, battleActions);
 
     assertThat(landParatroopers.getNames(), is(empty()));
 
     landParatroopers.execute(executionStack, delegateBridge);
-    verify(battleActions, never()).landParatroopers(eq(delegateBridge), anyList(), anyList());
+    verify(battleState, never()).removeDependentUnits(anyCollection());
   }
 
   @Test
@@ -106,7 +106,7 @@ class LandParatroopersTest {
     assertThat(landParatroopers.getNames(), is(empty()));
 
     landParatroopers.execute(executionStack, delegateBridge);
-    verify(battleActions, never()).landParatroopers(eq(delegateBridge), anyList(), anyList());
+    verify(battleState, never()).removeDependentUnits(anyCollection());
   }
 
   @Test
@@ -139,6 +139,7 @@ class LandParatroopersTest {
     assertThat(landParatroopers.getNames(), hasSize(1));
 
     landParatroopers.execute(executionStack, delegateBridge);
-    verify(battleActions).landParatroopers(eq(delegateBridge), eq(airTransports), eq(dependents));
+    verify(delegateBridge).addChange(any());
+    verify(battleState).removeDependentUnits(airTransports);
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/MarkNoMovementLeftTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/MarkNoMovementLeftTest.java
@@ -9,12 +9,14 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
-import games.strategy.engine.data.Change;
+import games.strategy.engine.data.CompositeChangeMatcher;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
+import games.strategy.engine.data.changefactory.ObjectPropertyChangeMatcher;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.ExecutionStack;
@@ -71,7 +73,12 @@ class MarkNoMovementLeftTest {
 
     markNoMovementLeft.execute(executionStack, delegateBridge);
 
-    verify(delegateBridge).addChange(any(Change.class));
+    verify(delegateBridge)
+        .addChange(
+            argThat(
+                CompositeChangeMatcher.compositeChangeContains(
+                    ObjectPropertyChangeMatcher.propertyChange(
+                        "alreadyMoved", BigDecimal.ONE, BigDecimal.ZERO))));
   }
 
   private Unit givenNonAirUnitWithMovementLeft(final BigDecimal movement) {
@@ -98,7 +105,12 @@ class MarkNoMovementLeftTest {
 
     markNoMovementLeft.execute(executionStack, delegateBridge);
 
-    verify(delegateBridge).addChange(any(Change.class));
+    verify(delegateBridge)
+        .addChange(
+            argThat(
+                CompositeChangeMatcher.compositeChangeContains(
+                    ObjectPropertyChangeMatcher.propertyChange(
+                        "alreadyMoved", BigDecimal.ONE, BigDecimal.ZERO))));
   }
 
   @Test
@@ -114,6 +126,6 @@ class MarkNoMovementLeftTest {
 
     markNoMovementLeft.execute(executionStack, delegateBridge);
 
-    verify(delegateBridge, never()).addChange(any(Change.class));
+    verify(delegateBridge, never()).addChange(any());
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/MarkNoMovementLeftTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/MarkNoMovementLeftTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Unit;
@@ -70,7 +71,7 @@ class MarkNoMovementLeftTest {
 
     markNoMovementLeft.execute(executionStack, delegateBridge);
 
-    verify(delegateBridge).addChange(any());
+    verify(delegateBridge).addChange(any(Change.class));
   }
 
   private Unit givenNonAirUnitWithMovementLeft(final BigDecimal movement) {
@@ -97,7 +98,7 @@ class MarkNoMovementLeftTest {
 
     markNoMovementLeft.execute(executionStack, delegateBridge);
 
-    verify(delegateBridge).addChange(any());
+    verify(delegateBridge).addChange(any(Change.class));
   }
 
   @Test
@@ -113,6 +114,6 @@ class MarkNoMovementLeftTest {
 
     markNoMovementLeft.execute(executionStack, delegateBridge);
 
-    verify(delegateBridge, never()).addChange(any());
+    verify(delegateBridge, never()).addChange(any(Change.class));
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/MarkNoMovementLeftTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/MarkNoMovementLeftTest.java
@@ -1,5 +1,7 @@
 package games.strategy.triplea.delegate.battle.steps.change;
 
+import static games.strategy.engine.data.CompositeChangeMatcher.compositeChangeContains;
+import static games.strategy.engine.data.changefactory.ObjectPropertyChangeMatcher.propertyChange;
 import static games.strategy.triplea.Constants.UNIT_ATTACHMENT_NAME;
 import static games.strategy.triplea.delegate.battle.FakeBattleState.givenBattleStateBuilder;
 import static org.mockito.ArgumentMatchers.any;
@@ -11,12 +13,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 
-import games.strategy.engine.data.CompositeChangeMatcher;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
-import games.strategy.engine.data.changefactory.ObjectPropertyChangeMatcher;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.ExecutionStack;
@@ -76,9 +76,8 @@ class MarkNoMovementLeftTest {
     verify(delegateBridge)
         .addChange(
             argThat(
-                CompositeChangeMatcher.compositeChangeContains(
-                    ObjectPropertyChangeMatcher.propertyChange(
-                        "alreadyMoved", BigDecimal.ONE, BigDecimal.ZERO))));
+                compositeChangeContains(
+                    propertyChange(Unit.ALREADY_MOVED, BigDecimal.ONE, BigDecimal.ZERO))));
   }
 
   private Unit givenNonAirUnitWithMovementLeft(final BigDecimal movement) {
@@ -108,9 +107,8 @@ class MarkNoMovementLeftTest {
     verify(delegateBridge)
         .addChange(
             argThat(
-                CompositeChangeMatcher.compositeChangeContains(
-                    ObjectPropertyChangeMatcher.propertyChange(
-                        "alreadyMoved", BigDecimal.ONE, BigDecimal.ZERO))));
+                compositeChangeContains(
+                    propertyChange(Unit.ALREADY_MOVED, BigDecimal.ONE, BigDecimal.ZERO))));
   }
 
   @Test

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/MarkNoMovementLeftTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/MarkNoMovementLeftTest.java
@@ -1,14 +1,27 @@
 package games.strategy.triplea.delegate.battle.steps.change;
 
+import static games.strategy.triplea.Constants.UNIT_ATTACHMENT_NAME;
 import static games.strategy.triplea.delegate.battle.FakeBattleState.givenBattleStateBuilder;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
 import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -22,24 +35,84 @@ class MarkNoMovementLeftTest {
   @Mock BattleActions battleActions;
 
   @Test
-  void runsOnFirstRound() {
-    final BattleState battleState = givenBattleStateBuilder().battleRound(1).build();
+  void doesNotRunOnFirstRoundAndHeadless() {
+    final BattleState battleState = givenBattleStateBuilder().battleRound(1).headless(true).build();
     final MarkNoMovementLeft markNoMovementLeft =
         new MarkNoMovementLeft(battleState, battleActions);
 
     markNoMovementLeft.execute(executionStack, delegateBridge);
 
-    verify(battleActions).markNoMovementLeft(eq(delegateBridge));
+    verify(delegateBridge, never()).addChange(any());
   }
 
   @Test
   void doesNotRunOnSecondRound() {
-    final BattleState battleState = givenBattleStateBuilder().battleRound(2).build();
+    final BattleState battleState =
+        givenBattleStateBuilder().battleRound(2).headless(false).build();
     final MarkNoMovementLeft markNoMovementLeft =
         new MarkNoMovementLeft(battleState, battleActions);
 
     markNoMovementLeft.execute(executionStack, delegateBridge);
 
-    verify(battleActions, never()).markNoMovementLeft(eq(delegateBridge));
+    verify(delegateBridge, never()).addChange(any());
+  }
+
+  @Test
+  void nonAirWithMovementLeftAreMarkedAsMoved() {
+    final BattleState battleState =
+        givenBattleStateBuilder()
+            .battleRound(1)
+            .headless(false)
+            .attackingUnits(List.of(givenNonAirUnitWithMovementLeft(BigDecimal.ONE)))
+            .build();
+    final MarkNoMovementLeft markNoMovementLeft =
+        new MarkNoMovementLeft(battleState, battleActions);
+
+    markNoMovementLeft.execute(executionStack, delegateBridge);
+
+    verify(delegateBridge).addChange(any());
+  }
+
+  private Unit givenNonAirUnitWithMovementLeft(final BigDecimal movement) {
+    final UnitType unitType = mock(UnitType.class);
+    final UnitAttachment unitAttachment = mock(UnitAttachment.class);
+    when(unitType.getAttachment(UNIT_ATTACHMENT_NAME)).thenReturn(unitAttachment);
+    when(unitAttachment.getIsAir()).thenReturn(false);
+    final Unit unit = spy(new Unit(unitType, mock(GamePlayer.class), mock(GameData.class)));
+    doReturn(movement).when(unit).getMovementLeft();
+    return unit;
+  }
+
+  @Test
+  @DisplayName("Units with ZERO movement left still get a markNoMovementChange")
+  void nonAirWithZeroMovementLeftAreMarkedAsMoved() {
+    final BattleState battleState =
+        givenBattleStateBuilder()
+            .battleRound(1)
+            .headless(false)
+            .attackingUnits(List.of(givenNonAirUnitWithMovementLeft(BigDecimal.ZERO)))
+            .build();
+    final MarkNoMovementLeft markNoMovementLeft =
+        new MarkNoMovementLeft(battleState, battleActions);
+
+    markNoMovementLeft.execute(executionStack, delegateBridge);
+
+    verify(delegateBridge).addChange(any());
+  }
+
+  @Test
+  void nonAirWithNegativeMovementLeftAreNotMarkedAsMoved() {
+    final BattleState battleState =
+        givenBattleStateBuilder()
+            .battleRound(1)
+            .headless(false)
+            .attackingUnits(List.of(givenNonAirUnitWithMovementLeft(BigDecimal.valueOf(-1))))
+            .build();
+    final MarkNoMovementLeft markNoMovementLeft =
+        new MarkNoMovementLeft(battleState, battleActions);
+
+    markNoMovementLeft.execute(executionStack, delegateBridge);
+
+    verify(delegateBridge, never()).addChange(any());
   }
 }


### PR DESCRIPTION
This removes two methods from the BattleActions api and moves the logic to the individual battle steps.

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
