### PR TITLE
Throw exception when 10,000 rounds are hit in a battle

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -1706,7 +1706,6 @@ public class MustFightBattle extends DependentBattle
                 throw new IllegalStateException(
                     "Round 10,000 reached in a battle. Something must be wrong."
                         + " Please report this to TripleA."
-
                         + " Attacking unit types: "
                         + attackingUnits.stream()
                             .map(Unit::getType)

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -106,6 +106,8 @@ public class MustFightBattle extends DependentBattle
 
   private static final long serialVersionUID = 5879502298361231540L;
 
+  private static final long MAX_INFINITE_ROUNDS = 10000;
+
   private final Collection<Unit> attackingWaitingToDie = new ArrayList<>();
 
   private final Collection<Unit> defendingWaitingToDie = new ArrayList<>();
@@ -1699,6 +1701,25 @@ public class MustFightBattle extends DependentBattle
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             if (!isOver) {
               round++;
+              if (round > MAX_INFINITE_ROUNDS) {
+                // the battle appears to be in an infinite loop
+                throw new IllegalStateException(
+                    "Round 10,000 reached in a battle. Something must be wrong."
+                        + " Attacking unit types: "
+                        + attackingUnits.stream()
+                            .map(Unit::getType)
+                            .collect(Collectors.toSet())
+                            .stream()
+                            .map(UnitType::getName)
+                            .collect(Collectors.joining(","))
+                        + ", Defending unit types: "
+                        + defendingUnits.stream()
+                            .map(Unit::getType)
+                            .collect(Collectors.toSet())
+                            .stream()
+                            .map(UnitType::getName)
+                            .collect(Collectors.joining(",")));
+              }
               // determine any AA
               updateOffensiveAaUnits();
               updateDefendingAaUnits();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -106,7 +106,7 @@ public class MustFightBattle extends DependentBattle
 
   private static final long serialVersionUID = 5879502298361231540L;
 
-  private static final long MAX_INFINITE_ROUNDS = 10000;
+  private static final long MAX_ROUNDS = 10000;
 
   private final Collection<Unit> attackingWaitingToDie = new ArrayList<>();
 
@@ -1701,10 +1701,12 @@ public class MustFightBattle extends DependentBattle
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             if (!isOver) {
               round++;
-              if (round > MAX_INFINITE_ROUNDS) {
+              if (round > MAX_ROUNDS) {
                 // the battle appears to be in an infinite loop
                 throw new IllegalStateException(
                     "Round 10,000 reached in a battle. Something must be wrong."
+                        + " Please report this to TripleA."
+
                         + " Attacking unit types: "
                         + attackingUnits.stream()
                             .map(Unit::getType)

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -1705,7 +1705,7 @@ public class MustFightBattle extends DependentBattle
                 // the battle appears to be in an infinite loop
                 throw new IllegalStateException(
                     "Round 10,000 reached in a battle. Something must be wrong."
-                        + " Please report this to TripleA."
+                        + " Please report this to TripleA.\n"
                         + " Attacking unit types: "
                         + attackingUnits.stream()
                             .map(Unit::getType)


### PR DESCRIPTION
Fixes #7848 

I think this is the last thing to fix for #7848.

## Testing
<!-- Describe any manual testing performed below. -->
Ran world at war with Hard AI to turn 13 just to see if I'd hit this exception in normal game play.  The exception did not occur.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE-->CHANGE|An exception will be thrown if a battle ever takes more than 10,000 rounds to help figure out how that happened.<!--END_RELEASE_NOTE-->
