### PR TITLE
Pass around CombatValue instead of its pieces

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
@@ -15,6 +15,7 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator;
 import games.strategy.triplea.delegate.battle.casualty.CasualtyUtil;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.delegate.power.calculator.TotalPowerAndTotalRolls;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -69,12 +70,13 @@ public final class ProBattleUtils {
         TotalPowerAndTotalRolls.getTotalPower(
             TotalPowerAndTotalRolls.getUnitPowerAndRollsForNormalBattles(
                 sortedUnitsList,
-                defendingUnits,
-                sortedUnitsList,
-                false,
-                data,
-                t,
-                TerritoryEffectHelper.getEffects(t)),
+                CombatValue.buildMainCombatValue(
+                    defendingUnits,
+                    sortedUnitsList,
+                    false,
+                    data,
+                    t,
+                    TerritoryEffectHelper.getEffects(t))),
             data);
     final List<Unit> defendersWithHitPoints =
         CollectionUtils.getMatches(defendingUnits, Matches.unitIsInfrastructure().negate());
@@ -156,12 +158,13 @@ public final class ProBattleUtils {
         TotalPowerAndTotalRolls.getTotalPower(
             TotalPowerAndTotalRolls.getUnitPowerAndRollsForNormalBattles(
                 sortedUnitsList,
-                enemyUnits,
-                sortedUnitsList,
-                !attacking,
-                data,
-                t,
-                TerritoryEffectHelper.getEffects(t)),
+                CombatValue.buildMainCombatValue(
+                    enemyUnits,
+                    sortedUnitsList,
+                    !attacking,
+                    data,
+                    t,
+                    TerritoryEffectHelper.getEffects(t))),
             data);
     return (myPower * 6.0 / data.getDiceSides());
   }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
@@ -12,6 +12,7 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.delegate.power.calculator.TotalPowerAndTotalRolls;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -216,7 +217,9 @@ public final class ProSortMoveOptionsUtils {
             (includeUnit ? 1 : -1)
                 * TotalPowerAndTotalRolls.getTotalPower(
                     TotalPowerAndTotalRolls.getUnitPowerAndRollsForNormalBattles(
-                        sortedUnits, defendingUnits, sortedUnits, false, data, t, effects),
+                        sortedUnits,
+                        CombatValue.buildMainCombatValue(
+                            defendingUnits, sortedUnits, false, data, t, effects)),
                     data);
       }
       if (powerDifference < minPower) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
@@ -15,6 +15,7 @@ import games.strategy.triplea.delegate.battle.BattleDelegate;
 import games.strategy.triplea.delegate.battle.BattleTracker;
 import games.strategy.triplea.delegate.battle.casualty.AaCasualtySelector;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.formatter.MyFormatter;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -325,11 +326,16 @@ class AaInMoveUtil implements Serializable {
       final String currentTypeAa) {
     final CasualtyDetails casualties =
         AaCasualtySelector.getAaCasualties(
-            false,
             validTargetedUnitsForThisRoll,
-            allFriendlyUnits,
             defendingAa,
-            allEnemyUnits,
+            CombatValue.buildMainCombatValue(
+                allEnemyUnits,
+                allFriendlyUnits,
+                false,
+                bridge.getData(),
+                territory,
+                TerritoryEffectHelper.getEffects(territory)),
+            CombatValue.buildAaCombatValue(allFriendlyUnits, allEnemyUnits, true, bridge.getData()),
             "Select "
                 + dice.getHits()
                 + " casualties from "
@@ -340,8 +346,7 @@ class AaInMoveUtil implements Serializable {
             bridge,
             player,
             null,
-            territory,
-            TerritoryEffectHelper.getEffects(territory));
+            territory);
     bridge
         .getRemotePlayer(player)
         .reportMessage(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -1,12 +1,10 @@
 package games.strategy.triplea.delegate;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.Table;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
-import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.delegate.IDelegateBridge;
@@ -15,6 +13,7 @@ import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Die.DieType;
 import games.strategy.triplea.delegate.battle.AirBattle;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.delegate.power.calculator.TotalPowerAndTotalRolls;
 import games.strategy.triplea.formatter.MyFormatter;
 import java.io.Externalizable;
@@ -84,8 +83,13 @@ public class DiceRoll implements Externalizable {
       final IDelegateBridge bridge,
       final Territory location,
       final boolean defending) {
+
     return rollAa(
-        validTargets, aaUnits, new ArrayList<>(), new ArrayList<>(), bridge, location, defending);
+        validTargets,
+        aaUnits,
+        bridge,
+        location,
+        CombatValue.buildAaCombatValue(List.of(), List.of(), defending, bridge.getData()));
   }
 
   /**
@@ -93,30 +97,21 @@ public class DiceRoll implements Externalizable {
    *
    * @param validTargets - potential AA targets
    * @param aaUnits - AA units that could potentially be rolling
-   * @param allEnemyUnitsAliveOrWaitingToDie - all enemy units to check for support
-   * @param allFriendlyUnitsAliveOrWaitingToDie - all allied units to check for support
    * @param bridge - delegate bridge
    * @param location - battle territory
-   * @param defending - whether AA units are defending or attacking
    * @return DiceRoll result which includes total hits and dice that were rolled
    */
   public static DiceRoll rollAa(
       final Collection<Unit> validTargets,
       final Collection<Unit> aaUnits,
-      final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie,
-      final Collection<Unit> allFriendlyUnitsAliveOrWaitingToDie,
       final IDelegateBridge bridge,
       final Territory location,
-      final boolean defending) {
+      final CombatValue combatValueCalculator) {
 
     final GameData data = bridge.getData();
     final Map<Unit, TotalPowerAndTotalRolls> unitPowerAndRollsMap =
         TotalPowerAndTotalRolls.getAaUnitPowerAndRollsForNormalBattles(
-            aaUnits,
-            allEnemyUnitsAliveOrWaitingToDie,
-            allFriendlyUnitsAliveOrWaitingToDie,
-            defending,
-            data);
+            aaUnits, combatValueCalculator);
 
     // Check that there are valid AA and targets to roll for
     final int totalAaAttacks =
@@ -129,7 +124,7 @@ public class DiceRoll implements Externalizable {
     // typeAA)
     final int diceSides =
         TotalPowerAndTotalRolls.getMaxAaAttackAndDiceSides(
-                aaUnits, data, defending, unitPowerAndRollsMap)
+                aaUnits, data, combatValueCalculator.isDefending(), unitPowerAndRollsMap)
             .getSecond();
 
     // Roll AA dice for LL or regular
@@ -138,7 +133,13 @@ public class DiceRoll implements Externalizable {
     final String typeAa = UnitAttachment.get(aaUnits.iterator().next().getType()).getTypeAa();
     final int totalPower =
         TotalPowerAndTotalRolls.getTotalAaPowerThenHitsAndFillSortedDiceThenIfAllUseSameAttack(
-                null, null, defending, unitPowerAndRollsMap, validTargets, data, false)
+                null,
+                null,
+                combatValueCalculator.isDefending(),
+                unitPowerAndRollsMap,
+                validTargets,
+                data,
+                false)
             .getFirst();
     final GamePlayer player = aaUnits.iterator().next().getOwner();
     final String annotation = "Roll " + typeAa + " in " + location.getName();
@@ -149,7 +150,13 @@ public class DiceRoll implements Externalizable {
           bridge.getRandom(diceSides, totalAaAttacks, player, DiceType.COMBAT, annotation);
       hits +=
           TotalPowerAndTotalRolls.getTotalAaPowerThenHitsAndFillSortedDiceThenIfAllUseSameAttack(
-                  dice, sortedDice, defending, unitPowerAndRollsMap, validTargets, data, true)
+                  dice,
+                  sortedDice,
+                  combatValueCalculator.isDefending(),
+                  unitPowerAndRollsMap,
+                  validTargets,
+                  data,
+                  true)
               .getSecond();
     }
 
@@ -191,65 +198,26 @@ public class DiceRoll implements Externalizable {
     return hits;
   }
 
