### PR TITLE
Simplify AvailableSupportCalculator api

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/UnitTypeList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitTypeList.java
@@ -19,6 +19,7 @@ public class UnitTypeList extends GameDataComponent implements Iterable<UnitType
   private final Map<String, UnitType> unitTypes = new LinkedHashMap<>();
   // Cached support rules. Marked transient as the cache does not need to be part of saved games.
   private transient @Nullable Set<UnitSupportAttachment> supportRules;
+  private transient @Nullable Set<UnitSupportAttachment> supportAaRules;
 
   public UnitTypeList(final GameData data) {
     super(data);
@@ -59,6 +60,21 @@ public class UnitTypeList extends GameDataComponent implements Iterable<UnitType
               .collect(Collectors.toSet());
     }
     return supportRules;
+  }
+
+  /**
+   * Returns the unit support rules for the unit types. Computed once and cached afterwards.
+   *
+   * @return The unit support rules.
+   */
+  public Set<UnitSupportAttachment> getSupportAaRules() {
+    if (supportAaRules == null) {
+      supportAaRules =
+          UnitSupportAttachment.get(getData()).stream()
+              .filter(usa -> (usa.getAaRoll() || usa.getAaStrength()))
+              .collect(Collectors.toSet());
+    }
+    return supportAaRules;
   }
 
   public int size() {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
@@ -283,7 +283,7 @@ public class ProPurchaseOption {
     units.addAll(unitsToPlace);
     units.addAll(unitType.create(1, player, true));
     final SupportCalculationResult supportCalculationResult =
-        AvailableSupportCalculator.getSortedSupport(
+        AvailableSupportCalculator.getSupport(
             units, data.getUnitTypeList().getSupportRules(), defense, true);
 
     final Set<List<UnitSupportAttachment>> supportsAvailable =

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AvailableSupportCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AvailableSupportCalculator.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.delegate.power.calculator;
 
-import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
@@ -14,27 +13,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 
 @UtilityClass
 public class AvailableSupportCalculator {
-  static SupportCalculationResult getSortedAaSupport(
-      final Collection<Unit> unitsGivingTheSupport,
-      final GameData data,
-      final boolean defence,
-      final boolean allies) {
-    final Set<UnitSupportAttachment> rules =
-        UnitSupportAttachment.get(data).parallelStream()
-            .filter(usa -> (usa.getAaRoll() || usa.getAaStrength()))
-            .collect(Collectors.toSet());
-    return getSortedSupport(unitsGivingTheSupport, rules, defence, allies);
-  }
 
   /** Sorts 'supportsAvailable' lists based on unit support attachment rules. */
-  public static SupportCalculationResult getSortedSupport(
+  static SupportCalculationResult getSortedSupport(
       final Collection<Unit> unitsGivingTheSupport,
       final Set<UnitSupportAttachment> rules,
       final boolean defence,
@@ -61,7 +48,7 @@ public class AvailableSupportCalculator {
    * @param defence are the receiving units defending?
    * @param allies are the receiving units allied to the giving units?
    */
-  private static SupportCalculationResult getSupport(
+  public static SupportCalculationResult getSupport(
       final Collection<Unit> unitsGivingTheSupport,
       final Set<UnitSupportAttachment> rules,
       final boolean defence,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRolls.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRolls.java
@@ -291,9 +291,9 @@ public class TotalPowerAndTotalRolls {
 
     // Get all friendly supports
     final SupportCalculationResult friendlySupports =
-        AvailableSupportCalculator.getSortedAaSupport(
+        AvailableSupportCalculator.getSortedSupport(
             allFriendlyUnitsAliveOrWaitingToDie, //
-            data,
+            data.getUnitTypeList().getSupportAaRules(),
             defending,
             true);
     final Set<List<UnitSupportAttachment>> supportRulesFriendly =
@@ -304,9 +304,9 @@ public class TotalPowerAndTotalRolls {
 
     // Get all enemy supports
     final SupportCalculationResult enemySupports =
-        AvailableSupportCalculator.getSortedAaSupport(
+        AvailableSupportCalculator.getSortedSupport(
             allEnemyUnitsAliveOrWaitingToDie, //
-            data,
+            data.getUnitTypeList().getSupportAaRules(),
             !defending,
             false);
 


### PR DESCRIPTION
This combines the `getSortedAaSupport` and `getSortedSupport` methods by moving the special logic in `getSortedAaSupport` to `UnitTypeList` similarly to how `getSortedSupport` works.

I also changed `ProPurchaseOption` to call `getSupport` instead of `getSortedSupport` because it isn't really using the sorted part.  It just loops through everything and doesn't "use" the support.  So sorting it doesn't really affect the calculations.  And I want to be able to rethink how the sorting works so this makes the sorting code internal to the power.calculator package.

## Testing
<!-- Describe any manual testing performed below. -->
Ran a hard ai game.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
