### PR TITLE
Allow power to go over diceSides in AirBattle

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -342,8 +342,7 @@ public class DiceRoll implements Externalizable {
     for (final Unit current : units) {
       final UnitAttachment ua = UnitAttachment.get(current.getType());
       final int rolls = AirBattle.getAirBattleRolls(current, defending);
-      int totalStrength = 0;
-      final int strength =
+      int unitStrength =
           Math.min(
               data.getDiceSides(),
               Math.max(
@@ -351,17 +350,18 @@ public class DiceRoll implements Externalizable {
                   (defending
                       ? ua.getAirDefense(current.getOwner())
                       : ua.getAirAttack(current.getOwner()))));
-      for (int i = 0; i < rolls; i++) {
-        // LHTR means pick the best dice roll, which doesn't really make sense in LL. So instead, we
-        // will just add +1
-        // onto the power to simulate the gains of having the best die picked.
-        if (i > 1 && (lhtrBombers || ua.getChooseBestRoll())) {
-          totalStrength += extraRollBonus;
-          continue;
+      if (rolls == 1) {
+        totalPower += unitStrength;
+      } else {
+        if (lhtrBombers || ua.getChooseBestRoll()) {
+          // LHTR means pick the best dice roll, which doesn't really make sense in LL. So instead,
+          // we will just add +1 onto the power to simulate the gains of having the best die picked.
+          unitStrength += extraRollBonus * (rolls - 1);
+          totalPower += Math.min(unitStrength, data.getDiceSides());
+        } else {
+          totalPower += rolls * unitStrength;
         }
-        totalStrength += strength;
       }
-      totalPower += Math.max(totalStrength, 0);
     }
 
     if (Properties.getLowLuck(data)) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -361,7 +361,7 @@ public class DiceRoll implements Externalizable {
         }
         totalStrength += strength;
       }
-      totalPower += Math.min(Math.max(totalStrength, 0), data.getDiceSides());
+      totalPower += Math.max(totalStrength, 0);
     }
 
     if (Properties.getLowLuck(data)) {


### PR DESCRIPTION
If an air unit had 2 rolls with a strength equal to the dice sides, that
unit should hit 2 targets in low luck. But with the power limited to
dice sides, the unit would only be able to hit 1 target. The dice sides
limit is not used in any other power calculation, either.

It looks like Battle for Arda and Greyhawk would be affected by this change.  They both have a "dragon" unit that has multiple rolls and the power will be higher after this change.  But they don't have low luck enabled by default so not sure how big of a change this will be to players.

<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Air Battle units with multiple rolls in Low Luck battles will be able to use all their power instead of being limited to the dice sides of the game.  Battle of Arda and Greyhawk are two such maps that will be affected in Low Luck.<!--END_RELEASE_NOTE-->