-  @VisibleForTesting
-  static DiceRoll rollDice(
-      final List<Unit> units,
-      final boolean defending,
-      final GamePlayer player,
-      final IDelegateBridge bridge,
-      final Territory territory,
-      final Collection<TerritoryEffect> territoryEffects) {
-    return rollDice(
-        units, defending, player, bridge, territory, "", territoryEffects, List.of(), units);
-  }
-
   /**
    * Used to roll dice for attackers and defenders in battles.
    *
    * @param units - units that could potentially be rolling
-   * @param defending - whether units are defending or attacking
    * @param player - that will be rolling the dice
    * @param bridge - delegate bridge
-   * @param territory - territory where the battle takes place
    * @param annotation - description of the battle being rolled for
-   * @param territoryEffects - list of territory effects for the battle
-   * @param allEnemyUnitsAliveOrWaitingToDie - all enemy units to check for support
-   * @param allFriendlyUnitsAliveOrWaitingToDie - all allied units to check for support
    * @return DiceRoll result which includes total hits and dice that were rolled
    */
   public static DiceRoll rollDice(
       final Collection<Unit> units,
-      final boolean defending,
       final GamePlayer player,
       final IDelegateBridge bridge,
-      final Territory territory,
       final String annotation,
-      final Collection<TerritoryEffect> territoryEffects,
-      final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie,
-      final Collection<Unit> allFriendlyUnitsAliveOrWaitingToDie) {
+      final CombatValue combatValueCalculator) {
 
     if (Properties.getLowLuck(bridge.getData())) {
-      return rollDiceLowLuck(
-          units,
-          defending,
-          player,
-          bridge,
-          territory,
-          annotation,
-          territoryEffects,
-          allEnemyUnitsAliveOrWaitingToDie,
-          allFriendlyUnitsAliveOrWaitingToDie);
+      return rollDiceLowLuck(units, player, bridge, annotation, combatValueCalculator);
     }
-    return rollDiceNormal(
-        units,
-        defending,
-        player,
-        bridge,
-        territory,
-        annotation,
-        territoryEffects,
-        allEnemyUnitsAliveOrWaitingToDie,
-        allFriendlyUnitsAliveOrWaitingToDie);
+    return rollDiceNormal(units, player, bridge, annotation, combatValueCalculator);
   }
 
   /**
@@ -278,26 +246,15 @@ public class DiceRoll implements Externalizable {
   /** Roll dice for units using low luck rules. */
   private static DiceRoll rollDiceLowLuck(
       final Collection<Unit> unitsList,
-      final boolean defending,
       final GamePlayer player,
       final IDelegateBridge bridge,
-      final Territory location,
       final String annotation,
-      final Collection<TerritoryEffect> territoryEffects,
-      final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie,
-      final Collection<Unit> allFriendlyUnitsAliveOrWaitingToDie) {
+      final CombatValue combatValueCalculator) {
 
     final List<Unit> units = new ArrayList<>(unitsList);
     final GameData data = bridge.getData();
     final Map<Unit, TotalPowerAndTotalRolls> unitPowerAndRollsMap =
-        TotalPowerAndTotalRolls.getUnitPowerAndRollsForNormalBattles(
-            units,
-            allEnemyUnitsAliveOrWaitingToDie,
-            allFriendlyUnitsAliveOrWaitingToDie,
-            defending,
-            data,
-            location,
-            territoryEffects);
+        TotalPowerAndTotalRolls.getUnitPowerAndRollsForNormalBattles(units, combatValueCalculator);
 
     final int power = TotalPowerAndTotalRolls.getTotalPower(unitPowerAndRollsMap, data);
     if (power == 0) {
@@ -481,27 +438,16 @@ public class DiceRoll implements Externalizable {
   /** Roll dice for units per normal rules. */
   private static DiceRoll rollDiceNormal(
       final Collection<Unit> unitsList,
-      final boolean defending,
       final GamePlayer player,
       final IDelegateBridge bridge,
-      final Territory location,
       final String annotation,
-      final Collection<TerritoryEffect> territoryEffects,
-      final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie,
-      final Collection<Unit> allFriendlyUnitsAliveOrWaitingToDie) {
+      final CombatValue combatValueCalculator) {
 
     final List<Unit> units = new ArrayList<>(unitsList);
     final GameData data = bridge.getData();
-    sortByStrength(units, defending);
+    sortByStrength(units, combatValueCalculator.isDefending());
     final Map<Unit, TotalPowerAndTotalRolls> unitPowerAndRollsMap =
-        TotalPowerAndTotalRolls.getUnitPowerAndRollsForNormalBattles(
-            units,
-            allEnemyUnitsAliveOrWaitingToDie,
-            allFriendlyUnitsAliveOrWaitingToDie,
-            defending,
-            data,
-            location,
-            territoryEffects);
+        TotalPowerAndTotalRolls.getUnitPowerAndRollsForNormalBattles(units, combatValueCalculator);
 
     final TotalPowerAndTotalRolls totalPowerAndRolls =
         TotalPowerAndTotalRolls.getTotalPowerAndRolls(unitPowerAndRollsMap, data);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
@@ -22,6 +22,7 @@ import games.strategy.triplea.delegate.battle.casualty.CasualtySelector;
 import games.strategy.triplea.delegate.battle.casualty.CasualtySortingUtil;
 import games.strategy.triplea.delegate.data.BattleRecord;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.util.TuvUtils;
 import java.util.ArrayList;
@@ -702,14 +703,17 @@ public class AirBattle extends AbstractBattle {
                   CasualtySelector.selectCasualties(
                       defender,
                       defendingUnits,
-                      defendingUnits,
-                      attackingUnits,
+                      CombatValue.buildMainCombatValue(
+                          attackingUnits,
+                          defendingUnits,
+                          true,
+                          bridge.getData(),
+                          battleSite,
+                          List.of()),
                       battleSite,
-                      null,
                       bridge,
                       ATTACKERS_FIRE,
                       dice,
-                      true,
                       battleId,
                       false,
                       dice.getHits(),
@@ -764,14 +768,17 @@ public class AirBattle extends AbstractBattle {
                   CasualtySelector.selectCasualties(
                       attacker,
                       attackingUnits,
-                      attackingUnits,
-                      defendingUnits,
+                      CombatValue.buildMainCombatValue(
+                          defendingUnits,
+                          attackingUnits,
+                          false,
+                          bridge.getData(),
+                          battleSite,
+                          List.of()),
                       battleSite,
-                      null,
                       bridge,
                       DEFENDERS_FIRE,
                       dice,
-                      false,
                       battleId,
                       false,
                       dice.getHits(),

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -32,6 +32,7 @@ import games.strategy.triplea.delegate.battle.IBattle.WhoWon;
 import games.strategy.triplea.delegate.data.BattleListing;
 import games.strategy.triplea.delegate.data.BattleRecord;
 import games.strategy.triplea.delegate.data.BattleRecords;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.delegate.power.calculator.TotalPowerAndTotalRolls;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.util.TuvUtils;
@@ -1369,12 +1370,13 @@ public class BattleTracker implements Serializable {
           && TotalPowerAndTotalRolls.getTotalPower(
                   TotalPowerAndTotalRolls.getUnitPowerAndRollsForNormalBattles(
                       sortedUnitsList,
-                      defenders,
-                      sortedUnitsList,
-                      true,
-                      gameData,
-                      territory,
-                      TerritoryEffectHelper.getEffects(territory)),
+                      CombatValue.buildMainCombatValue(
+                          defenders,
+                          sortedUnitsList,
+                          true,
+                          gameData,
+                          territory,
+                          TerritoryEffectHelper.getEffects(territory))),
                   gameData)
               == 0) {
         battle.fight(bridge);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/Fire.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/Fire.java
@@ -13,6 +13,7 @@ import games.strategy.triplea.delegate.IExecutable;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.battle.casualty.CasualtySelector;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -154,17 +155,20 @@ public class Fire implements IExecutable {
           DiceRoll.getAnnotation(
               units, firingPlayer, battle.getTerritory(), battle.getBattleRound());
     }
+
     dice =
         DiceRoll.rollDice(
             units,
-            defending,
             firingPlayer,
             bridge,
-            battle.getTerritory(),
             annotation,
-            territoryEffects,
-            allEnemyUnitsAliveOrWaitingToDie,
-            allFriendlyUnitsAliveOrWaitingToDie);
+            CombatValue.buildMainCombatValue(
+                allEnemyUnitsAliveOrWaitingToDie,
+                allFriendlyUnitsAliveOrWaitingToDie,
+                defending,
+                battle.getGameData(),
+                battle.getTerritory(),
+                territoryEffects));
   }
 
   private void selectCasualties(final IDelegateBridge bridge) {
@@ -255,14 +259,17 @@ public class Fire implements IExecutable {
     return CasualtySelector.selectCasualties(
         hitPlayer,
         targetsToPickFrom,
-        allEnemyUnitsNotIncludingWaitingToDie,
-        allFriendlyUnitsNotIncludingWaitingToDie,
+        CombatValue.buildMainCombatValue(
+            allFriendlyUnitsNotIncludingWaitingToDie,
+            allEnemyUnitsNotIncludingWaitingToDie,
+            !defending,
+            bridge.getData(),
+            battleSite,
+            territoryEffects),
         battleSite,
-        territoryEffects,
         bridge,
         text,
         dice,
-        !defending,
         battleId,
         headless,
         extraHits,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/FireAa.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/FireAa.java
@@ -15,6 +15,7 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.battle.MustFightBattle.ReturnFire;
 import games.strategy.triplea.delegate.battle.casualty.AaCasualtySelector;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -130,11 +131,13 @@ public class FireAa implements IExecutable {
                       DiceRoll.rollAa(
                           validTargets,
                           firingGroup,
-                          allEnemyUnitsAliveOrWaitingToDie,
-                          allFriendlyUnitsAliveOrWaitingToDie,
                           bridge,
                           battleSite,
-                          defending);
+                          CombatValue.buildAaCombatValue(
+                              allEnemyUnitsAliveOrWaitingToDie,
+                              allFriendlyUnitsAliveOrWaitingToDie,
+                              defending,
+                              bridge.getData()));
                   if (!headless) {
                     SoundUtils.playFireBattleAa(firingPlayer, aaType, dice.getHits() > 0, bridge);
                   }
@@ -195,18 +198,26 @@ public class FireAa implements IExecutable {
                 + currentTypeAa
                 + BattleStepStrings.CASUALTIES_SUFFIX);
     return AaCasualtySelector.getAaCasualties(
-        !defending,
         validAttackingUnitsForThisRoll,
-        allEnemyUnitsAliveOrWaitingToDie,
         defendingAa,
-        allFriendlyUnitsAliveOrWaitingToDie,
+        CombatValue.buildMainCombatValue(
+            allFriendlyUnitsAliveOrWaitingToDie,
+            allEnemyUnitsAliveOrWaitingToDie,
+            !defending,
+            bridge.getData(),
+            battleSite,
+            territoryEffects),
+        CombatValue.buildAaCombatValue(
+            allEnemyUnitsAliveOrWaitingToDie,
+            allFriendlyUnitsAliveOrWaitingToDie,
+            defending,
+            bridge.getData()),
         "Hits from " + currentTypeAa + ", ",
         dice,
         bridge,
         hitPlayer,
         battleId,
-        battleSite,
-        territoryEffects);
+        battleSite);
   }
 
   private void notifyCasualtiesAa(final IDelegateBridge bridge, final String currentTypeAa) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
@@ -32,6 +32,7 @@ import games.strategy.triplea.delegate.battle.casualty.CasualtySelector;
 import games.strategy.triplea.delegate.battle.casualty.CasualtySortingUtil;
 import games.strategy.triplea.delegate.data.BattleRecord;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.util.TuvUtils;
 import java.util.ArrayList;
@@ -587,33 +588,40 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
       return CasualtySelector.selectCasualties(
           attacker,
           validAttackingUnitsForThisRoll,
-          attackingUnits,
-          defendingUnits,
+          CombatValue.buildMainCombatValue(
+              defendingUnits,
+              attackingUnits,
+              false,
+              bridge.getData(),
+              battleSite,
+              territoryEffects),
           battleSite,
-          territoryEffects,
           bridge,
-          text, /* dice */
-          null,
-          /* defending */ false,
-          battleId, /* head-less */
-          false,
+          text,
+          null, /* dice */
+          battleId,
+          false, /* head-less */
           0,
           allowMultipleHitsPerUnit);
     }
     final CasualtyDetails casualties =
         AaCasualtySelector.getAaCasualties(
-            false,
             validAttackingUnitsForThisRoll,
-            attackingUnits,
             defendingAa,
-            defendingUnits,
+            CombatValue.buildMainCombatValue(
+                defendingUnits,
+                attackingUnits,
+                false,
+                bridge.getData(),
+                battleSite,
+                territoryEffects),
+            CombatValue.buildAaCombatValue(attackingUnits, defendingUnits, true, bridge.getData()),
             "Hits from " + currentTypeAa + ", ",
             dice,
             bridge,
             attacker,
             battleId,
-            battleSite,
-            territoryEffects);
+            battleSite);
     final int totalExpectingHits = Math.min(dice.getHits(), validAttackingUnitsForThisRoll.size());
     if (casualties.size() != totalExpectingHits) {
       throw new IllegalStateException(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLosses.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLosses.java
@@ -9,6 +9,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator.CombatModifiers;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.delegate.power.calculator.TotalPowerAndTotalRolls;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -39,8 +40,7 @@ class CasualtyOrderOfLosses {
   static class Parameters {
     @Nonnull Collection<Unit> targetsToPickFrom;
     @Nonnull GamePlayer player;
-    @Nonnull Collection<Unit> enemyUnits;
-    @Nonnull Collection<Unit> friendlyUnits;
+    @Nonnull CombatValue combatValue;
     @Nonnull Territory battlesite;
     @Nonnull IntegerMap<UnitType> costs;
     @Nonnull CombatModifiers combatModifiers;
@@ -106,15 +106,7 @@ class CasualtyOrderOfLosses {
     final Map<Unit, IntegerMap<Unit>> unitSupportRollsMap = new HashMap<>();
     final Map<Unit, TotalPowerAndTotalRolls> unitPowerAndRollsMap =
         TotalPowerAndTotalRolls.getUnitPowerAndRollsForNormalBattles(
-            sortedUnitsList,
-            new ArrayList<>(parameters.enemyUnits),
-            new ArrayList<>(parameters.friendlyUnits),
-            parameters.combatModifiers.isDefending(),
-            parameters.data,
-            parameters.battlesite,
-            parameters.combatModifiers.getTerritoryEffects(),
-            unitSupportPowerMap,
-            unitSupportRollsMap);
+            sortedUnitsList, parameters.combatValue, unitSupportPowerMap, unitSupportRollsMap);
 
     // Sort units starting with weakest for finding the worst units
     Collections.reverse(sortedUnitsList);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
@@ -3,7 +3,6 @@ package games.strategy.triplea.delegate.battle.casualty;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
-import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.delegate.IDelegateBridge;
@@ -17,6 +16,7 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator.CombatModifiers;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
 import games.strategy.triplea.delegate.data.CasualtyList;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.util.TuvUtils;
 import games.strategy.triplea.util.UnitCategory;
@@ -57,14 +57,11 @@ public class CasualtySelector {
   public static CasualtyDetails selectCasualties(
       final GamePlayer player,
       final Collection<Unit> targetsToPickFrom,
-      final Collection<Unit> friendlyUnits,
-      final Collection<Unit> enemyUnits,
+      final CombatValue combatValue,
       final Territory battlesite,
-      final Collection<TerritoryEffect> territoryEffects,
       final IDelegateBridge bridge,
       final String text,
       final DiceRoll dice,
-      final boolean defending,
       final UUID battleId,
       final boolean headLess,
       final int extraHits,
@@ -90,8 +87,8 @@ public class CasualtySelector {
           text,
           dice,
           player,
-          friendlyUnits,
-          enemyUnits,
+          combatValue.getFriendUnits(),
+          combatValue.getEnemyUnits(),
           false,
           List.of(),
           new CasualtyDetails(),
@@ -118,13 +115,10 @@ public class CasualtySelector {
         getDefaultCasualties(
             targetsToPickFrom,
             hitsRemaining,
-            defending,
             player,
-            enemyUnits,
-            friendlyUnits,
+            combatValue,
             battlesite,
             costs,
-            territoryEffects,
             data,
             allowMultipleHitsPerUnit);
     final CasualtyList defaultCasualties = defaultCasualtiesAndSortedTargets.getFirst();
@@ -148,8 +142,8 @@ public class CasualtySelector {
                 text,
                 dice,
                 player,
-                friendlyUnits,
-                enemyUnits,
+                combatValue.getFriendUnits(),
+                combatValue.getEnemyUnits(),
                 false,
                 List.of(),
                 defaultCasualties,
@@ -191,14 +185,11 @@ public class CasualtySelector {
       return selectCasualties(
           player,
           sortedTargetsToPickFrom,
-          friendlyUnits,
-          enemyUnits,
+          combatValue,
           battlesite,
-          territoryEffects,
           bridge,
           text,
           dice,
-          defending,
           battleId,
           headLess,
           extraHits,
@@ -218,14 +209,11 @@ public class CasualtySelector {
       return selectCasualties(
           player,
           sortedTargetsToPickFrom,
-          friendlyUnits,
-          enemyUnits,
+          combatValue,
           battlesite,
-          territoryEffects,
           bridge,
           text,
           dice,
-          defending,
           battleId,
           headLess,
           extraHits,
@@ -279,13 +267,10 @@ public class CasualtySelector {
   private static Tuple<CasualtyList, List<Unit>> getDefaultCasualties(
       final Collection<Unit> targetsToPickFrom,
       final int hits,
-      final boolean defending,
       final GamePlayer player,
-      final Collection<Unit> enemyUnits,
-      final Collection<Unit> friendlyUnits,
+      final CombatValue combatValue,
       final Territory battlesite,
       final IntegerMap<UnitType> costs,
-      final Collection<TerritoryEffect> territoryEffects,
       final GameData data,
       final boolean allowMultipleHitsPerUnit) {
     final CasualtyList defaultCasualtySelection = new CasualtyList();
@@ -296,12 +281,11 @@ public class CasualtySelector {
             CasualtyOrderOfLosses.Parameters.builder()
                 .targetsToPickFrom(targetsToPickFrom)
                 .player(player)
-                .enemyUnits(enemyUnits)
-                .friendlyUnits(friendlyUnits)
+                .combatValue(combatValue)
                 .combatModifiers(
                     CombatModifiers.builder()
-                        .territoryEffects(territoryEffects)
-                        .defending(defending)
+                        .territoryEffects(combatValue.getTerritoryEffects())
+                        .defending(combatValue.isDefending())
                         .build())
                 .battlesite(battlesite)
                 .costs(costs)

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEnd.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEnd.java
@@ -15,6 +15,7 @@ import games.strategy.triplea.delegate.battle.IBattle;
 import games.strategy.triplea.delegate.battle.steps.BattleStep;
 import games.strategy.triplea.delegate.battle.steps.RetreatChecks;
 import games.strategy.triplea.delegate.battle.steps.fire.general.FiringGroupSplitterGeneral;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.delegate.power.calculator.TotalPowerAndTotalRolls;
 import java.util.List;
 import java.util.Objects;
@@ -76,12 +77,13 @@ public class CheckGeneralBattleEnd implements BattleStep {
     return TotalPowerAndTotalRolls.getTotalPowerAndRolls(
             TotalPowerAndTotalRolls.getUnitPowerAndRollsForNormalBattles(
                 battleState.filterUnits(ALIVE, side),
-                battleState.filterUnits(ALIVE, side.getOpposite()),
-                battleState.filterUnits(ALIVE, side),
-                side == DEFENSE,
-                battleState.getGameData(),
-                battleState.getBattleSite(),
-                battleState.getTerritoryEffects()),
+                CombatValue.buildMainCombatValue(
+                    battleState.filterUnits(ALIVE, side.getOpposite()),
+                    battleState.filterUnits(ALIVE, side),
+                    side == DEFENSE,
+                    battleState.getGameData(),
+                    battleState.getBattleSite(),
+                    battleState.getTerritoryEffects())),
             battleState.getGameData())
         .getEffectivePower();
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/MainDiceRoller.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/MainDiceRoller.java
@@ -1,10 +1,11 @@
 package games.strategy.triplea.delegate.battle.steps.fire;
 
 import static games.strategy.triplea.delegate.battle.BattleState.Side.DEFENSE;
-import static games.strategy.triplea.delegate.battle.BattleState.UnitBattleFilter.ACTIVE;
+import static games.strategy.triplea.delegate.battle.BattleState.UnitBattleFilter.ALIVE;
 
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.delegate.DiceRoll;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import java.util.function.BiFunction;
 
 /** Rolls dice for normal (basically, anything that isn't AA) dice requests */
@@ -14,17 +15,19 @@ public class MainDiceRoller implements BiFunction<IDelegateBridge, RollDiceStep,
   public DiceRoll apply(final IDelegateBridge bridge, final RollDiceStep step) {
     return DiceRoll.rollDice(
         step.getFiringGroup().getFiringUnits(),
-        step.getSide() == DEFENSE,
         step.getBattleState().getPlayer(step.getSide()),
         bridge,
-        step.getBattleState().getBattleSite(),
         DiceRoll.getAnnotation(
             step.getFiringGroup().getFiringUnits(),
             step.getBattleState().getPlayer(step.getSide()),
             step.getBattleState().getBattleSite(),
             step.getBattleState().getStatus().getRound()),
-        step.getBattleState().getTerritoryEffects(),
-        step.getBattleState().filterUnits(ACTIVE, step.getSide().getOpposite()),
-        step.getBattleState().filterUnits(ACTIVE, step.getSide()));
+        CombatValue.buildMainCombatValue(
+            step.getBattleState().filterUnits(ALIVE, step.getSide().getOpposite()),
+            step.getBattleState().filterUnits(ALIVE, step.getSide()),
+            step.getSide() == DEFENSE,
+            step.getBattleState().getGameData(),
+            step.getBattleState().getBattleSite(),
+            step.getBattleState().getTerritoryEffects()));
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/SelectMainBattleCasualties.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/SelectMainBattleCasualties.java
@@ -1,7 +1,7 @@
 package games.strategy.triplea.delegate.battle.steps.fire;
 
 import static games.strategy.triplea.delegate.battle.BattleState.Side.DEFENSE;
-import static games.strategy.triplea.delegate.battle.BattleState.UnitBattleFilter.ACTIVE;
+import static games.strategy.triplea.delegate.battle.BattleState.UnitBattleFilter.ALIVE;
 
 import com.google.common.annotations.VisibleForTesting;
 import games.strategy.engine.data.GamePlayer;
@@ -13,6 +13,7 @@ import games.strategy.triplea.delegate.BaseEditDelegate;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.battle.casualty.CasualtySelector;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -152,14 +153,17 @@ public class SelectMainBattleCasualties
       return CasualtySelector.selectCasualties(
           step.getBattleState().getPlayer(step.getSide().getOpposite()),
           targetsToPickFrom,
-          step.getBattleState().filterUnits(ACTIVE, step.getSide().getOpposite()),
-          step.getBattleState().filterUnits(ACTIVE, step.getSide()),
+          CombatValue.buildMainCombatValue(
+              step.getBattleState().filterUnits(ALIVE, step.getSide()),
+              step.getBattleState().filterUnits(ALIVE, step.getSide().getOpposite()),
+              step.getSide().getOpposite() == DEFENSE,
+              step.getBattleState().getGameData(),
+              step.getBattleState().getBattleSite(),
+              step.getBattleState().getTerritoryEffects()),
           step.getBattleState().getBattleSite(),
-          step.getBattleState().getTerritoryEffects(),
           bridge,
           "Hits from " + step.getFiringGroup().getDisplayName() + ", ",
           step.getFireRoundState().getDice(),
-          step.getSide().getOpposite() == DEFENSE,
           step.getBattleState().getBattleId(),
           step.getBattleState().getStatus().isHeadless(),
           diceHitOverride,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaDefenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaDefenseCombatValue.java
@@ -35,11 +35,13 @@ class AaDefenseCombatValue implements CombatValue {
 
   @Getter(onMethod = @__({@Override}))
   @NonNull
-  Collection<Unit> friendUnits;
+  @Builder.Default
+  Collection<Unit> friendUnits = List.of();
 
   @Getter(onMethod = @__({@Override}))
   @NonNull
-  Collection<Unit> enemyUnits;
+  @Builder.Default
+  Collection<Unit> enemyUnits = List.of();
 
   @Getter(onMethod = @__({@Override}))
   Collection<TerritoryEffect> territoryEffects = List.of();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaDefenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaDefenseCombatValue.java
@@ -1,8 +1,11 @@
 package games.strategy.triplea.delegate.power.calculator;
 
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -29,6 +32,17 @@ class AaDefenseCombatValue implements CombatValue {
 
   @NonNull AvailableSupports supportFromFriends;
   @NonNull AvailableSupports supportFromEnemies;
+
+  @Getter(onMethod = @__({@Override}))
+  @NonNull
+  Collection<Unit> friendUnits;
+
+  @Getter(onMethod = @__({@Override}))
+  @NonNull
+  Collection<Unit> enemyUnits;
+
+  @Getter(onMethod = @__({@Override}))
+  Collection<TerritoryEffect> territoryEffects = List.of();
 
   @Override
   public RollCalculator getRoll() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaOffenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaOffenseCombatValue.java
@@ -1,8 +1,11 @@
 package games.strategy.triplea.delegate.power.calculator;
 
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
+import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -29,6 +32,17 @@ class AaOffenseCombatValue implements CombatValue {
 
   @NonNull AvailableSupports supportFromFriends;
   @NonNull AvailableSupports supportFromEnemies;
+
+  @Getter(onMethod = @__({@Override}))
+  @NonNull
+  Collection<Unit> friendUnits;
+
+  @Getter(onMethod = @__({@Override}))
+  @NonNull
+  Collection<Unit> enemyUnits;
+
+  @Getter(onMethod = @__({@Override}))
+  Collection<TerritoryEffect> territoryEffects = List.of();
 
   @Override
   public RollCalculator getRoll() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaOffenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaOffenseCombatValue.java
@@ -35,11 +35,13 @@ class AaOffenseCombatValue implements CombatValue {
 
   @Getter(onMethod = @__({@Override}))
   @NonNull
-  Collection<Unit> friendUnits;
+  @Builder.Default
+  Collection<Unit> friendUnits = List.of();
 
   @Getter(onMethod = @__({@Override}))
   @NonNull
-  Collection<Unit> enemyUnits;
+  @Builder.Default
+  Collection<Unit> enemyUnits = List.of();
 
   @Getter(onMethod = @__({@Override}))
   Collection<TerritoryEffect> territoryEffects = List.of();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/CombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/CombatValue.java
@@ -15,7 +15,13 @@ public interface CombatValue {
 
   boolean isDefending();
 
+  Collection<TerritoryEffect> getTerritoryEffects();
+
   GameData getGameData();
+
+  Collection<Unit> getFriendUnits();
+
+  Collection<Unit> getEnemyUnits();
 
   static CombatValue buildMainCombatValue(
       final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie,
@@ -48,12 +54,16 @@ public interface CombatValue {
             .gameData(data)
             .supportFromFriends(supportFromFriends)
             .supportFromEnemies(supportFromEnemies)
+            .friendUnits(allFriendlyUnitsAliveOrWaitingToDie)
+            .enemyUnits(allEnemyUnitsAliveOrWaitingToDie)
             .territoryEffects(territoryEffects)
             .build()
         : MainOffenseCombatValue.builder()
             .gameData(data)
             .supportFromFriends(supportFromFriends)
             .supportFromEnemies(supportFromEnemies)
+            .friendUnits(allFriendlyUnitsAliveOrWaitingToDie)
+            .enemyUnits(allEnemyUnitsAliveOrWaitingToDie)
             .territoryEffects(territoryEffects)
             .territoryIsLand(Matches.territoryIsLand().test(location))
             .build();
@@ -88,11 +98,15 @@ public interface CombatValue {
             .gameData(data)
             .supportFromFriends(supportFromFriends)
             .supportFromEnemies(supportFromEnemies)
+            .friendUnits(allFriendlyUnitsAliveOrWaitingToDie)
+            .enemyUnits(allEnemyUnitsAliveOrWaitingToDie)
             .build()
         : AaOffenseCombatValue.builder()
             .gameData(data)
             .supportFromFriends(supportFromFriends)
             .supportFromEnemies(supportFromEnemies)
+            .friendUnits(allFriendlyUnitsAliveOrWaitingToDie)
+            .enemyUnits(allEnemyUnitsAliveOrWaitingToDie)
             .build();
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainDefenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainDefenseCombatValue.java
@@ -35,7 +35,18 @@ class MainDefenseCombatValue implements CombatValue {
 
   @NonNull AvailableSupports supportFromFriends;
   @NonNull AvailableSupports supportFromEnemies;
-  @NonNull Collection<TerritoryEffect> territoryEffects;
+
+  @Getter(onMethod = @__({@Override}))
+  @NonNull
+  Collection<TerritoryEffect> territoryEffects;
+
+  @Getter(onMethod = @__({@Override}))
+  @NonNull
+  Collection<Unit> friendUnits;
+
+  @Getter(onMethod = @__({@Override}))
+  @NonNull
+  Collection<Unit> enemyUnits;
 
   @Override
   public RollCalculator getRoll() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainDefenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainDefenseCombatValue.java
@@ -9,6 +9,7 @@ import games.strategy.triplea.attachments.RulesAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -42,11 +43,13 @@ class MainDefenseCombatValue implements CombatValue {
 
   @Getter(onMethod = @__({@Override}))
   @NonNull
-  Collection<Unit> friendUnits;
+  @Builder.Default
+  Collection<Unit> friendUnits = List.of();
 
   @Getter(onMethod = @__({@Override}))
   @NonNull
-  Collection<Unit> enemyUnits;
+  @Builder.Default
+  Collection<Unit> enemyUnits = List.of();
 
   @Override
   public RollCalculator getRoll() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainOffenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainOffenseCombatValue.java
@@ -34,8 +34,20 @@ class MainOffenseCombatValue implements CombatValue {
 
   @NonNull AvailableSupports supportFromFriends;
   @NonNull AvailableSupports supportFromEnemies;
-  @NonNull Collection<TerritoryEffect> territoryEffects;
+
+  @Getter(onMethod = @__({@Override}))
+  @NonNull
+  Collection<TerritoryEffect> territoryEffects;
+
   boolean territoryIsLand;
+
+  @Getter(onMethod = @__({@Override}))
+  @NonNull
+  Collection<Unit> friendUnits;
+
+  @Getter(onMethod = @__({@Override}))
+  @NonNull
+  Collection<Unit> enemyUnits;
 
   @Override
   public RollCalculator getRoll() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainOffenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainOffenseCombatValue.java
@@ -7,6 +7,7 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -43,11 +44,13 @@ class MainOffenseCombatValue implements CombatValue {
 
   @Getter(onMethod = @__({@Override}))
   @NonNull
-  Collection<Unit> friendUnits;
+  @Builder.Default
+  Collection<Unit> friendUnits = List.of();
 
   @Getter(onMethod = @__({@Override}))
   @NonNull
-  Collection<Unit> enemyUnits;
+  @Builder.Default
+  Collection<Unit> enemyUnits = List.of();
 
   @Override
   public RollCalculator getRoll() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRolls.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRolls.java
@@ -2,8 +2,6 @@ package games.strategy.triplea.delegate.power.calculator;
 
 import com.google.common.annotations.VisibleForTesting;
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.Territory;
-import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.UnitAttachment;
@@ -273,19 +271,6 @@ public class TotalPowerAndTotalRolls {
    *     actual battle.
    */
   public static Map<Unit, TotalPowerAndTotalRolls> getAaUnitPowerAndRollsForNormalBattles(
-      final Collection<Unit> aaUnits,
-      final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie,
-      final Collection<Unit> allFriendlyUnitsAliveOrWaitingToDie,
-      final boolean defending,
-      final GameData data) {
-
-    final CombatValue calculator =
-        CombatValue.buildAaCombatValue(
-            allEnemyUnitsAliveOrWaitingToDie, allFriendlyUnitsAliveOrWaitingToDie, defending, data);
-    return getAaUnitPowerAndRollsForNormalBattles(aaUnits, calculator);
-  }
-
-  public static Map<Unit, TotalPowerAndTotalRolls> getAaUnitPowerAndRollsForNormalBattles(
       final Collection<Unit> aaUnits, final CombatValue calculator) {
 
     if (aaUnits == null || aaUnits.isEmpty()) {
@@ -338,28 +323,13 @@ public class TotalPowerAndTotalRolls {
   /**
    * Returns the power (strength) and rolls for each of the specified units.
    *
-   * @param unitsGettingPowerFor should be sorted from weakest to strongest, before the method is
-   *     called, for the actual battle.
+   * @param units should be sorted from weakest to strongest, before the method is called, for the
+   *     actual battle.
    */
   public static Map<Unit, TotalPowerAndTotalRolls> getUnitPowerAndRollsForNormalBattles(
-      final Collection<Unit> unitsGettingPowerFor,
-      final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie,
-      final Collection<Unit> allFriendlyUnitsAliveOrWaitingToDie,
-      final boolean defending,
-      final GameData data,
-      final Territory location,
-      final Collection<TerritoryEffect> territoryEffects) {
-
+      final Collection<Unit> units, final CombatValue calculator) {
     return getUnitPowerAndRollsForNormalBattles(
-        unitsGettingPowerFor,
-        allEnemyUnitsAliveOrWaitingToDie,
-        allFriendlyUnitsAliveOrWaitingToDie,
-        defending,
-        data,
-        location,
-        territoryEffects,
-        new HashMap<>(),
-        new HashMap<>());
+        units, calculator, new HashMap<>(), new HashMap<>());
   }
 
   /**
@@ -368,36 +338,6 @@ public class TotalPowerAndTotalRolls {
    * @param unitsGettingPowerFor should be sorted from weakest to strongest, before the method is
    *     called, for the actual battle.
    */
-  public static Map<Unit, TotalPowerAndTotalRolls> getUnitPowerAndRollsForNormalBattles(
-      final Collection<Unit> unitsGettingPowerFor,
-      final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie,
-      final Collection<Unit> allFriendlyUnitsAliveOrWaitingToDie,
-      final boolean defending,
-      final GameData data,
-      final Territory location,
-      final Collection<TerritoryEffect> territoryEffects,
-      final Map<Unit, IntegerMap<Unit>> unitSupportPowerMap,
-      final Map<Unit, IntegerMap<Unit>> unitSupportRollsMap) {
-
-    final CombatValue calculator =
-        CombatValue.buildMainCombatValue(
-            allEnemyUnitsAliveOrWaitingToDie,
-            allFriendlyUnitsAliveOrWaitingToDie,
-            defending,
-            data,
-            location,
-            territoryEffects);
-
-    return getUnitPowerAndRollsForNormalBattles(
-        unitsGettingPowerFor, calculator, unitSupportPowerMap, unitSupportRollsMap);
-  }
-
-  public static Map<Unit, TotalPowerAndTotalRolls> getUnitPowerAndRollsForNormalBattles(
-      final Collection<Unit> unitsGettingPowerFor, final CombatValue calculator) {
-    return getUnitPowerAndRollsForNormalBattles(
-        unitsGettingPowerFor, calculator, new HashMap<>(), new HashMap<>());
-  }
-
   public static Map<Unit, TotalPowerAndTotalRolls> getUnitPowerAndRollsForNormalBattles(
       final Collection<Unit> unitsGettingPowerFor,
       final CombatValue calculator,

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -15,6 +15,7 @@ import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.delegate.battle.BattleDelegate;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator;
 import games.strategy.triplea.delegate.battle.casualty.CasualtyUtil;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.delegate.power.calculator.TotalPowerAndTotalRolls;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.UiContext;
@@ -1439,13 +1440,17 @@ class BattleCalculatorPanel extends JPanel {
       final int attackPower =
           TotalPowerAndTotalRolls.getTotalPower(
               TotalPowerAndTotalRolls.getUnitPowerAndRollsForNormalBattles(
-                  attackers, defenders, attackers, false, data, location, territoryEffects),
+                  attackers,
+                  CombatValue.buildMainCombatValue(
+                      defenders, attackers, false, data, location, territoryEffects)),
               data);
       // defender is never amphibious
       final int defensePower =
           TotalPowerAndTotalRolls.getTotalPower(
               TotalPowerAndTotalRolls.getUnitPowerAndRollsForNormalBattles(
-                  defenders, attackers, defenders, true, data, location, territoryEffects),
+                  defenders,
+                  CombatValue.buildMainCombatValue(
+                      attackers, defenders, true, data, location, territoryEffects)),
               data);
       attackerUnitsTotalPower.setText("Power: " + attackPower);
       defenderUnitsTotalPower.setText("Power: " + defensePower);

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -20,6 +20,7 @@ import games.strategy.triplea.delegate.battle.IBattle.BattleType;
 import games.strategy.triplea.delegate.battle.casualty.CasualtyUtil;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
 import games.strategy.triplea.delegate.data.CasualtyList;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.delegate.power.calculator.TotalPowerAndTotalRolls;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.panels.map.MapPanel;
@@ -884,12 +885,13 @@ public class BattleDisplay extends JPanel {
           unitPowerAndRollsMap =
               TotalPowerAndTotalRolls.getUnitPowerAndRollsForNormalBattles(
                   units,
-                  new ArrayList<>(enemyBattleModel.getUnits()),
-                  units,
-                  !attack,
-                  gameData,
-                  location,
-                  territoryEffects);
+                  CombatValue.buildMainCombatValue(
+                      new ArrayList<>(enemyBattleModel.getUnits()),
+                      units,
+                      !attack,
+                      gameData,
+                      location,
+                      territoryEffects));
         } finally {
           gameData.releaseReadLock();
         }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -25,6 +25,7 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.battle.StrategicBombingRaidBattle;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -52,22 +53,62 @@ class DiceRollTest {
     // infantry defends
     final DiceRoll roll =
         DiceRoll.rollDice(
-            infantry, true, russians, bridge, mock(Territory.class), territoryEffects);
+            infantry,
+            russians,
+            bridge,
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                infantry,
+                true,
+                bridge.getData(),
+                mock(Territory.class),
+                territoryEffects));
     assertThat(roll.getHits(), is(1));
     // infantry
     final DiceRoll roll2 =
         DiceRoll.rollDice(
-            infantry, true, russians, bridge, mock(Territory.class), territoryEffects);
+            infantry,
+            russians,
+            bridge,
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                infantry,
+                true,
+                bridge.getData(),
+                mock(Territory.class),
+                territoryEffects));
     assertThat(roll2.getHits(), is(0));
     // infantry attacks
     final DiceRoll roll3 =
         DiceRoll.rollDice(
-            infantry, false, russians, bridge, mock(Territory.class), territoryEffects);
+            infantry,
+            russians,
+            bridge,
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                infantry,
+                false,
+                bridge.getData(),
+                mock(Territory.class),
+                territoryEffects));
     assertThat(roll3.getHits(), is(1));
     // infantry attack
     final DiceRoll roll4 =
         DiceRoll.rollDice(
-            infantry, false, russians, bridge, mock(Territory.class), territoryEffects);
+            infantry,
+            russians,
+            bridge,
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                infantry,
+                false,
+                bridge.getData(),
+                mock(Territory.class),
+                territoryEffects));
     assertThat(roll4.getHits(), is(0));
   }
 
@@ -89,22 +130,62 @@ class DiceRollTest {
     // infantry defends
     final DiceRoll roll =
         DiceRoll.rollDice(
-            infantry, true, russians, bridge, mock(Territory.class), territoryEffects);
+            infantry,
+            russians,
+            bridge,
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                infantry,
+                true,
+                bridge.getData(),
+                mock(Territory.class),
+                territoryEffects));
     assertThat(roll.getHits(), is(1));
     // infantry
     final DiceRoll roll2 =
         DiceRoll.rollDice(
-            infantry, true, russians, bridge, mock(Territory.class), territoryEffects);
+            infantry,
+            russians,
+            bridge,
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                infantry,
+                true,
+                bridge.getData(),
+                mock(Territory.class),
+                territoryEffects));
     assertThat(roll2.getHits(), is(0));
     // infantry attacks
     final DiceRoll roll3 =
         DiceRoll.rollDice(
-            infantry, false, russians, bridge, mock(Territory.class), territoryEffects);
+            infantry,
+            russians,
+            bridge,
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                infantry,
+                false,
+                bridge.getData(),
+                mock(Territory.class),
+                territoryEffects));
     assertThat(roll3.getHits(), is(1));
     // infantry attack
     final DiceRoll roll4 =
         DiceRoll.rollDice(
-            infantry, false, russians, bridge, mock(Territory.class), territoryEffects);
+            infantry,
+            russians,
+            bridge,
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                infantry,
+                false,
+                bridge.getData(),
+                mock(Territory.class),
+                territoryEffects));
     assertThat(roll4.getHits(), is(0));
   }
 
@@ -123,11 +204,16 @@ class DiceRollTest {
     final DiceRoll roll =
         DiceRoll.rollDice(
             units,
-            false,
             russians,
             bridge,
-            mock(Territory.class),
-            TerritoryEffectHelper.getEffects(westRussia));
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                units,
+                false,
+                bridge.getData(),
+                mock(Territory.class),
+                TerritoryEffectHelper.getEffects(westRussia)));
     assertThat(roll.getHits(), is(2));
   }
 
@@ -153,11 +239,16 @@ class DiceRollTest {
     final DiceRoll roll =
         DiceRoll.rollDice(
             units,
-            false,
             russians,
             bridge,
-            mock(Territory.class),
-            TerritoryEffectHelper.getEffects(westRussia));
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                units,
+                false,
+                bridge.getData(),
+                mock(Territory.class),
+                TerritoryEffectHelper.getEffects(westRussia)));
     assertThat(roll.getHits(), is(3));
   }
 
@@ -173,11 +264,16 @@ class DiceRollTest {
     final DiceRoll roll =
         DiceRoll.rollDice(
             units,
-            true,
             russians,
             bridge,
-            mock(Territory.class),
-            TerritoryEffectHelper.getEffects(westRussia));
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                units,
+                true,
+                bridge.getData(),
+                mock(Territory.class),
+                TerritoryEffectHelper.getEffects(westRussia)));
     assertThat(roll.getHits(), is(1));
     thenGetRandomShouldHaveBeenCalled(bridge, never());
   }
@@ -206,11 +302,16 @@ class DiceRollTest {
     final DiceRoll roll =
         DiceRoll.rollDice(
             attackers,
-            false,
             americans,
             bridge,
-            mock(Territory.class),
-            TerritoryEffectHelper.getEffects(algeria));
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                attackers,
+                false,
+                bridge.getData(),
+                mock(Territory.class),
+                TerritoryEffectHelper.getEffects(algeria)));
     assertThat(roll.getHits(), is(1));
   }
 
@@ -238,11 +339,16 @@ class DiceRollTest {
     final DiceRoll roll =
         DiceRoll.rollDice(
             attackers,
-            false,
             americans,
             bridge,
-            mock(Territory.class),
-            TerritoryEffectHelper.getEffects(algeria));
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                attackers,
+                false,
+                bridge.getData(),
+                mock(Territory.class),
+                TerritoryEffectHelper.getEffects(algeria)));
     assertThat(roll.getHits(), is(1));
     thenGetRandomShouldHaveBeenCalled(bridge, never());
   }
@@ -271,11 +377,16 @@ class DiceRollTest {
     final DiceRoll roll =
         DiceRoll.rollDice(
             attackers,
-            false,
             americans,
             bridge,
-            mock(Territory.class),
-            TerritoryEffectHelper.getEffects(algeria));
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                attackers,
+                false,
+                bridge.getData(),
+                mock(Territory.class),
+                TerritoryEffectHelper.getEffects(algeria)));
     assertThat(roll.getHits(), is(0));
   }
 
@@ -294,11 +405,21 @@ class DiceRollTest {
         .thenAnswer(withValues(1)); // aa misses at 1 (0 based)
     // aa hits
     final DiceRoll hit =
-        DiceRoll.rollAa(bombers, aaGunList, bombers, aaGunList, bridge, westRussia, true);
+        DiceRoll.rollAa(
+            bombers,
+            aaGunList,
+            bridge,
+            westRussia,
+            CombatValue.buildAaCombatValue(bombers, aaGunList, true, bridge.getData()));
     assertThat(hit.getHits(), is(1));
     // aa misses
     final DiceRoll miss =
-        DiceRoll.rollAa(bombers, aaGunList, bombers, aaGunList, bridge, westRussia, true);
+        DiceRoll.rollAa(
+            bombers,
+            aaGunList,
+            bridge,
+            westRussia,
+            CombatValue.buildAaCombatValue(bombers, aaGunList, true, bridge.getData()));
     assertThat(miss.getHits(), is(0));
   }
 
@@ -326,11 +447,9 @@ class DiceRollTest {
                     UnitAttachment.get(aaGunList.iterator().next().getType())
                         .getTargetsAa(gameData))),
             aaGunList,
-            fighterList,
-            aaGunList,
             bridge,
             westRussia,
-            true);
+            CombatValue.buildAaCombatValue(fighterList, aaGunList, true, bridge.getData()));
     assertThat(hit.getHits(), is(1));
     // aa misses
     final DiceRoll miss =
@@ -341,11 +460,9 @@ class DiceRollTest {
                     UnitAttachment.get(aaGunList.iterator().next().getType())
                         .getTargetsAa(gameData))),
             aaGunList,
-            fighterList,
-            aaGunList,
             bridge,
             westRussia,
-            true);
+            CombatValue.buildAaCombatValue(fighterList, aaGunList, true, bridge.getData()));
     assertThat(miss.getHits(), is(0));
     // 6 bombers, 1 should hit, and nothing should be rolled
     fighterList = fighterType.create(6, russians);
@@ -357,11 +474,9 @@ class DiceRollTest {
                     UnitAttachment.get(aaGunList.iterator().next().getType())
                         .getTargetsAa(gameData))),
             aaGunList,
-            fighterList,
-            aaGunList,
             bridge,
             westRussia,
-            true);
+            CombatValue.buildAaCombatValue(fighterList, aaGunList, true, bridge.getData()));
     assertThat(hitNoRoll.getHits(), is(1));
     thenGetRandomShouldHaveBeenCalled(bridge, times(2));
   }
