### PR TITLE
DiceRoll.rollDice only needs the territory out of the battle

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -602,10 +602,10 @@ public class DiceRoll implements Externalizable {
       final boolean defending,
       final GamePlayer player,
       final IDelegateBridge bridge,
-      final IBattle battle,
+      final Territory territory,
       final Collection<TerritoryEffect> territoryEffects) {
     return rollDice(
-        units, defending, player, bridge, battle, "", territoryEffects, List.of(), units);
+        units, defending, player, bridge, territory, "", territoryEffects, List.of(), units);
   }
 
   /**
@@ -615,7 +615,7 @@ public class DiceRoll implements Externalizable {
    * @param defending - whether units are defending or attacking
    * @param player - that will be rolling the dice
    * @param bridge - delegate bridge
-   * @param battle - which the dice are being rolled for
+   * @param territory - territory where the battle takes place
    * @param annotation - description of the battle being rolled for
    * @param territoryEffects - list of territory effects for the battle
    * @param allEnemyUnitsAliveOrWaitingToDie - all enemy units to check for support
@@ -623,11 +623,11 @@ public class DiceRoll implements Externalizable {
    * @return DiceRoll result which includes total hits and dice that were rolled
    */
   public static DiceRoll rollDice(
-      final List<Unit> units,
+      final Collection<Unit> units,
       final boolean defending,
       final GamePlayer player,
       final IDelegateBridge bridge,
-      final IBattle battle,
+      final Territory territory,
       final String annotation,
       final Collection<TerritoryEffect> territoryEffects,
       final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie,
@@ -639,7 +639,7 @@ public class DiceRoll implements Externalizable {
           defending,
           player,
           bridge,
-          battle,
+          territory,
           annotation,
           territoryEffects,
           allEnemyUnitsAliveOrWaitingToDie,
@@ -650,7 +650,7 @@ public class DiceRoll implements Externalizable {
         defending,
         player,
         bridge,
-        battle,
+        territory,
         annotation,
         territoryEffects,
         allEnemyUnitsAliveOrWaitingToDie,
@@ -945,7 +945,7 @@ public class DiceRoll implements Externalizable {
       final boolean defending,
       final GamePlayer player,
       final IDelegateBridge bridge,
-      final IBattle battle,
+      final Territory location,
       final String annotation,
       final Collection<TerritoryEffect> territoryEffects,
       final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie,
@@ -953,7 +953,6 @@ public class DiceRoll implements Externalizable {
 
     final List<Unit> units = new ArrayList<>(unitsList);
     final GameData data = bridge.getData();
-    final Territory location = battle.getTerritory();
     final Map<Unit, TotalPowerAndTotalRolls> unitPowerAndRollsMap =
         DiceRoll.getUnitPowerAndRollsForNormalBattles(
             units,
@@ -1149,7 +1148,7 @@ public class DiceRoll implements Externalizable {
       final boolean defending,
       final GamePlayer player,
       final IDelegateBridge bridge,
-      final IBattle battle,
+      final Territory location,
       final String annotation,
       final Collection<TerritoryEffect> territoryEffects,
       final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie,
@@ -1158,7 +1157,6 @@ public class DiceRoll implements Externalizable {
     final List<Unit> units = new ArrayList<>(unitsList);
     final GameData data = bridge.getData();
     sortByStrength(units, defending);
-    final Territory location = battle.getTerritory();
     final Map<Unit, TotalPowerAndTotalRolls> unitPowerAndRollsMap =
         DiceRoll.getUnitPowerAndRollsForNormalBattles(
             units,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/Fire.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/Fire.java
@@ -158,7 +158,7 @@ public class Fire implements IExecutable {
             defending,
             firingPlayer,
             bridge,
-            battle,
+            battle.getTerritory(),
             annotation,
             territoryEffects,
             allEnemyUnitsAliveOrWaitingToDie,

--- a/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -63,19 +63,23 @@ class DiceRollTest {
         .thenAnswer(withValues(1)); // infantry attack does not hit at 1 (0 based)
     // infantry defends
     final DiceRoll roll =
-        DiceRoll.rollDice(infantry, true, russians, bridge, battle, territoryEffects);
+        DiceRoll.rollDice(
+            infantry, true, russians, bridge, battle.getTerritory(), territoryEffects);
     assertThat(roll.getHits(), is(1));
     // infantry
     final DiceRoll roll2 =
-        DiceRoll.rollDice(infantry, true, russians, bridge, battle, territoryEffects);
+        DiceRoll.rollDice(
+            infantry, true, russians, bridge, battle.getTerritory(), territoryEffects);
     assertThat(roll2.getHits(), is(0));
     // infantry attacks
     final DiceRoll roll3 =
-        DiceRoll.rollDice(infantry, false, russians, bridge, battle, territoryEffects);
+        DiceRoll.rollDice(
+            infantry, false, russians, bridge, battle.getTerritory(), territoryEffects);
     assertThat(roll3.getHits(), is(1));
     // infantry attack
     final DiceRoll roll4 =
-        DiceRoll.rollDice(infantry, false, russians, bridge, battle, territoryEffects);
+        DiceRoll.rollDice(
+            infantry, false, russians, bridge, battle.getTerritory(), territoryEffects);
     assertThat(roll4.getHits(), is(0));
   }
 
@@ -97,19 +101,23 @@ class DiceRollTest {
         .thenAnswer(withValues(1)); // infantry attack does not hit at 1 (0 based)
     // infantry defends
     final DiceRoll roll =
-        DiceRoll.rollDice(infantry, true, russians, bridge, battle, territoryEffects);
+        DiceRoll.rollDice(
+            infantry, true, russians, bridge, battle.getTerritory(), territoryEffects);
     assertThat(roll.getHits(), is(1));
     // infantry
     final DiceRoll roll2 =
-        DiceRoll.rollDice(infantry, true, russians, bridge, battle, territoryEffects);
+        DiceRoll.rollDice(
+            infantry, true, russians, bridge, battle.getTerritory(), territoryEffects);
     assertThat(roll2.getHits(), is(0));
     // infantry attacks
     final DiceRoll roll3 =
-        DiceRoll.rollDice(infantry, false, russians, bridge, battle, territoryEffects);
+        DiceRoll.rollDice(
+            infantry, false, russians, bridge, battle.getTerritory(), territoryEffects);
     assertThat(roll3.getHits(), is(1));
     // infantry attack
     final DiceRoll roll4 =
-        DiceRoll.rollDice(infantry, false, russians, bridge, battle, territoryEffects);
+        DiceRoll.rollDice(
+            infantry, false, russians, bridge, battle.getTerritory(), territoryEffects);
     assertThat(roll4.getHits(), is(0));
   }
 
@@ -128,7 +136,12 @@ class DiceRollTest {
     whenGetRandom(bridge).thenAnswer(withValues(1, 1));
     final DiceRoll roll =
         DiceRoll.rollDice(
-            units, false, russians, bridge, battle, TerritoryEffectHelper.getEffects(westRussia));
+            units,
+            false,
+            russians,
+            bridge,
+            battle.getTerritory(),
+            TerritoryEffectHelper.getEffects(westRussia));
     assertThat(roll.getHits(), is(2));
   }
 
@@ -154,7 +167,12 @@ class DiceRollTest {
     whenGetRandom(bridge).thenAnswer(withValues(1, 1, 1));
     final DiceRoll roll =
         DiceRoll.rollDice(
-            units, false, russians, bridge, battle, TerritoryEffectHelper.getEffects(westRussia));
+            units,
+            false,
+            russians,
+            bridge,
+            battle.getTerritory(),
+            TerritoryEffectHelper.getEffects(westRussia));
     assertThat(roll.getHits(), is(3));
   }
 
@@ -170,7 +188,12 @@ class DiceRollTest {
     // 3 infantry on defense should produce exactly one hit, without rolling the dice
     final DiceRoll roll =
         DiceRoll.rollDice(
-            units, true, russians, bridge, battle, TerritoryEffectHelper.getEffects(westRussia));
+            units,
+            true,
+            russians,
+            bridge,
+            battle.getTerritory(),
+            TerritoryEffectHelper.getEffects(westRussia));
     assertThat(roll.getHits(), is(1));
     thenGetRandomShouldHaveBeenCalled(bridge, never());
   }
@@ -200,7 +223,12 @@ class DiceRollTest {
     when(battle.isAmphibious()).thenReturn(true);
     final DiceRoll roll =
         DiceRoll.rollDice(
-            attackers, false, americans, bridge, battle, TerritoryEffectHelper.getEffects(algeria));
+            attackers,
+            false,
+            americans,
+            bridge,
+            battle.getTerritory(),
+            TerritoryEffectHelper.getEffects(algeria));
     assertThat(roll.getHits(), is(1));
   }
 
@@ -229,7 +257,12 @@ class DiceRollTest {
     when(battle.isAmphibious()).thenReturn(true);
     final DiceRoll roll =
         DiceRoll.rollDice(
-            attackers, false, americans, bridge, battle, TerritoryEffectHelper.getEffects(algeria));
+            attackers,
+            false,
+            americans,
+            bridge,
+            battle.getTerritory(),
+            TerritoryEffectHelper.getEffects(algeria));
     assertThat(roll.getHits(), is(1));
     thenGetRandomShouldHaveBeenCalled(bridge, never());
   }
@@ -258,7 +291,12 @@ class DiceRollTest {
     final IBattle battle = mock(IBattle.class);
     final DiceRoll roll =
         DiceRoll.rollDice(
-            attackers, false, americans, bridge, battle, TerritoryEffectHelper.getEffects(algeria));
+            attackers,
+            false,
+            americans,
+            bridge,
+            battle.getTerritory(),
+            TerritoryEffectHelper.getEffects(algeria));
     assertThat(roll.getHits(), is(0));
   }
 
@@ -544,7 +582,7 @@ class DiceRollTest {
             false,
             british,
             testDelegateBridge,
-            mock(IBattle.class),
+            mock(Territory.class),
             TerritoryEffectHelper.getEffects(germany));
     assertThat(dice.getRolls(4).get(0).getType(), is(Die.DieType.HIT));
     assertThat(dice.getRolls(4).get(1).getType(), is(Die.DieType.HIT));
@@ -573,7 +611,7 @@ class DiceRollTest {
             true,
             british,
             testDelegateBridge,
-            mock(IBattle.class),
+            mock(Territory.class),
             TerritoryEffectHelper.getEffects(germany));
     assertThat(dice.getRolls(1).size(), is(1));
     assertThat(dice.getRolls(1).get(0).getType(), is(Die.DieType.HIT));
@@ -598,7 +636,7 @@ class DiceRollTest {
             true,
             british,
             testDelegateBridge,
-            mock(IBattle.class),
+            mock(Territory.class),
             TerritoryEffectHelper.getEffects(germany));
 
     assertThat(dice.getRolls(1).size(), is(1));
@@ -628,7 +666,7 @@ class DiceRollTest {
             false,
             british,
             testDelegateBridge,
-            mock(IBattle.class),
+            mock(Territory.class),
             TerritoryEffectHelper.getEffects(germany));
 
     assertThat(dice.getRolls(4).get(0).getType(), is(Die.DieType.HIT));
@@ -659,7 +697,7 @@ class DiceRollTest {
             false,
             british,
             testDelegateBridge,
-            mock(IBattle.class),
+            mock(Territory.class),
             TerritoryEffectHelper.getEffects(germany));
     assertThat(dice.getRolls(4).get(0).getType(), is(Die.DieType.HIT));
     assertThat(dice.getRolls(4).get(1).getType(), is(Die.DieType.IGNORED));
@@ -689,7 +727,7 @@ class DiceRollTest {
             true,
             british,
             testDelegateBridge,
-            mock(IBattle.class),
+            mock(Territory.class),
             TerritoryEffectHelper.getEffects(germany));
     assertThat(dice.getRolls(1).size(), is(2));
     assertThat(dice.getHits(), is(1));

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -17,6 +17,7 @@ import games.strategy.engine.data.Change;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.MoveDescription;
 import games.strategy.engine.data.Route;
+import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.changefactory.ChangeFactory;
@@ -445,7 +446,7 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
             false,
             russians,
             bridge,
-            battle,
+            battle.getTerritory(),
             TerritoryEffectHelper.getEffects(balticSeaZone));
     assertEquals(2, roll.getHits());
     advanceToStep(bridge, "russianNonCombatMove");
@@ -864,7 +865,7 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
             true,
             germans,
             bridge,
-            mock(IBattle.class),
+            mock(Territory.class),
             TerritoryEffectHelper.getEffects(balticSeaZone));
     assertEquals(0, roll.getHits());
     // Get total number of units in Finland before the retreat
@@ -933,7 +934,7 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
             true,
             germans,
             bridge,
-            mock(IBattle.class),
+            mock(Territory.class),
             TerritoryEffectHelper.getEffects(balticSeaZone));
     assertEquals(1, roll.getHits());
     // Get total number of units in Finland before the retreat
@@ -992,7 +993,7 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
             true,
             germans,
             bridge,
-            mock(IBattle.class),
+            mock(Territory.class),
             TerritoryEffectHelper.getEffects(balticSeaZone));
     assertEquals(0, roll.getHits());
     // Get total number of units in Finland before the retreat
