### PR TITLE
Catch any exception when a map fails to load

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
@@ -103,7 +103,7 @@ public final class GameParser {
           } catch (final EngineVersionException e) {
             log.log(Level.WARNING, "Game engine not compatible with: " + mapUri, e);
             return null;
-          } catch (final GameParseException | XmlParsingException e) {
+          } catch (final Exception e) {
             log.log(Level.SEVERE, "Could not parse:" + mapUri + ", " + e.getMessage(), e);
             return null;
           }


### PR DESCRIPTION
There's a number of places we can get a NPE or other exception
during map parsing. Thist update catches all such exceptions
so that the game does not outright crash and would report which
map XML is generating the issue.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Map parsing errors will be more gracefully handled, will no longer crash the game and will print the name of the map that generated the error.<!--END_RELEASE_NOTE-->
