### PR TITLE
Fix: When AI builds factories, set remainingConstruction, not remainingUnitProduction

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -1345,9 +1345,11 @@ class ProPurchaseAi {
           startOfTurnData,
           purchaseOptionsForTerritory,
           resourceTracker,
-          1,
+          0,
           new ArrayList<>(),
-          purchaseTerritories);
+          purchaseTerritories,
+          1,
+          maxTerritory);
       resourceTracker.clearTempPurchases();
 
       // Determine most expensive factory option (currently doesn't buy mobile factories)


### PR DESCRIPTION
During a reworking of the AI code (#5842), the method `ProPurchaseValidationUtils#removeInvalidPurchaseOptions` had its "remainingUnitProduction" parameter split to track "remainingConstructions" separately.  When the AI tried to buy a factory, it's code was not updated and it set "remainingUnitProduction" to 1 instead of "remainingConstructions".  This would cause the AI to always believe there wasn't enough space to build factories and so it would never build factories.

Fixes #7819

<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->
Using the save game from #7819, I stepped through the code and was able to see factories constructed now.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->FIX|Hard AI purchases factories/constructions again<!--END_RELEASE_NOTE-->
