### PR TITLE
Add unzipped maps to the map list again

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/AvailableGamesFileSystemReader.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/AvailableGamesFileSystemReader.java
@@ -82,7 +82,7 @@ public class AvailableGamesFileSystemReader {
               mapDir.toPath(),
               8,
               (path, basicAttributes) ->
-                  basicAttributes.isRegularFile() && path.getFileName().endsWith(".xml"))
+                  basicAttributes.isRegularFile() && path.getFileName().toString().endsWith(".xml"))
           .map(Path::toUri)
           .collect(Collectors.toList());
     } catch (final IOException e) {


### PR DESCRIPTION
The AvailableGamesFileSystemReader was added back in 86eafe8b82c84e34177c61311848f3a4f2371f13 and it was looking for xml files by using "Path#endsWith".  But "Path#endsWith" matches against the root component completely and not parts of it.

This converts the Path to a string and then uses "String#endsWith".

Fixes #7840

## Testing
I verified that my unzipped maps would show up in the map selector.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note
I'm not adding a release note as this is a pre-release regression.
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