@@ -388,11 +503,9 @@ class DiceRollTest {
                     UnitAttachment.get(aaGunList.iterator().next().getType())
                         .getTargetsAa(gameData))),
             aaGunList,
-            fighterList,
-            aaGunList,
             bridge,
             westRussia,
-            true);
+            CombatValue.buildAaCombatValue(fighterList, aaGunList, true, bridge.getData()));
     assertThat(hit.getHits(), is(1));
     thenGetRandomShouldHaveBeenCalled(bridge, never());
   }
@@ -423,11 +536,9 @@ class DiceRollTest {
                     UnitAttachment.get(aaGunList.iterator().next().getType())
                         .getTargetsAa(gameData))),
             aaGunList,
-            fighterList,
-            aaGunList,
             bridge,
             finnland,
-            true);
+            CombatValue.buildAaCombatValue(fighterList, aaGunList, true, bridge.getData()));
     assertThat(hit.getHits(), is(1));
     // aa misses
     final DiceRoll miss =
@@ -438,11 +549,9 @@ class DiceRollTest {
                     UnitAttachment.get(aaGunList.iterator().next().getType())
                         .getTargetsAa(gameData))),
             aaGunList,
-            fighterList,
-            aaGunList,
             bridge,
             finnland,
-            true);
+            CombatValue.buildAaCombatValue(fighterList, aaGunList, true, bridge.getData()));
     assertThat(miss.getHits(), is(0));
     // 6 bombers, 2 should hit, and nothing should be rolled
     fighterList = fighterType.create(6, russians);
