### PR TITLE
Give the launched process the same xss settings

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -74,7 +74,7 @@ public final class GameDataManager {
       } else {
         return Optional.empty();
       }
-    } catch (final ClassNotFoundException | IOException e) {
+    } catch (final Throwable e) {
       log.error("Error loading game data", e);
       return Optional.empty();
     }

--- a/game-core/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
@@ -28,6 +28,11 @@ final class ProcessRunnerUtil {
             .map(s -> s.substring(4))
             .findFirst();
     maxMemory.ifPresent(max -> commands.add("-Xmx" + max));
+    final Optional<String> maxStackSize =
+        ManagementFactory.getRuntimeMXBean().getInputArguments().stream()
+            .filter(s -> s.toLowerCase().startsWith("-xss"))
+            .findFirst();
+    maxStackSize.ifPresent(commands::add);
     if (SystemProperties.isMac()) {
       commands.add("-Dapple.laf.useScreenMenuBar=true");
       commands.add("-Xdock:name=\"TripleA\"");


### PR DESCRIPTION
This gives the sub process the same xss setting as the main client.  This should allow the sub process to open large saved games and map xml files.

## Testing
<!-- Describe any manual testing performed below. -->
I used the saved game from #8034.  I created a headless client and a headed client.  I joined the headless client, loaded the saved game, marked all of the players as me, and then let the game start.  Without this change, the game would not start and get stuck.  With this change, the game loads and I can play.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Playing large save/maps in the lobby will no longer hang because of a stack overflow error.<!--END_RELEASE_NOTE-->