@@ -1051,7 +1052,7 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
             true,
             germans,
             bridge,
-            mock(IBattle.class),
+            mock(Territory.class),
             TerritoryEffectHelper.getEffects(balticSeaZone));
     assertEquals(1, roll.getHits());
     // Get total number of units in Finland before the retreat

--- a/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
@@ -17,7 +17,6 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Constants;
-import games.strategy.triplea.delegate.battle.IBattle;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.Collection;
 import java.util.List;
@@ -108,19 +107,20 @@ class PacificTest extends AbstractDelegateTestCase {
     // Defending US infantry
     DiceRoll roll =
         DiceRoll.rollDice(
-            infantryUs, true, americans, bridge, mock(IBattle.class), territoryEffects);
+            infantryUs, true, americans, bridge, mock(Territory.class), territoryEffects);
     assertEquals(1, roll.getHits());
     // Defending US marines
     final List<Unit> marineUs = marine.create(1, americans);
     roll =
-        DiceRoll.rollDice(marineUs, true, americans, bridge, mock(IBattle.class), territoryEffects);
+        DiceRoll.rollDice(
+            marineUs, true, americans, bridge, mock(Territory.class), territoryEffects);
     assertEquals(1, roll.getHits());
     // Chinese units
     // Defending Chinese infantry
     final List<Unit> infantryChina = infantry.create(1, chinese);
     roll =
         DiceRoll.rollDice(
-            infantryChina, true, chinese, bridge, mock(IBattle.class), territoryEffects);
+            infantryChina, true, chinese, bridge, mock(Territory.class), territoryEffects);
     assertEquals(1, roll.getHits());
   }
 
