### PR TITLE
Handle FileSystemNotFoundException when check if the URI is invalid

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
@@ -237,6 +237,9 @@ public class GameSelectorModel extends Observable implements GameSelector {
    * method will find the location of the zip file itself.
    */
   private static Path getDefaultGameRealPath(final URI defaultGame) {
+    // The file system of the URI needs to be created before Path.of can be called.
+    // So, first see if the file system is already created and if that throws
+    // FileSystemNotFoundException, then try and create it.
     try {
       FileSystems.getFileSystem(defaultGame);
     } catch (final FileSystemNotFoundException notFoundException) {


### PR DESCRIPTION
@DanVanAtta , your fix in #8058 now causes an exception to be thrown when the default game is from a zip file.  That's because `Path.of()` will throw a `FileSystemNotFoundException` when the uri is a zip file and the file system hasn't been created.

## Testing
<!-- Describe any manual testing performed below. -->
In a build without #8058, load a zipped map.  Quit, rebuild with #8058, then start.  You'll get an error message saying `FileSystemNotFoundException`.  This PR prevents that exception from happening.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
