### PR TITLE
Re-add warning about save from a newer compatible version

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -95,27 +95,7 @@ public final class GameDataManager {
                 UrlConstants.DOWNLOAD_WEBSITE));
       } else if (!HeadlessGameServer.headless()
           && ((Version) version).isGreaterThan(ClientContext.engineVersion())) {
-        // we can still load it because our engine is compatible, however this save was made by a
-        // newer engine, so prompt the user to upgrade
-        final String messageString =
-            "Your TripleA engine is OUT OF DATE.  This save was made by a newer version of TripleA."
-                + "\nHowever, because the first version number is the same as your current version, we can "
-                + "still open the savegame."
-                + "\n\nThis TripleA engine is version "
-                + ClientContext.engineVersion().toString()
-                + " and you are trying to open a savegame made with version "
-                + ((Version) version).toString()
-                + "\n\nTo download the latest version of TripleA, Please visit "
-                + UrlConstants.DOWNLOAD_WEBSITE
-                + "\n\nIt is recommended that you upgrade to the latest version of TripleA before playing this "
-                + "savegame."
-                + "\n\nDo you wish to continue and open this save with your current 'old' version?";
-        final int answer =
-            JOptionPane.showConfirmDialog(
-                null, messageString, "Open Newer Save Game?", JOptionPane.YES_NO_OPTION);
-        if (answer != JOptionPane.YES_OPTION) {
-          throw new IOException("Loading the save game was aborted");
-        }
+        promptToLoadNewerSaveGame((Version) version);
       }
 
       final GameData data = (GameData) input.readObject();
@@ -124,6 +104,35 @@ public final class GameDataManager {
       return data;
     } catch (final ClassNotFoundException cnfe) {
       throw new IOException(cnfe.getMessage());
+    }
+  }
+
+  private static void promptToLoadNewerSaveGame(final Version version) throws IOException {
+    // we can still load it because our engine is compatible, however this save was made by a
+    // newer engine, so prompt the user to upgrade
+    // this is needed because a newer client might depend on variables that are part of the new
+    // save but will be stripped by the old client. When the old client re-saves the data, the
+    // new client will load the save game and be in odd state.
+    final String messageString =
+        "This save was made by a newer version of TripleA."
+            + "\nHowever, because the first version number is the same as your current version, "
+            + "we can still open the savegame. There is a possibility that if you save this game "
+            + "and then open it up in the version that created it, the game will be in an "
+            + "incorrect state."
+            + "\n\nThis TripleA engine is version "
+            + ClientContext.engineVersion().toString()
+            + " and you are trying to open a save game made with version "
+            + version.toString()
+            + "\n\nTo download the latest version of TripleA, Please visit "
+            + UrlConstants.DOWNLOAD_WEBSITE
+            + "\n\nIt is recommended that you upgrade to the latest version of TripleA before "
+            + "playing this save game."
+            + "\n\nDo you wish to continue and open this save with your current 'old' version?";
+    final int answer =
+        JOptionPane.showConfirmDialog(
+            null, messageString, "Open Newer Save Game?", JOptionPane.YES_NO_OPTION);
+    if (answer != JOptionPane.YES_OPTION) {
+      throw new IOException("Loading the save game was aborted");
     }
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -95,6 +95,8 @@ public final class GameDataManager {
                 UrlConstants.DOWNLOAD_WEBSITE));
       } else if (!HeadlessGameServer.headless()
           && ((Version) version).isGreaterThan(ClientContext.engineVersion())) {
+        // we can still load it because our engine is compatible, however this save was made by a
+        // newer engine, so prompt the user to upgrade
         promptToLoadNewerSaveGame((Version) version);
       }
 
@@ -108,26 +110,17 @@ public final class GameDataManager {
   }
 
   private static void promptToLoadNewerSaveGame(final Version version) throws IOException {
-    // we can still load it because our engine is compatible, however this save was made by a
-    // newer engine, so prompt the user to upgrade
     // this is needed because a newer client might depend on variables that are part of the new
     // save but will be stripped by the old client. When the old client re-saves the data, the
     // new client will load the save game and be in odd state.
     final String messageString =
         "This save was made by a newer version of TripleA."
-            + "\nHowever, because the first version number is the same as your current version, "
-            + "we can still open the savegame. There is a possibility that if you save this game "
-            + "and then open it up in the version that created it, the game will be in an "
-            + "incorrect state."
-            + "\n\nThis TripleA engine is version "
-            + ClientContext.engineVersion().toString()
-            + " and you are trying to open a save game made with version "
-            + version.toString()
-            + "\n\nTo download the latest version of TripleA, Please visit "
+            + "\nPlaying newer saves with an older engine can lead to unpredictable problems. "
+            + "It is recommended that you upgrade to the latest version of TripleA before playing "
+            + "this save game. To download the latest version of TripleA, Please visit "
             + UrlConstants.DOWNLOAD_WEBSITE
-            + "\n\nIt is recommended that you upgrade to the latest version of TripleA before "
-            + "playing this save game."
-            + "\n\nDo you wish to continue and open this save with your current 'old' version?";
+            + ".\n"
+            + "\n\nDo you wish to continue and open this save with your current 'old' version?;";
     final int answer =
         JOptionPane.showConfirmDialog(
             null, messageString, "Open Newer Save Game?", JOptionPane.YES_NO_OPTION);

--- a/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -97,7 +97,7 @@ public final class GameDataManager {
           && ((Version) version).isGreaterThan(ClientContext.engineVersion())) {
         // we can still load it because our engine is compatible, however this save was made by a
         // newer engine, so prompt the user to upgrade
-        promptToLoadNewerSaveGame((Version) version);
+        promptToLoadNewerSaveGame();
       }
 
       final GameData data = (GameData) input.readObject();
@@ -109,7 +109,7 @@ public final class GameDataManager {
     }
   }
 
-  private static void promptToLoadNewerSaveGame(final Version version) throws IOException {
+  private static void promptToLoadNewerSaveGame() throws IOException {
     // this is needed because a newer client might depend on variables that are part of the new
     // save but will be stripped by the old client. When the old client re-saves the data, the
     // new client will load the save game and be in odd state.


### PR DESCRIPTION
This was removed in 030cb1f because
of a swing deadlock issue and was also considered to be redundant.

It is needed because newer compatible versions might use new saved data
to add or change functionality. When an older version opens the saved
game, the new saved data will be removed and the functionality might end
up broken.

## Testing
<!-- Describe any manual testing performed below. -->
I changed the version of my build to 2.1 and then tried to load a saved game.  The warning showed up.  Clicking "Yes" allowed the game to be loaded.  Clicking "No" stopped the loading of the game.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->
<img width="846" alt="Screen Shot 2020-10-10 at 10 35 05 AM" src="https://user-images.githubusercontent.com/2044248/95660326-53390880-0ae4-11eb-965b-9e4bf16439f1.png">

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE-->CHANGE|Opening a save game from a newer version will warn that the versions are mismatched<!--END_RELEASE_NOTE-->
