### PR TITLE
Change Properties to accept GameProperties instead of GameData

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/Route.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Route.java
@@ -400,7 +400,7 @@ public class Route implements Serializable, Iterable<Territory> {
       final GameData data,
       final boolean ignoreFlat) {
 
-    if (!Properties.getUseFuelCost(data)) {
+    if (!Properties.getUseFuelCost(data.getProperties())) {
       return Tuple.of(new ResourceCollection(data), new HashSet<>());
     }
 

--- a/game-core/src/main/java/games/strategy/engine/data/Unit.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Unit.java
@@ -134,7 +134,7 @@ public class Unit extends GameDataComponent implements DynamicallyModifiable {
     if (!Matches.unitCanBeDamaged().test(this)) {
       return 0;
     }
-    return Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(getData())
+    return Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(getData().getProperties())
         ? Math.max(0, getHowMuchDamageCanThisUnitTakeTotal(t) - getUnitDamage())
         : Integer.MAX_VALUE;
   }
@@ -149,7 +149,7 @@ public class Unit extends GameDataComponent implements DynamicallyModifiable {
     }
     final UnitAttachment ua = UnitAttachment.get(getType());
     final int territoryUnitProduction = TerritoryAttachment.getUnitProduction(t);
-    if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(getData())) {
+    if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(getData().getProperties())) {
       if (ua.getMaxDamage() <= 0) {
         // factories may or may not have max damage set, so we must still determine here
         // assume that if maxDamage <= 0, then the max damage must be based on the territory value

--- a/game-core/src/main/java/games/strategy/engine/stats/ProductionStat.java
+++ b/game-core/src/main/java/games/strategy/engine/stats/ProductionStat.java
@@ -25,6 +25,6 @@ public class ProductionStat implements IStat {
      * Match will Check if terr is a Land Convoy Route and check ownership
      * of neighboring Sea Zone, or if contested
      */
-    return (double) production * Properties.getPuMultiplier(data);
+    return (double) production * Properties.getPuMultiplier(data.getProperties());
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/Properties.java
+++ b/game-core/src/main/java/games/strategy/triplea/Properties.java
@@ -1,7 +1,7 @@
 package games.strategy.triplea;
 
-import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.properties.GameProperties;
 
 /** Provides typed access to the properties of GameData. */
 public final class Properties implements Constants {
@@ -12,599 +12,608 @@ public final class Properties implements Constants {
   // wording of the constant to make it a negative of itself, then default to false.
   // (ex: "Do not do something", false; instead of "Do something", true;)
 
-  public static int getNeutralCharge(final GameData data) {
-    return data.getProperties().get(NEUTRAL_CHARGE_PROPERTY, 0);
+  public static int getNeutralCharge(final GameProperties properties) {
+    return properties.get(NEUTRAL_CHARGE_PROPERTY, 0);
   }
 
-  public static int getFactoriesPerCountry(final GameData data) {
-    return data.getProperties().get(FACTORIES_PER_COUNTRY_PROPERTY, 1);
+  public static int getFactoriesPerCountry(final GameProperties properties) {
+    return properties.get(FACTORIES_PER_COUNTRY_PROPERTY, 1);
   }
 
-  public static boolean getTwoHitBattleships(final GameData data) {
-    return data.getProperties().get(TWO_HIT_BATTLESHIP_PROPERTY, false);
+  public static boolean getTwoHitBattleships(final GameProperties properties) {
+    return properties.get(TWO_HIT_BATTLESHIP_PROPERTY, false);
   }
 
-  public static boolean getWW2V2(final GameData data) {
-    return data.getProperties().get(WW2V2, false);
+  public static boolean getWW2V2(final GameProperties properties) {
+    return properties.get(WW2V2, false);
   }
 
   /** World War 2 Version 3. */
-  public static boolean getWW2V3(final GameData data) {
-    return data.getProperties().get(WW2V3, false);
+  public static boolean getWW2V3(final GameProperties properties) {
+    return properties.get(WW2V3, false);
   }
 
   /** Can the player select the type of technology they are rolling for. */
-  public static boolean getWW2V3TechModel(final GameData data) {
-    return data.getProperties().get(WW2V3_TECH_MODEL, false);
+  public static boolean getWW2V3TechModel(final GameProperties properties) {
+    return properties.get(WW2V3_TECH_MODEL, false);
   }
 
-  public static boolean getPartialAmphibiousRetreat(final GameData data) {
-    return data.getProperties().get(PARTIAL_AMPHIBIOUS_RETREAT, false);
+  public static boolean getPartialAmphibiousRetreat(final GameProperties properties) {
+    return properties.get(PARTIAL_AMPHIBIOUS_RETREAT, false);
   }
 
-  public static boolean getTotalVictory(final GameData data) {
-    return data.getProperties().get(TOTAL_VICTORY, false);
+  public static boolean getTotalVictory(final GameProperties properties) {
+    return properties.get(TOTAL_VICTORY, false);
   }
 
-  public static boolean getHonorableSurrender(final GameData data) {
-    return data.getProperties().get(HONORABLE_SURRENDER, false);
+  public static boolean getHonorableSurrender(final GameProperties properties) {
+    return properties.get(HONORABLE_SURRENDER, false);
   }
 
-  public static boolean getProjectionOfPower(final GameData data) {
-    return data.getProperties().get(PROJECTION_OF_POWER, false);
+  public static boolean getProjectionOfPower(final GameProperties properties) {
+    return properties.get(PROJECTION_OF_POWER, false);
   }
 
-  public static boolean getAllRocketsAttack(final GameData data) {
-    return data.getProperties().get(ALL_ROCKETS_ATTACK, false);
+  public static boolean getAllRocketsAttack(final GameProperties properties) {
+    return properties.get(ALL_ROCKETS_ATTACK, false);
   }
 
-  public static boolean getNeutralsImpassable(final GameData data) {
-    return data.getProperties().get(NEUTRALS_ARE_IMPASSABLE, false);
+  public static boolean getNeutralsImpassable(final GameProperties properties) {
+    return properties.get(NEUTRALS_ARE_IMPASSABLE, false);
   }
 
-  public static boolean getNeutralsBlitzable(final GameData data) {
-    return data.getProperties().get(NEUTRALS_ARE_BLITZABLE, false);
+  public static boolean getNeutralsBlitzable(final GameProperties properties) {
+    return properties.get(NEUTRALS_ARE_BLITZABLE, false);
   }
 
-  public static boolean getRocketsCanFlyOverImpassables(final GameData data) {
-    return data.getProperties().get(ROCKETS_CAN_FLY_OVER_IMPASSABLES, false);
+  public static boolean getRocketsCanFlyOverImpassables(final GameProperties properties) {
+    return properties.get(ROCKETS_CAN_FLY_OVER_IMPASSABLES, false);
   }
 
-  public static boolean getSequentiallyTargetedRockets(final GameData data) {
-    return data.getProperties().get(TARGET_ROCKETS_SEQUENTIALLY_AND_AFTER_SBR, false);
+  public static boolean getSequentiallyTargetedRockets(final GameProperties properties) {
+    return properties.get(TARGET_ROCKETS_SEQUENTIALLY_AND_AFTER_SBR, false);
   }
 
   /** Pacific Theater. */
-  public static boolean getPacificTheater(final GameData data) {
-    return data.getProperties().get(PACIFIC_THEATER, false);
+  public static boolean getPacificTheater(final GameProperties properties) {
+    return properties.get(PACIFIC_THEATER, false);
   }
 
   /** Economic Victory Condition. */
-  public static boolean getEconomicVictory(final GameData data) {
-    return data.getProperties().get(ECONOMIC_VICTORY, false);
+  public static boolean getEconomicVictory(final GameProperties properties) {
+    return properties.get(ECONOMIC_VICTORY, false);
   }
 
   /** Triggered Victory Condition. */
-  public static boolean getTriggeredVictory(final GameData data) {
-    return data.getProperties().get(TRIGGERED_VICTORY, false);
+  public static boolean getTriggeredVictory(final GameProperties properties) {
+    return properties.get(TRIGGERED_VICTORY, false);
   }
 
   /** Indicates the number of units that can be placed at a factory is restricted. */
-  public static boolean getPlacementRestrictedByFactory(final GameData data) {
-    return data.getProperties().get(PLACEMENT_RESTRICTED_BY_FACTORY, false);
+  public static boolean getPlacementRestrictedByFactory(final GameProperties properties) {
+    return properties.get(PLACEMENT_RESTRICTED_BY_FACTORY, false);
   }
 
   /** Can the player select the type of technology they are rolling for. */
-  public static boolean getSelectableTechRoll(final GameData data) {
-    return data.getProperties().get(SELECTABLE_TECH_ROLL, false);
+  public static boolean getSelectableTechRoll(final GameProperties properties) {
+    return properties.get(SELECTABLE_TECH_ROLL, false);
   }
 
   /** Use Advanced Technology. */
-  public static boolean getTechDevelopment(final GameData data) {
-    return data.getProperties().get(TECH_DEVELOPMENT, false);
+  public static boolean getTechDevelopment(final GameProperties properties) {
+    return properties.get(TECH_DEVELOPMENT, false);
   }
 
   /** Are transports restricted from unloading in multiple territories in a turn. */
-  public static boolean getTransportUnloadRestricted(final GameData data) {
-    return data.getProperties().get(TRANSPORT_UNLOAD_RESTRICTED, false);
+  public static boolean getTransportUnloadRestricted(final GameProperties properties) {
+    return properties.get(TRANSPORT_UNLOAD_RESTRICTED, false);
   }
 
   /** Are AA casualties chosen randomly. */
-  public static boolean getRandomAaCasualties(final GameData data) {
-    return data.getProperties().get(RANDOM_AA_CASUALTIES, false);
+  public static boolean getRandomAaCasualties(final GameProperties properties) {
+    return properties.get(RANDOM_AA_CASUALTIES, false);
   }
 
   /** Indicates AA dice for each type of aircraft are rolled separately. */
-  public static boolean getRollAaIndividually(final GameData data) {
-    return data.getProperties().get(ROLL_AA_INDIVIDUALLY, false);
+  public static boolean getRollAaIndividually(final GameProperties properties) {
+    return properties.get(ROLL_AA_INDIVIDUALLY, false);
   }
 
   /**
    * Limit the damage caused by each bomber on rockets and Strategic Bomb Raids to production of
    * territory.
    */
-  public static boolean getLimitRocketAndSbrDamageToProduction(final GameData data) {
-    return data.getProperties().get(LIMIT_ROCKET_AND_SBR_DAMAGE_TO_PRODUCTION, false);
+  public static boolean getLimitRocketAndSbrDamageToProduction(final GameProperties properties) {
+    return properties.get(LIMIT_ROCKET_AND_SBR_DAMAGE_TO_PRODUCTION, false);
   }
 
   /** Limit the TOTAL damage caused by Bombers in a turn to territory's production. */
-  public static boolean getLimitSbrDamagePerTurn(final GameData data) {
-    return data.getProperties().get(LIMIT_SBR_DAMAGE_PER_TURN, false);
+  public static boolean getLimitSbrDamagePerTurn(final GameProperties properties) {
+    return properties.get(LIMIT_SBR_DAMAGE_PER_TURN, false);
   }
 
   /** Limit the TOTAL damage caused by Rockets in a turn to territory's production. */
-  public static boolean getLimitRocketDamagePerTurn(final GameData data) {
-    return data.getProperties().get(LIMIT_ROCKET_DAMAGE_PER_TURN, false);
+  public static boolean getLimitRocketDamagePerTurn(final GameProperties properties) {
+    return properties.get(LIMIT_ROCKET_DAMAGE_PER_TURN, false);
   }
 
   /** Limit the TOTAL PUs lost to Bombers/Rockets in a turn to territory's production. */
-  public static boolean getPuCap(final GameData data) {
-    return data.getProperties().get(PU_CAP, false);
+  public static boolean getPuCap(final GameProperties properties) {
+    return properties.get(PU_CAP, false);
   }
 
   /** Reduce Victory Points by Strategic Bombing. */
-  public static boolean getSbrVictoryPoints(final GameData data) {
-    return data.getProperties().get(SBR_VICTORY_POINTS, false);
+  public static boolean getSbrVictoryPoints(final GameProperties properties) {
+    return properties.get(SBR_VICTORY_POINTS, false);
   }
 
   /** Are allied aircraft dependents of CVs. */
-  public static boolean getAlliedAirIndependent(final GameData data) {
-    return data.getProperties().get(ALLIED_AIR_INDEPENDENT, false);
+  public static boolean getAlliedAirIndependent(final GameProperties properties) {
+    return properties.get(ALLIED_AIR_INDEPENDENT, false);
   }
 
   /** Defending subs sneak attack. */
-  public static boolean getDefendingSubsSneakAttack(final GameData data) {
-    return data.getProperties().get(DEFENDING_SUBS_SNEAK_ATTACK, false);
+  public static boolean getDefendingSubsSneakAttack(final GameProperties properties) {
+    return properties.get(DEFENDING_SUBS_SNEAK_ATTACK, false);
   }
 
   /** Attacker retreat planes from Amphib assault. */
-  public static boolean getAttackerRetreatPlanes(final GameData data) {
-    return data.getProperties().get(ATTACKER_RETREAT_PLANES, false);
+  public static boolean getAttackerRetreatPlanes(final GameProperties properties) {
+    return properties.get(ATTACKER_RETREAT_PLANES, false);
   }
 
   /** Can surviving air at sea move to land on friendly land/carriers. */
-  public static boolean getSurvivingAirMoveToLand(final GameData data) {
-    return data.getProperties().get(SURVIVING_AIR_MOVE_TO_LAND, false);
+  public static boolean getSurvivingAirMoveToLand(final GameProperties properties) {
+    return properties.get(SURVIVING_AIR_MOVE_TO_LAND, false);
   }
 
   /** Naval Bombard casualties restricted from return fire. */
-  public static boolean getNavalBombardCasualtiesReturnFire(final GameData data) {
-    return data.getProperties().get(NAVAL_BOMBARD_CASUALTIES_RETURN_FIRE, false);
+  public static boolean getNavalBombardCasualtiesReturnFire(final GameProperties properties) {
+    return properties.get(NAVAL_BOMBARD_CASUALTIES_RETURN_FIRE, false);
   }
 
   /** Restricted from blitz through territories with factories/AA. */
-  public static boolean getBlitzThroughFactoriesAndAaRestricted(final GameData data) {
-    return data.getProperties().get(BLITZ_THROUGH_FACTORIES_AND_AA_RESTRICTED, false);
+  public static boolean getBlitzThroughFactoriesAndAaRestricted(final GameProperties properties) {
+    return properties.get(BLITZ_THROUGH_FACTORIES_AND_AA_RESTRICTED, false);
   }
 
   /** Can place new units in occupied sea zones. */
-  public static boolean getUnitPlacementInEnemySeas(final GameData data) {
-    return data.getProperties().get(UNIT_PLACEMENT_IN_ENEMY_SEAS, false);
+  public static boolean getUnitPlacementInEnemySeas(final GameProperties properties) {
+    return properties.get(UNIT_PLACEMENT_IN_ENEMY_SEAS, false);
   }
 
   /** Subs restricted from controlling sea zones. */
-  public static boolean getSubControlSeaZoneRestricted(final GameData data) {
-    return data.getProperties().get(SUB_CONTROL_SEA_ZONE_RESTRICTED, false);
+  public static boolean getSubControlSeaZoneRestricted(final GameProperties properties) {
+    return properties.get(SUB_CONTROL_SEA_ZONE_RESTRICTED, false);
   }
 
   /** Can Transports control sea zones. */
-  public static boolean getTransportControlSeaZone(final GameData data) {
-    return data.getProperties().get(TRANSPORT_CONTROL_SEA_ZONE, false);
+  public static boolean getTransportControlSeaZone(final GameProperties properties) {
+    return properties.get(TRANSPORT_CONTROL_SEA_ZONE, false);
   }
 
   /** Production restricted to 1 unit per X owned territories. */
-  public static boolean getProductionPerXTerritoriesRestricted(final GameData data) {
-    return data.getProperties().get(PRODUCTION_PER_X_TERRITORIES_RESTRICTED, false);
+  public static boolean getProductionPerXTerritoriesRestricted(final GameProperties properties) {
+    return properties.get(PRODUCTION_PER_X_TERRITORIES_RESTRICTED, false);
   }
 
   /** Production restricted to 1 unit per owned territory with an PU value. */
-  public static boolean getProductionPerValuedTerritoryRestricted(final GameData data) {
-    return data.getProperties().get(PRODUCTION_PER_VALUED_TERRITORY_RESTRICTED, false);
+  public static boolean getProductionPerValuedTerritoryRestricted(final GameProperties properties) {
+    return properties.get(PRODUCTION_PER_VALUED_TERRITORY_RESTRICTED, false);
   }
 
   /** Can units be placed in any owned territory. */
-  public static boolean getPlaceInAnyTerritory(final GameData data) {
-    return data.getProperties().get(PLACE_IN_ANY_TERRITORY, false);
+  public static boolean getPlaceInAnyTerritory(final GameProperties properties) {
+    return properties.get(PLACE_IN_ANY_TERRITORY, false);
   }
 
   /** Limit the number of units that can be in a territory. */
-  public static boolean getUnitPlacementPerTerritoryRestricted(final GameData data) {
-    return data.getProperties().get(UNIT_PLACEMENT_PER_TERRITORY_RESTRICTED, false);
+  public static boolean getUnitPlacementPerTerritoryRestricted(final GameProperties properties) {
+    return properties.get(UNIT_PLACEMENT_PER_TERRITORY_RESTRICTED, false);
   }
 
   /** Movement restricted for territories. */
-  public static boolean getMovementByTerritoryRestricted(final GameData data) {
-    return data.getProperties().get(MOVEMENT_BY_TERRITORY_RESTRICTED, false);
+  public static boolean getMovementByTerritoryRestricted(final GameProperties properties) {
+    return properties.get(MOVEMENT_BY_TERRITORY_RESTRICTED, false);
   }
 
   /** Transports restricted from being taken as casualties. */
-  public static boolean getTransportCasualtiesRestricted(final GameData data) {
-    return data.getProperties().get(TRANSPORT_CASUALTIES_RESTRICTED, false);
+  public static boolean getTransportCasualtiesRestricted(final GameProperties properties) {
+    return properties.get(TRANSPORT_CASUALTIES_RESTRICTED, false);
   }
 
   /** Transports do not restrict movement of other units. */
-  public static boolean getIgnoreTransportInMovement(final GameData data) {
-    return data.getProperties().get(IGNORE_TRANSPORT_IN_MOVEMENT, false);
+  public static boolean getIgnoreTransportInMovement(final GameProperties properties) {
+    return properties.get(IGNORE_TRANSPORT_IN_MOVEMENT, false);
   }
 
   /**
    * Subs do not restrict movement of other units. When 'isSub' unit option is used this sets
    * 'canBeMovedThroughByEnemies' unit option to true.
    */
-  public static boolean getIgnoreSubInMovement(final GameData data) {
-    return data.getProperties().get(IGNORE_SUB_IN_MOVEMENT, false);
+  public static boolean getIgnoreSubInMovement(final GameProperties properties) {
+    return properties.get(IGNORE_SUB_IN_MOVEMENT, false);
   }
 
-  public static boolean getUnplacedUnitsLive(final GameData data) {
-    return data.getProperties().get(UNPLACED_UNITS_LIVE, false);
+  public static boolean getUnplacedUnitsLive(final GameProperties properties) {
+    return properties.get(UNPLACED_UNITS_LIVE, false);
   }
 
   /**
    * Air restricted from attacking subs unless DD present. When 'isSub' unit option is used this
    * sets 'canNotBeTargetedBy' unit option to all air units.
    */
-  public static boolean getAirAttackSubRestricted(final GameData data) {
-    return data.getProperties().get(AIR_ATTACK_SUB_RESTRICTED, false);
+  public static boolean getAirAttackSubRestricted(final GameProperties properties) {
+    return properties.get(AIR_ATTACK_SUB_RESTRICTED, false);
   }
 
   /** Allows units with zero movement to be selected to be moved. */
-  public static boolean getSelectableZeroMovementUnits(final GameData data) {
-    return data.getProperties().get(SELECTABLE_ZERO_MOVEMENT_UNITS, false);
+  public static boolean getSelectableZeroMovementUnits(final GameProperties properties) {
+    return properties.get(SELECTABLE_ZERO_MOVEMENT_UNITS, false);
   }
 
   /**
    * Allows paratroopers to move ground units to friendly territories during non-combat move phase.
    */
-  public static boolean getParatroopersCanMoveDuringNonCombat(final GameData data) {
-    return data.getProperties().get(PARATROOPERS_CAN_MOVE_DURING_NON_COMBAT, false);
+  public static boolean getParatroopersCanMoveDuringNonCombat(final GameProperties properties) {
+    return properties.get(PARATROOPERS_CAN_MOVE_DURING_NON_COMBAT, false);
   }
 
-  public static boolean getSubRetreatBeforeBattle(final GameData data) {
-    return data.getProperties().get(SUB_RETREAT_BEFORE_BATTLE, false);
+  public static boolean getSubRetreatBeforeBattle(final GameProperties properties) {
+    return properties.get(SUB_RETREAT_BEFORE_BATTLE, false);
   }
 
   /** Shore Bombard per Ground Unit Restricted. */
-  public static boolean getShoreBombardPerGroundUnitRestricted(final GameData data) {
-    return data.getProperties().get(SHORE_BOMBARD_PER_GROUND_UNIT_RESTRICTED, false);
+  public static boolean getShoreBombardPerGroundUnitRestricted(final GameProperties properties) {
+    return properties.get(SHORE_BOMBARD_PER_GROUND_UNIT_RESTRICTED, false);
   }
 
   /** AA restricted to Attacked Territory Only. */
-  public static boolean getAaTerritoryRestricted(final GameData data) {
-    return data.getProperties().get(AA_TERRITORY_RESTRICTED, false);
+  public static boolean getAaTerritoryRestricted(final GameProperties properties) {
+    return properties.get(AA_TERRITORY_RESTRICTED, false);
   }
 
-  public static boolean getMultipleAaPerTerritory(final GameData data) {
-    return data.getProperties().get(MULTIPLE_AA_PER_TERRITORY, false);
+  public static boolean getMultipleAaPerTerritory(final GameProperties properties) {
+    return properties.get(MULTIPLE_AA_PER_TERRITORY, false);
   }
 
-  public static boolean getNationalObjectives(final GameData data) {
-    return data.getProperties().get(NATIONAL_OBJECTIVES, false);
+  public static boolean getNationalObjectives(final GameProperties properties) {
+    return properties.get(NATIONAL_OBJECTIVES, false);
   }
 
-  public static boolean getTriggers(final GameData data) {
-    return data.getProperties().get(TRIGGERS, false);
+  public static boolean getTriggers(final GameProperties properties) {
+    return properties.get(TRIGGERS, false);
   }
 
-  public static boolean getAlwaysOnAa(final GameData data) {
-    return data.getProperties().get(ALWAYS_ON_AA_PROPERTY, false);
+  public static boolean getAlwaysOnAa(final GameProperties properties) {
+    return properties.get(ALWAYS_ON_AA_PROPERTY, false);
   }
 
-  public static boolean getLhtrCarrierProductionRules(final GameData data) {
-    return data.getProperties().get(LHTR_CARRIER_PRODUCTION_RULES, false);
+  public static boolean getLhtrCarrierProductionRules(final GameProperties properties) {
+    return properties.get(LHTR_CARRIER_PRODUCTION_RULES, false);
   }
 
   /** Atomic units of the fighter/carrier production rules. */
-  public static boolean getProduceFightersOnCarriers(final GameData data) {
-    return data.getProperties().get(CAN_PRODUCE_FIGHTERS_ON_CARRIERS, false);
+  public static boolean getProduceFightersOnCarriers(final GameProperties properties) {
+    return properties.get(CAN_PRODUCE_FIGHTERS_ON_CARRIERS, false);
   }
 
-  public static boolean getProduceNewFightersOnOldCarriers(final GameData data) {
-    return data.getProperties().get(PRODUCE_NEW_FIGHTERS_ON_OLD_CARRIERS, false);
+  public static boolean getProduceNewFightersOnOldCarriers(final GameProperties properties) {
+    return properties.get(PRODUCE_NEW_FIGHTERS_ON_OLD_CARRIERS, false);
   }
 
-  public static boolean getMoveExistingFightersToNewCarriers(final GameData data) {
-    return data.getProperties().get(MOVE_EXISTING_FIGHTERS_TO_NEW_CARRIERS, false);
+  public static boolean getMoveExistingFightersToNewCarriers(final GameProperties properties) {
+    return properties.get(MOVE_EXISTING_FIGHTERS_TO_NEW_CARRIERS, false);
   }
 
-  public static boolean getLandExistingFightersOnNewCarriers(final GameData data) {
-    return data.getProperties().get(LAND_EXISTING_FIGHTERS_ON_NEW_CARRIERS, false);
+  public static boolean getLandExistingFightersOnNewCarriers(final GameProperties properties) {
+    return properties.get(LAND_EXISTING_FIGHTERS_ON_NEW_CARRIERS, false);
   }
 
-  public static int getHeavyBomberDiceRolls(final GameData data) {
-    return data.getProperties().get(HEAVY_BOMBER_DICE_ROLLS, 2);
+  public static int getHeavyBomberDiceRolls(final GameProperties properties) {
+    return properties.get(HEAVY_BOMBER_DICE_ROLLS, 2);
   }
 
-  public static boolean getBattleshipsRepairAtEndOfRound(final GameData data) {
-    return data.getProperties().get(TWO_HIT_BATTLESHIPS_REPAIR_END_OF_TURN, false);
+  public static boolean getBattleshipsRepairAtEndOfRound(final GameProperties properties) {
+    return properties.get(TWO_HIT_BATTLESHIPS_REPAIR_END_OF_TURN, false);
   }
 
-  public static boolean getBattleshipsRepairAtBeginningOfRound(final GameData data) {
-    return data.getProperties().get(TWO_HIT_BATTLESHIPS_REPAIR_BEGINNING_OF_TURN, false);
+  public static boolean getBattleshipsRepairAtBeginningOfRound(final GameProperties properties) {
+    return properties.get(TWO_HIT_BATTLESHIPS_REPAIR_BEGINNING_OF_TURN, false);
   }
 
-  public static boolean getTwoHitPointUnitsRequireRepairFacilities(final GameData data) {
-    return data.getProperties().get(TWO_HITPOINT_UNITS_REQUIRE_REPAIR_FACILITIES, false);
+  public static boolean getTwoHitPointUnitsRequireRepairFacilities(
+      final GameProperties properties) {
+    return properties.get(TWO_HITPOINT_UNITS_REQUIRE_REPAIR_FACILITIES, false);
   }
 
-  public static boolean getChooseAaCasualties(final GameData data) {
-    return data.getProperties().get(CHOOSE_AA, false);
+  public static boolean getChooseAaCasualties(final GameProperties properties) {
+    return properties.get(CHOOSE_AA, false);
   }
 
-  public static boolean getSubmersibleSubs(final GameData data) {
-    return data.getProperties().get(SUBMERSIBLE_SUBS, false);
+  public static boolean getSubmersibleSubs(final GameProperties properties) {
+    return properties.get(SUBMERSIBLE_SUBS, false);
   }
 
-  public static boolean getUseDestroyersAndArtillery(final GameData data) {
-    return data.getProperties().get(USE_DESTROYERS_AND_ARTILLERY, false);
+  public static boolean getUseDestroyersAndArtillery(final GameProperties properties) {
+    return properties.get(USE_DESTROYERS_AND_ARTILLERY, false);
   }
 
-  public static boolean getUseShipyards(final GameData data) {
-    return data.getProperties().get(USE_SHIPYARDS, false);
+  public static boolean getUseShipyards(final GameProperties properties) {
+    return properties.get(USE_SHIPYARDS, false);
   }
 
-  public static boolean getLowLuck(final GameData data) {
-    return data.getProperties().get(LOW_LUCK, false);
+  public static boolean getLowLuck(final GameProperties properties) {
+    return properties.get(LOW_LUCK, false);
   }
 
-  public static boolean getLowLuckAaOnly(final GameData data) {
-    return data.getProperties().get(LL_AA_ONLY, false);
+  public static boolean getLowLuckAaOnly(final GameProperties properties) {
+    return properties.get(LL_AA_ONLY, false);
   }
 
-  public static boolean getLowLuckTechOnly(final GameData data) {
-    return data.getProperties().get(LL_TECH_ONLY, false);
+  public static boolean getLowLuckTechOnly(final GameProperties properties) {
+    return properties.get(LL_TECH_ONLY, false);
   }
 
-  public static boolean getLowLuckDamageOnly(final GameData data) {
-    return data.getProperties().get(LL_DAMAGE_ONLY, false);
+  public static boolean getLowLuckDamageOnly(final GameProperties properties) {
+    return properties.get(LL_DAMAGE_ONLY, false);
   }
 
-  public static boolean getKamikazeAirplanes(final GameData data) {
-    return data.getProperties().get(KAMIKAZE, false);
+  public static boolean getKamikazeAirplanes(final GameProperties properties) {
+    return properties.get(KAMIKAZE, false);
   }
 
-  public static boolean getLhtrHeavyBombers(final GameData data) {
-    return data.getProperties().get(LHTR_HEAVY_BOMBERS, false);
+  public static boolean getLhtrHeavyBombers(final GameProperties properties) {
+    return properties.get(LHTR_HEAVY_BOMBERS, false);
   }
 
-  public static int getSuperSubDefenseBonus(final GameData data) {
-    return data.getProperties().get(SUPER_SUB_DEFENSE_BONUS, 0);
+  public static int getSuperSubDefenseBonus(final GameProperties properties) {
+    return properties.get(SUPER_SUB_DEFENSE_BONUS, 0);
   }
 
-  public static boolean getScrambleRulesInEffect(final GameData data) {
-    return data.getProperties().get(SCRAMBLE_RULES_IN_EFFECT, false);
+  public static boolean getScrambleRulesInEffect(final GameProperties properties) {
+    return properties.get(SCRAMBLE_RULES_IN_EFFECT, false);
   }
 
-  public static boolean getScrambledUnitsReturnToBase(final GameData data) {
-    return data.getProperties().get(SCRAMBLED_UNITS_RETURN_TO_BASE, false);
+  public static boolean getScrambledUnitsReturnToBase(final GameProperties properties) {
+    return properties.get(SCRAMBLED_UNITS_RETURN_TO_BASE, false);
   }
 
-  public static boolean getScrambleToSeaOnly(final GameData data) {
-    return data.getProperties().get(SCRAMBLE_TO_SEA_ONLY, false);
+  public static boolean getScrambleToSeaOnly(final GameProperties properties) {
+    return properties.get(SCRAMBLE_TO_SEA_ONLY, false);
   }
 
-  public static boolean getScrambleFromIslandOnly(final GameData data) {
-    return data.getProperties().get(SCRAMBLE_FROM_ISLAND_ONLY, false);
+  public static boolean getScrambleFromIslandOnly(final GameProperties properties) {
+    return properties.get(SCRAMBLE_FROM_ISLAND_ONLY, false);
   }
 
-  public static boolean getScrambleToAnyAmphibiousAssault(final GameData data) {
-    return data.getProperties().get(SCRAMBLE_TO_ANY_AMPHIBIOUS_ASSAULT, false);
+  public static boolean getScrambleToAnyAmphibiousAssault(final GameProperties properties) {
+    return properties.get(SCRAMBLE_TO_ANY_AMPHIBIOUS_ASSAULT, false);
   }
 
-  public static int getPuMultiplier(final GameData data) {
-    return data.getProperties().get(PU_MULTIPLIER, 1);
+  public static int getPuMultiplier(final GameProperties properties) {
+    return properties.get(PU_MULTIPLIER, 1);
   }
 
-  public static boolean getUnlimitedConstructions(final GameData data) {
-    return data.getProperties().get(UNLIMITED_CONSTRUCTIONS, false);
+  public static boolean getUnlimitedConstructions(final GameProperties properties) {
+    return properties.get(UNLIMITED_CONSTRUCTIONS, false);
   }
 
-  public static boolean getMoreConstructionsWithoutFactory(final GameData data) {
-    return data.getProperties().get(MORE_CONSTRUCTIONS_WITHOUT_FACTORY, false);
+  public static boolean getMoreConstructionsWithoutFactory(final GameProperties properties) {
+    return properties.get(MORE_CONSTRUCTIONS_WITHOUT_FACTORY, false);
   }
 
-  public static boolean getMoreConstructionsWithFactory(final GameData data) {
-    return data.getProperties().get(MORE_CONSTRUCTIONS_WITH_FACTORY, false);
+  public static boolean getMoreConstructionsWithFactory(final GameProperties properties) {
+    return properties.get(MORE_CONSTRUCTIONS_WITH_FACTORY, false);
   }
 
-  public static boolean getUnitPlacementRestrictions(final GameData data) {
-    return data.getProperties().get(UNIT_PLACEMENT_RESTRICTIONS, false);
+  public static boolean getUnitPlacementRestrictions(final GameProperties properties) {
+    return properties.get(UNIT_PLACEMENT_RESTRICTIONS, false);
   }
 
-  public static boolean getGiveUnitsByTerritory(final GameData data) {
-    return data.getProperties().get(GIVE_UNITS_BY_TERRITORY, false);
+  public static boolean getGiveUnitsByTerritory(final GameProperties properties) {
+    return properties.get(GIVE_UNITS_BY_TERRITORY, false);
   }
 
-  public static boolean getUnitsCanBeDestroyedInsteadOfCaptured(final GameData data) {
-    return data.getProperties().get(UNITS_CAN_BE_DESTROYED_INSTEAD_OF_CAPTURED, false);
+  public static boolean getUnitsCanBeDestroyedInsteadOfCaptured(final GameProperties properties) {
+    return properties.get(UNITS_CAN_BE_DESTROYED_INSTEAD_OF_CAPTURED, false);
   }
 
-  public static boolean getSuicideAndMunitionCasualtiesRestricted(final GameData data) {
-    return data.getProperties().get(SUICIDE_AND_MUNITION_CASUALTIES_RESTRICTED, false);
+  public static boolean getSuicideAndMunitionCasualtiesRestricted(final GameProperties properties) {
+    return properties.get(SUICIDE_AND_MUNITION_CASUALTIES_RESTRICTED, false);
   }
 
-  public static boolean getDefendingSuicideAndMunitionUnitsDoNotFire(final GameData data) {
-    return data.getProperties().get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false);
+  public static boolean getDefendingSuicideAndMunitionUnitsDoNotFire(
+      final GameProperties properties) {
+    return properties.get(DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE, false);
   }
 
   public static boolean getNavalUnitsMayNotNonCombatMoveIntoControlledSeaZones(
-      final GameData data) {
-    return data.getProperties()
-        .get(NAVAL_UNITS_MAY_NOT_NONCOMBAT_MOVE_INTO_CONTROLLED_SEA_ZONES, false);
+      final GameProperties properties) {
+    return properties.get(NAVAL_UNITS_MAY_NOT_NONCOMBAT_MOVE_INTO_CONTROLLED_SEA_ZONES, false);
   }
 
-  public static boolean getUnitsMayGiveBonusMovement(final GameData data) {
-    return data.getProperties().get(UNITS_MAY_GIVE_BONUS_MOVEMENT, false);
+  public static boolean getUnitsMayGiveBonusMovement(final GameProperties properties) {
+    return properties.get(UNITS_MAY_GIVE_BONUS_MOVEMENT, false);
   }
 
-  public static boolean getCaptureUnitsOnEnteringTerritory(final GameData data) {
-    return data.getProperties().get(CAPTURE_UNITS_ON_ENTERING_TERRITORY, false);
+  public static boolean getCaptureUnitsOnEnteringTerritory(final GameProperties properties) {
+    return properties.get(CAPTURE_UNITS_ON_ENTERING_TERRITORY, false);
   }
 
-  public static boolean getOnEnteringUnitsDestroyedInsteadOfCaptured(final GameData data) {
-    return data.getProperties().get(DESTROY_UNITS_ON_ENTERING_TERRITORY, false);
+  public static boolean getOnEnteringUnitsDestroyedInsteadOfCaptured(
+      final GameProperties properties) {
+    return properties.get(DESTROY_UNITS_ON_ENTERING_TERRITORY, false);
   }
 
-  public static boolean getDamageFromBombingDoneToUnitsInsteadOfTerritories(final GameData data) {
-    return data.getProperties()
-        .get(
-            DAMAGE_FROM_BOMBING_DONE_TO_UNITS_INSTEAD_OF_TERRITORIES,
-            data.getProperties().get(SBR_AFFECTS_UNIT_PRODUCTION, false));
+  public static boolean getDamageFromBombingDoneToUnitsInsteadOfTerritories(
+      final GameProperties properties) {
+    return properties.get(
+        DAMAGE_FROM_BOMBING_DONE_TO_UNITS_INSTEAD_OF_TERRITORIES,
+        properties.get(SBR_AFFECTS_UNIT_PRODUCTION, false));
   }
 
-  public static boolean getNeutralFlyoverAllowed(final GameData data) {
-    return data.getProperties().get(NEUTRAL_FLYOVER_ALLOWED, false);
+  public static boolean getNeutralFlyoverAllowed(final GameProperties properties) {
+    return properties.get(NEUTRAL_FLYOVER_ALLOWED, false);
   }
 
-  public static boolean getUnitsCanBeChangedOnCapture(final GameData data) {
-    return data.getProperties().get(UNITS_CAN_BE_CHANGED_ON_CAPTURE, false);
+  public static boolean getUnitsCanBeChangedOnCapture(final GameProperties properties) {
+    return properties.get(UNITS_CAN_BE_CHANGED_ON_CAPTURE, false);
   }
 
-  public static boolean getUsePolitics(final GameData data) {
-    return data.getProperties().get(USE_POLITICS, false);
+  public static boolean getUsePolitics(final GameProperties properties) {
+    return properties.get(USE_POLITICS, false);
   }
 
-  public static int getIncomePercentage(final GamePlayer gamePlayer, final GameData data) {
-    return data.getProperties().get(Constants.getIncomePercentageFor(gamePlayer), 100);
+  public static int getIncomePercentage(
+      final GamePlayer gamePlayer, final GameProperties properties) {
+    return properties.get(Constants.getIncomePercentageFor(gamePlayer), 100);
   }
 
-  public static int getPuIncomeBonus(final GamePlayer gamePlayer, final GameData data) {
-    return data.getProperties().get(Constants.getPuIncomeBonus(gamePlayer), 0);
+  public static int getPuIncomeBonus(final GamePlayer gamePlayer, final GameProperties properties) {
+    return properties.get(Constants.getPuIncomeBonus(gamePlayer), 0);
   }
 
-  public static int getRelationshipsLastExtraRounds(final GameData data) {
-    return data.getProperties().get(RELATIONSHIPS_LAST_EXTRA_ROUNDS, 0);
+  public static int getRelationshipsLastExtraRounds(final GameProperties properties) {
+    return properties.get(RELATIONSHIPS_LAST_EXTRA_ROUNDS, 0);
   }
 
-  public static boolean getAlliancesCanChainTogether(final GameData data) {
-    return data.getProperties().get(ALLIANCES_CAN_CHAIN_TOGETHER, false);
+  public static boolean getAlliancesCanChainTogether(final GameProperties properties) {
+    return properties.get(ALLIANCES_CAN_CHAIN_TOGETHER, false);
   }
 
-  public static boolean getRaidsMayBePreceededByAirBattles(final GameData data) {
-    return data.getProperties().get(RAIDS_MAY_BE_PRECEEDED_BY_AIR_BATTLES, false);
+  public static boolean getRaidsMayBePreceededByAirBattles(final GameProperties properties) {
+    return properties.get(RAIDS_MAY_BE_PRECEEDED_BY_AIR_BATTLES, false);
   }
 
-  public static boolean getBattlesMayBePreceededByAirBattles(final GameData data) {
-    return data.getProperties().get(BATTLES_MAY_BE_PRECEEDED_BY_AIR_BATTLES, false);
+  public static boolean getBattlesMayBePreceededByAirBattles(final GameProperties properties) {
+    return properties.get(BATTLES_MAY_BE_PRECEEDED_BY_AIR_BATTLES, false);
   }
 
-  public static boolean getUseKamikazeSuicideAttacks(final GameData data) {
-    return data.getProperties().get(USE_KAMIKAZE_SUICIDE_ATTACKS, false);
+  public static boolean getUseKamikazeSuicideAttacks(final GameProperties properties) {
+    return properties.get(USE_KAMIKAZE_SUICIDE_ATTACKS, false);
   }
 
-  public static boolean getKamikazeSuicideAttacksDoneByCurrentTerritoryOwner(final GameData data) {
-    return data.getProperties()
-        .get(KAMIKAZE_SUICIDE_ATTACKS_DONE_BY_CURRENT_TERRITORY_OWNER, false);
+  public static boolean getKamikazeSuicideAttacksDoneByCurrentTerritoryOwner(
+      final GameProperties properties) {
+    return properties.get(KAMIKAZE_SUICIDE_ATTACKS_DONE_BY_CURRENT_TERRITORY_OWNER, false);
   }
 
-  public static boolean getForceAaAttacksForLastStepOfFlyOver(final GameData data) {
-    return data.getProperties().get(FORCE_AA_ATTACKS_FOR_LAST_STEP_OF_FLY_OVER, false);
+  public static boolean getForceAaAttacksForLastStepOfFlyOver(final GameProperties properties) {
+    return properties.get(FORCE_AA_ATTACKS_FOR_LAST_STEP_OF_FLY_OVER, false);
   }
 
-  public static boolean getParatroopersCanAttackDeepIntoEnemyTerritory(final GameData data) {
-    return data.getProperties().get(PARATROOPERS_CAN_ATTACK_DEEP_INTO_ENEMY_TERRITORY, false);
+  public static boolean getParatroopersCanAttackDeepIntoEnemyTerritory(
+      final GameProperties properties) {
+    return properties.get(PARATROOPERS_CAN_ATTACK_DEEP_INTO_ENEMY_TERRITORY, false);
   }
 
-  public static boolean getUseBombingMaxDiceSidesAndBonus(final GameData data) {
-    return data.getProperties().get(USE_BOMBING_MAX_DICE_SIDES_AND_BONUS, false);
+  public static boolean getUseBombingMaxDiceSidesAndBonus(final GameProperties properties) {
+    return properties.get(USE_BOMBING_MAX_DICE_SIDES_AND_BONUS, false);
   }
 
-  public static boolean getConvoyBlockadesRollDiceForCost(final GameData data) {
-    return data.getProperties().get(CONVOY_BLOCKADES_ROLL_DICE_FOR_COST, false);
+  public static boolean getConvoyBlockadesRollDiceForCost(final GameProperties properties) {
+    return properties.get(CONVOY_BLOCKADES_ROLL_DICE_FOR_COST, false);
   }
 
-  public static boolean getAirborneAttacksOnlyInExistingBattles(final GameData data) {
-    return data.getProperties().get(AIRBORNE_ATTACKS_ONLY_IN_EXISTING_BATTLES, false);
+  public static boolean getAirborneAttacksOnlyInExistingBattles(final GameProperties properties) {
+    return properties.get(AIRBORNE_ATTACKS_ONLY_IN_EXISTING_BATTLES, false);
   }
 
-  public static boolean getAirborneAttacksOnlyInEnemyTerritories(final GameData data) {
-    return data.getProperties().get(AIRBORNE_ATTACKS_ONLY_IN_ENEMY_TERRITORIES, false);
+  public static boolean getAirborneAttacksOnlyInEnemyTerritories(final GameProperties properties) {
+    return properties.get(AIRBORNE_ATTACKS_ONLY_IN_ENEMY_TERRITORIES, false);
   }
 
-  public static boolean getSubsCanEndNonCombatMoveWithEnemies(final GameData data) {
-    return data.getProperties().get(SUBS_CAN_END_NONCOMBAT_MOVE_WITH_ENEMIES, false);
+  public static boolean getSubsCanEndNonCombatMoveWithEnemies(final GameProperties properties) {
+    return properties.get(SUBS_CAN_END_NONCOMBAT_MOVE_WITH_ENEMIES, false);
   }
 
-  public static boolean getRemoveAllTechTokensAtEndOfTurn(final GameData data) {
-    return data.getProperties().get(REMOVE_ALL_TECH_TOKENS_AT_END_OF_TURN, false);
+  public static boolean getRemoveAllTechTokensAtEndOfTurn(final GameProperties properties) {
+    return properties.get(REMOVE_ALL_TECH_TOKENS_AT_END_OF_TURN, false);
   }
 
-  public static boolean getKamikazeSuicideAttacksOnlyWhereBattlesAre(final GameData data) {
-    return data.getProperties().get(KAMIKAZE_SUICIDE_ATTACKS_ONLY_WHERE_BATTLES_ARE, false);
+  public static boolean getKamikazeSuicideAttacksOnlyWhereBattlesAre(
+      final GameProperties properties) {
+    return properties.get(KAMIKAZE_SUICIDE_ATTACKS_ONLY_WHERE_BATTLES_ARE, false);
   }
 
-  public static boolean getSubmarinesPreventUnescortedAmphibiousAssaults(final GameData data) {
-    return data.getProperties().get(SUBMARINES_PREVENT_UNESCORTED_AMPHIBIOUS_ASSAULTS, false);
+  public static boolean getSubmarinesPreventUnescortedAmphibiousAssaults(
+      final GameProperties properties) {
+    return properties.get(SUBMARINES_PREVENT_UNESCORTED_AMPHIBIOUS_ASSAULTS, false);
   }
 
-  public static boolean getSubmarinesDefendingMaySubmergeOrRetreat(final GameData data) {
-    return data.getProperties().get(SUBMARINES_DEFENDING_MAY_SUBMERGE_OR_RETREAT, false);
+  public static boolean getSubmarinesDefendingMaySubmergeOrRetreat(
+      final GameProperties properties) {
+    return properties.get(SUBMARINES_DEFENDING_MAY_SUBMERGE_OR_RETREAT, false);
   }
 
-  public static int getAirBattleRounds(final GameData data) {
-    return data.getProperties().get(AIR_BATTLE_ROUNDS, 1);
+  public static int getAirBattleRounds(final GameProperties properties) {
+    return properties.get(AIR_BATTLE_ROUNDS, 1);
   }
 
-  public static int getSeaBattleRounds(final GameData data) {
+  public static int getSeaBattleRounds(final GameProperties properties) {
     // negative = infinite
-    return data.getProperties().get(SEA_BATTLE_ROUNDS, -1);
+    return properties.get(SEA_BATTLE_ROUNDS, -1);
   }
 
-  public static int getLandBattleRounds(final GameData data) {
+  public static int getLandBattleRounds(final GameProperties properties) {
     // negative = infinite
-    return data.getProperties().get(LAND_BATTLE_ROUNDS, -1);
+    return properties.get(LAND_BATTLE_ROUNDS, -1);
   }
 
-  public static boolean getAirBattleAttackersCanRetreat(final GameData data) {
-    return data.getProperties().get(AIR_BATTLE_ATTACKERS_CAN_RETREAT, false);
+  public static boolean getAirBattleAttackersCanRetreat(final GameProperties properties) {
+    return properties.get(AIR_BATTLE_ATTACKERS_CAN_RETREAT, false);
   }
 
-  public static boolean getAirBattleDefendersCanRetreat(final GameData data) {
-    return data.getProperties().get(AIR_BATTLE_DEFENDERS_CAN_RETREAT, false);
+  public static boolean getAirBattleDefendersCanRetreat(final GameProperties properties) {
+    return properties.get(AIR_BATTLE_DEFENDERS_CAN_RETREAT, false);
   }
 
-  public static boolean getCanScrambleIntoAirBattles(final GameData data) {
-    return data.getProperties().get(CAN_SCRAMBLE_INTO_AIR_BATTLES, false);
+  public static boolean getCanScrambleIntoAirBattles(final GameProperties properties) {
+    return properties.get(CAN_SCRAMBLE_INTO_AIR_BATTLES, false);
   }
 
-  public static boolean getTerritoriesAreAssignedRandomly(final GameData data) {
-    return data.getProperties().get(TERRITORIES_ARE_ASSIGNED_RANDOMLY, false);
+  public static boolean getTerritoriesAreAssignedRandomly(final GameProperties properties) {
+    return properties.get(TERRITORIES_ARE_ASSIGNED_RANDOMLY, false);
   }
 
-  public static boolean getUseFuelCost(final GameData data) {
-    return data.getProperties().get(USE_FUEL_COST, false);
+  public static boolean getUseFuelCost(final GameProperties properties) {
+    return properties.get(USE_FUEL_COST, false);
   }
 
-  public static boolean getRetreatingUnitsRemainInPlace(final GameData data) {
-    return data.getProperties().get(RETREATING_UNITS_REMAIN_IN_PLACE, false);
+  public static boolean getRetreatingUnitsRemainInPlace(final GameProperties properties) {
+    return properties.get(RETREATING_UNITS_REMAIN_IN_PLACE, false);
   }
 
-  public static boolean getContestedTerritoriesProduceNoIncome(final GameData data) {
-    return data.getProperties().get(CONTESTED_TERRITORIES_PRODUCE_NO_INCOME, false);
+  public static boolean getContestedTerritoriesProduceNoIncome(final GameProperties properties) {
+    return properties.get(CONTESTED_TERRITORIES_PRODUCE_NO_INCOME, false);
   }
 
-  public static boolean getSeaBattlesMayBeIgnored(final GameData data) {
-    return data.getProperties().get(SEA_BATTLES_MAY_BE_IGNORED, false);
+  public static boolean getSeaBattlesMayBeIgnored(final GameProperties properties) {
+    return properties.get(SEA_BATTLES_MAY_BE_IGNORED, false);
   }
 
-  public static boolean getAbandonedTerritoriesMayBeTakenOverImmediately(final GameData data) {
-    return data.getProperties().get(ABANDONED_TERRITORIES_MAY_BE_TAKEN_OVER_IMMEDIATELY, false);
+  public static boolean getAbandonedTerritoriesMayBeTakenOverImmediately(
+      final GameProperties properties) {
+    return properties.get(ABANDONED_TERRITORIES_MAY_BE_TAKEN_OVER_IMMEDIATELY, false);
   }
 
-  public static boolean getDisabledPlayersAssetsDeleted(final GameData data) {
-    return data.getProperties().get(DISABLED_PLAYERS_ASSETS_DELETED, false);
+  public static boolean getDisabledPlayersAssetsDeleted(final GameProperties properties) {
+    return properties.get(DISABLED_PLAYERS_ASSETS_DELETED, false);
   }
 
-  public static boolean getControlAllCanalsBetweenTerritoriesToPass(final GameData data) {
-    return data.getProperties().get(CONTROL_ALL_CANALS_BETWEEN_TERRITORIES_TO_PASS, false);
+  public static boolean getControlAllCanalsBetweenTerritoriesToPass(
+      final GameProperties properties) {
+    return properties.get(CONTROL_ALL_CANALS_BETWEEN_TERRITORIES_TO_PASS, false);
   }
 
   public static boolean getEnterTerritoriesWithHigherMovementCostsThenRemainingMovement(
-      final GameData data) {
-    return data.getProperties()
-        .get(ENTER_TERRITORIES_WITH_HIGHER_MOVEMENT_COSTS_THEN_REMAINING_MOVEMENT, false);
+      final GameProperties properties) {
+    return properties.get(
+        ENTER_TERRITORIES_WITH_HIGHER_MOVEMENT_COSTS_THEN_REMAINING_MOVEMENT, false);
   }
 
-  public static boolean getUnitsCanLoadInHostileSeaZones(final GameData data) {
-    return data.getProperties().get(UNITS_CAN_LOAD_IN_HOSTILE_SEA_ZONES, false);
+  public static boolean getUnitsCanLoadInHostileSeaZones(final GameProperties properties) {
+    return properties.get(UNITS_CAN_LOAD_IN_HOSTILE_SEA_ZONES, false);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -410,7 +410,7 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer {
     if (gamePlayer.getRepairFrontier() != null
         && gamePlayer.getRepairFrontier().getRules() != null
         && !gamePlayer.getRepairFrontier().getRules().isEmpty()
-        && Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
+        && Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data.getProperties())) {
       Predicate<Unit> myDamaged =
           Matches.unitIsOwnedBy(gamePlayer).and(Matches.unitHasTakenSomeBombingUnitDamage());
       if (isOnlyRepairIfDisabled) {

--- a/game-core/src/main/java/games/strategy/triplea/UnitUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/UnitUtils.java
@@ -110,7 +110,7 @@ public class UnitUtils {
     }
     int productionCapacity;
     if (accountForDamage) {
-      if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
+      if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data.getProperties())) {
         if (ua.getCanProduceXUnits() < 0) {
           // we could use territoryUnitProduction OR
           // territoryProduction if we wanted to, however we should
@@ -122,22 +122,31 @@ public class UnitUtils {
       } else {
         productionCapacity = territoryProduction;
         if (productionCapacity < 1) {
-          productionCapacity = (Properties.getWW2V2(data) || Properties.getWW2V3(data)) ? 0 : 1;
+          productionCapacity =
+              (Properties.getWW2V2(data.getProperties())
+                      || Properties.getWW2V3(data.getProperties()))
+                  ? 0
+                  : 1;
         }
       }
     } else {
       if (ua.getCanProduceXUnits() < 0
-          && !Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
+          && !Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(
+              data.getProperties())) {
         productionCapacity = territoryProduction;
       } else if (ua.getCanProduceXUnits() < 0
-          && Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
+          && Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data.getProperties())) {
         productionCapacity = territoryUnitProduction;
       } else {
         productionCapacity = ua.getCanProduceXUnits();
       }
       if (productionCapacity < 1
-          && !Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
-        productionCapacity = (Properties.getWW2V2(data) || Properties.getWW2V3(data)) ? 0 : 1;
+          && !Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(
+              data.getProperties())) {
+        productionCapacity =
+            (Properties.getWW2V2(data.getProperties()) || Properties.getWW2V3(data.getProperties()))
+                ? 0
+                : 1;
       }
     }
     // Increase production if have industrial technology

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
@@ -396,7 +396,7 @@ public abstract class AbstractProAi extends AbstractAi {
         final double strengthDifference =
             ProBattleUtils.estimateStrengthDifference(proData, battleSite, attackers, defenders);
         int minStrengthDifference = 60;
-        if (!Properties.getLowLuck(data)) {
+        if (!Properties.getLowLuck(data.getProperties())) {
           minStrengthDifference = 55;
         }
         if (strengthDifference > minStrengthDifference) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -894,7 +894,7 @@ public class ProCombatMoveAi {
                       Matches.unitCanProduceUnitsAndCanBeDamaged()
                           .and(Matches.unitIsLegalBombingTargetBy(unit)));
           final boolean canCreateAirBattle =
-              Properties.getRaidsMayBePreceededByAirBattles(data)
+              Properties.getRaidsMayBePreceededByAirBattles(data.getProperties())
                   && AirBattle.territoryCouldPossiblyHaveAirBattleDefenders(t, player, data, true);
           if (canBeBombedByThisUnit
               && !canCreateAirBattle
@@ -1483,7 +1483,7 @@ public class ProCombatMoveAi {
 
     // If transports can take casualties try placing in naval battles first
     final List<Unit> alreadyAttackedWithTransports = new ArrayList<>();
-    if (!Properties.getTransportCasualtiesRestricted(data)) {
+    if (!Properties.getTransportCasualtiesRestricted(data.getProperties())) {
 
       // Loop through all my transports and see which territories they can attack from current list
       final Map<Unit, Set<Territory>> transportAttackOptions = new HashMap<>();

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProData.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProData.java
@@ -65,7 +65,7 @@ public final class ProData {
     this.player = player;
     this.isSimulation = isSimulation;
 
-    if (!Properties.getLowLuck(data)) {
+    if (!Properties.getLowLuck(data.getProperties())) {
       winPercentage = 90;
       minWinPercentage = 65;
     }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -921,7 +921,7 @@ class ProNonCombatMoveAi {
 
       // Loop through all my transports and see which territories they can defend from current list
       final List<Unit> alreadyMovedTransports = new ArrayList<>();
-      if (!Properties.getTransportCasualtiesRestricted(data)) {
+      if (!Properties.getTransportCasualtiesRestricted(data.getProperties())) {
         final Map<Unit, Set<Territory>> transportDefendOptions = new HashMap<>();
         for (final Unit unit : transportMoveMap.keySet()) {
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -86,7 +86,7 @@ class ProPurchaseAi {
             data.getMap().getTerritories(),
             ProMatches.territoryHasFactoryAndIsNotConqueredOwnedLand(player, data));
     if (player.getRepairFrontier() != null
-        && Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
+        && Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data.getProperties())) {
       ProLogger.debug("Factories can be damaged");
       final Map<Unit, Territory> unitsThatCanProduceNeedingRepair = new HashMap<>();
       for (final Territory fixTerr : rfactories) {
@@ -884,7 +884,10 @@ class ProPurchaseAi {
           final Set<Territory> nearbyLandTerritories =
               data.getMap()
                   .getNeighbors(
-                      t, 9, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data));
+                      t,
+                      9,
+                      ProMatches.territoryCanPotentiallyMoveLandUnits(
+                          player, data.getProperties()));
           final int numNearbyEnemyTerritories =
               CollectionUtils.countMatches(
                   nearbyLandTerritories,
@@ -1025,7 +1028,7 @@ class ProPurchaseAi {
               .getNeighbors(
                   placeTerritory.getTerritory(),
                   9,
-                  ProMatches.territoryCanPotentiallyMoveLandUnits(player, data));
+                  ProMatches.territoryCanPotentiallyMoveLandUnits(player, data.getProperties()));
       final List<Territory> enemyLandTerritories =
           CollectionUtils.getMatches(
               landTerritories, Matches.isTerritoryOwnedBy(ProUtils.getEnemyPlayers(player)));
@@ -1540,7 +1543,7 @@ class ProPurchaseAi {
                 initialDefendingUnits,
                 enemyAttackOptions.getMax(t).getMaxBombardUnits());
         boolean hasOnlyRetreatingSubs =
-            Properties.getSubRetreatBeforeBattle(data)
+            Properties.getSubRetreatBeforeBattle(data.getProperties())
                 && !initialDefendingUnits.isEmpty()
                 && initialDefendingUnits.stream().allMatch(Matches.unitCanEvade())
                 && enemyAttackOptions.getMax(t).getMaxUnits().stream()
@@ -1648,7 +1651,7 @@ class ProPurchaseAi {
                     defendingUnits,
                     enemyAttackOptions.getMax(t).getMaxBombardUnits());
             hasOnlyRetreatingSubs =
-                Properties.getSubRetreatBeforeBattle(data)
+                Properties.getSubRetreatBeforeBattle(data.getProperties())
                     && !defendingUnits.isEmpty()
                     && defendingUnits.stream().allMatch(Matches.unitCanEvade())
                     && enemyAttackOptions.getMax(t).getMaxUnits().stream()

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
@@ -38,7 +38,7 @@ final class ProTechAi {
   private ProTechAi() {}
 
   static void tech(final ITechDelegate techDelegate, final GameData data, final GamePlayer player) {
-    if (!Properties.getWW2V3TechModel(data)) {
+    if (!Properties.getWW2V3TechModel(data.getProperties())) {
       return;
     }
     final Territory myCapitol =
@@ -387,7 +387,7 @@ final class ProTechAi {
         Matches.unitIsOwnedBy(enemyPlayer).and(Matches.unitCanBlitz()).and(Matches.unitCanMove());
     final Predicate<Territory> validBlitzRoute =
         Matches.territoryHasNoEnemyUnits(enemyPlayer, data)
-            .and(Matches.territoryIsNotImpassableToLandUnits(enemyPlayer, data));
+            .and(Matches.territoryIsNotImpassableToLandUnits(enemyPlayer, data.getProperties()));
     final List<Route> routes = new ArrayList<>();
     final List<Unit> blitzUnits =
         findAttackers(
@@ -565,7 +565,7 @@ final class ProTechAi {
         PredicateBuilder.of(Matches.unitIsInfrastructure().negate())
             .and(Matches.alliedUnit(player, data).negate())
             .and(Matches.unitCanBeMovedThroughByEnemies().negate())
-            .andIf(Properties.getIgnoreTransportInMovement(data), transport)
+            .andIf(Properties.getIgnoreTransportInMovement(data.getProperties()), transport)
             .build();
     final Predicate<Territory> routeCond =
         Matches.territoryHasUnitsThatMatch(unitCond).negate().and(Matches.territoryIsWater());
@@ -593,7 +593,7 @@ final class ProTechAi {
     final List<Territory> checkList = getExactNeighbors(check, data);
     for (final Territory t : checkList) {
       if (Matches.isTerritoryAllied(player, data).test(t)
-          && Matches.territoryIsNotImpassableToLandUnits(player, data).test(t)) {
+          && Matches.territoryIsNotImpassableToLandUnits(player, data.getProperties()).test(t)) {
         territories.add(t);
       }
     }
@@ -607,7 +607,7 @@ final class ProTechAi {
     final Predicate<Territory> endCond =
         PredicateBuilder.of(Matches.territoryIsImpassable().negate())
             .andIf(
-                Properties.getNeutralsImpassable(data),
+                Properties.getNeutralsImpassable(data.getProperties()),
                 Matches.territoryIsNeutralButNotWater().negate())
             .build();
     return findFrontier(territory, endCond, Matches.always(), data);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
@@ -215,7 +215,7 @@ public class ProPurchaseOption {
     if (isAir
         && (carrierCost <= 0
             || carrierCost > unusedCarrierCapacity
-            || !Properties.getProduceFightersOnCarriers(data))) {
+            || !Properties.getProduceFightersOnCarriers(data.getProperties()))) {
       return 0;
     }
     final double supportAttackFactor =

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseTerritory.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseTerritory.java
@@ -51,8 +51,8 @@ public class ProPurchaseTerritory {
     if (!isBid
         && ProMatches.territoryHasFactoryAndIsNotConqueredOwnedLand(player, data).test(territory)) {
       for (final Territory t : data.getMap().getNeighbors(territory, Matches.territoryIsWater())) {
-        if (Properties.getWW2V2(data)
-            || Properties.getUnitPlacementInEnemySeas(data)
+        if (Properties.getWW2V2(data.getProperties())
+            || Properties.getUnitPlacementInEnemySeas(data.getProperties())
             || !t.getUnitCollection().anyMatch(Matches.enemyUnit(player, data))) {
           canPlaceTerritories.add(new ProPlaceTerritory(t));
         }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritory.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritory.java
@@ -145,7 +145,7 @@ public class ProTerritory {
 
   public Collection<Unit> getAllDefendersForCarrierCalcs(
       final GameData data, final GamePlayer player) {
-    if (Properties.getProduceNewFightersOnOldCarriers(data)) {
+    if (Properties.getProduceNewFightersOnOldCarriers(data.getProperties())) {
       return getAllDefenders();
     }
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -370,7 +370,7 @@ public class ProTerritoryManager {
       final ProData proData, final GamePlayer player, final Map<Territory, ProTerritory> moveMap) {
     final GameData data = proData.getData();
 
-    if (!Properties.getScrambleRulesInEffect(data)) {
+    if (!Properties.getScrambleRulesInEffect(data.getProperties())) {
       return;
     }
 
@@ -903,7 +903,7 @@ public class ProTerritoryManager {
                       myLandUnit,
                       range,
                       ProMatches.territoryCanPotentiallyMoveSpecificLandUnit(
-                          player, data, myLandUnit));
+                          player, data.getProperties(), myLandUnit));
         }
         possibleMoveTerritories.add(myUnitTerritory);
         final Set<Territory> potentialTerritories =
@@ -1072,7 +1072,7 @@ public class ProTerritoryManager {
                       myUnitTerritory,
                       myAirUnit,
                       range,
-                      ProMatches.territoryCanPotentiallyMoveAirUnits(player, data));
+                      ProMatches.territoryCanPotentiallyMoveAirUnits(player, data.getProperties()));
         }
         possibleMoveTerritories.add(myUnitTerritory);
         final Set<Territory> potentialTerritories =
@@ -1176,7 +1176,7 @@ public class ProTerritoryManager {
               .and(moveAmphibToTerritoryMatch);
       if (isIgnoringRelationships) {
         unloadAmphibTerritoryMatch =
-            ProMatches.territoryCanPotentiallyMoveLandUnits(player, data)
+            ProMatches.territoryCanPotentiallyMoveLandUnits(player, data.getProperties())
                 .and(moveAmphibToTerritoryMatch);
       }
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
@@ -126,7 +126,7 @@ public final class ProBattleUtils {
     List<Unit> unitsThatCanFight =
         CollectionUtils.getMatches(
             myUnits, Matches.unitCanBeInBattle(attacking, !t.isWater(), 1, true));
-    if (Properties.getTransportCasualtiesRestricted(data)) {
+    if (Properties.getTransportCasualtiesRestricted(data.getProperties())) {
       unitsThatCanFight =
           CollectionUtils.getMatches(
               unitsThatCanFight, Matches.unitIsTransportButNotCombatTransport().negate());

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -5,6 +5,7 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
+import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.AbstractMoveDelegate;
@@ -43,16 +44,16 @@ public final class ProMatches {
 
   public static Predicate<Territory> territoryCanMoveAirUnits(
       final GamePlayer player, final GameData data, final boolean isCombatMove) {
-    return Matches.territoryDoesNotCostMoneyToEnter(data)
+    return Matches.territoryDoesNotCostMoneyToEnter(data.getProperties())
         .and(
             Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(
                 player, data, isCombatMove, false, false, true, false));
   }
 
   public static Predicate<Territory> territoryCanPotentiallyMoveAirUnits(
-      final GamePlayer player, final GameData data) {
-    return Matches.territoryDoesNotCostMoneyToEnter(data)
-        .and(Matches.territoryIsPassableAndNotRestricted(player, data));
+      final GamePlayer player, final GameProperties properties) {
+    return Matches.territoryDoesNotCostMoneyToEnter(properties)
+        .and(Matches.territoryIsPassableAndNotRestricted(player, properties));
   }
 
   public static Predicate<Territory> territoryCanMoveAirUnitsAndNoAa(
@@ -65,7 +66,7 @@ public final class ProMatches {
       final GamePlayer player, final GameData data, final boolean isCombatMove, final Unit u) {
     return t -> {
       final Predicate<Territory> territoryMatch =
-          Matches.territoryDoesNotCostMoneyToEnter(data)
+          Matches.territoryDoesNotCostMoneyToEnter(data.getProperties())
               .and(
                   Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(
                       player, data, isCombatMove, true, false, false, false));
@@ -78,11 +79,11 @@ public final class ProMatches {
   }
 
   public static Predicate<Territory> territoryCanPotentiallyMoveSpecificLandUnit(
-      final GamePlayer player, final GameData data, final Unit u) {
+      final GamePlayer player, final GameProperties properties, final Unit u) {
     return t -> {
       final Predicate<Territory> territoryMatch =
-          Matches.territoryDoesNotCostMoneyToEnter(data)
-              .and(Matches.territoryIsPassableAndNotRestricted(player, data));
+          Matches.territoryDoesNotCostMoneyToEnter(properties)
+              .and(Matches.territoryIsPassableAndNotRestricted(player, properties));
       final Predicate<Unit> unitMatch =
           Matches.unitIsOfTypes(
                   TerritoryEffectHelper.getUnitTypesForUnitsNotAllowedIntoTerritory(t))
@@ -93,17 +94,17 @@ public final class ProMatches {
 
   public static Predicate<Territory> territoryCanMoveLandUnits(
       final GamePlayer player, final GameData data, final boolean isCombatMove) {
-    return Matches.territoryDoesNotCostMoneyToEnter(data)
+    return Matches.territoryDoesNotCostMoneyToEnter(data.getProperties())
         .and(
             Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(
                 player, data, isCombatMove, true, false, false, false));
   }
 
   public static Predicate<Territory> territoryCanPotentiallyMoveLandUnits(
-      final GamePlayer player, final GameData data) {
+      final GamePlayer player, final GameProperties properties) {
     return Matches.territoryIsLand()
-        .and(Matches.territoryDoesNotCostMoneyToEnter(data))
-        .and(Matches.territoryIsPassableAndNotRestricted(player, data));
+        .and(Matches.territoryDoesNotCostMoneyToEnter(properties))
+        .and(Matches.territoryIsPassableAndNotRestricted(player, properties));
   }
 
   public static Predicate<Territory> territoryCanMoveLandUnitsAndIsAllied(
@@ -175,15 +176,16 @@ public final class ProMatches {
       final GamePlayer player, final GameData data, final boolean isCombatMove) {
     return t -> {
       final boolean navalMayNotNonComIntoControlled =
-          Properties.getWW2V2(data)
-              || Properties.getNavalUnitsMayNotNonCombatMoveIntoControlledSeaZones(data);
+          Properties.getWW2V2(data.getProperties())
+              || Properties.getNavalUnitsMayNotNonCombatMoveIntoControlledSeaZones(
+                  data.getProperties());
       if (!isCombatMove
           && navalMayNotNonComIntoControlled
           && Matches.isTerritoryEnemyAndNotUnownedWater(player, data).test(t)) {
         return false;
       }
       final Predicate<Territory> match =
-          Matches.territoryDoesNotCostMoneyToEnter(data)
+          Matches.territoryDoesNotCostMoneyToEnter(data.getProperties())
               .and(
                   Matches.territoryIsPassableAndNotRestrictedAndOkByRelationships(
                       player, data, isCombatMove, false, true, false, false));

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProOddsCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProOddsCalculator.java
@@ -167,7 +167,7 @@ public class ProOddsCalculator {
       final Collection<Unit> defendingUnits,
       final boolean checkSubmerge) {
     return checkSubmerge
-        && Properties.getSubRetreatBeforeBattle(data)
+        && Properties.getSubRetreatBeforeBattle(data.getProperties())
         && defendingUnits.stream().allMatch(Matches.unitCanEvade())
         && attackingUnits.stream().noneMatch(Matches.unitIsDestroyer());
   }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseValidationUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseValidationUtils.java
@@ -113,7 +113,7 @@ public final class ProPurchaseValidationUtils {
 
   private static boolean isPlacingFightersOnNewCarriers(final Territory t, final List<Unit> units) {
     return t.isWater()
-        && Properties.getProduceFightersOnCarriers(t.getData())
+        && Properties.getProduceFightersOnCarriers(t.getData().getProperties())
         && units.stream().anyMatch(Matches.unitIsAir())
         && units.stream().anyMatch(Matches.unitIsCarrier());
   }
@@ -267,9 +267,9 @@ public final class ProPurchaseValidationUtils {
     final String constructionType = purchaseOption.getConstructionType();
     if (!constructionType.equals(Constants.CONSTRUCTION_TYPE_FACTORY)
         && !constructionType.endsWith(Constants.CONSTRUCTION_TYPE_STRUCTURE)) {
-      if (Properties.getUnlimitedConstructions(data)) {
+      if (Properties.getUnlimitedConstructions(data.getProperties())) {
         maxConstructionType = Integer.MAX_VALUE;
-      } else if (Properties.getMoreConstructionsWithFactory(data)) {
+      } else if (Properties.getMoreConstructionsWithFactory(data.getProperties())) {
         int production = 0;
         final TerritoryAttachment terrAttachment = TerritoryAttachment.get(territory);
         if (terrAttachment != null) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -178,7 +178,8 @@ public final class ProTerritoryValueUtils {
 
   protected static int findMaxLandMassSize(final GamePlayer player) {
     final GameData data = player.getData();
-    final Predicate<Territory> cond = ProMatches.territoryCanPotentiallyMoveLandUnits(player, data);
+    final Predicate<Territory> cond =
+        ProMatches.territoryCanPotentiallyMoveLandUnits(player, data.getProperties());
 
     final var visited = new HashSet<Territory>();
 
@@ -252,7 +253,10 @@ public final class ProTerritoryValueUtils {
       final int landMassSize =
           1
               + data.getMap()
-                  .getNeighbors(t, 6, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data))
+                  .getNeighbors(
+                      t,
+                      6,
+                      ProMatches.territoryCanPotentiallyMoveLandUnits(player, data.getProperties()))
                   .size();
       final double value =
           Math.sqrt(factoryProduction + Math.sqrt(playerProduction))
@@ -290,7 +294,7 @@ public final class ProTerritoryValueUtils {
               .getDistance(
                   t,
                   enemyCapitalOrFactory,
-                  ProMatches.territoryCanPotentiallyMoveLandUnits(player, data));
+                  ProMatches.territoryCanPotentiallyMoveLandUnits(player, data.getProperties()));
       if (distance > 0) {
         values.add(enemyCapitalsAndFactoriesMap.get(enemyCapitalOrFactory) / Math.pow(2, distance));
       }
@@ -306,7 +310,10 @@ public final class ProTerritoryValueUtils {
     double nearbyEnemyValue = 0;
     final Set<Territory> nearbyTerritories =
         data.getMap()
-            .getNeighbors(t, 2, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data));
+            .getNeighbors(
+                t,
+                2,
+                ProMatches.territoryCanPotentiallyMoveLandUnits(player, data.getProperties()));
     final List<Territory> nearbyEnemyTerritories =
         CollectionUtils.getMatches(
             nearbyTerritories,
@@ -318,7 +325,7 @@ public final class ProTerritoryValueUtils {
               .getDistance(
                   t,
                   nearbyEnemyTerritory,
-                  ProMatches.territoryCanPotentiallyMoveLandUnits(player, data));
+                  ProMatches.territoryCanPotentiallyMoveLandUnits(player, data.getProperties()));
       if (distance > 0) {
         double value = TerritoryAttachment.getProduction(nearbyEnemyTerritory);
         if (ProUtils.isNeutralLand(nearbyEnemyTerritory)) {
@@ -336,7 +343,10 @@ public final class ProTerritoryValueUtils {
     final int landMassSize =
         1
             + data.getMap()
-                .getNeighbors(t, 6, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data))
+                .getNeighbors(
+                    t,
+                    6,
+                    ProMatches.territoryCanPotentiallyMoveLandUnits(player, data.getProperties()))
                 .size();
     double value = nearbyEnemyValue * landMassSize / maxLandMassSize + capitalOrFactoryValue;
     if (ProMatches.territoryHasInfraFactoryAndIsLand().test(t)) {
@@ -397,7 +407,8 @@ public final class ProTerritoryValueUtils {
             .getNeighborsIgnoreEnd(t, 3, ProMatches.territoryCanMoveSeaUnits(player, data, true));
     final List<Territory> nearbyLandTerritories =
         CollectionUtils.getMatches(
-            nearbyTerritories, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data));
+            nearbyTerritories,
+            ProMatches.territoryCanPotentiallyMoveLandUnits(player, data.getProperties()));
     nearbyLandTerritories.removeAll(territoriesToAttack);
     for (final Territory nearbyLandTerritory : nearbyLandTerritories) {
       final Route route =

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
@@ -123,7 +123,7 @@ public final class ProUtils {
         production += TerritoryAttachment.getProduction(place);
       }
     }
-    production *= Properties.getPuMultiplier(data);
+    production *= Properties.getPuMultiplier(data.getProperties());
     return production;
   }
 
@@ -139,7 +139,8 @@ public final class ProUtils {
     }
     enemyCapitals.retainAll(
         CollectionUtils.getMatches(
-            enemyCapitals, Matches.territoryIsNotImpassableToLandUnits(player, data)));
+            enemyCapitals,
+            Matches.territoryIsNotImpassableToLandUnits(player, data.getProperties())));
     enemyCapitals.retainAll(
         CollectionUtils.getMatches(
             enemyCapitals, Matches.isTerritoryOwnedBy(getPotentialEnemyPlayers(player))));
@@ -156,7 +157,7 @@ public final class ProUtils {
     }
     capitals.retainAll(
         CollectionUtils.getMatches(
-            capitals, Matches.territoryIsNotImpassableToLandUnits(player, data)));
+            capitals, Matches.territoryIsNotImpassableToLandUnits(player, data.getProperties())));
     capitals.retainAll(
         CollectionUtils.getMatches(capitals, Matches.isTerritoryAllied(player, data)));
     return capitals;
@@ -171,7 +172,10 @@ public final class ProUtils {
       final GameData data, final GamePlayer player, final Territory t) {
     final Set<Territory> landTerritories =
         data.getMap()
-            .getNeighbors(t, 9, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data));
+            .getNeighbors(
+                t,
+                9,
+                ProMatches.territoryCanPotentiallyMoveLandUnits(player, data.getProperties()));
     final List<Territory> enemyLandTerritories =
         CollectionUtils.getMatches(
             landTerritories, Matches.isTerritoryOwnedBy(getPotentialEnemyPlayers(player)));
@@ -182,7 +186,7 @@ public final class ProUtils {
               .getDistance(
                   t,
                   enemyLandTerritory,
-                  ProMatches.territoryCanPotentiallyMoveLandUnits(player, data));
+                  ProMatches.territoryCanPotentiallyMoveLandUnits(player, data.getProperties()));
       if (distance < minDistance) {
         minDistance = distance;
       }
@@ -202,7 +206,10 @@ public final class ProUtils {
       final Map<Territory, Double> territoryValueMap) {
     final Set<Territory> landTerritories =
         data.getMap()
-            .getNeighbors(t, 9, ProMatches.territoryCanPotentiallyMoveLandUnits(player, data));
+            .getNeighbors(
+                t,
+                9,
+                ProMatches.territoryCanPotentiallyMoveLandUnits(player, data.getProperties()));
     final List<Territory> enemyLandTerritories =
         CollectionUtils.getMatches(
             landTerritories, Matches.isTerritoryOwnedBy(getEnemyPlayers(player)));
@@ -216,7 +223,7 @@ public final class ProUtils {
               .getDistance(
                   t,
                   enemyLandTerritory,
-                  ProMatches.territoryCanPotentiallyMoveLandUnits(player, data));
+                  ProMatches.territoryCanPotentiallyMoveLandUnits(player, data.getProperties()));
       if (ProUtils.isNeutralLand(enemyLandTerritory)) {
         distance++;
       }

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -530,7 +530,7 @@ public class WeakAi extends AbstractAi {
     // find the territories we can just walk into
     final Predicate<Territory> walkInto =
         Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(player, data)
-            .or(Matches.isTerritoryFreeNeutral(data));
+            .or(Matches.isTerritoryFreeNeutral(data.getProperties()));
     final List<Territory> enemyOwned =
         CollectionUtils.getMatches(data.getMap().getTerritories(), walkInto);
     Collections.shuffle(enemyOwned);
@@ -814,7 +814,7 @@ public class WeakAi extends AbstractAi {
             Utils.findUnitTerr(data, ourFactories), Matches.isTerritoryOwnedBy(player));
     // figure out if anything needs to be repaired
     if (player.getRepairFrontier() != null
-        && Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
+        && Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data.getProperties())) {
       repairRules = player.getRepairFrontier().getRules();
       final IntegerMap<RepairRule> repairMap = new IntegerMap<>();
       final Map<Unit, IntegerMap<RepairRule>> repair = new HashMap<>();

--- a/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/AbstractRulesAttachment.java
@@ -257,7 +257,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
               CollectionUtils.getMatches(
                   OriginalOwnerTracker.getOriginallyOwned(data, player),
                   // TODO: does this account for occupiedTerrOf???
-                  Matches.territoryIsNotImpassableToLandUnits(player, data)));
+                  Matches.territoryIsNotImpassableToLandUnits(player, data.getProperties())));
         }
         setTerritoryCount(originalTerritories.size());
         return originalTerritories;
@@ -275,7 +275,7 @@ public abstract class AbstractRulesAttachment extends AbstractConditionsAttachme
           ownedTerrsNoWater.addAll(
               CollectionUtils.getMatches(
                   gameMap.getTerritoriesOwnedBy(player),
-                  Matches.territoryIsNotImpassableToLandUnits(player, data)));
+                  Matches.territoryIsNotImpassableToLandUnits(player, data.getProperties())));
         }
         setTerritoryCount(ownedTerrsNoWater.size());
         return ownedTerrsNoWater;

--- a/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/PoliticalActionAttachment.java
@@ -173,7 +173,7 @@ public class PoliticalActionAttachment extends AbstractUserActionAttachment {
       final GamePlayer player,
       final Map<ICondition, Boolean> testedConditions,
       final GameData data) {
-    if (!Properties.getUsePolitics(data) || !player.amNotDeadYet(data)) {
+    if (!Properties.getUsePolitics(data.getProperties()) || !player.amNotDeadYet(data)) {
       return new ArrayList<>();
     }
     return CollectionUtils.getMatches(

--- a/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -968,7 +968,8 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
   private boolean relationshipExistsLongEnough(
       final Relationship relationship, final int relationshipsExistence) {
     int roundCurrentRelationshipWasCreated = relationship.getRoundCreated();
-    roundCurrentRelationshipWasCreated += Properties.getRelationshipsLastExtraRounds(getData());
+    roundCurrentRelationshipWasCreated +=
+        Properties.getRelationshipsLastExtraRounds(getData().getProperties());
     return getData().getSequence().getRound() - roundCurrentRelationshipWasCreated
         >= relationshipsExistence;
   }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -856,7 +856,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
                 CollectionUtils.getMatches(
                     data.getUnitTypeList().getAllUnitTypes(),
                     Matches.unitTypeIsAir().and(Matches.unitTypeIsStrategicBomber().negate()));
-            final boolean ww2v3TechModel = Properties.getWW2V3TechModel(data);
+            final boolean ww2v3TechModel = Properties.getWW2V3TechModel(data.getProperties());
             for (final UnitType jet : allJets) {
               if (ww2v3TechModel) {
                 taa.setAttackBonus("1:" + jet.getName());
@@ -915,8 +915,9 @@ public class TechAbilityAttachment extends DefaultAttachment {
             final List<UnitType> allBombers =
                 CollectionUtils.getMatches(
                     data.getUnitTypeList().getAllUnitTypes(), Matches.unitTypeIsStrategicBomber());
-            final int heavyBomberDiceRollsTotal = Properties.getHeavyBomberDiceRolls(data);
-            final boolean heavyBombersLhtr = Properties.getLhtrHeavyBombers(data);
+            final int heavyBomberDiceRollsTotal =
+                Properties.getHeavyBomberDiceRolls(data.getProperties());
+            final boolean heavyBombersLhtr = Properties.getLhtrHeavyBombers(data.getProperties());
             for (final UnitType bomber : allBombers) {
               // TODO: The bomber dice rolls get set when the xml is parsed.
               // we subtract the base rolls to get the bonus

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -726,7 +726,8 @@ public class TerritoryAttachment extends DefaultAttachment {
     sb.append(br);
     if (!t.isWater()
         && unitProduction > 0
-        && Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(getData())) {
+        && Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(
+            getData().getProperties())) {
       sb.append("Base Unit Production: ");
       sb.append(unitProduction);
       sb.append(br);

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -2424,7 +2424,7 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
         for (int i = 0; i < eachMultiple; ++i) {
           int toAdd = t.getResourceCount();
           if (t.getResource().equals(Constants.PUS)) {
-            toAdd *= Properties.getPuMultiplier(data);
+            toAdd *= Properties.getPuMultiplier(data.getProperties());
           }
           resources.add(data.getResourceList().getResource(t.getResource()), toAdd);
           int total = player.getResources().getQuantity(t.getResource()) + toAdd;

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -682,7 +682,8 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public boolean getCanMoveThroughEnemies() {
-    return canMoveThroughEnemies || (isSub && Properties.getSubmersibleSubs(getData()));
+    return canMoveThroughEnemies
+        || (isSub && Properties.getSubmersibleSubs(getData().getProperties()));
   }
 
   private void setCanBeMovedThroughByEnemies(final Boolean s) {
@@ -690,7 +691,8 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public boolean getCanBeMovedThroughByEnemies() {
-    return canBeMovedThroughByEnemies || (isSub && Properties.getIgnoreSubInMovement(getData()));
+    return canBeMovedThroughByEnemies
+        || (isSub && Properties.getIgnoreSubInMovement(getData().getProperties()));
   }
 
   private void setCanNotTarget(final String value) throws GameParseException {
@@ -753,7 +755,7 @@ public class UnitAttachment extends DefaultAttachment {
   public Set<UnitType> getCanNotBeTargetedBy() {
     if (canNotBeTargetedBy == null) {
       canNotBeTargetedBy =
-          Properties.getAirAttackSubRestricted(getData())
+          Properties.getAirAttackSubRestricted(getData().getProperties())
               ? new HashSet<>(
                   CollectionUtils.getMatches(
                       getData().getUnitTypeList().getAllUnitTypes(), Matches.unitTypeIsAir()))
@@ -1587,7 +1589,7 @@ public class UnitAttachment extends DefaultAttachment {
             + TechAbilityAttachment.getDefenseBonus(
                 (UnitType) this.getAttachedTo(), player, getData());
     if (defenseValue > 0 && getIsFirstStrike() && TechTracker.hasSuperSubs(player)) {
-      final int bonus = Properties.getSuperSubDefenseBonus(getData());
+      final int bonus = Properties.getSuperSubDefenseBonus(getData().getProperties());
       defenseValue += bonus;
     }
     return Math.min(getData().getDiceSides(), Math.max(0, defenseValue));
@@ -1833,7 +1835,8 @@ public class UnitAttachment extends DefaultAttachment {
   public boolean getIsSuicideOnDefense() {
     return isSuicideOnDefense
         // Global property controlled whether isSuicide units would suicide on defense
-        || (isSuicide && !Properties.getDefendingSuicideAndMunitionUnitsDoNotFire(getData()));
+        || (isSuicide
+            && !Properties.getDefendingSuicideAndMunitionUnitsDoNotFire(getData().getProperties()));
   }
 
   private void setIsSuicideOnHit(final String s) {
@@ -2722,9 +2725,9 @@ public class UnitAttachment extends DefaultAttachment {
     // under certain rules (classic rules) there can only be 1 aa gun in a territory.
     if (max == Integer.MAX_VALUE
         && (ua.getIsAaForBombingThisUnitOnly() || ua.getIsAaForCombatOnly())
-        && !(Properties.getWW2V2(data)
-            || Properties.getWW2V3(data)
-            || Properties.getMultipleAaPerTerritory(data))) {
+        && !(Properties.getWW2V2(data.getProperties())
+            || Properties.getWW2V3(data.getProperties())
+            || Properties.getMultipleAaPerTerritory(data.getProperties()))) {
       max = 1;
     }
     final Predicate<Unit> stackingMatch;
@@ -2807,7 +2810,7 @@ public class UnitAttachment extends DefaultAttachment {
     }
     if (isSea
         && transportCapacity != -1
-        && Properties.getTransportCasualtiesRestricted(data)
+        && Properties.getTransportCasualtiesRestricted(data.getProperties())
         && (attack > 0 || defense > 0)
         && !isCombatTransport) {
       throw new GameParseException(
@@ -3284,7 +3287,7 @@ public class UnitAttachment extends DefaultAttachment {
       sb.append("Can Rocket Attack, ");
       final int bombingBonus = getBombingBonus();
       if ((getBombingMaxDieSides() != -1 || bombingBonus != 0)
-          && Properties.getUseBombingMaxDiceSidesAndBonus(getData())) {
+          && Properties.getUseBombingMaxDiceSidesAndBonus(getData().getProperties())) {
         sb.append(bombingBonus != 0 ? bombingBonus + 1 : 1)
             .append("-")
             .append(
@@ -3307,7 +3310,8 @@ public class UnitAttachment extends DefaultAttachment {
 
     // TODO: Rework damaged description
     if (getCanBeDamaged()
-        && Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(getData())) {
+        && Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(
+            getData().getProperties())) {
       final StringBuilder sb = new StringBuilder();
       sb.append("Can be Damaged by Raids, ");
       if (getMaxOperationalDamage() > -1) {
@@ -3328,10 +3332,10 @@ public class UnitAttachment extends DefaultAttachment {
       tuples.add(Tuple.of("Can be Damaged by Raids", ""));
     }
 
-    if (getIsAirBase() && Properties.getScrambleRulesInEffect(getData())) {
+    if (getIsAirBase() && Properties.getScrambleRulesInEffect(getData().getProperties())) {
       tuples.add(Tuple.of("Allows Scrambling", ""));
     }
-    if (getCanScramble() && Properties.getScrambleRulesInEffect(getData())) {
+    if (getCanScramble() && Properties.getScrambleRulesInEffect(getData().getProperties())) {
       tuples.add(
           Tuple.of(
               "Scramble Range",
@@ -3402,7 +3406,7 @@ public class UnitAttachment extends DefaultAttachment {
       final StringBuilder sb = new StringBuilder();
       final int bombingBonus = getBombingBonus();
       if ((getBombingMaxDieSides() != -1 || bombingBonus != 0)
-          && Properties.getUseBombingMaxDiceSidesAndBonus(getData())) {
+          && Properties.getUseBombingMaxDiceSidesAndBonus(getData().getProperties())) {
         sb.append(bombingBonus != 0 ? bombingBonus + 1 : 1)
             .append("-")
             .append(
@@ -3464,7 +3468,8 @@ public class UnitAttachment extends DefaultAttachment {
     if (getIsSuicideOnHit()) {
       tuples.add(Tuple.of("Suicide on Hit Unit", ""));
     }
-    if (getIsAir() && (getIsKamikaze() || Properties.getKamikazeAirplanes(getData()))) {
+    if (getIsAir()
+        && (getIsKamikaze() || Properties.getKamikazeAirplanes(getData().getProperties()))) {
       tuples.add(Tuple.of("Is Kamikaze", "Can use all Movement to Attack Target"));
     }
 
@@ -3512,9 +3517,9 @@ public class UnitAttachment extends DefaultAttachment {
 
     if (getRepairsUnits() != null
         && !getRepairsUnits().isEmpty()
-        && Properties.getTwoHitPointUnitsRequireRepairFacilities(getData())
-        && (Properties.getBattleshipsRepairAtBeginningOfRound(getData())
-            || Properties.getBattleshipsRepairAtEndOfRound(getData()))) {
+        && Properties.getTwoHitPointUnitsRequireRepairFacilities(getData().getProperties())
+        && (Properties.getBattleshipsRepairAtBeginningOfRound(getData().getProperties())
+            || Properties.getBattleshipsRepairAtEndOfRound(getData().getProperties()))) {
       if (getRepairsUnits().size() <= 4) {
         tuples.add(
             Tuple.of(
@@ -3527,7 +3532,7 @@ public class UnitAttachment extends DefaultAttachment {
 
     if (getGivesMovement() != null
         && getGivesMovement().totalValues() > 0
-        && Properties.getUnitsMayGiveBonusMovement(getData())) {
+        && Properties.getUnitsMayGiveBonusMovement(getData().getProperties())) {
       if (getGivesMovement().size() <= 4) {
         tuples.add(
             Tuple.of(
@@ -3555,7 +3560,7 @@ public class UnitAttachment extends DefaultAttachment {
 
     if (getRequiresUnits() != null
         && !getRequiresUnits().isEmpty()
-        && Properties.getUnitPlacementRestrictions(getData())) {
+        && Properties.getUnitPlacementRestrictions(getData().getProperties())) {
       final List<String> totalUnitsListed = new ArrayList<>();
       for (final String[] list : getRequiresUnits()) {
         totalUnitsListed.addAll(List.of(list));
@@ -3580,7 +3585,7 @@ public class UnitAttachment extends DefaultAttachment {
     }
 
     if (getUnitPlacementRestrictions() != null
-        && Properties.getUnitPlacementRestrictions(getData())) {
+        && Properties.getUnitPlacementRestrictions(getData().getProperties())) {
       if (getUnitPlacementRestrictions().length > 4) {
         tuples.add(Tuple.of("Has Placement Restrictions", ""));
       } else {
@@ -3589,7 +3594,7 @@ public class UnitAttachment extends DefaultAttachment {
       }
     }
     if (getCanOnlyBePlacedInTerritoryValuedAtX() > 0
-        && Properties.getUnitPlacementRestrictions(getData())) {
+        && Properties.getUnitPlacementRestrictions(getData().getProperties())) {
       tuples.add(
           Tuple.of(
               "Must be Placed in Territory with Value of at Least",
@@ -3603,9 +3608,9 @@ public class UnitAttachment extends DefaultAttachment {
     if (getMovementLimit() != null) {
       if (getMovementLimit().getFirst() == Integer.MAX_VALUE
           && (getIsAaForBombingThisUnitOnly() || getIsAaForCombatOnly())
-          && !(Properties.getWW2V2(getData())
-              || Properties.getWW2V3(getData())
-              || Properties.getMultipleAaPerTerritory(getData()))) {
+          && !(Properties.getWW2V2(getData().getProperties())
+              || Properties.getWW2V3(getData().getProperties())
+              || Properties.getMultipleAaPerTerritory(getData().getProperties()))) {
         tuples.add(
             Tuple.of("Max " + getMovementLimit().getSecond() + " Units Moving per Territory", "1"));
       } else if (getMovementLimit().getFirst() < 10000) {
@@ -3619,9 +3624,9 @@ public class UnitAttachment extends DefaultAttachment {
     if (getAttackingLimit() != null) {
       if (getAttackingLimit().getFirst() == Integer.MAX_VALUE
           && (getIsAaForBombingThisUnitOnly() || getIsAaForCombatOnly())
-          && !(Properties.getWW2V2(getData())
-              || Properties.getWW2V3(getData())
-              || Properties.getMultipleAaPerTerritory(getData()))) {
+          && !(Properties.getWW2V2(getData().getProperties())
+              || Properties.getWW2V3(getData().getProperties())
+              || Properties.getMultipleAaPerTerritory(getData().getProperties()))) {
         tuples.add(
             Tuple.of(
                 "Max " + getAttackingLimit().getSecond() + " Units Attacking per Territory", "1"));
@@ -3636,9 +3641,9 @@ public class UnitAttachment extends DefaultAttachment {
     if (getPlacementLimit() != null) {
       if (getPlacementLimit().getFirst() == Integer.MAX_VALUE
           && (getIsAaForBombingThisUnitOnly() || getIsAaForCombatOnly())
-          && !(Properties.getWW2V2(getData())
-              || Properties.getWW2V3(getData())
-              || Properties.getMultipleAaPerTerritory(getData()))) {
+          && !(Properties.getWW2V2(getData().getProperties())
+              || Properties.getWW2V3(getData().getProperties())
+              || Properties.getMultipleAaPerTerritory(getData().getProperties()))) {
         tuples.add(
             Tuple.of(
                 "Max " + getPlacementLimit().getSecond() + " Units Placed per Territory", "1"));
@@ -3719,11 +3724,11 @@ public class UnitAttachment extends DefaultAttachment {
   private String getAaKey() {
     if (getIsAaForCombatOnly()
         && getIsAaForFlyOverOnly()
-        && !Properties.getAaTerritoryRestricted(getData())) {
+        && !Properties.getAaTerritoryRestricted(getData().getProperties())) {
       return " for Combat & Move Through";
     } else if (getIsAaForBombingThisUnitOnly()
         && getIsAaForFlyOverOnly()
-        && !Properties.getAaTerritoryRestricted(getData())) {
+        && !Properties.getAaTerritoryRestricted(getData().getProperties())) {
       return " for Raids & Move Through";
     } else if (getIsAaForCombatOnly()) {
       return " for Combat";

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
@@ -219,9 +219,9 @@ class AaInMoveUtil implements Serializable {
 
   Collection<Territory> getTerritoriesWhereAaWillFire(
       final Route route, final Collection<Unit> units) {
-    final boolean alwaysOnAa = Properties.getAlwaysOnAa(getData());
+    final boolean alwaysOnAa = Properties.getAlwaysOnAa(getData().getProperties());
     // Just the attacked territory will have AA firing
-    if (!alwaysOnAa && Properties.getAaTerritoryRestricted(getData())) {
+    if (!alwaysOnAa && Properties.getAaTerritoryRestricted(getData().getProperties())) {
       return List.of();
     }
     final GameData data = getData();
@@ -252,7 +252,7 @@ class AaInMoveUtil implements Serializable {
         territoriesWhereAaWillFire.add(current);
       }
     }
-    if (Properties.getForceAaAttacksForLastStepOfFlyOver(data)) {
+    if (Properties.getForceAaAttacksForLastStepOfFlyOver(data.getProperties())) {
       if (route.getEnd().getUnitCollection().anyMatch(hasAa)) {
         territoriesWhereAaWillFire.add(route.getEnd());
       }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -70,7 +70,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate
           && step.getDelegate().getName().equals("endTurn")) {
         final List<Territory> territories = data.getMap().getTerritoriesOwnedBy(player);
         final int pusFromTerritories =
-            getProduction(territories, data) * Properties.getPuMultiplier(data);
+            getProduction(territories, data) * Properties.getPuMultiplier(data.getProperties());
         resources.add(new Resource(Constants.PUS, data), pusFromTerritories);
         resources.add(EndTurnDelegate.getResourceProduction(territories, data));
       }
@@ -108,7 +108,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate
       int toAdd = getProduction(territories);
       final int blockadeLoss = getBlockadeProductionLoss(player, data, bridge, endTurnReport);
       toAdd -= blockadeLoss;
-      toAdd *= Properties.getPuMultiplier(data);
+      toAdd *= Properties.getPuMultiplier(data.getProperties());
       int total = player.getResources().getQuantity(pus) + toAdd;
       final String transcriptText;
       if (blockadeLoss == 0) {
@@ -224,7 +224,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate
     if (GameStepPropertiesHelper.isRepairUnits(data)) {
       MoveDelegate.repairMultipleHitPointUnits(bridge, bridge.getGamePlayer());
     }
-    if (Properties.getGiveUnitsByTerritory(getData())
+    if (Properties.getGiveUnitsByTerritory(getData().getProperties())
         && pa != null
         && pa.getGiveUnitControl() != null
         && !pa.getGiveUnitControl().isEmpty()) {
@@ -468,7 +468,8 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate
     }
     final Predicate<Unit> enemyUnits = Matches.enemyUnit(player, data);
     int totalLoss = 0;
-    final boolean rollDiceForBlockadeDamage = Properties.getConvoyBlockadesRollDiceForCost(data);
+    final boolean rollDiceForBlockadeDamage =
+        Properties.getConvoyBlockadesRollDiceForCost(data.getProperties());
     final Collection<String> transcripts = new ArrayList<>();
     final Map<Territory, Tuple<Integer, List<Territory>>> damagePerBlockadeZone = new HashMap<>();
     boolean rolledDice = false;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -70,7 +70,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     // clear all units not placed
     final Collection<Unit> units = player.getUnits();
     final GameData data = getData();
-    if (!Properties.getUnplacedUnitsLive(data) && !units.isEmpty()) {
+    if (!Properties.getUnplacedUnitsLive(data.getProperties()) && !units.isEmpty()) {
       bridge
           .getHistoryWriter()
           .startEvent(
@@ -221,7 +221,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
         unitsCanBePlacedByThisProducer = new ArrayList<>(unitsLeftToPlace);
       } else {
         unitsCanBePlacedByThisProducer =
-            (Properties.getUnitPlacementRestrictions(getData())
+            (Properties.getUnitPlacementRestrictions(getData().getProperties())
                 ? CollectionUtils.getMatches(
                     unitsLeftToPlace, unitWhichRequiresUnitsHasRequiredUnits(producer, true))
                 : new ArrayList<>(unitsLeftToPlace));
@@ -382,7 +382,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
         // around at all
         if (placeTerritory.isWater()
             && !placeTerritory.equals(producer)
-            && (!Properties.getUnitPlacementRestrictions(getData())
+            && (!Properties.getUnitPlacementRestrictions(getData().getProperties())
                 || placement.getUnits().stream()
                     .noneMatch(Matches.unitRequiresUnitsOnCreation()))) {
           // found placement move of producer that can be taken over
@@ -508,8 +508,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     if (!at.isWater()) {
       return null;
     }
-    if (!Properties.getMoveExistingFightersToNewCarriers(getData())
-        || Properties.getLhtrCarrierProductionRules(getData())) {
+    if (!Properties.getMoveExistingFightersToNewCarriers(getData().getProperties())
+        || Properties.getLhtrCarrierProductionRules(getData().getProperties())) {
       return null;
     }
     if (units.stream().noneMatch(Matches.unitIsCarrier())) {
@@ -695,13 +695,14 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       return null;
     }
     // make sure some unit has fullfilled requiresUnits requirements
-    if (Properties.getUnitPlacementRestrictions(getData())
+    if (Properties.getUnitPlacementRestrictions(getData().getProperties())
         && !testUnits.isEmpty()
         && testUnits.stream().noneMatch(unitWhichRequiresUnitsHasRequiredUnits(producer, true))) {
       return "You do not have the required units to build in " + producer.getName();
     }
     if (to.isWater()
-        && (!Properties.getWW2V2(getData()) && !Properties.getUnitPlacementInEnemySeas(getData()))
+        && (!Properties.getWW2V2(getData().getProperties())
+            && !Properties.getUnitPlacementInEnemySeas(getData().getProperties()))
         && to.getUnitCollection().anyMatch(Matches.enemyUnit(player, getData()))) {
       return "Cannot place sea units with enemy naval units";
     }
@@ -866,7 +867,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       return "Units Cannot Go Over Stacking Limit";
     }
     // now return null (valid placement) if we have placement restrictions disabled in game options
-    if (!Properties.getUnitPlacementRestrictions(getData())) {
+    if (!Properties.getUnitPlacementRestrictions(getData().getProperties())) {
       return null;
     }
     // account for any unit placement restrictions by territory
@@ -921,7 +922,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       final Territory to, final Collection<Unit> allUnits, final GamePlayer player) {
     final boolean water = to.isWater();
     if (water
-        && (!Properties.getWW2V2(getData()) && !Properties.getUnitPlacementInEnemySeas(getData()))
+        && (!Properties.getWW2V2(getData().getProperties())
+            && !Properties.getUnitPlacementInEnemySeas(getData().getProperties()))
         && to.getUnitCollection().anyMatch(Matches.enemyUnit(player, getData()))) {
       return null;
     }
@@ -948,12 +950,12 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
             CollectionUtils.getMatches(
                 units, Matches.unitIsAir().and(Matches.unitIsNotConstruction())));
       } else if (((isBid
-                  || Properties.getProduceFightersOnCarriers(getData())
-                  || Properties.getLhtrCarrierProductionRules(getData()))
+                  || Properties.getProduceFightersOnCarriers(getData().getProperties())
+                  || Properties.getLhtrCarrierProductionRules(getData().getProperties()))
               && allProducedUnits.stream().anyMatch(Matches.unitIsCarrier()))
           || ((isBid
-                  || Properties.getProduceNewFightersOnOldCarriers(getData())
-                  || Properties.getLhtrCarrierProductionRules(getData()))
+                  || Properties.getProduceNewFightersOnOldCarriers(getData().getProperties())
+                  || Properties.getLhtrCarrierProductionRules(getData().getProperties()))
               && to.getUnitCollection()
                   .anyMatch(
                       Matches.unitIsCarrier()
@@ -1017,7 +1019,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
                   "placementLimit", ut, to, player, getData()),
               Matches.unitIsOfType(ut)));
     }
-    if (!Properties.getUnitPlacementRestrictions(getData())) {
+    if (!Properties.getUnitPlacementRestrictions(getData().getProperties())) {
       return placeableUnits2;
     }
     final Collection<Unit> placeableUnits3 = new ArrayList<>();
@@ -1135,7 +1137,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     final Map<Territory, Integer> currentAvailablePlacementForOtherProducers = new HashMap<>();
     for (final Territory producerTerritory : producers) {
       final Collection<Unit> unitsCanBePlacedByThisProducer =
-          (Properties.getUnitPlacementRestrictions(getData())
+          (Properties.getUnitPlacementRestrictions(getData().getProperties())
               ? CollectionUtils.getMatches(
                   units, unitWhichRequiresUnitsHasRequiredUnits(producerTerritory, true))
               : new ArrayList<>(units));
@@ -1173,7 +1175,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       final Map<Territory, Integer> currentAvailablePlacementForOtherProducers) {
     // we may have special units with requiresUnits restrictions
     final Collection<Unit> unitsCanBePlacedByThisProducer =
-        (Properties.getUnitPlacementRestrictions(getData())
+        (Properties.getUnitPlacementRestrictions(getData().getProperties())
             ? CollectionUtils.getMatches(
                 units, unitWhichRequiresUnitsHasRequiredUnits(producer, true))
             : new ArrayList<>(units));
@@ -1190,7 +1192,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     final Collection<Unit> factoryUnits = producer.getUnitCollection().getMatches(factoryMatch);
     // boolean placementRestrictedByFactory = isPlacementRestrictedByFactory();
     final boolean unitPlacementPerTerritoryRestricted =
-        Properties.getUnitPlacementPerTerritoryRestricted(getData());
+        Properties.getUnitPlacementPerTerritoryRestricted(getData().getProperties());
     final boolean originalFactory = (ta != null && ta.getOriginalFactory());
     final boolean playerIsOriginalOwner =
         !factoryUnits.isEmpty() && this.player.equals(getOriginalFactoryOwner(producer));
@@ -1273,7 +1275,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
           // to mess with
           // logically, so we ignore them for our special 'move shit around' methods.
           if (!placeTerritory.isWater()
-              || (Properties.getUnitPlacementRestrictions(getData())
+              || (Properties.getUnitPlacementRestrictions(getData().getProperties())
                   && unitsPlacedByCurrentPlacementMove.stream()
                       .anyMatch(Matches.unitRequiresUnitsOnCreation()))) {
             productionCanNotBeMoved += unitsPlacedByCurrentPlacementMove.size();
@@ -1377,7 +1379,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     final IntegerMap<String> unitMapHeld = new IntegerMap<>();
     final IntegerMap<String> unitMapMaxType = new IntegerMap<>();
     final IntegerMap<String> unitMapTypePerTurn = new IntegerMap<>();
-    final int maxFactory = Properties.getFactoriesPerCountry(getData());
+    final int maxFactory = Properties.getFactoriesPerCountry(getData().getProperties());
     // Can be null!
     final TerritoryAttachment terrAttachment = TerritoryAttachment.get(to);
     int toProduction = 0;
@@ -1387,7 +1389,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     for (final Unit currentUnit : CollectionUtils.getMatches(units, Matches.unitIsConstruction())) {
       final UnitAttachment ua = UnitAttachment.get(currentUnit.getType());
       // account for any unit placement restrictions by territory
-      if (Properties.getUnitPlacementRestrictions(getData())) {
+      if (Properties.getUnitPlacementRestrictions(getData().getProperties())) {
         final String[] terrs = ua.getUnitPlacementRestrictions();
         final Collection<Territory> listedTerrs = getListedTerritories(terrs);
         if (listedTerrs.contains(to)) {
@@ -1416,9 +1418,12 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
         unitMapMaxType.put(ua.getConstructionType(), ua.getMaxConstructionsPerTypePerTerr());
       }
     }
-    final boolean moreWithoutFactory = Properties.getMoreConstructionsWithoutFactory(getData());
-    final boolean moreWithFactory = Properties.getMoreConstructionsWithFactory(getData());
-    final boolean unlimitedConstructions = Properties.getUnlimitedConstructions(getData());
+    final boolean moreWithoutFactory =
+        Properties.getMoreConstructionsWithoutFactory(getData().getProperties());
+    final boolean moreWithFactory =
+        Properties.getMoreConstructionsWithFactory(getData().getProperties());
+    final boolean unlimitedConstructions =
+        Properties.getUnlimitedConstructions(getData().getProperties());
     final boolean wasFactoryThereAtStart =
         wasOwnedUnitThatCanProduceUnitsOrIsFactoryInTerritoryAtStartOfStep(to, player);
     // build an integer map of each construction unit in the territory
@@ -1534,7 +1539,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
 
   private boolean getCanAllUnitsWithRequiresUnitsBePlacedCorrectly(
       final Collection<Unit> units, final Territory to) {
-    if (!Properties.getUnitPlacementRestrictions(getData())
+    if (!Properties.getUnitPlacementRestrictions(getData().getProperties())
         || units.stream().noneMatch(Matches.unitRequiresUnitsOnCreation())) {
       return true;
     }
@@ -1737,7 +1742,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
   }
 
   private boolean isPlayerAllowedToPlacementAnyTerritoryOwnedLand(final GamePlayer player) {
-    if (Properties.getPlaceInAnyTerritory(getData())) {
+    if (Properties.getPlaceInAnyTerritory(getData().getProperties())) {
       final RulesAttachment ra =
           (RulesAttachment) player.getAttachment(Constants.RULES_ATTACHMENT_NAME);
       return ra != null && ra.getPlacementAnyTerritory();
@@ -1746,7 +1751,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
   }
 
   private boolean isPlayerAllowedToPlacementAnySeaZoneByOwnedLand(final GamePlayer player) {
-    if (Properties.getPlaceInAnyTerritory(getData())) {
+    if (Properties.getPlaceInAnyTerritory(getData().getProperties())) {
       final RulesAttachment ra =
           (RulesAttachment) player.getAttachment(Constants.RULES_ATTACHMENT_NAME);
       return ra != null && ra.getPlacementAnySeaZone();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BaseTripleADelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BaseTripleADelegate.java
@@ -72,7 +72,7 @@ public abstract class BaseTripleADelegate extends AbstractDelegate {
 
   private void triggerWhenTriggerAttachments(final String beforeOrAfter) {
     final GameData data = getData();
-    if (Properties.getTriggers(data)) {
+    if (Properties.getTriggers(data.getProperties())) {
       final String stepName = data.getSequence().getStep().getName();
       // we use AND in order to make sure there are uses and when is set correctly.
       final Predicate<TriggerAttachment> baseDelegateWhenTriggerMatch =

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -129,7 +129,8 @@ public class DiceRoll implements Externalizable {
     final int totalPower = unitPowerAndRollsMap.calculateTotalPower();
     final GamePlayer player = aaUnits.iterator().next().getOwner();
     final String annotation = "Roll " + typeAa + " in " + location.getName();
-    if (Properties.getLowLuck(data) || Properties.getLowLuckAaOnly(data)) {
+    if (Properties.getLowLuck(data.getProperties())
+        || Properties.getLowLuckAaOnly(data.getProperties())) {
       sortedDice = new ArrayList<>();
       hits = getAaLowLuckHits(bridge, sortedDice, totalPower, diceSides, player, annotation);
     } else {
@@ -193,7 +194,7 @@ public class DiceRoll implements Externalizable {
       final String annotation,
       final CombatValue combatValueCalculator) {
 
-    if (Properties.getLowLuck(bridge.getData())) {
+    if (Properties.getLowLuck(bridge.getData().getProperties())) {
       return rollDiceLowLuck(units, player, bridge, annotation, combatValueCalculator);
     }
     return rollDiceNormal(units, player, bridge, annotation, combatValueCalculator);
@@ -307,7 +308,7 @@ public class DiceRoll implements Externalizable {
         PowerStrengthAndRolls.build(unitsList, combatValueCalculator);
 
     final GameData data = bridge.getData();
-    final boolean lhtrBombers = Properties.getLhtrHeavyBombers(data);
+    final boolean lhtrBombers = Properties.getLhtrHeavyBombers(data.getProperties());
     final List<Unit> units = new ArrayList<>(unitsList);
     final int rollCount = unitPowerAndRollsMap.calculateTotalRolls();
     if (rollCount == 0) {
@@ -320,7 +321,7 @@ public class DiceRoll implements Externalizable {
     // bonus is normally 1 for most games
     final int totalPower = unitPowerAndRollsMap.calculateTotalPower();
 
-    if (Properties.getLowLuck(data)) {
+    if (Properties.getLowLuck(data.getProperties())) {
       // Get number of hits
       hitCount = totalPower / data.getDiceSides();
       random = new int[0];
@@ -405,7 +406,7 @@ public class DiceRoll implements Externalizable {
 
     final int[] random =
         bridge.getRandom(data.getDiceSides(), rollCount, player, DiceType.COMBAT, annotation);
-    final boolean lhtrBombers = Properties.getLhtrHeavyBombers(data);
+    final boolean lhtrBombers = Properties.getLhtrHeavyBombers(data.getProperties());
     final List<Die> dice = new ArrayList<>();
     int hitCount = 0;
     int diceIndex = 0;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -115,7 +115,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
             + MyFormatter.unitsToTextNoOwner(units),
         units);
     bridge.addChange(ChangeFactory.addUnits(territory, units));
-    if (Properties.getUnitsMayGiveBonusMovement(getData())
+    if (Properties.getUnitsMayGiveBonusMovement(getData().getProperties())
         && GameStepPropertiesHelper.isGiveBonusMovement(data)) {
       bridge.addChange(MoveDelegate.giveBonusMovementToUnits(player, data, territory));
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -153,7 +153,7 @@ final class EditValidator {
     if (player == null) {
       return "No player selected";
     }
-    if (!Properties.getTechDevelopment(data)) {
+    if (!Properties.getTechDevelopment(data.getProperties())) {
       return "Technology not enabled";
     }
     if (player.getAttachment(Constants.TECH_ATTACHMENT_NAME) == null) {
@@ -179,7 +179,7 @@ final class EditValidator {
     if (player == null) {
       return "No player selected";
     }
-    if (!Properties.getTechDevelopment(data)) {
+    if (!Properties.getTechDevelopment(data.getProperties())) {
       return "Technology not enabled";
     }
     for (final TechAdvance tech : techs) {
@@ -239,7 +239,7 @@ final class EditValidator {
     if (result != null) {
       return result;
     }
-    if (!Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
+    if (!Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data.getProperties())) {
       return "Game does not allow bombing damage";
     }
     final Collection<Unit> units = new ArrayList<>(unitDamageMap.keySet());

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -46,7 +46,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
     }
     String victoryMessage;
     final GameData data = getData();
-    if (Properties.getPacificTheater(getData())) {
+    if (Properties.getPacificTheater(getData().getProperties())) {
       final GamePlayer japanese = data.getPlayerList().getPlayerId(Constants.PLAYER_NAME_JAPANESE);
       final PlayerAttachment pa = PlayerAttachment.get(japanese);
       if (pa != null && pa.getVps() >= 22) {
@@ -60,19 +60,20 @@ public class EndRoundDelegate extends BaseTripleADelegate {
       }
     }
     // Check for Winning conditions
-    if (Properties.getTotalVictory(getData())) { // Check for Win by Victory Cities
+    if (Properties.getTotalVictory(getData().getProperties())) { // Check for Win by Victory Cities
       victoryMessage = " achieve TOTAL VICTORY with ";
       checkVictoryCities(bridge, victoryMessage, " Total Victory VCs");
     }
-    if (Properties.getHonorableSurrender(getData())) {
+    if (Properties.getHonorableSurrender(getData().getProperties())) {
       victoryMessage = " achieve an HONORABLE VICTORY with ";
       checkVictoryCities(bridge, victoryMessage, " Honorable Victory VCs");
     }
-    if (Properties.getProjectionOfPower(getData())) {
+    if (Properties.getProjectionOfPower(getData().getProperties())) {
       victoryMessage = " achieve victory through a PROJECTION OF POWER with ";
       checkVictoryCities(bridge, victoryMessage, " Projection of Power VCs");
     }
-    if (Properties.getEconomicVictory(getData())) { // Check for regular economic victory
+    if (Properties.getEconomicVictory(
+        getData().getProperties())) { // Check for regular economic victory
       for (final String allianceName : data.getAllianceTracker().getAlliances()) {
         final int victoryAmount = getEconomicVictoryAmount(data, allianceName);
         final Set<GamePlayer> teamMembers =
@@ -92,7 +93,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
       }
     }
     // now check for generic trigger based victories
-    if (Properties.getTriggeredVictory(getData())) {
+    if (Properties.getTriggeredVictory(getData().getProperties())) {
       // First set up a match for what we want to have fire as a default in this delegate. List out
       // as a composite match
       // OR.
@@ -125,7 +126,8 @@ public class EndRoundDelegate extends BaseTripleADelegate {
         // signalGameOver itself
       }
     }
-    if (Properties.getWW2V2(getData()) || Properties.getWW2V3(getData())) {
+    if (Properties.getWW2V2(getData().getProperties())
+        || Properties.getWW2V3(getData().getProperties())) {
       return;
     }
     final PlayerList playerList = data.getPlayerList();
@@ -192,7 +194,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
   public void end() {
     super.end();
     final GameData data = getData();
-    if (Properties.getTriggers(data)) {
+    if (Properties.getTriggers(data.getProperties())) {
       final CompositeChange change = new CompositeChange();
       for (final GamePlayer player : data.getPlayerList().getPlayers()) {
         change.add(AbstractTriggerAttachment.triggerSetUsedForThisRound(player));

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -48,7 +48,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     final StringBuilder endTurnReport = new StringBuilder();
 
     // do national objectives
-    if (Properties.getNationalObjectives(getData())) {
+    if (Properties.getNationalObjectives(getData().getProperties())) {
       final String nationalObjectivesText = determineNationalObjectives(bridge);
       if (!nationalObjectivesText.isBlank()) {
         endTurnReport.append(nationalObjectivesText).append("<br />");
@@ -236,7 +236,8 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     }
     final Resource pus = new Resource(Constants.PUS, data);
     if (resourceTotalsMap.containsKey(pus)) {
-      resourceTotalsMap.put(pus, resourceTotalsMap.getInt(pus) * Properties.getPuMultiplier(data));
+      resourceTotalsMap.put(
+          pus, resourceTotalsMap.getInt(pus) * Properties.getPuMultiplier(data.getProperties()));
     }
     return resourceTotalsMap;
   }
@@ -254,7 +255,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
 
     // Find triggers value
     final IntegerMap<Resource> resources;
-    final boolean useTriggers = Properties.getTriggers(data);
+    final boolean useTriggers = Properties.getTriggers(data.getProperties());
     if (useTriggers && !triggers.isEmpty()) {
       final Set<TriggerAttachment> toFireTestedAndSatisfied =
           new HashSet<>(
@@ -272,7 +273,10 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
       if (uses == 0 || !rule.isSatisfied(testedConditions)) {
         continue;
       }
-      pus += (rule.getObjectiveValue() * rule.getEachMultiple() * Properties.getPuMultiplier(data));
+      pus +=
+          (rule.getObjectiveValue()
+              * rule.getEachMultiple()
+              * Properties.getPuMultiplier(data.getProperties()));
     }
     resources.add(data.getResourceList().getResource(Constants.PUS), pus);
 
@@ -292,7 +296,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
 
     // Execute triggers
     final StringBuilder endTurnReport = new StringBuilder();
-    final boolean useTriggers = Properties.getTriggers(data);
+    final boolean useTriggers = Properties.getTriggers(data.getProperties());
     if (useTriggers && !triggers.isEmpty()) {
       final Set<TriggerAttachment> toFireTestedAndSatisfied =
           new HashSet<>(
@@ -314,7 +318,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
         continue;
       }
       int toAdd = rule.getObjectiveValue();
-      toAdd *= Properties.getPuMultiplier(data);
+      toAdd *= Properties.getPuMultiplier(data.getProperties());
       toAdd *= rule.getEachMultiple();
       int total = player.getResources().getQuantity(Constants.PUS) + toAdd;
       if (total < 0) {
@@ -357,7 +361,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
     // First figure out all the conditions that will be tested, so we can test them all at the same
     // time.
     final Set<ICondition> allConditionsNeeded = new HashSet<>();
-    final boolean useTriggers = Properties.getTriggers(data);
+    final boolean useTriggers = Properties.getTriggers(data.getProperties());
     if (useTriggers) {
 
       // Add conditions required for triggers

--- a/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/GameStepPropertiesHelper.java
@@ -153,8 +153,9 @@ public final class GameStepPropertiesHelper {
     data.acquireReadLock();
     try {
       final boolean repairAtStartAndOnlyOwn =
-          Properties.getBattleshipsRepairAtBeginningOfRound(data);
-      final boolean repairAtEndAndAll = Properties.getBattleshipsRepairAtEndOfRound(data);
+          Properties.getBattleshipsRepairAtBeginningOfRound(data.getProperties());
+      final boolean repairAtEndAndAll =
+          Properties.getBattleshipsRepairAtEndOfRound(data.getProperties());
       // if both are off, we do no repairing, no matter what
       if (!repairAtStartAndOnlyOwn && !repairAtEndAndAll) {
         return false;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/ImprovedShipyardsAdvance.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/ImprovedShipyardsAdvance.java
@@ -27,7 +27,7 @@ public final class ImprovedShipyardsAdvance extends TechAdvance {
   @Override
   public void perform(final GamePlayer gamePlayer, final IDelegateBridge bridge) {
     final GameData data = bridge.getData();
-    if (!Properties.getUseShipyards(data)) {
+    if (!Properties.getUseShipyards(data.getProperties())) {
       return;
     }
     final ProductionFrontier current = gamePlayer.getProductionFrontier();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -169,7 +169,7 @@ public class InitializationDelegate extends BaseTripleADelegate {
 
   private static void initDeleteAssetsOfDisabledPlayers(final IDelegateBridge bridge) {
     final GameData data = bridge.getData();
-    if (!Properties.getDisabledPlayersAssetsDeleted(data)) {
+    if (!Properties.getDisabledPlayersAssetsDeleted(data.getProperties())) {
       return;
     }
     for (final GamePlayer player : data.getPlayerList().getPlayers()) {
@@ -235,8 +235,9 @@ public class InitializationDelegate extends BaseTripleADelegate {
 
   private static void initDestroyerArtillery(final IDelegateBridge bridge) {
     final GameData data = bridge.getData();
-    final boolean addArtilleryAndDestroyers = Properties.getUseDestroyersAndArtillery(data);
-    if (!Properties.getWW2V2(data) && addArtilleryAndDestroyers) {
+    final boolean addArtilleryAndDestroyers =
+        Properties.getUseDestroyersAndArtillery(data.getProperties());
+    if (!Properties.getWW2V2(data.getProperties()) && addArtilleryAndDestroyers) {
       final CompositeChange change = new CompositeChange();
       final ProductionRule artillery =
           data.getProductionRuleList().getProductionRule("buyArtillery");
@@ -277,7 +278,7 @@ public class InitializationDelegate extends BaseTripleADelegate {
 
   private static void initShipyards(final IDelegateBridge bridge) {
     final GameData data = bridge.getData();
-    final boolean useShipyards = Properties.getUseShipyards(data);
+    final boolean useShipyards = Properties.getUseShipyards(data.getProperties());
     if (useShipyards) {
       final CompositeChange change = new CompositeChange();
       final ProductionFrontier frontierShipyards =
@@ -309,7 +310,7 @@ public class InitializationDelegate extends BaseTripleADelegate {
 
   private static void initTwoHitBattleship(final IDelegateBridge bridge) {
     final GameData data = bridge.getData();
-    final boolean userEnabled = Properties.getTwoHitBattleships(data);
+    final boolean userEnabled = Properties.getTwoHitBattleships(data.getProperties());
     final UnitType battleShipUnit =
         data.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_BATTLESHIP);
     if (battleShipUnit == null) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -12,6 +12,7 @@ import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
+import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.AbstractUserActionAttachment;
@@ -114,13 +115,13 @@ public final class Matches {
     return unit -> UnitAttachment.get(unit.getType()).getIsFirstStrike();
   }
 
-  public static Predicate<Unit> unitIsFirstStrikeOnDefense(final GameData gameData) {
+  public static Predicate<Unit> unitIsFirstStrikeOnDefense(final GameProperties properties) {
     Predicate<Unit> matcher = Matches.unitIsFirstStrike();
 
     // units with the deprecated isSuicide attribute automatically get isFirstStrike
     // but they shouldn't have first strike on defense if
     // DEFENDING_SUICIDE_AND_MUNITION_UNITS_DO_NOT_FIRE is true.
-    if (Properties.getDefendingSuicideAndMunitionUnitsDoNotFire(gameData)) {
+    if (Properties.getDefendingSuicideAndMunitionUnitsDoNotFire(properties)) {
       matcher =
           matcher.and(
               // normal isFirstStrike units won't have suicideOnAttack
@@ -283,9 +284,9 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitCanBeCapturedOnEnteringToInThisTerritory(
-      final GamePlayer player, final Territory terr, final GameData data) {
+      final GamePlayer player, final Territory terr, final GameProperties properties) {
     return unit -> {
-      if (!Properties.getCaptureUnitsOnEnteringTerritory(data)) {
+      if (!Properties.getCaptureUnitsOnEnteringTerritory(properties)) {
         return false;
       }
       final GamePlayer unitOwner = unit.getOwner();
@@ -367,7 +368,8 @@ public final class Matches {
       if (!ua.getCanBeDamaged()) {
         return true;
       }
-      if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(unit.getData())) {
+      if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(
+          unit.getData().getProperties())) {
         return unit.getUnitDamage() >= unit.getHowMuchDamageCanThisUnitTakeTotal(t);
       }
       return false;
@@ -395,7 +397,8 @@ public final class Matches {
       if (!unitCanBeDamaged().test(unit)) {
         return false;
       }
-      if (!Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(unit.getData())) {
+      if (!Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(
+          unit.getData().getProperties())) {
         return false;
       }
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
@@ -503,10 +506,10 @@ public final class Matches {
   }
 
   public static Predicate<Unit> unitIsNotInfrastructureAndNotCapturedOnEntering(
-      final GamePlayer player, final Territory terr, final GameData data) {
+      final GamePlayer player, final Territory terr, final GameProperties properties) {
     return unit ->
         !UnitAttachment.get(unit.getType()).getIsInfrastructure()
-            && !unitCanBeCapturedOnEnteringToInThisTerritory(player, terr, data).test(unit);
+            && !unitCanBeCapturedOnEnteringToInThisTerritory(player, terr, properties).test(unit);
   }
 
   public static Predicate<UnitType> unitTypeIsSuicideOnAttack() {
@@ -871,7 +874,8 @@ public final class Matches {
    */
   public static Predicate<Territory> territoryCanCollectIncomeFrom(
       final GamePlayer player, final GameData data) {
-    final boolean contestedDoNotProduce = Properties.getContestedTerritoriesProduceNoIncome(data);
+    final boolean contestedDoNotProduce =
+        Properties.getContestedTerritoriesProduceNoIncome(data.getProperties());
     return t -> {
       final TerritoryAttachment ta = TerritoryAttachment.get(t);
       if (ta == null) {
@@ -1008,9 +1012,11 @@ public final class Matches {
     return territoryIsImpassable().negate();
   }
 
-  public static Predicate<Territory> seaCanMoveOver(final GamePlayer player, final GameData data) {
+  public static Predicate<Territory> seaCanMoveOver(
+      final GamePlayer player, final GameProperties properties) {
     return t ->
-        territoryIsWater().test(t) && territoryIsPassableAndNotRestricted(player, data).test(t);
+        territoryIsWater().test(t)
+            && territoryIsPassableAndNotRestricted(player, properties).test(t);
   }
 
   public static Predicate<Territory> airCanFlyOver(
@@ -1019,19 +1025,19 @@ public final class Matches {
       if (!areNeutralsPassableByAir && territoryIsNeutralButNotWater().test(t)) {
         return false;
       }
-      return territoryIsPassableAndNotRestricted(player, data).test(t)
+      return territoryIsPassableAndNotRestricted(player, data.getProperties()).test(t)
           && !(territoryIsLand().test(t)
               && !data.getRelationshipTracker().canMoveAirUnitsOverOwnedLand(player, t.getOwner()));
     };
   }
 
   public static Predicate<Territory> territoryIsPassableAndNotRestricted(
-      final GamePlayer player, final GameData data) {
+      final GamePlayer player, final GameProperties properties) {
     return t -> {
       if (territoryIsImpassable().test(t)) {
         return false;
       }
-      if (!Properties.getMovementByTerritoryRestricted(data)) {
+      if (!Properties.getMovementByTerritoryRestricted(properties)) {
         return true;
       }
       final RulesAttachment ra =
@@ -1047,13 +1053,14 @@ public final class Matches {
   }
 
   private static Predicate<Territory> territoryIsImpassableToLandUnits(
-      final GamePlayer player, final GameData data) {
-    return t -> t.isWater() || territoryIsPassableAndNotRestricted(player, data).negate().test(t);
+      final GamePlayer player, final GameProperties properties) {
+    return t ->
+        t.isWater() || territoryIsPassableAndNotRestricted(player, properties).negate().test(t);
   }
 
   public static Predicate<Territory> territoryIsNotImpassableToLandUnits(
-      final GamePlayer player, final GameData data) {
-    return t -> territoryIsImpassableToLandUnits(player, data).negate().test(t);
+      final GamePlayer player, final GameProperties properties) {
+    return t -> territoryIsImpassableToLandUnits(player, properties).negate().test(t);
   }
 
   /**
@@ -1073,9 +1080,9 @@ public final class Matches {
       final boolean hasSeaUnitsNotBeingTransported,
       final boolean hasAirUnitsNotBeingTransported,
       final boolean isLandingZoneOnLandForAirUnits) {
-    final boolean neutralsPassable = !Properties.getNeutralsImpassable(data);
+    final boolean neutralsPassable = !Properties.getNeutralsImpassable(data.getProperties());
     final boolean areNeutralsPassableByAir =
-        neutralsPassable && Properties.getNeutralFlyoverAllowed(data);
+        neutralsPassable && Properties.getNeutralFlyoverAllowed(data.getProperties());
     return t -> {
       if (territoryIsImpassable().test(t)) {
         return false;
@@ -1084,7 +1091,7 @@ public final class Matches {
           && territoryIsNeutralButNotWater().test(t)) {
         return false;
       }
-      if (Properties.getMovementByTerritoryRestricted(data)) {
+      if (Properties.getMovementByTerritoryRestricted(data.getProperties())) {
         final RulesAttachment ra =
             (RulesAttachment)
                 playerWhoOwnsAllTheUnitsMoving.getAttachment(Constants.RULES_ATTACHMENT_NAME);
@@ -1186,7 +1193,7 @@ public final class Matches {
       }
       final boolean hasMovementForRoute = left.compareTo(route.getMovementCost(unit)) >= 0;
       if (Properties.getEnterTerritoriesWithHigherMovementCostsThenRemainingMovement(
-          unit.getData())) {
+          unit.getData().getProperties())) {
         return hasMovementForRoute || left.compareTo(route.getMovementCostIgnoreEnd(unit)) > 0;
       }
       return hasMovementForRoute;
@@ -1303,7 +1310,7 @@ public final class Matches {
       if (t.getOwner().equals(GamePlayer.NULL_PLAYERID) && t.isWater()) {
         return false;
       }
-      return territoryIsPassableAndNotRestricted(player, data).test(t)
+      return territoryIsPassableAndNotRestricted(player, data.getProperties()).test(t)
           && data.getRelationshipTracker().isAtWar(player, t.getOwner());
     };
   }
@@ -1316,7 +1323,8 @@ public final class Matches {
         return false;
       }
       // cant blitz on neutrals
-      if (t.getOwner().equals(GamePlayer.NULL_PLAYERID) && !Properties.getNeutralsBlitzable(data)) {
+      if (t.getOwner().equals(GamePlayer.NULL_PLAYERID)
+          && !Properties.getNeutralsBlitzable(data.getProperties())) {
         return false;
       }
       // was conquered but not blitzed
@@ -1330,24 +1338,26 @@ public final class Matches {
               // WW2V2, cant blitz through factories and aa guns
               // WW2V1, you can
               .orIf(
-                  !Properties.getWW2V2(data)
-                      && !Properties.getBlitzThroughFactoriesAndAaRestricted(data),
+                  !Properties.getWW2V2(data.getProperties())
+                      && !Properties.getBlitzThroughFactoriesAndAaRestricted(data.getProperties()),
                   unitIsInfrastructure())
               .build();
       return t.getUnitCollection().allMatch(blitzableUnits);
     };
   }
 
-  public static Predicate<Territory> isTerritoryFreeNeutral(final GameData data) {
+  public static Predicate<Territory> isTerritoryFreeNeutral(final GameProperties properties) {
     return t ->
-        t.getOwner().equals(GamePlayer.NULL_PLAYERID) && Properties.getNeutralCharge(data) <= 0;
+        t.getOwner().equals(GamePlayer.NULL_PLAYERID)
+            && Properties.getNeutralCharge(properties) <= 0;
   }
 
-  public static Predicate<Territory> territoryDoesNotCostMoneyToEnter(final GameData data) {
+  public static Predicate<Territory> territoryDoesNotCostMoneyToEnter(
+      final GameProperties properties) {
     return t ->
         territoryIsLand().negate().test(t)
             || !t.getOwner().equals(GamePlayer.NULL_PLAYERID)
-            || Properties.getNeutralCharge(data) <= 0;
+            || Properties.getNeutralCharge(properties) <= 0;
   }
 
   public static Predicate<Unit> enemyUnit(final GamePlayer player, final GameData data) {
@@ -1573,7 +1583,7 @@ public final class Matches {
         PredicateBuilder.of(unitIsInfrastructure().negate())
             .and(alliedUnit(player, data).negate())
             .and(unitCanBeMovedThroughByEnemies().negate())
-            .andIf(Properties.getIgnoreTransportInMovement(data), transport)
+            .andIf(Properties.getIgnoreTransportInMovement(data.getProperties()), transport)
             .build();
     return territoryHasUnitsThatMatch(unitCond).negate().and(territoryIsWater());
   }
@@ -2281,7 +2291,7 @@ public final class Matches {
       if (t.getOwner().equals(GamePlayer.NULL_PLAYERID) && t.isWater()) {
         return false;
       }
-      return territoryIsPassableAndNotRestricted(attacker, t.getData()).test(t)
+      return territoryIsPassableAndNotRestricted(attacker, t.getData().getProperties()).test(t)
           && relationshipTypeCanTakeOverOwnedTerritory()
               .test(
                   t.getData().getRelationshipTracker().getRelationshipType(attacker, t.getOwner()));

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -91,7 +91,8 @@ public class MoveDelegate extends AbstractMoveDelegate {
               .and(TriggerAttachment.placeMatch());
       final Predicate<TriggerAttachment> moveCombatDelegateAllTriggerMatch =
           moveCombatDelegateBeforeBonusTriggerMatch.or(moveCombatDelegateAfterBonusTriggerMatch);
-      if (GameStepPropertiesHelper.isCombatMove(data) && Properties.getTriggers(data)) {
+      if (GameStepPropertiesHelper.isCombatMove(data)
+          && Properties.getTriggers(data.getProperties())) {
         final Set<TriggerAttachment> toFirePossible =
             TriggerAttachment.collectForAllTriggersMatching(
                 Set.of(player), moveCombatDelegateAllTriggerMatch);
@@ -153,7 +154,8 @@ public class MoveDelegate extends AbstractMoveDelegate {
 
       // placing triggered units at beginning of combat move, but after bonuses and repairing, etc,
       // have been done.
-      if (GameStepPropertiesHelper.isCombatMove(data) && Properties.getTriggers(data)) {
+      if (GameStepPropertiesHelper.isCombatMove(data)
+          && Properties.getTriggers(data.getProperties())) {
         final Set<TriggerAttachment> toFireAfterBonus =
             TriggerAttachment.collectForAllTriggersMatching(
                 Set.of(player), moveCombatDelegateAfterBonusTriggerMatch);
@@ -189,7 +191,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
       addedHistoryEvent = true;
     }
     Change changeBonus = null;
-    if (Properties.getUnitsMayGiveBonusMovement(getData())) {
+    if (Properties.getUnitsMayGiveBonusMovement(getData().getProperties())) {
       changeBonus = giveBonusMovement(bridge, player);
     }
     if (changeBonus != null && !changeBonus.isEmpty()) {
@@ -436,14 +438,14 @@ public class MoveDelegate extends AbstractMoveDelegate {
   static void repairMultipleHitPointUnits(final IDelegateBridge bridge, final GamePlayer player) {
     final GameData data = bridge.getData();
     final boolean repairOnlyOwn =
-        Properties.getBattleshipsRepairAtBeginningOfRound(bridge.getData());
+        Properties.getBattleshipsRepairAtBeginningOfRound(bridge.getData().getProperties());
     final Predicate<Unit> damagedUnits =
         Matches.unitHasMoreThanOneHitPointTotal().and(Matches.unitHasTakenSomeDamage());
     final Predicate<Unit> damagedUnitsOwned = damagedUnits.and(Matches.unitIsOwnedBy(player));
     final Map<Territory, Set<Unit>> damagedMap = new HashMap<>();
     for (final Territory current : data.getMap().getTerritories()) {
       final Set<Unit> damaged;
-      if (!Properties.getTwoHitPointUnitsRequireRepairFacilities(data)) {
+      if (!Properties.getTwoHitPointUnitsRequireRepairFacilities(data.getProperties())) {
         damaged =
             new HashSet<>(
                 current
@@ -560,7 +562,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
   /** This has to be the exact same as Matches.UnitCanBeRepairedByFacilitiesInItsTerritory() */
   private static int getLargestRepairRateForThisUnit(
       final Unit unitToBeRepaired, final Territory territoryUnitIsIn, final GameData data) {
-    if (!Properties.getTwoHitPointUnitsRequireRepairFacilities(data)) {
+    if (!Properties.getTwoHitPointUnitsRequireRepairFacilities(data.getProperties())) {
       return 1;
     }
     final GamePlayer owner = unitToBeRepaired.getOwner();
@@ -633,7 +635,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
       return errorMsg.append(result.getDisallowedUnitWarning(0)).append(numErrorsMsg).toString();
     }
     boolean isKamikaze = false;
-    final boolean getKamikazeAir = Properties.getKamikazeAirplanes(data);
+    final boolean getKamikazeAir = Properties.getKamikazeAirplanes(data.getProperties());
     Collection<Unit> kamikazeUnits = new ArrayList<>();
 
     // confirm kamikaze moves, and remove them from unresolved units
@@ -694,8 +696,8 @@ public class MoveDelegate extends AbstractMoveDelegate {
   private void removeAirThatCantLand() {
     final GameData data = getData();
     final boolean lhtrCarrierProd =
-        Properties.getLhtrCarrierProductionRules(data)
-            || Properties.getLandExistingFightersOnNewCarriers(data);
+        Properties.getLhtrCarrierProductionRules(data.getProperties())
+            || Properties.getLandExistingFightersOnNewCarriers(data.getProperties());
     boolean hasProducedCarriers = false;
     for (final GamePlayer p : GameStepPropertiesHelper.getCombinedTurns(data, player)) {
       if (p.getUnitCollection().anyMatch(Matches.unitIsCarrier())) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -186,7 +186,7 @@ public class MovePerformer implements Serializable {
                       Matches.unitCanBeDamaged().and(Matches.unitIsBeingTransported().negate()));
               final boolean canCreateAirBattle =
                   !enemyTargetsTotal.isEmpty()
-                      && Properties.getRaidsMayBePreceededByAirBattles(data)
+                      && Properties.getRaidsMayBePreceededByAirBattles(data.getProperties())
                       && AirBattle.territoryCouldPossiblyHaveAirBattleDefenders(
                           route.getEnd(), gamePlayer, data, true);
               final Predicate<Unit> allBombingRaid =
@@ -220,7 +220,8 @@ public class MovePerformer implements Serializable {
                   // determine which unit to bomb
                   final Unit target;
                   if (enemyTargets.size() > 1
-                      && Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)
+                      && Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(
+                          data.getProperties())
                       && !canCreateAirBattle) {
                     target =
                         getRemotePlayer()
@@ -253,7 +254,7 @@ public class MovePerformer implements Serializable {
                 }
               }
               // Ignore Trn on Trn forces.
-              if (Properties.getIgnoreTransportInMovement(bridge.getData())) {
+              if (Properties.getIgnoreTransportInMovement(bridge.getData().getProperties())) {
                 final boolean allOwnedTransports =
                     !arrived.isEmpty()
                         && arrived.stream()
@@ -381,7 +382,7 @@ public class MovePerformer implements Serializable {
       }
     }
     if (routeEnd != null
-        && Properties.getSubsCanEndNonCombatMoveWithEnemies(data)
+        && Properties.getSubsCanEndNonCombatMoveWithEnemies(data.getProperties())
         && GameStepPropertiesHelper.isNonCombatMove(data, false)
         && routeEnd
             .getUnitCollection()

--- a/game-core/src/main/java/games/strategy/triplea/delegate/NoPuPurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/NoPuPurchaseDelegate.java
@@ -26,7 +26,7 @@ public class NoPuPurchaseDelegate extends PurchaseDelegate {
   @Override
   public void start() {
     super.start();
-    isPacific = Properties.getPacificTheater(getData());
+    isPacific = Properties.getPacificTheater(getData().getProperties());
     final GamePlayer player = bridge.getGamePlayer();
     final Collection<Territory> territories = getData().getMap().getTerritoriesOwnedBy(player);
     final Collection<Unit> units = getProductionUnits(territories, player);
@@ -39,8 +39,8 @@ public class NoPuPurchaseDelegate extends PurchaseDelegate {
   private Collection<Unit> getProductionUnits(
       final Collection<Territory> territories, final GamePlayer player) {
     final Collection<Unit> productionUnits = new ArrayList<>();
-    if (!(Properties.getProductionPerXTerritoriesRestricted(getData())
-        || Properties.getProductionPerValuedTerritoryRestricted(getData()))) {
+    if (!(Properties.getProductionPerXTerritoriesRestricted(getData().getProperties())
+        || Properties.getProductionPerValuedTerritoryRestricted(getData().getProperties()))) {
       return productionUnits;
     }
     IntegerMap<UnitType> productionPerXTerritories = new IntegerMap<>();
@@ -49,13 +49,14 @@ public class NoPuPurchaseDelegate extends PurchaseDelegate {
     // if they have no rules attachments, but are calling NoPU purchase, and have the game property
     // isProductionPerValuedTerritoryRestricted, then they want 1 infantry for each territory with
     // PU value > 0
-    if (Properties.getProductionPerValuedTerritoryRestricted(getData())
+    if (Properties.getProductionPerValuedTerritoryRestricted(getData().getProperties())
         && (ra == null
             || ra.getProductionPerXTerritories() == null
             || ra.getProductionPerXTerritories().isEmpty())) {
       productionPerXTerritories.put(
           getData().getUnitTypeList().getUnitType(Constants.UNIT_TYPE_INFANTRY), 1);
-    } else if (Properties.getProductionPerXTerritoriesRestricted(getData()) && ra != null) {
+    } else if (Properties.getProductionPerXTerritoriesRestricted(getData().getProperties())
+        && ra != null) {
       productionPerXTerritories = ra.getProductionPerXTerritories();
     } else {
       return productionUnits;
@@ -69,7 +70,7 @@ public class NoPuPurchaseDelegate extends PurchaseDelegate {
       }
       int terrCount = 0;
       for (final Territory current : territories) {
-        if (!Properties.getProductionPerValuedTerritoryRestricted(getData())) {
+        if (!Properties.getProductionPerValuedTerritoryRestricted(getData().getProperties())) {
           terrCount++;
         } else {
           if (TerritoryAttachment.getProduction(current) > 0) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PoliticsDelegate.java
@@ -38,7 +38,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
   public void end() {
     super.end();
     resetAttempts();
-    if (Properties.getTriggers(getData())) {
+    if (Properties.getTriggers(getData().getProperties())) {
       // First set up a match for what we want to have fire as a default in this delegate. List out
       // as a composite match
       // OR.
@@ -90,7 +90,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
     if (!player.amNotDeadYet(getData())) {
       return false;
     }
-    return Properties.getUsePolitics(getData()) && !getValidActions().isEmpty();
+    return Properties.getUsePolitics(getData().getProperties()) && !getValidActions().isEmpty();
   }
 
   public Map<ICondition, Boolean> getTestedConditions() {
@@ -120,7 +120,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
 
   @Override
   public void attemptAction(final PoliticalActionAttachment paa) {
-    if (!Properties.getUsePolitics(getData())) {
+    if (!Properties.getUsePolitics(getData().getProperties())) {
       notifyPoliticsTurnedOff();
       return;
     }
@@ -180,7 +180,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
                     Matches.relationshipTypeIsAtWar(),
                     Matches.relationshipTypeIsAtWar().negate(),
                     data));
-    if (!Properties.getAlliancesCanChainTogether(data)
+    if (!Properties.getAlliancesCanChainTogether(data.getProperties())
         || !intoAlliedChainOrIntoOrOutOfWar.test(paa)) {
       for (final GamePlayer player : paa.getActionAccept()) {
         if (!getRemotePlayer(player)
@@ -459,7 +459,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
   private static void getMyselfOutOfAlliance(
       final PoliticalActionAttachment paa, final GamePlayer player, final IDelegateBridge bridge) {
     final GameData data = bridge.getData();
-    if (!Properties.getAlliancesCanChainTogether(data)) {
+    if (!Properties.getAlliancesCanChainTogether(data.getProperties())) {
       return;
     }
     final Collection<GamePlayer> players = data.getPlayerList().getPlayers();
@@ -514,7 +514,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
   private static void getNeutralOutOfWarWithAllies(
       final PoliticalActionAttachment paa, final GamePlayer player, final IDelegateBridge bridge) {
     final GameData data = bridge.getData();
-    if (!Properties.getAlliancesCanChainTogether(data)) {
+    if (!Properties.getAlliancesCanChainTogether(data.getProperties())) {
       return;
     }
 
@@ -575,7 +575,7 @@ public class PoliticsDelegate extends BaseTripleADelegate implements IPoliticsDe
 
   static void chainAlliancesTogether(final IDelegateBridge bridge) {
     final GameData data = bridge.getData();
-    if (!Properties.getAlliancesCanChainTogether(data)) {
+    if (!Properties.getAlliancesCanChainTogether(data.getProperties())) {
       return;
     }
     final Collection<RelationshipType> allTypes =

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -57,7 +57,7 @@ public class PurchaseDelegate extends BaseTripleADelegate
     super.start();
     final GameData data = getData();
     if (needToInitialize) {
-      if (Properties.getTriggers(data)) {
+      if (Properties.getTriggers(data.getProperties())) {
         // First set up a match for what we want to have fire as a default in this delegate. List
         // out as a composite
         // match OR.
@@ -261,7 +261,8 @@ public class PurchaseDelegate extends BaseTripleADelegate
     if (!canAfford(costs, player)) {
       return NOT_ENOUGH_RESOURCES;
     }
-    if (!Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(getData())) {
+    if (!Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(
+        getData().getProperties())) {
       return null;
     }
     // Get the map of the factories that were repaired and how much for each

--- a/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/RandomStartDelegate.java
@@ -69,7 +69,8 @@ public class RandomStartDelegate extends BaseTripleADelegate {
 
   private void setupBoard() {
     final GameData data = getData();
-    final boolean randomTerritories = Properties.getTerritoriesAreAssignedRandomly(data);
+    final boolean randomTerritories =
+        Properties.getTerritoriesAreAssignedRandomly(data.getProperties());
     final Predicate<Territory> pickableTerritoryMatch = getTerritoryPickableMatch();
     final Predicate<GamePlayer> playerCanPickMatch = getPlayerCanPickMatch();
     final List<Territory> allPickableTerritories =

--- a/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -50,9 +50,10 @@ public class RocketsFireHelper implements Serializable {
     // WW2V2/WW2V3, now fires at the start of the BattleDelegate
     // WW2V1, fires at end of non combat move so does not call here
     helper.needToFindRocketTargets = false;
-    if ((Properties.getWW2V2(data) || Properties.getAllRocketsAttack(data))
+    if ((Properties.getWW2V2(data.getProperties())
+            || Properties.getAllRocketsAttack(data.getProperties()))
         && TechTracker.hasRocket(bridge.getGamePlayer())) {
-      if (Properties.getSequentiallyTargetedRockets(data)) {
+      if (Properties.getSequentiallyTargetedRockets(data.getProperties())) {
         helper.needToFindRocketTargets = true;
       } else {
         helper.findRocketTargetsAndFireIfNeeded(bridge, false);
@@ -69,8 +70,8 @@ public class RocketsFireHelper implements Serializable {
     final GamePlayer player = bridge.getGamePlayer();
     // If we don't have rockets or aren't V1 then do nothing.
     if (!TechTracker.hasRocket(player)
-        || Properties.getWW2V2(data)
-        || Properties.getAllRocketsAttack(data)) {
+        || Properties.getWW2V2(data.getProperties())
+        || Properties.getAllRocketsAttack(data.getProperties())) {
       return;
     }
     final Set<Territory> rocketTerritories = getTerritoriesWithRockets(data, player);
@@ -127,7 +128,7 @@ public class RocketsFireHelper implements Serializable {
             CollectionUtils.getMatches(
                 enemyUnits, Matches.unitIsAtMaxDamageOrNotCanBeDamaged(targetTerritory).negate());
         Unit unitTarget = null;
-        if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
+        if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data.getProperties())) {
           final Collection<Unit> rocketTargets =
               new ArrayList<>(
                   CollectionUtils.getMatches(attackFrom.getUnits(), rocketMatch(player)));
@@ -225,7 +226,7 @@ public class RocketsFireHelper implements Serializable {
     final Predicate<Territory> allowed =
         PredicateBuilder.of(Matches.territoryAllowsRocketsCanFlyOver(player, data))
             .andIf(
-                !Properties.getRocketsCanFlyOverImpassables(data),
+                !Properties.getRocketsCanFlyOverImpassables(data.getProperties()),
                 Matches.territoryIsNotImpassable())
             .build();
     final Collection<Territory> possible =
@@ -263,7 +264,7 @@ public class RocketsFireHelper implements Serializable {
     final GamePlayer attacked = attackedTerritory.getOwner();
     final Resource pus = data.getResourceList().getResource(Constants.PUS);
     final boolean damageFromBombingDoneToUnits =
-        Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data);
+        Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data.getProperties());
     // unit damage vs territory damage
     final Collection<Unit> enemyUnits =
         attackedTerritory
@@ -292,9 +293,9 @@ public class RocketsFireHelper implements Serializable {
     }
     final String transcript;
     final boolean doNotUseBombingBonus =
-        !Properties.getUseBombingMaxDiceSidesAndBonus(data) || attackFrom == null;
+        !Properties.getUseBombingMaxDiceSidesAndBonus(data.getProperties()) || attackFrom == null;
     int cost = 0;
-    if (!Properties.getLowLuckDamageOnly(data)) {
+    if (!Properties.getLowLuckDamageOnly(data.getProperties())) {
       if (doNotUseBombingBonus) {
         // no low luck, and no bonus, so just roll based on the map's dice sides
         final int[] rolls =
@@ -453,10 +454,11 @@ public class RocketsFireHelper implements Serializable {
       bridge.addChange(ChangeFactory.bombingUnitDamage(damageMap));
       // attackedTerritory.notifyChanged();
       // in WW2V2, limit rocket attack cost to production value of factory.
-    } else if (Properties.getWW2V2(data)
-        || Properties.getLimitRocketAndSbrDamageToProduction(data)) {
+    } else if (Properties.getWW2V2(data.getProperties())
+        || Properties.getLimitRocketAndSbrDamageToProduction(data.getProperties())) {
       // If we are limiting total PUs lost then take that into account
-      if (Properties.getPuCap(data) || Properties.getLimitRocketDamagePerTurn(data)) {
+      if (Properties.getPuCap(data.getProperties())
+          || Properties.getLimitRocketDamagePerTurn(data.getProperties())) {
         final int alreadyLost = DelegateFinder.moveDelegate(data).pusAlreadyLost(attackedTerritory);
         territoryProduction -= alreadyLost;
         territoryProduction = Math.max(0, territoryProduction);
@@ -492,7 +494,7 @@ public class RocketsFireHelper implements Serializable {
                   + " damage to "
                   + unit);
     } else {
-      cost *= Properties.getPuMultiplier(data);
+      cost *= Properties.getPuMultiplier(data.getProperties());
       getRemote(bridge)
           .reportMessage(
               "Rocket attack in " + attackedTerritory.getName() + " costs:" + cost,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -54,7 +54,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
       return;
     }
     final boolean onlyWhereUnderAttackAlready =
-        Properties.getAirborneAttacksOnlyInExistingBattles(data);
+        Properties.getAirborneAttacksOnlyInExistingBattles(data.getProperties());
     final BattleTracker battleTracker = AbstractMoveDelegate.getBattleTracker(data);
     if (needToInitialize && onlyWhereUnderAttackAlready) {
       // we do this to clear any 'finishedBattles' and also to create battles for units that didn't
@@ -259,11 +259,13 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
     }
     final BattleTracker battleTracker = AbstractMoveDelegate.getBattleTracker(data);
     final boolean onlyWhereUnderAttackAlready =
-        Properties.getAirborneAttacksOnlyInExistingBattles(data);
-    final boolean onlyEnemyTerritories = Properties.getAirborneAttacksOnlyInEnemyTerritories(data);
+        Properties.getAirborneAttacksOnlyInExistingBattles(data.getProperties());
+    final boolean onlyEnemyTerritories =
+        Properties.getAirborneAttacksOnlyInEnemyTerritories(data.getProperties());
     final List<Territory> steps = route.getSteps();
     if (steps.isEmpty()
-        || !steps.stream().allMatch(Matches.territoryIsPassableAndNotRestricted(player, data))) {
+        || !steps.stream()
+            .allMatch(Matches.territoryIsPassableAndNotRestricted(player, data.getProperties()))) {
       return result.setErrorReturnResult("May Not Fly Over Impassable or Restricted Territories");
     }
     if (steps.isEmpty()

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechActivationDelegate.java
@@ -45,7 +45,7 @@ public class TechActivationDelegate extends BaseTripleADelegate {
     }
     // empty
     techMap.put(player, null);
-    if (Properties.getTriggers(data)) {
+    if (Properties.getTriggers(data.getProperties())) {
       // First set up a match for what we want to have fire as a default in this delegate. List out
       // as a composite match
       // OR.

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechAdvance.java
@@ -140,8 +140,8 @@ public abstract class TechAdvance extends NamedAttachable {
   /** For the game parser only. */
   public static void createDefaultTechAdvances(final GameData data) {
     final TechnologyFrontier tf = data.getTechnologyFrontier();
-    final boolean ww2v2 = Properties.getWW2V2(data);
-    final boolean ww2v3 = Properties.getWW2V3(data);
+    final boolean ww2v2 = Properties.getWW2V2(data.getProperties());
+    final boolean ww2v3 = Properties.getWW2V3(data.getProperties());
     if (ww2v2) {
       createWW2V2Advances(tf);
     } else if (ww2v3) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -65,7 +65,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
     if (!needToInitialize) {
       return;
     }
-    if (Properties.getTriggers(getData())) {
+    if (Properties.getTriggers(getData().getProperties())) {
       // First set up a match for what we want to have fire as a default in this delegate. List out
       // as a composite match
       // OR.
@@ -122,13 +122,13 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
 
   @Override
   public boolean delegateCurrentlyRequiresUserInput() {
-    if (!Properties.getTechDevelopment(getData())) {
+    if (!Properties.getTechDevelopment(getData().getProperties())) {
       return false;
     }
     if (!TerritoryAttachment.doWeHaveEnoughCapitalsToProduce(player, getData())) {
       return false;
     }
-    if (Properties.getWW2V3TechModel(getData())) {
+    if (Properties.getWW2V3TechModel(getData().getProperties())) {
       final Resource techTokens = getData().getResourceList().getResource(Constants.TECH_TOKENS);
       if (techTokens != null && player.getResources().getQuantity(techTokens) > 0) {
         return true;
@@ -164,7 +164,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
       final int newTokens,
       final IntegerMap<GamePlayer> whoPaysHowMuch) {
     int rollCount = techRolls;
-    if (Properties.getWW2V3TechModel(getData())) {
+    if (Properties.getWW2V3TechModel(getData().getProperties())) {
       rollCount = newTokens;
     }
     final boolean canPay = checkEnoughMoney(rollCount, whoPaysHowMuch);
@@ -173,12 +173,12 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
     }
     chargeForTechRolls(rollCount, whoPaysHowMuch);
     int currTokens = 0;
-    if (Properties.getWW2V3TechModel(getData())) {
+    if (Properties.getWW2V3TechModel(getData().getProperties())) {
       currTokens = player.getResources().getQuantity(Constants.TECH_TOKENS);
     }
     final GameData data = getData();
     if (getAvailableTechs(player, data).isEmpty()) {
-      if (Properties.getWW2V3TechModel(getData())) {
+      if (Properties.getWW2V3TechModel(getData().getProperties())) {
         final Resource techTokens = data.getResourceList().getResource(Constants.TECH_TOKENS);
         final String transcriptText = player.getName() + " No more available tech advances.";
         bridge.getHistoryWriter().startEvent(transcriptText);
@@ -197,7 +197,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
       final Player tripleaPlayer = bridge.getRemotePlayer();
       random = tripleaPlayer.selectFixedDice(techRolls, diceSides, annotation, diceSides);
       techHits = getTechHits(random);
-    } else if (Properties.getLowLuckTechOnly(getData())) {
+    } else if (Properties.getLowLuckTechOnly(getData().getProperties())) {
       techHits = techRolls / diceSides;
       remainder = techRolls % diceSides;
       if (remainder > 0) {
@@ -214,12 +214,12 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
       techHits = getTechHits(random);
     }
     final boolean isRevisedModel =
-        Properties.getWW2V2(getData())
-            || (Properties.getSelectableTechRoll(getData())
-                && !Properties.getWW2V3TechModel(getData()));
+        Properties.getWW2V2(getData().getProperties())
+            || (Properties.getSelectableTechRoll(getData().getProperties())
+                && !Properties.getWW2V3TechModel(getData().getProperties()));
     final String directedTechInfo = isRevisedModel ? " for " + techToRollFor.getTechs().get(0) : "";
     final DiceRoll renderDice =
-        (Properties.getLowLuckTechOnly(getData())
+        (Properties.getLowLuckTechOnly(getData().getProperties())
             ? new DiceRoll(random, techHits, remainder, false)
             : new DiceRoll(random, techHits, diceSides - 1, true));
     bridge
@@ -234,8 +234,8 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
                 + " "
                 + MyFormatter.pluralize("hit", techHits),
             renderDice);
-    if (Properties.getWW2V3TechModel(getData())
-        && (techHits > 0 || Properties.getRemoveAllTechTokensAtEndOfTurn(data))) {
+    if (Properties.getWW2V3TechModel(getData().getProperties())
+        && (techHits > 0 || Properties.getRemoveAllTechTokensAtEndOfTurn(data.getProperties()))) {
       techCategory = techToRollFor;
       // remove all the tokens
       final Resource techTokens = data.getResourceList().getResource(Constants.TECH_TOKENS);
@@ -333,7 +333,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
         bridge.addChange(charge);
       }
     }
-    if (Properties.getWW2V3TechModel(getData())) {
+    if (Properties.getWW2V3TechModel(getData().getProperties())) {
       final Resource tokens = getData().getResourceList().getResource(Constants.TECH_TOKENS);
       final Change newTokens =
           ChangeFactory.changeResourcesChange(bridge.getGamePlayer(), tokens, rolls);
@@ -354,7 +354,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
   private Collection<TechAdvance> getTechAdvances(final int initialHits) {
     final List<TechAdvance> available;
     int hits = initialHits;
-    if (hits > 0 && Properties.getWW2V3TechModel(getData())) {
+    if (hits > 0 && Properties.getWW2V3TechModel(getData().getProperties())) {
       available = getAvailableAdvancesForCategory(techCategory);
       hits = 1;
     } else {
@@ -372,7 +372,8 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
     final Collection<TechAdvance> newAdvances = new ArrayList<>(hits);
     final String annotation = player.getName() + " rolling to see what tech advances are acquired";
     final int[] random;
-    if (Properties.getSelectableTechRoll(getData()) || BaseEditDelegate.getEditMode(getData())) {
+    if (Properties.getSelectableTechRoll(getData().getProperties())
+        || BaseEditDelegate.getEditMode(getData())) {
       final Player tripleaPlayer = bridge.getRemotePlayer();
       random = tripleaPlayer.selectFixedDice(hits, 0, annotation, available.size());
     } else {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
@@ -241,7 +241,8 @@ public class TransportTracker {
     // See if transport has unloaded anywhere yet
     final GameData data = transport.getData();
     for (final Unit unit : unloaded) {
-      if (Properties.getWW2V2(data) || Properties.getTransportUnloadRestricted(data)) {
+      if (Properties.getWW2V2(data.getProperties())
+          || Properties.getTransportUnloadRestricted(data.getProperties())) {
         // cannot unload to two different territories
         if (!unit.getUnloadedTo().equals(territory)) {
           return true;
@@ -281,7 +282,8 @@ public class TransportTracker {
   /** For ww2v3+ and LHTR, if a transport has been in combat then it can't load in NCM. */
   public static boolean isTransportLoadRestrictedAfterCombat(final Unit transport) {
     final GameData data = transport.getData();
-    return (Properties.getWW2V3(data) || Properties.getLhtrCarrierProductionRules(data))
+    return (Properties.getWW2V3(data.getProperties())
+            || Properties.getLhtrCarrierProductionRules(data.getProperties()))
         && GameStepPropertiesHelper.isNonCombatMove(data, true)
         && transport.getWasInCombat();
   }
@@ -297,7 +299,7 @@ public class TransportTracker {
     // carrier unit
     final Collection<Unit> carriers =
         CollectionUtils.getMatches(attackingUnits, Matches.unitIsCarrier());
-    if (!carriers.isEmpty() && !Properties.getAlliedAirIndependent(data)) {
+    if (!carriers.isEmpty() && !Properties.getAlliedAirIndependent(data.getProperties())) {
       final Predicate<Unit> alliedFighters =
           Matches.isUnitAllied(attacker, data)
               .and(Matches.unitIsOwnedBy(attacker).negate())

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
@@ -133,8 +133,9 @@ public class UndoableMove extends AbstractUndoableMove {
                                 Set.of(unit), Matches.unitIsStrategicBomber()),
                             data)));
             if (enemyTargets.size() > 1
-                && Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)
-                && !Properties.getRaidsMayBePreceededByAirBattles(data)) {
+                && Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(
+                    data.getProperties())
+                && !Properties.getRaidsMayBePreceededByAirBattles(data.getProperties())) {
               while (target == null) {
                 target =
                     bridge

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
@@ -70,7 +70,7 @@ public class AirBattle extends AbstractBattle {
       final BattleTracker battleTracker) {
     super(battleSite, attacker, battleTracker, battleType, data);
     isAmphibious = false;
-    maxRounds = Properties.getAirBattleRounds(data);
+    maxRounds = Properties.getAirBattleRounds(data.getProperties());
     updateDefendingUnits();
   }
 
@@ -150,13 +150,13 @@ public class AirBattle extends AbstractBattle {
   protected boolean canAttackerRetreat() {
     return !shouldEndBattleDueToMaxRounds()
         && shouldFightAirBattle()
-        && Properties.getAirBattleAttackersCanRetreat(gameData);
+        && Properties.getAirBattleAttackersCanRetreat(gameData.getProperties());
   }
 
   protected boolean canDefenderRetreat() {
     return !shouldEndBattleDueToMaxRounds()
         && shouldFightAirBattle()
-        && Properties.getAirBattleDefendersCanRetreat(gameData);
+        && Properties.getAirBattleDefendersCanRetreat(gameData.getProperties());
   }
 
   List<IExecutable> getBattleExecutables(final boolean firstRun) {
@@ -358,7 +358,8 @@ public class AirBattle extends AbstractBattle {
           if (!enemyTargets.isEmpty()) {
             Unit target = null;
             if (enemyTargets.size() > 1
-                && Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(gameData)) {
+                && Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(
+                    gameData.getProperties())) {
               while (target == null) {
                 target =
                     getRemote(bridge).whatShouldBomberBomb(battleSite, enemyTargets, List.of(unit));
@@ -616,7 +617,7 @@ public class AirBattle extends AbstractBattle {
         // if normal battle, we may choose to withdraw some air units (keep them grounded for both
         // Air battle and the
         // subsequent normal battle) instead of launching
-        if (Properties.getAirBattleDefendersCanRetreat(gameData)) {
+        if (Properties.getAirBattleDefendersCanRetreat(gameData.getProperties())) {
           interceptors =
               getRemote(defender, bridge)
                   .selectUnitsQuery(
@@ -813,7 +814,9 @@ public class AirBattle extends AbstractBattle {
     return PredicateBuilder.of(Matches.unitCanAirBattle())
         .and(Matches.unitIsEnemyOf(data, attacker))
         .and(Matches.unitWasInAirBattle().negate())
-        .andIf(!Properties.getCanScrambleIntoAirBattles(data), Matches.unitWasScrambled().negate())
+        .andIf(
+            !Properties.getCanScrambleIntoAirBattles(data.getProperties()),
+            Matches.unitWasScrambled().negate())
         .build();
   }
 
@@ -828,7 +831,8 @@ public class AirBattle extends AbstractBattle {
             .and(Matches.unitIsEnemyOf(data, attacker))
             .and(Matches.unitWasInAirBattle().negate())
             .andIf(
-                !Properties.getCanScrambleIntoAirBattles(data), Matches.unitWasScrambled().negate())
+                !Properties.getCanScrambleIntoAirBattles(data.getProperties()),
+                Matches.unitWasScrambled().negate())
             .build();
     final Predicate<Unit> airbasesCanIntercept =
         Matches.unitIsEnemyOf(data, attacker)
@@ -847,7 +851,8 @@ public class AirBattle extends AbstractBattle {
       final GamePlayer attacker,
       final GameData data,
       final boolean bombing) {
-    final boolean canScrambleToAirBattle = Properties.getCanScrambleIntoAirBattles(data);
+    final boolean canScrambleToAirBattle =
+        Properties.getCanScrambleIntoAirBattles(data.getProperties());
     final Predicate<Unit> defendingAirMatch =
         bombing
             ? defendingBombingRaidInterceptors(territory, attacker, data)

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -280,7 +280,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
           for (final Unit u : listedBombardUnits) {
             final IBattle battle = selectBombardingBattle(u, t, battles);
             if (battle != null) {
-              if (Properties.getShoreBombardPerGroundUnitRestricted(getData())
+              if (Properties.getShoreBombardPerGroundUnitRestricted(getData().getProperties())
                   && battle.getAttackingUnits().stream().filter(Matches.unitWasAmphibious()).count()
                       <= battle.getBombardingUnits().size()) {
                 battles.remove(battle);
@@ -348,7 +348,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     for (final IBattle battle : battles) {
       // If Restricted & # of bombarding units => landing units, don't add territory to list to
       // bombard
-      if (!Properties.getShoreBombardPerGroundUnitRestricted(getData())
+      if (!Properties.getShoreBombardPerGroundUnitRestricted(getData().getProperties())
           || (battle.getBombardingUnits().size()
               < battle.getAttackingUnits().stream().filter(Matches.unitWasAmphibious()).count())) {
         territories.add(battle.getTerritory());
@@ -405,7 +405,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       final BattleTracker battleTracker, final IDelegateBridge bridge) {
     final GamePlayer player = bridge.getGamePlayer();
     final GameData data = bridge.getData();
-    final boolean ignoreTransports = Properties.getIgnoreTransportInMovement(data);
+    final boolean ignoreTransports = Properties.getIgnoreTransportInMovement(data.getProperties());
     final Predicate<Unit> seaTransports =
         Matches.unitIsTransportButNotCombatTransport().and(Matches.unitIsSea());
     final Predicate<Unit> seaTranportsOrSubs = seaTransports.or(Matches.unitCanEvade());
@@ -517,7 +517,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       // possibility to ignore battle altogether
       if (!attackingUnits.isEmpty()) {
         final Player remotePlayer = bridge.getRemotePlayer();
-        if (territory.isWater() && Properties.getSeaBattlesMayBeIgnored(data)) {
+        if (territory.isWater() && Properties.getSeaBattlesMayBeIgnored(data.getProperties())) {
           if (!remotePlayer.selectAttackUnits(territory)) {
             final BattleResults results = new BattleResults(battle, WhoWon.NOT_FINISHED, data);
             battleTracker
@@ -607,7 +607,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
   private static void setupTerritoriesAbandonedToTheEnemy(
       final BattleTracker battleTracker, final IDelegateBridge bridge) {
     final GameData data = bridge.getData();
-    if (!Properties.getAbandonedTerritoriesMayBeTakenOverImmediately(data)) {
+    if (!Properties.getAbandonedTerritoriesMayBeTakenOverImmediately(data.getProperties())) {
       return;
     }
     final GamePlayer player = bridge.getGamePlayer();
@@ -686,13 +686,13 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
 
   private void doScrambling() {
     final GameData data = getData();
-    if (!Properties.getScrambleRulesInEffect(data)) {
+    if (!Properties.getScrambleRulesInEffect(data.getProperties())) {
       return;
     }
     final BattleListing pendingBattleSites = battleTracker.getPendingBattleSites();
     final Set<Territory> territoriesWithBattles =
         pendingBattleSites.getNormalBattlesIncludingAirBattles();
-    if (Properties.getCanScrambleIntoAirBattles(data)) {
+    if (Properties.getCanScrambleIntoAirBattles(data.getProperties())) {
       territoriesWithBattles.addAll(
           pendingBattleSites.getStrategicBombingRaidsIncludingAirBattles());
     }
@@ -972,10 +972,10 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     // return scrambled units to their original territories, or let them move 1 or x to a new
     // territory.
     final GameData data = getData();
-    if (!Properties.getScrambleRulesInEffect(data)) {
+    if (!Properties.getScrambleRulesInEffect(data.getProperties())) {
       return;
     }
-    final boolean mustReturnToBase = Properties.getScrambledUnitsReturnToBase(data);
+    final boolean mustReturnToBase = Properties.getScrambledUnitsReturnToBase(data.getProperties());
     for (final Territory t : data.getMap().getTerritories()) {
       int carrierCostOfCurrentTerr = 0;
       final Collection<Unit> wasScrambled =
@@ -1034,7 +1034,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
   private static void resetMaxScrambleCount(final IDelegateBridge bridge) {
     // reset the tripleaUnit property for all airbases that were used
     final GameData data = bridge.getData();
-    if (!Properties.getScrambleRulesInEffect(data)) {
+    if (!Properties.getScrambleRulesInEffect(data.getProperties())) {
       return;
     }
     final CompositeChange change = new CompositeChange();
@@ -1058,7 +1058,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
 
   private void airBattleCleanup() {
     final GameData data = getData();
-    if (!Properties.getRaidsMayBePreceededByAirBattles(data)) {
+    if (!Properties.getRaidsMayBePreceededByAirBattles(data.getProperties())) {
       return;
     }
     final CompositeChange change = new CompositeChange();
@@ -1078,7 +1078,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final Map<Territory, Collection<Unit>> defendingAirThatCanNotLand =
         battleTracker.getDefendingAirThatCanNotLand();
     final boolean isWW2v2orIsSurvivingAirMoveToLand =
-        Properties.getWW2V2(data) || Properties.getSurvivingAirMoveToLand(data);
+        Properties.getWW2V2(data.getProperties())
+            || Properties.getSurvivingAirMoveToLand(data.getProperties());
     final Predicate<Unit> alliedDefendingAir =
         Matches.unitIsAir().and(Matches.unitWasScrambled().negate());
     for (final Entry<Territory, Collection<Unit>> entry : defendingAirThatCanNotLand.entrySet()) {
@@ -1256,7 +1257,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
    */
   private void doKamikazeSuicideAttacks() {
     final GameData data = getData();
-    if (!Properties.getUseKamikazeSuicideAttacks(data)) {
+    if (!Properties.getUseKamikazeSuicideAttacks(data.getProperties())) {
       return;
     }
     // the current player is not the one who is doing these attacks, it is the all the enemies of
@@ -1274,7 +1275,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             .and(Matches.unitIsNotTransportButCouldBeCombatTransport())
             .and(Matches.unitCanEvade().negate());
     final boolean onlyWhereThereAreBattlesOrAmphibious =
-        Properties.getKamikazeSuicideAttacksOnlyWhereBattlesAre(data);
+        Properties.getKamikazeSuicideAttacksOnlyWhereBattlesAre(data.getProperties());
     final Collection<Territory> pendingBattles = battleTracker.getPendingBattleSites(false);
     // create a list of all kamikaze zones, listed by enemy
     final Map<GamePlayer, Collection<Territory>> kamikazeZonesByEnemy = new HashMap<>();
@@ -1284,7 +1285,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         continue;
       }
       final GamePlayer owner =
-          !Properties.getKamikazeSuicideAttacksDoneByCurrentTerritoryOwner(data)
+          !Properties.getKamikazeSuicideAttacksDoneByCurrentTerritoryOwner(data.getProperties())
               ? ta.getOriginalOwner()
               : t.getOwner();
       if (owner == null) {
@@ -1433,7 +1434,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final CompositeChange change = new CompositeChange();
     int hits = 0;
     int[] rolls = null;
-    if (Properties.getLowLuck(data)) {
+    if (Properties.getLowLuck(data.getProperties())) {
       int power = 0;
       for (final Entry<Resource, Integer> entry : numberOfAttacks.entrySet()) {
         final Resource r = entry.getKey();
@@ -1557,7 +1558,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       return List.of(currentTerr);
     }
     final boolean areNeutralsPassableByAir =
-        (Properties.getNeutralFlyoverAllowed(data) && !Properties.getNeutralsImpassable(data));
+        (Properties.getNeutralFlyoverAllowed(data.getProperties())
+            && !Properties.getNeutralsImpassable(data.getProperties()));
     final Set<Territory> canNotLand = new HashSet<>();
     canNotLand.addAll(battleTracker.getPendingBattleSites(false));
     canNotLand.addAll(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/ScrambleLogic.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/ScrambleLogic.java
@@ -49,7 +49,7 @@ public class ScrambleLogic {
       final GamePlayer player,
       final Set<Territory> territoriesWithBattles,
       final BattleTracker battleTracker) {
-    if (!Properties.getScrambleRulesInEffect(data)) {
+    if (!Properties.getScrambleRulesInEffect(data.getProperties())) {
       throw new IllegalStateException("Scrambling not supported");
     }
     this.data = data;
@@ -69,7 +69,9 @@ public class ScrambleLogic {
                         .and(Matches.unitIsEnemyOf(data, player))
                         .and(Matches.unitIsNotDisabled())))
             .and(Matches.territoryHasUnitsThatMatch(airbaseThatCanScramblePredicate))
-            .andIf(Properties.getScrambleFromIslandOnly(data), Matches.territoryIsIsland())
+            .andIf(
+                Properties.getScrambleFromIslandOnly(data.getProperties()),
+                Matches.territoryIsIsland())
             .build();
     this.maxScrambleDistance = computeMaxScrambleDistance(data);
   }
@@ -118,8 +120,9 @@ public class ScrambleLogic {
     // first, figure out all the territories where scrambling units could scramble to
     // then ask the defending player if they wish to scramble units there, and actually move the
     // units there
-    final boolean toSeaOnly = Properties.getScrambleToSeaOnly(data);
-    final boolean toAnyAmphibious = Properties.getScrambleToAnyAmphibiousAssault(data);
+    final boolean toSeaOnly = Properties.getScrambleToSeaOnly(data.getProperties());
+    final boolean toAnyAmphibious =
+        Properties.getScrambleToAnyAmphibiousAssault(data.getProperties());
 
     final Collection<Territory> territoriesWithBattlesWater =
         CollectionUtils.getMatches(territoriesWithBattles, Matches.territoryIsWater());

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
@@ -251,7 +251,8 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           @Override
           public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
             bridge.getDisplayChannelBroadcaster().gotoBattleStep(battleId, RAID);
-            if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(gameData)) {
+            if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(
+                gameData.getProperties())) {
               bridge
                   .getHistoryWriter()
                   .addChildToEvent(
@@ -275,7 +276,8 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
                           + MyFormatter.pluralize("PU", bombingRaidTotal));
             }
             // TODO remove the reference to the constant.japanese- replace with a rule
-            if ((Properties.getPacificTheater(gameData) || Properties.getSbrVictoryPoints(gameData))
+            if ((Properties.getPacificTheater(gameData.getProperties())
+                    || Properties.getSbrVictoryPoints(gameData.getProperties()))
                 && defender.getName().equals(Constants.PLAYER_NAME_JAPANESE)) {
               final PlayerAttachment pa = PlayerAttachment.get(defender);
               if (pa != null) {
@@ -363,7 +365,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
   }
 
   private void end(final IDelegateBridge bridge) {
-    if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(gameData)) {
+    if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(gameData.getProperties())) {
       bridge
           .getDisplayChannelBroadcaster()
           .battleEnd(
@@ -727,14 +729,14 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
         dice = attacker.selectFixedDice(rollCount, 0, annotation, gameData.getDiceSides());
       } else {
         final boolean doNotUseBombingBonus =
-            !Properties.getUseBombingMaxDiceSidesAndBonus(gameData);
+            !Properties.getUseBombingMaxDiceSidesAndBonus(gameData.getProperties());
         final String annotation =
             attacker.getName()
                 + " rolling to allocate cost of strategic bombing raid against "
                 + defender.getName()
                 + " in "
                 + battleSite.getName();
-        if (!Properties.getLowLuckDamageOnly(gameData)) {
+        if (!Properties.getLowLuckDamageOnly(gameData.getProperties())) {
           if (doNotUseBombingBonus) {
             // no low luck, and no bonus, so just roll based on the map's dice sides
             dice =
@@ -849,11 +851,11 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
       }
       int damageLimit = TerritoryAttachment.getProduction(battleSite);
       int cost = 0;
-      final boolean lhtrBombers = Properties.getLhtrHeavyBombers(gameData);
+      final boolean lhtrBombers = Properties.getLhtrHeavyBombers(gameData.getProperties());
       int index = 0;
       final boolean limitDamage =
-          Properties.getWW2V2(gameData)
-              || Properties.getLimitRocketAndSbrDamageToProduction(gameData);
+          Properties.getWW2V2(gameData.getProperties())
+              || Properties.getLimitRocketAndSbrDamageToProduction(gameData.getProperties());
       final List<Die> dice = new ArrayList<>();
       final Map<Unit, List<Die>> targetToDiceMap = new HashMap<>();
       // limit to maxDamage
@@ -911,7 +913,8 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
         }
       }
       // Limit PUs lost if we would like to cap PUs lost at territory value
-      if (Properties.getPuCap(gameData) || Properties.getLimitSbrDamagePerTurn(gameData)) {
+      if (Properties.getPuCap(gameData.getProperties())
+          || Properties.getLimitSbrDamagePerTurn(gameData.getProperties())) {
         final int alreadyLost = DelegateFinder.moveDelegate(gameData).pusAlreadyLost(battleSite);
         final int limit = Math.max(0, damageLimit - alreadyLost);
         cost = Math.min(cost, limit);
@@ -924,7 +927,8 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
         }
       }
       // If we damage units instead of territories
-      if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(gameData)) {
+      if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(
+          gameData.getProperties())) {
         // at this point, bombingRaidDamage should contain all units that targets contains
         if (!targets.keySet().containsAll(bombingRaidDamage.keySet())) {
           throw new IllegalStateException("targets should contain all damaged units");
@@ -982,7 +986,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
       } else {
         // Record PUs lost
         DelegateFinder.moveDelegate(gameData).pusLost(battleSite, cost);
-        cost *= Properties.getPuMultiplier(gameData);
+        cost *= Properties.getPuMultiplier(gameData.getProperties());
         bridge.getDisplayChannelBroadcaster().bombingResults(battleId, dice, cost);
         if (cost > 0) {
           bridge

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/UnitBattleComparator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/UnitBattleComparator.java
@@ -59,8 +59,8 @@ public class UnitBattleComparator implements Comparator<Unit> {
     this.reversedCombatValueCalculator = combatValueCalculator.buildOppositeCombatValue();
     this.bonus = bonus;
     this.ignorePrimaryPower = ignorePrimaryPower;
-    if (Properties.getBattleshipsRepairAtEndOfRound(data)
-        || Properties.getBattleshipsRepairAtBeginningOfRound(data)) {
+    if (Properties.getBattleshipsRepairAtEndOfRound(data.getProperties())
+        || Properties.getBattleshipsRepairAtBeginningOfRound(data.getProperties())) {
       for (final UnitType ut : data.getUnitTypeList()) {
         if (Matches.unitTypeHasMoreThanOneHitPointTotal().test(ut)) {
           multiHitpointCanRepair.add(ut);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelector.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelector.java
@@ -48,7 +48,8 @@ public class AaCasualtySelector {
         !defendingAa.isEmpty()
             && defendingAa.stream()
                 .allMatch(Matches.unitAaShotDamageableInsteadOfKillingInstantly());
-    if (BaseEditDelegate.getEditMode(data) || Properties.getChooseAaCasualties(data)) {
+    if (BaseEditDelegate.getEditMode(data)
+        || Properties.getChooseAaCasualties(data.getProperties())) {
       return CasualtySelector.selectCasualties(
           hitPlayer,
           planes,
@@ -63,18 +64,19 @@ public class AaCasualtySelector {
           allowMultipleHitsPerUnit);
     }
 
-    if (Properties.getLowLuck(data) || Properties.getLowLuckAaOnly(data)) {
+    if (Properties.getLowLuck(data.getProperties())
+        || Properties.getLowLuckAaOnly(data.getProperties())) {
       return getLowLuckAaCasualties(
           planes, defendingAa, aaCombatValueCalculator, dice, bridge, allowMultipleHitsPerUnit);
     }
 
     // priority goes: choose -> individually -> random
     // if none are set, we roll individually
-    if (Properties.getRollAaIndividually(data)) {
+    if (Properties.getRollAaIndividually(data.getProperties())) {
       return individuallyFiredAaCasualties(
           planes, defendingAa, aaCombatValueCalculator, dice, bridge, allowMultipleHitsPerUnit);
     }
-    if (Properties.getRandomAaCasualties(data)) {
+    if (Properties.getRandomAaCasualties(data.getProperties())) {
       return randomAaCasualties(planes, dice, bridge, allowMultipleHitsPerUnit);
     }
     return individuallyFiredAaCasualties(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
@@ -76,7 +76,9 @@ public class CasualtySelector {
         headLess ? Map.of() : CasualtyUtil.getDependents(targetsToPickFrom);
 
     final int hitsRemaining =
-        Properties.getTransportCasualtiesRestricted(data) ? extraHits : dice.getHits();
+        Properties.getTransportCasualtiesRestricted(data.getProperties())
+            ? extraHits
+            : dice.getHits();
 
     if (BaseEditDelegate.getEditMode(data)) {
       return tripleaPlayer.selectCasualties(
@@ -151,7 +153,7 @@ public class CasualtySelector {
                 allowMultipleHitsPerUnit);
     final List<Unit> killed = casualtySelection.getKilled();
     // if partial retreat is possible, kill amphibious units first
-    if (Properties.getPartialAmphibiousRetreat(data)) {
+    if (Properties.getPartialAmphibiousRetreat(data.getProperties())) {
       killAmphibiousFirst(killed, sortedTargetsToPickFrom);
     }
     final List<Unit> damaged = casualtySelection.getDamaged();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/RetreatChecks.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/RetreatChecks.java
@@ -29,7 +29,7 @@ public class RetreatChecks {
 
   public static boolean onlyDefenselessTransportsLeft(
       final @NonNull Collection<Unit> units, final @NonNull GameData gameData) {
-    return Properties.getTransportCasualtiesRestricted(gameData)
+    return Properties.getTransportCasualtiesRestricted(gameData.getProperties())
         && !units.isEmpty()
         && units.stream().allMatch(Matches.unitIsTransportButNotCombatTransport());
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/RemoveUnprotectedUnits.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/RemoveUnprotectedUnits.java
@@ -35,7 +35,7 @@ public class RemoveUnprotectedUnits implements BattleStep {
   @Override
   public List<String> getNames() {
     if (battleState.getBattleSite().isWater()
-        && Properties.getTransportCasualtiesRestricted(battleState.getGameData())
+        && Properties.getTransportCasualtiesRestricted(battleState.getGameData().getProperties())
         && (battleState.filterUnits(ALIVE, OFFENSE).stream().anyMatch(Matches.unitIsTransport())
             || battleState.filterUnits(ALIVE, DEFENSE).stream()
                 .anyMatch(Matches.unitIsTransport()))) {
@@ -57,7 +57,7 @@ public class RemoveUnprotectedUnits implements BattleStep {
 
   @RemoveOnNextMajorRelease("This doesn't need to be public in the next major release")
   public void removeUnprotectedUnits(final IDelegateBridge bridge, final BattleState.Side side) {
-    if (!Properties.getTransportCasualtiesRestricted(battleState.getGameData())) {
+    if (!Properties.getTransportCasualtiesRestricted(battleState.getGameData().getProperties())) {
       return;
     }
     // if we are the attacker, we can retreat instead of dying

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/FiringGroupSplitterBombard.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/FiringGroupSplitterBombard.java
@@ -35,7 +35,7 @@ public class FiringGroupSplitterBombard implements Function<BattleState, Collect
             Matches.unitIsNotInfrastructureAndNotCapturedOnEntering(
                 battleState.getPlayer(OFFENSE),
                 battleState.getBattleSite(),
-                battleState.getGameData()));
+                battleState.getGameData().getProperties()));
 
     return FiringGroup.groupBySuicideOnHit(
         NAVAL_BOMBARD, battleState.getBombardingUnits(), enemyUnits);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/NavalBombardment.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/NavalBombardment.java
@@ -83,7 +83,8 @@ public class NavalBombardment implements BattleStep {
         .firingGroupSplitter(FiringGroupSplitterBombard.of())
         .side(side)
         .returnFire(
-            Properties.getNavalBombardCasualtiesReturnFire(battleState.getGameData())
+            Properties.getNavalBombardCasualtiesReturnFire(
+                    battleState.getGameData().getProperties())
                 ? MustFightBattle.ReturnFire.ALL
                 : MustFightBattle.ReturnFire.NONE)
         .diceRoller(new BombardmentDiceRoller())

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/SelectMainBattleCasualties.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/SelectMainBattleCasualties.java
@@ -90,7 +90,8 @@ public class SelectMainBattleCasualties
 
   private TargetUnits getTargetUnits(final SelectCasualties step) {
     final TargetUnits targetUnits;
-    if (Properties.getTransportCasualtiesRestricted(step.getBattleState().getGameData())) {
+    if (Properties.getTransportCasualtiesRestricted(
+        step.getBattleState().getGameData().getProperties())) {
       targetUnits =
           TargetUnits.of(
               CollectionUtils.getMatches(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/ClearFirstStrikeCasualties.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/ClearFirstStrikeCasualties.java
@@ -57,13 +57,13 @@ public class ClearFirstStrikeCasualties implements BattleStep {
 
   private State calculateDefenseState() {
     if (battleState.filterUnits(ALIVE, DEFENSE).stream()
-        .anyMatch(Matches.unitIsFirstStrikeOnDefense(battleState.getGameData()))) {
+        .anyMatch(Matches.unitIsFirstStrikeOnDefense(battleState.getGameData().getProperties()))) {
       final GameData gameData = battleState.getGameData();
       // WWW2V2 always gives defending subs sneak attack
       final boolean canSneakAttack =
           battleState.filterUnits(ALIVE, OFFENSE).stream().noneMatch(Matches.unitIsDestroyer())
-              && (Properties.getWW2V2(gameData)
-                  || Properties.getDefendingSubsSneakAttack(gameData));
+              && (Properties.getWW2V2(gameData.getProperties())
+                  || Properties.getDefendingSubsSneakAttack(gameData.getProperties()));
       if (canSneakAttack) {
         return State.SNEAK_ATTACK;
       }
@@ -100,7 +100,7 @@ public class ClearFirstStrikeCasualties implements BattleStep {
   }
 
   private EnumSet<BattleState.Side> getSidesToClear() {
-    if (Properties.getWW2V2(battleState.getGameData())) {
+    if (Properties.getWW2V2(battleState.getGameData().getProperties())) {
       // WWW2V2 subs always fire in a surprise attack phase even if their casualties will
       // be able to fire back.
       // So only clear the casualties if that side doesn't have sneak attack

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/DefensiveFirstStrike.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/DefensiveFirstStrike.java
@@ -60,19 +60,19 @@ public class DefensiveFirstStrike implements BattleStep {
 
   private State calculateState() {
     if (battleState.filterUnits(ALIVE, side).stream()
-        .noneMatch(Matches.unitIsFirstStrikeOnDefense(battleState.getGameData()))) {
+        .noneMatch(Matches.unitIsFirstStrikeOnDefense(battleState.getGameData().getProperties()))) {
       return State.NOT_APPLICABLE;
     }
 
     // ww2v2 rules require subs to always fire in a sub phase
-    if (Properties.getWW2V2(battleState.getGameData())) {
+    if (Properties.getWW2V2(battleState.getGameData().getProperties())) {
       return State.FIRST_STRIKE;
     }
 
     final boolean canSneakAttack =
         battleState.filterUnits(ALIVE, side.getOpposite()).stream()
                 .noneMatch(Matches.unitIsDestroyer())
-            && Properties.getDefendingSubsSneakAttack(battleState.getGameData());
+            && Properties.getDefendingSubsSneakAttack(battleState.getGameData().getProperties());
     if (canSneakAttack) {
       return State.FIRST_STRIKE;
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/OffensiveFirstStrike.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/OffensiveFirstStrike.java
@@ -64,7 +64,7 @@ public class OffensiveFirstStrike implements BattleStep {
     }
 
     // ww2v2 rules require subs to always fire in a sub phase
-    if (Properties.getWW2V2(battleState.getGameData())) {
+    if (Properties.getWW2V2(battleState.getGameData().getProperties())) {
       return State.FIRST_STRIKE;
     }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/general/FiringGroupSplitterGeneral.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/general/FiringGroupSplitterGeneral.java
@@ -60,7 +60,8 @@ public class FiringGroupSplitterGeneral implements Function<BattleState, Collect
                 // Remove offense allied units if allied air can not participate
                 .andIf(
                     side == OFFENSE
-                        && !Properties.getAlliedAirIndependent(battleState.getGameData()),
+                        && !Properties.getAlliedAirIndependent(
+                            battleState.getGameData().getProperties()),
                     Matches.unitIsOwnedBy(battleState.getPlayer(side)))
                 .build());
 
@@ -97,7 +98,7 @@ public class FiringGroupSplitterGeneral implements Function<BattleState, Collect
     final Predicate<Unit> predicate =
         (side == OFFENSE)
             ? Matches.unitIsFirstStrike()
-            : Matches.unitIsFirstStrikeOnDefense(battleState.getGameData());
+            : Matches.unitIsFirstStrikeOnDefense(battleState.getGameData().getProperties());
     return type == Type.NORMAL ? predicate.negate() : predicate;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreat.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreat.java
@@ -53,7 +53,7 @@ public class DefensiveSubsRetreat implements BattleStep {
   }
 
   private String getName() {
-    if (Properties.getSubmersibleSubs(battleState.getGameData())) {
+    if (Properties.getSubmersibleSubs(battleState.getGameData().getProperties())) {
       return battleState.getPlayer(DEFENSE).getName() + SUBS_SUBMERGE;
     } else {
       return battleState.getPlayer(DEFENSE).getName() + SUBS_WITHDRAW;
@@ -62,7 +62,7 @@ public class DefensiveSubsRetreat implements BattleStep {
 
   @Override
   public Order getOrder() {
-    if (Properties.getSubRetreatBeforeBattle(battleState.getGameData())) {
+    if (Properties.getSubRetreatBeforeBattle(battleState.getGameData().getProperties())) {
       return SUB_DEFENSIVE_RETREAT_BEFORE_BATTLE;
     } else {
       return SUB_DEFENSIVE_RETREAT_AFTER_BATTLE;
@@ -85,11 +85,12 @@ public class DefensiveSubsRetreat implements BattleStep {
     }
 
     final Collection<Territory> retreatTerritories;
-    if (Properties.getSubmersibleSubs(battleState.getGameData())) {
+    if (Properties.getSubmersibleSubs(battleState.getGameData().getProperties())) {
       retreatTerritories = List.of(battleState.getBattleSite());
     } else {
       retreatTerritories = new ArrayList<>(getEmptyOrFriendlySeaNeighbors());
-      if (Properties.getSubmarinesDefendingMaySubmergeOrRetreat(battleState.getGameData())) {
+      if (Properties.getSubmarinesDefendingMaySubmergeOrRetreat(
+          battleState.getGameData().getProperties())) {
         retreatTerritories.add(battleState.getBattleSite());
       }
     }
@@ -116,8 +117,9 @@ public class DefensiveSubsRetreat implements BattleStep {
   }
 
   private boolean isRetreatNotPossible() {
-    return !(Properties.getSubmersibleSubs(battleState.getGameData())
-            || Properties.getSubmarinesDefendingMaySubmergeOrRetreat(battleState.getGameData()))
+    return !(Properties.getSubmersibleSubs(battleState.getGameData().getProperties())
+            || Properties.getSubmarinesDefendingMaySubmergeOrRetreat(
+                battleState.getGameData().getProperties()))
         && getEmptyOrFriendlySeaNeighbors().isEmpty();
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveGeneralRetreat.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveGeneralRetreat.java
@@ -59,7 +59,7 @@ public class OffensiveGeneralRetreat implements BattleStep {
   }
 
   private boolean canAttackerRetreatPartialAmphib() {
-    if (!Properties.getPartialAmphibiousRetreat(battleState.getGameData())) {
+    if (!Properties.getPartialAmphibiousRetreat(battleState.getGameData().getProperties())) {
       return false;
     }
     // Only include land units when checking for allow amphibious retreat
@@ -70,9 +70,9 @@ public class OffensiveGeneralRetreat implements BattleStep {
 
   private boolean canAttackerRetreatAmphibPlanes() {
     final GameData gameData = battleState.getGameData();
-    return (Properties.getWW2V2(gameData)
-            || Properties.getAttackerRetreatPlanes(gameData)
-            || Properties.getPartialAmphibiousRetreat(gameData))
+    return (Properties.getWW2V2(gameData.getProperties())
+            || Properties.getAttackerRetreatPlanes(gameData.getProperties())
+            || Properties.getPartialAmphibiousRetreat(gameData.getProperties()))
         && battleState.filterUnits(ALIVE, OFFENSE).stream().anyMatch(Matches.unitIsAir());
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveSubsRetreat.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveSubsRetreat.java
@@ -49,7 +49,7 @@ public class OffensiveSubsRetreat implements BattleStep {
   }
 
   private String getName() {
-    if (Properties.getSubmersibleSubs(battleState.getGameData())) {
+    if (Properties.getSubmersibleSubs(battleState.getGameData().getProperties())) {
       return battleState.getPlayer(OFFENSE).getName() + SUBS_SUBMERGE;
     } else {
       return battleState.getPlayer(OFFENSE).getName() + SUBS_WITHDRAW;
@@ -58,7 +58,7 @@ public class OffensiveSubsRetreat implements BattleStep {
 
   @Override
   public Order getOrder() {
-    if (Properties.getSubRetreatBeforeBattle(battleState.getGameData())) {
+    if (Properties.getSubRetreatBeforeBattle(battleState.getGameData().getProperties())) {
       return SUB_OFFENSIVE_RETREAT_BEFORE_BATTLE;
     } else {
       return SUB_OFFENSIVE_RETREAT_AFTER_BATTLE;
@@ -89,7 +89,7 @@ public class OffensiveSubsRetreat implements BattleStep {
             .bridge(bridge)
             .units(unitsToRetreat)
             .build(),
-        Properties.getSubmersibleSubs(battleState.getGameData())
+        Properties.getSubmersibleSubs(battleState.getGameData().getProperties())
             ? List.of(battleState.getBattleSite())
             : battleState.getAttackerRetreatTerritories(),
         getName());
@@ -104,7 +104,7 @@ public class OffensiveSubsRetreat implements BattleStep {
   }
 
   private boolean isRetreatNotPossible() {
-    return !Properties.getSubmersibleSubs(battleState.getGameData())
+    return !Properties.getSubmersibleSubs(battleState.getGameData().getProperties())
         && !RetreatChecks.canAttackerRetreat(
             battleState.filterUnits(ALIVE, DEFENSE),
             battleState.getGameData(),

--- a/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/AirMovementValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/AirMovementValidator.java
@@ -56,7 +56,7 @@ public final class AirMovementValidator {
         || Matches.airCanLandOnThisAlliedNonConqueredLandTerritory(player, data)
             .test(route.getEnd())
         // if kamikaze - we do not do any validation at all, cus they can all die and we don't care
-        || Properties.getKamikazeAirplanes(data)) {
+        || Properties.getKamikazeAirplanes(data.getProperties())) {
       return result;
     }
     // Find which aircraft cannot find friendly land to land on
@@ -141,16 +141,18 @@ public final class AirMovementValidator {
                 Matches.airCanFlyOver(player, data, areNeutralsPassableByAir(data))));
     // we only want to consider
     landingSpots.removeAll(
-        CollectionUtils.getMatches(landingSpots, Matches.seaCanMoveOver(player, data).negate()));
+        CollectionUtils.getMatches(
+            landingSpots, Matches.seaCanMoveOver(player, data.getProperties()).negate()));
     // places we can move carriers to
-    landingSpots.sort(getLowestToHighestDistance(routeEnd, Matches.seaCanMoveOver(player, data)));
+    landingSpots.sort(
+        getLowestToHighestDistance(routeEnd, Matches.seaCanMoveOver(player, data.getProperties())));
     final Collection<Territory> potentialCarrierOrigins = new LinkedHashSet<>(landingSpots);
     potentialCarrierOrigins.addAll(
         data.getMap()
             .getNeighbors(
                 new HashSet<>(landingSpots),
                 maxMovementLeftForAllOwnedCarriers,
-                Matches.seaCanMoveOver(player, data)));
+                Matches.seaCanMoveOver(player, data.getProperties())));
     potentialCarrierOrigins.remove(routeEnd);
     potentialCarrierOrigins.removeAll(
         CollectionUtils.getMatches(
@@ -208,8 +210,8 @@ public final class AirMovementValidator {
             .and(Matches.isUnitAllied(player, data))
             .and(Matches.unitIsCarrier());
     final boolean landAirOnNewCarriers =
-        Properties.getLhtrCarrierProductionRules(data)
-            || Properties.getLandExistingFightersOnNewCarriers(data);
+        Properties.getLhtrCarrierProductionRules(data.getProperties())
+            || Properties.getLandExistingFightersOnNewCarriers(data.getProperties());
     final List<Unit> carriersInProductionQueue =
         GameStepPropertiesHelper.getCombinedTurns(data, player).stream()
             .map(GamePlayer::getUnitCollection)
@@ -437,7 +439,7 @@ public final class AirMovementValidator {
                 .getRouteForUnits(
                     carrierSpot,
                     landingSpot,
-                    Matches.seaCanMoveOver(player, data),
+                    Matches.seaCanMoveOver(player, data.getProperties()),
                     ownedCarriersInCarrierSpot,
                     player);
         if (toLandingSpot == null) {
@@ -842,7 +844,8 @@ public final class AirMovementValidator {
   }
 
   private static boolean areNeutralsPassableByAir(final GameData data) {
-    return Properties.getNeutralFlyoverAllowed(data) && !Properties.getNeutralsImpassable(data);
+    return Properties.getNeutralFlyoverAllowed(data.getProperties())
+        && !Properties.getNeutralsImpassable(data.getProperties());
   }
 
   private static int getNeutralCharge(final GameData data, final Route route) {
@@ -850,6 +853,6 @@ public final class AirMovementValidator {
   }
 
   private static int getNeutralCharge(final GameData data, final int numberOfTerritories) {
-    return numberOfTerritories * Properties.getNeutralCharge(data);
+    return numberOfTerritories * Properties.getNeutralCharge(data.getProperties());
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
@@ -248,7 +248,7 @@ public class MoveValidator {
     if (getEditMode(data)) {
       return result;
     }
-    if (!Properties.getUseFuelCost(data)) {
+    if (!Properties.getUseFuelCost(data.getProperties())) {
       return result;
     }
     final ResourceCollection fuelCost = Route.getMovementFuelCostCharge(units, route, player, data);
@@ -303,8 +303,10 @@ public class MoveValidator {
           }
           failureMessage = canPassThroughCanal(canalAttachment, unit, player);
           final boolean canPass = failureMessage.isEmpty();
-          if ((!Properties.getControlAllCanalsBetweenTerritoriesToPass(data) && canPass)
-              || (Properties.getControlAllCanalsBetweenTerritoriesToPass(data) && !canPass)) {
+          if ((!Properties.getControlAllCanalsBetweenTerritoriesToPass(data.getProperties())
+                  && canPass)
+              || (Properties.getControlAllCanalsBetweenTerritoriesToPass(data.getProperties())
+                  && !canPass)) {
             break; // If need to control any canal and can pass OR need to control all canals and
             // can't pass
           }
@@ -358,8 +360,9 @@ public class MoveValidator {
       final Collection<Unit> unitsWithoutDependents =
           findNonDependentUnits(units, route, new HashMap<>());
       canPass = canAnyPassThroughCanal(canalAttachment, unitsWithoutDependents, player).isEmpty();
-      if ((!Properties.getControlAllCanalsBetweenTerritoriesToPass(data) && canPass)
-          || (Properties.getControlAllCanalsBetweenTerritoriesToPass(data) && !canPass)) {
+      if ((!Properties.getControlAllCanalsBetweenTerritoriesToPass(data.getProperties()) && canPass)
+          || (Properties.getControlAllCanalsBetweenTerritoriesToPass(data.getProperties())
+              && !canPass)) {
         break; // If need to control any canal and can pass OR need to control all canals and can't
         // pass
       }
@@ -492,7 +495,8 @@ public class MoveValidator {
     // check aircraft
     if (units.stream().anyMatch(Matches.unitIsAir())
         && route.hasSteps()
-        && (!Properties.getNeutralFlyoverAllowed(data) || Properties.getNeutralsImpassable(data))
+        && (!Properties.getNeutralFlyoverAllowed(data.getProperties())
+            || Properties.getNeutralsImpassable(data.getProperties()))
         && route.getMiddleSteps().stream().anyMatch(Matches.territoryIsNeutralButNotWater())) {
       return result.setErrorReturnResult("Air units cannot fly over neutral territories");
     }
@@ -544,15 +548,17 @@ public class MoveValidator {
     if (route.anyMatch(Matches.territoryIsImpassable())) {
       return result.setErrorReturnResult(CANT_MOVE_THROUGH_IMPASSABLE);
     }
-    if (!route.anyMatch(Matches.territoryIsPassableAndNotRestricted(player, data))) {
+    if (!route.anyMatch(
+        Matches.territoryIsPassableAndNotRestricted(player, data.getProperties()))) {
       return result.setErrorReturnResult(CANT_MOVE_THROUGH_RESTRICTED);
     }
     final Predicate<Territory> neutralOrEnemy =
         Matches.territoryIsNeutralButNotWater()
             .or(Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(player, data));
     final boolean navalMayNotNonComIntoControlled =
-        Properties.getWW2V2(data)
-            || Properties.getNavalUnitsMayNotNonCombatMoveIntoControlledSeaZones(data);
+        Properties.getWW2V2(data.getProperties())
+            || Properties.getNavalUnitsMayNotNonCombatMoveIntoControlledSeaZones(
+                data.getProperties());
     // TODO need to account for subs AND transports that are ignored, not just OR
     final Territory end = route.getEnd();
     if (neutralOrEnemy.test(end)) {
@@ -575,7 +581,7 @@ public class MoveValidator {
             .anyMatch(Matches.enemyUnit(player, data).and(Matches.unitIsSubmerged().negate()))
         && !onlyIgnoredUnitsOnPath(route, player, false)
         && !(end.isWater() && units.stream().allMatch(Matches.unitIsAir()))
-        && !(Properties.getSubsCanEndNonCombatMoveWithEnemies(data)
+        && !(Properties.getSubsCanEndNonCombatMoveWithEnemies(data.getProperties())
             && units.stream().allMatch(Matches.unitCanMoveThroughEnemies()))) {
       return result.setErrorReturnResult("Cannot advance to battle in non combat");
     }
@@ -590,8 +596,8 @@ public class MoveValidator {
       // otherwise we can generally fly over anything in noncombat
       if (route.anyMatch(
               Matches.territoryIsNeutralButNotWater().and(Matches.territoryIsWater().negate()))
-          && (!Properties.getNeutralFlyoverAllowed(data)
-              || Properties.getNeutralsImpassable(data))) {
+          && (!Properties.getNeutralFlyoverAllowed(data.getProperties())
+              || Properties.getNeutralsImpassable(data.getProperties()))) {
         return result.setErrorReturnResult(
             "Air units cannot fly over neutral territories in non combat");
       }
@@ -620,7 +626,7 @@ public class MoveValidator {
     if (getEditMode(data)) {
       return result;
     }
-    if (!Properties.getMovementByTerritoryRestricted(data)) {
+    if (!Properties.getMovementByTerritoryRestricted(data.getProperties())) {
       return result;
     }
     final RulesAttachment ra =
@@ -834,7 +840,7 @@ public class MoveValidator {
     if (canCrossNeutralTerritory(route, player, result).getError() != null) {
       return result;
     }
-    if (Properties.getNeutralsImpassable(data)
+    if (Properties.getNeutralsImpassable(data.getProperties())
         && !isNeutralsBlitzable(data)
         && !route.getMatches(Matches.territoryIsNeutralButNotWater()).isEmpty()) {
       return result.setErrorReturnResult(CANNOT_VIOLATE_NEUTRALITY);
@@ -965,7 +971,8 @@ public class MoveValidator {
             .or(Matches.unitCanBeMovedThroughByEnemies())
             .or(Matches.enemyUnit(player, data).negate());
     final Predicate<Unit> transportOrSubOnly = transportOnly.or(subOnly);
-    final boolean getIgnoreTransportInMovement = Properties.getIgnoreTransportInMovement(data);
+    final boolean getIgnoreTransportInMovement =
+        Properties.getIgnoreTransportInMovement(data.getProperties());
     final List<Territory> steps;
     if (ignoreRouteEnd) {
       steps = route.getMiddleSteps();
@@ -1168,10 +1175,10 @@ public class MoveValidator {
       }
       final Collection<Unit> transports = TransportUtils.mapTransports(route, units, null).values();
       final boolean isScramblingOrKamikazeAttacksEnabled =
-          Properties.getScrambleRulesInEffect(data)
-              || Properties.getUseKamikazeSuicideAttacks(data);
+          Properties.getScrambleRulesInEffect(data.getProperties())
+              || Properties.getUseKamikazeSuicideAttacks(data.getProperties());
       final boolean subsPreventUnescortedAmphibAssaults =
-          Properties.getSubmarinesPreventUnescortedAmphibiousAssaults(data);
+          Properties.getSubmarinesPreventUnescortedAmphibiousAssaults(data.getProperties());
       final Predicate<Unit> enemySubMatch =
           Matches.unitIsEnemyOf(data, player).and(Matches.unitCanBeMovedThroughByEnemies());
       final Predicate<Unit> ownedSeaNonTransportMatch =
@@ -1294,7 +1301,7 @@ public class MoveValidator {
       }
       final Predicate<Unit> enemyNonSubmerged =
           Matches.enemyUnit(player, data).and(Matches.unitIsSubmerged().negate());
-      if (!Properties.getUnitsCanLoadInHostileSeaZones(data)
+      if (!Properties.getUnitsCanLoadInHostileSeaZones(data.getProperties())
           && route.getEnd().getUnitCollection().anyMatch(enemyNonSubmerged)
           && nonParatroopersPresent(player, landAndAir)
           && !onlyIgnoredUnitsOnPath(route, player, false)
@@ -1441,7 +1448,7 @@ public class MoveValidator {
         || units.stream().noneMatch(Matches.unitIsAirTransport())) {
       return result;
     }
-    if (nonCombat && !Properties.getParatroopersCanMoveDuringNonCombat(data)) {
+    if (nonCombat && !Properties.getParatroopersCanMoveDuringNonCombat(data.getProperties())) {
       return result.setErrorReturnResult("Paratroops may not move during NonCombat");
     }
     if (!getEditMode(data)) {
@@ -1475,17 +1482,17 @@ public class MoveValidator {
           result.addDisallowedUnit("Cannot paratroop units that have already moved", paratroop);
         }
         if (Matches.isTerritoryFriendly(player, data).test(routeEnd)
-            && !Properties.getParatroopersCanMoveDuringNonCombat(data)) {
+            && !Properties.getParatroopersCanMoveDuringNonCombat(data.getProperties())) {
           result.addDisallowedUnit("Paratroops must advance to battle", paratroop);
         }
         if (!nonCombat
             && Matches.isTerritoryFriendly(player, data).test(routeEnd)
-            && Properties.getParatroopersCanMoveDuringNonCombat(data)) {
+            && Properties.getParatroopersCanMoveDuringNonCombat(data.getProperties())) {
           result.addDisallowedUnit(
               "Paratroops may only airlift during Non-Combat Movement Phase", paratroop);
         }
       }
-      if (!Properties.getParatroopersCanAttackDeepIntoEnemyTerritory(data)) {
+      if (!Properties.getParatroopersCanAttackDeepIntoEnemyTerritory(data.getProperties())) {
         for (final Territory current :
             CollectionUtils.getMatches(route.getMiddleSteps(), Matches.territoryIsLand())) {
           if (Matches.isTerritoryEnemy(player, data).test(current)) {
@@ -1695,11 +1702,12 @@ public class MoveValidator {
     final boolean hasLand = units.stream().anyMatch(Matches.unitIsLand());
     final boolean hasAir = units.stream().anyMatch(Matches.unitIsAir());
     final boolean isNeutralsImpassable =
-        Properties.getNeutralsImpassable(data)
-            || (hasAir && !Properties.getNeutralFlyoverAllowed(data));
+        Properties.getNeutralsImpassable(data.getProperties())
+            || (hasAir && !Properties.getNeutralFlyoverAllowed(data.getProperties()));
     final Predicate<Territory> noNeutral = Matches.territoryIsNeutralButNotWater().negate();
     final Predicate<Territory> noImpassableOrRestrictedOrNeutral =
-        PredicateBuilder.of(Matches.territoryIsPassableAndNotRestricted(player, data))
+        PredicateBuilder.of(
+                Matches.territoryIsPassableAndNotRestricted(player, data.getProperties()))
             .and(Matches.territoryEffectsAllowUnits(units))
             .andIf(hasAir, Matches.territoryAllowsCanMoveAirUnitsOverOwnedLand(player, data))
             .andIf(hasLand, Matches.territoryAllowsCanMoveLandUnitsOverOwnedLand(player, data))
@@ -1833,10 +1841,11 @@ public class MoveValidator {
   }
 
   private static boolean isNeutralsBlitzable(final GameData data) {
-    return Properties.getNeutralsBlitzable(data) && !Properties.getNeutralsImpassable(data);
+    return Properties.getNeutralsBlitzable(data.getProperties())
+        && !Properties.getNeutralsImpassable(data.getProperties());
   }
 
   private static int getNeutralCharge(final GameData data, final int numberOfTerritories) {
-    return numberOfTerritories * Properties.getNeutralCharge(data);
+    return numberOfTerritories * Properties.getNeutralCharge(data.getProperties());
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AirBattleDefenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AirBattleDefenseCombatValue.java
@@ -51,7 +51,8 @@ class AirBattleDefenseCombatValue implements CombatValue {
 
   @Override
   public boolean chooseBestRoll(final Unit unit) {
-    return Properties.getLhtrHeavyBombers(gameData) || unit.getUnitAttachment().getChooseBestRoll();
+    return Properties.getLhtrHeavyBombers(gameData.getProperties())
+        || unit.getUnitAttachment().getChooseBestRoll();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AirBattleOffenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AirBattleOffenseCombatValue.java
@@ -51,7 +51,8 @@ class AirBattleOffenseCombatValue implements CombatValue {
 
   @Override
   public boolean chooseBestRoll(final Unit unit) {
-    return Properties.getLhtrHeavyBombers(gameData) || unit.getUnitAttachment().getChooseBestRoll();
+    return Properties.getLhtrHeavyBombers(gameData.getProperties())
+        || unit.getUnitAttachment().getChooseBestRoll();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/BombardmentCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/BombardmentCombatValue.java
@@ -72,7 +72,8 @@ public class BombardmentCombatValue implements CombatValue {
 
   @Override
   public boolean chooseBestRoll(final Unit unit) {
-    return Properties.getLhtrHeavyBombers(gameData) || unit.getUnitAttachment().getChooseBestRoll();
+    return Properties.getLhtrHeavyBombers(gameData.getProperties())
+        || unit.getUnitAttachment().getChooseBestRoll();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainDefenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainDefenseCombatValue.java
@@ -73,7 +73,8 @@ class MainDefenseCombatValue implements CombatValue {
 
   @Override
   public boolean chooseBestRoll(final Unit unit) {
-    return Properties.getLhtrHeavyBombers(gameData) || unit.getUnitAttachment().getChooseBestRoll();
+    return Properties.getLhtrHeavyBombers(gameData.getProperties())
+        || unit.getUnitAttachment().getChooseBestRoll();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainOffenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainOffenseCombatValue.java
@@ -72,7 +72,8 @@ class MainOffenseCombatValue implements CombatValue {
 
   @Override
   public boolean chooseBestRoll(final Unit unit) {
-    return Properties.getLhtrHeavyBombers(gameData) || unit.getUnitAttachment().getChooseBestRoll();
+    return Properties.getLhtrHeavyBombers(gameData.getProperties())
+        || unit.getUnitAttachment().getChooseBestRoll();
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -160,7 +160,7 @@ class BattleCalculatorPanel extends JPanel {
     numRuns.setMax(20000);
 
     final int simulationCount =
-        Properties.getLowLuck(data)
+        Properties.getLowLuck(data.getProperties())
             ? ClientSetting.battleCalcSimulationCountLowLuck.getValueOrThrow()
             : ClientSetting.battleCalcSimulationCountDice.getValueOrThrow();
     numRuns.setValue(simulationCount);
@@ -1208,7 +1208,7 @@ class BattleCalculatorPanel extends JPanel {
                   attacking.removeAll(bombarding);
                   final int numLandUnits =
                       CollectionUtils.countMatches(attacking, Matches.unitIsLand());
-                  if (Properties.getShoreBombardPerGroundUnitRestricted(data)
+                  if (Properties.getShoreBombardPerGroundUnitRestricted(data.getProperties())
                       && numLandUnits < bombarding.size()) {
                     BattleDelegate.sortUnitsToBombard(bombarding);
                     // Create new list as needs to be serializable which subList isn't
@@ -1499,8 +1499,8 @@ class BattleCalculatorPanel extends JPanel {
     data.acquireReadLock();
     try {
       return isLand
-          ? Properties.getLandBattleRounds(data) > 0
-          : Properties.getSeaBattleRounds(data) > 0;
+          ? Properties.getLandBattleRounds(data.getProperties()) > 0
+          : Properties.getSeaBattleRounds(data.getProperties()) > 0;
     } finally {
       data.releaseReadLock();
     }

--- a/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -910,7 +910,7 @@ class EditPanel extends ActionPanel {
     add(new JButton(delUnitsAction));
     add(new JButton(changeTerritoryOwnerAction));
     add(new JButton(changePUsAction));
-    if (Properties.getTechDevelopment(getData())) {
+    if (Properties.getTechDevelopment(getData().getProperties())) {
       add(new JButton(addTechAction));
       add(new JButton(removeTechAction));
     }
@@ -920,7 +920,7 @@ class EditPanel extends ActionPanel {
       if (allUnitTypes.stream().anyMatch(Matches.unitTypeHasMoreThanOneHitPointTotal())) {
         add(new JButton(changeUnitHitDamageAction));
       }
-      if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)
+      if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data.getProperties())
           && allUnitTypes.stream().anyMatch(Matches.unitTypeCanBeDamaged())) {
         add(new JButton(changeUnitBombingDamageAction));
       }

--- a/game-core/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ExtendedStats.java
@@ -67,7 +67,7 @@ public class ExtendedStats extends StatPanel {
       this.statsExtended = statsExtended.toArray(new IStat[0]);
     }
     // add tech related stuff
-    if (Properties.getTechDevelopment(data)) {
+    if (Properties.getTechDevelopment(data.getProperties())) {
       // add tech tokens
       if (data.getResourceList().getResource(Constants.TECH_TOKENS) != null) {
         final List<IStat> statsExtended = new ArrayList<>(List.of(this.statsExtended));

--- a/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -228,9 +228,9 @@ class PlacePanel extends AbstractMovePanel implements GameDataChangeListener {
       // get the units that can be placed on this territory.
       Collection<Unit> units = getCurrentPlayer().getUnits();
       if (territory.isWater()) {
-        if (!(Properties.getProduceFightersOnCarriers(getData())
-            || Properties.getProduceNewFightersOnOldCarriers(getData())
-            || Properties.getLhtrCarrierProductionRules(getData())
+        if (!(Properties.getProduceFightersOnCarriers(getData().getProperties())
+            || Properties.getProduceNewFightersOnOldCarriers(getData().getProperties())
+            || Properties.getLhtrCarrierProductionRules(getData().getProperties())
             || GameStepPropertiesHelper.isBid(getData()))) {
           units = CollectionUtils.getMatches(units, Matches.unitIsSea());
         } else {

--- a/game-core/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
@@ -123,7 +123,7 @@ class ProductionRepairPanel extends JPanel {
       final Collection<GamePlayer> allowedPlayersToRepair,
       final GameData data,
       final Map<Unit, IntegerMap<RepairRule>> initialPurchase) {
-    if (!Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)) {
+    if (!Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data.getProperties())) {
       return;
     }
     this.data.acquireReadLock();

--- a/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
@@ -147,7 +147,8 @@ public class PurchasePanel extends ActionPanel {
     }
     // give a warning if the
     // player tries to produce too much
-    if (Properties.getWW2V2(getData()) || Properties.getPlacementRestrictedByFactory(getData())) {
+    if (Properties.getWW2V2(getData().getProperties())
+        || Properties.getPlacementRestrictedByFactory(getData().getProperties())) {
       getData().acquireReadLock();
       int totalProd = 0;
       try {

--- a/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
@@ -177,7 +177,7 @@ public class SimpleUnitPanel extends JPanel {
       repairRules.addAll(rules.keySet());
       for (final RepairRule repairRule : repairRules) {
         // check to see if the repair rule matches the damaged unit
-        if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)
+        if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data.getProperties())
             && unit.getType().equals(repairRule.getResults().keySet().iterator().next())) {
           addUnits(
               player,

--- a/game-core/src/main/java/games/strategy/triplea/ui/TechPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TechPanel.java
@@ -52,9 +52,9 @@ class TechPanel extends ActionPanel {
           "Roll Tech...",
           e -> {
             TechAdvance advance = null;
-            if (Properties.getWW2V2(getData())
-                || (Properties.getSelectableTechRoll(getData())
-                    && !Properties.getWW2V3TechModel(getData()))) {
+            if (Properties.getWW2V2(getData().getProperties())
+                || (Properties.getSelectableTechRoll(getData().getProperties())
+                    && !Properties.getWW2V3TechModel(getData().getProperties()))) {
               final List<TechAdvance> available = getAvailableTechs();
               if (available.isEmpty()) {
                 JOptionPane.showMessageDialog(TechPanel.this, "No more available tech advances");
@@ -230,7 +230,7 @@ class TechPanel extends ActionPanel {
           removeAll();
           actionLabel.setText(gamePlayer.getName() + " Tech Roll");
           add(actionLabel);
-          if (Properties.getWW2V3TechModel(getData())) {
+          if (Properties.getWW2V3TechModel(getData().getProperties())) {
             add(new JButton(getTechTokenAction));
             add(new JButton(justRollTech));
           } else {

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -994,8 +994,8 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
     }
     sb.append("</ul></html>");
     final boolean lhtrProd =
-        Properties.getLhtrCarrierProductionRules(data)
-            || Properties.getLandExistingFightersOnNewCarriers(data);
+        Properties.getLhtrCarrierProductionRules(data.getProperties())
+            || Properties.getLandExistingFightersOnNewCarriers(data.getProperties());
     final int carrierCount =
         GameStepPropertiesHelper.getCombinedTurns(data, gamePlayer).stream()
             .map(GamePlayer::getUnitCollection)
@@ -1130,11 +1130,15 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
   public boolean getStrategicBombingRaid(final Territory location) {
     messageAndDialogThreadPool.waitForAll();
     final String message =
-        (Properties.getRaidsMayBePreceededByAirBattles(data) ? "Bomb/Escort" : "Bomb")
+        (Properties.getRaidsMayBePreceededByAirBattles(data.getProperties())
+                ? "Bomb/Escort"
+                : "Bomb")
             + " in "
             + location.getName();
     final String bomb =
-        (Properties.getRaidsMayBePreceededByAirBattles(data) ? "Bomb/Escort" : "Bomb");
+        (Properties.getRaidsMayBePreceededByAirBattles(data.getProperties())
+            ? "Bomb/Escort"
+            : "Bomb");
     final String normal = "Attack";
     final String[] choices = {bomb, normal};
     int choice = -1;

--- a/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
@@ -279,7 +279,8 @@ public class MovePanel extends AbstractMovePanel {
             mouseLastUpdatePoint = mouseDetails.getMapPoint();
             final Route route = getRoute(getFirstSelectedTerritory(), t, selectedUnits);
             // Load Bombers with paratroops
-            if ((!nonCombat || Properties.getParatroopersCanMoveDuringNonCombat(getData()))
+            if ((!nonCombat
+                    || Properties.getParatroopersCanMoveDuringNonCombat(getData().getProperties()))
                 && TechAttachment.isAirTransportable(getCurrentPlayer())
                 && selectedUnits.stream()
                     .anyMatch(Matches.unitIsAirTransport().and(Matches.unitHasNotMoved()))) {
@@ -618,7 +619,7 @@ public class MovePanel extends AbstractMovePanel {
           if (!ClientSetting.showBetaFeatures.getValueOrThrow() || !willStartBattle(territory)) {
             return true;
           }
-          if (!Properties.getScrambleRulesInEffect(getData())) {
+          if (!Properties.getScrambleRulesInEffect(getData().getProperties())) {
             return true;
           }
           final var scrambleLogic = new ScrambleLogic(getData(), getCurrentPlayer(), territory);
@@ -1001,7 +1002,7 @@ public class MovePanel extends AbstractMovePanel {
      * if you do not have selection of zero-movement units enabled,
      * this will restrict selection to units with 1 or more movement
      */
-    if (!Properties.getSelectableZeroMovementUnits(getData())) {
+    if (!Properties.getSelectableZeroMovementUnits(getData().getProperties())) {
       movableBuilder.and(Matches.unitCanMove());
     }
     if (!nonCombat) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -226,7 +226,7 @@ public class UnitsDrawer extends AbstractDrawable {
     }
     displayHitDamage(bounds, graphics);
     // Display Factory Damage
-    if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data)
+    if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data.getProperties())
         && Matches.unitTypeCanBeDamaged().test(type)) {
       displayFactoryDamage(bounds, graphics);
     }

--- a/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/KamikazeZoneDrawable.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/KamikazeZoneDrawable.java
@@ -35,7 +35,7 @@ public class KamikazeZoneDrawable extends AbstractDrawable {
     final Territory terr = data.getMap().getTerritory(location);
     final TerritoryAttachment ta = TerritoryAttachment.get(terr);
     GamePlayer owner;
-    if (Properties.getKamikazeSuicideAttacksDoneByCurrentTerritoryOwner(data)) {
+    if (Properties.getKamikazeSuicideAttacksDoneByCurrentTerritoryOwner(data.getProperties())) {
       owner = terr.getOwner();
       if (owner == null) {
         owner = GamePlayer.NULL_PLAYERID;

--- a/game-core/src/main/java/games/strategy/triplea/util/BonusIncomeUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/BonusIncomeUtils.java
@@ -22,10 +22,11 @@ public final class BonusIncomeUtils {
     final StringBuilder sb = new StringBuilder();
     for (final Resource resource : income.keySet()) {
       final int amount = income.getInt(resource);
-      final int incomePercent = Properties.getIncomePercentage(player, bridge.getData());
+      final int incomePercent =
+          Properties.getIncomePercentage(player, bridge.getData().getProperties());
       int puIncomeBonus = 0;
       if (resource.getName().equals(Constants.PUS)) {
-        puIncomeBonus = Properties.getPuIncomeBonus(player, bridge.getData());
+        puIncomeBonus = Properties.getPuIncomeBonus(player, bridge.getData().getProperties());
       }
       final int bonusIncome =
           (int) Math.round(((double) amount * (double) (incomePercent - 100) / 100))


### PR DESCRIPTION
This allows callers to Properties not have to use a `GameData`.  Several methods in `Matches` have been changed to only accept a `GameProperties` instead of `GameData`.  There is probably more places where `GameProperties` can be used instead of `GameData` but that can be worked on as they are found.

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
