### PR TITLE
DiceRoll.getAnnotation only needs territory and round from the battle

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -1275,7 +1275,10 @@ public class DiceRoll implements Externalizable {
   }
 
   public static String getAnnotation(
-      final Collection<Unit> units, final GamePlayer player, final IBattle battle) {
+      final Collection<Unit> units,
+      final GamePlayer player,
+      final Territory territory,
+      final int battleRound) {
     final StringBuilder buffer = new StringBuilder(80);
     // Note: This pattern is parsed when loading saved games to restore dice stats to get the player
     // name via the
@@ -1285,14 +1288,11 @@ public class DiceRoll implements Externalizable {
     buffer
         .append(player.getName())
         .append(" roll dice for ")
-        .append(MyFormatter.unitsToTextNoOwner(units));
-    if (battle != null) {
-      buffer
-          .append(" in ")
-          .append(battle.getTerritory().getName())
-          .append(", round ")
-          .append((battle.getBattleRound() + 1));
-    }
+        .append(MyFormatter.unitsToTextNoOwner(units))
+        .append(" in ")
+        .append(territory.getName())
+        .append(", round ")
+        .append(battleRound + 1);
     return buffer.toString();
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/Fire.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/Fire.java
@@ -150,7 +150,9 @@ public class Fire implements IExecutable {
     if (headless) {
       annotation = "";
     } else {
-      annotation = DiceRoll.getAnnotation(units, firingPlayer, battle);
+      annotation =
+          DiceRoll.getAnnotation(
+              units, firingPlayer, battle.getTerritory(), battle.getBattleRound());
     }
     dice =
         DiceRoll.rollDice(


### PR DESCRIPTION
This is a piece of #7823.  DiceRoll.getAnnotation doesn't need the full battle object.  It only needs the territory and round.  And the only caller of DiceRoll.getAnnotation (`Fire`) is guaranteed to have a battle object so the null check isn't needed.

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
