### PR TITLE
Remove TLS 1.1 from forums Nginx

### DIFF
--- a/infrastructure/ansible/roles/nginx_forums_conf/files/sites-enabled-default
+++ b/infrastructure/ansible/roles/nginx_forums_conf/files/sites-enabled-default
@@ -21,7 +21,7 @@ server {
     ssl_stapling on;
     ssl_stapling_verify on;
     # add_header Strict-Transport-Security "max-age=31536000";
-    ssl_protocols TLSv1.1 TLSv1.2;
+    ssl_protocols TLSv1.2;
     ssl_ciphers 'EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH';
     ssl_prefer_server_ciphers on;
     ssl_dhparam /etc/dhparam/dhparams.pem;


### PR DESCRIPTION
Leaves just TLS 1.2, 1.1 is considered weak.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
