### PR TITLE
Fight step names test preparation

### DIFF
--- a/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -33,12 +33,8 @@ import static games.strategy.triplea.delegate.MockDelegateBridge.thenGetRandomSh
 import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
 import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
 import static games.strategy.triplea.delegate.battle.BattleStepStrings.ATTACKER_WITHDRAW;
-import static games.strategy.triplea.delegate.battle.BattleStepStrings.FIRE;
-import static games.strategy.triplea.delegate.battle.BattleStepStrings.FIRST_STRIKE_UNITS_FIRE;
 import static games.strategy.triplea.delegate.battle.BattleStepStrings.REMOVE_CASUALTIES;
 import static games.strategy.triplea.delegate.battle.BattleStepStrings.REMOVE_SNEAK_ATTACK_CASUALTIES;
-import static games.strategy.triplea.delegate.battle.BattleStepStrings.SELECT_CASUALTIES;
-import static games.strategy.triplea.delegate.battle.BattleStepStrings.SELECT_FIRST_STRIKE_CASUALTIES;
 import static games.strategy.triplea.delegate.battle.BattleStepStrings.SUBS_SUBMERGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -72,6 +68,7 @@ import games.strategy.triplea.delegate.battle.IBattle;
 import games.strategy.triplea.delegate.battle.IBattle.BattleType;
 import games.strategy.triplea.delegate.battle.MustFightBattle;
 import games.strategy.triplea.delegate.battle.StrategicBombingRaidBattle;
+import games.strategy.triplea.delegate.battle.steps.BattleStepsTest;
 import games.strategy.triplea.delegate.battle.steps.fire.firststrike.DefensiveFirstStrike;
 import games.strategy.triplea.delegate.battle.steps.fire.firststrike.OffensiveFirstStrike;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
