### PR TITLE
Remove need for infrastructure setup step

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -1,9 +1,8 @@
 # Infrastructure Project
 
-This project hosts the code and configuration that controls
-deployments. For design, conventions and a description of
-the deployment process, please see the documentation in
- the [/docs](/docs) folder.
+Hosts the code and configuration that controls deployments.
+
+Design and conventions is in the [/infrastructure/docs](./docs) folder.
 
 ## Local Development with Vagrant
 
@@ -12,7 +11,6 @@ virtual machines via CLI.
 
 - Use vagrant to test deployments and configuration updates.
 
-- Don't worry, the initial setup is not too bad and once done it's pretty easy.
 
 ### Installation
 
@@ -80,3 +78,4 @@ sudo -u postgres psql
 ```bash
 vagrant destroy -f
 ```
+

--- a/infrastructure/ansible/inventory/prod2
+++ b/infrastructure/ansible/inventory/prod2
@@ -1,7 +1,3 @@
-[setup]
-prod2-bot01.triplea-game.org
-prod2-bot02.triplea-game.org
-
 [dropwizardHosts]
 prod2-lobby.triplea-game.org
 

--- a/infrastructure/ansible/roles/system/firewall/tasks/main.yml
+++ b/infrastructure/ansible/roles/system/firewall/tasks/main.yml
@@ -1,25 +1,35 @@
+- name: Gather ufw status
+  shell: ufw status verbose
+  register: ufw_status
+  changed_when: false
+
 - name: UFW allow SSH
+  when: ufw_status.stdout is not regex("\(OpenSSH\)\s*ALLOW")
   ufw:
     rule: allow
     name: OpenSSH
 
-- name: Turn on firewall
-  ufw:
-    state: enabled
-
 - name: UFW deny incoming by default
+  when: ufw_status.stdout is not regex("deny \(incoming\)")
   ufw:
     default: deny
     direction: incoming
 
 - name: UFW allow outgoing by default
+  when: ufw_status.stdout is not regex("allow \(outgoing\)")
   ufw:
     default: allow
     direction: outgoing
 
 - name: turn on ssh rate limiting
+  when: ufw_status.stdout is not regex("22/tcp\s*LIMIT IN")
   ufw:
     rule: limit
     port: ssh
     proto: tcp
+
+- name: Turn on firewall
+  when: "ufw_status.stdout is not regex('Status: active')"
+  ufw:
+    state: enabled
 

--- a/infrastructure/ansible/setup.yml
+++ b/infrastructure/ansible/setup.yml
@@ -1,8 +1,0 @@
-- hosts: setup
-  tags: setup
-  roles:
-    - system/hostname
-    - system/apt_update
-    - system/apt_common_tools
-    - system/firewall
-    - system/security

--- a/infrastructure/ansible/site.yml
+++ b/infrastructure/ansible/site.yml
@@ -1,7 +1,12 @@
 - hosts: all
   tags: system
   roles:
+    - system/hostname
+    - system/apt_update
+    - system/firewall
+    - system/security
     - system/admin_user
+    - system/apt_common_tools
     - system/journald
 
 - hosts: support
@@ -40,3 +45,4 @@
     - java
     - bot
     - support/log_aggregation_sender
+

--- a/infrastructure/docs/server-setup.md
+++ b/infrastructure/docs/server-setup.md
@@ -1,61 +1,40 @@
-# Server Setup (How To add a bot)
+# Adding a New Server
 
