### PR TITLE
Move map validation outside of game parsing

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
@@ -203,13 +203,6 @@ public final class GameParser {
     // and parse all game options/properties)
     TechAbilityAttachment.setDefaultTechnologyAttachments(data);
 
-    final List<String> validationErrors = new GameParsingValidation(data).validate();
-    if (!validationErrors.isEmpty()) {
-      throw new GameParseException(
-          String.format(
-              "map name: '%s', validation failed: %s",
-              mapName, String.join("\n", validationErrors)));
-    }
     return data;
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
@@ -4,6 +4,7 @@ import com.google.common.base.Preconditions;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.gameparser.GameParser;
+import games.strategy.engine.data.gameparser.GameParsingValidation;
 import games.strategy.engine.data.gameparser.XmlGameElementMapper;
 import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.startup.mc.ClientModel;
@@ -12,17 +13,20 @@ import games.strategy.triplea.ai.pro.ProAi;
 import games.strategy.triplea.settings.ClientSetting;
 import java.io.File;
 import java.net.URI;
+import java.util.List;
 import java.util.Observable;
 import java.util.Optional;
 import java.util.function.Function;
 import javax.annotation.Nullable;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Model class that tracks the currently 'selected' game. This is the info that appears in the game
  * selector panel on the staging screens, eg: map, round, filename.
  */
+@Slf4j
 public class GameSelectorModel extends Observable implements GameSelector {
 
   private final Function<URI, Optional<GameData>> gameParser;
@@ -51,7 +55,7 @@ public class GameSelectorModel extends Observable implements GameSelector {
 
   public void load(final URI uri) {
     fileName = null;
-    this.gameData = gameParser.apply(uri).orElse(null);
+    this.gameData = parseAndValidate(uri);
     if (gameData == null || gameData.getGameName() == null || uri == null) {
       ClientSetting.defaultGameName.resetValue();
       ClientSetting.defaultGameUri.resetValue();
@@ -64,6 +68,25 @@ public class GameSelectorModel extends Observable implements GameSelector {
       ClientSetting.defaultGameUri.setValue(uri.toString());
     }
     ClientSetting.flush();
+  }
+
+  @Nullable
+  private GameData parseAndValidate(final URI uri) {
+    final GameData gameData = gameParser.apply(uri).orElse(null);
+    if (gameData == null) {
+      return null;
+    }
+    final List<String> validationErrors = new GameParsingValidation(gameData).validate();
+
+    if (validationErrors.isEmpty()) {
+      return gameData;
+    } else {
+      log.error(
+          "Validation errors parsing map: {}, errors:\n{}",
+          uri,
+          String.join("\n", validationErrors));
+      return null;
+    }
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
@@ -53,6 +53,29 @@ public class GameSelectorModel extends Observable implements GameSelector {
     this.gameParser = gameParser;
   }
 
+  /**
+   * Loads game data by parsing a given file.
+   *
+   * @throws Exception If file parsing is successful and an internal {@code GameData} was set.
+   */
+  public void load(final File file) throws Exception {
+    Preconditions.checkArgument(
+        file.exists(),
+        "Programming error, expected file to have already been checked to exist: "
+            + file.getAbsolutePath());
+
+    // if the file name is xml, load it as a new game
+    if (file.getName().toLowerCase().endsWith("xml")) {
+      load(file.toURI());
+    } else {
+      // try to load it as a saved game whatever the extension
+      final GameData newData = GameDataManager.loadGame(file);
+      newData.setSaveGameFileName(file.getName());
+      this.fileName = file.getName();
+      setGameData(newData);
+    }
+  }
+
   public void load(final URI uri) {
     fileName = null;
     this.gameData = parseAndValidate(uri);
@@ -86,29 +109,6 @@ public class GameSelectorModel extends Observable implements GameSelector {
           uri,
           String.join("\n", validationErrors));
       return null;
-    }
-  }
-
-  /**
-   * Loads game data by parsing a given file.
-   *
-   * @throws Exception If file parsing is successful and an internal {@code GameData} was set.
-   */
-  public void load(final File file) throws Exception {
-    Preconditions.checkArgument(
-        file.exists(),
-        "Programming error, expected file to have already been checked to exist: "
-            + file.getAbsolutePath());
-
-    // if the file name is xml, load it as a new game
-    if (file.getName().toLowerCase().endsWith("xml")) {
-      load(file.toURI());
-    } else {
-      // try to load it as a saved game whatever the extension
-      final GameData newData = GameDataManager.loadGame(file);
-      newData.setSaveGameFileName(file.getName());
-      this.fileName = file.getName();
-      setGameData(newData);
     }
   }
 

--- a/game-core/src/test/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModelTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModelTest.java
@@ -13,9 +13,7 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameSequence;
 import games.strategy.engine.framework.startup.mc.ClientModel;
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
-import java.net.URI;
 import java.util.Observer;
-import java.util.Optional;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -119,18 +117,6 @@ class GameSelectorModelTest extends AbstractClientSettingTestCase {
     assertThat(testObj.getGameName(), is(newGameName));
     assertThat(testObj.getGameRound(), is(newGameRound));
     assertThat(testObj.getGameVersion(), is(newGameVersion));
-  }
-
-  @Test
-  void testLoadFromNewGameChooserEntry() throws Exception {
-    prepareMockGameDataExpectations();
-    testObj = new GameSelectorModel(uri -> Optional.of(mockGameData));
-
-    testObj.load(new URI("abc"));
-
-    assertThat(testObj.getFileName(), is("-"));
-    assertThat(testObj.getGameData(), sameInstance(mockGameData));
-    assertHasFakeTestData(testObj);
   }
 
   @Test


### PR DESCRIPTION
Rather than having game parsing and validation be done in the same step,
this move extracts the validation to the caller of game parsing so that
they are done as separate steps.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/wiki/PR-Release-Notes
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