@@ -454,11 +563,9 @@ class DiceRollTest {
                     UnitAttachment.get(aaGunList.iterator().next().getType())
                         .getTargetsAa(gameData))),
             aaGunList,
-            fighterList,
-            aaGunList,
             bridge,
             finnland,
-            true);
+            CombatValue.buildAaCombatValue(fighterList, aaGunList, true, bridge.getData()));
     assertThat(hitNoRoll.getHits(), is(2));
     thenGetRandomShouldHaveBeenCalled(bridge, times(2));
   }
@@ -489,28 +596,58 @@ class DiceRollTest {
 
     // 1 AT gun
     final DiceRoll hit =
-        DiceRoll.rollAa(targets, atGuns, targets, atGuns, bridge, westernFrance, true);
+        DiceRoll.rollAa(
+            targets,
+            atGuns,
+            bridge,
+            westernFrance,
+            CombatValue.buildAaCombatValue(targets, atGuns, true, bridge.getData()));
     assertThat(hit.getHits(), is(1));
     final DiceRoll miss =
-        DiceRoll.rollAa(targets, atGuns, targets, atGuns, bridge, westernFrance, true);
+        DiceRoll.rollAa(
+            targets,
+            atGuns,
+            bridge,
+            westernFrance,
+            CombatValue.buildAaCombatValue(targets, atGuns, true, bridge.getData()));
     assertThat(miss.getHits(), is(0));
 
     // 1 AT gun + 1 AT support (AT support is a unit that provides +2 AA strength for 3 units)
     final List<Unit> supportUnits = GameDataTestUtil.germanAtSupport(gameData).create(1, germany);
     final DiceRoll hitWithSupport =
-        DiceRoll.rollAa(targets, atGuns, targets, supportUnits, bridge, westernFrance, true);
+        DiceRoll.rollAa(
+            targets,
+            atGuns,
+            bridge,
+            westernFrance,
+            CombatValue.buildAaCombatValue(targets, supportUnits, true, bridge.getData()));
     assertThat(hitWithSupport.getHits(), is(1));
     final DiceRoll missWithSupport =
-        DiceRoll.rollAa(targets, atGuns, targets, supportUnits, bridge, westernFrance, true);
+        DiceRoll.rollAa(
+            targets,
+            atGuns,
+            bridge,
+            westernFrance,
+            CombatValue.buildAaCombatValue(targets, supportUnits, true, bridge.getData()));
     assertThat(missWithSupport.getHits(), is(0));
 
     // 2 AT guns + 1 AT support
     atGuns.addAll(GameDataTestUtil.germanAntiTankGun(gameData).create(1, germany));
     final DiceRoll hitWith2AtAndSupport =
-        DiceRoll.rollAa(targets, atGuns, targets, supportUnits, bridge, westernFrance, true);
+        DiceRoll.rollAa(
+            targets,
+            atGuns,
+            bridge,
+            westernFrance,
+            CombatValue.buildAaCombatValue(targets, supportUnits, true, bridge.getData()));
     assertThat(hitWith2AtAndSupport.getHits(), is(1));
     final DiceRoll missWith2AtAndSupport =
-        DiceRoll.rollAa(targets, atGuns, targets, supportUnits, bridge, westernFrance, true);
+        DiceRoll.rollAa(
+            targets,
+            atGuns,
+            bridge,
+            westernFrance,
+            CombatValue.buildAaCombatValue(targets, supportUnits, true, bridge.getData()));
     assertThat(missWith2AtAndSupport.getHits(), is(0));
 
     // 2 AT guns + 1 AT support + 1 enemy AT counter (AT counter is a unit that provides -10 AA
@@ -520,7 +657,12 @@ class DiceRollTest {
         GameDataTestUtil.americanAtCounter(gameData).create(1, usa);
     final DiceRoll missWith2AtAndSupportAndEnemySupport =
         DiceRoll.rollAa(
-            targets, atGuns, enemySupportUnits, supportUnits, bridge, westernFrance, true);
+            targets,
+            atGuns,
+            bridge,
+            westernFrance,
+            CombatValue.buildAaCombatValue(
+                enemySupportUnits, supportUnits, true, bridge.getData()));
     assertThat(missWith2AtAndSupportAndEnemySupport.getHits(), is(0));
 
     // 4 AT guns + 1 AT support + 1 enemy AT counter
@@ -528,11 +670,21 @@ class DiceRollTest {
     atGuns.addAll(GameDataTestUtil.germanAntiTankGun(gameData).create(2, germany));
     final DiceRoll hitWith4AtAndSupportAndEnemySupport =
         DiceRoll.rollAa(
-            targets, atGuns, enemySupportUnits, supportUnits, bridge, westernFrance, true);
+            targets,
+            atGuns,
+            bridge,
+            westernFrance,
+            CombatValue.buildAaCombatValue(
+                enemySupportUnits, supportUnits, true, bridge.getData()));
     assertThat(hitWith4AtAndSupportAndEnemySupport.getHits(), is(1));
     final DiceRoll missWith4AtAndSupportAndEnemySupport =
         DiceRoll.rollAa(
-            targets, atGuns, enemySupportUnits, supportUnits, bridge, westernFrance, true);
+            targets,
+            atGuns,
+            bridge,
+            westernFrance,
+            CombatValue.buildAaCombatValue(
+                enemySupportUnits, supportUnits, true, bridge.getData()));
     assertThat(missWith4AtAndSupportAndEnemySupport.getHits(), is(0));
 
     thenGetRandomShouldHaveBeenCalled(bridge, times(8));
