### PR TITLE
Create an object to track state between fire rounds

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/FireRoundState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/FireRoundState.java
@@ -1,0 +1,14 @@
+package games.strategy.triplea.delegate.battle.steps.fire;
+
+import games.strategy.triplea.delegate.DiceRoll;
+import games.strategy.triplea.delegate.data.CasualtyDetails;
+import lombok.Data;
+
+/** Tracks the state through a Fire round (dice roll, select casualties, remove casualties) */
+@Data
+public class FireRoundState {
+
+  private DiceRoll dice;
+
+  private CasualtyDetails casualties;
+}


### PR DESCRIPTION
This is a piece of #7823.  In `FireAa` and `Fire`, they track the state between each of the "fire", "select", and "remove" steps by using member variables.  Moving to individual steps require a separate state object.

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
