### PR TITLE
Allow AA to target all infrastructure

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -1753,8 +1753,10 @@ public class UnitAttachment extends DefaultAttachment {
     isInfrastructure = getBool(s);
   }
 
-  private void setIsInfrastructure(final Boolean s) {
+  @VisibleForTesting
+  public UnitAttachment setIsInfrastructure(final Boolean s) {
     isInfrastructure = s;
+    return this;
   }
 
   public boolean getIsInfrastructure() {
@@ -2298,8 +2300,10 @@ public class UnitAttachment extends DefaultAttachment {
     maxRoundsAa = getInt(s);
   }
 
-  private void setMaxRoundsAa(final Integer s) {
+  @VisibleForTesting
+  public UnitAttachment setMaxRoundsAa(final Integer s) {
     maxRoundsAa = s;
+    return this;
   }
 
   public int getMaxRoundsAa() {
@@ -2348,8 +2352,10 @@ public class UnitAttachment extends DefaultAttachment {
     isAaForCombatOnly = getBool(s);
   }
 
-  private void setIsAaForCombatOnly(final Boolean s) {
+  @VisibleForTesting
+  public UnitAttachment setIsAaForCombatOnly(final Boolean s) {
     isAaForCombatOnly = s;
+    return this;
   }
 
   public boolean getIsAaForCombatOnly() {
@@ -2448,8 +2454,10 @@ public class UnitAttachment extends DefaultAttachment {
     }
   }
 
-  private void setTargetsAa(final Set<UnitType> value) {
+  @VisibleForTesting
+  public UnitAttachment setTargetsAa(final Set<UnitType> value) {
     targetsAa = value;
+    return this;
   }
 
   private Set<UnitType> getTargetsAa() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -653,7 +653,7 @@ public final class Matches {
   }
 
   /** Checks if the unit type can be hit with AA fire by one of the firingUnits */
-  private static Predicate<UnitType> unitTypeCanByHitByAaFire(
+  private static Predicate<UnitType> unitTypeCanBeHitByAaFire(
       final Collection<UnitType> firingUnits, final GameData gameData, final int battleRound) {
     // make sure the aa firing units are valid for combat and during this round
     final Collection<UnitType> aaFiringUnits =
@@ -2345,15 +2345,14 @@ public final class Matches {
       final boolean doNotIncludeBombardingSeaUnits,
       final Collection<UnitType> firingUnits) {
 
+    // remove infrastructure units unless it can support or fight
+    // or it is AA that can fire this round
+    // or it can be shot at by AA
     final PredicateBuilder<UnitType> canBeInBattleBuilder =
-        // remove infrastructure units
         PredicateBuilder.of(unitTypeIsInfrastructure().negate())
-            // unless it can support or fight
             .or(unitTypeIsSupporterOrHasCombatAbility(attack, player))
-            // or it is AA that can fire this round
             .or(unitTypeIsAaForCombatOnly().and(unitTypeIsAaThatCanFireOnRound(battleRound)))
-            // or it can be shot at by AA
-            .or(unitTypeCanByHitByAaFire(firingUnits, player.getData(), battleRound));
+            .or(unitTypeCanBeHitByAaFire(firingUnits, player.getData(), battleRound));
 
     if (attack) {
       if (!includeAttackersThatCanNotMove) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -652,6 +652,23 @@ public final class Matches {
     };
   }
 
+  /** Checks if the unit type can be hit with AA fire by one of the firingUnits */
+  private static Predicate<UnitType> unitTypeCanByHitByAaFire(
+      final Collection<UnitType> firingUnits, final GameData gameData, final int battleRound) {
+    // make sure the aa firing units are valid for combat and during this round
+    final Collection<UnitType> aaFiringUnits =
+        CollectionUtils.getMatches(
+            firingUnits,
+            unitTypeIsAaForCombatOnly().and(unitTypeIsAaThatCanFireOnRound(battleRound)));
+    return unitType ->
+        aaFiringUnits.stream()
+            .anyMatch(
+                type -> {
+                  final UnitAttachment attachment = UnitAttachment.get(type);
+                  return attachment.getTargetsAa(gameData).contains(unitType);
+                });
+  }
+
   public static Predicate<Unit> unitIsAaOfTypeAa(final String typeAa) {
     return obj -> UnitAttachment.get(obj.getType()).getTypeAa().matches(typeAa);
   }
@@ -2287,7 +2304,17 @@ public final class Matches {
       final int battleRound,
       final boolean doNotIncludeBombardingSeaUnits) {
     return unitCanBeInBattle(
-        attack, isLandBattle, battleRound, true, doNotIncludeBombardingSeaUnits);
+        attack, isLandBattle, battleRound, doNotIncludeBombardingSeaUnits, List.of());
+  }
+
+  public static Predicate<Unit> unitCanBeInBattle(
+      final boolean attack,
+      final boolean isLandBattle,
+      final int battleRound,
+      final boolean doNotIncludeBombardingSeaUnits,
+      final Collection<UnitType> firingUnits) {
+    return unitCanBeInBattle(
+        attack, isLandBattle, battleRound, true, doNotIncludeBombardingSeaUnits, firingUnits);
   }
 
   public static Predicate<Unit> unitCanBeInBattle(
@@ -2295,7 +2322,8 @@ public final class Matches {
       final boolean isLandBattle,
       final int battleRound,
       final boolean includeAttackersThatCanNotMove,
-      final boolean doNotIncludeBombardingSeaUnits) {
+      final boolean doNotIncludeBombardingSeaUnits,
+      final Collection<UnitType> firingUnits) {
     return unit ->
         unitTypeCanBeInBattle(
                 attack,
@@ -2303,7 +2331,8 @@ public final class Matches {
                 unit.getOwner(),
                 battleRound,
                 includeAttackersThatCanNotMove,
-                doNotIncludeBombardingSeaUnits)
+                doNotIncludeBombardingSeaUnits,
+                firingUnits)
             .test(unit.getType());
   }
 
@@ -2313,14 +2342,18 @@ public final class Matches {
       final GamePlayer player,
       final int battleRound,
       final boolean includeAttackersThatCanNotMove,
-      final boolean doNotIncludeBombardingSeaUnits) {
+      final boolean doNotIncludeBombardingSeaUnits,
+      final Collection<UnitType> firingUnits) {
 
-    // Filter out anything like factories, or units that have no combat ability AND cannot be taken
-    // casualty
     final PredicateBuilder<UnitType> canBeInBattleBuilder =
+        // remove infrastructure units
         PredicateBuilder.of(unitTypeIsInfrastructure().negate())
+            // unless it can support or fight
             .or(unitTypeIsSupporterOrHasCombatAbility(attack, player))
-            .or(unitTypeIsAaForCombatOnly().and(unitTypeIsAaThatCanFireOnRound(battleRound)));
+            // or it is AA that can fire this round
+            .or(unitTypeIsAaForCombatOnly().and(unitTypeIsAaThatCanFireOnRound(battleRound)))
+            // or it can be shot at by AA
+            .or(unitTypeCanByHitByAaFire(firingUnits, player.getData(), battleRound));
 
     if (attack) {
       if (!includeAttackersThatCanNotMove) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/FireAa.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/FireAa.java
@@ -78,9 +78,7 @@ public class FireAa implements IExecutable {
       final List<Unit> allEnemyUnitsAliveOrWaitingToDie,
       final List<String> aaTypes) {
     this.attackableUnits =
-        CollectionUtils.getMatches(
-            attackableUnits,
-            Matches.unitIsNotInfrastructure().and(Matches.unitIsBeingTransported().negate()));
+        CollectionUtils.getMatches(attackableUnits, Matches.unitIsBeingTransported().negate());
     this.firingUnits = firingUnits;
     this.battle = battle;
     this.hitPlayer = hitPlayer;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -774,8 +774,8 @@ public class MustFightBattle extends DependentBattle
           battleId,
           battleSite,
           getBattleTitle(),
-          removeNonCombatants(attackingUnits, true, false),
-          removeNonCombatants(defendingUnits, false, false),
+          removeNonCombatants(attackingUnits, defendingUnits, true, false),
+          removeNonCombatants(defendingUnits, attackingUnits, false, false),
           killed,
           attackingWaitingToDie,
           defendingWaitingToDie,
@@ -811,8 +811,8 @@ public class MustFightBattle extends DependentBattle
         battleId,
         battleSite,
         getBattleTitle(),
-        removeNonCombatants(attackingUnits, true, false),
-        removeNonCombatants(defendingUnits, false, false),
+        removeNonCombatants(attackingUnits, defendingUnits, true, false),
+        removeNonCombatants(defendingUnits, attackingUnits, false, false),
         killed,
         attackingWaitingToDie,
         defendingWaitingToDie,
@@ -1572,8 +1572,10 @@ public class MustFightBattle extends DependentBattle
 
   @Override
   public void removeNonCombatants(final IDelegateBridge bridge) {
-    final List<Unit> notRemovedDefending = removeNonCombatants(defendingUnits, false, true);
-    final List<Unit> notRemovedAttacking = removeNonCombatants(attackingUnits, true, true);
+    final List<Unit> notRemovedDefending =
+        removeNonCombatants(defendingUnits, attackingUnits, false, true);
+    final List<Unit> notRemovedAttacking =
+        removeNonCombatants(attackingUnits, defendingUnits, true, true);
     final Collection<Unit> toRemoveDefending =
         CollectionUtils.difference(defendingUnits, notRemovedDefending);
     final Collection<Unit> toRemoveAttacking =
@@ -1601,7 +1603,10 @@ public class MustFightBattle extends DependentBattle
    *     as factories, aa guns, land units in a water battle.
    */
   private List<Unit> removeNonCombatants(
-      final Collection<Unit> units, final boolean attacking, final boolean removeForNextRound) {
+      final Collection<Unit> units,
+      final Collection<Unit> enemyUnits,
+      final boolean attacking,
+      final boolean removeForNextRound) {
     final List<Unit> unitList = new ArrayList<>(units);
     if (battleSite.isWater()) {
       unitList.removeAll(CollectionUtils.getMatches(unitList, Matches.unitIsLand()));
@@ -1615,7 +1620,8 @@ public class MustFightBattle extends DependentBattle
                     attacking,
                     !battleSite.isWater(),
                     (removeForNextRound ? round + 1 : round),
-                    false)
+                    false,
+                    enemyUnits.stream().map(Unit::getType).collect(Collectors.toSet()))
                 .negate()));
     // remove capturableOnEntering units (veqryn)
     unitList.removeAll(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/FiringGroupSplitterAa.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/FiringGroupSplitterAa.java
@@ -62,7 +62,7 @@ public class FiringGroupSplitterAa implements Function<BattleState, List<FiringG
     final Collection<Unit> validTargetUnits =
         CollectionUtils.getMatches(
             battleState.filterUnits(ALIVE, side.getOpposite()),
-            Matches.unitIsNotInfrastructure().and(Matches.unitIsBeingTransported().negate()));
+            Matches.unitIsBeingTransported().negate());
 
     final List<FiringGroup> firingGroups = new ArrayList<>();
     // go through each of the typeAas in the game and find any units in validTargetUnits

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -1021,7 +1021,7 @@ class BattleCalculatorPanel extends JPanel {
                   Matches.unitIsOwnedBy(getDefender())
                       .and(
                           Matches.unitCanBeInBattle(
-                              true, isLand(), 1, hasMaxRounds(isLand(), data), true)));
+                              true, isLand(), 1, hasMaxRounds(isLand(), data), true, List.of())));
           final List<Unit> newDefenders =
               CollectionUtils.getMatches(
                   attackingUnitsPanel.getUnits(),
@@ -1336,7 +1336,8 @@ class BattleCalculatorPanel extends JPanel {
         getAttacker(),
         CollectionUtils.getMatches(
             units,
-            Matches.unitCanBeInBattle(true, isLand(), 1, hasMaxRounds(isLand(), data), false)),
+            Matches.unitCanBeInBattle(
+                true, isLand(), 1, hasMaxRounds(isLand(), data), false, List.of())),
         isLand());
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/PlayerUnitsPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/PlayerUnitsPanel.java
@@ -226,7 +226,8 @@ public class PlayerUnitsPanel extends JPanel {
                 player,
                 1,
                 BattleCalculatorPanel.hasMaxRounds(isLand, data),
-                false));
+                false,
+                List.of()));
 
     return unitTypes;
   }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MatchesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MatchesTest.java
@@ -16,7 +16,6 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
-import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
@@ -371,8 +370,7 @@ final class MatchesTest {
           new UnitAttachment("infrastructure", unitType, gameData);
       unitAttachment.setIsInfrastructure(true);
       final UnitSupportAttachment unitSupportAttachment =
-          new UnitSupportAttachment(
-              Constants.SUPPORT_ATTACHMENT_PREFIX + "support", unitType, gameData);
+          new UnitSupportAttachment(SUPPORT_ATTACHMENT_PREFIX + "support", unitType, gameData);
       unitType.addAttachment(UNIT_ATTACHMENT_NAME, unitAttachment);
       unitType.addAttachment(SUPPORT_ATTACHMENT_PREFIX, unitSupportAttachment);
       final Unit unit = unitType.create(1, player, true).get(0);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MatchesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MatchesTest.java
@@ -1,19 +1,28 @@
 package games.strategy.triplea.delegate;
 
+import static games.strategy.triplea.Constants.SUPPORT_ATTACHMENT_PREFIX;
+import static games.strategy.triplea.Constants.UNIT_ATTACHMENT_NAME;
+import static games.strategy.triplea.delegate.battle.steps.MockGameData.givenGameData;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.when;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.TerritoryAttachment;
+import games.strategy.triplea.attachments.UnitAttachment;
+import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Predicate;
 import javax.annotation.Nullable;
 import org.hamcrest.Description;
@@ -22,7 +31,11 @@ import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 final class MatchesTest {
   private static final Object VALUE = new Object();
 
@@ -252,6 +265,182 @@ final class MatchesTest {
       TerritoryAttachment.remove(seaTerritory);
 
       assertThat(newMatch(), notMatches(seaTerritory));
+    }
+  }
+
+  @Nested
+  @ExtendWith(MockitoExtension.class)
+  final class UnitCanBeInBattle {
+
+    @Mock GamePlayer player;
+    GameData gameData;
+
+    @BeforeEach
+    void setupGameData() {
+      gameData = givenGameData().build();
+    }
+
+    @Test
+    void infrastructureShouldNormallyNotBeInBattle() {
+      when(gameData.getDiceSides()).thenReturn(6);
+      final UnitType unitType = new UnitType("infrastructure", gameData);
+      final UnitAttachment unitAttachment =
+          new UnitAttachment("infrastructure", unitType, gameData);
+      unitAttachment.setIsInfrastructure(true);
+      unitType.addAttachment(UNIT_ATTACHMENT_NAME, unitAttachment);
+      final Unit unit = unitType.create(1, player, true).get(0);
+
+      assertThat(
+          "An infrastructure unit normally can not be in battle",
+          Matches.unitCanBeInBattle(true, true, 1, false, List.of()).test(unit),
+          is(false));
+    }
+
+    @Test
+    void infrastructureWithAttackCanBeInBattleWhenAttacking() {
+      when(gameData.getDiceSides()).thenReturn(6);
+      final UnitType unitType = new UnitType("infrastructure", gameData);
+      final UnitAttachment unitAttachment =
+          new UnitAttachment("infrastructure", unitType, gameData);
+      unitAttachment.setIsInfrastructure(true);
+      unitAttachment.setAttack(1);
+      unitType.addAttachment(UNIT_ATTACHMENT_NAME, unitAttachment);
+      final Unit unit = unitType.create(1, player, true).get(0);
+
+      assertThat(
+          "An infrastructure unit with attack can be in battle when it is attacking",
+          Matches.unitCanBeInBattle(true, true, 1, false, List.of()).test(unit),
+          is(true));
+    }
+
+    @Test
+    void infrastructureWithAttackCanNotBeInBattleWhenDefending() {
+      when(gameData.getDiceSides()).thenReturn(6);
+      final UnitType unitType = new UnitType("infrastructure", gameData);
+      final UnitAttachment unitAttachment =
+          new UnitAttachment("infrastructure", unitType, gameData);
+      unitAttachment.setIsInfrastructure(true);
+      unitAttachment.setAttack(1);
+      unitType.addAttachment(UNIT_ATTACHMENT_NAME, unitAttachment);
+      final Unit unit = unitType.create(1, player, true).get(0);
+
+      assertThat(
+          "An infrastructure unit with attack can not be in battle when it is attacking",
+          Matches.unitCanBeInBattle(false, true, 1, false, List.of()).test(unit),
+          is(false));
+    }
+
+    @Test
+    void infrastructureWithDefenseCanBeInBattleWhenDefending() {
+      when(gameData.getDiceSides()).thenReturn(6);
+      final UnitType unitType = new UnitType("infrastructure", gameData);
+      final UnitAttachment unitAttachment =
+          new UnitAttachment("infrastructure", unitType, gameData);
+      unitAttachment.setIsInfrastructure(true);
+      unitAttachment.setDefense(1);
+      unitType.addAttachment(UNIT_ATTACHMENT_NAME, unitAttachment);
+      final Unit unit = unitType.create(1, player, true).get(0);
+
+      assertThat(
+          "An infrastructure unit with defense can be in battle when it is defending",
+          Matches.unitCanBeInBattle(false, true, 1, false, List.of()).test(unit),
+          is(true));
+    }
+
+    @Test
+    void infrastructureWithDefenseCanNotBeInBattleWhenAttacking() {
+      when(gameData.getDiceSides()).thenReturn(6);
+      final UnitType unitType = new UnitType("infrastructure", gameData);
+      final UnitAttachment unitAttachment =
+          new UnitAttachment("infrastructure", unitType, gameData);
+      unitAttachment.setIsInfrastructure(true);
+      unitAttachment.setDefense(1);
+      unitType.addAttachment(UNIT_ATTACHMENT_NAME, unitAttachment);
+      final Unit unit = unitType.create(1, player, true).get(0);
+
+      assertThat(
+          "An infrastructure unit with defense can not be in battle when it is attacking",
+          Matches.unitCanBeInBattle(true, true, 1, false, List.of()).test(unit),
+          is(false));
+    }
+
+    @Test
+    void infrastructureThatGivesAnyTypeOfSupportCanBeInBattle() {
+      final UnitType unitType = new UnitType("infrastructure", gameData);
+      final UnitAttachment unitAttachment =
+          new UnitAttachment("infrastructure", unitType, gameData);
+      unitAttachment.setIsInfrastructure(true);
+      final UnitSupportAttachment unitSupportAttachment =
+          new UnitSupportAttachment(
+              Constants.SUPPORT_ATTACHMENT_PREFIX + "support", unitType, gameData);
+      unitType.addAttachment(UNIT_ATTACHMENT_NAME, unitAttachment);
+      unitType.addAttachment(SUPPORT_ATTACHMENT_PREFIX, unitSupportAttachment);
+      final Unit unit = unitType.create(1, player, true).get(0);
+
+      assertThat(
+          "An infrastructure unit that gives some support can be in battle",
+          Matches.unitCanBeInBattle(true, true, 1, false, List.of()).test(unit),
+          is(true));
+    }
+
+    @Test
+    void infrastructureThatIsAaForCombatCanBeInBattleAndCanFireCanBeInTheBattle() {
+      final UnitType unitType = new UnitType("infrastructure", gameData);
+      final UnitAttachment unitAttachment =
+          new UnitAttachment("infrastructure", unitType, gameData);
+      unitAttachment.setIsInfrastructure(true);
+      unitAttachment.setIsAaForCombatOnly(true);
+      unitAttachment.setMaxRoundsAa(1);
+      unitType.addAttachment(UNIT_ATTACHMENT_NAME, unitAttachment);
+      final Unit unit = unitType.create(1, player, true).get(0);
+
+      assertThat(
+          "An infrastructure unit that is combat AA and can fire in the round can be "
+              + "in battle",
+          Matches.unitCanBeInBattle(true, true, 1, false, List.of()).test(unit),
+          is(true));
+    }
+
+    @Test
+    void infrastructureThatIsAaForCombatCanBeInBattleAndCanNotFireCanNotBeInTheBattle() {
+      final UnitType unitType = new UnitType("infrastructure", gameData);
+      final UnitAttachment unitAttachment =
+          new UnitAttachment("infrastructure", unitType, gameData);
+      unitAttachment.setIsInfrastructure(true);
+      unitAttachment.setIsAaForCombatOnly(true);
+      unitAttachment.setMaxRoundsAa(1);
+      unitType.addAttachment(UNIT_ATTACHMENT_NAME, unitAttachment);
+      final Unit unit = unitType.create(1, player, true).get(0);
+
+      assertThat(
+          "An infrastructure unit that is combat AA but can only fire in round 1 and "
+              + "it is round 2 can not be in battle",
+          Matches.unitCanBeInBattle(true, true, 2, false, List.of()).test(unit),
+          is(false));
+    }
+
+    @Test
+    void infrastructureThatIsAnAaTargetCanBeInBattle() {
+      final UnitType unitType = new UnitType("infrastructure", gameData);
+      final UnitAttachment unitAttachment =
+          new UnitAttachment("infrastructure", unitType, gameData);
+      unitAttachment.setIsInfrastructure(true);
+      unitType.addAttachment(UNIT_ATTACHMENT_NAME, unitAttachment);
+      final Unit unit = unitType.create(1, player, true).get(0);
+
+      final UnitType firingUnitType = new UnitType("firingAa", gameData);
+      final UnitAttachment firingUnitAttachment =
+          new UnitAttachment("firingAa", firingUnitType, gameData);
+      firingUnitAttachment.setTargetsAa(Set.of(unitType));
+      firingUnitAttachment.setIsAaForCombatOnly(true);
+      firingUnitAttachment.setMaxRoundsAa(1);
+      firingUnitType.addAttachment(UNIT_ATTACHMENT_NAME, firingUnitAttachment);
+
+      assertThat(
+          "An infrastructure unit that is combat AA but can only fire in round 1 and "
+              + "it is round 2 can not be in battle",
+          Matches.unitCanBeInBattle(true, true, 1, false, List.of(firingUnitType)).test(unit),
+          is(true));
     }
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/FiringGroupSplitterAaTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/aa/FiringGroupSplitterAaTest.java
@@ -6,7 +6,6 @@ import static games.strategy.triplea.delegate.battle.BattleState.Side.OFFENSE;
 import static games.strategy.triplea.delegate.battle.FakeBattleState.givenBattleStateBuilder;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenAnyUnit;
 import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitIsCombatAa;
-import static games.strategy.triplea.delegate.battle.steps.BattleStepsTest.givenUnitIsInfrastructure;
 import static games.strategy.triplea.delegate.battle.steps.MockGameData.givenGameData;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
@@ -253,31 +252,6 @@ class FiringGroupSplitterAaTest {
     final Unit targetUnit = givenAnyUnit();
     final Unit targetUnit2 = givenAnyUnit();
     when(targetUnit2.getTransportedBy()).thenReturn(mock(Unit.class));
-    final Unit fireUnit =
-        givenUnitIsCombatAa(Set.of(targetUnit.getType(), targetUnit2.getType()), attacker, OFFENSE);
-    when(fireUnit.getOwner()).thenReturn(attacker);
-
-    final List<FiringGroup> firingGroups =
-        FiringGroupSplitterAa.of(OFFENSE)
-            .apply(
-                givenBattleStateBuilder()
-                    .gameData(givenGameData().withWarRelationship(defender, attacker, true).build())
-                    .attacker(attacker)
-                    .defender(defender)
-                    .attackingUnits(List.of(fireUnit))
-                    .defendingUnits(List.of(targetUnit, targetUnit2))
-                    .build());
-
-    assertThat(firingGroups, hasSize(1));
-    assertThat(firingGroups.get(0).getFiringUnits(), contains(fireUnit));
-    assertThat(firingGroups.get(0).getTargetUnits(), contains(targetUnit));
-    assertThat(firingGroups.get(0).isSuicideOnHit(), is(false));
-  }
-
-  @Test
-  void firingGroupIgnoresInfrastructureUnits() {
-    final Unit targetUnit = givenAnyUnit();
-    final Unit targetUnit2 = givenUnitIsInfrastructure();
     final Unit fireUnit =
         givenUnitIsCombatAa(Set.of(targetUnit.getType(), targetUnit2.getType()), attacker, OFFENSE);
     when(fireUnit.getOwner()).thenReturn(attacker);


### PR DESCRIPTION
Fixes #7833

This modifies `Matches.unitTypeCanBeInBattle` to accept the list of attackers and checks if any of those attackers can hit the unit using `targetsAa`.  I've also added tests around the infrastructure part of that method.

This should allow any infrastructure units that are listed in `targetsAa` to be part of the battle.  They'll show up in the Battle UI and can be taken as casualties.

## Testing
<!-- Describe any manual testing performed below. -->
I used the save https://github.com/triplea-game/triplea/pull/7823#issuecomment-703055893 to verify that the air_transports would be taken as casualties.

I also ran a hard ai for a few rounds.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE-->CHANGE|Removed from "infrastructure" units the ability to be immune to targeted (AA-like) fire and made infrastructures targetable also beyond the first round of combat (in accordance to the fact that TripleA allows infrastructures to remain in combat beyond the first round of it).<!--END_RELEASE_NOTE-->
