### PR TITLE
Add unittests for TotalPowerAndTotalRolls

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryEffectAttachment.java
@@ -19,6 +19,10 @@ import org.triplea.java.collections.IntegerMap;
 
 /** An attachment for instances of {@link TerritoryEffect}. */
 public class TerritoryEffectAttachment extends DefaultAttachment {
+
+  public static final String COMBAT_OFFENSE_EFFECT = "combatOffenseEffect";
+  public static final String COMBAT_DEFENSE_EFFECT = "combatDefenseEffect";
+
   private static final long serialVersionUID = 6379810228136325991L;
 
   private IntegerMap<UnitType> combatDefenseEffect = new IntegerMap<>();
@@ -190,14 +194,14 @@ public class TerritoryEffectAttachment extends DefaultAttachment {
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put(
-            "combatDefenseEffect",
+            COMBAT_DEFENSE_EFFECT,
             MutableProperty.of(
                 this::setCombatDefenseEffect,
                 this::setCombatDefenseEffect,
                 this::getCombatDefenseEffect,
                 this::resetCombatDefenseEffect))
         .put(
-            "combatOffenseEffect",
+            COMBAT_OFFENSE_EFFECT,
             MutableProperty.of(
                 this::setCombatOffenseEffect,
                 this::setCombatOffenseEffect,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -42,6 +42,22 @@ import org.triplea.util.Tuple;
 public class UnitAttachment extends DefaultAttachment {
   public static final String UNITSMAYNOTLANDONCARRIER = "unitsMayNotLandOnCarrier";
   public static final String UNITSMAYNOTLEAVEALLIEDCARRIER = "unitsMayNotLeaveAlliedCarrier";
+
+  public static final String IS_SEA = "isSea";
+  public static final String DEFENSE_STRENGTH = "defense";
+  public static final String ATTACK_STRENGTH = "attack";
+  public static final String ATTACK_ROLL = "attackRolls";
+  public static final String DEFENSE_ROLL = "defenseRolls";
+  public static final String ATTACK_AA = "attackAA";
+  public static final String OFFENSIVE_ATTACK_AA = "offensiveAttackAA";
+  public static final String MAX_AA_ATTACKS = "maxAAattacks";
+  public static final String ATTACK_AA_MAX_DIE_SIDES = "attackAAmaxDieSides";
+  public static final String OFFENSIVE_ATTACK_AA_MAX_DIE_SIDES = "offensiveAttackAAmaxDieSides";
+  public static final String MAY_OVERSTACK_AA = "mayOverStackAA";
+  public static final String IS_MARINE = "isMarine";
+  public static final String BOMBARD = "bombard";
+  public static final String CHOOSE_BEST_ROLL = "chooseBestRoll";
+
   private static final long serialVersionUID = -2946748686268541820L;
 
   // movement related
@@ -3691,7 +3707,7 @@ public class UnitAttachment extends DefaultAttachment {
             "isAir",
             MutableProperty.of(this::setIsAir, this::setIsAir, this::getIsAir, this::resetIsAir))
         .put(
-            "isSea",
+            IS_SEA,
             MutableProperty.of(this::setIsSea, this::setIsSea, this::getIsSea, this::resetIsSea))
         .put(
             "movement",
@@ -3741,11 +3757,11 @@ public class UnitAttachment extends DefaultAttachment {
                 this::getMovementLimit,
                 this::resetMovementLimit))
         .put(
-            "attack",
+            ATTACK_STRENGTH,
             MutableProperty.of(
                 this::setAttack, this::setAttack, this::getAttack, this::resetAttack))
         .put(
-            "defense",
+            DEFENSE_STRENGTH,
             MutableProperty.of(
                 this::setDefense, this::setDefense, this::getDefense, this::resetDefense))
         .put(
@@ -3763,7 +3779,7 @@ public class UnitAttachment extends DefaultAttachment {
                 this::getCanBombard,
                 this::resetCanBombard))
         .put(
-            "bombard",
+            BOMBARD,
             MutableProperty.ofMapper(
                 DefaultAttachment::getInt, this::setBombard, this::getBombard, () -> -1))
         .put("isSub", MutableProperty.<Boolean>ofWriteOnly(this::setIsSub, this::setIsSub))
@@ -3832,7 +3848,7 @@ public class UnitAttachment extends DefaultAttachment {
                 this::getUnitSupportCount,
                 this::resetUnitSupportCount))
         .put(
-            "isMarine",
+            IS_MARINE,
             MutableProperty.of(
                 this::setIsMarine, this::setIsMarine, this::getIsMarine, this::resetIsMarine))
         .put(
@@ -3868,21 +3884,21 @@ public class UnitAttachment extends DefaultAttachment {
                 this::getAttackingLimit,
                 this::resetAttackingLimit))
         .put(
-            "attackRolls",
+            ATTACK_ROLL,
             MutableProperty.of(
                 this::setAttackRolls,
                 this::setAttackRolls,
                 this::getAttackRolls,
                 this::resetAttackRolls))
         .put(
-            "defenseRolls",
+            DEFENSE_ROLL,
             MutableProperty.of(
                 this::setDefenseRolls,
                 this::setDefenseRolls,
                 this::getDefenseRolls,
                 this::resetDefenseRolls))
         .put(
-            "chooseBestRoll",
+            CHOOSE_BEST_ROLL,
             MutableProperty.of(
                 this::setChooseBestRoll,
                 this::setChooseBestRoll,
@@ -3977,32 +3993,32 @@ public class UnitAttachment extends DefaultAttachment {
             MutableProperty.of(
                 this::setIsRocket, this::setIsRocket, this::getIsRocket, this::resetIsRocket))
         .put(
-            "attackAA",
+            ATTACK_AA,
             MutableProperty.of(
                 this::setAttackAa, this::setAttackAa, this::getAttackAa, this::resetAttackAa))
         .put(
-            "offensiveAttackAA",
+            OFFENSIVE_ATTACK_AA,
             MutableProperty.of(
                 this::setOffensiveAttackAa,
                 this::setOffensiveAttackAa,
                 this::getOffensiveAttackAa,
                 this::resetOffensiveAttackAa))
         .put(
-            "attackAAmaxDieSides",
+            ATTACK_AA_MAX_DIE_SIDES,
             MutableProperty.of(
                 this::setAttackAaMaxDieSides,
                 this::setAttackAaMaxDieSides,
                 this::getAttackAaMaxDieSides,
                 this::resetAttackAaMaxDieSides))
         .put(
-            "offensiveAttackAAmaxDieSides",
+            OFFENSIVE_ATTACK_AA_MAX_DIE_SIDES,
             MutableProperty.of(
                 this::setOffensiveAttackAaMaxDieSides,
                 this::setOffensiveAttackAaMaxDieSides,
                 this::getOffensiveAttackAaMaxDieSides,
                 this::resetOffensiveAttackAaMaxDieSides))
         .put(
-            "maxAAattacks",
+            MAX_AA_ATTACKS,
             MutableProperty.of(
                 this::setMaxAaAttacks,
                 this::setMaxAaAttacks,
@@ -4022,7 +4038,7 @@ public class UnitAttachment extends DefaultAttachment {
             MutableProperty.of(
                 this::setTargetsAa, this::setTargetsAa, this::getTargetsAa, this::resetTargetsAa))
         .put(
-            "mayOverStackAA",
+            MAY_OVERSTACK_AA,
             MutableProperty.of(
                 this::setMayOverStackAa,
                 this::setMayOverStackAa,

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -855,8 +855,10 @@ public class UnitAttachment extends DefaultAttachment {
     isSea = getBool(s);
   }
 
-  private void setIsSea(final Boolean s) {
+  @VisibleForTesting
+  public UnitAttachment setIsSea(final Boolean s) {
     isSea = s;
+    return this;
   }
 
   public boolean getIsSea() {
@@ -1277,8 +1279,10 @@ public class UnitAttachment extends DefaultAttachment {
     }
   }
 
-  private void setIsMarine(final Integer s) {
+  @VisibleForTesting
+  public UnitAttachment setIsMarine(final Integer s) {
     isMarine = s;
+    return this;
   }
 
   public int getIsMarine() {
@@ -1474,8 +1478,9 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @VisibleForTesting
-  public void setBombard(final int s) {
+  public UnitAttachment setBombard(final int s) {
     bombard = s;
+    return this;
   }
 
   public int getBombard() {
@@ -1510,8 +1515,10 @@ public class UnitAttachment extends DefaultAttachment {
     attack = getInt(s);
   }
 
-  private void setAttack(final Integer s) {
+  @VisibleForTesting
+  public UnitAttachment setAttack(final Integer s) {
     attack = s;
+    return this;
   }
 
   int getAttack() {
@@ -1534,8 +1541,10 @@ public class UnitAttachment extends DefaultAttachment {
     attackRolls = getInt(s);
   }
 
-  private void setAttackRolls(final Integer s) {
+  @VisibleForTesting
+  public UnitAttachment setAttackRolls(final Integer s) {
     attackRolls = s;
+    return this;
   }
 
   private int getAttackRolls() {
@@ -1558,8 +1567,10 @@ public class UnitAttachment extends DefaultAttachment {
     defense = getInt(s);
   }
 
-  private void setDefense(final Integer s) {
+  @VisibleForTesting
+  public UnitAttachment setDefense(final Integer s) {
     defense = s;
+    return this;
   }
 
   private int getDefense() {
@@ -1586,8 +1597,10 @@ public class UnitAttachment extends DefaultAttachment {
     defenseRolls = getInt(s);
   }
 
-  private void setDefenseRolls(final Integer s) {
+  @VisibleForTesting
+  public UnitAttachment setDefenseRolls(final Integer s) {
     defenseRolls = s;
+    return this;
   }
 
   private int getDefenseRolls() {
@@ -1610,8 +1623,10 @@ public class UnitAttachment extends DefaultAttachment {
     chooseBestRoll = getBool(s);
   }
 
-  private void setChooseBestRoll(final Boolean s) {
+  @VisibleForTesting
+  public UnitAttachment setChooseBestRoll(final Boolean s) {
     chooseBestRoll = s;
+    return this;
   }
 
   public boolean getChooseBestRoll() {
@@ -2151,8 +2166,10 @@ public class UnitAttachment extends DefaultAttachment {
     attackAa = getInt(s);
   }
 
-  private void setAttackAa(final Integer s) {
+  @VisibleForTesting
+  public UnitAttachment setAttackAa(final Integer s) {
     attackAa = s;
+    return this;
   }
 
   private int getAttackAa() {
@@ -2180,8 +2197,10 @@ public class UnitAttachment extends DefaultAttachment {
     offensiveAttackAa = getInt(s);
   }
 
-  private void setOffensiveAttackAa(final Integer s) {
+  @VisibleForTesting
+  public UnitAttachment setOffensiveAttackAa(final Integer s) {
     offensiveAttackAa = s;
+    return this;
   }
 
   private int getOffensiveAttackAa() {
@@ -2209,8 +2228,10 @@ public class UnitAttachment extends DefaultAttachment {
     attackAaMaxDieSides = getInt(s);
   }
 
-  private void setAttackAaMaxDieSides(final Integer s) {
+  @VisibleForTesting
+  public UnitAttachment setAttackAaMaxDieSides(final Integer s) {
     attackAaMaxDieSides = s;
+    return this;
   }
 
   public int getAttackAaMaxDieSides() {
@@ -2228,8 +2249,10 @@ public class UnitAttachment extends DefaultAttachment {
     offensiveAttackAaMaxDieSides = getInt(s);
   }
 
-  private void setOffensiveAttackAaMaxDieSides(final Integer s) {
+  @VisibleForTesting
+  public UnitAttachment setOffensiveAttackAaMaxDieSides(final Integer s) {
     offensiveAttackAaMaxDieSides = s;
+    return this;
   }
 
   public int getOffensiveAttackAaMaxDieSides() {
@@ -2252,8 +2275,10 @@ public class UnitAttachment extends DefaultAttachment {
     maxAaAttacks = getInt(s);
   }
 
-  private void setMaxAaAttacks(final Integer s) {
+  @VisibleForTesting
+  public UnitAttachment setMaxAaAttacks(final Integer s) {
     maxAaAttacks = s;
+    return this;
   }
 
   public int getMaxAaAttacks() {
@@ -2289,8 +2314,10 @@ public class UnitAttachment extends DefaultAttachment {
     mayOverStackAa = getBool(s);
   }
 
-  private void setMayOverStackAa(final Boolean s) {
+  @VisibleForTesting
+  public UnitAttachment setMayOverStackAa(final Boolean s) {
     mayOverStackAa = s;
+    return this;
   }
 
   public boolean getMayOverStackAa() {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitSupportAttachment.java
@@ -26,6 +26,11 @@ import lombok.Value;
  * support other units.
  */
 public class UnitSupportAttachment extends DefaultAttachment {
+  public static final String BONUS = "bonus";
+  public static final String BONUS_TYPE = "bonusType";
+  public static final String DICE = "dice";
+  public static final String UNIT_TYPE = "unitType";
+
   private static final long serialVersionUID = -3015679930172496082L;
 
   private Set<UnitType> unitType = null;
@@ -423,7 +428,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
   public Map<String, MutableProperty<?>> getPropertyMap() {
     return ImmutableMap.<String, MutableProperty<?>>builder()
         .put(
-            "unitType",
+            UNIT_TYPE,
             MutableProperty.of(
                 this::setUnitType, this::setUnitType, this::getUnitType, this::resetUnitType))
         .put("offence", MutableProperty.ofReadOnly(this::getOffence))
@@ -433,7 +438,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
         .put("aaRoll", MutableProperty.ofReadOnly(this::getAaRoll))
         .put("aaStrength", MutableProperty.ofReadOnly(this::getAaStrength))
         .put(
-            "bonus",
+            BONUS,
             MutableProperty.of(this::setBonus, this::setBonus, this::getBonus, this::resetBonus))
         .put(
             "number",
@@ -442,7 +447,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
         .put("allied", MutableProperty.ofReadOnly(this::getAllied))
         .put("enemy", MutableProperty.ofReadOnly(this::getEnemy))
         .put(
-            "bonusType",
+            BONUS_TYPE,
             MutableProperty.of(
                 this::setBonusType, this::setBonusType, this::getBonusType, this::resetBonusType))
         .put(
@@ -456,7 +461,7 @@ public class UnitSupportAttachment extends DefaultAttachment {
                 this::setImpArtTech,
                 this::getImpArtTech,
                 this::resetImpArtTech))
-        .put("dice", MutableProperty.ofString(this::setDice, this::getDice, this::resetDice))
+        .put(DICE, MutableProperty.ofString(this::setDice, this::getDice, this::resetDice))
         .put("side", MutableProperty.ofString(this::setSide, this::getSide, this::resetSide))
         .put(
             "faction",

--- a/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -12,7 +12,6 @@ import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.when;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
@@ -25,7 +24,6 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
-import games.strategy.triplea.delegate.battle.IBattle;
 import games.strategy.triplea.delegate.battle.StrategicBombingRaidBattle;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.math.BigDecimal;
@@ -40,7 +38,6 @@ class DiceRollTest {
   @Test
   void testSimple() {
     final Territory westRussia = gameData.getMap().getTerritory("West Russia");
-    final IBattle battle = mock(IBattle.class);
     final GamePlayer russians = GameDataTestUtil.russians(gameData);
     final IDelegateBridge bridge = newDelegateBridge(russians);
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
@@ -55,22 +52,22 @@ class DiceRollTest {
     // infantry defends
     final DiceRoll roll =
         DiceRoll.rollDice(
-            infantry, true, russians, bridge, battle.getTerritory(), territoryEffects);
+            infantry, true, russians, bridge, mock(Territory.class), territoryEffects);
     assertThat(roll.getHits(), is(1));
     // infantry
     final DiceRoll roll2 =
         DiceRoll.rollDice(
-            infantry, true, russians, bridge, battle.getTerritory(), territoryEffects);
+            infantry, true, russians, bridge, mock(Territory.class), territoryEffects);
     assertThat(roll2.getHits(), is(0));
     // infantry attacks
     final DiceRoll roll3 =
         DiceRoll.rollDice(
-            infantry, false, russians, bridge, battle.getTerritory(), territoryEffects);
+            infantry, false, russians, bridge, mock(Territory.class), territoryEffects);
     assertThat(roll3.getHits(), is(1));
     // infantry attack
     final DiceRoll roll4 =
         DiceRoll.rollDice(
-            infantry, false, russians, bridge, battle.getTerritory(), territoryEffects);
+            infantry, false, russians, bridge, mock(Territory.class), territoryEffects);
     assertThat(roll4.getHits(), is(0));
   }
 
@@ -78,7 +75,6 @@ class DiceRollTest {
   void testSimpleLowLuck() {
     GameDataTestUtil.makeGameLowLuck(gameData);
     final Territory westRussia = gameData.getMap().getTerritory("West Russia");
-    final IBattle battle = mock(IBattle.class);
     final GamePlayer russians = GameDataTestUtil.russians(gameData);
     final IDelegateBridge bridge = newDelegateBridge(russians);
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
@@ -93,29 +89,28 @@ class DiceRollTest {
     // infantry defends
     final DiceRoll roll =
         DiceRoll.rollDice(
-            infantry, true, russians, bridge, battle.getTerritory(), territoryEffects);
+            infantry, true, russians, bridge, mock(Territory.class), territoryEffects);
     assertThat(roll.getHits(), is(1));
     // infantry
     final DiceRoll roll2 =
         DiceRoll.rollDice(
-            infantry, true, russians, bridge, battle.getTerritory(), territoryEffects);
+            infantry, true, russians, bridge, mock(Territory.class), territoryEffects);
     assertThat(roll2.getHits(), is(0));
     // infantry attacks
     final DiceRoll roll3 =
         DiceRoll.rollDice(
-            infantry, false, russians, bridge, battle.getTerritory(), territoryEffects);
+            infantry, false, russians, bridge, mock(Territory.class), territoryEffects);
     assertThat(roll3.getHits(), is(1));
     // infantry attack
     final DiceRoll roll4 =
         DiceRoll.rollDice(
-            infantry, false, russians, bridge, battle.getTerritory(), territoryEffects);
+            infantry, false, russians, bridge, mock(Territory.class), territoryEffects);
     assertThat(roll4.getHits(), is(0));
   }
 
   @Test
   void testArtillerySupport() {
     final Territory westRussia = gameData.getMap().getTerritory("West Russia");
-    final IBattle battle = mock(IBattle.class);
     final GamePlayer russians = GameDataTestUtil.russians(gameData);
     final IDelegateBridge bridge = newDelegateBridge(russians);
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
@@ -131,7 +126,7 @@ class DiceRollTest {
             false,
             russians,
             bridge,
-            battle.getTerritory(),
+            mock(Territory.class),
             TerritoryEffectHelper.getEffects(westRussia));
     assertThat(roll.getHits(), is(2));
   }
@@ -139,7 +134,6 @@ class DiceRollTest {
   @Test
   void testVariableArtillerySupport() {
     final Territory westRussia = gameData.getMap().getTerritory("West Russia");
-    final IBattle battle = mock(IBattle.class);
     final GamePlayer russians = GameDataTestUtil.russians(gameData);
     final IDelegateBridge bridge = newDelegateBridge(russians);
     // Add 1 artillery
@@ -162,7 +156,7 @@ class DiceRollTest {
             false,
             russians,
             bridge,
-            battle.getTerritory(),
+            mock(Territory.class),
             TerritoryEffectHelper.getEffects(westRussia));
     assertThat(roll.getHits(), is(3));
   }
@@ -171,7 +165,6 @@ class DiceRollTest {
   void testLowLuck() {
     GameDataTestUtil.makeGameLowLuck(gameData);
     final Territory westRussia = gameData.getMap().getTerritory("West Russia");
-    final IBattle battle = mock(IBattle.class);
     final GamePlayer russians = GameDataTestUtil.russians(gameData);
     final IDelegateBridge bridge = newDelegateBridge(russians);
     final UnitType infantryType = GameDataTestUtil.infantry(gameData);
@@ -183,7 +176,7 @@ class DiceRollTest {
             true,
             russians,
             bridge,
-            battle.getTerritory(),
+            mock(Territory.class),
             TerritoryEffectHelper.getEffects(westRussia));
     assertThat(roll.getHits(), is(1));
     thenGetRandomShouldHaveBeenCalled(bridge, never());
@@ -210,15 +203,13 @@ class DiceRollTest {
         });
     final IDelegateBridge bridge = newDelegateBridge(americans);
     whenGetRandom(bridge).thenAnswer(withValues(1));
-    final IBattle battle = mock(IBattle.class);
-    when(battle.isAmphibious()).thenReturn(true);
     final DiceRoll roll =
         DiceRoll.rollDice(
             attackers,
             false,
             americans,
             bridge,
-            battle.getTerritory(),
+            mock(Territory.class),
             TerritoryEffectHelper.getEffects(algeria));
     assertThat(roll.getHits(), is(1));
   }
@@ -244,15 +235,13 @@ class DiceRollTest {
                   });
         });
     final IDelegateBridge bridge = newDelegateBridge(americans);
-    final IBattle battle = mock(IBattle.class);
-    when(battle.isAmphibious()).thenReturn(true);
     final DiceRoll roll =
         DiceRoll.rollDice(
             attackers,
             false,
             americans,
             bridge,
-            battle.getTerritory(),
+            mock(Territory.class),
             TerritoryEffectHelper.getEffects(algeria));
     assertThat(roll.getHits(), is(1));
     thenGetRandomShouldHaveBeenCalled(bridge, never());
@@ -279,14 +268,13 @@ class DiceRollTest {
         });
     final IDelegateBridge bridge = newDelegateBridge(americans);
     whenGetRandom(bridge).thenAnswer(withValues(1));
-    final IBattle battle = mock(IBattle.class);
     final DiceRoll roll =
         DiceRoll.rollDice(
             attackers,
             false,
             americans,
             bridge,
-            battle.getTerritory(),
+            mock(Territory.class),
             TerritoryEffectHelper.getEffects(algeria));
     assertThat(roll.getHits(), is(0));
   }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/MockGameData.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/MockGameData.java
@@ -18,6 +18,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameMap;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.GameSequence;
+import games.strategy.engine.data.GameStep;
 import games.strategy.engine.data.RelationshipTracker;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.UnitTypeList;
@@ -50,6 +51,14 @@ public class MockGameData {
 
   public MockGameData withDiceSides(final int diceSides) {
     when(gameData.getDiceSides()).thenReturn(diceSides);
+    return this;
+  }
+
+  public MockGameData withRound(final int round, final GamePlayer player) {
+    when(gameSequence.getRound()).thenReturn(round);
+    final GameStep gameStep = mock(GameStep.class);
+    when(gameStep.getPlayerId()).thenReturn(player);
+    when(gameSequence.getStep()).thenReturn(gameStep);
     return this;
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRollsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRollsTest.java
@@ -3237,7 +3237,7 @@ class TotalPowerAndTotalRollsTest {
       assertThat(
           TotalPowerAndTotalRolls.getTotalAaAttacks(
               Map.of(
-                  givenUnit("test", BattleType.NORMAL, gameData, OFFENSE, 1, -1),
+                  givenUnit("test", BattleType.AA, gameData, OFFENSE, 1, -1),
                   TotalPowerAndTotalRolls.builder().totalPower(1).totalRolls(-1).build()),
               List.of(mock(Unit.class), mock(Unit.class), mock(Unit.class))),
           is(3));
@@ -3248,11 +3248,12 @@ class TotalPowerAndTotalRollsTest {
         throws MutableProperty.InvalidValueException {
       final GameData gameData = givenGameData().build();
       assertThat(
+          "Infinite unit means all enemies are rolled for but no overstacking",
           TotalPowerAndTotalRolls.getTotalAaAttacks(
               Map.of(
-                  givenUnit("test", BattleType.NORMAL, gameData, OFFENSE, 1, -1),
+                  givenUnit("test", BattleType.AA, gameData, OFFENSE, 1, -1),
                   TotalPowerAndTotalRolls.builder().totalPower(1).totalRolls(-1).build(),
-                  givenUnit("test2", BattleType.NORMAL, gameData, OFFENSE, 1, -1),
+                  givenUnit("test2", BattleType.AA, gameData, OFFENSE, 1, -1),
                   TotalPowerAndTotalRolls.builder().totalPower(1).totalRolls(-1).build()),
               List.of(mock(Unit.class), mock(Unit.class), mock(Unit.class))),
           is(3));
@@ -3263,11 +3264,12 @@ class TotalPowerAndTotalRollsTest {
         throws MutableProperty.InvalidValueException {
       final GameData gameData = givenGameData().build();
       assertThat(
+          "Infinite unit means all enemies are rolled for",
           TotalPowerAndTotalRolls.getTotalAaAttacks(
               Map.of(
-                  givenUnit("test", BattleType.NORMAL, gameData, OFFENSE, 1, -1),
+                  givenUnit("test", BattleType.AA, gameData, OFFENSE, 1, -1),
                   TotalPowerAndTotalRolls.builder().totalPower(1).totalRolls(-1).build(),
-                  givenUnit("test2", BattleType.NORMAL, gameData, OFFENSE, 1, 10),
+                  givenUnit("test2", BattleType.AA, gameData, OFFENSE, 1, 10),
                   TotalPowerAndTotalRolls.builder().totalPower(1).totalRolls(10).build()),
               List.of(mock(Unit.class), mock(Unit.class), mock(Unit.class))),
           is(3));
@@ -3277,9 +3279,10 @@ class TotalPowerAndTotalRollsTest {
     void rollsOfNonInfiniteUnitEqualsAttack() throws MutableProperty.InvalidValueException {
       final GameData gameData = givenGameData().build();
       assertThat(
+          "Unit only has one roll",
           TotalPowerAndTotalRolls.getTotalAaAttacks(
               Map.of(
-                  givenUnit("test", BattleType.NORMAL, gameData, OFFENSE, 1, 1),
+                  givenUnit("test", BattleType.AA, gameData, OFFENSE, 1, 1),
                   TotalPowerAndTotalRolls.builder().totalPower(1).totalRolls(1).build()),
               List.of(mock(Unit.class), mock(Unit.class), mock(Unit.class))),
           is(1));
@@ -3290,11 +3293,12 @@ class TotalPowerAndTotalRollsTest {
         throws MutableProperty.InvalidValueException {
       final GameData gameData = givenGameData().build();
       assertThat(
+          "There is only 3 units and no overstack so only allow 3",
           TotalPowerAndTotalRolls.getTotalAaAttacks(
               Map.of(
-                  givenUnit("test", BattleType.NORMAL, gameData, OFFENSE, 1, 2),
+                  givenUnit("test", BattleType.AA, gameData, OFFENSE, 1, 2),
                   TotalPowerAndTotalRolls.builder().totalPower(1).totalRolls(2).build(),
-                  givenUnit("test2", BattleType.NORMAL, gameData, OFFENSE, 1, 2),
+                  givenUnit("test2", BattleType.AA, gameData, OFFENSE, 1, 2),
                   TotalPowerAndTotalRolls.builder().totalPower(1).totalRolls(2).build()),
               List.of(mock(Unit.class), mock(Unit.class), mock(Unit.class))),
           is(3));
@@ -3304,17 +3308,18 @@ class TotalPowerAndTotalRollsTest {
     void overstackUnitCanCauseAttackToGoOverTargetCount()
         throws MutableProperty.InvalidValueException {
       final GameData gameData = givenGameData().build();
-      final Unit overstackUnit = givenUnit("test", BattleType.NORMAL, gameData, OFFENSE, 1, 3);
+      final Unit overstackUnit = givenUnit("test", BattleType.AA, gameData, OFFENSE, 1, 2);
       overstackUnit.getUnitAttachment().getPropertyOrThrow(MAY_OVERSTACK_AA).setValue(true);
 
       assertThat(
+          "Infinite gives total attacks equal to number of units (3) and the overstacked unit adds 2 more",
           TotalPowerAndTotalRolls.getTotalAaAttacks(
               Map.of(
                   overstackUnit,
                   TotalPowerAndTotalRolls.builder().totalPower(1).totalRolls(2).build(),
-                  givenUnit("test2", BattleType.NORMAL, gameData, OFFENSE, 1, 3),
+                  givenUnit("test2", BattleType.AA, gameData, OFFENSE, 1, 3),
                   TotalPowerAndTotalRolls.builder().totalPower(1).totalRolls(3).build(),
-                  givenUnit("test3", BattleType.NORMAL, gameData, OFFENSE, 1, -1),
+                  givenUnit("test3", BattleType.AA, gameData, OFFENSE, 1, -1),
                   TotalPowerAndTotalRolls.builder().totalPower(1).totalRolls(-1).build()),
               List.of(mock(Unit.class), mock(Unit.class), mock(Unit.class))),
           is(5));

--- a/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRollsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRollsTest.java
@@ -127,7 +127,7 @@ class TotalPowerAndTotalRollsTest {
   class GetTotalAaPowerThenHitsAndFillSortedDiceThenIfAllUseSameAttack {
 
     @Test
-    void singleAaWithOneRoll() throws MutableProperty.InvalidValueException {
+    void singleAaWithOneRoll() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(1);
@@ -171,7 +171,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void singleAaWithOneRollNoHit() throws MutableProperty.InvalidValueException {
+    void singleAaWithOneRollNoHit() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(1);
@@ -186,7 +186,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void singleAaWithTwoRoll() throws MutableProperty.InvalidValueException {
+    void singleAaWithTwoRoll() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(2);
@@ -202,7 +202,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void twoAaWithSamePower() throws MutableProperty.InvalidValueException {
+    void twoAaWithSamePower() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(1);
@@ -220,7 +220,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void twoAaWithDifferentPower() throws MutableProperty.InvalidValueException {
+    void twoAaWithDifferentPower() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(1);
@@ -239,7 +239,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void twoAaWithDifferentPowerAndOnlyOneHit() throws MutableProperty.InvalidValueException {
+    void twoAaWithDifferentPowerAndOnlyOneHit() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(1);
@@ -257,7 +257,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void oneAaWithInfinite() throws MutableProperty.InvalidValueException {
+    void oneAaWithInfinite() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(-1);
@@ -279,7 +279,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void twoAaWithInfiniteWithSamePower() throws MutableProperty.InvalidValueException {
+    void twoAaWithInfiniteWithSamePower() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(-1);
@@ -303,7 +303,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void twoAaWithInfiniteWithDifferentPower() throws MutableProperty.InvalidValueException {
+    void twoAaWithInfiniteWithDifferentPower() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(-1);
@@ -327,7 +327,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void twoAaWithInfiniteWithDifferentDice() throws MutableProperty.InvalidValueException {
+    void twoAaWithInfiniteWithDifferentDice() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment()
@@ -359,7 +359,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void twoAaWithOneRollAndInfiniteSamePower() throws MutableProperty.InvalidValueException {
+    void twoAaWithOneRollAndInfiniteSamePower() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(1);
@@ -383,8 +383,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void twoAaWithOneRollAndInfiniteWhereInfiniteIsHigher()
-        throws MutableProperty.InvalidValueException {
+    void twoAaWithOneRollAndInfiniteWhereInfiniteIsHigher() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(1);
@@ -409,8 +408,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void twoAaWithOneRollAndInfiniteWhereInfiniteIsLower()
-        throws MutableProperty.InvalidValueException {
+    void twoAaWithOneRollAndInfiniteWhereInfiniteIsLower() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(3).setMaxAaAttacks(1);
@@ -435,7 +433,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void oneAaWithOverStack() throws MutableProperty.InvalidValueException {
+    void oneAaWithOverStack() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(2).setMayOverStackAa(true);
@@ -451,7 +449,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void oneAaWithOverStackAndMoreRollsThanTargets() throws MutableProperty.InvalidValueException {
+    void oneAaWithOverStackAndMoreRollsThanTargets() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(5).setMayOverStackAa(true);
@@ -474,7 +472,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void oneAaWithOverstackAndInfinite() throws MutableProperty.InvalidValueException {
+    void oneAaWithOverstackAndInfinite() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(-1).setMayOverStackAa(true);
@@ -496,7 +494,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void oneOverstackAndOneInfinite() throws MutableProperty.InvalidValueException {
+    void oneOverstackAndOneInfinite() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(-1);
@@ -523,7 +521,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void oneOverstackAndOneInfiniteDifferentPowers() throws MutableProperty.InvalidValueException {
+    void oneOverstackAndOneInfiniteDifferentPowers() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(-1);
@@ -550,7 +548,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void oneOverstackAndOneNormal() throws MutableProperty.InvalidValueException {
+    void oneOverstackAndOneNormal() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(2);
@@ -575,7 +573,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void oneOverstackAndOneNormalDifferentPowers() throws MutableProperty.InvalidValueException {
+    void oneOverstackAndOneNormalDifferentPowers() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(2);
@@ -600,8 +598,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void oneOverstackOneInfiniteAndOneNormalSamePower()
-        throws MutableProperty.InvalidValueException {
+    void oneOverstackOneInfiniteAndOneNormalSamePower() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(-1);
@@ -630,8 +627,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void oneOverstackOneInfiniteAndOneNormalDifferentPowersWhereNormalIsBest()
-        throws MutableProperty.InvalidValueException {
+    void oneOverstackOneInfiniteAndOneNormalDifferentPowersWhereNormalIsBest() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(3).setMaxAaAttacks(-1);
@@ -660,8 +656,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void oneOverstackOneInfiniteAndOneNormalDifferentPowersWhereNormalIsWorst()
-        throws MutableProperty.InvalidValueException {
+    void oneOverstackOneInfiniteAndOneNormalDifferentPowersWhereNormalIsWorst() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(3).setMaxAaAttacks(-1);
@@ -758,8 +753,7 @@ class TotalPowerAndTotalRollsTest {
   class GetMaxAaAttackAndDiceSides {
 
     @Test
-    void singleUnitWithNoCustomDiceAndNoPowerRollsMap()
-        throws MutableProperty.InvalidValueException {
+    void singleUnitWithNoCustomDiceAndNoPowerRollsMap() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(1);
@@ -771,8 +765,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void singleDefensiveUnitWithNoCustomDiceAndNoPowerRollsMap()
-        throws MutableProperty.InvalidValueException {
+    void singleDefensiveUnitWithNoCustomDiceAndNoPowerRollsMap() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setAttackAa(2).setMaxAaAttacks(1);
@@ -784,7 +777,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void singleUnitWithCustomDiceAndNoPowerRollsMap() throws MutableProperty.InvalidValueException {
+    void singleUnitWithCustomDiceAndNoPowerRollsMap() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment()
@@ -799,8 +792,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void singleDefensiveUnitWithCustomDiceAndNoPowerRollsMap()
-        throws MutableProperty.InvalidValueException {
+    void singleDefensiveUnitWithCustomDiceAndNoPowerRollsMap() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setAttackAa(2).setMaxAaAttacks(1).setAttackAaMaxDieSides(8);
@@ -812,7 +804,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void singleUnitWithPowerRollsMap() throws MutableProperty.InvalidValueException {
+    void singleUnitWithPowerRollsMap() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(1);
@@ -829,7 +821,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void singleDefensiveUnitWithPowerRollsMap() throws MutableProperty.InvalidValueException {
+    void singleDefensiveUnitWithPowerRollsMap() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setAttackAa(2).setMaxAaAttacks(1);
@@ -846,7 +838,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void limitAttackToDiceSides() throws MutableProperty.InvalidValueException {
+    void limitAttackToDiceSides() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment()
@@ -866,7 +858,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void multipleUnitsWithSameDice() throws MutableProperty.InvalidValueException {
+    void multipleUnitsWithSameDice() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(1);
@@ -884,7 +876,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void multipleUnitsWithDifferentDice() throws MutableProperty.InvalidValueException {
+    void multipleUnitsWithDifferentDice() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment()
@@ -912,7 +904,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void multipleUnitsWithDifferentDice2() throws MutableProperty.InvalidValueException {
+    void multipleUnitsWithDifferentDice2() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment()
@@ -944,7 +936,7 @@ class TotalPowerAndTotalRollsTest {
   class GetAaUnitPowerAndRollsForNormalBattles {
 
     @Test
-    void attackUnitWithNoSupport() throws MutableProperty.InvalidValueException {
+    void attackUnitWithNoSupport() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(1).setMaxAaAttacks(1);
@@ -963,7 +955,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void defenseUnitWithNoSupport() throws MutableProperty.InvalidValueException {
+    void defenseUnitWithNoSupport() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setAttackAa(1).setMaxAaAttacks(1);
@@ -982,7 +974,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void unitWithZeroRollsAlwaysGetsZeroPower() throws MutableProperty.InvalidValueException {
+    void unitWithZeroRollsAlwaysGetsZeroPower() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(1).setMaxAaAttacks(0);
@@ -1001,7 +993,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void unitWithZeroPowerAlwaysGetsZeroRolls() throws MutableProperty.InvalidValueException {
+    void unitWithZeroPowerAlwaysGetsZeroRolls() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(0).setMaxAaAttacks(1);
@@ -1503,7 +1495,7 @@ class TotalPowerAndTotalRollsTest {
   class GetUnitPowerAndRollsForNormalBattles {
 
     @Test
-    void attackUnitWithNoSupport() throws MutableProperty.InvalidValueException {
+    void attackUnitWithNoSupport() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setAttack(1).setAttackRolls(1);
@@ -1526,7 +1518,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void defenseUnitWithNoSupport() throws MutableProperty.InvalidValueException {
+    void defenseUnitWithNoSupport() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setDefense(1).setDefenseRolls(1);
@@ -1601,7 +1593,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void attackBombardmentWithNoSupport() throws MutableProperty.InvalidValueException {
+    void attackBombardmentWithNoSupport() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setAttack(1).setAttackRolls(1).setBombard(3).setIsSea(true);
@@ -1625,7 +1617,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void defenseBombardmentWithNoSupport() throws MutableProperty.InvalidValueException {
+    void defenseBombardmentWithNoSupport() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setDefense(1).setDefenseRolls(1).setBombard(3).setIsSea(true);
@@ -1649,7 +1641,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void unitWithZeroRollsAlwaysGetsZeroPower() throws MutableProperty.InvalidValueException {
+    void unitWithZeroRollsAlwaysGetsZeroPower() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setAttack(1).setAttackRolls(0);
@@ -1672,7 +1664,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void unitWithZeroPowerAlwaysGetsZeroRolls() throws MutableProperty.InvalidValueException {
+    void unitWithZeroPowerAlwaysGetsZeroRolls() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setAttack(0).setAttackRolls(1);
@@ -2723,7 +2715,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void attackShouldNotHaveFirstTurnLimiting() throws MutableProperty.InvalidValueException {
+    void attackShouldNotHaveFirstTurnLimiting() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
 
       final Unit unit = givenUnit("test", gameData);
@@ -2764,7 +2756,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void defenseWithFirstTurnLimited() throws MutableProperty.InvalidValueException {
+    void defenseWithFirstTurnLimited() {
       final GamePlayer attacker = mock(GamePlayer.class);
       final RulesAttachment rulesAttachment = mock(RulesAttachment.class);
       when(rulesAttachment.getDominatingFirstRoundAttack()).thenReturn(true);
@@ -3157,7 +3149,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void rollIsMultipliedWithPower() throws MutableProperty.InvalidValueException {
+    void rollIsMultipliedWithPower() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setAttack(3).setAttackRolls(2);
@@ -3177,7 +3169,7 @@ class TotalPowerAndTotalRollsTest {
 
     @Test
     @DisplayName("If the power is more than the dice sides, then dice sides will be used")
-    void individualPowerIsLimitedToDiceSides() throws MutableProperty.InvalidValueException {
+    void individualPowerIsLimitedToDiceSides() {
       final GameData gameData = givenGameData().withDiceSides(6).build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setAttack(8).setAttackRolls(2);
@@ -3196,8 +3188,7 @@ class TotalPowerAndTotalRollsTest {
         final int rolls,
         final int diceSides,
         final int expectedPower,
-        final int expectedRolls)
-        throws MutableProperty.InvalidValueException {
+        final int expectedRolls) {
       final GameData gameData =
           givenGameData().withDiceSides(diceSides).withLhtrHeavyBombers(true).build();
 
@@ -3235,8 +3226,7 @@ class TotalPowerAndTotalRollsTest {
         final int rolls,
         final int diceSides,
         final int expectedPower,
-        final int expectedRolls)
-        throws MutableProperty.InvalidValueException {
+        final int expectedRolls) {
       final GameData gameData = givenGameData().withDiceSides(diceSides).build();
 
       final Unit unit = givenUnit("test", gameData);
@@ -3290,8 +3280,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void unitWithInfiniteRollsMeansAttacksEqualToTarget()
-        throws MutableProperty.InvalidValueException {
+    void unitWithInfiniteRollsMeansAttacksEqualToTarget() {
       final GameData gameData = givenGameData().build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(1).setMaxAaAttacks(-1);
@@ -3303,8 +3292,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void multipleUnitsWithInfiniteRollsMeansAttacksEqualToTarget()
-        throws MutableProperty.InvalidValueException {
+    void multipleUnitsWithInfiniteRollsMeansAttacksEqualToTarget() {
       final GameData gameData = givenGameData().build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(1).setMaxAaAttacks(-1);
@@ -3323,8 +3311,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void infiniteUnitAndNonInfiniteUnitMeansAttacksEqualsToTarget()
-        throws MutableProperty.InvalidValueException {
+    void infiniteUnitAndNonInfiniteUnitMeansAttacksEqualsToTarget() {
       final GameData gameData = givenGameData().build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(1).setMaxAaAttacks(-1);
@@ -3343,7 +3330,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void rollsOfNonInfiniteUnitEqualsAttack() throws MutableProperty.InvalidValueException {
+    void rollsOfNonInfiniteUnitEqualsAttack() {
       final GameData gameData = givenGameData().build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(1).setMaxAaAttacks(1);
@@ -3356,8 +3343,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void rollsOfNonInfiniteUnitGreaterThanTargetCountMeansAttackEqualsTarget()
-        throws MutableProperty.InvalidValueException {
+    void rollsOfNonInfiniteUnitGreaterThanTargetCountMeansAttackEqualsTarget() {
       final GameData gameData = givenGameData().build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(1).setMaxAaAttacks(2);
@@ -3376,8 +3362,7 @@ class TotalPowerAndTotalRollsTest {
     }
 
     @Test
-    void overstackUnitCanCauseAttackToGoOverTargetCount()
-        throws MutableProperty.InvalidValueException {
+    void overstackUnitCanCauseAttackToGoOverTargetCount() {
       final GameData gameData = givenGameData().build();
       final Unit overstackUnit = givenUnit("test", gameData);
       overstackUnit
@@ -3391,7 +3376,8 @@ class TotalPowerAndTotalRollsTest {
       unit2.getUnitAttachment().setOffensiveAttackAa(1).setMaxAaAttacks(-1);
 
       assertThat(
-          "Infinite gives total attacks equal to number of units (3) and the overstacked unit adds 2 more",
+          "Infinite gives total attacks equal to number of units (3)"
+              + " and the overstacked unit adds 2 more",
           TotalPowerAndTotalRolls.getTotalAaAttacks(
               Map.of(
                   overstackUnit,


### PR DESCRIPTION
This adds unittests.  The only non-test changes were to make the tests easier.  I created several constants for attributes and I made split two methods in TotalPowerAndTotalRolls so that I could pass in an easier object during tests.

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