@@ -985,7 +982,9 @@ class RevisedTest {
   @Test
   void testLandBattleNoSneakAttack() {
     final String defender = "Germans";
+    final GamePlayer defenderPlayer = germans(gameData);
     final String attacker = "British";
+    final GamePlayer attackerPlayer = british(gameData);
     final Territory attacked = territory("Libya", gameData);
     final Territory from = territory("Anglo Egypt", gameData);
     final IDelegateBridge bridge = newDelegateBridge(british(gameData));
@@ -999,13 +998,10 @@ class RevisedTest {
             AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings();
     assertEquals(
-        List.of(
-                attacker + FIRE,
-                defender + SELECT_CASUALTIES,
-                defender + FIRE,
-                attacker + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES,
-                attacker + ATTACKER_WITHDRAW)
+        BattleStepsTest.mergeSteps(
+                BattleStepsTest.generalFightStepStrings(attackerPlayer, defenderPlayer),
+                BattleStepsTest.generalFightStepStrings(defenderPlayer, attackerPlayer),
+                List.of(REMOVE_CASUALTIES, attacker + ATTACKER_WITHDRAW))
             .toString(),
         steps.toString());
   }
@@ -1013,7 +1009,9 @@ class RevisedTest {
   @Test
   void testSeaBattleNoSneakAttack() {
     final String defender = "Germans";
+    final GamePlayer defenderPlayer = germans(gameData);
     final String attacker = "British";
+    final GamePlayer attackerPlayer = british(gameData);
     final Territory attacked = territory("31 Sea Zone", gameData);
     final Territory from = territory("32 Sea Zone", gameData);
     // 1 destroyer attacks 1 destroyer
@@ -1030,13 +1028,10 @@ class RevisedTest {
             AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings();
     assertEquals(
-        List.of(
-                attacker + FIRE,
-                defender + SELECT_CASUALTIES,
-                defender + FIRE,
-                attacker + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES,
-                attacker + ATTACKER_WITHDRAW)
+        BattleStepsTest.mergeSteps(
+                BattleStepsTest.generalFightStepStrings(attackerPlayer, defenderPlayer),
+                BattleStepsTest.generalFightStepStrings(defenderPlayer, attackerPlayer),
+                List.of(REMOVE_CASUALTIES, attacker + ATTACKER_WITHDRAW))
             .toString(),
         steps.toString());
   }
@@ -1044,7 +1039,9 @@ class RevisedTest {
   @Test
   void testAttackSubsOnSubs() {
     final String defender = "Germans";
+    final GamePlayer defenderPlayer = germans(gameData);
     final String attacker = "British";
+    final GamePlayer attackerPlayer = british(gameData);
     final Territory attacked = territory("31 Sea Zone", gameData);
     final Territory from = territory("32 Sea Zone", gameData);
     // 1 sub attacks 1 sub
@@ -1061,16 +1058,15 @@ class RevisedTest {
             AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings();
     assertEquals(
-        List.of(
-                attacker + FIRST_STRIKE_UNITS_FIRE,
-                defender + SELECT_FIRST_STRIKE_CASUALTIES,
-                defender + FIRST_STRIKE_UNITS_FIRE,
-                attacker + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                REMOVE_CASUALTIES,
-                attacker + SUBS_SUBMERGE,
-                attacker + ATTACKER_WITHDRAW,
-                defender + SUBS_SUBMERGE)
+        BattleStepsTest.mergeSteps(
+                BattleStepsTest.firstStrikeFightStepStrings(attackerPlayer, defenderPlayer),
+                BattleStepsTest.firstStrikeFightStepStrings(defenderPlayer, attackerPlayer),
+                List.of(
+                    REMOVE_SNEAK_ATTACK_CASUALTIES,
+                    REMOVE_CASUALTIES,
+                    attacker + SUBS_SUBMERGE,
+                    attacker + ATTACKER_WITHDRAW,
+                    defender + SUBS_SUBMERGE))
             .toString(),
         steps.toString());
     final List<IExecutable> execs = battle.getBattleExecutables();
@@ -1087,7 +1083,9 @@ class RevisedTest {
   @Test
   void testAttackSubsOnDestroyer() {
     final String defender = "Germans";
+    final GamePlayer defenderPlayer = germans(gameData);
     final String attacker = "British";
+    final GamePlayer attackerPlayer = british(gameData);
     final Territory attacked = territory("31 Sea Zone", gameData);
     final Territory from = territory("32 Sea Zone", gameData);
     // 2 sub attacks 1 sub and 1 destroyer
@@ -1119,18 +1117,16 @@ class RevisedTest {
      * going to the scrap heap.
      */
     assertEquals(
-        List.of(
-                attacker + FIRST_STRIKE_UNITS_FIRE,
-                defender + SELECT_FIRST_STRIKE_CASUALTIES,
-                defender + FIRST_STRIKE_UNITS_FIRE,
-                attacker + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                defender + FIRE,
-                attacker + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES,
-                attacker + SUBS_SUBMERGE,
-                attacker + ATTACKER_WITHDRAW,
-                defender + SUBS_SUBMERGE)
+        BattleStepsTest.mergeSteps(
+                BattleStepsTest.firstStrikeFightStepStrings(attackerPlayer, defenderPlayer),
+                BattleStepsTest.firstStrikeFightStepStrings(defenderPlayer, attackerPlayer),
+                List.of(REMOVE_SNEAK_ATTACK_CASUALTIES),
+                BattleStepsTest.generalFightStepStrings(defenderPlayer, attackerPlayer),
+                List.of(
+                    REMOVE_CASUALTIES,
+                    attacker + SUBS_SUBMERGE,
+                    attacker + ATTACKER_WITHDRAW,
+                    defender + SUBS_SUBMERGE))
             .toString(),
         steps.toString());
     final List<IExecutable> execs = battle.getBattleExecutables();
@@ -1157,7 +1153,9 @@ class RevisedTest {
   @Test
   void testAttackSubsAndBattleshipOnDestroyerAndSubs() {
     final String defender = "Germans";
+    final GamePlayer defenderPlayer = germans(gameData);
     final String attacker = "British";
+    final GamePlayer attackerPlayer = british(gameData);
     final Territory attacked = territory("31 Sea Zone", gameData);
     final Territory from = territory("32 Sea Zone", gameData);
     // 1 sub and 1 BB (two hp) attacks 3 subs and 1 destroyer
@@ -1190,20 +1188,17 @@ class RevisedTest {
      * going to the scrap heap.
      */
     assertEquals(
-        List.of(
-                attacker + FIRST_STRIKE_UNITS_FIRE,
-                defender + SELECT_FIRST_STRIKE_CASUALTIES,
-                defender + FIRST_STRIKE_UNITS_FIRE,
-                attacker + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                attacker + FIRE,
-                defender + SELECT_CASUALTIES,
-                defender + FIRE,
-                attacker + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES,
-                attacker + SUBS_SUBMERGE,
-                attacker + ATTACKER_WITHDRAW,
-                defender + SUBS_SUBMERGE)
+        BattleStepsTest.mergeSteps(
+                BattleStepsTest.firstStrikeFightStepStrings(attackerPlayer, defenderPlayer),
+                BattleStepsTest.firstStrikeFightStepStrings(defenderPlayer, attackerPlayer),
+                List.of(REMOVE_SNEAK_ATTACK_CASUALTIES),
+                BattleStepsTest.generalFightStepStrings(attackerPlayer, defenderPlayer),
+                BattleStepsTest.generalFightStepStrings(defenderPlayer, attackerPlayer),
+                List.of(
+                    REMOVE_CASUALTIES,
+                    attacker + SUBS_SUBMERGE,
+                    attacker + ATTACKER_WITHDRAW,
+                    defender + SUBS_SUBMERGE))
             .toString(),
         steps.toString());
     final List<IExecutable> execs = battle.getBattleExecutables();
@@ -1228,7 +1223,9 @@ class RevisedTest {
   @Test
   void testAttackDestroyerAndSubsAgainstSub() {
     final String defender = "Germans";
+    final GamePlayer defenderPlayer = germans(gameData);
     final String attacker = "British";
+    final GamePlayer attackerPlayer = british(gameData);
     final Territory attacked = territory("31 Sea Zone", gameData);
     final Territory from = territory("32 Sea Zone", gameData);
     // 1 sub and 1 destroyer attack 1 sub
@@ -1247,18 +1244,16 @@ class RevisedTest {
             AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings();
     assertEquals(
-        List.of(
-                attacker + FIRST_STRIKE_UNITS_FIRE,
-                defender + SELECT_FIRST_STRIKE_CASUALTIES,
-                defender + FIRST_STRIKE_UNITS_FIRE,
-                attacker + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                attacker + FIRE,
-                defender + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES,
-                attacker + SUBS_SUBMERGE,
-                attacker + ATTACKER_WITHDRAW,
-                defender + SUBS_SUBMERGE)
+        BattleStepsTest.mergeSteps(
+                BattleStepsTest.firstStrikeFightStepStrings(attackerPlayer, defenderPlayer),
+                BattleStepsTest.firstStrikeFightStepStrings(defenderPlayer, attackerPlayer),
+                List.of(REMOVE_SNEAK_ATTACK_CASUALTIES),
+                BattleStepsTest.generalFightStepStrings(attackerPlayer, defenderPlayer),
+                List.of(
+                    REMOVE_CASUALTIES,
+                    attacker + SUBS_SUBMERGE,
+                    attacker + ATTACKER_WITHDRAW,
+                    defender + SUBS_SUBMERGE))
             .toString(),
         steps.toString());
     final List<IExecutable> execs = battle.getBattleExecutables();
@@ -1283,7 +1278,9 @@ class RevisedTest {
   @Test
   void testAttackSubsAndDestroyerOnBatleshipAndSubs() {
     final String defender = "Germans";
+    final GamePlayer defenderPlayer = germans(gameData);
     final String attacker = "British";
+    final GamePlayer attackerPlayer = british(gameData);
     final Territory attacked = territory("31 Sea Zone", gameData);
     final Territory from = territory("32 Sea Zone", gameData);
     // 1 sub and 1 BB (two hp) attacks 3 subs and 1 destroyer
@@ -1315,20 +1312,17 @@ class RevisedTest {
      * on the battle board until step 6, allowing them to fire back before going to the scrap heap.
      */
     assertEquals(
-        List.of(
-                attacker + FIRST_STRIKE_UNITS_FIRE,
-                defender + SELECT_FIRST_STRIKE_CASUALTIES,
-                defender + FIRST_STRIKE_UNITS_FIRE,
-                attacker + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                attacker + FIRE,
-                defender + SELECT_CASUALTIES,
-                defender + FIRE,
-                attacker + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES,
-                attacker + SUBS_SUBMERGE,
-                attacker + ATTACKER_WITHDRAW,
-                defender + SUBS_SUBMERGE)
+        BattleStepsTest.mergeSteps(
+                BattleStepsTest.firstStrikeFightStepStrings(attackerPlayer, defenderPlayer),
+                BattleStepsTest.firstStrikeFightStepStrings(defenderPlayer, attackerPlayer),
+                List.of(REMOVE_SNEAK_ATTACK_CASUALTIES),
+                BattleStepsTest.generalFightStepStrings(attackerPlayer, defenderPlayer),
+                BattleStepsTest.generalFightStepStrings(defenderPlayer, attackerPlayer),
+                List.of(
+                    REMOVE_CASUALTIES,
+                    attacker + SUBS_SUBMERGE,
+                    attacker + ATTACKER_WITHDRAW,
+                    defender + SUBS_SUBMERGE))
             .toString(),
         steps.toString());
     final List<IExecutable> execs = battle.getBattleExecutables();
@@ -1353,7 +1347,9 @@ class RevisedTest {
   @Test
   void testAttackDestroyerAndSubsAgainstSubAndDestroyer() {
     final String defender = "Germans";
+    final GamePlayer defenderPlayer = germans(gameData);
     final String attacker = "British";
+    final GamePlayer attackerPlayer = british(gameData);
     final Territory attacked = territory("31 Sea Zone", gameData);
     final Territory from = territory("32 Sea Zone", gameData);
     // 1 sub and 1 destroyer attack 1 sub and 1 destroyer
@@ -1373,19 +1369,16 @@ class RevisedTest {
             AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings();
     assertEquals(
-        List.of(
-                attacker + FIRST_STRIKE_UNITS_FIRE,
-                defender + SELECT_FIRST_STRIKE_CASUALTIES,
-                defender + FIRST_STRIKE_UNITS_FIRE,
-                attacker + SELECT_FIRST_STRIKE_CASUALTIES,
-                attacker + FIRE,
-                defender + SELECT_CASUALTIES,
-                defender + FIRE,
-                attacker + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES,
-                attacker + SUBS_SUBMERGE,
-                attacker + ATTACKER_WITHDRAW,
-                defender + SUBS_SUBMERGE)
+        BattleStepsTest.mergeSteps(
+                BattleStepsTest.firstStrikeFightStepStrings(attackerPlayer, defenderPlayer),
+                BattleStepsTest.firstStrikeFightStepStrings(defenderPlayer, attackerPlayer),
+                BattleStepsTest.generalFightStepStrings(attackerPlayer, defenderPlayer),
+                BattleStepsTest.generalFightStepStrings(defenderPlayer, attackerPlayer),
+                List.of(
+                    REMOVE_CASUALTIES,
+                    attacker + SUBS_SUBMERGE,
+                    attacker + ATTACKER_WITHDRAW,
+                    defender + SUBS_SUBMERGE))
             .toString(),
         steps.toString());
     final List<IExecutable> execs = battle.getBattleExecutables();

--- a/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/RevisedTest.java
@@ -981,7 +981,6 @@ class RevisedTest {
 
   @Test
   void testLandBattleNoSneakAttack() {
-    final String defender = "Germans";
     final GamePlayer defenderPlayer = germans(gameData);
     final String attacker = "British";
     final GamePlayer attackerPlayer = british(gameData);
@@ -1008,7 +1007,6 @@ class RevisedTest {
 
   @Test
   void testSeaBattleNoSneakAttack() {
-    final String defender = "Germans";
     final GamePlayer defenderPlayer = germans(gameData);
     final String attacker = "British";
     final GamePlayer attackerPlayer = british(gameData);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -1050,7 +1050,6 @@ class WW2V3Year41Test {
 
   @Test
   void testAttackDestroyerAndSubsAgainstSub() {
-    final String defender = "Germans";
     final GamePlayer defenderPlayer = germans(gameData);
     final String attacker = "British";
     final GamePlayer attackerPlayer = british(gameData);
@@ -1096,7 +1095,6 @@ class WW2V3Year41Test {
 
   @Test
   void testAttackDestroyerAndSubsAgainstSubAndDestroyer() {
-    final String defender = "Germans";
     final GamePlayer defenderPlayer = germans(gameData);
     final String attacker = "British";
     final GamePlayer attackerPlayer = british(gameData);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -35,12 +35,8 @@ import static games.strategy.triplea.delegate.MockDelegateBridge.thenGetRandomSh
 import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
 import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
 import static games.strategy.triplea.delegate.battle.BattleStepStrings.ATTACKER_WITHDRAW;
-import static games.strategy.triplea.delegate.battle.BattleStepStrings.FIRE;
-import static games.strategy.triplea.delegate.battle.BattleStepStrings.FIRST_STRIKE_UNITS_FIRE;
 import static games.strategy.triplea.delegate.battle.BattleStepStrings.REMOVE_CASUALTIES;
 import static games.strategy.triplea.delegate.battle.BattleStepStrings.REMOVE_SNEAK_ATTACK_CASUALTIES;
-import static games.strategy.triplea.delegate.battle.BattleStepStrings.SELECT_CASUALTIES;
-import static games.strategy.triplea.delegate.battle.BattleStepStrings.SELECT_FIRST_STRIKE_CASUALTIES;
 import static games.strategy.triplea.delegate.battle.BattleStepStrings.SUBS_SUBMERGE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -79,6 +75,7 @@ import games.strategy.triplea.delegate.battle.BattleDelegate;
 import games.strategy.triplea.delegate.battle.IBattle.BattleType;
 import games.strategy.triplea.delegate.battle.MustFightBattle;
 import games.strategy.triplea.delegate.battle.casualty.AaCasualtySelector;
+import games.strategy.triplea.delegate.battle.steps.BattleStepsTest;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
 import games.strategy.triplea.delegate.data.MoveValidationResult;
 import games.strategy.triplea.delegate.data.PlaceableUnits;
@@ -968,13 +965,15 @@ class WW2V3Year41Test {
   @Test
   void testAttackSubsOnSubs() {
     final String defender = "Germans";
+    final GamePlayer defenderPlayer = germans(gameData);
     final String attacker = "British";
+    final GamePlayer attackerPlayer = british(gameData);
     final Territory attacked = territory("31 Sea Zone", gameData);
     final Territory from = territory("32 Sea Zone", gameData);
     // 1 sub attacks 1 sub
-    addTo(from, submarine(gameData).create(1, british(gameData)));
-    addTo(attacked, submarine(gameData).create(1, germans(gameData)));
-    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
+    addTo(from, submarine(gameData).create(1, attackerPlayer));
+    addTo(attacked, submarine(gameData).create(1, defenderPlayer));
+    final IDelegateBridge bridge = newDelegateBridge(attackerPlayer);
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -985,16 +984,14 @@ class WW2V3Year41Test {
             AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings();
     assertEquals(
-        List.of(
-                attacker + SUBS_SUBMERGE,
-                defender + SUBS_SUBMERGE,
-                attacker + FIRST_STRIKE_UNITS_FIRE,
-                defender + SELECT_FIRST_STRIKE_CASUALTIES,
-                defender + FIRST_STRIKE_UNITS_FIRE,
-                attacker + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                REMOVE_CASUALTIES,
-                attacker + ATTACKER_WITHDRAW)
+        BattleStepsTest.mergeSteps(
+                List.of(attacker + SUBS_SUBMERGE, defender + SUBS_SUBMERGE),
+                BattleStepsTest.firstStrikeFightStepStrings(attackerPlayer, defenderPlayer),
+                BattleStepsTest.firstStrikeFightStepStrings(defenderPlayer, attackerPlayer),
+                List.of(
+                    REMOVE_SNEAK_ATTACK_CASUALTIES,
+                    REMOVE_CASUALTIES,
+                    attacker + ATTACKER_WITHDRAW))
             .toString(),
         steps.toString());
     // fight, each sub should fire
@@ -1008,15 +1005,17 @@ class WW2V3Year41Test {
   @Test
   void testAttackSubsOnDestroyer() {
     final String defender = "Germans";
+    final GamePlayer defenderPlayer = germans(gameData);
     final String attacker = "British";
+    final GamePlayer attackerPlayer = british(gameData);
     final Territory attacked = territory("31 Sea Zone", gameData);
     final Territory from = territory("32 Sea Zone", gameData);
     // 1 sub attacks 1 sub and 1 destroyer
     // defender sneak attacks, not attacker
-    addTo(from, submarine(gameData).create(1, british(gameData)));
-    addTo(attacked, submarine(gameData).create(1, germans(gameData)));
-    addTo(attacked, destroyer(gameData).create(1, germans(gameData)));
-    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
+    addTo(from, submarine(gameData).create(1, attackerPlayer));
+    addTo(attacked, submarine(gameData).create(1, defenderPlayer));
+    addTo(attacked, destroyer(gameData).create(1, defenderPlayer));
+    final IDelegateBridge bridge = newDelegateBridge(attackerPlayer);
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -1027,17 +1026,13 @@ class WW2V3Year41Test {
             AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings();
     assertEquals(
-        List.of(
-                defender + SUBS_SUBMERGE,
-                defender + FIRST_STRIKE_UNITS_FIRE,
-                attacker + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                attacker + FIRST_STRIKE_UNITS_FIRE,
-                defender + SELECT_FIRST_STRIKE_CASUALTIES,
-                defender + FIRE,
-                attacker + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES,
-                attacker + ATTACKER_WITHDRAW)
+        BattleStepsTest.mergeSteps(
+                List.of(defender + SUBS_SUBMERGE),
+                BattleStepsTest.firstStrikeFightStepStrings(defenderPlayer, attackerPlayer),
+                List.of(REMOVE_SNEAK_ATTACK_CASUALTIES),
+                BattleStepsTest.firstStrikeFightStepStrings(attackerPlayer, defenderPlayer),
+                BattleStepsTest.generalFightStepStrings(defenderPlayer, attackerPlayer),
+                List.of(REMOVE_CASUALTIES, attacker + ATTACKER_WITHDRAW))
             .toString(),
         steps.toString());
     // defending subs sneak attack and hit
@@ -1056,15 +1051,17 @@ class WW2V3Year41Test {
   @Test
   void testAttackDestroyerAndSubsAgainstSub() {
     final String defender = "Germans";
+    final GamePlayer defenderPlayer = germans(gameData);
     final String attacker = "British";
+    final GamePlayer attackerPlayer = british(gameData);
     final Territory attacked = territory("31 Sea Zone", gameData);
     final Territory from = territory("32 Sea Zone", gameData);
     // 1 sub and 1 destroyer attack 1 sub
     // defender sneak attacks, not attacker
-    addTo(from, submarine(gameData).create(1, british(gameData)));
-    addTo(from, destroyer(gameData).create(1, british(gameData)));
-    addTo(attacked, submarine(gameData).create(1, germans(gameData)));
-    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
+    addTo(from, submarine(gameData).create(1, attackerPlayer));
+    addTo(from, destroyer(gameData).create(1, attackerPlayer));
+    addTo(attacked, submarine(gameData).create(1, defenderPlayer));
+    final IDelegateBridge bridge = newDelegateBridge(attackerPlayer);
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -1075,17 +1072,13 @@ class WW2V3Year41Test {
             AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings();
     assertEquals(
-        List.of(
-                attacker + SUBS_SUBMERGE,
-                attacker + FIRST_STRIKE_UNITS_FIRE,
-                defender + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                attacker + FIRE,
-                defender + SELECT_CASUALTIES,
-                defender + FIRST_STRIKE_UNITS_FIRE,
-                attacker + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_CASUALTIES,
-                attacker + ATTACKER_WITHDRAW)
+        BattleStepsTest.mergeSteps(
+                List.of(attacker + SUBS_SUBMERGE),
+                BattleStepsTest.firstStrikeFightStepStrings(attackerPlayer, defenderPlayer),
+                List.of(REMOVE_SNEAK_ATTACK_CASUALTIES),
+                BattleStepsTest.generalFightStepStrings(attackerPlayer, defenderPlayer),
+                BattleStepsTest.firstStrikeFightStepStrings(defenderPlayer, attackerPlayer),
+                List.of(REMOVE_CASUALTIES, attacker + ATTACKER_WITHDRAW))
             .toString(),
         steps.toString());
     // attacking subs sneak attack and hit
@@ -1104,16 +1097,18 @@ class WW2V3Year41Test {
   @Test
   void testAttackDestroyerAndSubsAgainstSubAndDestroyer() {
     final String defender = "Germans";
+    final GamePlayer defenderPlayer = germans(gameData);
     final String attacker = "British";
+    final GamePlayer attackerPlayer = british(gameData);
     final Territory attacked = territory("31 Sea Zone", gameData);
     final Territory from = territory("32 Sea Zone", gameData);
     // 1 sub and 1 destroyer attack 1 sub and 1 destroyer
     // no sneak attacks
-    addTo(from, submarine(gameData).create(1, british(gameData)));
-    addTo(from, destroyer(gameData).create(1, british(gameData)));
-    addTo(attacked, submarine(gameData).create(1, germans(gameData)));
-    addTo(attacked, destroyer(gameData).create(1, germans(gameData)));
-    final IDelegateBridge bridge = newDelegateBridge(british(gameData));
+    addTo(from, submarine(gameData).create(1, attackerPlayer));
+    addTo(from, destroyer(gameData).create(1, attackerPlayer));
+    addTo(attacked, submarine(gameData).create(1, defenderPlayer));
+    addTo(attacked, destroyer(gameData).create(1, defenderPlayer));
+    final IDelegateBridge bridge = newDelegateBridge(attackerPlayer);
     advanceToStep(bridge, "CombatMove");
     moveDelegate(gameData).setDelegateBridgeAndPlayer(bridge);
     moveDelegate(gameData).start();
@@ -1124,17 +1119,12 @@ class WW2V3Year41Test {
             AbstractMoveDelegate.getBattleTracker(gameData).getPendingBattle(attacked);
     final List<String> steps = battle.determineStepStrings();
     assertEquals(
-        List.of(
-                attacker + FIRST_STRIKE_UNITS_FIRE,
-                defender + SELECT_FIRST_STRIKE_CASUALTIES,
-                attacker + FIRE,
-                defender + SELECT_CASUALTIES,
-                defender + FIRST_STRIKE_UNITS_FIRE,
-                attacker + SELECT_FIRST_STRIKE_CASUALTIES,
-                defender + FIRE,
-                attacker + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES,
-                attacker + ATTACKER_WITHDRAW)
+        BattleStepsTest.mergeSteps(
+                BattleStepsTest.firstStrikeFightStepStrings(attackerPlayer, defenderPlayer),
+                BattleStepsTest.generalFightStepStrings(attackerPlayer, defenderPlayer),
+                BattleStepsTest.firstStrikeFightStepStrings(defenderPlayer, attackerPlayer),
+                BattleStepsTest.generalFightStepStrings(defenderPlayer, attackerPlayer),
+                List.of(REMOVE_CASUALTIES, attacker + ATTACKER_WITHDRAW))
             .toString(),
         steps.toString());
     givenRemotePlayerWillSelectCasualtiesPer(

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
@@ -1,19 +1,12 @@
 package games.strategy.triplea.delegate.battle.steps;
 
-import static games.strategy.triplea.Constants.ATTACKER_RETREAT_PLANES;
-import static games.strategy.triplea.Constants.DEFENDING_SUBS_SNEAK_ATTACK;
-import static games.strategy.triplea.Constants.DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE;
-import static games.strategy.triplea.Constants.PARTIAL_AMPHIBIOUS_RETREAT;
-import static games.strategy.triplea.Constants.SUBMERSIBLE_SUBS;
-import static games.strategy.triplea.Constants.SUB_RETREAT_BEFORE_BATTLE;
-import static games.strategy.triplea.Constants.TRANSPORT_CASUALTIES_RESTRICTED;
 import static games.strategy.triplea.Constants.UNIT_ATTACHMENT_NAME;
-import static games.strategy.triplea.Constants.WW2V2;
 import static games.strategy.triplea.delegate.battle.BattleStepStrings.AA_GUNS_FIRE_SUFFIX;
 import static games.strategy.triplea.delegate.battle.BattleStepStrings.AIR_ATTACK_NON_SUBS;
 import static games.strategy.triplea.delegate.battle.BattleStepStrings.AIR_DEFEND_NON_SUBS;
 import static games.strategy.triplea.delegate.battle.BattleStepStrings.ATTACKER_WITHDRAW;
 import static games.strategy.triplea.delegate.battle.BattleStepStrings.CASUALTIES_SUFFIX;
+import static games.strategy.triplea.delegate.battle.BattleStepStrings.FIRE;
 import static games.strategy.triplea.delegate.battle.BattleStepStrings.FIRST_STRIKE_UNITS_FIRE;
 import static games.strategy.triplea.delegate.battle.BattleStepStrings.LAND_PARATROOPS;
 import static games.strategy.triplea.delegate.battle.BattleStepStrings.NAVAL_BOMBARDMENT;
@@ -29,7 +22,7 @@ import static games.strategy.triplea.delegate.battle.BattleStepStrings.SUBMERGE_
 import static games.strategy.triplea.delegate.battle.BattleStepStrings.SUBS_SUBMERGE;
 import static games.strategy.triplea.delegate.battle.BattleStepStrings.SUBS_WITHDRAW;
 import static games.strategy.triplea.delegate.battle.FakeBattleState.givenBattleStateBuilder;
-import static games.strategy.triplea.delegate.battle.steps.BattleSteps.FIRE;
+import static games.strategy.triplea.delegate.battle.steps.MockGameData.givenGameData;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.ArgumentMatchers.any;
@@ -40,14 +33,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.GameMap;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitCollection;
 import games.strategy.engine.data.UnitType;
-import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
@@ -69,9 +59,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 public class BattleStepsTest {
 
-  @Mock GameData gameData;
-  @Mock GameProperties gameProperties;
-  @Mock GameMap gameMap;
   @Mock BattleActions battleActions;
 
   @Mock Territory battleSite;
@@ -80,14 +67,9 @@ public class BattleStepsTest {
   @Mock TechAttachment techAttachment;
 
   @BeforeEach
-  void setupMocks() {
-    when(gameData.getProperties()).thenReturn(gameProperties);
-    lenient().when(gameData.getMap()).thenReturn(gameMap);
-  }
-
-  private void givenPlayers() {
-    when(attacker.getName()).thenReturn("mockAttacker");
-    when(defender.getName()).thenReturn("mockDefender");
+  public void givenPlayers() {
+    lenient().when(attacker.getName()).thenReturn("mockAttacker");
+    lenient().when(defender.getName()).thenReturn("mockDefender");
   }
 
   public static Territory givenSeaBattleSite() {
@@ -181,6 +163,13 @@ public class BattleStepsTest {
     return unitAndAttachment.unit;
   }
 
+  public static Unit givenUnitIsCombatAa() {
+    final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
+    when(unitAndAttachment.unitAttachment.getTypeAa()).thenReturn("AntiAirGun");
+    when(unitAndAttachment.unitAttachment.getIsAaForCombatOnly()).thenReturn(true);
+    return unitAndAttachment.unit;
+  }
+
   public static Unit givenUnitIsCombatAa(
       final Set<UnitType> aaTarget, final GamePlayer player, final BattleState.Side side) {
     return givenUnitIsCombatAa(aaTarget, player, side, "AntiAirGun");
@@ -230,17 +219,40 @@ public class BattleStepsTest {
   }
 
   @SafeVarargs
-  private List<String> mergeSteps(final List<String>... steps) {
+  public static List<String> mergeSteps(final List<String>... steps) {
     return Stream.of(steps).flatMap(Collection::stream).collect(Collectors.toList());
   }
 
-  private List<String> basicFightSteps() {
+  private List<String> basicFightStepStrings() {
+    return mergeSteps(
+        generalFightStepStrings(attacker, defender),
+        generalFightStepStrings(defender, attacker),
+        List.of(REMOVE_CASUALTIES));
+  }
+
+  public static List<String> generalFightStepStrings(
+      final GamePlayer firingPlayer, final GamePlayer hitPlayer) {
+    return List.of(firingPlayer.getName() + FIRE, hitPlayer.getName() + SELECT_CASUALTIES);
+  }
+
+  public static List<String> firstStrikeFightStepStrings(
+      final GamePlayer firingPlayer, final GamePlayer hitPlayer) {
     return List.of(
-        attacker.getName() + FIRE,
-        defender.getName() + SELECT_CASUALTIES,
-        defender.getName() + FIRE,
-        attacker.getName() + SELECT_CASUALTIES,
-        REMOVE_CASUALTIES);
+        firingPlayer.getName() + FIRST_STRIKE_UNITS_FIRE,
+        hitPlayer.getName() + SELECT_FIRST_STRIKE_CASUALTIES);
+  }
+
+  private List<String> navalBombardmentFightStepStrings(
+      final GamePlayer firingPlayer, final GamePlayer hitPlayer) {
+    return List.of(NAVAL_BOMBARDMENT, SELECT_NAVAL_BOMBARDMENT_CASUALTIES);
+  }
+
+  private List<String> aAFightStepStrings(
+      final String name, final GamePlayer firingPlayer, final GamePlayer hitPlayer) {
+    return List.of(
+        firingPlayer.getName() + " " + name + AA_GUNS_FIRE_SUFFIX,
+        hitPlayer.getName() + SELECT_PREFIX + name + CASUALTIES_SUFFIX,
+        hitPlayer.getName() + REMOVE_PREFIX + name + CASUALTIES_SUFFIX);
   }
 
   private List<String> givenBattleSteps(final BattleState battleState) {
@@ -257,7 +269,7 @@ public class BattleStepsTest {
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(givenGameData().build())
                 .attacker(attacker)
                 .defender(defender)
                 .build());
@@ -270,13 +282,16 @@ public class BattleStepsTest {
   @Test
   @DisplayName("Verify basic land battle (no aa, air, bombard, etc)")
   void basicLandBattle() {
-    givenPlayers();
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenAnyUnit();
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -284,25 +299,24 @@ public class BattleStepsTest {
                 .battleSite(battleSite)
                 .build());
 
-    assertThat(steps, is(basicFightSteps()));
+    assertThat(steps, is(basicFightStepStrings()));
     verify(battleSite, never()).getUnits();
   }
 
   @Test
   @DisplayName("Verify basic land battle with bombard on first run")
   void bombardOnFirstRun() {
-    givenPlayers();
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenAnyUnit();
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(givenGameData().build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
                 .defendingUnits(List.of(unit2))
-                .bombardingUnits(List.of(mock(Unit.class)))
+                .bombardingUnits(List.of(givenAnyUnit()))
                 .battleSite(battleSite)
                 .battleRound(1)
                 .build());
@@ -311,21 +325,23 @@ public class BattleStepsTest {
         steps,
         is(
             mergeSteps(
-                List.of(NAVAL_BOMBARDMENT, SELECT_NAVAL_BOMBARDMENT_CASUALTIES),
-                basicFightSteps())));
+                navalBombardmentFightStepStrings(attacker, defender), basicFightStepStrings())));
     verify(battleSite, never()).getUnits();
   }
 
   @Test
   @DisplayName("Verify basic land battle with bombard on subsequent run")
   void bombardOnSubsequentRun() {
-    givenPlayers();
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenAnyUnit();
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .battleRound(2)
@@ -334,20 +350,24 @@ public class BattleStepsTest {
                 .battleSite(battleSite)
                 .build());
 
-    assertThat(steps, is(basicFightSteps()));
+    assertThat(steps, is(basicFightStepStrings()));
     verify(battleSite, never()).getUnits();
   }
 
   @Test
   @DisplayName("Verify impossible sea battle with bombarding will not add a bombarding step")
   void impossibleSeaBattleWithBombarding() {
-    givenPlayers();
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenAnyUnit();
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .withTransportCasualtiesRestricted(false)
+                        .build())
                 .battleRound(1)
                 .attacker(attacker)
                 .defender(defender)
@@ -357,7 +377,7 @@ public class BattleStepsTest {
                 .battleSite(givenSeaBattleSite())
                 .build());
 
-    assertThat(steps, is(basicFightSteps()));
+    assertThat(steps, is(basicFightStepStrings()));
 
     verify(attacker, never()).getAttachment(Constants.TECH_ATTACHMENT_NAME);
   }
@@ -365,7 +385,6 @@ public class BattleStepsTest {
   @Test
   @DisplayName("Verify basic land battle with paratroopers on first run")
   void paratroopersFirstRun() {
-    givenPlayers();
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenAnyUnit();
     final Unit unit3 = givenUnitAirTransport();
@@ -380,7 +399,7 @@ public class BattleStepsTest {
         givenBattleSteps(
             givenBattleStateBuilder()
                 .battleRound(1)
-                .gameData(gameData)
+                .gameData(givenGameData().build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1, unit3))
@@ -389,14 +408,13 @@ public class BattleStepsTest {
                 .dependentUnits(List.of(mock(Unit.class)))
                 .build());
 
-    assertThat(steps, is(mergeSteps(List.of(LAND_PARATROOPS), basicFightSteps())));
+    assertThat(steps, is(mergeSteps(List.of(LAND_PARATROOPS), basicFightStepStrings())));
     verify(battleSite, times(1)).getUnits();
   }
 
   @Test
   @DisplayName("Verify basic land battle with no AirTransport tech on first run")
   void noAirTransportTech() {
-    givenPlayers();
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenAnyUnit();
     final Unit unit3 = givenAnyUnit();
@@ -405,7 +423,11 @@ public class BattleStepsTest {
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .build())
                 .battleRound(1)
                 .attacker(attacker)
                 .defender(defender)
@@ -414,20 +436,23 @@ public class BattleStepsTest {
                 .battleSite(battleSite)
                 .build());
 
-    assertThat(steps, is(basicFightSteps()));
+    assertThat(steps, is(basicFightStepStrings()));
     verify(battleSite, never()).getUnits();
   }
 
   @Test
   @DisplayName("Verify basic land battle with paratroopers on subsequent run")
   void paratroopersSubsequentRun() {
-    givenPlayers();
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenAnyUnit();
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .battleRound(2)
@@ -436,7 +461,7 @@ public class BattleStepsTest {
                 .battleSite(battleSite)
                 .build());
 
-    assertThat(steps, is(basicFightSteps()));
+    assertThat(steps, is(basicFightStepStrings()));
     verify(attacker, never()).getAttachment(Constants.TECH_ATTACHMENT_NAME);
     verify(battleSite, never()).getUnits();
   }
@@ -444,7 +469,6 @@ public class BattleStepsTest {
   @Test
   @DisplayName("Verify basic land battle with empty paratroopers on first run")
   void emptyParatroopersFirstRun() {
-    givenPlayers();
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenAnyUnit();
     final Unit unit3 = givenUnitAirTransport();
@@ -458,7 +482,7 @@ public class BattleStepsTest {
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(givenGameData().build())
                 .battleRound(1)
                 .attacker(attacker)
                 .defender(defender)
@@ -467,7 +491,7 @@ public class BattleStepsTest {
                 .battleSite(battleSite)
                 .build());
 
-    assertThat(steps, is(basicFightSteps()));
+    assertThat(steps, is(basicFightStepStrings()));
 
     verify(battleSite, times(1)).getUnits();
   }
@@ -475,13 +499,17 @@ public class BattleStepsTest {
   @Test
   @DisplayName("Verify impossible sea battle with paratroopers will not add a paratrooper step")
   void impossibleSeaBattleWithParatroopers() {
-    givenPlayers();
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenAnyUnit();
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .withTransportCasualtiesRestricted(false)
+                        .build())
                 .battleRound(1)
                 .attacker(attacker)
                 .defender(defender)
@@ -490,7 +518,7 @@ public class BattleStepsTest {
                 .battleSite(givenSeaBattleSite())
                 .build());
 
-    assertThat(steps, is(basicFightSteps()));
+    assertThat(steps, is(basicFightStepStrings()));
 
     verify(attacker, never()).getAttachment(Constants.TECH_ATTACHMENT_NAME);
   }
@@ -498,14 +526,13 @@ public class BattleStepsTest {
   @Test
   @DisplayName("Verify basic land battle with offensive Aa")
   void offensiveAaFire() {
-    givenPlayers();
-    final Unit unit1 = givenUnitWithTypeAa();
     final Unit unit2 = givenAnyUnit();
+    final Unit unit1 = givenUnitWithTypeAa();
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(givenGameData().build())
                 .attacker(attacker)
                 .defender(defender)
                 .offensiveAa(List.of(unit1))
@@ -518,11 +545,7 @@ public class BattleStepsTest {
         steps,
         is(
             mergeSteps(
-                List.of(
-                    attacker.getName() + " " + "AntiAirGun" + AA_GUNS_FIRE_SUFFIX,
-                    defender.getName() + SELECT_PREFIX + "AntiAirGun" + CASUALTIES_SUFFIX,
-                    defender.getName() + REMOVE_PREFIX + "AntiAirGun" + CASUALTIES_SUFFIX),
-                basicFightSteps())));
+                aAFightStepStrings("AntiAirGun", attacker, defender), basicFightStepStrings())));
 
     verify(battleSite, never()).getUnits();
   }
@@ -530,19 +553,18 @@ public class BattleStepsTest {
   @Test
   @DisplayName("Verify basic land battle with defensive Aa")
   void defensiveAaFire() {
-    givenPlayers();
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenUnitWithTypeAa();
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(givenGameData().build())
                 .attacker(attacker)
                 .defender(defender)
-                .defendingAa(List.of(unit2))
                 .attackingUnits(List.of(unit1))
                 .defendingUnits(List.of(unit2))
+                .defendingAa(List.of(unit2))
                 .battleSite(battleSite)
                 .build());
 
@@ -550,11 +572,7 @@ public class BattleStepsTest {
         steps,
         is(
             mergeSteps(
-                List.of(
-                    defender.getName() + " " + "AntiAirGun" + AA_GUNS_FIRE_SUFFIX,
-                    attacker.getName() + SELECT_PREFIX + "AntiAirGun" + CASUALTIES_SUFFIX,
-                    attacker.getName() + REMOVE_PREFIX + "AntiAirGun" + CASUALTIES_SUFFIX),
-                basicFightSteps())));
+                aAFightStepStrings("AntiAirGun", defender, attacker), basicFightStepStrings())));
 
     verify(battleSite, never()).getUnits();
   }
@@ -562,20 +580,19 @@ public class BattleStepsTest {
   @Test
   @DisplayName("Verify basic land battle with offensive and defensive Aa")
   void offensiveAndDefensiveAaFire() {
-    givenPlayers();
     final Unit unit1 = givenUnitWithTypeAa();
     final Unit unit2 = givenUnitWithTypeAa();
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(givenGameData().build())
                 .attacker(attacker)
                 .defender(defender)
-                .offensiveAa(List.of(unit1))
-                .defendingAa(List.of(unit2))
                 .attackingUnits(List.of(unit1))
+                .offensiveAa(List.of(unit1))
                 .defendingUnits(List.of(unit2))
+                .defendingAa(List.of(unit2))
                 .battleSite(battleSite)
                 .build());
 
@@ -583,14 +600,9 @@ public class BattleStepsTest {
         steps,
         is(
             mergeSteps(
-                List.of(
-                    attacker.getName() + " " + "AntiAirGun" + AA_GUNS_FIRE_SUFFIX,
-                    defender.getName() + SELECT_PREFIX + "AntiAirGun" + CASUALTIES_SUFFIX,
-                    defender.getName() + REMOVE_PREFIX + "AntiAirGun" + CASUALTIES_SUFFIX,
-                    defender.getName() + " " + "AntiAirGun" + AA_GUNS_FIRE_SUFFIX,
-                    attacker.getName() + SELECT_PREFIX + "AntiAirGun" + CASUALTIES_SUFFIX,
-                    attacker.getName() + REMOVE_PREFIX + "AntiAirGun" + CASUALTIES_SUFFIX),
-                basicFightSteps())));
+                aAFightStepStrings("AntiAirGun", attacker, defender),
+                aAFightStepStrings("AntiAirGun", defender, attacker),
+                basicFightStepStrings())));
 
     verify(battleSite, never()).getUnits();
   }
@@ -599,19 +611,18 @@ public class BattleStepsTest {
   @DisplayName(
       "Verify defending canEvade units can retreat if SUB_RETREAT_BEFORE_BATTLE and no destroyers")
   void defendingSubsRetreatIfNoDestroyersAndCanRetreatBeforeBattle() {
-    givenPlayers();
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenUnitCanEvade();
-
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(true);
-    when(gameProperties.get(SUBMERSIBLE_SUBS, false)).thenReturn(true);
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(true)
+                        .withSubmersibleSubs(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -620,26 +631,26 @@ public class BattleStepsTest {
                 .build());
 
     assertThat(
-        steps, is(mergeSteps(List.of(defender.getName() + SUBS_SUBMERGE), basicFightSteps())));
+        steps,
+        is(mergeSteps(List.of(defender.getName() + SUBS_SUBMERGE), basicFightStepStrings())));
   }
 
   @Test
   @DisplayName(
       "Verify defending canEvade units can not retreat if SUB_RETREAT_BEFORE_BATTLE and destroyers")
   void defendingSubsNotRetreatIfDestroyersAndCanRetreatBeforeBattle() {
-    givenPlayers();
     final Unit unit1 = givenUnitDestroyer();
     final Unit unit2 = givenUnitCanEvade();
-
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(true);
-    when(gameProperties.get(SUBMERSIBLE_SUBS, false)).thenReturn(true);
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(true)
+                        .withSubmersibleSubs(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -647,25 +658,24 @@ public class BattleStepsTest {
                 .battleSite(battleSite)
                 .build());
 
-    assertThat(steps, is(basicFightSteps()));
+    assertThat(steps, is(basicFightStepStrings()));
   }
 
   @Test
   @DisplayName(
       "Verify defending canEvade units can not retreat if SUB_RETREAT_BEFORE_BATTLE is false")
   void defendingSubsRetreatIfCanNotRetreatBeforeBattle() {
-    givenPlayers();
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenUnitCanEvade();
-
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -673,7 +683,7 @@ public class BattleStepsTest {
                 .battleSite(battleSite)
                 .build());
 
-    assertThat(steps, is(basicFightSteps()));
+    assertThat(steps, is(basicFightStepStrings()));
   }
 
   @Test
@@ -681,20 +691,20 @@ public class BattleStepsTest {
       "Verify defending firstStrike submerge before battle "
           + "if SUB_RETREAT_BEFORE_BATTLE and SUBMERSIBLE_SUBS are true")
   void defendingFirstStrikeSubmergeBeforeBattleIfSubmersibleSubsAndRetreatBeforeBattle() {
-    givenPlayers();
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(true);
-    when(gameProperties.get(SUBMERSIBLE_SUBS, false)).thenReturn(true);
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(WW2V2, false)).thenReturn(false);
-    when(gameProperties.get(DEFENDING_SUBS_SNEAK_ATTACK, false)).thenReturn(true);
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withSubRetreatBeforeBattle(true)
+                        .withSubmersibleSubs(true)
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withWW2V2(false)
+                        .withDefendingSubsSneakAttack(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -705,31 +715,29 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                defender.getName() + SUBS_SUBMERGE,
-                defender.getName() + FIRST_STRIKE_UNITS_FIRE,
-                attacker.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                attacker.getName() + FIRE,
-                defender.getName() + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES)));
+            mergeSteps(
+                List.of(defender.getName() + SUBS_SUBMERGE),
+                firstStrikeFightStepStrings(defender, attacker),
+                List.of(REMOVE_SNEAK_ATTACK_CASUALTIES),
+                generalFightStepStrings(attacker, defender),
+                List.of(REMOVE_CASUALTIES))));
   }
 
   @Test
   @DisplayName("Verify unescorted attacking transports are removed if casualties are restricted")
   void unescortedAttackingTransportsAreRemovedWhenCasualtiesAreRestricted() {
-    givenPlayers();
     final Unit unit1 = givenUnitSeaTransport();
     final Unit unit2 = givenAnyUnit();
 
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(true);
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .withTransportCasualtiesRestricted(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -737,25 +745,26 @@ public class BattleStepsTest {
                 .battleSite(givenSeaBattleSite())
                 .build());
 
-    assertThat(steps, is(mergeSteps(List.of(REMOVE_UNESCORTED_TRANSPORTS), basicFightSteps())));
+    assertThat(
+        steps, is(mergeSteps(List.of(REMOVE_UNESCORTED_TRANSPORTS), basicFightStepStrings())));
   }
 
   @Test
   @DisplayName(
       "Verify unescorted attacking transports are not removed if casualties are not restricted")
   void unescortedAttackingTransportsAreNotRemovedWhenCasualtiesAreNotRestricted() {
-    givenPlayers();
     final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
     final Unit unit1 = unitAndAttachment.unit;
     final Unit unit2 = givenAnyUnit();
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .withTransportCasualtiesRestricted(false)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -763,25 +772,25 @@ public class BattleStepsTest {
                 .battleSite(givenSeaBattleSite())
                 .build());
 
-    assertThat(steps, is(basicFightSteps()));
+    assertThat(steps, is(basicFightStepStrings()));
     verify(unitAndAttachment.unitAttachment, never()).getTransportCapacity();
   }
 
   @Test
   @DisplayName("Verify unescorted defending transports are removed if casualties are restricted")
   void unescortedDefendingTransportsAreRemovedWhenCasualtiesAreRestricted() {
-    givenPlayers();
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenUnitSeaTransport();
 
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(true);
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .withTransportCasualtiesRestricted(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -789,25 +798,27 @@ public class BattleStepsTest {
                 .battleSite(givenSeaBattleSite())
                 .build());
 
-    assertThat(steps, is(mergeSteps(List.of(REMOVE_UNESCORTED_TRANSPORTS), basicFightSteps())));
+    assertThat(
+        steps, is(mergeSteps(List.of(REMOVE_UNESCORTED_TRANSPORTS), basicFightStepStrings())));
   }
 
   @Test
   @DisplayName(
       "Verify unescorted defending transports are removed if casualties are not restricted")
   void unescortedDefendingTransportsAreNotRemovedWhenCasualtiesAreNotRestricted() {
-    givenPlayers();
     final Unit unit1 = givenAnyUnit();
     final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
     final Unit unit2 = unitAndAttachment.unit;
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
+
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .withTransportCasualtiesRestricted(false)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -815,7 +826,7 @@ public class BattleStepsTest {
                 .battleSite(givenSeaBattleSite())
                 .build());
 
-    assertThat(steps, is(basicFightSteps()));
+    assertThat(steps, is(basicFightStepStrings()));
     verify(unitAndAttachment.unitAttachment, never()).getTransportCapacity();
   }
 
@@ -824,14 +835,18 @@ public class BattleStepsTest {
       "Verify basic attacker firstStrike "
           + "(no other attackers, no special defenders, all options false)")
   void attackingFirstStrikeBasic() {
-    givenPlayers();
     final Unit unit1 = givenUnitFirstStrikeAndEvade();
     final Unit unit2 = givenAnyUnit();
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withWW2V2(false)
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -842,26 +857,28 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                attacker.getName() + FIRST_STRIKE_UNITS_FIRE,
-                defender.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                defender.getName() + FIRE,
-                attacker.getName() + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES)));
+            mergeSteps(
+                firstStrikeFightStepStrings(attacker, defender),
+                List.of(REMOVE_SNEAK_ATTACK_CASUALTIES),
+                generalFightStepStrings(defender, attacker),
+                List.of(REMOVE_CASUALTIES))));
   }
 
   @Test
   @DisplayName("Verify attacker firstStrike with destroyers")
   void attackingFirstStrikeWithDestroyers() {
-    givenPlayers();
     final Unit unit1 = givenUnitFirstStrike();
     final Unit unit2 = givenUnitDestroyer();
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withWW2V2(false)
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -872,12 +889,10 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                attacker.getName() + FIRST_STRIKE_UNITS_FIRE,
-                defender.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                defender.getName() + FIRE,
-                attacker.getName() + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES)));
+            mergeSteps(
+                firstStrikeFightStepStrings(attacker, defender),
+                generalFightStepStrings(defender, attacker),
+                List.of(REMOVE_CASUALTIES))));
   }
 
   @Test
@@ -885,14 +900,19 @@ public class BattleStepsTest {
       "Verify basic defender firstStrike "
           + "(no other attackers, no special defenders, all options false)")
   void defendingFirstStrikeBasic() {
-    givenPlayers();
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withWW2V2(false)
+                        .withDefendingSubsSneakAttack(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -903,32 +923,29 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                attacker.getName() + FIRE,
-                defender.getName() + SELECT_CASUALTIES,
-                defender.getName() + FIRST_STRIKE_UNITS_FIRE,
-                attacker.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_CASUALTIES)));
+            mergeSteps(
+                generalFightStepStrings(attacker, defender),
+                firstStrikeFightStepStrings(defender, attacker),
+                List.of(REMOVE_CASUALTIES))));
   }
 
   @Test
   @DisplayName("Verify defender firstStrike with DEFENDING_SUBS_SNEAK_ATTACK true")
   void defendingFirstStrikeWithSneakAttackAllowed() {
-    givenPlayers();
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenUnitFirstStrikeAndEvade();
-
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
-    when(gameProperties.get(WW2V2, false)).thenReturn(false);
-    when(gameProperties.get(DEFENDING_SUBS_SNEAK_ATTACK, false)).thenReturn(true);
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withSubRetreatBeforeBattle(false)
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withTransportCasualtiesRestricted(false)
+                        .withWW2V2(false)
+                        .withDefendingSubsSneakAttack(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -939,32 +956,29 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                defender.getName() + FIRST_STRIKE_UNITS_FIRE,
-                attacker.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                attacker.getName() + FIRE,
-                defender.getName() + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES)));
+            mergeSteps(
+                firstStrikeFightStepStrings(defender, attacker),
+                List.of(REMOVE_SNEAK_ATTACK_CASUALTIES),
+                generalFightStepStrings(attacker, defender),
+                List.of(REMOVE_CASUALTIES))));
   }
 
   @Test
   @DisplayName("Verify defender firstStrike with WW2v2 true")
   void defendingFirstStrikeWithWW2v2() {
-    givenPlayers();
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenUnitFirstStrikeAndEvade();
-
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
-    when(gameProperties.get(WW2V2, false)).thenReturn(true);
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withSubRetreatBeforeBattle(false)
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withTransportCasualtiesRestricted(false)
+                        .withWW2V2(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -975,32 +989,29 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                defender.getName() + FIRST_STRIKE_UNITS_FIRE,
-                attacker.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                attacker.getName() + FIRE,
-                defender.getName() + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES)));
+            mergeSteps(
+                firstStrikeFightStepStrings(defender, attacker),
+                List.of(REMOVE_SNEAK_ATTACK_CASUALTIES),
+                generalFightStepStrings(attacker, defender),
+                List.of(REMOVE_CASUALTIES))));
   }
 
   @Test
   @DisplayName("Verify defender firstStrike with WW2v2 true and attacker destroyers")
   void defendingFirstStrikeWithWW2v2AndDestroyers() {
-    givenPlayers();
     final Unit unit1 = givenUnitDestroyer();
     final Unit unit2 = givenUnitFirstStrikeAndEvade();
-
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
-    when(gameProperties.get(WW2V2, false)).thenReturn(true);
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withSubRetreatBeforeBattle(false)
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withTransportCasualtiesRestricted(false)
+                        .withWW2V2(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1011,12 +1022,10 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                defender.getName() + FIRST_STRIKE_UNITS_FIRE,
-                attacker.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                attacker.getName() + FIRE,
-                defender.getName() + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES)));
+            mergeSteps(
+                firstStrikeFightStepStrings(defender, attacker),
+                generalFightStepStrings(attacker, defender),
+                List.of(REMOVE_CASUALTIES))));
   }
 
   @Test
@@ -1024,14 +1033,19 @@ public class BattleStepsTest {
       "Verify basic attacker and defender firstStrikes "
           + "(no other attackers, no special defenders, all options false)")
   void attackingDefendingFirstStrikeBasic() {
-    givenPlayers();
     final Unit unit1 = givenUnitFirstStrikeAndEvade();
     final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withWW2V2(false)
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withDefendingSubsSneakAttack(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1042,33 +1056,30 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                attacker.getName() + FIRST_STRIKE_UNITS_FIRE,
-                defender.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                defender.getName() + FIRST_STRIKE_UNITS_FIRE,
-                attacker.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_CASUALTIES)));
+            mergeSteps(
+                firstStrikeFightStepStrings(attacker, defender),
+                List.of(REMOVE_SNEAK_ATTACK_CASUALTIES),
+                firstStrikeFightStepStrings(defender, attacker),
+                List.of(REMOVE_CASUALTIES))));
   }
 
   @Test
   @DisplayName("Verify attacking/defender firstStrikes with DEFENDING_SUBS_SNEAK_ATTACK true")
   void attackingDefendingFirstStrikeWithSneakAttackAllowed() {
-    givenPlayers();
     final Unit unit1 = givenUnitFirstStrikeAndEvade();
     final Unit unit2 = givenUnitFirstStrikeAndEvade();
-
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
-    when(gameProperties.get(WW2V2, false)).thenReturn(false);
-    when(gameProperties.get(DEFENDING_SUBS_SNEAK_ATTACK, false)).thenReturn(true);
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .withTransportCasualtiesRestricted(false)
+                        .withWW2V2(false)
+                        .withDefendingSubsSneakAttack(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1079,33 +1090,28 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                attacker.getName() + FIRST_STRIKE_UNITS_FIRE,
-                defender.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                defender.getName() + FIRST_STRIKE_UNITS_FIRE,
-                attacker.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                // TODO: BUG? should this have been skipped
-                REMOVE_CASUALTIES)));
+            mergeSteps(
+                firstStrikeFightStepStrings(attacker, defender),
+                firstStrikeFightStepStrings(defender, attacker),
+                List.of(REMOVE_SNEAK_ATTACK_CASUALTIES, REMOVE_CASUALTIES))));
   }
 
   @Test
   @DisplayName("Verify attacking/defender firstStrikes with WW2v2 true")
   void attackingDefendingFirstStrikeWithWW2v2() {
-    givenPlayers();
     final Unit unit1 = givenUnitFirstStrikeAndEvade();
     final Unit unit2 = givenUnitFirstStrikeAndEvade();
-
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
-    when(gameProperties.get(WW2V2, false)).thenReturn(true);
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .withTransportCasualtiesRestricted(false)
+                        .withWW2V2(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1116,36 +1122,31 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                attacker.getName() + FIRST_STRIKE_UNITS_FIRE,
-                defender.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                defender.getName() + FIRST_STRIKE_UNITS_FIRE,
-                attacker.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                // TODO: BUG? should this have been skipped
-                REMOVE_CASUALTIES)));
+            mergeSteps(
+                firstStrikeFightStepStrings(attacker, defender),
+                firstStrikeFightStepStrings(defender, attacker),
+                List.of(REMOVE_SNEAK_ATTACK_CASUALTIES, REMOVE_CASUALTIES))));
   }
 
   @Test
   @DisplayName(
       "Verify attacking/defender firstStrikes with WW2v2 true and attacker/defender destroyers")
   void attackingDefendingFirstStrikeWithWW2v2AndDestroyers() {
-    givenPlayers();
     final Unit unit1 = givenUnitFirstStrike();
     final Unit unit2 = givenUnitFirstStrikeAndEvade();
     final Unit unit3 = givenUnitDestroyer();
     final Unit unit4 = givenUnitDestroyer();
 
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
-    when(gameProperties.get(WW2V2, false)).thenReturn(true);
-
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .withTransportCasualtiesRestricted(false)
+                        .withWW2V2(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1, unit3))
@@ -1156,16 +1157,12 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                attacker.getName() + FIRST_STRIKE_UNITS_FIRE,
-                defender.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                defender.getName() + FIRST_STRIKE_UNITS_FIRE,
-                attacker.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                attacker.getName() + FIRE,
-                defender.getName() + SELECT_CASUALTIES,
-                defender.getName() + FIRE,
-                attacker.getName() + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES)));
+            mergeSteps(
+                firstStrikeFightStepStrings(attacker, defender),
+                firstStrikeFightStepStrings(defender, attacker),
+                generalFightStepStrings(attacker, defender),
+                generalFightStepStrings(defender, attacker),
+                List.of(REMOVE_CASUALTIES))));
   }
 
   @Test
