### PR TITLE
Fix AA support calculation

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/FireAa.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/FireAa.java
@@ -197,9 +197,9 @@ public class FireAa implements IExecutable {
     return AaCasualtySelector.getAaCasualties(
         !defending,
         validAttackingUnitsForThisRoll,
-        attackableUnits,
+        allEnemyUnitsAliveOrWaitingToDie,
         defendingAa,
-        firingUnits,
+        allFriendlyUnitsAliveOrWaitingToDie,
         "Hits from " + currentTypeAa + ", ",
         dice,
         bridge,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelector.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelector.java
@@ -127,7 +127,7 @@ public class AaCasualtySelector {
     final GameData data = bridge.getData();
     final Map<Unit, TotalPowerAndTotalRolls> unitPowerAndRollsMap =
         TotalPowerAndTotalRolls.getAaUnitPowerAndRollsForNormalBattles(
-            defendingAa, allEnemyUnits, allFriendlyUnits, !defending, data);
+            defendingAa, allFriendlyUnits, allEnemyUnits, !defending, data);
 
     // if we can damage units, do it now
     final CasualtyDetails finalCasualtyDetails = new CasualtyDetails();
@@ -324,7 +324,7 @@ public class AaCasualtySelector {
         (allowMultipleHitsPerUnit ? CasualtyUtil.getTotalHitpointsLeft(planes) : planes.size());
     final Map<Unit, TotalPowerAndTotalRolls> unitPowerAndRollsMap =
         TotalPowerAndTotalRolls.getAaUnitPowerAndRollsForNormalBattles(
-            defendingAa, allFriendlyUnits, allEnemyUnits, defending, bridge.getData());
+            defendingAa, allFriendlyUnits, allEnemyUnits, !defending, bridge.getData());
     if (TotalPowerAndTotalRolls.getTotalAaAttacks(unitPowerAndRollsMap, planes) != planeHitPoints) {
       return randomAaCasualties(planes, dice, bridge, allowMultipleHitsPerUnit);
     }


### PR DESCRIPTION
All of the friendly and enemy units need to be used to calculate the
support during casualty selection.

When getting the total power and total strength values for the
defendingAa, the "defending" value needs to be flipped since the
"defending" value is the side of the targeted planes and not the side
of the AA.  And the enemy/friendly units need to be flipped as well.

<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->
The only map with AA unit support is Warcraft War Heroes so I ran several Hard AI games and also used breakpoints to go through the code and make sure things were correct.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->
I came across this while working on refactoring the TotalPowerAndTotalRolls code.  The AA unit supports is correctly calculated for the dice roll step but it wasn't being correctly calculated for the casualty selection step.

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
