### PR TITLE
Create a new audio device for each clip.

### DIFF
--- a/game-core/src/main/java/org/triplea/sound/ClipPlayer.java
+++ b/game-core/src/main/java/org/triplea/sound/ClipPlayer.java
@@ -27,7 +27,6 @@ import java.util.prefs.Preferences;
 import java.util.stream.Collectors;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
-import javax.annotation.Nullable;
 import javazoom.jl.decoder.JavaLayerException;
 import javazoom.jl.player.AudioDevice;
 import javazoom.jl.player.FactoryRegistry;
@@ -121,7 +120,7 @@ public class ClipPlayer {
   protected final Map<String, List<URL>> sounds = new HashMap<>();
   private final Set<String> mutedClips = new HashSet<>();
 
-  @Nullable private final AudioDevice audioDevice;
+  private final boolean systemHasAudio;
   private final ResourceLoader resourceLoader;
 
   private ClipPlayer(final ResourceLoader resourceLoader) {
@@ -129,7 +128,7 @@ public class ClipPlayer {
     final Preferences prefs = Preferences.userNodeForPackage(ClipPlayer.class);
     final Set<String> choices = SoundPath.getAllSoundOptions();
 
-    audioDevice = createAudio();
+    systemHasAudio = checkSystemForAudio();
 
     for (final String sound : choices) {
       final boolean muted = prefs.getBoolean(SOUND_PREFERENCE_PREFIX + sound, false);
@@ -139,15 +138,16 @@ public class ClipPlayer {
     }
   }
 
-  private static AudioDevice createAudio() {
+  private static boolean checkSystemForAudio() {
     try {
-      return FactoryRegistry.systemRegistry().createAudioDevice();
+      FactoryRegistry.systemRegistry().createAudioDevice();
+      return true;
     } catch (final JavaLayerException e) {
       log.log(
           Level.INFO,
           "Unable to create audio device, is there audio on the system? " + e.getMessage(),
           e);
-      return null;
+      return false;
     }
   }
 
@@ -165,7 +165,7 @@ public class ClipPlayer {
   }
 
   public static boolean hasAudio() {
-    return getInstance().audioDevice != null;
+    return getInstance().systemHasAudio;
   }
 
   boolean isSoundClipMuted(final String clipName) {

--- a/game-core/src/main/java/org/triplea/sound/ClipPlayer.java
+++ b/game-core/src/main/java/org/triplea/sound/ClipPlayer.java
@@ -261,6 +261,8 @@ public class ClipPlayer {
                       URI.create(clip.toString()),
                       inputStream -> {
                         try {
+                          final AudioDevice audioDevice =
+                              FactoryRegistry.systemRegistry().createAudioDevice();
                           new AdvancedPlayer(inputStream, audioDevice).play();
                         } catch (final Exception e) {
                           log.log(Level.SEVERE, "Failed to play: " + clip, e);


### PR DESCRIPTION
Multiple clips can play together and they each need their own audio
device. Otherwise, the sound comes out garbled.

Fixes #7905 and #7865

<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->
Play Dragon War with Hard AI for all players.  The sounds should play correctly.  Each battle generally plays about 3 clips at the same time.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