@@ -1173,22 +1170,21 @@ public class BattleStepsTest {
       "Verify attacking/defender firstStrikes with "
           + "DEFENDING_SUBS_SNEAK_ATTACK true and defender destroyers")
   void attackingDefendingFirstStrikeWithSneakAttackAllowedAndDefendingDestroyers() {
-    givenPlayers();
     final Unit unit1 = givenUnitFirstStrike();
     final Unit unit2 = givenUnitFirstStrikeAndEvade();
     final Unit unit3 = givenUnitDestroyer();
 
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
-    when(gameProperties.get(WW2V2, false)).thenReturn(false);
-    when(gameProperties.get(DEFENDING_SUBS_SNEAK_ATTACK, false)).thenReturn(true);
-
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .withTransportCasualtiesRestricted(false)
+                        .withWW2V2(false)
+                        .withDefendingSubsSneakAttack(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1199,35 +1195,31 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                defender.getName() + FIRST_STRIKE_UNITS_FIRE,
-                attacker.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                attacker.getName() + FIRST_STRIKE_UNITS_FIRE,
-                defender.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                defender.getName() + FIRE,
-                attacker.getName() + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES)));
+            mergeSteps(
+                firstStrikeFightStepStrings(defender, attacker),
+                List.of(REMOVE_SNEAK_ATTACK_CASUALTIES),
+                firstStrikeFightStepStrings(attacker, defender),
+                generalFightStepStrings(defender, attacker),
+                List.of(REMOVE_CASUALTIES))));
   }
 
   @Test
   @DisplayName("Verify attacking/defender firstStrikes with WW2v2 true and defender destroyers")
   void attackingDefendingFirstStrikeWithWW2v2AndDefendingDestroyers() {
-    givenPlayers();
     final Unit unit1 = givenUnitFirstStrike();
     final Unit unit2 = givenUnitFirstStrikeAndEvade();
     final Unit unit3 = givenUnitDestroyer();
 
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
-    when(gameProperties.get(WW2V2, false)).thenReturn(true);
-
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .withTransportCasualtiesRestricted(false)
+                        .withWW2V2(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1238,35 +1230,31 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                attacker.getName() + FIRST_STRIKE_UNITS_FIRE,
-                defender.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                defender.getName() + FIRST_STRIKE_UNITS_FIRE,
-                attacker.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                defender.getName() + FIRE,
-                attacker.getName() + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES)));
+            mergeSteps(
+                firstStrikeFightStepStrings(attacker, defender),
+                firstStrikeFightStepStrings(defender, attacker),
+                List.of(REMOVE_SNEAK_ATTACK_CASUALTIES),
+                generalFightStepStrings(defender, attacker),
+                List.of(REMOVE_CASUALTIES))));
   }
 
   @Test
   @DisplayName("Verify attacking/defender firstStrikes with WW2v2 true and attacking destroyers")
   void attackingDefendingFirstStrikeWithWW2v2AndAttackingDestroyers() {
-    givenPlayers();
     final Unit unit1 = givenUnitFirstStrikeAndEvade();
     final Unit unit2 = givenUnitFirstStrikeAndEvade();
     final Unit unit3 = givenUnitDestroyer();
 
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
-    when(gameProperties.get(WW2V2, false)).thenReturn(true);
-
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .withTransportCasualtiesRestricted(false)
+                        .withWW2V2(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1, unit3))
@@ -1277,34 +1265,30 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                attacker.getName() + FIRST_STRIKE_UNITS_FIRE,
-                defender.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                defender.getName() + FIRST_STRIKE_UNITS_FIRE,
-                attacker.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                attacker.getName() + FIRE,
-                defender.getName() + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES)));
+            mergeSteps(
+                firstStrikeFightStepStrings(attacker, defender),
+                firstStrikeFightStepStrings(defender, attacker),
+                List.of(REMOVE_SNEAK_ATTACK_CASUALTIES),
+                generalFightStepStrings(attacker, defender),
+                List.of(REMOVE_CASUALTIES))));
   }
 
   @Test
   @DisplayName("Verify attacking firstStrikes against air")
   void attackingFirstStrikeVsAir() {
-    givenPlayers();
     final Unit unit2 = givenUnitIsAir();
     final Unit unit1 = givenUnitFirstStrikeAndEvadeAndCanNotBeTargetedBy(unit2.getType());
-
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
-    when(gameProperties.get(WW2V2, false)).thenReturn(true);
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .withTransportCasualtiesRestricted(false)
+                        .withWW2V2(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1315,35 +1299,31 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                SUBMERGE_SUBS_VS_AIR_ONLY,
-                attacker.getName() + FIRST_STRIKE_UNITS_FIRE,
-                defender.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                AIR_DEFEND_NON_SUBS,
-                defender.getName() + FIRE,
-                attacker.getName() + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES)));
+            mergeSteps(
+                List.of(SUBMERGE_SUBS_VS_AIR_ONLY),
+                firstStrikeFightStepStrings(attacker, defender),
+                List.of(REMOVE_SNEAK_ATTACK_CASUALTIES, AIR_DEFEND_NON_SUBS),
+                generalFightStepStrings(defender, attacker),
+                List.of(REMOVE_CASUALTIES))));
   }
 
   @Test
   @DisplayName("Verify attacking firstStrikes against air with destroyer")
   void attackingFirstStrikeVsAirAndDestroyer() {
-    givenPlayers();
     final Unit unit2 = givenUnitIsAir();
     final Unit unit1 = givenUnitFirstStrike();
     final Unit unit3 = givenUnitDestroyer();
 
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
-    when(gameProperties.get(WW2V2, false)).thenReturn(true);
-
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .withTransportCasualtiesRestricted(false)
+                        .withWW2V2(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1354,31 +1334,28 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                attacker.getName() + FIRST_STRIKE_UNITS_FIRE,
-                defender.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                defender.getName() + FIRE,
-                attacker.getName() + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES)));
+            mergeSteps(
+                firstStrikeFightStepStrings(attacker, defender),
+                generalFightStepStrings(defender, attacker),
+                List.of(REMOVE_CASUALTIES))));
   }
 
   @Test
   @DisplayName("Verify defending firstStrikes against air")
   void defendingFirstStrikeVsAir() {
-    givenPlayers();
     final Unit unit1 = givenUnitIsAir();
     final Unit unit2 = givenUnitFirstStrikeAndEvadeAndCanNotBeTargetedBy(mock(UnitType.class));
-
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
-    when(gameProperties.get(WW2V2, false)).thenReturn(true);
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .withTransportCasualtiesRestricted(false)
+                        .withWW2V2(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1389,36 +1366,31 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                SUBMERGE_SUBS_VS_AIR_ONLY,
-                defender.getName() + FIRST_STRIKE_UNITS_FIRE,
-                attacker.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                AIR_ATTACK_NON_SUBS,
-                attacker.getName() + FIRE,
-                defender.getName() + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES,
-                attacker.getName() + ATTACKER_WITHDRAW)));
+            mergeSteps(
+                List.of(SUBMERGE_SUBS_VS_AIR_ONLY),
+                firstStrikeFightStepStrings(defender, attacker),
+                List.of(REMOVE_SNEAK_ATTACK_CASUALTIES, AIR_ATTACK_NON_SUBS),
+                generalFightStepStrings(attacker, defender),
+                List.of(REMOVE_CASUALTIES, attacker.getName() + ATTACKER_WITHDRAW))));
   }
 
   @Test
   @DisplayName("Verify defending firstStrikes against air with destroyer")
   void defendingFirstStrikeVsAirAndDestroyer() {
-    givenPlayers();
     final Unit unit1 = givenUnitIsAir();
     final Unit unit2 = givenUnitFirstStrikeAndEvade();
     final Unit unit3 = givenUnitDestroyer();
 
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
-    when(gameProperties.get(WW2V2, false)).thenReturn(true);
-
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .withTransportCasualtiesRestricted(false)
+                        .withWW2V2(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1, unit3))
@@ -1429,32 +1401,29 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                defender.getName() + FIRST_STRIKE_UNITS_FIRE,
-                attacker.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                attacker.getName() + FIRE,
-                defender.getName() + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES,
-                attacker.getName() + ATTACKER_WITHDRAW)));
+            mergeSteps(
+                firstStrikeFightStepStrings(defender, attacker),
+                generalFightStepStrings(attacker, defender),
+                List.of(REMOVE_CASUALTIES, attacker.getName() + ATTACKER_WITHDRAW))));
   }
 
   @Test
   @DisplayName("Verify attacking firstStrike can submerge if SUBMERSIBLE_SUBS is true")
   void attackingFirstStrikeCanSubmergeIfSubmersibleSubs() {
-    givenPlayers();
     final Unit unit1 = givenUnitFirstStrikeAndEvade();
     final Unit unit2 = givenAnyUnit();
 
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
-    when(gameProperties.get(WW2V2, false)).thenReturn(false);
-    when(gameProperties.get(SUBMERSIBLE_SUBS, false)).thenReturn(true);
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withSubRetreatBeforeBattle(false)
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withTransportCasualtiesRestricted(false)
+                        .withWW2V2(false)
+                        .withSubmersibleSubs(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1465,34 +1434,31 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                attacker.getName() + FIRST_STRIKE_UNITS_FIRE,
-                defender.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                defender.getName() + FIRE,
-                attacker.getName() + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES,
-                attacker.getName() + SUBS_SUBMERGE)));
+            mergeSteps(
+                firstStrikeFightStepStrings(attacker, defender),
+                List.of(REMOVE_SNEAK_ATTACK_CASUALTIES),
+                generalFightStepStrings(defender, attacker),
+                List.of(REMOVE_CASUALTIES, attacker.getName() + SUBS_SUBMERGE))));
   }
 
   @Test
   @DisplayName("Verify defending firstStrike can submerge if SUBMERSIBLE_SUBS is true")
   void defendingFirstStrikeCanSubmergeIfSubmersibleSubs() {
-    givenPlayers();
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
-    when(gameProperties.get(WW2V2, false)).thenReturn(false);
-    when(gameProperties.get(DEFENDING_SUBS_SNEAK_ATTACK, false)).thenReturn(true);
-    when(gameProperties.get(SUBMERSIBLE_SUBS, false)).thenReturn(true);
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withSubRetreatBeforeBattle(false)
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withTransportCasualtiesRestricted(false)
+                        .withWW2V2(false)
+                        .withDefendingSubsSneakAttack(true)
+                        .withSubmersibleSubs(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1503,34 +1469,31 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                defender.getName() + FIRST_STRIKE_UNITS_FIRE,
-                attacker.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                attacker.getName() + FIRE,
-                defender.getName() + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES,
-                defender.getName() + SUBS_SUBMERGE)));
+            mergeSteps(
+                firstStrikeFightStepStrings(defender, attacker),
+                List.of(REMOVE_SNEAK_ATTACK_CASUALTIES),
+                generalFightStepStrings(attacker, defender),
+                List.of(REMOVE_CASUALTIES, defender.getName() + SUBS_SUBMERGE))));
   }
 
   @Test
   @DisplayName(
       "Verify defending firstStrike can submerge if SUBMERSIBLE_SUBS is true even with destroyers")
   void defendingFirstStrikeCanSubmergeIfSubmersibleSubsAndDestroyers() {
-    givenPlayers();
     final Unit unit1 = givenUnitDestroyer();
     final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
-    when(gameProperties.get(WW2V2, false)).thenReturn(false);
-    when(gameProperties.get(SUBMERSIBLE_SUBS, false)).thenReturn(true);
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withSubRetreatBeforeBattle(false)
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withTransportCasualtiesRestricted(false)
+                        .withWW2V2(false)
+                        .withSubmersibleSubs(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1541,26 +1504,27 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                attacker.getName() + FIRE,
-                defender.getName() + SELECT_CASUALTIES,
-                defender.getName() + FIRST_STRIKE_UNITS_FIRE,
-                attacker.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_CASUALTIES,
-                defender.getName() + SUBS_SUBMERGE)));
+            mergeSteps(
+                generalFightStepStrings(attacker, defender),
+                firstStrikeFightStepStrings(defender, attacker),
+                List.of(REMOVE_CASUALTIES, defender.getName() + SUBS_SUBMERGE))));
   }
 
   @Test
   @DisplayName("Verify attacking firstStrike can withdraw when SUBMERSIBLE_SUBS is false")
   void attackingFirstStrikeWithdrawIfAble() {
-    givenPlayers();
     final Unit unit1 = givenUnitFirstStrikeAndEvade();
     final Unit unit2 = givenAnyUnit();
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withWW2V2(false)
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1572,15 +1536,14 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                attacker.getName() + FIRST_STRIKE_UNITS_FIRE,
-                defender.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                defender.getName() + FIRE,
-                attacker.getName() + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES,
-                attacker.getName() + SUBS_WITHDRAW,
-                attacker.getName() + ATTACKER_WITHDRAW)));
+            mergeSteps(
+                firstStrikeFightStepStrings(attacker, defender),
+                List.of(REMOVE_SNEAK_ATTACK_CASUALTIES),
+                generalFightStepStrings(defender, attacker),
+                List.of(
+                    REMOVE_CASUALTIES,
+                    attacker.getName() + SUBS_WITHDRAW,
+                    attacker.getName() + ATTACKER_WITHDRAW))));
   }
 
   @Test