@@ -144,34 +144,36 @@ class PacificTest extends AbstractDelegateTestCase {
     // Defending US infantry
     DiceRoll roll =
         DiceRoll.rollDice(
-            infantryUs, true, americans, bridge, mock(IBattle.class), territoryEffects);
+            infantryUs, true, americans, bridge, mock(Territory.class), territoryEffects);
     assertEquals(0, roll.getHits());
     // Defending US marines
     final List<Unit> marineUs = marine.create(1, americans);
     roll =
-        DiceRoll.rollDice(marineUs, true, americans, bridge, mock(IBattle.class), territoryEffects);
+        DiceRoll.rollDice(
+            marineUs, true, americans, bridge, mock(Territory.class), territoryEffects);
     assertEquals(0, roll.getHits());
     // Chinese units
     // Defending Chinese infantry
     final List<Unit> infantryChina = infantry.create(1, chinese);
     roll =
         DiceRoll.rollDice(
-            infantryChina, true, chinese, bridge, mock(IBattle.class), territoryEffects);
+            infantryChina, true, chinese, bridge, mock(Territory.class), territoryEffects);
     assertEquals(1, roll.getHits());
     // Defending US infantry
     roll =
         DiceRoll.rollDice(
-            infantryUs, true, americans, bridge, mock(IBattle.class), territoryEffects);
+            infantryUs, true, americans, bridge, mock(Territory.class), territoryEffects);
     assertEquals(1, roll.getHits());
     // Defending US marines
     roll =
