### PR TITLE
Documentation: 'skinny' conversion of html map-maker files to md

### DIFF
--- a/docs/map-making/creating-custom-map-xml.md
+++ b/docs/map-making/creating-custom-map-xml.md
@@ -1,49 +1,5 @@
+## Creating Custom Maps
 
-<h2>Map XML and Custom Maps Documentation :: Quick Nav</h2>
-<ul>
-	<li>
-		<b>5.0</b> <a href="#sec_5">Creating Custom Games</a>
-		<ul>
-			<li>
-				<b>5.1</b> <a href="#sec_5.1">Map Utilities</a>
-				<ul>
-					<li><b>5.1.8</b> <a href="#sec_5.1.8">Making a Map</a></li>
-				</ul>
-			</li>
-			<li>
-				<b>5.2</b> <a href="#sec_5.2">Map Configuration</a>
-				<ul>
-					<li><b>5.2.1</b> <a href="#sec_5.2.1">Map Properties</a></li>
-					<li><b>5.2.2</b> <a href="#sec_5.2.2">Capital Cities</a></li>
-					<li><b>5.2.3</b> <a href="#sec_5.2.3">Victory Cities</a></li>
-				</ul>
-			</li>
-			<li>
-				<b>5.3</b> <a href="#sec_5.3">Customizing The XML Game File</a>
-				<ul>
-					<li><b>5.3.1</b> <a href="#sec_5.3.1">Game Information Header</a></li>
-					<li><b>5.3.2</b> <a href="#sec_5.3.2">Territories</a></li>
-					<li><b>5.3.3</b> <a href="#sec_5.3.3">Territory Connections</a></li>
-					<li><b>5.3.4</b> <a href="#sec_5.3.4">Resources</a></li>
-					<li><b>5.3.5</b> <a href="#sec_5.3.5">Players &amp; Alliances</a></li>
-					<li><b>5.3.6</b> <a href="#sec_5.3.6">Units</a></li>
-					<li><b>5.3.7</b> <a href="#sec_5.3.7">Game-play Delegates</a></li>
-					<li><b>5.3.8</b> <a href="#sec_5.3.8">Game-play Sequence &amp; Steps</a></li>
-					<li><b>5.3.9</b> <a href="#sec_5.3.9">Production Rules</a></li>
-					<li><b>5.3.10</b> <a href="#sec_5.3.10">Unit Attachment</a></li>
-					<li><b>5.3.11</b> <a href="#sec_5.3.11">Tech Attachment</a></li>
-				</ul>
-			</li>
-		</ul>
-	</li>
-	<li>
-		<b>6.0</b> <a href="#sec_6.5">Engine Code Overview</a>
-		<ul>
-			<li><b>6.5</b> <a href="#sec_6.5">Game Play Sequence</a></li>
-			<li><b>6.6</b> <a href="#sec_6.6">Delegates</a></li>
-		</ul>
-	</li>
-</ul>
 <hr>
 <h4><a id="sec_5.1.8">5.1.8</a> Making a Map</h4>
 <p>
@@ -64,7 +20,7 @@
 	XML game file for that game. For example; revised.xml has the mapName
 	field showing a value of <b>revised</b> thus the folder where TripleA will find
 	the map is also <b>revised</b><br></li>
-	<li>All map configuration files must be located inside:
+	<li>All of the following map configuration files must be located inside the directory:
 		<ul>
 			<li>centers.txt</li>
 			<li>polygons.txt</li>

--- a/docs/map-making/map-and-map-skin-making.md
+++ b/docs/map-making/map-and-map-skin-making.md
@@ -1,31 +1,4 @@
-<h2>Map and Map Skin Making Overview :: Quick Nav</h2>
-<ul>
-	<li>
-		<b>1.0</b> <a href="#sec_1">Introduction to TripleA Maps, and Map Skins</a>
-		<ul>
-			<li><b>1.1.1</b> <a href="#sec_1.1.1">Making Your First Map Skin in Under 5 Minutes</a></li>
-		</ul>
-	</li>
-	<li><b>2.0</b> <a href="#sec_2">The Map Creator</a></li>
-	<li><b>3.0</b> <a href="#sec_3">Creating a Custom Map Territory Border Image</a></li>
-	<li>
-		<b>4.0</b> <a href="#sec_4">Map Skin Utilities</a>
-		<ul>
-			<li><b>4.1.1</b> <a href="#sec_4.1.1">Map Properties Maker</a></li>
-			<li><b>4.1.2</b> <a href="#sec_4.1.2">Center Picker</a></li>
-			<li><b>4.1.3</b> <a href="#sec_4.1.3">Polygon Grabber</a></li>
-			<li><b>4.1.4</b> <a href="#sec_4.1.4">Auto-Placement Finder</a></li>
-			<li><b>4.1.5</b> <a href="#sec_4.1.5">Placement Picker</a></li>
-			<li><b>4.1.6</b> <a href="#sec_4.1.6">Tile Image Breaker</a></li>
-			<li><b>4.1.7</b> <a href="#sec_4.1.7">Decoration Placer</a></li>
-			<li><b>4.1.8</b> <a href="#sec_4.1.8">Relief Image Breaker</a></li>
-			<li><b>4.1.9</b> <a href="#sec_4.1.9">Image Shrinker</a></li>
-			<li><b>4.1.10</b> <a href="#sec_4.1.10">Tile Image Reconstructor</a></li>
-		</ul>
-	</li>
-	<li><b>5.0</b> <a href="#sec_5">Filling in the Other Folders and Files</a></li>
-	<li><b>10.0</b> <a href="#sec_10">Credits &amp;Acknowledgements</a></li>
-</ul>
+# Map and Map Skin Making Overview
 <hr>
 <br>
 <h2><a id="sec_1">1.0</a> Introduction to TripleA Maps, and Map Skins</h2>


### PR DESCRIPTION
This update is a minimal conversion of HTML documentation to
'md' such that they'll render and not be presented as source
code in github. [skip ci]


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