@@ -1588,14 +1551,18 @@ public class BattleStepsTest {
       "Verify attacking firstStrike can't withdraw when "
           + "SUBMERSIBLE_SUBS is false and no retreat territories")
   void attackingFirstStrikeNoWithdrawIfEmptyTerritories() {
-    givenPlayers();
     final Unit unit1 = givenUnitFirstStrikeAndEvade();
     final Unit unit2 = givenAnyUnit();
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withWW2V2(false)
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1606,13 +1573,11 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                attacker.getName() + FIRST_STRIKE_UNITS_FIRE,
-                defender.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                defender.getName() + FIRE,
-                attacker.getName() + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES)));
+            mergeSteps(
+                firstStrikeFightStepStrings(attacker, defender),
+                List.of(REMOVE_SNEAK_ATTACK_CASUALTIES),
+                generalFightStepStrings(defender, attacker),
+                List.of(REMOVE_CASUALTIES))));
   }
 
   @Test
@@ -1620,14 +1585,18 @@ public class BattleStepsTest {
       "Verify attacking firstStrike can't withdraw when "
           + "SUBMERSIBLE_SUBS is false and destroyers present")
   void attackingFirstStrikeNoWithdrawIfDestroyers() {
-    givenPlayers();
     final Unit unit1 = givenUnitFirstStrike();
     final Unit unit2 = givenUnitDestroyer();
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withWW2V2(false)
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1639,13 +1608,10 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                attacker.getName() + FIRST_STRIKE_UNITS_FIRE,
-                defender.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                defender.getName() + FIRE,
-                attacker.getName() + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES,
-                attacker.getName() + ATTACKER_WITHDRAW)));
+            mergeSteps(
+                firstStrikeFightStepStrings(attacker, defender),
+                generalFightStepStrings(defender, attacker),
+                List.of(REMOVE_CASUALTIES, attacker.getName() + ATTACKER_WITHDRAW))));
   }
 
   @Test
