### PR TITLE
If no units can hit each other, then trigger a stalemate

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -708,8 +708,10 @@ public class UnitAttachment extends DefaultAttachment {
     }
   }
 
-  private void setCanNotTarget(final Set<UnitType> value) {
+  @VisibleForTesting
+  public UnitAttachment setCanNotTarget(final Set<UnitType> value) {
     canNotTarget = value;
+    return this;
   }
 
   public Set<UnitType> getCanNotTarget() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEnd.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEnd.java
@@ -14,6 +14,7 @@ import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.IBattle;
 import games.strategy.triplea.delegate.battle.steps.BattleStep;
 import games.strategy.triplea.delegate.battle.steps.RetreatChecks;
+import games.strategy.triplea.delegate.battle.steps.fire.general.FiringGroupSplitterGeneral;
 import games.strategy.triplea.delegate.power.calculator.TotalPowerAndTotalRolls;
 import java.util.List;
 import java.util.Objects;
@@ -67,7 +68,8 @@ public class CheckGeneralBattleEnd implements BattleStep {
 
   protected boolean isStalemate() {
     return battleState.getStatus().isLastRound()
-        || (getPower(OFFENSE) == 0 && getPower(DEFENSE) == 0);
+        || (getPower(OFFENSE) == 0 && getPower(DEFENSE) == 0)
+        || (hasNoTargets(OFFENSE) && hasNoTargets(DEFENSE));
   }
 
   private int getPower(final BattleState.Side side) {
@@ -82,6 +84,16 @@ public class CheckGeneralBattleEnd implements BattleStep {
                 battleState.getTerritoryEffects()),
             battleState.getGameData())
         .getEffectivePower();
+  }
+
+  private boolean hasNoTargets(final BattleState.Side side) {
+    return FiringGroupSplitterGeneral.of(side, FiringGroupSplitterGeneral.Type.NORMAL, "stalemate")
+            .apply(battleState)
+            .isEmpty()
+        && FiringGroupSplitterGeneral.of(
+                side, FiringGroupSplitterGeneral.Type.FIRST_STRIKE, "stalemate")
+            .apply(battleState)
+            .isEmpty();
   }
 
   protected boolean canAttackerRetreatInStalemate() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckStalemateBattleEnd.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckStalemateBattleEnd.java
@@ -1,5 +1,8 @@
 package games.strategy.triplea.delegate.battle.steps.change;
 
+import static games.strategy.triplea.delegate.battle.BattleState.Side.DEFENSE;
+import static games.strategy.triplea.delegate.battle.BattleState.Side.OFFENSE;
+
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleActions;
@@ -27,7 +30,7 @@ public class CheckStalemateBattleEnd extends CheckGeneralBattleEnd {
 
   @Override
   public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-    if (isStalemate()) {
+    if (!hasSideLost(OFFENSE) && !hasSideLost(DEFENSE) && isStalemate()) {
       getBattleActions().endBattle(IBattle.WhoWon.DRAW, bridge);
     }
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckStalemateBattleEnd.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckStalemateBattleEnd.java
@@ -1,8 +1,5 @@
 package games.strategy.triplea.delegate.battle.steps.change;
 
-import static games.strategy.triplea.delegate.battle.BattleState.Side.DEFENSE;
-import static games.strategy.triplea.delegate.battle.BattleState.Side.OFFENSE;
-
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleActions;
@@ -30,7 +27,7 @@ public class CheckStalemateBattleEnd extends CheckGeneralBattleEnd {
 
   @Override
   public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-    if (!hasSideLost(OFFENSE) && !hasSideLost(DEFENSE) && isStalemate()) {
+    if (!getBattleState().getStatus().isOver() && isStalemate()) {
       getBattleActions().endBattle(IBattle.WhoWon.DRAW, bridge);
     }
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/general/FiringGroupSplitterGeneral.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/general/FiringGroupSplitterGeneral.java
@@ -39,11 +39,9 @@ import org.triplea.java.collections.CollectionUtils;
 @Value(staticConstructor = "of")
 public class FiringGroupSplitterGeneral implements Function<BattleState, List<FiringGroup>> {
 
-  enum Type {
-    OFFENSIVE_NORMAL,
-    DEFENSIVE_NORMAL,
-    OFFENSIVE_FIRST_STRIKE,
-    DEFENSIVE_FIRST_STRIKE
+  public enum Type {
+    NORMAL,
+    FIRST_STRIKE
   }
 
   BattleState.Side side;
@@ -96,17 +94,11 @@ public class FiringGroupSplitterGeneral implements Function<BattleState, List<Fi
   }
 
   private Predicate<Unit> getFiringUnitPredicate(final BattleState battleState) {
-    switch (type) {
-      case OFFENSIVE_NORMAL:
-      default:
-        return Matches.unitIsFirstStrike().negate();
-      case DEFENSIVE_NORMAL:
-        return Matches.unitIsFirstStrikeOnDefense(battleState.getGameData()).negate();
-      case OFFENSIVE_FIRST_STRIKE:
-        return Matches.unitIsFirstStrike();
-      case DEFENSIVE_FIRST_STRIKE:
-        return Matches.unitIsFirstStrikeOnDefense(battleState.getGameData());
-    }
+    final Predicate<Unit> predicate =
+        (side == OFFENSE)
+            ? Matches.unitIsFirstStrike()
+            : Matches.unitIsFirstStrikeOnDefense(battleState.getGameData());
+    return type == Type.NORMAL ? predicate.negate() : predicate;
   }
 
   private List<FiringGroup> buildFiringGroups(

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/general/FiringGroupSplitterGeneralTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/general/FiringGroupSplitterGeneralTest.java
@@ -46,8 +46,7 @@ class FiringGroupSplitterGeneralTest {
     final Unit fireUnit = givenAnyUnit();
 
     final List<FiringGroup> firingGroups =
-        FiringGroupSplitterGeneral.of(
-                OFFENSE, FiringGroupSplitterGeneral.Type.OFFENSIVE_NORMAL, UNITS)
+        FiringGroupSplitterGeneral.of(OFFENSE, FiringGroupSplitterGeneral.Type.NORMAL, UNITS)
             .apply(
                 givenBattleStateBuilder()
                     .gameData(givenGameData().withAlliedAirIndependent(true).build())
@@ -70,7 +69,7 @@ class FiringGroupSplitterGeneralTest {
     final Unit fireUnit = givenAnyUnit();
 
     final List<FiringGroup> firingGroups =
-        FiringGroupSplitterGeneral.of(OFFENSE, FiringGroupSplitterGeneral.Type.OFFENSIVE_NORMAL, "")
+        FiringGroupSplitterGeneral.of(OFFENSE, FiringGroupSplitterGeneral.Type.NORMAL, "")
             .apply(
                 givenBattleStateBuilder()
                     .gameData(givenGameData().withAlliedAirIndependent(true).build())
@@ -94,7 +93,7 @@ class FiringGroupSplitterGeneralTest {
     final Unit fireUnit2 = givenUnitFirstStrike();
 
     final List<FiringGroup> firingGroups =
-        FiringGroupSplitterGeneral.of(OFFENSE, FiringGroupSplitterGeneral.Type.OFFENSIVE_NORMAL, "")
+        FiringGroupSplitterGeneral.of(OFFENSE, FiringGroupSplitterGeneral.Type.NORMAL, "")
             .apply(
                 givenBattleStateBuilder()
                     .gameData(givenGameData().withAlliedAirIndependent(true).build())
@@ -115,18 +114,14 @@ class FiringGroupSplitterGeneralTest {
     final Unit fireUnit2 = givenUnitFirstStrike();
 
     final List<FiringGroup> firingGroups =
-        FiringGroupSplitterGeneral.of(OFFENSE, FiringGroupSplitterGeneral.Type.DEFENSIVE_NORMAL, "")
+        FiringGroupSplitterGeneral.of(DEFENSE, FiringGroupSplitterGeneral.Type.NORMAL, "")
             .apply(
                 givenBattleStateBuilder()
-                    .gameData(
-                        givenGameData()
-                            .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                            .withAlliedAirIndependent(true)
-                            .build())
+                    .gameData(givenGameData().build())
                     .attacker(attacker)
                     .defender(defender)
-                    .attackingUnits(List.of(fireUnit, fireUnit2))
-                    .defendingUnits(List.of(targetUnit))
+                    .attackingUnits(List.of(targetUnit))
+                    .defendingUnits(List.of(fireUnit, fireUnit2))
                     .build());
 
     assertThat(firingGroups, hasSize(1));
@@ -140,8 +135,7 @@ class FiringGroupSplitterGeneralTest {
     final Unit fireUnit2 = givenAnyUnit();
 
     final List<FiringGroup> firingGroups =
-        FiringGroupSplitterGeneral.of(
-                OFFENSE, FiringGroupSplitterGeneral.Type.OFFENSIVE_FIRST_STRIKE, "")
+        FiringGroupSplitterGeneral.of(OFFENSE, FiringGroupSplitterGeneral.Type.FIRST_STRIKE, "")
             .apply(
                 givenBattleStateBuilder()
                     .gameData(givenGameData().withAlliedAirIndependent(true).build())
@@ -162,19 +156,14 @@ class FiringGroupSplitterGeneralTest {
     final Unit fireUnit2 = givenAnyUnit();
 
     final List<FiringGroup> firingGroups =
-        FiringGroupSplitterGeneral.of(
-                OFFENSE, FiringGroupSplitterGeneral.Type.DEFENSIVE_FIRST_STRIKE, "")
+        FiringGroupSplitterGeneral.of(DEFENSE, FiringGroupSplitterGeneral.Type.FIRST_STRIKE, "")
             .apply(
                 givenBattleStateBuilder()
-                    .gameData(
-                        givenGameData()
-                            .withDefendingSuicideAndMunitionUnitsDoNotFire(false)
-                            .withAlliedAirIndependent(true)
-                            .build())
+                    .gameData(givenGameData().build())
                     .attacker(attacker)
                     .defender(defender)
-                    .attackingUnits(List.of(fireUnit, fireUnit2))
-                    .defendingUnits(List.of(targetUnit))
+                    .attackingUnits(List.of(targetUnit))
+                    .defendingUnits(List.of(fireUnit, fireUnit2))
                     .build());
 
     assertThat(firingGroups, hasSize(1));
@@ -190,7 +179,7 @@ class FiringGroupSplitterGeneralTest {
     when(fireUnit2.getOwner()).thenReturn(mock(GamePlayer.class));
 
     final List<FiringGroup> firingGroups =
-        FiringGroupSplitterGeneral.of(OFFENSE, FiringGroupSplitterGeneral.Type.OFFENSIVE_NORMAL, "")
+        FiringGroupSplitterGeneral.of(OFFENSE, FiringGroupSplitterGeneral.Type.NORMAL, "")
             .apply(
                 givenBattleStateBuilder()
                     .gameData(givenGameData().withAlliedAirIndependent(false).build())
@@ -213,7 +202,7 @@ class FiringGroupSplitterGeneralTest {
     final Unit fireUnit2 = givenAnyUnit();
 
     final List<FiringGroup> firingGroups =
-        FiringGroupSplitterGeneral.of(DEFENSE, FiringGroupSplitterGeneral.Type.OFFENSIVE_NORMAL, "")
+        FiringGroupSplitterGeneral.of(DEFENSE, FiringGroupSplitterGeneral.Type.NORMAL, "")
             .apply(
                 givenBattleStateBuilder()
                     .gameData(givenGameData().build())
@@ -252,7 +241,7 @@ class FiringGroupSplitterGeneralTest {
     final Unit fireUnit = givenAnyUnit();
 
     final List<FiringGroup> firingGroups =
-        FiringGroupSplitterGeneral.of(OFFENSE, FiringGroupSplitterGeneral.Type.OFFENSIVE_NORMAL, "")
+        FiringGroupSplitterGeneral.of(OFFENSE, FiringGroupSplitterGeneral.Type.NORMAL, "")
             .apply(
                 givenBattleStateBuilder()
                     .gameData(givenGameData().withAlliedAirIndependent(true).build())
@@ -283,7 +272,7 @@ class FiringGroupSplitterGeneralTest {
     final Unit fireUnit = givenAnyUnit();
 
     final List<FiringGroup> firingGroups =
-        FiringGroupSplitterGeneral.of(DEFENSE, FiringGroupSplitterGeneral.Type.OFFENSIVE_NORMAL, "")
+        FiringGroupSplitterGeneral.of(DEFENSE, FiringGroupSplitterGeneral.Type.NORMAL, "")
             .apply(
                 givenBattleStateBuilder()
                     .gameData(givenGameData().build())
@@ -309,7 +298,7 @@ class FiringGroupSplitterGeneralTest {
     final Unit fireUnit = givenAnyUnit();
 
     final List<FiringGroup> firingGroups =
-        FiringGroupSplitterGeneral.of(OFFENSE, FiringGroupSplitterGeneral.Type.OFFENSIVE_NORMAL, "")
+        FiringGroupSplitterGeneral.of(OFFENSE, FiringGroupSplitterGeneral.Type.NORMAL, "")
             .apply(
                 givenBattleStateBuilder()
                     .gameData(givenGameData().withAlliedAirIndependent(true).build())
@@ -334,7 +323,7 @@ class FiringGroupSplitterGeneralTest {
     final Unit fireUnit = givenAnyUnit();
 
     final List<FiringGroup> firingGroups =
-        FiringGroupSplitterGeneral.of(OFFENSE, FiringGroupSplitterGeneral.Type.OFFENSIVE_NORMAL, "")
+        FiringGroupSplitterGeneral.of(OFFENSE, FiringGroupSplitterGeneral.Type.NORMAL, "")
             .apply(
                 givenBattleStateBuilder()
                     .gameData(givenGameData().withAlliedAirIndependent(true).build())
@@ -369,8 +358,7 @@ class FiringGroupSplitterGeneralTest {
     when(unitAttachment2.getCanNotTarget()).thenReturn(Set.of(targetUnitType));
 
     final List<FiringGroup> firingGroups =
-        FiringGroupSplitterGeneral.of(
-                OFFENSE, FiringGroupSplitterGeneral.Type.OFFENSIVE_NORMAL, UNITS)
+        FiringGroupSplitterGeneral.of(OFFENSE, FiringGroupSplitterGeneral.Type.NORMAL, UNITS)
             .apply(
                 givenBattleStateBuilder()
                     .gameData(givenGameData().withAlliedAirIndependent(true).build())
@@ -407,8 +395,7 @@ class FiringGroupSplitterGeneralTest {
     final Unit defendingSeaUnit = givenAnyUnit();
 
     final List<FiringGroup> firingGroups =
-        FiringGroupSplitterGeneral.of(
-                OFFENSE, FiringGroupSplitterGeneral.Type.OFFENSIVE_NORMAL, UNITS)
+        FiringGroupSplitterGeneral.of(OFFENSE, FiringGroupSplitterGeneral.Type.NORMAL, UNITS)
             .apply(
                 givenBattleStateBuilder()
                     .gameData(givenGameData().withAlliedAirIndependent(true).build())


### PR DESCRIPTION
This uses the new FiringGroup splitters to figure out if either side can hit each other.  This should fix the infinite loop in #7848 as well as future maps that start to utilize `canNotTarget` and `canNotBeTargetedBy`.

## Testing
<!-- Describe any manual testing performed below. -->
Ran a few Hard AI to make sure battles were resolved.  Played a few battles manually in 1940 global, iron war, and domination 1914 (with conscripts to see if that would cause any issues).

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE-->CHANGE|A battle that only contains units that can not hit each other because of canNotTarget and canNotBeTargetedBy will result in a stalemate.<!--END_RELEASE_NOTE-->
