### PR TITLE
Only skip giveUnitControl if the value is false or true

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
@@ -895,9 +895,6 @@ public final class GameParser {
       }
       // decapitalize the property name for backwards compatibility
       final String name = LegacyPropertyMapper.mapLegacyOptionName(decapitalize(option.getName()));
-      if (LegacyPropertyMapper.ignoreOptionName(name)) {
-        continue;
-      }
 
       if (name.isEmpty()) {
         throw new GameParseException(
@@ -905,6 +902,9 @@ public final class GameParser {
       }
       final String value = option.getValue();
       final String count = option.getCount();
+      if (LegacyPropertyMapper.ignoreOptionName(name, value)) {
+        continue;
+      }
       final String countAndValue = (count != null && !count.isEmpty() ? count + ":" : "") + value;
       if (containsEmptyForeachVariable(countAndValue, foreach)) {
         continue; // Skip adding option if contains empty foreach variable

--- a/game-core/src/main/java/games/strategy/engine/data/gameparser/LegacyPropertyMapper.java
+++ b/game-core/src/main/java/games/strategy/engine/data/gameparser/LegacyPropertyMapper.java
@@ -55,7 +55,9 @@ class LegacyPropertyMapper {
     return propertyName;
   }
 
-  static boolean ignoreOptionName(final String name) {
-    return name.equalsIgnoreCase("takeUnitControl") || name.equalsIgnoreCase("giveUnitControl");
+  static boolean ignoreOptionName(final String name, final String value) {
+    return name.equalsIgnoreCase("takeUnitControl")
+        || (name.equalsIgnoreCase("giveUnitControl")
+            && (value.equals("false") || value.equals("true")));
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/gameparser/LegacyPropertyMapper.java
+++ b/game-core/src/main/java/games/strategy/engine/data/gameparser/LegacyPropertyMapper.java
@@ -58,6 +58,6 @@ class LegacyPropertyMapper {
   static boolean ignoreOptionName(final String name, final String value) {
     return name.equalsIgnoreCase("takeUnitControl")
         || (name.equalsIgnoreCase("giveUnitControl")
-            && (value.equals("false") || value.equals("true")));
+            && (value == null || value.equals("false") || value.equals("true")));
   }
 }


### PR DESCRIPTION
Fixes #7990

In #1033, @Cernelius said to remove `giveUnitControl` if its values was a boolean.  But he said to leave it alone if the value wasn't a boolean.  In #7631, it was just skipped without looking at the value.  This changes it to check the value and only skip it if it is a boolean.

I think this breaks all of the world_war_ii_global games as well as several others.

## Testing
Played World War 2 Global 1940 2nd to UK_Pacific Place round, placed some units in India, finished the place round and checked that the new units are now British units.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|World War 2 Global will correctly switch unit ownership of units placed in India from UK_Pacific to British.<!--END_RELEASE_NOTE-->