@@ -1653,20 +1619,20 @@ public class BattleStepsTest {
       "Verify attacking firstStrike can withdraw when "
           + "SUBMERSIBLE_SUBS is false and defenseless transports with non restricted casualties")
   void attackingFirstStrikeWithdrawIfNonRestrictedDefenselessTransports() {
-    givenPlayers();
     final Unit unit1 = givenUnitFirstStrikeAndEvade();
     final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
     final Unit unit2 = unitAndAttachment.unit;
 
-    when(gameProperties.get(WW2V2, false)).thenReturn(false);
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(false);
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withWW2V2(false)
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .withTransportCasualtiesRestricted(false)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1678,22 +1644,20 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                attacker.getName() + FIRST_STRIKE_UNITS_FIRE,
-                defender.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_SNEAK_ATTACK_CASUALTIES,
-                defender.getName() + FIRE,
-                attacker.getName() + SELECT_CASUALTIES,
-                REMOVE_CASUALTIES,
-                attacker.getName() + SUBS_WITHDRAW,
-                attacker.getName() + ATTACKER_WITHDRAW)));
+            mergeSteps(
+                firstStrikeFightStepStrings(attacker, defender),
+                List.of(REMOVE_SNEAK_ATTACK_CASUALTIES),
+                generalFightStepStrings(defender, attacker),
+                List.of(
+                    REMOVE_CASUALTIES,
+                    attacker.getName() + SUBS_WITHDRAW,
+                    attacker.getName() + ATTACKER_WITHDRAW))));
     verify(unitAndAttachment.unitAttachment, never()).getTransportCapacity();
   }
 
   @Test
   @DisplayName("Verify defending firstStrike can withdraw when SUBMERSIBLE_SUBS is false")
   void defendingFirstStrikeWithdrawIfAble() {
-    givenPlayers();
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
@@ -1701,14 +1665,17 @@ public class BattleStepsTest {
     when(retreatTerritory.isWater()).thenReturn(true);
     when(retreatTerritory.getUnitCollection()).thenReturn(mock(UnitCollection.class));
 
-    final GameMap gameMap = mock(GameMap.class);
-    lenient().when(gameData.getMap()).thenReturn(gameMap);
-    when(gameMap.getNeighbors(battleSite)).thenReturn(Set.of(retreatTerritory));
-
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withTerritoryHasNeighbors(battleSite, Set.of(retreatTerritory))
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withWW2V2(false)
+                        .withDefendingSubsSneakAttack(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1719,13 +1686,10 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                attacker.getName() + FIRE,
-                defender.getName() + SELECT_CASUALTIES,
-                defender.getName() + FIRST_STRIKE_UNITS_FIRE,
-                attacker.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_CASUALTIES,
-                defender.getName() + SUBS_WITHDRAW)));
+            mergeSteps(
+                generalFightStepStrings(attacker, defender),
+                firstStrikeFightStepStrings(defender, attacker),
+                List.of(REMOVE_CASUALTIES, defender.getName() + SUBS_WITHDRAW))));
   }
 
   @Test