-- Add a [linode server](https://linode.com)
-- Create a [DNS entry](https://namecheap.com)
-- Update inventory fileto include the new server
-- Commit & submit for PR
+## Requirements
 
-One day, Travis will do a production deployment automatically
-on merge and deploy software to the new bot server and bring it up.
+- You have an account in linode
+- You have been added to the TripleA org in linode
+- You have an account on namecheap
+- You have been added to the TripleA org in namecheap
+- You have access to the administrator secrets document
 
-For now, run ansible deployment by-hand:
+## General Steps
 
-```
-cd --------/triplea/infrastructure
+1. Add a [linode server](https://linode.com)
+1. Create a [DNS entry](https://namecheap.com)
+1. Add server to inventory, commit & submit PR
 
-# create a file called 'vault_password' containing the
-# ansible vault password
+# Add a linode server
 
-ansible-vault view \
-     --vault-password-file=vault_password \
-     ansible_ssh_key.ed25519 \
-  | ssh-add -
+Login to linode and create a server.
 
-ansible-playbook \
-   --vault-password-file vault_password \
-   -i ansible/inventory/production \
-   ansible/site.yml \
-   --limit=[BOT-DNS-NAME] \
-   -t bots \
-   -v
-```
+Typical configuration:
 
-# Adding a linode
+- nanode ($5/month)
+- Ubuntu latest LTS
+- Region, somewhere in US or Europe
+- Set linode label (follow naming convention)
+- Set root password per admin secrets document 
+- Select to add a SSH key
 
-- Login to linode.
-- Select the linode size
-
-Update the following:
-
-Choose a distribution (typically latest ubuntu):
-![choose-distribution](https://user-images.githubusercontent.com/12397753/77502467-32df8000-6e18-11ea-984f-05c1561cdd4b.png)
-
-Select a region, spread these out with highest concentration in US and EU.
-Set a linode label & root password, follow naming pattern where number
-jumps and we match the name to the region:
-
-![select-region](https://user-images.githubusercontent.com/12397753/77502468-33781680-6e18-11ea-901e-904e9a2367e2.png)
-
-Last, select the common SSH key (if none is displayed, ask your fellow admins
-and add it by clicking the 'add key' button).
-
-![select-label-and-password](https://user-images.githubusercontent.com/12397753/77502470-3410ad00-6e18-11ea-85b8-7bbb7e5edd67.png)
 
 # Adding DNS Entries
 
-Create a DNS entries on [namecheap.com > account > dashboard > "manage" button > "advanced DNS"](https://ap.www.namecheap.com/Domains/DomainControlPanel/triplea-game.org/advancedns)
+Create a DNS entries on [namecheap.com > account > dashboard > "manage" button > "advanced DNS"
+](https://ap.www.namecheap.com/Domains/DomainControlPanel/triplea-game.org/advancedns)
 
-All servers will have both an 'A' (IPv4 address) and 'AAAA' (IPv6 address) record. You can get both IPv4 and IPv6 addresses from the linode dashboard.
+All servers will have both an 'A' (IPv4 address) and 'AAAA' (IPv6 address) record. 
+You can get both IPv4 and IPv6 addresses from the linode dashboard.
 
 ## Create an 'A' Record
 
@@ -70,3 +49,8 @@ This is needed for lobby server or any server that will be serving https traffic
 
 ![Screenshot from 2019-11-19 13-06-13](https://user-images.githubusercontent.com/12397753/69196411-48980e00-0ae3-11ea-9130-61e1fd5368b3.png)
 
+## Update inventory file
+
+- Add the server to [inventory configuration](/infrastructure/ansible/inventory)
+- Commit the changes and submit for a PR. After the PR is merged, travis will run a deployment
+  automatically deploying all needed configurations to the server. 


### PR DESCRIPTION
This update removes the setup step by adding conditional checks
that skip the core UFW setup commands if they are not needed.

Deployments were previously broken up into two phase, a one time
setup and then a regular deployment. A problem with this is
that it was two step and required updates to remove machines
from the setup inventory group.

The reason for the split was to avoid re-running UFW commands
which have a tendency to fail or collide.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing

```
cd infrastructure
vagrant destroy
vagrant up
./run_ansible_vagrant
# Verified ansible showed changes
vagrant ssh
sudo ufw status
# verified UFW settings
exit
./run_ansible_vagrant
# Verified UFW steps were skipped
vagrant ssh
sudo ufw disable
exit
./run_ansible_vagrant
# Verified UFW was re-installed
```
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
