### PR TITLE
Set bot version to 2.5.22202 [skip ci]

### DIFF
--- a/infrastructure/ansible/group_vars/prod2_bot.yml
+++ b/infrastructure/ansible/group_vars/prod2_bot.yml
@@ -1,2 +1,2 @@
-version: "2.1.20765"
+version: "2.5.22202"
 journalctl_applications: ["bot@01", "bot@02", "bot@03", "bot@04", "bot@05"]


### PR DESCRIPTION
v2.5.22202 adds the JVM arg:  -Xss1250K


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
