### PR TITLE
Move TotalPowerAndTotalRolls to power.calculator and mark helper classes as package only

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
@@ -15,7 +15,7 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator;
 import games.strategy.triplea.delegate.battle.casualty.CasualtyUtil;
-import games.strategy.triplea.delegate.dice.TotalPowerAndTotalRolls;
+import games.strategy.triplea.delegate.power.calculator.TotalPowerAndTotalRolls;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
@@ -12,7 +12,7 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator;
-import games.strategy.triplea.delegate.dice.TotalPowerAndTotalRolls;
+import games.strategy.triplea.delegate.power.calculator.TotalPowerAndTotalRolls;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.LinkedHashMap;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -15,7 +15,7 @@ import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Die.DieType;
 import games.strategy.triplea.delegate.battle.AirBattle;
-import games.strategy.triplea.delegate.dice.TotalPowerAndTotalRolls;
+import games.strategy.triplea.delegate.power.calculator.TotalPowerAndTotalRolls;
 import games.strategy.triplea.formatter.MyFormatter;
 import java.io.Externalizable;
 import java.io.IOException;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -32,7 +32,7 @@ import games.strategy.triplea.delegate.battle.IBattle.WhoWon;
 import games.strategy.triplea.delegate.data.BattleListing;
 import games.strategy.triplea.delegate.data.BattleRecord;
 import games.strategy.triplea.delegate.data.BattleRecords;
-import games.strategy.triplea.delegate.dice.TotalPowerAndTotalRolls;
+import games.strategy.triplea.delegate.power.calculator.TotalPowerAndTotalRolls;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.util.TuvUtils;
 import java.io.Serializable;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelector.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelector.java
@@ -15,7 +15,7 @@ import games.strategy.triplea.delegate.Die;
 import games.strategy.triplea.delegate.Die.DieType;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
-import games.strategy.triplea.delegate.dice.TotalPowerAndTotalRolls;
+import games.strategy.triplea.delegate.power.calculator.TotalPowerAndTotalRolls;
 import games.strategy.triplea.util.UnitCategory;
 import games.strategy.triplea.util.UnitSeparator;
 import java.util.ArrayList;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLosses.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLosses.java
@@ -9,7 +9,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator.CombatModifiers;
-import games.strategy.triplea.delegate.dice.TotalPowerAndTotalRolls;
+import games.strategy.triplea.delegate.power.calculator.TotalPowerAndTotalRolls;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEnd.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEnd.java
@@ -14,7 +14,7 @@ import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.IBattle;
 import games.strategy.triplea.delegate.battle.steps.BattleStep;
 import games.strategy.triplea.delegate.battle.steps.RetreatChecks;