@@ -558,11 +710,16 @@ class DiceRollTest {
     final DiceRoll dice =
         DiceRoll.rollDice(
             bombers,
-            false,
             british,
             testDelegateBridge,
-            mock(Territory.class),
-            TerritoryEffectHelper.getEffects(germany));
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                bombers,
+                false,
+                testDelegateBridge.getData(),
+                mock(Territory.class),
+                TerritoryEffectHelper.getEffects(germany)));
     assertThat(dice.getRolls(4).get(0).getType(), is(Die.DieType.HIT));
     assertThat(dice.getRolls(4).get(1).getType(), is(Die.DieType.HIT));
   }
@@ -587,11 +744,16 @@ class DiceRollTest {
     final DiceRoll dice =
         DiceRoll.rollDice(
             bombers,
-            true,
             british,
             testDelegateBridge,
-            mock(Territory.class),
-            TerritoryEffectHelper.getEffects(germany));
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                bombers,
+                true,
+                testDelegateBridge.getData(),
+                mock(Territory.class),
+                TerritoryEffectHelper.getEffects(germany)));
     assertThat(dice.getRolls(1).size(), is(1));
     assertThat(dice.getRolls(1).get(0).getType(), is(Die.DieType.HIT));
   }
@@ -612,11 +774,16 @@ class DiceRollTest {
     final DiceRoll dice =
         DiceRoll.rollDice(
             bombers,
-            true,
             british,
             testDelegateBridge,
-            mock(Territory.class),
-            TerritoryEffectHelper.getEffects(germany));
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                bombers,
+                true,
+                testDelegateBridge.getData(),
+                mock(Territory.class),
+                TerritoryEffectHelper.getEffects(germany)));
 
     assertThat(dice.getRolls(1).size(), is(1));
     assertThat(dice.getRolls(1).get(0).getType(), is(Die.DieType.HIT));