@@ -1733,14 +1697,19 @@ public class BattleStepsTest {
       "Verify defending firstStrike can't withdraw when "
           + "SUBMERSIBLE_SUBS is false and no retreat territories")
   void defendingFirstStrikeNoWithdrawIfEmptyTerritories() {
-    givenPlayers();
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .withWW2V2(false)
+                        .withDefendingSubsSneakAttack(false)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1751,12 +1720,10 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                attacker.getName() + FIRE,
-                defender.getName() + SELECT_CASUALTIES,
-                defender.getName() + FIRST_STRIKE_UNITS_FIRE,
-                attacker.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_CASUALTIES)));
+            mergeSteps(
+                generalFightStepStrings(attacker, defender),
+                firstStrikeFightStepStrings(defender, attacker),
+                List.of(REMOVE_CASUALTIES))));
   }
 
   @Test
@@ -1764,14 +1731,18 @@ public class BattleStepsTest {
       "Verify defending firstStrike can't withdraw when "
           + "SUBMERSIBLE_SUBS is false and destroyers present")
   void defendingFirstStrikeNoWithdrawIfDestroyers() {
-    givenPlayers();
     final Unit unit1 = givenUnitDestroyer();
     final Unit unit2 = givenUnitFirstStrikeAndEvade();
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withWW2V2(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1782,25 +1753,27 @@ public class BattleStepsTest {
     assertThat(
         steps,
         is(
-            List.of(
-                attacker.getName() + FIRE,
-                defender.getName() + SELECT_CASUALTIES,
-                defender.getName() + FIRST_STRIKE_UNITS_FIRE,
-                attacker.getName() + SELECT_FIRST_STRIKE_CASUALTIES,
-                REMOVE_CASUALTIES)));
+            mergeSteps(
+                generalFightStepStrings(attacker, defender),
+                firstStrikeFightStepStrings(defender, attacker),
+                List.of(REMOVE_CASUALTIES))));
   }
 
   @Test
   @DisplayName("Verify attacking air units at sea can withdraw")
   void attackingAirUnitsAtSeaCanWithdraw() {
-    givenPlayers();
     final Unit unit1 = givenUnitIsAir();
     final Unit unit2 = givenAnyUnit();
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .withTransportCasualtiesRestricted(false)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1809,26 +1782,28 @@ public class BattleStepsTest {
                 .build());
 
     assertThat(
-        steps, is(mergeSteps(basicFightSteps(), List.of(attacker.getName() + ATTACKER_WITHDRAW))));
+        steps,
+        is(mergeSteps(basicFightStepStrings(), List.of(attacker.getName() + ATTACKER_WITHDRAW))));
   }
 
   @Test
   @DisplayName("Verify partial amphibious attack can withdraw if a unit was not amphibious")
   void partialAmphibiousAttackCanWithdrawIfHasNonAmphibious() {
-    givenPlayers();
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenAnyUnit();
     final Unit unit3 = givenAnyUnit();
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(PARTIAL_AMPHIBIOUS_RETREAT, false)).thenReturn(true);
     when(unit1.getWasAmphibious()).thenReturn(true);
     when(unit3.getWasAmphibious()).thenReturn(false);