-import games.strategy.triplea.delegate.dice.TotalPowerAndTotalRolls;
+import games.strategy.triplea.delegate.power.calculator.TotalPowerAndTotalRolls;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AvailableSupportCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AvailableSupportCalculator.java
@@ -21,7 +21,7 @@ import org.triplea.java.collections.IntegerMap;
 
 @UtilityClass
 public class AvailableSupportCalculator {
-  public static SupportCalculationResult getSortedAaSupport(
+  static SupportCalculationResult getSortedAaSupport(
       final Collection<Unit> unitsGivingTheSupport,
       final GameData data,
       final boolean defence,
@@ -61,7 +61,7 @@ public class AvailableSupportCalculator {
    * @param defence are the receiving units defending?
    * @param allies are the receiving units allied to the giving units?
    */
-  public static SupportCalculationResult getSupport(
+  private static SupportCalculationResult getSupport(
       final Collection<Unit> unitsGivingTheSupport,
       final Set<UnitSupportAttachment> rules,
       final boolean defence,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportBonusCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportBonusCalculator.java
@@ -11,7 +11,7 @@ import lombok.experimental.UtilityClass;
 import org.triplea.java.collections.IntegerMap;
 
 @UtilityClass
-public class SupportBonusCalculator {
+class SupportBonusCalculator {
   /**
    * Returns the support for this unit type, and decrements the supportLeft counters.
    *

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportCalculationResult.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportCalculationResult.java
@@ -7,11 +7,12 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Value;
 import org.triplea.java.collections.IntegerMap;
 
-@Builder
+@Builder(access = AccessLevel.PACKAGE)
 @Value
 public class SupportCalculationResult {
   public static final SupportCalculationResult EMPTY_RESULT =

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportRuleSort.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportRuleSort.java
@@ -11,7 +11,7 @@ import javax.annotation.Nonnull;
 import lombok.Builder;
 
 @Builder
-public class SupportRuleSort implements Comparator<UnitSupportAttachment> {
+class SupportRuleSort implements Comparator<UnitSupportAttachment> {
   @Nonnull private final Boolean defense;
   @Nonnull private final Boolean friendly;
   @Nonnull private final Predicate<UnitSupportAttachment> roll;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRolls.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRolls.java
@@ -1,4 +1,4 @@
-package games.strategy.triplea.delegate.dice;
+package games.strategy.triplea.delegate.power.calculator;
 
 import com.google.common.annotations.VisibleForTesting;
 import games.strategy.engine.data.GameData;
@@ -14,9 +14,6 @@ import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.Die;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
-import games.strategy.triplea.delegate.power.calculator.AvailableSupportCalculator;
-import games.strategy.triplea.delegate.power.calculator.SupportBonusCalculator;
-import games.strategy.triplea.delegate.power.calculator.SupportCalculationResult;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -219,7 +216,7 @@ public class TotalPowerAndTotalRolls {
   }
 
   @VisibleForTesting
-  public static void sortAaHighToLow(
+  static void sortAaHighToLow(
       final List<Unit> units,
       final GameData data,
       final boolean defending,
@@ -594,6 +591,12 @@ public class TotalPowerAndTotalRolls {
         && isDominatingFirstRoundAttack(data.getSequence().getStep().getPlayerId());
   }
 
+  private static boolean isNegateDominatingFirstRoundAttack(final GamePlayer player) {
+    final RulesAttachment ra =
+        (RulesAttachment) player.getAttachment(Constants.RULES_ATTACHMENT_NAME);
+    return ra != null && ra.getNegateDominatingFirstRoundAttack();
+  }
+
   private static boolean isDominatingFirstRoundAttack(final GamePlayer player) {
     if (player == null) {
       return false;
@@ -601,12 +604,6 @@ public class TotalPowerAndTotalRolls {
     final RulesAttachment ra =
         (RulesAttachment) player.getAttachment(Constants.RULES_ATTACHMENT_NAME);
     return ra != null && ra.getDominatingFirstRoundAttack();
-  }
-
-  private static boolean isNegateDominatingFirstRoundAttack(final GamePlayer player) {
-    final RulesAttachment ra =
-        (RulesAttachment) player.getAttachment(Constants.RULES_ATTACHMENT_NAME);
-    return ra != null && ra.getNegateDominatingFirstRoundAttack();
   }
 
   public static int getTotalPower(

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -15,7 +15,7 @@ import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.delegate.battle.BattleDelegate;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator;
 import games.strategy.triplea.delegate.battle.casualty.CasualtyUtil;
-import games.strategy.triplea.delegate.dice.TotalPowerAndTotalRolls;
+import games.strategy.triplea.delegate.power.calculator.TotalPowerAndTotalRolls;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.util.TuvUtils;

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -20,7 +20,7 @@ import games.strategy.triplea.delegate.battle.IBattle.BattleType;
 import games.strategy.triplea.delegate.battle.casualty.CasualtyUtil;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
 import games.strategy.triplea.delegate.data.CasualtyList;
-import games.strategy.triplea.delegate.dice.TotalPowerAndTotalRolls;
+import games.strategy.triplea.delegate.power.calculator.TotalPowerAndTotalRolls;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.panels.map.MapPanel;
 import games.strategy.triplea.util.UnitCategory;

--- a/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -9,8 +9,6 @@ import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
 import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -29,19 +27,11 @@ import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.battle.IBattle;
 import games.strategy.triplea.delegate.battle.StrategicBombingRaidBattle;
-import games.strategy.triplea.delegate.dice.TotalPowerAndTotalRolls;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.math.BigDecimal;
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 import org.triplea.java.collections.CollectionUtils;
 
 class DiceRollTest {
@@ -759,126 +749,5 @@ class DiceRollTest {
     gameData.getProperties().set(Constants.LHTR_HEAVY_BOMBERS, Boolean.TRUE);
     assertThat(StrategicBombingRaidBattle.getSbrRolls(bomber, british), is(2));
     assertThat(StrategicBombingRaidBattle.getSbrRolls(bomber, british), is(2));
-  }
-
-  @Test
-  void testGetTotalPowerForSupportBonusTypeCount() {
-    final GameData twwGameData = TestMapGameData.TWW.getGameData();
-
-    // Move regular units
-    final GamePlayer germans = GameDataTestUtil.germany(twwGameData);
-    final Territory berlin = territory("Berlin", twwGameData);
-    final List<Unit> attackers = new ArrayList<>();
-
-    attackers.addAll(GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
-    attackers.addAll(GameDataTestUtil.germanArtillery(twwGameData).create(1, germans));
-    int attackPower =
-        TotalPowerAndTotalRolls.getTotalPower(
-            TotalPowerAndTotalRolls.getUnitPowerAndRollsForNormalBattles(
-                attackers,
-                new ArrayList<>(),
-                attackers,
-                false,
-                twwGameData,
-                berlin,
-                new ArrayList<>()),
-            twwGameData);
-    assertEquals(attackPower, 6, "1 artillery should provide +1 support to the infantry");
-
-    attackers.addAll(GameDataTestUtil.germanArtillery(twwGameData).create(1, germans));
-    attackPower =
-        TotalPowerAndTotalRolls.getTotalPower(
-            TotalPowerAndTotalRolls.getUnitPowerAndRollsForNormalBattles(
-                attackers,
-                new ArrayList<>(),
-                attackers,
-                false,
-                twwGameData,
-                berlin,
-                new ArrayList<>()),
-            twwGameData);
-    assertEquals(
-        attackPower,
-        10,
-        "2 artillery should provide +2 support to the infantry as stack count is 2");
-
-    attackers.addAll(GameDataTestUtil.germanArtillery(twwGameData).create(1, germans));
-    attackPower =
-        TotalPowerAndTotalRolls.getTotalPower(
-            TotalPowerAndTotalRolls.getUnitPowerAndRollsForNormalBattles(
-                attackers,
-                new ArrayList<>(),
-                attackers,
-                false,
-                twwGameData,
-                berlin,
-                new ArrayList<>()),
-            twwGameData);
-    assertEquals(
-        attackPower,
-        13,
-        "3 artillery should provide +2 support to the infantry as can't provide more than 2");
-  }
-
-  @Nested
-  @ExtendWith(MockitoExtension.class)
-  class SortAaHighToLowTest {
-
-    @Mock private Unit unit1;
-    @Mock private Unit unit2;
-    @Mock private Unit unit3;
-    @Mock private Unit unit4;
-    @Mock private Unit unit5;
-
-    private final List<Unit> units = new ArrayList<>();
-
-    private UnitAttachment setupUnitAttachment(final Unit unit) {
-      final UnitType unitTypeMock = mock(UnitType.class);
-      final UnitAttachment unitAttachment = mock(UnitAttachment.class);
-      when(unitTypeMock.getAttachment(any())).thenReturn(unitAttachment);
-      when(unit.getType()).thenReturn(unitTypeMock);
-      return unitAttachment;
-    }
-
-    @BeforeEach
-    void setUp() {
-      units.addAll(List.of(unit1, unit2, unit3, unit4, unit5));
-    }
-
-    @Test
-    void testAttacking() {
-      int index = 4;
-      for (final var unit : units) {
-        final var unitAttachment = setupUnitAttachment(unit);
-        // We're integer dividing the index at this point to get duplicate sorting keys
-        // in order to reach some edge cases
-        when(unitAttachment.getOffensiveAttackAa(any())).thenReturn(index / 2);
-        index--;
-      }
-      TotalPowerAndTotalRolls.sortAaHighToLow(units, gameData, false, new HashMap<>());
-      assertThat(units.get(0), is(unit1));
-      assertThat(units.get(1), is(unit2));
-      assertThat(units.get(2), is(unit3));
-      assertThat(units.get(3), is(unit4));
-      assertThat(units.get(4), is(unit5));
-    }
-
-    @Test
-    void testDefending() {
-      int index = 0;
-      for (final var unit : units) {
-        final var unitAttachment = setupUnitAttachment(unit);
-        // We're integer dividing the index at this point to get duplicate sorting keys
-        // in order to reach some edge cases
-        when(unitAttachment.getAttackAa(any())).thenReturn(index / 2);
-        index++;
-      }
-      TotalPowerAndTotalRolls.sortAaHighToLow(units, gameData, true, new HashMap<>());
-      assertThat(units.get(0), is(unit5));
-      assertThat(units.get(1), is(unit3));
-      assertThat(units.get(2), is(unit4));
-      assertThat(units.get(3), is(unit1));
-      assertThat(units.get(4), is(unit2));
-    }
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRollsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRollsTest.java
@@ -1,0 +1,153 @@
+package games.strategy.triplea.delegate.power.calculator;
+
+import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.attachments.UnitAttachment;
+import games.strategy.triplea.delegate.GameDataTestUtil;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+class TotalPowerAndTotalRollsTest {
+
+  @Nested
+  @ExtendWith(MockitoExtension.class)
+  class SortAaHighToLowTest {
+
+    private final GameData gameData = TestMapGameData.LHTR.getGameData();
+
+    @Mock private Unit unit1;
+    @Mock private Unit unit2;
+    @Mock private Unit unit3;
+    @Mock private Unit unit4;
+    @Mock private Unit unit5;
+
+    private final List<Unit> units = new ArrayList<>();
+
+    private UnitAttachment setupUnitAttachment(final Unit unit) {
+      final UnitType unitTypeMock = mock(UnitType.class);
+      final UnitAttachment unitAttachment = mock(UnitAttachment.class);
+      when(unitTypeMock.getAttachment(any())).thenReturn(unitAttachment);
+      when(unit.getType()).thenReturn(unitTypeMock);
+      return unitAttachment;
+    }
+
+    @BeforeEach
+    void setUp() {
+      units.addAll(List.of(unit1, unit2, unit3, unit4, unit5));
+    }
+
+    @Test
+    void testAttacking() {
+      int index = 4;
+      for (final var unit : units) {
+        final var unitAttachment = setupUnitAttachment(unit);
+        // We're integer dividing the index at this point to get duplicate sorting keys
+        // in order to reach some edge cases
+        when(unitAttachment.getOffensiveAttackAa(any())).thenReturn(index / 2);
+        index--;
+      }
+      TotalPowerAndTotalRolls.sortAaHighToLow(units, gameData, false, new HashMap<>());
+      assertThat(units.get(0), is(unit1));
+      assertThat(units.get(1), is(unit2));
+      assertThat(units.get(2), is(unit3));
+      assertThat(units.get(3), is(unit4));
+      assertThat(units.get(4), is(unit5));
+    }
+
+    @Test
+    void testDefending() {
+      int index = 0;
+      for (final var unit : units) {
+        final var unitAttachment = setupUnitAttachment(unit);
+        // We're integer dividing the index at this point to get duplicate sorting keys
+        // in order to reach some edge cases
+        when(unitAttachment.getAttackAa(any())).thenReturn(index / 2);
+        index++;
+      }
+      TotalPowerAndTotalRolls.sortAaHighToLow(units, gameData, true, new HashMap<>());
+      assertThat(units.get(0), is(unit5));
+      assertThat(units.get(1), is(unit3));
+      assertThat(units.get(2), is(unit4));
+      assertThat(units.get(3), is(unit1));
+      assertThat(units.get(4), is(unit2));
+    }
+  }
+
+  @Test
+  void testGetTotalPowerForSupportBonusTypeCount() {
+    final GameData twwGameData = TestMapGameData.TWW.getGameData();
+
+    // Move regular units
+    final GamePlayer germans = GameDataTestUtil.germany(twwGameData);
+    final Territory berlin = territory("Berlin", twwGameData);
+    final List<Unit> attackers = new ArrayList<>();
+
+    attackers.addAll(GameDataTestUtil.germanInfantry(twwGameData).create(1, germans));
+    attackers.addAll(GameDataTestUtil.germanArtillery(twwGameData).create(1, germans));
+    int attackPower =
+        TotalPowerAndTotalRolls.getTotalPower(
+            TotalPowerAndTotalRolls.getUnitPowerAndRollsForNormalBattles(
+                attackers,
+                new ArrayList<>(),
+                attackers,
+                false,
+                twwGameData,
+                berlin,
+                new ArrayList<>()),
+            twwGameData);
+    assertEquals(attackPower, 6, "1 artillery should provide +1 support to the infantry");
+
+    attackers.addAll(GameDataTestUtil.germanArtillery(twwGameData).create(1, germans));
+    attackPower =
+        TotalPowerAndTotalRolls.getTotalPower(
+            TotalPowerAndTotalRolls.getUnitPowerAndRollsForNormalBattles(
+                attackers,
+                new ArrayList<>(),
+                attackers,
+                false,
+                twwGameData,
+                berlin,
+                new ArrayList<>()),
+            twwGameData);
+    assertEquals(
+        attackPower,
+        10,
+        "2 artillery should provide +2 support to the infantry as stack count is 2");
+
+    attackers.addAll(GameDataTestUtil.germanArtillery(twwGameData).create(1, germans));
+    attackPower =
+        TotalPowerAndTotalRolls.getTotalPower(
+            TotalPowerAndTotalRolls.getUnitPowerAndRollsForNormalBattles(
+                attackers,
+                new ArrayList<>(),
+                attackers,
+                false,
+                twwGameData,
+                berlin,
+                new ArrayList<>()),
+            twwGameData);
+    assertEquals(
+        attackPower,
+        13,
+        "3 artillery should provide +2 support to the infantry as can't provide more than 2");
+  }
+}


### PR DESCRIPTION
I noticed that the classes in power.calculator were just helper classes for TotalPowerAndTotalRolls.  So I moved it there and marked many of those classes as package visible instead of public.

I found some tests specific to TotalPowerAndTotalRolls in the DiceRoll tests and moved them to a separate test file.

I also moved a method to fit the code style of declaring methods immediately after they are used.

This change has no behavioral changes.

<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