@@ -642,11 +809,16 @@ class DiceRollTest {
     final DiceRoll dice =
         DiceRoll.rollDice(
             bombers,
-            false,
             british,
             testDelegateBridge,
-            mock(Territory.class),
-            TerritoryEffectHelper.getEffects(germany));
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                bombers,
+                false,
+                testDelegateBridge.getData(),
+                mock(Territory.class),
+                TerritoryEffectHelper.getEffects(germany)));
 
     assertThat(dice.getRolls(4).get(0).getType(), is(Die.DieType.HIT));
     assertThat(dice.getRolls(4).get(1).getType(), is(Die.DieType.IGNORED));
@@ -673,11 +845,16 @@ class DiceRollTest {
     final DiceRoll dice =
         DiceRoll.rollDice(
             bombers,
-            false,
             british,
             testDelegateBridge,
-            mock(Territory.class),
-            TerritoryEffectHelper.getEffects(germany));
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                bombers,
+                false,
+                testDelegateBridge.getData(),
+                mock(Territory.class),
+                TerritoryEffectHelper.getEffects(germany)));
     assertThat(dice.getRolls(4).get(0).getType(), is(Die.DieType.HIT));
     assertThat(dice.getRolls(4).get(1).getType(), is(Die.DieType.IGNORED));
     assertThat(dice.getHits(), is(1));
@@ -703,11 +880,16 @@ class DiceRollTest {
     final DiceRoll dice =
         DiceRoll.rollDice(
             bombers,
-            true,
             british,
             testDelegateBridge,
-            mock(Territory.class),
-            TerritoryEffectHelper.getEffects(germany));
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                bombers,
+                true,
+                testDelegateBridge.getData(),
+                mock(Territory.class),
+                TerritoryEffectHelper.getEffects(germany)));
     assertThat(dice.getRolls(1).size(), is(2));
     assertThat(dice.getHits(), is(1));
     assertThat(dice.getRolls(1).get(0).getType(), is(Die.DieType.HIT));

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -28,6 +28,7 @@ import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.BattleTracker;
 import games.strategy.triplea.delegate.battle.IBattle;
 import games.strategy.triplea.delegate.battle.steps.retreat.OffensiveGeneralRetreat;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.util.TransportUtils;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -443,11 +444,16 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
     final DiceRoll roll =
         DiceRoll.rollDice(
             attackList,
-            false,
             russians,
             bridge,
-            battle.getTerritory(),
-            TerritoryEffectHelper.getEffects(balticSeaZone));
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                attackList,
+                false,
+                bridge.getData(),
+                battle.getTerritory(),
+                TerritoryEffectHelper.getEffects(balticSeaZone)));
     assertEquals(2, roll.getHits());
     advanceToStep(bridge, "russianNonCombatMove");
     // Test the move
@@ -862,11 +868,16 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
     final DiceRoll roll =
         DiceRoll.rollDice(
             defendList,
-            true,
             germans,
             bridge,
-            mock(Territory.class),
-            TerritoryEffectHelper.getEffects(balticSeaZone));
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                defendList,
+                true,
+                bridge.getData(),
+                mock(Territory.class),
+                TerritoryEffectHelper.getEffects(balticSeaZone)));
     assertEquals(0, roll.getHits());
     // Get total number of units in Finland before the retreat
     final int preCountInt = finlandNorway.getUnitCollection().size();
@@ -931,11 +942,16 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
     final DiceRoll roll =
         DiceRoll.rollDice(
             defendList,
-            true,
             germans,
             bridge,
-            mock(Territory.class),
-            TerritoryEffectHelper.getEffects(balticSeaZone));
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                defendList,
+                true,
+                bridge.getData(),
+                mock(Territory.class),
+                TerritoryEffectHelper.getEffects(balticSeaZone)));
     assertEquals(1, roll.getHits());
     // Get total number of units in Finland before the retreat
     final int preCountInt = finlandNorway.getUnitCollection().size();
@@ -990,11 +1006,16 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
     final DiceRoll roll =
         DiceRoll.rollDice(
             defendList,
-            true,
             germans,
             bridge,
-            mock(Territory.class),
-            TerritoryEffectHelper.getEffects(balticSeaZone));
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                defendList,
+                true,
+                bridge.getData(),
+                mock(Territory.class),
+                TerritoryEffectHelper.getEffects(balticSeaZone)));
     assertEquals(0, roll.getHits());
     // Get total number of units in Finland before the retreat
     final int preCountInt = karelia.getUnitCollection().size();
@@ -1049,11 +1070,16 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
     final DiceRoll roll =
         DiceRoll.rollDice(
             defendList,
-            true,
             germans,
             bridge,
-            mock(Territory.class),
-            TerritoryEffectHelper.getEffects(balticSeaZone));
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                defendList,
+                true,
+                bridge.getData(),
+                mock(Territory.class),
+                TerritoryEffectHelper.getEffects(balticSeaZone)));
     assertEquals(1, roll.getHits());
     // Get total number of units in Finland before the retreat
     final int preCountInt = karelia.getUnitCollection().size();

--- a/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
@@ -17,6 +17,7 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Constants;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.Collection;
 import java.util.List;