+
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withSubRetreatBeforeBattle(false)
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withPartialAmphibiousRetreat(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1, unit3))
@@ -1838,28 +1813,30 @@ public class BattleStepsTest {
                 .build());
 
     assertThat(
-        steps, is(mergeSteps(basicFightSteps(), List.of(attacker.getName() + ATTACKER_WITHDRAW))));
+        steps,
+        is(mergeSteps(basicFightStepStrings(), List.of(attacker.getName() + ATTACKER_WITHDRAW))));
   }
 
   @Test
   @DisplayName("Verify partial amphibious attack can not withdraw if all units were amphibious")
   void partialAmphibiousAttackCanNotWithdrawIfHasAllAmphibious() {
-    givenPlayers();
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenAnyUnit();
     final Unit unit3 = givenAnyUnit();
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(WW2V2, false)).thenReturn(false);
-    when(gameProperties.get(ATTACKER_RETREAT_PLANES, false)).thenReturn(false);
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(PARTIAL_AMPHIBIOUS_RETREAT, false)).thenReturn(true);
     when(unit1.getWasAmphibious()).thenReturn(true);
     when(unit3.getWasAmphibious()).thenReturn(true);
+
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withSubRetreatBeforeBattle(false)
+                        .withWW2V2(false)
+                        .withAttackerRetreatPlanes(false)
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withPartialAmphibiousRetreat(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1, unit3))
@@ -1868,7 +1845,7 @@ public class BattleStepsTest {
                 .amphibious(true)
                 .build());
 
