### PR TITLE
Make the gameChooser use DefaultGameChooserEntry instead of String

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/AvailableGamesList.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/AvailableGamesList.java
@@ -24,6 +24,10 @@ public class AvailableGamesList {
         .collect(Collectors.toList());
   }
 
+  public List<DefaultGameChooserEntry> getSortedGameEntries() {
+    return availableGames.stream().sorted().collect(Collectors.toList());
+  }
+
   public boolean hasGame(final String gameName) {
     return findGameUriByName(gameName).isPresent();
   }

--- a/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/MapZipReaderUtil.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/MapZipReaderUtil.java
@@ -21,7 +21,6 @@ class MapZipReaderUtil {
 
   /**
    * Finds all game XMLs in a zip file. More specifically, given a zip file, finds all '*.xml' files
-   * that have a 'games/' folder on the zip file path.
    */
   List<URI> findGameXmlFilesInZip(final File zip) {
     final List<URI> zipFiles = new ArrayList<>();

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
@@ -22,7 +22,6 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
 import javax.swing.SwingUtilities;
-import lombok.extern.java.Log;
 import org.triplea.java.UrlStreams;
 import org.triplea.map.data.elements.PropertyList;
 import org.triplea.map.data.elements.ShallowParsedGame;
@@ -38,7 +37,6 @@ import org.triplea.util.LocalizeHtml;
  * A modal dialog that prompts the user to select a game (map) from the list of installed games
  * (maps).
  */
-@Log
 public class GameChooser extends JDialog {
   private static final long serialVersionUID = -3223711652118741132L;
 

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
@@ -42,12 +42,12 @@ import org.triplea.util.LocalizeHtml;
 public class GameChooser extends JDialog {
   private static final long serialVersionUID = -3223711652118741132L;
 
-  private String chosen;
+  private DefaultGameChooserEntry chosen;
 
   private GameChooser(
       final Frame owner, final GameChooserModel gameChooserModel, final String gameName) {
     super(owner, "Select a Game", true);
-    final JList<String> gameList = new JList<>(gameChooserModel);
+    final JList<DefaultGameChooserEntry> gameList = new JList<>(gameChooserModel);
     if (gameName == null || gameName.equals("-")) {
       gameList.setSelectedIndex(0);
     } else {
@@ -99,11 +99,7 @@ public class GameChooser extends JDialog {
     notesPanel.setContentType("text/html");
     notesPanel.setForeground(Color.BLACK);
 
-    notesPanel.setText(
-        gameChooserModel
-            .lookupGameUriByName(gameList.getSelectedValue())
-            .map(GameChooser::buildGameNotesText)
-            .orElse("Map not found.."));
+    notesPanel.setText(GameChooser.buildGameNotesText(gameList.getSelectedValue().getUri()));
 
     final JPanel infoPanel = new JPanel();
     infoPanel.setLayout(new BorderLayout());
@@ -138,10 +134,7 @@ public class GameChooser extends JDialog {
         e -> {
           if (!e.getValueIsAdjusting()) {
             notesPanel.setText(
-                gameChooserModel
-                    .lookupGameUriByName(gameList.getSelectedValue())
-                    .map(GameChooser::buildGameNotesText)
-                    .orElse("Map not found.."));
+                GameChooser.buildGameNotesText(gameList.getSelectedValue().getUri()));
             // scroll to the top of the notes screen
             SwingUtilities.invokeLater(
                 () -> notesPanel.scrollRectToVisible(new Rectangle(0, 0, 0, 0)));
@@ -161,8 +154,7 @@ public class GameChooser extends JDialog {
   }
 
   /**
-   * Displays the Game Chooser dialog and returns the game selected by the user or {@code null} if
-   * no game was selected.
+   * Displays the Game Chooser dialog and returns the game selected by the user or an empty option
    */
   public static Optional<URI> chooseGame(
       final Frame parent, final GameChooserModel gameChooserModel, final String defaultGameName) {
@@ -172,16 +164,7 @@ public class GameChooser extends JDialog {
     chooser.setDefaultCloseOperation(DISPOSE_ON_CLOSE);
     chooser.setVisible(true); // Blocking and waits for user action
 
-    return Optional.ofNullable(chooser.chosen)
-        .map(
-            uri ->
-                gameChooserModel
-                    .lookupGameUriByName(uri)
-                    .orElseGet(
-                        () -> {
-                          log.severe("Unable to load game (was it deleted on disk?): " + uri);
-                          return null;
-                        }));
+    return Optional.ofNullable(chooser.chosen).map(DefaultGameChooserEntry::getUri);
   }
 
   private static String buildGameNotesText(final URI gameUri) {

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
@@ -2,7 +2,6 @@ package games.strategy.engine.framework.ui;
 
 import games.strategy.engine.framework.map.file.system.loader.AvailableGamesFileSystemReader;
 import games.strategy.engine.framework.map.file.system.loader.AvailableGamesList;
-import java.net.URI;
 import java.util.Optional;
 import java.util.stream.IntStream;
 import javax.swing.DefaultListModel;
@@ -12,7 +11,6 @@ import lombok.extern.java.Log;
 @Log
 public final class GameChooserModel extends DefaultListModel<DefaultGameChooserEntry> {
   private static final long serialVersionUID = -2044689419834812524L;
-  private final AvailableGamesList availableGamesList;
 
   /**
    * Initializes a new {@code GameChooserModel} using all available maps installed in the user's
@@ -24,7 +22,6 @@ public final class GameChooserModel extends DefaultListModel<DefaultGameChooserE
   }
 
   public GameChooserModel(final AvailableGamesList availableGamesList) {
-    this.availableGamesList = availableGamesList;
     availableGamesList.getSortedGameEntries().forEach(this::addElement);
   }
 
@@ -39,9 +36,5 @@ public final class GameChooserModel extends DefaultListModel<DefaultGameChooserE
         .mapToObj(this::get)
         .filter(entry -> entry.getGameName().equals(name))
         .findAny();
-  }
-
-  Optional<URI> lookupGameUriByName(final String selectedValue) {
-    return availableGamesList.findGameUriByName(selectedValue);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooserModel.java
@@ -10,7 +10,7 @@ import lombok.extern.java.Log;
 
 /** The model for a {@link GameChooser} dialog. */
 @Log
-public final class GameChooserModel extends DefaultListModel<String> {
+public final class GameChooserModel extends DefaultListModel<DefaultGameChooserEntry> {
   private static final long serialVersionUID = -2044689419834812524L;
   private final AvailableGamesList availableGamesList;
 
@@ -25,17 +25,20 @@ public final class GameChooserModel extends DefaultListModel<String> {
 
   public GameChooserModel(final AvailableGamesList availableGamesList) {
     this.availableGamesList = availableGamesList;
-    availableGamesList.getSortedGameList().forEach(this::addElement);
+    availableGamesList.getSortedGameEntries().forEach(this::addElement);
   }
 
   @Override
-  public String get(final int i) {
+  public DefaultGameChooserEntry get(final int i) {
     return super.get(i);
   }
 
   /** Searches for a GameChooserEntry whose gameName matches the input parameter. */
-  public Optional<String> findByName(final String name) {
-    return IntStream.range(0, size()).mapToObj(this::get).filter(name::equals).findAny();
+  public Optional<DefaultGameChooserEntry> findByName(final String name) {
+    return IntStream.range(0, size())
+        .mapToObj(this::get)
+        .filter(entry -> entry.getGameName().equals(name))
+        .findAny();
   }
 
   Optional<URI> lookupGameUriByName(final String selectedValue) {

--- a/game-core/src/test/java/games/strategy/engine/framework/ui/GameChooserModelTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/ui/GameChooserModelTest.java
@@ -1,10 +1,13 @@
 package games.strategy.engine.framework.ui;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import games.strategy.engine.framework.map.file.system.loader.AvailableGamesList;
+import java.net.URI;
 import java.util.Set;
 import javax.swing.SwingUtilities;
 import org.junit.jupiter.api.Test;
@@ -22,14 +25,21 @@ class GameChooserModelTest {
           final DefaultGameChooserEntry entry3 = mock(DefaultGameChooserEntry.class);
 
           when(entry1.getGameName()).thenReturn("b");
+          when(entry1.getUri()).thenReturn(URI.create("b"));
           when(entry2.getGameName()).thenReturn("a");
+          when(entry2.getUri()).thenReturn(URI.create("a"));
           when(entry3.getGameName()).thenReturn("c");
+          when(entry3.getUri()).thenReturn(URI.create("c"));
+          // use the real compareTo methods so it is sorted correctly
+          when(entry1.compareTo(any())).thenCallRealMethod();
+          when(entry2.compareTo(any())).thenCallRealMethod();
+          when(entry3.compareTo(any())).thenCallRealMethod();
 
           final GameChooserModel model =
               new GameChooserModel(new AvailableGamesList(Set.of(entry1, entry2, entry3)));
-          assertEquals("a", model.get(0));
-          assertEquals("b", model.get(1));
-          assertEquals("c", model.get(2));
+          assertThat(model.get(0), is(entry2));
+          assertThat(model.get(1), is(entry1));
+          assertThat(model.get(2), is(entry3));
         });
   }
 }


### PR DESCRIPTION
Fixes #8076

In Battle for Arda, there appears to be an old game map in the root directory.  The engine is able to find a game name in it and it has the same game name as the real map.  This causes it to show up in the selector twice.  But the selector finds the game by name in the list and so if the bad game xml is first in the list, it will pull it out first.

This changes the UI selector to use the DefaultGameChooserEntry instead of a String so that it can properly choose the entry.

## Testing
<!-- Describe any manual testing performed below. -->
Install Battle for Arda.  Select both of the entries in the UI.  One should throw an error because it is an invalid map.  The other should load without issue.  Without this PR, both entries might load without issue or throw an error (depending on how it is sorted internally).  I generally get an error thrown.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->
We should modify the map and remove the bad XML from it.

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE-->Fix|Battle for Arda will have a map that can be selected in the UI and it won't throw an error.<!--END_RELEASE_NOTE-->
