### PR TITLE
Roll dice step

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleStepStrings.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleStepStrings.java
@@ -4,6 +4,7 @@ package games.strategy.triplea.delegate.battle;
 public interface BattleStepStrings {
 
   String AA_GUNS_FIRE_SUFFIX = " fire";
+  String FIRE_SUFFIX = " fire";
   String SELECT_PREFIX = " select ";
   String REMOVE_PREFIX = " remove ";
   String CASUALTIES_SUFFIX = " casualties";

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleStep.java
@@ -75,6 +75,9 @@ public interface BattleStep extends IExecutable {
     OFFENSIVE_GENERAL_RETREAT,
     STALEMATE_BATTLE_END_CHECK,
     SUB_DEFENSIVE_RETREAT_AFTER_BATTLE,
+
+    // Fire Round steps
+    ROLL_DICE,
   }
 
   /** @return a list of names that will be shown in {@link games.strategy.triplea.ui.BattlePanel} */

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleStep.java
@@ -76,8 +76,7 @@ public interface BattleStep extends IExecutable {
     STALEMATE_BATTLE_END_CHECK,
     SUB_DEFENSIVE_RETREAT_AFTER_BATTLE,
 
-    // Fire Round steps
-    ROLL_DICE,
+    FIRE_ROUND_ROLL_DICE,
   }
 
   /** @return a list of names that will be shown in {@link games.strategy.triplea.ui.BattlePanel} */

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/RollDice.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/RollDice.java
@@ -38,20 +38,24 @@ public class RollDice implements BattleStep {
 
   private String getName() {
     return battleState.getPlayer(side).getName()
-        // displaying UNITS makes the text feel redundant so hide it if that is the group name
+        // If the firing group's name is the default "UNITS", then the displayed string will be
+        // "Germans units fire". In that case, it would be better to say "Germans fire".
+        // If the firing group's name is something else, then the displayed string will be
+        // something like "Germans submarines fire" which is ok.
         + (firingGroup.getDisplayName().equals(UNITS) ? "" : " " + firingGroup.getDisplayName())
         + FIRE_SUFFIX;
   }
 
   @Override
   public Order getOrder() {
-    return Order.ROLL_DICE;
+    return Order.FIRE_ROUND_ROLL_DICE;
   }
 
   @Override
   public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
 
-    // remove any target unit that was hit by other units
+    // retain the targets that are still alive since the targets might have been shot
+    // in an earlier firing round
     firingGroup.retainAliveTargets(battleState.filterUnits(ALIVE, side.getOpposite()));
 
     final DiceRoll dice = rollDice.apply(bridge, this);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/RollDice.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/RollDice.java
@@ -1,0 +1,61 @@
+package games.strategy.triplea.delegate.battle.steps.fire;
+
+import static games.strategy.triplea.delegate.battle.BattleState.UnitBattleFilter.ALIVE;
+import static games.strategy.triplea.delegate.battle.BattleStepStrings.FIRE_SUFFIX;
+import static games.strategy.triplea.delegate.battle.BattleStepStrings.UNITS;
+
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.delegate.DiceRoll;
+import games.strategy.triplea.delegate.ExecutionStack;
+import games.strategy.triplea.delegate.battle.BattleState;
+import games.strategy.triplea.delegate.battle.steps.BattleStep;
+import java.util.List;
+import java.util.function.BiFunction;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/** Step where the dice are rolled for the firing units */
+@RequiredArgsConstructor
+public class RollDice implements BattleStep {
+
+  private static final long serialVersionUID = 3248059314449726590L;
+
+  @Getter private final BattleState battleState;
+
+  /** The side of the firing player */
+  @Getter private final BattleState.Side side;
+
+  @Getter private final FiringGroup firingGroup;
+
+  private final FireRoundState fireRoundState;
+
+  private final BiFunction<IDelegateBridge, RollDice, DiceRoll> rollDice;
+
+  @Override
+  public List<String> getNames() {
+    return List.of(getName());
+  }
+
+  private String getName() {
+    return battleState.getPlayer(side).getName()
+        // displaying UNITS makes the text feel redundant so hide it if that is the group name
+        + (firingGroup.getDisplayName().equals(UNITS) ? "" : " " + firingGroup.getDisplayName())
+        + FIRE_SUFFIX;
+  }
+
+  @Override
+  public Order getOrder() {
+    return Order.ROLL_DICE;
+  }
+
+  @Override
+  public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+
+    // remove any target unit that was hit by other units
+    firingGroup.retainAliveTargets(battleState.filterUnits(ALIVE, side.getOpposite()));
+
+    final DiceRoll dice = rollDice.apply(bridge, this);
+
+    fireRoundState.setDice(dice);
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/RollMainDice.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/RollMainDice.java
@@ -8,7 +8,7 @@ import games.strategy.triplea.delegate.DiceRoll;
 import java.util.function.BiFunction;
 
 /** Rolls dice for normal (basically, anything that isn't AA) dice requests */
-public class RollNormal implements BiFunction<IDelegateBridge, RollDice, DiceRoll> {
+public class RollMainDice implements BiFunction<IDelegateBridge, RollDice, DiceRoll> {
 
   @Override
   public DiceRoll apply(final IDelegateBridge bridge, final RollDice step) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/RollNormal.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/RollNormal.java
@@ -1,0 +1,30 @@
+package games.strategy.triplea.delegate.battle.steps.fire;
+
+import static games.strategy.triplea.delegate.battle.BattleState.Side.DEFENSE;
+import static games.strategy.triplea.delegate.battle.BattleState.UnitBattleFilter.ACTIVE;
+
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.delegate.DiceRoll;
+import java.util.function.BiFunction;
+
+/** Rolls dice for normal (basically, anything that isn't AA) dice requests */
+public class RollNormal implements BiFunction<IDelegateBridge, RollDice, DiceRoll> {
+
+  @Override
+  public DiceRoll apply(final IDelegateBridge bridge, final RollDice step) {
+    return DiceRoll.rollDice(
+        step.getFiringGroup().getFiringUnits(),
+        step.getSide() == DEFENSE,
+        step.getBattleState().getPlayer(step.getSide()),
+        bridge,
+        step.getBattleState().getBattleSite(),
+        DiceRoll.getAnnotation(
+            step.getFiringGroup().getFiringUnits(),
+            step.getBattleState().getPlayer(step.getSide()),
+            step.getBattleState().getBattleSite(),
+            step.getBattleState().getStatus().getRound()),
+        step.getBattleState().getTerritoryEffects(),
+        step.getBattleState().filterUnits(ACTIVE, step.getSide().getOpposite()),
+        step.getBattleState().filterUnits(ACTIVE, step.getSide()));
+  }
+}


### PR DESCRIPTION
This is a part of #7823. 

During the firing part of the battle, there are three steps that are performed (you can see the originals in `Fire` and `FireAa`).  This is the step that rolls the dice.  There are two different ways to roll dice: AA and Normal.  So, I moved that logic into `BiFunction`s that are passed into this object.  `RollNormal` is the normal version.  And `AaFireAndCasualtyStep.RollAa` is the Aa version.


## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
