### PR TITLE
Add forums & forums nginx conf to ansible management

### DIFF
--- a/infrastructure/ansible/inventory/prod2
+++ b/infrastructure/ansible/inventory/prod2
@@ -1,3 +1,6 @@
+[forums]
+forums.triplea-game.org
+
 [dropwizardHosts]
 prod2-lobby.triplea-game.org
 

--- a/infrastructure/ansible/inventory/vagrant
+++ b/infrastructure/ansible/inventory/vagrant
@@ -1,3 +1,6 @@
+[forums]
+vagrant
+
 [setup]
 vagrant
 

--- a/infrastructure/ansible/roles/nginx_forums_conf/files/nginx.conf
+++ b/infrastructure/ansible/roles/nginx_forums_conf/files/nginx.conf
@@ -1,0 +1,69 @@
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+
+events {
+        worker_connections 768;
+        # multi_accept on;
+}
+
+http {
+
+    log_format compression '$remote_addr - $remote_user [$time_local] '
+                           '"$request" $status $body_bytes_sent '
+                           '"$http_referer" "$http_user_agent" "$gzip_ratio"';
+
+        ##
+        # Basic Settings
+        ##
+
+        sendfile on;
+        tcp_nopush on;
+        tcp_nodelay on;
+        keepalive_timeout 65;
+        types_hash_max_size 2048;
+        # server_tokens off;
+
+        # server_names_hash_bucket_size 64;
+        # server_name_in_redirect off;
+
+        include /etc/nginx/mime.types;
+        default_type application/octet-stream;
+
+        ##
+        # SSL Settings
+        ##
+
+        ssl_protocols TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+        ssl_prefer_server_ciphers on;
+
+        ##
+        # Logging Settings
+        ##
+
+        access_log /var/log/nginx/access.log;
+        error_log /var/log/nginx/error.log;
+
+        ##
+        # Gzip Settings
+        ##
+
+        gzip on;
+        gzip_disable "msie6";
+
+        # gzip_vary on;
+        # gzip_proxied any;
+        # gzip_comp_level 6;
+        # gzip_buffers 16 8k;
+        # gzip_http_version 1.1;
+        # gzip_types text/plain text/css application/json application/javascript text/xml application/xml application/xml+rss text/javascript;
+
+        ##
+        # Virtual Host Configs
+        ##
+
+        include /etc/nginx/conf.d/*.conf;
+        include /etc/nginx/sites-enabled/*;
+}
+
+

--- a/infrastructure/ansible/roles/nginx_forums_conf/files/sites-enabled-default
+++ b/infrastructure/ansible/roles/nginx_forums_conf/files/sites-enabled-default
@@ -1,0 +1,60 @@
+# Session caching for improved performance
+
+ssl_session_cache shared:ssl_session_cache:10m;
+
+server {
+    listen 80;
+    listen [::]:80;
+    server_name forums.triplea-game.org;
+    return 301 https://forums.triplea-game.org$request_uri;
+}
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name forums.triplea-game.org;
+    ssl_certificate /etc/letsencrypt/live/forums.triplea-game.org/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/forums.triplea-game.org/privkey.pem;
+
+    # Turn on OCSP stapling as recommended at 
+    # https://community.letsencrypt.org/t/integration-guide/13123 
+    # requires nginx version >= 1.3.7
+    ssl_stapling on;
+    ssl_stapling_verify on;
+    # add_header Strict-Transport-Security "max-age=31536000";
+    ssl_protocols TLSv1.1 TLSv1.2;
+    ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
+    ssl_prefer_server_ciphers on;
+    ssl_dhparam /etc/dhparam/dhparams.pem;
+
+    location /.well-known {
+        alias /var/www/nodebb/.well-known;
+    }
+
+    # Display a more friendly error page for being displayed when updating.
+
+    error_page 502 /502.html;
+
+    location /502.html {
+       alias /var/www/nodebb/502.html;
+    }
+    
+    location / {
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header Host $http_host;
+        proxy_set_header X-NginX-Proxy true;
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        proxy_pass http://127.0.0.1:4567;
+        proxy_redirect off;
+
+        # Socket.IO Support
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+
+        # NodeBB has an independent max upload size setting
+        client_max_body_size 4096K;
+    }
+}
+

--- a/infrastructure/ansible/roles/nginx_forums_conf/tasks/main.yml
+++ b/infrastructure/ansible/roles/nginx_forums_conf/tasks/main.yml
@@ -1,0 +1,24 @@
+- name: ensure nginx folders exist
+  file: 
+    path: "{{ item }}"
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+  loop:
+    - /etc/nginx
+    - /etc/nginx/sites-enabled
+
+- name: deploy nginx.conf
+  copy:
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    mode: 0644
+    owner: root
+    group: root
+  loop:
+    - src: nginx.conf
+      dest: /etc/nginx/nginx.conf
+    - src: sites-enabled-default
+      dest: /etc/nginx/sites-enabled/default
+

--- a/infrastructure/ansible/site.yml
+++ b/infrastructure/ansible/site.yml
@@ -14,6 +14,11 @@
   roles:
     - support/log_aggregation_server
 
+- hosts: forums
+  tags: forums
+  roles:
+    - nginx_forums_conf
+
 - hosts: postgresHosts
   tags: [database, flyway]
   roles:


### PR DESCRIPTION
- Add forums server to ansible deployment. This will
  deploy common tools and configuration & ssh keys.

- Add nginx config files (nginx.conf & sites-enabled/defualt)
  to deployment. The checked in files match the current
  that are deployed.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
