### PR TITLE
Do not restart prod lobby on new version deployments & fix zip file name

### DIFF
--- a/infrastructure/ansible/group_vars/prod2_lobby.yml
+++ b/infrastructure/ansible/group_vars/prod2_lobby.yml
@@ -1,3 +1,4 @@
 version: "2.4.22192"
 journalctl_applications: ["lobby_server"]
+lobby_restart_on_new_deployment: false
 

--- a/infrastructure/ansible/roles/lobby_server/defaults/main.yml
+++ b/infrastructure/ansible/roles/lobby_server/defaults/main.yml
@@ -16,4 +16,7 @@ lobby_server_db_user: "{{ lobby_db_user }}"
 
 create_issues_github_api_token: test
 
-lobby_server_zip_download: "https://github.com/triplea-game/triplea/releases/download/{{ version }}/triplea-http-server-{{ version }}.zip"
+lobby_server_zip_download: "https://github.com/triplea-game/triplea/releases/download/{{ version }}/triplea-lobby-server-{{ version }}.zip"
+
+lobby_restart_on_new_deployment: true
+

--- a/infrastructure/ansible/roles/lobby_server/tasks/main.yml
+++ b/infrastructure/ansible/roles/lobby_server/tasks/main.yml
@@ -76,7 +76,7 @@
     enabled: yes
 
 - name: restart service if new jar file deployed
-  when: (deploy_jar_file.changed) or (deploy_config_file.changed)
+  when: (lobby_restart_on_new_deployment) and ((deploy_jar_file.changed) or (deploy_config_file.changed))
   service:
     name: lobby_server
     state: restarted


### PR DESCRIPTION
To have a new version take effect, we can/will restart the lobby service
manually. Meanwhile this update allows us to deploy new versions without
them taking effect, which means we can get them ready and activate them
easily with a service restart


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
