### PR TITLE
Simplify detection of invalid URI, avoid using 'path.of' due to FileSystemNotFoundException

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
@@ -213,14 +213,11 @@ public class GameSelectorModel extends Observable implements GameSelector {
 
   @SuppressWarnings("ReturnValueIgnored")
   private static boolean gameUriExistsOnFileSystem(final String gameUri) {
-    try {
-      Path.of(URI.create(gameUri));
-    } catch (final IllegalArgumentException ignored) {
-      // thrown if the URI is invalid (EG: missing URI scheme)
+    final URI uri = URI.create(gameUri);
+    if (uri.getScheme() == null) {
       return false;
     }
-
-    final Path realPath = getDefaultGameRealPath(URI.create(gameUri));
+    final Path realPath = getDefaultGameRealPath(uri);
 
     // starts with check is because we don't want to load a game file by default that is not within
     // the map folders. (ie: if a previous version of triplea was using running a game within its

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
@@ -234,6 +234,9 @@ public class GameSelectorModel extends Observable implements GameSelector {
    * method will find the location of the zip file itself.
    */
   private static Path getDefaultGameRealPath(final URI defaultGame) {
+    // The file system of the URI needs to be created before Path.of can be called.
+    // So, first see if the file system is already created and if that throws
+    // FileSystemNotFoundException, then try and create it.
     try {
       FileSystems.getFileSystem(defaultGame);
     } catch (final FileSystemNotFoundException notFoundException) {


### PR DESCRIPTION
In response to: https://github.com/triplea-game/triplea/issues/8062

This update has already been applied to the release/2.5 branch (hotfix)


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