@@ -107,20 +108,50 @@ class PacificTest extends AbstractDelegateTestCase {
     // Defending US infantry
     DiceRoll roll =
         DiceRoll.rollDice(
-            infantryUs, true, americans, bridge, mock(Territory.class), territoryEffects);
+            infantryUs,
+            americans,
+            bridge,
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                infantryUs,
+                true,
+                bridge.getData(),
+                mock(Territory.class),
+                territoryEffects));
     assertEquals(1, roll.getHits());
     // Defending US marines
     final List<Unit> marineUs = marine.create(1, americans);
     roll =
         DiceRoll.rollDice(
-            marineUs, true, americans, bridge, mock(Territory.class), territoryEffects);
+            marineUs,
+            americans,
+            bridge,
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                marineUs,
+                true,
+                bridge.getData(),
+                mock(Territory.class),
+                territoryEffects));
     assertEquals(1, roll.getHits());
     // Chinese units
     // Defending Chinese infantry
     final List<Unit> infantryChina = infantry.create(1, chinese);
     roll =
         DiceRoll.rollDice(
-            infantryChina, true, chinese, bridge, mock(Territory.class), territoryEffects);
+            infantryChina,
+            chinese,
+            bridge,
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                infantryChina,
+                true,
+                bridge.getData(),
+                mock(Territory.class),
+                territoryEffects));
     assertEquals(1, roll.getHits());
   }
 
@@ -144,36 +175,96 @@ class PacificTest extends AbstractDelegateTestCase {
     // Defending US infantry
     DiceRoll roll =
         DiceRoll.rollDice(
-            infantryUs, true, americans, bridge, mock(Territory.class), territoryEffects);
+            infantryUs,
+            americans,
+            bridge,
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                infantryUs,
+                true,
+                bridge.getData(),
+                mock(Territory.class),
+                territoryEffects));
     assertEquals(0, roll.getHits());
     // Defending US marines
     final List<Unit> marineUs = marine.create(1, americans);
     roll =
         DiceRoll.rollDice(
-            marineUs, true, americans, bridge, mock(Territory.class), territoryEffects);
+            marineUs,
+            americans,
+            bridge,
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                marineUs,
+                true,
+                bridge.getData(),
+                mock(Territory.class),
+                territoryEffects));
     assertEquals(0, roll.getHits());
     // Chinese units
     // Defending Chinese infantry
     final List<Unit> infantryChina = infantry.create(1, chinese);
     roll =
         DiceRoll.rollDice(
-            infantryChina, true, chinese, bridge, mock(Territory.class), territoryEffects);
+            infantryChina,
+            chinese,
+            bridge,
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                infantryChina,
+                true,
+                bridge.getData(),
+                mock(Territory.class),
+                territoryEffects));
     assertEquals(1, roll.getHits());
     // Defending US infantry
     roll =
         DiceRoll.rollDice(
-            infantryUs, true, americans, bridge, mock(Territory.class), territoryEffects);
+            infantryUs,
+            americans,
+            bridge,
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                infantryUs,
+                true,
+                bridge.getData(),
+                mock(Territory.class),
+                territoryEffects));
     assertEquals(1, roll.getHits());
     // Defending US marines
     roll =
         DiceRoll.rollDice(
-            marineUs, true, americans, bridge, mock(Territory.class), territoryEffects);
+            marineUs,
+            americans,
+            bridge,
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                marineUs,
+                true,
+                bridge.getData(),
+                mock(Territory.class),
+                territoryEffects));
     assertEquals(1, roll.getHits());
     // Chinese units
     // Defending Chinese infantry
     roll =
         DiceRoll.rollDice(
-            infantryChina, true, chinese, bridge, mock(Territory.class), territoryEffects);
+            infantryChina,
+            chinese,
+            bridge,
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                infantryChina,
+                true,
+                bridge.getData(),
+                mock(Territory.class),
+                territoryEffects));
     assertEquals(1, roll.getHits());
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -81,6 +81,7 @@ import games.strategy.triplea.delegate.data.MoveValidationResult;
 import games.strategy.triplea.delegate.data.PlaceableUnits;
 import games.strategy.triplea.delegate.data.TechResults;
 import games.strategy.triplea.delegate.move.validation.MoveValidator;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.ArrayList;
@@ -171,25 +172,28 @@ class WW2V3Year41Test {
                     UnitAttachment.get(defendingAa.iterator().next().getType())
                         .getTargetsAa(gameData))),
             defendingAa,
-            planes,
-            territory("Germany", gameData).getUnits(),
             bridge,
             territory("Germany", gameData),
-            true);
+            CombatValue.buildAaCombatValue(
+                planes, territory("Germany", gameData).getUnits(), true, bridge.getData()));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
-                false,
-                planes,
                 planes,
                 defendingAa,
-                defendingAa,
+                CombatValue.buildMainCombatValue(
+                    defendingAa,
+                    planes,
+                    false,
+                    gameData,
+                    territory("Germany", gameData),
+                    List.of()),
+                CombatValue.buildAaCombatValue(planes, defendingAa, true, gameData),
                 "",
                 roll,
                 bridge,
                 null,
                 null,
-                territory("Germany", gameData),
-                null)
+                territory("Germany", gameData))
             .getKilled();
     assertEquals(2, casualties.size());
     // should be 1 fighter and 1 bomber
@@ -225,27 +229,30 @@ class WW2V3Year41Test {
                     UnitAttachment.get(defendingAa.iterator().next().getType())
                         .getTargetsAa(gameData))),
             defendingAa,
-            planes,
-            territory("Germany", gameData).getUnits(),
             bridge,
             territory("Germany", gameData),
-            true);
+            CombatValue.buildAaCombatValue(
+                planes, territory("Germany", gameData).getUnits(), true, bridge.getData()));
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
-                false,
-                planes,
                 planes,
                 defendingAa,
-                defendingAa,
+                CombatValue.buildMainCombatValue(
+                    defendingAa,
+                    planes,
+                    false,
+                    gameData,
+                    territory("Germany", gameData),
+                    List.of()),
+                CombatValue.buildAaCombatValue(planes, defendingAa, true, gameData),
                 "",
                 roll,
                 bridge,
                 null,
                 null,
-                territory("Germany", gameData),
-                null)
+                territory("Germany", gameData))
             .getKilled();
     assertEquals(3, casualties.size());
     // should be 1 fighter and 2 bombers
@@ -283,28 +290,31 @@ class WW2V3Year41Test {
                     UnitAttachment.get(defendingAa.iterator().next().getType())
                         .getTargetsAa(gameData))),
             defendingAa,
-            planes,
-            territory("Germany", gameData).getUnits(),
             bridge,
             territory("Germany", gameData),
-            true);
+            CombatValue.buildAaCombatValue(
+                planes, territory("Germany", gameData).getUnits(), true, bridge.getData()));
     assertEquals(2, roll.getHits());
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
-                false,
-                planes,
                 planes,
                 defendingAa,
-                defendingAa,
+                CombatValue.buildMainCombatValue(
+                    defendingAa,
+                    planes,
+                    false,
+                    gameData,
+                    territory("Germany", gameData),
+                    List.of()),
+                CombatValue.buildAaCombatValue(planes, defendingAa, true, gameData),
                 "",
                 roll,
                 bridge,
                 null,
                 null,
-                territory("Germany", gameData),
-                null)
+                territory("Germany", gameData))
             .getKilled();
     assertEquals(2, casualties.size());
     thenGetRandomShouldHaveBeenCalled(bridge, times(3));