-        DiceRoll.rollDice(marineUs, true, americans, bridge, mock(IBattle.class), territoryEffects);
+        DiceRoll.rollDice(
+            marineUs, true, americans, bridge, mock(Territory.class), territoryEffects);
     assertEquals(1, roll.getHits());
     // Chinese units
     // Defending Chinese infantry
     roll =
         DiceRoll.rollDice(
-            infantryChina, true, chinese, bridge, mock(IBattle.class), territoryEffects);
+            infantryChina, true, chinese, bridge, mock(Territory.class), territoryEffects);
     assertEquals(1, roll.getHits());
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -76,7 +76,6 @@ import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.battle.BattleDelegate;
-import games.strategy.triplea.delegate.battle.IBattle;
 import games.strategy.triplea.delegate.battle.IBattle.BattleType;
 import games.strategy.triplea.delegate.battle.MustFightBattle;
 import games.strategy.triplea.delegate.battle.casualty.AaCasualtySelector;
@@ -691,12 +690,12 @@ class WW2V3Year41Test {
     // Attacking fighter
     final DiceRoll roll1 =
         DiceRoll.rollDice(
-            germanFighter, false, germans, delegateBridge, mock(IBattle.class), territoryEffects);
+            germanFighter, false, germans, delegateBridge, mock(Territory.class), territoryEffects);
     assertEquals(1, roll1.getHits());
     // Defending fighter
     final DiceRoll roll2 =
         DiceRoll.rollDice(
-            germanFighter, true, germans, delegateBridge, mock(IBattle.class), territoryEffects);
+            germanFighter, true, germans, delegateBridge, mock(Territory.class), territoryEffects);
     assertEquals(0, roll2.getHits());
   }
 


### PR DESCRIPTION
This is a piece of #7823.  I noticed that DiceRoll.rollDice only grabs the territory of of the battle object.  So instead of passing the entire battle object around, I changed it to only pass the territory.

I also noticed that the units passed into DiceRoll.rollDice can be a `Collection` instead of a `List` so I changed that as well.

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