-    assertThat(steps, is(basicFightSteps()));
+    assertThat(steps, is(basicFightStepStrings()));
   }
 
   @Test
@@ -1876,14 +1853,17 @@ public class BattleStepsTest {
       "Verify partial amphibious attack can not withdraw if "
           + "partial amphibious withdrawal not allowed")
   void partialAmphibiousAttackCanNotWithdrawIfNotAllowed() {
-    givenPlayers();
     final Unit unit1 = givenAnyUnit();
     final Unit unit2 = givenAnyUnit();
     final Unit unit3 = givenAnyUnit();
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1, unit3))
@@ -1892,7 +1872,7 @@ public class BattleStepsTest {
                 .amphibious(true)
                 .build());
 
-    assertThat(steps, is(basicFightSteps()));
+    assertThat(steps, is(basicFightStepStrings()));
     // should never check for amphibious units
     verify(unit1, never()).getWasAmphibious();
   }
@@ -1900,19 +1880,19 @@ public class BattleStepsTest {
   @Test
   @DisplayName("Verify attacker planes can withdraw if ww2v2 and amphibious")
   void attackingPlanesCanWithdrawWW2v2AndAmphibious() {
-    givenPlayers();
     final Unit unit1 = givenUnitIsAir();
     final Unit unit2 = givenAnyUnit();
 
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(PARTIAL_AMPHIBIOUS_RETREAT, false)).thenReturn(false);
-    when(gameProperties.get(WW2V2, false)).thenReturn(true);
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .withPartialAmphibiousRetreat(false)
+                        .withWW2V2(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1922,7 +1902,8 @@ public class BattleStepsTest {
                 .build());
 
     assertThat(
-        steps, is(mergeSteps(basicFightSteps(), List.of(attacker.getName() + ATTACKER_WITHDRAW))));
+        steps,
+        is(mergeSteps(basicFightStepStrings(), List.of(attacker.getName() + ATTACKER_WITHDRAW))));
   }
 
   @Test
@@ -1930,22 +1911,22 @@ public class BattleStepsTest {
       "Verify attacker planes can withdraw if "
           + "attacker can partial amphibious retreat and amphibious")
   void attackingPlanesCanWithdrawPartialAmphibiousAndAmphibious() {
-    givenPlayers();
     final Unit unit1 = givenUnitIsAir();
     final Unit unit2 = givenAnyUnit();
     final Unit unit3 = givenAnyUnit();
     when(unit3.getWasAmphibious()).thenReturn(true);
 
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(WW2V2, false)).thenReturn(false);
-    when(gameProperties.get(ATTACKER_RETREAT_PLANES, false)).thenReturn(false);
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(PARTIAL_AMPHIBIOUS_RETREAT, false)).thenReturn(true);
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withSubRetreatBeforeBattle(false)
+                        .withWW2V2(false)
+                        .withAttackerRetreatPlanes(false)
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withPartialAmphibiousRetreat(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1, unit3))
@@ -1955,26 +1936,27 @@ public class BattleStepsTest {
                 .build());
 
     assertThat(
-        steps, is(mergeSteps(basicFightSteps(), List.of(attacker.getName() + ATTACKER_WITHDRAW))));
+        steps,
+        is(mergeSteps(basicFightStepStrings(), List.of(attacker.getName() + ATTACKER_WITHDRAW))));
   }
 
   @Test
   @DisplayName("Verify attacker planes can withdraw if attacker can retreat planes and amphibious")
   void attackingPlanesCanWithdrawPlanesRetreatAndAmphibious() {
-    givenPlayers();
     final Unit unit1 = givenUnitIsAir();
     final Unit unit2 = givenAnyUnit();
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(WW2V2, false)).thenReturn(false);
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(PARTIAL_AMPHIBIOUS_RETREAT, false)).thenReturn(false);
-    when(gameProperties.get(ATTACKER_RETREAT_PLANES, false)).thenReturn(true);
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withSubRetreatBeforeBattle(false)
+                        .withWW2V2(false)
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withPartialAmphibiousRetreat(false)
+                        .withAttackerRetreatPlanes(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -1984,24 +1966,25 @@ public class BattleStepsTest {
                 .build());
 
     assertThat(
-        steps, is(mergeSteps(basicFightSteps(), List.of(attacker.getName() + ATTACKER_WITHDRAW))));
+        steps,
+        is(mergeSteps(basicFightStepStrings(), List.of(attacker.getName() + ATTACKER_WITHDRAW))));
   }
 
   @Test
   @DisplayName("Verify attacker planes can not withdraw if ww2v2 and not amphibious")
   void attackingPlanesCanNotWithdrawWW2v2AndNotAmphibious() {
-    givenPlayers();
     final Unit unit1 = givenUnitIsAir();
     final Unit unit2 = givenAnyUnit();
-    when(gameProperties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false))
-        .thenReturn(false);
-    when(gameProperties.get(SUB_RETREAT_BEFORE_BATTLE, false)).thenReturn(false);
-    when(gameProperties.get(TRANSPORT_CASUALTIES_RESTRICTED, false)).thenReturn(true);
 
     final List<String> steps =
         givenBattleSteps(
             givenBattleStateBuilder()
-                .gameData(gameData)
+                .gameData(
+                    givenGameData()
+                        .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
+                        .withSubRetreatBeforeBattle(false)
+                        .withTransportCasualtiesRestricted(true)
+                        .build())
                 .attacker(attacker)
                 .defender(defender)
                 .attackingUnits(List.of(unit1))
@@ -2010,6 +1993,6 @@ public class BattleStepsTest {
                 .amphibious(false)
                 .build());
 
-    assertThat(steps, is(basicFightSteps()));
+    assertThat(steps, is(basicFightStepStrings()));
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
@@ -242,8 +242,7 @@ public class BattleStepsTest {
         hitPlayer.getName() + SELECT_FIRST_STRIKE_CASUALTIES);
   }
 
-  private List<String> navalBombardmentFightStepStrings(
-      final GamePlayer firingPlayer, final GamePlayer hitPlayer) {
+  private List<String> navalBombardmentFightStepStrings() {
     return List.of(NAVAL_BOMBARDMENT, SELECT_NAVAL_BOMBARDMENT_CASUALTIES);
   }
 
@@ -321,11 +320,7 @@ public class BattleStepsTest {
                 .battleRound(1)
                 .build());
 
-    assertThat(
-        steps,
-        is(
-            mergeSteps(
-                navalBombardmentFightStepStrings(attacker, defender), basicFightStepStrings())));
+    assertThat(steps, is(mergeSteps(navalBombardmentFightStepStrings(), basicFightStepStrings())));
     verify(battleSite, never()).getUnits();
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
@@ -247,7 +247,7 @@ public class BattleStepsTest {
     return List.of(NAVAL_BOMBARDMENT, SELECT_NAVAL_BOMBARDMENT_CASUALTIES);
   }
 
-  private List<String> aAFightStepStrings(
+  private List<String> aaFightStepStrings(
       final String name, final GamePlayer firingPlayer, final GamePlayer hitPlayer) {
     return List.of(
         firingPlayer.getName() + " " + name + AA_GUNS_FIRE_SUFFIX,
@@ -545,7 +545,7 @@ public class BattleStepsTest {
         steps,
         is(
             mergeSteps(
-                aAFightStepStrings("AntiAirGun", attacker, defender), basicFightStepStrings())));
+                aaFightStepStrings("AntiAirGun", attacker, defender), basicFightStepStrings())));
 
     verify(battleSite, never()).getUnits();
   }
@@ -572,7 +572,7 @@ public class BattleStepsTest {
         steps,
         is(
             mergeSteps(
-                aAFightStepStrings("AntiAirGun", defender, attacker), basicFightStepStrings())));
+                aaFightStepStrings("AntiAirGun", defender, attacker), basicFightStepStrings())));
 
     verify(battleSite, never()).getUnits();
   }
@@ -600,8 +600,8 @@ public class BattleStepsTest {
         steps,
         is(
             mergeSteps(
-                aAFightStepStrings("AntiAirGun", attacker, defender),
-                aAFightStepStrings("AntiAirGun", defender, attacker),
+                aaFightStepStrings("AntiAirGun", attacker, defender),
+                aaFightStepStrings("AntiAirGun", defender, attacker),
                 basicFightStepStrings())));
 
     verify(battleSite, never()).getUnits();

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/MockGameData.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/MockGameData.java
@@ -2,9 +2,11 @@ package games.strategy.triplea.delegate.battle.steps;
 
 import static games.strategy.triplea.Constants.ALLIED_AIR_INDEPENDENT;
 import static games.strategy.triplea.Constants.ATTACKER_RETREAT_PLANES;
+import static games.strategy.triplea.Constants.CAPTURE_UNITS_ON_ENTERING_TERRITORY;
 import static games.strategy.triplea.Constants.DEFENDING_SUBS_SNEAK_ATTACK;
 import static games.strategy.triplea.Constants.DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE;
 import static games.strategy.triplea.Constants.LHTR_HEAVY_BOMBERS;
+import static games.strategy.triplea.Constants.NAVAL_BOMBARD_CASUALTIES_RETURN_FIRE;
 import static games.strategy.triplea.Constants.PARTIAL_AMPHIBIOUS_RETREAT;
 import static games.strategy.triplea.Constants.SUBMARINES_DEFENDING_MAY_SUBMERGE_OR_RETREAT;
 import static games.strategy.triplea.Constants.SUBMERSIBLE_SUBS;
@@ -141,6 +143,16 @@ public class MockGameData {
 
   public MockGameData withAlliedAirIndependent(final boolean value) {
     when(gameProperties.get(ALLIED_AIR_INDEPENDENT, false)).thenReturn(value);
+    return this;
+  }
+
+  public MockGameData withNavalBombardCasualtiesReturnFire(final boolean value) {
+    when(gameProperties.get(NAVAL_BOMBARD_CASUALTIES_RETURN_FIRE, false)).thenReturn(value);
+    return this;
+  }
+
+  public MockGameData withCaptureUnitsOnEnteringTerritory(final boolean value) {
+    when(gameProperties.get(CAPTURE_UNITS_ON_ENTERING_TERRITORY, false)).thenReturn(value);
     return this;
   }
 }


### PR DESCRIPTION
This is part of #7823.  This only changes test files to get them ready for the fire round step changes.

Because the step names are changing, a lot of tests have to be updated.  This PR creates helper methods to generate the step names in the tests.  The tests have been updated to use those helper methods.  When the final PR is created, it will just update the helper methods and not update all of the individual locations.

The gameData also has to have additional mocks and so I switched the BattleStepsTest to use the `MockGameData` where most of it is already done.

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