@@ -690,12 +700,32 @@ class WW2V3Year41Test {
     // Attacking fighter
     final DiceRoll roll1 =
         DiceRoll.rollDice(
-            germanFighter, false, germans, delegateBridge, mock(Territory.class), territoryEffects);
+            germanFighter,
+            germans,
+            delegateBridge,
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                germanFighter,
+                false,
+                delegateBridge.getData(),
+                mock(Territory.class),
+                territoryEffects));
     assertEquals(1, roll1.getHits());
     // Defending fighter
     final DiceRoll roll2 =
         DiceRoll.rollDice(
-            germanFighter, true, germans, delegateBridge, mock(Territory.class), territoryEffects);
+            germanFighter,
+            germans,
+            delegateBridge,
+            "",
+            CombatValue.buildMainCombatValue(
+                List.of(),
+                germanFighter,
+                true,
+                delegateBridge.getData(),
+                mock(Territory.class),
+                territoryEffects));
     assertEquals(0, roll2.getHits());
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTest.java
@@ -11,8 +11,10 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.UnitType;
+import games.strategy.engine.data.UnitTypeList;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -26,6 +28,7 @@ import org.triplea.java.collections.IntegerMap;
 class CasualtyOrderOfLossesTest {
 
   @Mock GameData gameData;
+  @Mock UnitTypeList unitTypeList;
   @Mock GamePlayer player;
   @Mock UnitAttachment unitAttachment;
 
@@ -65,6 +68,7 @@ class CasualtyOrderOfLossesTest {
   }
 
   private CasualtyOrderOfLosses.Parameters withFakeParameters() {
+    when(gameData.getUnitTypeList()).thenReturn(unitTypeList);
     final GamePlayer player = mock(GamePlayer.class);
     when(player.getName()).thenReturn("player");
     final Territory territory = mock(Territory.class);
@@ -77,8 +81,9 @@ class CasualtyOrderOfLossesTest {
                 .territoryEffects(List.of())
                 .build())
         .player(player)
-        .enemyUnits(List.of())
-        .friendlyUnits(List.of())
+        .combatValue(
+            CombatValue.buildMainCombatValue(
+                List.of(), List.of(), false, gameData, territory, List.of()))
         .battlesite(territory)
         .costs(IntegerMap.of(Map.of()))
         .data(gameData)

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnBigWorldV3.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnBigWorldV3.java
@@ -8,6 +8,7 @@ import games.strategy.engine.data.MutableProperty;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.delegate.ImprovedArtillerySupportAdvance;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator.CombatModifiers;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.xml.TestDataBigWorld1942V3;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -64,8 +65,9 @@ class CasualtyOrderOfLossesTestOnBigWorldV3 {
         .combatModifiers(
             CombatModifiers.builder().defending(false).territoryEffects(List.of()).build())
         .player(testData.british)
-        .enemyUnits(List.of())
-        .friendlyUnits(amphibUnits)
+        .combatValue(
+            CombatValue.buildMainCombatValue(
+                List.of(), amphibUnits, false, testData.gameData, testData.france, List.of()))
         .battlesite(testData.france)
         .costs(testData.costMap)
         .data(testData.gameData)
@@ -193,8 +195,14 @@ class CasualtyOrderOfLossesTestOnBigWorldV3 {
                 .combatModifiers(
                     CombatModifiers.builder().defending(false).territoryEffects(List.of()).build())
                 .player(testData.british)
-                .enemyUnits(List.of())
-                .friendlyUnits(attackingUnits)
+                .combatValue(
+                    CombatValue.buildMainCombatValue(
+                        List.of(),
+                        attackingUnits,
+                        false,
+                        testData.gameData,
+                        testData.france,
+                        List.of()))
                 .battlesite(testData.france)
                 .costs(testData.costMap)
                 .data(testData.gameData)
@@ -242,8 +250,14 @@ class CasualtyOrderOfLossesTestOnBigWorldV3 {
                 .combatModifiers(
                     CombatModifiers.builder().defending(false).territoryEffects(List.of()).build())
                 .player(testData.british)
-                .enemyUnits(List.of())
-                .friendlyUnits(attackingUnits)
+                .combatValue(
+                    CombatValue.buildMainCombatValue(
+                        List.of(),
+                        attackingUnits,
+                        false,
+                        testData.gameData,
+                        testData.france,
+                        List.of()))
                 .battlesite(testData.france)
                 .costs(testData.costMap)
                 .data(testData.gameData)
@@ -262,8 +276,14 @@ class CasualtyOrderOfLossesTestOnBigWorldV3 {
                 .combatModifiers(
                     CombatModifiers.builder().defending(false).territoryEffects(List.of()).build())
                 .player(testData.british)
-                .enemyUnits(List.of())
-                .friendlyUnits(attackingUnits.subList(0, 3))
+                .combatValue(
+                    CombatValue.buildMainCombatValue(
+                        List.of(),
+                        attackingUnits.subList(0, 3),
+                        false,
+                        testData.gameData,
+                        testData.france,
+                        List.of()))
                 .battlesite(testData.france)
                 .costs(testData.costMap)
                 .data(testData.gameData)

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnGlobal.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnGlobal.java
@@ -18,6 +18,7 @@ import games.strategy.triplea.delegate.HeavyBomberAdvance;
 import games.strategy.triplea.delegate.ImprovedArtillerySupportAdvance;
 import games.strategy.triplea.delegate.TechAdvance;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator.CombatModifiers;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -134,8 +135,8 @@ class CasualtyOrderOfLossesTestOnGlobal {
         .combatModifiers(
             CombatModifiers.builder().defending(false).territoryEffects(List.of()).build())
         .player(BRITISH)
-        .enemyUnits(List.of())
-        .friendlyUnits(units)
+        .combatValue(
+            CombatValue.buildMainCombatValue(List.of(), units, false, data, FRANCE, List.of()))
         .battlesite(FRANCE)
         .costs(COST_MAP)
         .data(data)
@@ -218,8 +219,9 @@ class CasualtyOrderOfLossesTestOnGlobal {
         .combatModifiers(
             CombatModifiers.builder().defending(false).territoryEffects(List.of()).build())
         .player(BRITISH)
-        .enemyUnits(List.of())
-        .friendlyUnits(amphibUnits)
+        .combatValue(
+            CombatValue.buildMainCombatValue(
+                List.of(), amphibUnits, false, data, FRANCE, List.of()))
         .battlesite(FRANCE)
         .costs(COST_MAP)
         .data(data)
@@ -299,8 +301,8 @@ class CasualtyOrderOfLossesTestOnGlobal {
         .combatModifiers(
             CombatModifiers.builder().defending(true).territoryEffects(List.of()).build())
         .player(BRITISH)
-        .enemyUnits(List.of())
-        .friendlyUnits(units)
+        .combatValue(
+            CombatValue.buildMainCombatValue(List.of(), units, true, data, FRANCE, List.of()))
         .battlesite(FRANCE)
         .costs(COST_MAP)
         .data(data)

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnNapoleonic.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnNapoleonic.java
@@ -12,6 +12,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator.CombatModifiers;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -93,8 +94,8 @@ class CasualtyOrderOfLossesTestOnNapoleonic {
         .combatModifiers(
             CombatModifiers.builder().defending(false).territoryEffects(List.of()).build())
         .player(BRITISH)
-        .enemyUnits(List.of())
-        .friendlyUnits(units)
+        .combatValue(
+            CombatValue.buildMainCombatValue(List.of(), units, false, data, NORMANDY, List.of()))
         .battlesite(NORMANDY)
         .costs(COST_MAP)
         .data(data)

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelectorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelectorTest.java
@@ -25,6 +25,7 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
+import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -83,18 +84,17 @@ class CasualtySelectorTest {
     whenGetRandom(bridge).thenAnswer(withValues(0));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
-                false,
-                planes,
                 planes,
                 defendingAa,
-                defendingAa,
+                CombatValue.buildMainCombatValue(
+                    defendingAa, planes, false, data, territory("Germany", data), List.of()),
+                CombatValue.buildAaCombatValue(planes, defendingAa, true, data),
                 "",
                 roll,
                 bridge,
                 null,
                 null,
-                territory("Germany", data),
-                null)
+                territory("Germany", data))
             .getKilled();
     assertEquals(1, casualties.size());
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
@@ -113,18 +113,17 @@ class CasualtySelectorTest {
     planes.get(0).setAlreadyMoved(BigDecimal.ONE);
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
-                false,
-                planes,
                 planes,
                 defendingAa,
-                defendingAa,
+                CombatValue.buildMainCombatValue(
+                    defendingAa, planes, false, data, territory("Germany", data), List.of()),
+                CombatValue.buildAaCombatValue(planes, defendingAa, true, data),
                 "",
                 roll,
                 bridge,
                 null,
                 null,
-                territory("Germany", data),
-                List.of())
+                territory("Germany", data))
             .getKilled();
     assertEquals(1, casualties.size());
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
@@ -149,25 +148,23 @@ class CasualtySelectorTest {
                     UnitAttachment.get(defendingAa.iterator().next().getType())
                         .getTargetsAa(data))),
             defendingAa,
-            planes,
-            territory("Germany", data).getUnits(),
             bridge,
             territory("Germany", data),
-            true);
+            CombatValue.buildAaCombatValue(
+                planes, territory("Germany", data).getUnits(), true, bridge.getData()));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
-                false,
-                planes,
                 planes,
                 defendingAa,
-                defendingAa,
+                CombatValue.buildMainCombatValue(
+                    defendingAa, planes, false, data, territory("Germany", data), List.of()),
+                CombatValue.buildAaCombatValue(planes, defendingAa, true, data),
                 "",
                 roll,
                 bridge,
                 null,
                 null,
-                territory("Germany", data),
-                List.of())
+                territory("Germany", data))
             .getKilled();
     assertEquals(2, casualties.size());
     // should be 1 fighter and 1 bomber
@@ -197,26 +194,24 @@ class CasualtySelectorTest {
                     UnitAttachment.get(defendingAa.iterator().next().getType())
                         .getTargetsAa(data))),
             defendingAa,
-            planes,
-            territory("Germany", data).getUnits(),
             bridge,
             territory("Germany", data),
-            true);
+            CombatValue.buildAaCombatValue(
+                planes, territory("Germany", data).getUnits(), true, bridge.getData()));
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
-                false,
-                planes,
                 planes,
                 defendingAa,
-                defendingAa,
+                CombatValue.buildMainCombatValue(
+                    defendingAa, planes, false, data, territory("Germany", data), List.of()),
+                CombatValue.buildAaCombatValue(planes, defendingAa, true, data),
                 "",
                 roll,
                 bridge,
                 null,
                 null,
-                territory("Germany", data),
-                null)
+                territory("Germany", data))
             .getKilled();
     assertEquals(2, casualties.size());
     // two extra rolls to pick which units are hit
@@ -247,25 +242,23 @@ class CasualtySelectorTest {
                     UnitAttachment.get(defendingAa.iterator().next().getType())
                         .getTargetsAa(data))),
             defendingAa,
-            planes,
-            territory("Germany", data).getUnits(),
             bridge,
             territory("Germany", data),
-            true);
+            CombatValue.buildAaCombatValue(
+                planes, territory("Germany", data).getUnits(), true, bridge.getData()));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
-                false,
-                planes,
                 planes,
                 defendingAa,
-                defendingAa,
+                CombatValue.buildMainCombatValue(
+                    defendingAa, planes, false, data, territory("Germany", data), List.of()),
+                CombatValue.buildAaCombatValue(planes, defendingAa, true, data),
                 "",
                 roll,
                 bridge,
                 british(data),
                 null,
-                territory("Germany", data),
-                List.of())
+                territory("Germany", data))
             .getKilled();
     assertEquals(2, casualties.size());
     // we selected all bombers
@@ -296,25 +289,23 @@ class CasualtySelectorTest {
                     UnitAttachment.get(defendingAa.iterator().next().getType())
                         .getTargetsAa(data))),
             defendingAa,
-            planes,
-            territory("Germany", data).getUnits(),
             bridge,
             territory("Germany", data),
-            true);
+            CombatValue.buildAaCombatValue(
+                planes, territory("Germany", data).getUnits(), true, bridge.getData()));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
-                false,
-                planes,
                 planes,
                 defendingAa,
-                defendingAa,
+                CombatValue.buildMainCombatValue(
+                    defendingAa, planes, false, data, territory("Germany", data), List.of()),
+                CombatValue.buildAaCombatValue(planes, defendingAa, true, data),
                 "",
                 roll,
                 bridge,
                 british(data),
                 null,
-                territory("Germany", data),
-                List.of())
+                territory("Germany", data))
             .getKilled();
     assertEquals(3, casualties.size());
     // we selected all bombers
@@ -345,27 +336,25 @@ class CasualtySelectorTest {
                     UnitAttachment.get(defendingAa.iterator().next().getType())
                         .getTargetsAa(data))),
             defendingAa,
-            planes,
-            territory("Germany", data).getUnits(),
             bridge,
             territory("Germany", data),
-            true);
+            CombatValue.buildAaCombatValue(
+                planes, territory("Germany", data).getUnits(), true, bridge.getData()));
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
-                false,
-                planes,
                 planes,
                 defendingAa,
-                defendingAa,
+                CombatValue.buildMainCombatValue(
+                    defendingAa, planes, false, data, territory("Germany", data), List.of()),
+                CombatValue.buildAaCombatValue(planes, defendingAa, true, data),
                 "",
                 roll,
                 bridge,
                 null,
                 null,
-                territory("Germany", data),
-                null)
+                territory("Germany", data))
             .getKilled();
     assertEquals(3, casualties.size());
     // a second roll for choosing which unit
@@ -400,27 +389,25 @@ class CasualtySelectorTest {
                     UnitAttachment.get(defendingAa.iterator().next().getType())
                         .getTargetsAa(data))),
             defendingAa,
-            planes,
-            territory("Germany", data).getUnits(),
             bridge,
             territory("Germany", data),
-            true);
+            CombatValue.buildAaCombatValue(
+                planes, territory("Germany", data).getUnits(), true, bridge.getData()));
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
-                false,
-                planes,
                 planes,
                 defendingAa,
-                defendingAa,
+                CombatValue.buildMainCombatValue(
+                    defendingAa, planes, false, data, territory("Germany", data), List.of()),
+                CombatValue.buildAaCombatValue(planes, defendingAa, true, data),
                 "",
                 roll,
                 bridge,
                 null,
                 null,
-                territory("Germany", data),
-                null)
+                territory("Germany", data))
             .getKilled();
     assertEquals(2, casualties.size());
     thenGetRandomShouldHaveBeenCalled(bridge, times(3));
@@ -450,27 +437,25 @@ class CasualtySelectorTest {
                     UnitAttachment.get(defendingAa.iterator().next().getType())
                         .getTargetsAa(data))),
             defendingAa,
-            planes,
-            territory("Germany", data).getUnits(),
             bridge,
             territory("Germany", data),
-            true);
+            CombatValue.buildAaCombatValue(
+                planes, territory("Germany", data).getUnits(), true, bridge.getData()));
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
-                false,
-                planes,
                 planes,
                 defendingAa,
-                defendingAa,
+                CombatValue.buildMainCombatValue(
+                    defendingAa, planes, false, data, territory("Germany", data), List.of()),
+                CombatValue.buildAaCombatValue(planes, defendingAa, true, data),
                 "",
                 roll,
                 bridge,
                 null,
                 null,
-                territory("Germany", data),
-                null)
+                territory("Germany", data))
             .getKilled();
     assertEquals(3, casualties.size());
     // should be 2 fighters and 1 bombers


### PR DESCRIPTION
This simplifies several of the apis of DiceRoll and CasualtySelector by using CombatValue as a parameter.

## Testing
<!-- Describe any manual testing performed below. -->
Ran World at War with Hard AI starting in a round 10+.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
