### PR TITLE
DefensiveSubsRetreat#getEmptyOrFriendlySeaNeighbors can return an immutable list

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreat.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreat.java
@@ -20,6 +20,7 @@ import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.steps.BattleStep;
 import games.strategy.triplea.delegate.move.validation.MoveValidator;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Predicate;
@@ -87,7 +88,7 @@ public class DefensiveSubsRetreat implements BattleStep {
     if (Properties.getSubmersibleSubs(battleState.getGameData())) {
       retreatTerritories = List.of(battleState.getBattleSite());
     } else {
-      retreatTerritories = getEmptyOrFriendlySeaNeighbors();
+      retreatTerritories = new ArrayList<>(getEmptyOrFriendlySeaNeighbors());
       if (Properties.getSubmarinesDefendingMaySubmergeOrRetreat(battleState.getGameData())) {
         retreatTerritories.add(battleState.getBattleSite());
       }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreatTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreatTest.java
@@ -310,6 +310,49 @@ class DefensiveSubsRetreatTest {
 
       verify(battleState).retreatUnits(DEFENSE, retreatingUnits);
     }
+
+    @Test
+    void retreatHappensWhenDefendingIsSubmersibleAndHasRetreatTerritoriesAndIsHeadless() {
+
+      final Territory retreatTerritory = mock(Territory.class);
+      final UnitCollection retreatTerritoryCollection = mock(UnitCollection.class);
+      when(retreatTerritory.getUnitCollection()).thenReturn(retreatTerritoryCollection);
+      when(retreatTerritoryCollection.getHolder()).thenReturn(retreatTerritory);
+
+      final GameData gameData =
+          givenGameData()
+              .withSubmersibleSubs(false)
+              .withSubmarinesDefendingMaySubmergeOrRetreat(true)
+              .withTerritoryHasNeighbors(battleSite, Set.of(retreatTerritory))
+              .build();
+
+      final Unit unit = givenRealUnitCanEvade(gameData, defender);
+      final Collection<Unit> retreatingUnits = List.of(unit);
+
+      final BattleState battleState =
+          spy(
+              givenBattleStateBuilder()
+                  .defendingUnits(retreatingUnits)
+                  .defender(defender)
+                  .battleSite(battleSite)
+                  .headless(true)
+                  .gameData(gameData)
+                  .build());
+
+      when(battleActions.queryRetreatTerritory(
+              battleState,
+              delegateBridge,
+              defender,
+              List.of(retreatTerritory, battleSite),
+              "defender retreat subs?"))
+          .thenReturn(retreatTerritory);
+
+      final DefensiveSubsRetreat defensiveSubsRetreat =
+          new DefensiveSubsRetreat(battleState, battleActions);
+      defensiveSubsRetreat.execute(executionStack, delegateBridge);
+
+      verify(battleState).retreatUnits(DEFENSE, retreatingUnits);
+    }
   }
 
   @Test


### PR DESCRIPTION
Fixes #7986

In headless mode, getEmptyOrFriendlySeaNeighbors returns the set of
neighboring territories that the gameData map has.  This set is an
immutable set. For non-headless mode, the set is changed into an array
list that can be modified.

This makes quite a few games unplayable against the AI.  I think we might need a quick hotfix @DanVanAtta .

Almost all maps in "classic_variations" and almost all maps in "world_war_ii_classic" are unplayable.

<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Maps with "Submarines Defending May Submerge Or Retreat" set to true and "Submersible Subs" set to false (such as world_war_ii_classic and classic_variations) will no longer throw an exception about "DefensiveSubsRetreat" during AI calculations or the Battle Calculator.<!--END_RELEASE_NOTE-->
