### PR TITLE
Fix error report uploads - set GameVersion field

### DIFF
--- a/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceReportModel.java
+++ b/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceReportModel.java
@@ -1,5 +1,6 @@
 package org.triplea.debug.error.reporting;
 
+import games.strategy.engine.ClientContext;
 import games.strategy.triplea.ResourceLoader;
 import games.strategy.triplea.ui.UiContext;
 import java.util.Optional;
@@ -38,6 +39,7 @@ class StackTraceReportModel {
                     .orElse(null),
                 DebugUtils.getMemory(),
                 stackTraceRecord))
+        .gameVersion(ClientContext.engineVersion().toString())
         .build();
   }
 

--- a/game-core/src/test/java/org/triplea/debug/error/reporting/ErrorReportUploadActionTest.java
+++ b/game-core/src/test/java/org/triplea/debug/error/reporting/ErrorReportUploadActionTest.java
@@ -26,6 +26,7 @@ class ErrorReportUploadActionTest {
       ErrorReportRequest.builder()
           .title("Extums prarere in audax tornacum!")
           .body("Rector de barbatus gemna, desiderium candidatus!")
+          .gameVersion("version")
           .build();
 
   private static final ErrorReportResponse SUCCESS_RESPONSE =

--- a/http-clients/src/main/java/org/triplea/http/client/error/report/ErrorReportRequest.java
+++ b/http-clients/src/main/java/org/triplea/http/client/error/report/ErrorReportRequest.java
@@ -1,6 +1,7 @@
 package org.triplea.http.client.error.report;
 
 import com.google.common.base.Ascii;
+import javax.annotation.Nonnull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -16,17 +17,15 @@ import org.triplea.http.client.github.issues.GithubIssueClient;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ErrorReportRequest {
-  private String title;
-  private String body;
-  @Getter private String gameVersion;
+  @Nonnull private String title;
+  @Nonnull private String body;
+  @Nonnull @Getter private String gameVersion;
 
   public String getTitle() {
-    return title == null ? null : Ascii.truncate(title, GithubIssueClient.TITLE_MAX_LENGTH, "...");
+    return Ascii.truncate(title, GithubIssueClient.TITLE_MAX_LENGTH, "...");
   }
 
   public String getBody() {
-    return body == null
-        ? null
-        : Ascii.truncate(body, GithubIssueClient.REPORT_BODY_MAX_LENGTH, "...");
+    return Ascii.truncate(body, GithubIssueClient.REPORT_BODY_MAX_LENGTH, "...");
   }
 }

--- a/http-clients/src/test/java/org/triplea/http/client/error/report/ErrorReportClientTest.java
+++ b/http-clients/src/test/java/org/triplea/http/client/error/report/ErrorReportClientTest.java
@@ -53,6 +53,7 @@ class ErrorReportClientTest extends WireMockTest {
             ErrorReportRequest.builder()
                 .title("Guttuss cadunt in germanus oenipons!")
                 .body(MESSAGE_FROM_USER)
+                .gameVersion("version")
                 .build());
   }
 


### PR DESCRIPTION
1. Set game version field to avoid throwing an error server side
   due to missing data.

2. Mark ErrorReportRequest data as non-null to help avoid this
   problem in the future.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->


## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
