### PR TITLE
Make sure the default game is there or clear it if it isn't

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
@@ -12,8 +12,14 @@ import games.strategy.engine.framework.startup.mc.GameSelector;
 import games.strategy.triplea.ai.pro.ProAi;
 import games.strategy.triplea.settings.ClientSetting;
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
+import java.nio.file.FileSystemNotFoundException;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.List;
+import java.util.Map;
 import java.util.Observable;
 import java.util.Optional;
 import java.util.function.Function;
@@ -83,22 +89,30 @@ public class GameSelectorModel extends Observable implements GameSelector {
 
   public void load(final URI uri) {
     fileName = null;
-    this.gameData = parseAndValidate(uri);
-    if (gameData == null || gameData.getGameName() == null || uri == null) {
-      this.resetDefaultGame();
+    GameData gameData = null;
+    if (uri != null) {
+      gameData = parseAndValidate(uri);
+      if (gameData != null && gameData.getGameName() == null) {
+        gameData = null;
+      }
+    }
+    this.setDefaultGame(uri, gameData);
+  }
+
+  private void setDefaultGame(@Nullable final URI uri, @Nullable final GameData gameData) {
+    setGameData(gameData);
+    if (gameData == null || uri == null) {
+      ClientSetting.defaultGameName.resetValue();
+      ClientSetting.defaultGameUri.resetValue();
     } else {
-      setGameData(gameData);
       ClientSetting.defaultGameName.setValue(gameData.getGameName());
       ClientSetting.defaultGameUri.setValue(uri.toString());
-      ClientSetting.flush();
     }
+    ClientSetting.flush();
   }
 
   private void resetDefaultGame() {
-    setGameData(null);
-    ClientSetting.defaultGameName.resetValue();
-    ClientSetting.defaultGameUri.resetValue();
-    ClientSetting.flush();
+    setDefaultGame(null, null);
   }
 
   @Nullable
@@ -185,32 +199,43 @@ public class GameSelectorModel extends Observable implements GameSelector {
   public void loadDefaultGameSameThread() {
     ClientSetting.defaultGameUri
         .getValue()
+        .map(URI::create)
         // we don't want to load a game file by default that is not within the map folders we
         // can load. (ie: if a previous version of triplea was using running a game within its
         // root folder, we shouldn't open it)
         .filter(
-            defaultGame -> {
-              String rootFolder = ClientFileSystemHelper.getUserRootFolder().toURI().toString();
-              if (rootFolder.startsWith("file:")) {
-                // strip off this prefix so it matches better against the defaultGame string
-                rootFolder = rootFolder.substring("file:".length());
-              }
-              return defaultGame.contains(rootFolder);
-            })
+            defaultGame ->
+                getDefaultGameRealPath(defaultGame)
+                    .startsWith(ClientFileSystemHelper.getUserRootFolder().toPath()))
         // ensure the default game hasn't been deleted since it was last loaded
-        .filter(
-            defaultGame -> {
-              if (defaultGame.startsWith("jar:file:")) {
-                // when the game is from a zip file, it starts with jar:file: and uses a '!'
-                // to separate the local file from the zip content
-                defaultGame = defaultGame.substring("jar:file:".length(), defaultGame.indexOf('!'));
-              } else if (defaultGame.startsWith("file://")) {
-                // when the game is from a local file, it starts with file://
-                defaultGame = defaultGame.substring("file://".length());
-              }
-              return new File(defaultGame).exists();
-            })
-        .map(URI::create)
+        .filter(defaultGame -> getDefaultGameRealPath(defaultGame).toFile().exists())
         .ifPresentOrElse(this::load, this::resetDefaultGame);
+  }
+
+  /**
+   * Determine the real path of the default game.
+   *
+   * <p>A default game from a zip file will point to the file inside of the zip file. So, this
+   * method will find the location of the zip file itself.
+   */
+  private static Path getDefaultGameRealPath(final URI defaultGame) {
+    try {
+      FileSystems.getFileSystem(defaultGame);
+    } catch (final FileSystemNotFoundException notFoundException) {
+      try {
+        FileSystems.newFileSystem(defaultGame, Map.of());
+      } catch (final IOException ioException) {
+        // just ignore this error as Path.of() will throw a better error if the file is unable to
+        // be read
+      }
+    } catch (final IllegalArgumentException illegalArgumentException) {
+      // just ignore this error as Path.of() will throw a better error if the file is unable to
+      // be read
+    }
+    final Path defaultGamePath = Path.of(defaultGame);
+    if (defaultGamePath.getFileSystem().getFileStores().iterator().next().type().equals("zipfs")) {
+      return Paths.get(defaultGamePath.getFileSystem().getFileStores().iterator().next().name());
+    }
+    return defaultGamePath;
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
@@ -96,11 +96,11 @@ public class GameSelectorModel extends Observable implements GameSelector {
         gameData = null;
       }
     }
+    setGameData(gameData);
     this.setDefaultGame(uri, gameData);
   }
 
   private void setDefaultGame(@Nullable final URI uri, @Nullable final GameData gameData) {
-    setGameData(gameData);
     if (gameData == null || uri == null) {
       ClientSetting.defaultGameName.resetValue();
       ClientSetting.defaultGameUri.resetValue();
@@ -112,6 +112,7 @@ public class GameSelectorModel extends Observable implements GameSelector {
   }
 
   private void resetDefaultGame() {
+    setGameData(null);
     setDefaultGame(null, null);
   }
 


### PR DESCRIPTION
If the default game is not on the system, it wasn't being cleared out of
the game.  This would leave the game in an odd state where it is
partially loaded but has unused objects listening for events.

By calling resetDefaultGame when the default game is missing, the game
can be reset to an initial state where no map has been selected.

In addition, the checks to see if the file exists had issues when the
uri had special prefixes and suffixes.  So those are stripped before the
checks.

Fixes #7839

<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->
To test non-zip maps, I had to cherry-pick the code from #7910.  I don't have that code in this actual PR.
I tested on OSX and the prefix stripping was needed for that operating system.  I tested with both zip and unzip maps.  I also tested with deleting the map and starting the game to ensure that it didn't throw an error.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note
This is a pre-release regression, so no release notes.
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
