### PR TITLE
Use BattleState.Side instead of a boolean flag

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOption.java
@@ -13,6 +13,7 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TechTracker;
+import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.power.calculator.SupportCalculator;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -282,7 +283,11 @@ public class ProPurchaseOption {
     units.addAll(unitsToPlace);
     units.addAll(unitType.create(1, player, true));
     final SupportCalculator availableSupports =
-        new SupportCalculator(units, data.getUnitTypeList().getSupportRules(), defense, true);
+        new SupportCalculator(
+            units,
+            data.getUnitTypeList().getSupportRules(),
+            defense ? BattleState.Side.DEFENSE : BattleState.Side.OFFENSE,
+            true);
 
     double totalSupportFactor = 0;
     for (final UnitSupportAttachment usa : unitSupportAttachments) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
@@ -13,6 +13,7 @@ import games.strategy.triplea.ai.pro.data.ProTerritory;
 import games.strategy.triplea.ai.pro.logging.ProLogger;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
+import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator;
 import games.strategy.triplea.delegate.battle.casualty.CasualtyUtil;
 import games.strategy.triplea.delegate.power.calculator.CombatValue;
@@ -64,7 +65,11 @@ public final class ProBattleUtils {
                 proData.getUnitValueMap(),
                 data,
                 CombatValue.buildMainCombatValue(
-                    List.of(), List.of(), false, data, TerritoryEffectHelper.getEffects(t)))
+                    List.of(),
+                    List.of(),
+                    BattleState.Side.OFFENSE,
+                    data,
+                    TerritoryEffectHelper.getEffects(t)))
             .reversed());
     final int attackPower =
         PowerStrengthAndRolls.build(
@@ -72,7 +77,7 @@ public final class ProBattleUtils {
                 CombatValue.buildMainCombatValue(
                     defendingUnits,
                     sortedUnitsList,
-                    false,
+                    BattleState.Side.OFFENSE,
                     data,
                     TerritoryEffectHelper.getEffects(t)))
             .calculateTotalPower();
@@ -153,7 +158,11 @@ public final class ProBattleUtils {
                 proData.getUnitValueMap(),
                 data,
                 CombatValue.buildMainCombatValue(
-                    List.of(), List.of(), !attacking, data, TerritoryEffectHelper.getEffects(t)))
+                    List.of(),
+                    List.of(),
+                    attacking ? BattleState.Side.OFFENSE : BattleState.Side.DEFENSE,
+                    data,
+                    TerritoryEffectHelper.getEffects(t)))
             .reversed());
     final int myPower =
         PowerStrengthAndRolls.build(
@@ -161,7 +170,7 @@ public final class ProBattleUtils {
                 CombatValue.buildMainCombatValue(
                     enemyUnits,
                     sortedUnitsList,
-                    !attacking,
+                    attacking ? BattleState.Side.OFFENSE : BattleState.Side.DEFENSE,
                     data,
                     TerritoryEffectHelper.getEffects(t)))
             .calculateTotalPower();

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
@@ -11,6 +11,7 @@ import games.strategy.triplea.ai.pro.data.ProTerritory;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
+import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator;
 import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.delegate.power.calculator.PowerStrengthAndRolls;
@@ -204,7 +205,8 @@ public final class ProSortMoveOptionsUtils {
           new UnitBattleComparator(
               proData.getUnitValueMap(),
               data,
-              CombatValue.buildMainCombatValue(List.of(), List.of(), false, data, effects));
+              CombatValue.buildMainCombatValue(
+                  List.of(), List.of(), BattleState.Side.OFFENSE, data, effects));
 
       final List<Unit> defendingUnits =
           t.getUnitCollection().getMatches(Matches.enemyUnit(player, data));
@@ -221,7 +223,7 @@ public final class ProSortMoveOptionsUtils {
                 * PowerStrengthAndRolls.build(
                         sortedUnits,
                         CombatValue.buildMainCombatValue(
-                            defendingUnits, sortedUnits, false, data, effects))
+                            defendingUnits, sortedUnits, BattleState.Side.OFFENSE, data, effects))
                     .calculateTotalPower();
       }
       if (powerDifference < minPower) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
@@ -12,6 +12,7 @@ import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.TechAbilityAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.battle.BattleDelegate;
+import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.BattleTracker;
 import games.strategy.triplea.delegate.battle.casualty.AaCasualtySelector;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
@@ -121,7 +122,7 @@ class AaInMoveUtil implements Serializable {
                         currentPossibleAa,
                         AaInMoveUtil.this.bridge,
                         territory,
-                        true));
+                        BattleState.Side.DEFENSE));
               }
             }
           };
@@ -331,10 +332,11 @@ class AaInMoveUtil implements Serializable {
             CombatValue.buildMainCombatValue(
                 allEnemyUnits,
                 allFriendlyUnits,
-                false,
+                BattleState.Side.OFFENSE,
                 bridge.getData(),
                 TerritoryEffectHelper.getEffects(territory)),
-            CombatValue.buildAaCombatValue(allFriendlyUnits, allEnemyUnits, true, bridge.getData()),
+            CombatValue.buildAaCombatValue(
+                allFriendlyUnits, allEnemyUnits, BattleState.Side.DEFENSE, bridge.getData()),
             "Select "
                 + dice.getHits()
                 + " casualties from "

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -12,6 +12,7 @@ import games.strategy.engine.random.IRandomStats.DiceType;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Die.DieType;
+import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.power.calculator.AaPowerStrengthAndRolls;
 import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.delegate.power.calculator.PowerStrengthAndRolls;
@@ -82,14 +83,14 @@ public class DiceRoll implements Externalizable {
       final Collection<Unit> aaUnits,
       final IDelegateBridge bridge,
       final Territory location,
-      final boolean defending) {
+      final BattleState.Side side) {
 
     return rollAa(
         validTargets,
         aaUnits,
         bridge,
         location,
-        CombatValue.buildAaCombatValue(List.of(), List.of(), defending, bridge.getData()));
+        CombatValue.buildAaCombatValue(List.of(), List.of(), side, bridge.getData()));
   }
 
   /**
@@ -270,17 +271,17 @@ public class DiceRoll implements Externalizable {
   /**
    * Sorts the specified collection of units in ascending order of their attack or defense strength.
    *
-   * @param defending {@code true} if the units should be sorted by their defense strength;
-   *     otherwise the units will be sorted by their attack strength.
+   * @param side {@code DEFENSE} if the units should be sorted by their defense strength; otherwise
+   *     the units will be sorted by their attack strength.
    */
-  public static void sortByStrength(final List<Unit> units, final boolean defending) {
+  public static void sortByStrength(final List<Unit> units, final BattleState.Side side) {
     // Pre-compute unit strength information to speed up the sort.
     final Table<UnitType, GamePlayer, Integer> strengthTable = HashBasedTable.create();
     for (final Unit unit : units) {
       final UnitType type = unit.getType();
       final GamePlayer owner = unit.getOwner();
       if (!strengthTable.contains(type, owner)) {
-        if (defending) {
+        if (side == BattleState.Side.DEFENSE) {
           strengthTable.put(type, owner, UnitAttachment.get(type).getDefense(owner));
         } else {
           strengthTable.put(type, owner, UnitAttachment.get(type).getAttack(owner));
@@ -394,7 +395,7 @@ public class DiceRoll implements Externalizable {
 
     final List<Unit> units = new ArrayList<>(unitsList);
     final GameData data = bridge.getData();
-    sortByStrength(units, combatValueCalculator.isDefending());
+    sortByStrength(units, combatValueCalculator.getBattleSide());
     final PowerStrengthAndRolls unitPowerAndRollsMap =
         PowerStrengthAndRolls.build(units, combatValueCalculator);
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
@@ -695,7 +695,8 @@ public class AirBattle extends AbstractBattle {
                       attacker,
                       bridge,
                       "Attackers Fire, ",
-                      CombatValue.buildAirBattleCombatValue(false, bridge.getData()));
+                      CombatValue.buildAirBattleCombatValue(
+                          BattleState.Side.OFFENSE, bridge.getData()));
             }
           };
       final IExecutable calculateCasualties =
@@ -709,7 +710,11 @@ public class AirBattle extends AbstractBattle {
                       defender,
                       defendingUnits,
                       CombatValue.buildMainCombatValue(
-                          attackingUnits, defendingUnits, true, bridge.getData(), List.of()),
+                          attackingUnits,
+                          defendingUnits,
+                          BattleState.Side.DEFENSE,
+                          bridge.getData(),
+                          List.of()),
                       battleSite,
                       bridge,
                       ATTACKERS_FIRE,
@@ -761,7 +766,8 @@ public class AirBattle extends AbstractBattle {
                       defender,
                       bridge,
                       "Defenders Fire, ",
-                      CombatValue.buildAirBattleCombatValue(true, bridge.getData()));
+                      CombatValue.buildAirBattleCombatValue(
+                          BattleState.Side.DEFENSE, bridge.getData()));
             }
           };
       final IExecutable calculateCasualties =
@@ -775,7 +781,11 @@ public class AirBattle extends AbstractBattle {
                       attacker,
                       attackingUnits,
                       CombatValue.buildMainCombatValue(
-                          defendingUnits, attackingUnits, false, bridge.getData(), List.of()),
+                          defendingUnits,
+                          attackingUnits,
+                          BattleState.Side.OFFENSE,
+                          bridge.getData(),
+                          List.of()),
                       battleSite,
                       bridge,
                       DEFENDERS_FIRE,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -1372,7 +1372,7 @@ public class BattleTracker implements Serializable {
                       CombatValue.buildMainCombatValue(
                           defenders,
                           sortedUnitsList,
-                          true,
+                          BattleState.Side.DEFENSE,
                           gameData,
                           TerritoryEffectHelper.getEffects(territory)))
                   .calculateTotalPower()
@@ -1403,7 +1403,7 @@ public class BattleTracker implements Serializable {
                 CombatValue.buildMainCombatValue(
                     List.of(),
                     List.of(),
-                    true,
+                    BattleState.Side.DEFENSE,
                     gameData,
                     TerritoryEffectHelper.getEffects(territory)))
             .reversed());

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
@@ -483,7 +483,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
                           currentPossibleAa,
                           bridge,
                           battleSite,
-                          true);
+                          BattleState.Side.DEFENSE);
                   if (currentTypeAa.equals("AA")) {
                     if (dice.getHits() > 0) {
                       bridge
@@ -589,7 +589,11 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           attacker,
           validAttackingUnitsForThisRoll,
           CombatValue.buildMainCombatValue(
-              defendingUnits, attackingUnits, false, bridge.getData(), territoryEffects),
+              defendingUnits,
+              attackingUnits,
+              BattleState.Side.OFFENSE,
+              bridge.getData(),
+              territoryEffects),
           battleSite,
           bridge,
           text,
@@ -604,8 +608,13 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
             validAttackingUnitsForThisRoll,
             defendingAa,
             CombatValue.buildMainCombatValue(
-                defendingUnits, attackingUnits, false, bridge.getData(), territoryEffects),
-            CombatValue.buildAaCombatValue(attackingUnits, defendingUnits, true, bridge.getData()),
+                defendingUnits,
+                attackingUnits,
+                BattleState.Side.OFFENSE,
+                bridge.getData(),
+                territoryEffects),
+            CombatValue.buildAaCombatValue(
+                attackingUnits, defendingUnits, BattleState.Side.DEFENSE, bridge.getData()),
             "Hits from " + currentTypeAa + ", ",
             dice,
             bridge,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLosses.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLosses.java
@@ -265,7 +265,7 @@ class CasualtyOrderOfLosses {
         + "|"
         + parameters.battlesite.getName()
         + "|"
-        + parameters.combatValue.isDefending()
+        + parameters.combatValue.getBattleSide()
         + "|"
         + Objects.hashCode(targetTypes);
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEnd.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEnd.java
@@ -79,7 +79,7 @@ public class CheckGeneralBattleEnd implements BattleStep {
             CombatValue.buildMainCombatValue(
                 battleState.filterUnits(ALIVE, side.getOpposite()),
                 battleState.filterUnits(ALIVE, side),
-                side == DEFENSE,
+                side,
                 battleState.getGameData(),
                 battleState.getTerritoryEffects()))
         .hasStrengthOrRolls();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/MainDiceRoller.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/MainDiceRoller.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.delegate.battle.steps.fire;
 
-import static games.strategy.triplea.delegate.battle.BattleState.Side.DEFENSE;
 import static games.strategy.triplea.delegate.battle.BattleState.UnitBattleFilter.ALIVE;
 
 import games.strategy.engine.delegate.IDelegateBridge;
@@ -25,7 +24,7 @@ public class MainDiceRoller implements BiFunction<IDelegateBridge, RollDiceStep,
         CombatValue.buildMainCombatValue(
             step.getBattleState().filterUnits(ALIVE, step.getSide().getOpposite()),
             step.getBattleState().filterUnits(ALIVE, step.getSide()),
-            step.getSide() == DEFENSE,
+            step.getSide(),
             step.getBattleState().getGameData(),
             step.getBattleState().getTerritoryEffects()));
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/SelectMainBattleCasualties.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/SelectMainBattleCasualties.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.delegate.battle.steps.fire;
 
-import static games.strategy.triplea.delegate.battle.BattleState.Side.DEFENSE;
 import static games.strategy.triplea.delegate.battle.BattleState.UnitBattleFilter.ALIVE;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -156,7 +155,7 @@ public class SelectMainBattleCasualties
           CombatValue.buildMainCombatValue(
               step.getBattleState().filterUnits(ALIVE, step.getSide()),
               step.getBattleState().filterUnits(ALIVE, step.getSide().getOpposite()),
-              step.getSide().getOpposite() == DEFENSE,
+              step.getSide().getOpposite(),
               step.getBattleState().getGameData(),
               step.getBattleState().getTerritoryEffects()),
           step.getBattleState().getBattleSite(),

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/AaFireAndCasualtyStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/AaFireAndCasualtyStep.java
@@ -1,7 +1,5 @@
 package games.strategy.triplea.delegate.battle.steps.fire.aa;
 
-import static games.strategy.triplea.delegate.battle.BattleState.Side.DEFENSE;
-import static games.strategy.triplea.delegate.battle.BattleState.Side.OFFENSE;
 import static games.strategy.triplea.delegate.battle.BattleState.UnitBattleFilter.ALIVE;
 
 import games.strategy.engine.delegate.IDelegateBridge;
@@ -74,13 +72,13 @@ public abstract class AaFireAndCasualtyStep implements BattleStep {
           CombatValue.buildMainCombatValue(
               step.getBattleState().filterUnits(ALIVE, step.getSide()),
               step.getBattleState().filterUnits(ALIVE, step.getSide().getOpposite()),
-              step.getSide() == OFFENSE,
+              step.getSide().getOpposite(),
               step.getBattleState().getGameData(),
               step.getBattleState().getTerritoryEffects()),
           CombatValue.buildAaCombatValue(
               step.getBattleState().filterUnits(ALIVE, step.getSide().getOpposite()),
               step.getBattleState().filterUnits(ALIVE, step.getSide()),
-              step.getSide() == DEFENSE,
+              step.getSide(),
               step.getBattleState().getGameData()),
           "Hits from " + step.getFiringGroup().getDisplayName() + ", ",
           step.getFireRoundState().getDice(),
@@ -104,7 +102,7 @@ public abstract class AaFireAndCasualtyStep implements BattleStep {
               CombatValue.buildAaCombatValue(
                   step.getBattleState().filterUnits(ALIVE, step.getSide().getOpposite()),
                   step.getBattleState().filterUnits(ALIVE, step.getSide()),
-                  step.getSide() == DEFENSE,
+                  step.getSide(),
                   step.getBattleState().getGameData()));
 
       SoundUtils.playFireBattleAa(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaDefenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaDefenseCombatValue.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.delegate.power.calculator;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
+import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -59,8 +60,8 @@ class AaDefenseCombatValue implements CombatValue {
   }
 
   @Override
-  public boolean isDefending() {
-    return true;
+  public BattleState.Side getBattleSide() {
+    return BattleState.Side.DEFENSE;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaOffenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaOffenseCombatValue.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.delegate.power.calculator;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
+import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -59,8 +60,8 @@ class AaOffenseCombatValue implements CombatValue {
   }
 
   @Override
-  public boolean isDefending() {
-    return false;
+  public BattleState.Side getBattleSide() {
+    return BattleState.Side.OFFENSE;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaPowerStrengthAndRolls.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaPowerStrengthAndRolls.java
@@ -102,7 +102,10 @@ public class AaPowerStrengthAndRolls implements TotalPowerAndTotalRolls {
             .sorted(
                 sortAaHighToLow(
                     CombatValue.buildAaCombatValue(
-                        List.of(), List.of(), calculator.isDefending(), calculator.getGameData())))
+                        List.of(),
+                        List.of(),
+                        calculator.getBattleSide(),
+                        calculator.getGameData())))
             .collect(Collectors.toList()),
         targetCount,
         calculator);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AirBattleDefenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AirBattleDefenseCombatValue.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.delegate.power.calculator;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.Properties;
+import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -40,8 +41,8 @@ class AirBattleDefenseCombatValue implements CombatValue {
   }
 
   @Override
-  public boolean isDefending() {
-    return false;
+  public BattleState.Side getBattleSide() {
+    return BattleState.Side.OFFENSE;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AirBattleOffenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AirBattleOffenseCombatValue.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.delegate.power.calculator;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.Properties;
+import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -40,8 +41,8 @@ class AirBattleOffenseCombatValue implements CombatValue {
   }
 
   @Override
-  public boolean isDefending() {
-    return false;
+  public BattleState.Side getBattleSide() {
+    return BattleState.Side.OFFENSE;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AvailableSupports.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AvailableSupports.java
@@ -46,7 +46,7 @@ class AvailableSupports {
 
     final SupportRuleSort supportRuleSort =
         SupportRuleSort.builder()
-            .defense(supportCalculator.isDefence())
+            .side(supportCalculator.getSide())
             .friendly(supportCalculator.isAllies())
             .roll(UnitSupportAttachment::getRoll)
             .strength(UnitSupportAttachment::getStrength)

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/BombardmentCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/BombardmentCombatValue.java
@@ -7,6 +7,7 @@ import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
+import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -66,8 +67,8 @@ public class BombardmentCombatValue implements CombatValue {
   }
 
   @Override
-  public boolean isDefending() {
-    return false;
+  public BattleState.Side getBattleSide() {
+    return BattleState.Side.OFFENSE;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/CombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/CombatValue.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.delegate.power.calculator;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
+import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.Collection;
 
 public interface CombatValue {
@@ -18,7 +19,7 @@ public interface CombatValue {
 
   int getDiceSides(Unit unit);
 
-  boolean isDefending();
+  BattleState.Side getBattleSide();
 
   boolean chooseBestRoll(Unit unit);
 
@@ -35,7 +36,7 @@ public interface CombatValue {
   static CombatValue buildMainCombatValue(
       final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie,
       final Collection<Unit> allFriendlyUnitsAliveOrWaitingToDie,
-      final boolean defending,
+      final BattleState.Side side,
       final GameData gameData,
       final Collection<TerritoryEffect> territoryEffects) {
 
@@ -45,7 +46,7 @@ public interface CombatValue {
             new SupportCalculator(
                 allFriendlyUnitsAliveOrWaitingToDie,
                 gameData.getUnitTypeList().getSupportRules(),
-                defending,
+                side,
                 true));
 
     // Get all enemy supports
@@ -54,10 +55,10 @@ public interface CombatValue {
             new SupportCalculator(
                 allEnemyUnitsAliveOrWaitingToDie,
                 gameData.getUnitTypeList().getSupportRules(),
-                !defending,
+                side.getOpposite(),
                 false));
 
-    return defending
+    return side == BattleState.Side.DEFENSE
         ? MainDefenseCombatValue.builder()
             .gameData(gameData)
             .supportFromFriends(supportFromFriends)
@@ -79,7 +80,7 @@ public interface CombatValue {
   static CombatValue buildAaCombatValue(
       final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie,
       final Collection<Unit> allFriendlyUnitsAliveOrWaitingToDie,
-      final boolean defending,
+      final BattleState.Side side,
       final GameData gameData) {
 
     // Get all friendly supports
@@ -88,7 +89,7 @@ public interface CombatValue {
             new SupportCalculator(
                 allFriendlyUnitsAliveOrWaitingToDie, //
                 gameData.getUnitTypeList().getSupportAaRules(),
-                defending,
+                side,
                 true));
 
     // Get all enemy supports
@@ -97,10 +98,10 @@ public interface CombatValue {
             new SupportCalculator(
                 allEnemyUnitsAliveOrWaitingToDie, //
                 gameData.getUnitTypeList().getSupportAaRules(),
-                !defending,
+                side.getOpposite(),
                 false));
 
-    return defending
+    return side == BattleState.Side.DEFENSE
         ? AaDefenseCombatValue.builder()
             .gameData(gameData)
             .supportFromFriends(supportFromFriends)
@@ -129,7 +130,7 @@ public interface CombatValue {
             new SupportCalculator(
                 allFriendlyUnitsAliveOrWaitingToDie,
                 gameData.getUnitTypeList().getSupportRules(),
-                false,
+                BattleState.Side.OFFENSE,
                 true));
 
     // Get all enemy supports
@@ -138,7 +139,7 @@ public interface CombatValue {
             new SupportCalculator(
                 allEnemyUnitsAliveOrWaitingToDie,
                 gameData.getUnitTypeList().getSupportRules(),
-                true,
+                BattleState.Side.DEFENSE,
                 false));
 
     return BombardmentCombatValue.builder()
@@ -151,9 +152,10 @@ public interface CombatValue {
         .build();
   }
 
-  static CombatValue buildAirBattleCombatValue(final boolean defending, final GameData gameData) {
+  static CombatValue buildAirBattleCombatValue(
+      final BattleState.Side side, final GameData gameData) {
 
-    return defending
+    return side == BattleState.Side.DEFENSE
         ? AirBattleDefenseCombatValue.builder().gameData(gameData).build()
         : AirBattleOffenseCombatValue.builder().gameData(gameData).build();
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainDefenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainDefenseCombatValue.java
@@ -9,6 +9,7 @@ import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.RulesAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
+import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -67,8 +68,8 @@ class MainDefenseCombatValue implements CombatValue {
   }
 
   @Override
-  public boolean isDefending() {
-    return true;
+  public BattleState.Side getBattleSide() {
+    return BattleState.Side.DEFENSE;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainOffenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/MainOffenseCombatValue.java
@@ -7,6 +7,7 @@ import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
+import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -66,8 +67,8 @@ class MainOffenseCombatValue implements CombatValue {
   }
 
   @Override
-  public boolean isDefending() {
-    return false;
+  public BattleState.Side getBattleSide() {
+    return BattleState.Side.OFFENSE;
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportCalculator.java
@@ -4,6 +4,7 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.Matches;
+import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -26,19 +27,19 @@ public class SupportCalculator {
 
   Map<UnitSupportAttachment.BonusType, List<UnitSupportAttachment>> supportRules;
   Map<UnitSupportAttachment, IntegerMap<Unit>> supportUnits;
-  boolean defence;
+  BattleState.Side side;
   boolean allies;
 
   /**
-   * @param defence are the receiving units defending?
+   * @param side are the receiving units defending?
    * @param allies are the receiving units allied to the giving units?
    */
   public SupportCalculator(
       final Collection<Unit> unitsGivingTheSupport,
       final Collection<UnitSupportAttachment> rules,
-      final boolean defence,
+      final BattleState.Side side,
       final boolean allies) {
-    this.defence = defence;
+    this.side = side;
     this.allies = allies;
     supportRules = new HashMap<>();
     supportUnits = new HashMap<>();
@@ -52,7 +53,8 @@ public class SupportCalculator {
       if (rule.getPlayers().isEmpty() || types == null || types.isEmpty()) {
         continue;
       }
-      if (!((defence && rule.getDefence()) || (!defence && rule.getOffence()))) {
+      if (!((side == BattleState.Side.DEFENSE && rule.getDefence())
+          || (side == BattleState.Side.OFFENSE && rule.getOffence()))) {
         continue;
       }
       if (!((allies && rule.getAllied()) || (!allies && rule.getEnemy()))) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportRuleSort.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportRuleSort.java
@@ -4,6 +4,7 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
+import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.Comparator;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -12,7 +13,7 @@ import lombok.Builder;
 
 @Builder
 class SupportRuleSort implements Comparator<UnitSupportAttachment> {
-  @Nonnull private final Boolean defense;
+  @Nonnull private final BattleState.Side side;
   @Nonnull private final Boolean friendly;
   @Nonnull private final Predicate<UnitSupportAttachment> roll;
   @Nonnull private final Predicate<UnitSupportAttachment> strength;
@@ -28,8 +29,8 @@ class SupportRuleSort implements Comparator<UnitSupportAttachment> {
     // We should actually apply enemy negative support in order from worst to least bad, on a
     // unit list that is
     // ordered from strongest to weakest.
-    final boolean u1CanBonus = defense ? u1.getDefence() : u1.getOffence();
-    final boolean u2CanBonus = defense ? u2.getDefence() : u2.getOffence();
+    final boolean u1CanBonus = side == BattleState.Side.DEFENSE ? u1.getDefence() : u1.getOffence();
+    final boolean u2CanBonus = side == BattleState.Side.DEFENSE ? u2.getDefence() : u2.getOffence();
     if (friendly) {
       // favor rolls over strength
       if (roll.test(u1) || roll.test(u2)) {

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -13,6 +13,7 @@ import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.delegate.battle.BattleDelegate;
+import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator;
 import games.strategy.triplea.delegate.battle.casualty.CasualtyUtil;
 import games.strategy.triplea.delegate.power.calculator.CombatValue;
@@ -1424,7 +1425,7 @@ class BattleCalculatorPanel extends JPanel {
                   costs,
                   data,
                   CombatValue.buildMainCombatValue(
-                      List.of(), List.of(), false, data, territoryEffects))
+                      List.of(), List.of(), BattleState.Side.OFFENSE, data, territoryEffects))
               .reversed());
       if (isAmphibiousBattle()) {
         attackers.stream()
@@ -1446,14 +1447,14 @@ class BattleCalculatorPanel extends JPanel {
           PowerStrengthAndRolls.build(
                   attackers,
                   CombatValue.buildMainCombatValue(
-                      defenders, attackers, false, data, territoryEffects))
+                      defenders, attackers, BattleState.Side.OFFENSE, data, territoryEffects))
               .calculateTotalPower();
       // defender is never amphibious
       final int defensePower =
           PowerStrengthAndRolls.build(
                   defenders,
                   CombatValue.buildMainCombatValue(
-                      attackers, defenders, true, data, territoryEffects))
+                      attackers, defenders, BattleState.Side.DEFENSE, data, territoryEffects))
               .calculateTotalPower();
       attackerUnitsTotalPower.setText("Power: " + attackPower);
       defenderUnitsTotalPower.setText("Power: " + defensePower);

--- a/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -18,6 +18,7 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TechAdvance;
 import games.strategy.triplea.delegate.TechTracker;
 import games.strategy.triplea.delegate.TechnologyDelegate;
+import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator;
 import games.strategy.triplea.delegate.data.MustMoveWithDetails;
 import games.strategy.triplea.delegate.move.validation.MoveValidator;
@@ -688,7 +689,7 @@ class EditPanel extends ActionPanel {
                         TuvUtils.getCostsForTuv(player, getData()),
                         getData(),
                         CombatValue.buildMainCombatValue(
-                            List.of(), List.of(), false, getData(), List.of()),
+                            List.of(), List.of(), BattleState.Side.OFFENSE, getData(), List.of()),
                         true)
                     .reversed());
             // unit mapped to <max, min, current>
@@ -766,7 +767,7 @@ class EditPanel extends ActionPanel {
                         TuvUtils.getCostsForTuv(player, getData()),
                         getData(),
                         CombatValue.buildMainCombatValue(
-                            List.of(), List.of(), false, getData(), List.of()),
+                            List.of(), List.of(), BattleState.Side.OFFENSE, getData(), List.of()),
                         true)
                     .reversed());
             // unit mapped to <max, min, current>

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -52,6 +52,7 @@ import games.strategy.triplea.delegate.GameStepPropertiesHelper;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.delegate.battle.AirBattle;
+import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.IBattle.BattleType;
 import games.strategy.triplea.delegate.battle.ScrambleLogic;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator;
@@ -1425,7 +1426,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
                         CombatValue.buildMainCombatValue(
                             List.of(),
                             List.of(),
-                            false,
+                            BattleState.Side.OFFENSE,
                             data,
                             TerritoryEffectHelper.getEffects(entry.getKey())),
                         true)

--- a/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -23,6 +23,7 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
+import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.StrategicBombingRaidBattle;
 import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.xml.TestMapGameData;
@@ -57,7 +58,7 @@ class DiceRollTest {
             bridge,
             "",
             CombatValue.buildMainCombatValue(
-                List.of(), infantry, true, bridge.getData(), territoryEffects));
+                List.of(), infantry, BattleState.Side.DEFENSE, bridge.getData(), territoryEffects));
     assertThat(roll.getHits(), is(1));
     // infantry
     final DiceRoll roll2 =
@@ -67,7 +68,7 @@ class DiceRollTest {
             bridge,
             "",
             CombatValue.buildMainCombatValue(
-                List.of(), infantry, true, bridge.getData(), territoryEffects));
+                List.of(), infantry, BattleState.Side.DEFENSE, bridge.getData(), territoryEffects));
     assertThat(roll2.getHits(), is(0));
     // infantry attacks
     final DiceRoll roll3 =
@@ -77,7 +78,7 @@ class DiceRollTest {
             bridge,
             "",
             CombatValue.buildMainCombatValue(
-                List.of(), infantry, false, bridge.getData(), territoryEffects));
+                List.of(), infantry, BattleState.Side.OFFENSE, bridge.getData(), territoryEffects));
     assertThat(roll3.getHits(), is(1));
     // infantry attack
     final DiceRoll roll4 =
@@ -87,7 +88,7 @@ class DiceRollTest {
             bridge,
             "",
             CombatValue.buildMainCombatValue(
-                List.of(), infantry, false, bridge.getData(), territoryEffects));
+                List.of(), infantry, BattleState.Side.OFFENSE, bridge.getData(), territoryEffects));
     assertThat(roll4.getHits(), is(0));
   }
 
@@ -114,7 +115,7 @@ class DiceRollTest {
             bridge,
             "",
             CombatValue.buildMainCombatValue(
-                List.of(), infantry, true, bridge.getData(), territoryEffects));
+                List.of(), infantry, BattleState.Side.DEFENSE, bridge.getData(), territoryEffects));
     assertThat(roll.getHits(), is(1));
     // infantry
     final DiceRoll roll2 =
@@ -124,7 +125,7 @@ class DiceRollTest {
             bridge,
             "",
             CombatValue.buildMainCombatValue(
-                List.of(), infantry, true, bridge.getData(), territoryEffects));
+                List.of(), infantry, BattleState.Side.DEFENSE, bridge.getData(), territoryEffects));
     assertThat(roll2.getHits(), is(0));
     // infantry attacks
     final DiceRoll roll3 =
@@ -134,7 +135,7 @@ class DiceRollTest {
             bridge,
             "",
             CombatValue.buildMainCombatValue(
-                List.of(), infantry, false, bridge.getData(), territoryEffects));
+                List.of(), infantry, BattleState.Side.OFFENSE, bridge.getData(), territoryEffects));
     assertThat(roll3.getHits(), is(1));
     // infantry attack
     final DiceRoll roll4 =
@@ -144,7 +145,7 @@ class DiceRollTest {
             bridge,
             "",
             CombatValue.buildMainCombatValue(
-                List.of(), infantry, false, bridge.getData(), territoryEffects));
+                List.of(), infantry, BattleState.Side.OFFENSE, bridge.getData(), territoryEffects));
     assertThat(roll4.getHits(), is(0));
   }
 
@@ -169,7 +170,7 @@ class DiceRollTest {
             CombatValue.buildMainCombatValue(
                 List.of(),
                 units,
-                false,
+                BattleState.Side.OFFENSE,
                 bridge.getData(),
                 TerritoryEffectHelper.getEffects(westRussia)));
     assertThat(roll.getHits(), is(2));
@@ -203,7 +204,7 @@ class DiceRollTest {
             CombatValue.buildMainCombatValue(
                 List.of(),
                 units,
-                false,
+                BattleState.Side.OFFENSE,
                 bridge.getData(),
                 TerritoryEffectHelper.getEffects(westRussia)));
     assertThat(roll.getHits(), is(3));
@@ -227,7 +228,7 @@ class DiceRollTest {
             CombatValue.buildMainCombatValue(
                 List.of(),
                 units,
-                true,
+                BattleState.Side.DEFENSE,
                 bridge.getData(),
                 TerritoryEffectHelper.getEffects(westRussia)));
     assertThat(roll.getHits(), is(1));
@@ -264,7 +265,7 @@ class DiceRollTest {
             CombatValue.buildMainCombatValue(
                 List.of(),
                 attackers,
-                false,
+                BattleState.Side.OFFENSE,
                 bridge.getData(),
                 TerritoryEffectHelper.getEffects(algeria)));
     assertThat(roll.getHits(), is(1));
@@ -300,7 +301,7 @@ class DiceRollTest {
             CombatValue.buildMainCombatValue(
                 List.of(),
                 attackers,
-                false,
+                BattleState.Side.OFFENSE,
                 bridge.getData(),
                 TerritoryEffectHelper.getEffects(algeria)));
     assertThat(roll.getHits(), is(1));
@@ -337,7 +338,7 @@ class DiceRollTest {
             CombatValue.buildMainCombatValue(
                 List.of(),
                 attackers,
-                false,
+                BattleState.Side.OFFENSE,
                 bridge.getData(),
                 TerritoryEffectHelper.getEffects(algeria)));
     assertThat(roll.getHits(), is(0));
@@ -363,7 +364,8 @@ class DiceRollTest {
             aaGunList,
             bridge,
             westRussia,
-            CombatValue.buildAaCombatValue(bombers, aaGunList, true, bridge.getData()));
+            CombatValue.buildAaCombatValue(
+                bombers, aaGunList, BattleState.Side.DEFENSE, bridge.getData()));
     assertThat(hit.getHits(), is(1));
     // aa misses
     final DiceRoll miss =
@@ -372,7 +374,8 @@ class DiceRollTest {
             aaGunList,
             bridge,
             westRussia,
-            CombatValue.buildAaCombatValue(bombers, aaGunList, true, bridge.getData()));
+            CombatValue.buildAaCombatValue(
+                bombers, aaGunList, BattleState.Side.DEFENSE, bridge.getData()));
     assertThat(miss.getHits(), is(0));
   }
 
@@ -402,7 +405,8 @@ class DiceRollTest {
             aaGunList,
             bridge,
             westRussia,
-            CombatValue.buildAaCombatValue(fighterList, aaGunList, true, bridge.getData()));
+            CombatValue.buildAaCombatValue(
+                fighterList, aaGunList, BattleState.Side.DEFENSE, bridge.getData()));
     assertThat(hit.getHits(), is(1));
     // aa misses
     final DiceRoll miss =
@@ -415,7 +419,8 @@ class DiceRollTest {
             aaGunList,
             bridge,
             westRussia,
-            CombatValue.buildAaCombatValue(fighterList, aaGunList, true, bridge.getData()));
+            CombatValue.buildAaCombatValue(
+                fighterList, aaGunList, BattleState.Side.DEFENSE, bridge.getData()));
     assertThat(miss.getHits(), is(0));
     // 6 bombers, 1 should hit, and nothing should be rolled
     fighterList = fighterType.create(6, russians);
@@ -429,7 +434,8 @@ class DiceRollTest {
             aaGunList,
             bridge,
             westRussia,
-            CombatValue.buildAaCombatValue(fighterList, aaGunList, true, bridge.getData()));
+            CombatValue.buildAaCombatValue(
+                fighterList, aaGunList, BattleState.Side.DEFENSE, bridge.getData()));
     assertThat(hitNoRoll.getHits(), is(1));
     thenGetRandomShouldHaveBeenCalled(bridge, times(2));
   }
@@ -458,7 +464,8 @@ class DiceRollTest {
             aaGunList,
             bridge,
             westRussia,
-            CombatValue.buildAaCombatValue(fighterList, aaGunList, true, bridge.getData()));
+            CombatValue.buildAaCombatValue(
+                fighterList, aaGunList, BattleState.Side.DEFENSE, bridge.getData()));
     assertThat(hit.getHits(), is(1));
     thenGetRandomShouldHaveBeenCalled(bridge, never());
   }
@@ -491,7 +498,8 @@ class DiceRollTest {
             aaGunList,
             bridge,
             finnland,
-            CombatValue.buildAaCombatValue(fighterList, aaGunList, true, bridge.getData()));
+            CombatValue.buildAaCombatValue(
+                fighterList, aaGunList, BattleState.Side.DEFENSE, bridge.getData()));
     assertThat(hit.getHits(), is(1));
     // aa misses
     final DiceRoll miss =
@@ -504,7 +512,8 @@ class DiceRollTest {
             aaGunList,
             bridge,
             finnland,
-            CombatValue.buildAaCombatValue(fighterList, aaGunList, true, bridge.getData()));
+            CombatValue.buildAaCombatValue(
+                fighterList, aaGunList, BattleState.Side.DEFENSE, bridge.getData()));
     assertThat(miss.getHits(), is(0));
     // 6 bombers, 2 should hit, and nothing should be rolled
     fighterList = fighterType.create(6, russians);
@@ -518,7 +527,8 @@ class DiceRollTest {
             aaGunList,
             bridge,
             finnland,
-            CombatValue.buildAaCombatValue(fighterList, aaGunList, true, bridge.getData()));
+            CombatValue.buildAaCombatValue(
+                fighterList, aaGunList, BattleState.Side.DEFENSE, bridge.getData()));
     assertThat(hitNoRoll.getHits(), is(2));
     thenGetRandomShouldHaveBeenCalled(bridge, times(2));
   }
@@ -554,7 +564,8 @@ class DiceRollTest {
             atGuns,
             bridge,
             westernFrance,
-            CombatValue.buildAaCombatValue(targets, atGuns, true, bridge.getData()));
+            CombatValue.buildAaCombatValue(
+                targets, atGuns, BattleState.Side.DEFENSE, bridge.getData()));
     assertThat(hit.getHits(), is(1));
     final DiceRoll miss =
         DiceRoll.rollAa(
@@ -562,7 +573,8 @@ class DiceRollTest {
             atGuns,
             bridge,
             westernFrance,
-            CombatValue.buildAaCombatValue(targets, atGuns, true, bridge.getData()));
+            CombatValue.buildAaCombatValue(
+                targets, atGuns, BattleState.Side.DEFENSE, bridge.getData()));
     assertThat(miss.getHits(), is(0));
 
     // 1 AT gun + 1 AT support (AT support is a unit that provides +2 AA strength for 3 units)
@@ -573,7 +585,8 @@ class DiceRollTest {
             atGuns,
             bridge,
             westernFrance,
-            CombatValue.buildAaCombatValue(targets, supportUnits, true, bridge.getData()));
+            CombatValue.buildAaCombatValue(
+                targets, supportUnits, BattleState.Side.DEFENSE, bridge.getData()));
     assertThat(hitWithSupport.getHits(), is(1));
     final DiceRoll missWithSupport =
         DiceRoll.rollAa(
@@ -581,7 +594,8 @@ class DiceRollTest {
             atGuns,
             bridge,
             westernFrance,
-            CombatValue.buildAaCombatValue(targets, supportUnits, true, bridge.getData()));
+            CombatValue.buildAaCombatValue(
+                targets, supportUnits, BattleState.Side.DEFENSE, bridge.getData()));
     assertThat(missWithSupport.getHits(), is(0));
 
     // 2 AT guns + 1 AT support
@@ -592,7 +606,8 @@ class DiceRollTest {
             atGuns,
             bridge,
             westernFrance,
-            CombatValue.buildAaCombatValue(targets, supportUnits, true, bridge.getData()));
+            CombatValue.buildAaCombatValue(
+                targets, supportUnits, BattleState.Side.DEFENSE, bridge.getData()));
     assertThat(hitWith2AtAndSupport.getHits(), is(1));
     final DiceRoll missWith2AtAndSupport =
         DiceRoll.rollAa(
@@ -600,7 +615,8 @@ class DiceRollTest {
             atGuns,
             bridge,
             westernFrance,
-            CombatValue.buildAaCombatValue(targets, supportUnits, true, bridge.getData()));
+            CombatValue.buildAaCombatValue(
+                targets, supportUnits, BattleState.Side.DEFENSE, bridge.getData()));
     assertThat(missWith2AtAndSupport.getHits(), is(0));
 
     // 2 AT guns + 1 AT support + 1 enemy AT counter (AT counter is a unit that provides -10 AA
@@ -615,7 +631,7 @@ class DiceRollTest {
             bridge,
             westernFrance,
             CombatValue.buildAaCombatValue(
-                enemySupportUnits, supportUnits, true, bridge.getData()));
+                enemySupportUnits, supportUnits, BattleState.Side.DEFENSE, bridge.getData()));
     assertThat(missWith2AtAndSupportAndEnemySupport.getHits(), is(0));
 
     // 4 AT guns + 1 AT support + 1 enemy AT counter
@@ -628,7 +644,7 @@ class DiceRollTest {
             bridge,
             westernFrance,
             CombatValue.buildAaCombatValue(
-                enemySupportUnits, supportUnits, true, bridge.getData()));
+                enemySupportUnits, supportUnits, BattleState.Side.DEFENSE, bridge.getData()));
     assertThat(hitWith4AtAndSupportAndEnemySupport.getHits(), is(1));
     final DiceRoll missWith4AtAndSupportAndEnemySupport =
         DiceRoll.rollAa(
@@ -637,7 +653,7 @@ class DiceRollTest {
             bridge,
             westernFrance,
             CombatValue.buildAaCombatValue(
-                enemySupportUnits, supportUnits, true, bridge.getData()));
+                enemySupportUnits, supportUnits, BattleState.Side.DEFENSE, bridge.getData()));
     assertThat(missWith4AtAndSupportAndEnemySupport.getHits(), is(0));
 
     thenGetRandomShouldHaveBeenCalled(bridge, times(8));
@@ -669,7 +685,7 @@ class DiceRollTest {
             CombatValue.buildMainCombatValue(
                 List.of(),
                 bombers,
-                false,
+                BattleState.Side.OFFENSE,
                 testDelegateBridge.getData(),
                 TerritoryEffectHelper.getEffects(germany)));
     assertThat(dice.getRolls(4).get(0).getType(), is(Die.DieType.HIT));
@@ -702,7 +718,7 @@ class DiceRollTest {
             CombatValue.buildMainCombatValue(
                 List.of(),
                 bombers,
-                true,
+                BattleState.Side.DEFENSE,
                 testDelegateBridge.getData(),
                 TerritoryEffectHelper.getEffects(germany)));
     assertThat(dice.getRolls(1).size(), is(1));
@@ -731,7 +747,7 @@ class DiceRollTest {
             CombatValue.buildMainCombatValue(
                 List.of(),
                 bombers,
-                true,
+                BattleState.Side.DEFENSE,
                 testDelegateBridge.getData(),
                 TerritoryEffectHelper.getEffects(germany)));
 
@@ -765,7 +781,7 @@ class DiceRollTest {
             CombatValue.buildMainCombatValue(
                 List.of(),
                 bombers,
-                false,
+                BattleState.Side.OFFENSE,
                 testDelegateBridge.getData(),
                 TerritoryEffectHelper.getEffects(germany)));
 
@@ -800,7 +816,7 @@ class DiceRollTest {
             CombatValue.buildMainCombatValue(
                 List.of(),
                 bombers,
-                false,
+                BattleState.Side.OFFENSE,
                 testDelegateBridge.getData(),
                 TerritoryEffectHelper.getEffects(germany)));
     assertThat(dice.getRolls(4).get(0).getType(), is(Die.DieType.HIT));
@@ -834,7 +850,7 @@ class DiceRollTest {
             CombatValue.buildMainCombatValue(
                 List.of(),
                 bombers,
-                true,
+                BattleState.Side.DEFENSE,
                 testDelegateBridge.getData(),
                 TerritoryEffectHelper.getEffects(germany)));
     assertThat(dice.getRolls(1).size(), is(2));

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -449,7 +449,7 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
             CombatValue.buildMainCombatValue(
                 List.of(),
                 attackList,
-                false,
+                BattleState.Side.OFFENSE,
                 bridge.getData(),
                 TerritoryEffectHelper.getEffects(balticSeaZone)));
     assertEquals(2, roll.getHits());
@@ -872,7 +872,7 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
             CombatValue.buildMainCombatValue(
                 List.of(),
                 defendList,
-                true,
+                BattleState.Side.DEFENSE,
                 bridge.getData(),
                 TerritoryEffectHelper.getEffects(balticSeaZone)));
     assertEquals(0, roll.getHits());
@@ -945,7 +945,7 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
             CombatValue.buildMainCombatValue(
                 List.of(),
                 defendList,
-                true,
+                BattleState.Side.DEFENSE,
                 bridge.getData(),
                 TerritoryEffectHelper.getEffects(balticSeaZone)));
     assertEquals(1, roll.getHits());
@@ -1008,7 +1008,7 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
             CombatValue.buildMainCombatValue(
                 List.of(),
                 defendList,
-                true,
+                BattleState.Side.DEFENSE,
                 bridge.getData(),
                 TerritoryEffectHelper.getEffects(balticSeaZone)));
     assertEquals(0, roll.getHits());
@@ -1071,7 +1071,7 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
             CombatValue.buildMainCombatValue(
                 List.of(),
                 defendList,
-                true,
+                BattleState.Side.DEFENSE,
                 bridge.getData(),
                 TerritoryEffectHelper.getEffects(balticSeaZone)));
     assertEquals(1, roll.getHits());

--- a/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
@@ -16,6 +16,7 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Constants;
+import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.Collection;
@@ -112,7 +113,11 @@ class PacificTest extends AbstractDelegateTestCase {
             bridge,
             "",
             CombatValue.buildMainCombatValue(
-                List.of(), infantryUs, true, bridge.getData(), territoryEffects));
+                List.of(),
+                infantryUs,
+                BattleState.Side.DEFENSE,
+                bridge.getData(),
+                territoryEffects));
     assertEquals(1, roll.getHits());
     // Defending US marines
     final List<Unit> marineUs = marine.create(1, americans);
@@ -123,7 +128,7 @@ class PacificTest extends AbstractDelegateTestCase {
             bridge,
             "",
             CombatValue.buildMainCombatValue(
-                List.of(), marineUs, true, bridge.getData(), territoryEffects));
+                List.of(), marineUs, BattleState.Side.DEFENSE, bridge.getData(), territoryEffects));
     assertEquals(1, roll.getHits());
     // Chinese units
     // Defending Chinese infantry
@@ -135,7 +140,11 @@ class PacificTest extends AbstractDelegateTestCase {
             bridge,
             "",
             CombatValue.buildMainCombatValue(
-                List.of(), infantryChina, true, bridge.getData(), territoryEffects));
+                List.of(),
+                infantryChina,
+                BattleState.Side.DEFENSE,
+                bridge.getData(),
+                territoryEffects));
     assertEquals(1, roll.getHits());
   }
 
@@ -164,7 +173,11 @@ class PacificTest extends AbstractDelegateTestCase {
             bridge,
             "",
             CombatValue.buildMainCombatValue(
-                List.of(), infantryUs, true, bridge.getData(), territoryEffects));
+                List.of(),
+                infantryUs,
+                BattleState.Side.DEFENSE,
+                bridge.getData(),
+                territoryEffects));
     assertEquals(0, roll.getHits());
     // Defending US marines
     final List<Unit> marineUs = marine.create(1, americans);
@@ -175,7 +188,7 @@ class PacificTest extends AbstractDelegateTestCase {
             bridge,
             "",
             CombatValue.buildMainCombatValue(
-                List.of(), marineUs, true, bridge.getData(), territoryEffects));
+                List.of(), marineUs, BattleState.Side.DEFENSE, bridge.getData(), territoryEffects));
     assertEquals(0, roll.getHits());
     // Chinese units
     // Defending Chinese infantry
@@ -187,7 +200,11 @@ class PacificTest extends AbstractDelegateTestCase {
             bridge,
             "",
             CombatValue.buildMainCombatValue(
-                List.of(), infantryChina, true, bridge.getData(), territoryEffects));
+                List.of(),
+                infantryChina,
+                BattleState.Side.DEFENSE,
+                bridge.getData(),
+                territoryEffects));
     assertEquals(1, roll.getHits());
     // Defending US infantry
     roll =
@@ -197,7 +214,11 @@ class PacificTest extends AbstractDelegateTestCase {
             bridge,
             "",
             CombatValue.buildMainCombatValue(
-                List.of(), infantryUs, true, bridge.getData(), territoryEffects));
+                List.of(),
+                infantryUs,
+                BattleState.Side.DEFENSE,
+                bridge.getData(),
+                territoryEffects));
     assertEquals(1, roll.getHits());
     // Defending US marines
     roll =
@@ -207,7 +228,7 @@ class PacificTest extends AbstractDelegateTestCase {
             bridge,
             "",
             CombatValue.buildMainCombatValue(
-                List.of(), marineUs, true, bridge.getData(), territoryEffects));
+                List.of(), marineUs, BattleState.Side.DEFENSE, bridge.getData(), territoryEffects));
     assertEquals(1, roll.getHits());
     // Chinese units
     // Defending Chinese infantry
@@ -218,7 +239,11 @@ class PacificTest extends AbstractDelegateTestCase {
             bridge,
             "",
             CombatValue.buildMainCombatValue(
-                List.of(), infantryChina, true, bridge.getData(), territoryEffects));
+                List.of(),
+                infantryChina,
+                BattleState.Side.DEFENSE,
+                bridge.getData(),
+                territoryEffects));
     assertEquals(1, roll.getHits());
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -71,6 +71,7 @@ import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.battle.BattleDelegate;
+import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.IBattle.BattleType;
 import games.strategy.triplea.delegate.battle.MustFightBattle;
 import games.strategy.triplea.delegate.battle.casualty.AaCasualtySelector;
@@ -174,13 +175,18 @@ class WW2V3Year41Test {
             bridge,
             territory("Germany", gameData),
             CombatValue.buildAaCombatValue(
-                planes, territory("Germany", gameData).getUnits(), true, bridge.getData()));
+                planes,
+                territory("Germany", gameData).getUnits(),
+                BattleState.Side.DEFENSE,
+                bridge.getData()));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
                 planes,
                 defendingAa,
-                CombatValue.buildMainCombatValue(defendingAa, planes, false, gameData, List.of()),
-                CombatValue.buildAaCombatValue(planes, defendingAa, true, gameData),
+                CombatValue.buildMainCombatValue(
+                    defendingAa, planes, BattleState.Side.OFFENSE, gameData, List.of()),
+                CombatValue.buildAaCombatValue(
+                    planes, defendingAa, BattleState.Side.DEFENSE, gameData),
                 "",
                 roll,
                 bridge,
@@ -225,15 +231,20 @@ class WW2V3Year41Test {
             bridge,
             territory("Germany", gameData),
             CombatValue.buildAaCombatValue(
-                planes, territory("Germany", gameData).getUnits(), true, bridge.getData()));
+                planes,
+                territory("Germany", gameData).getUnits(),
+                BattleState.Side.DEFENSE,
+                bridge.getData()));
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
                 planes,
                 defendingAa,
-                CombatValue.buildMainCombatValue(defendingAa, planes, false, gameData, List.of()),
-                CombatValue.buildAaCombatValue(planes, defendingAa, true, gameData),
+                CombatValue.buildMainCombatValue(
+                    defendingAa, planes, BattleState.Side.OFFENSE, gameData, List.of()),
+                CombatValue.buildAaCombatValue(
+                    planes, defendingAa, BattleState.Side.DEFENSE, gameData),
                 "",
                 roll,
                 bridge,
@@ -280,7 +291,10 @@ class WW2V3Year41Test {
             bridge,
             territory("Germany", gameData),
             CombatValue.buildAaCombatValue(
-                planes, territory("Germany", gameData).getUnits(), true, bridge.getData()));
+                planes,
+                territory("Germany", gameData).getUnits(),
+                BattleState.Side.DEFENSE,
+                bridge.getData()));
     assertEquals(2, roll.getHits());
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
@@ -288,8 +302,10 @@ class WW2V3Year41Test {
         AaCasualtySelector.getAaCasualties(
                 planes,
                 defendingAa,
-                CombatValue.buildMainCombatValue(defendingAa, planes, false, gameData, List.of()),
-                CombatValue.buildAaCombatValue(planes, defendingAa, true, gameData),
+                CombatValue.buildMainCombatValue(
+                    defendingAa, planes, BattleState.Side.OFFENSE, gameData, List.of()),
+                CombatValue.buildAaCombatValue(
+                    planes, defendingAa, BattleState.Side.DEFENSE, gameData),
                 "",
                 roll,
                 bridge,
@@ -686,7 +702,11 @@ class WW2V3Year41Test {
             delegateBridge,
             "",
             CombatValue.buildMainCombatValue(
-                List.of(), germanFighter, false, delegateBridge.getData(), territoryEffects));
+                List.of(),
+                germanFighter,
+                BattleState.Side.OFFENSE,
+                delegateBridge.getData(),
+                territoryEffects));
     assertEquals(1, roll1.getHits());
     // Defending fighter
     final DiceRoll roll2 =
@@ -696,7 +716,11 @@ class WW2V3Year41Test {
             delegateBridge,
             "",
             CombatValue.buildMainCombatValue(
-                List.of(), germanFighter, true, delegateBridge.getData(), territoryEffects));
+                List.of(),
+                germanFighter,
+                BattleState.Side.DEFENSE,
+                delegateBridge.getData(),
+                territoryEffects));
     assertEquals(0, roll2.getHits());
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTest.java
@@ -13,6 +13,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.UnitTypeList;
 import games.strategy.triplea.attachments.UnitAttachment;
+import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import java.util.List;
 import java.util.Map;
@@ -76,7 +77,8 @@ class CasualtyOrderOfLossesTest {
         .targetsToPickFrom(List.of())
         .player(player)
         .combatValue(
-            CombatValue.buildMainCombatValue(List.of(), List.of(), false, gameData, List.of()))
+            CombatValue.buildMainCombatValue(
+                List.of(), List.of(), BattleState.Side.OFFENSE, gameData, List.of()))
         .battlesite(territory)
         .costs(IntegerMap.of(Map.of()))
         .data(gameData)

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnBigWorldV3.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnBigWorldV3.java
@@ -7,6 +7,7 @@ import static org.hamcrest.core.Is.is;
 import games.strategy.engine.data.MutableProperty;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.delegate.ImprovedArtillerySupportAdvance;
+import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.xml.TestDataBigWorld1942V3;
 import java.util.ArrayList;
@@ -64,7 +65,7 @@ class CasualtyOrderOfLossesTestOnBigWorldV3 {
         .player(testData.british)
         .combatValue(
             CombatValue.buildMainCombatValue(
-                List.of(), amphibUnits, false, testData.gameData, List.of()))
+                List.of(), amphibUnits, BattleState.Side.OFFENSE, testData.gameData, List.of()))
         .battlesite(testData.france)
         .costs(testData.costMap)
         .data(testData.gameData)
@@ -192,7 +193,11 @@ class CasualtyOrderOfLossesTestOnBigWorldV3 {
                 .player(testData.british)
                 .combatValue(
                     CombatValue.buildMainCombatValue(
-                        List.of(), attackingUnits, false, testData.gameData, List.of()))
+                        List.of(),
+                        attackingUnits,
+                        BattleState.Side.OFFENSE,
+                        testData.gameData,
+                        List.of()))
                 .battlesite(testData.france)
                 .costs(testData.costMap)
                 .data(testData.gameData)
@@ -240,7 +245,11 @@ class CasualtyOrderOfLossesTestOnBigWorldV3 {
                 .player(testData.british)
                 .combatValue(
                     CombatValue.buildMainCombatValue(
-                        List.of(), attackingUnits, false, testData.gameData, List.of()))
+                        List.of(),
+                        attackingUnits,
+                        BattleState.Side.OFFENSE,
+                        testData.gameData,
+                        List.of()))
                 .battlesite(testData.france)
                 .costs(testData.costMap)
                 .data(testData.gameData)
@@ -261,7 +270,7 @@ class CasualtyOrderOfLossesTestOnBigWorldV3 {
                     CombatValue.buildMainCombatValue(
                         List.of(),
                         attackingUnits.subList(0, 3),
-                        false,
+                        BattleState.Side.OFFENSE,
                         testData.gameData,
                         List.of()))
                 .battlesite(testData.france)

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnGlobal.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnGlobal.java
@@ -17,6 +17,7 @@ import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.delegate.HeavyBomberAdvance;
 import games.strategy.triplea.delegate.ImprovedArtillerySupportAdvance;
 import games.strategy.triplea.delegate.TechAdvance;
+import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.ArrayList;
@@ -132,7 +133,9 @@ class CasualtyOrderOfLossesTestOnGlobal {
     return CasualtyOrderOfLosses.Parameters.builder()
         .targetsToPickFrom(units)
         .player(BRITISH)
-        .combatValue(CombatValue.buildMainCombatValue(List.of(), units, false, data, List.of()))
+        .combatValue(
+            CombatValue.buildMainCombatValue(
+                List.of(), units, BattleState.Side.OFFENSE, data, List.of()))
         .battlesite(FRANCE)
         .costs(COST_MAP)
         .data(data)
@@ -214,7 +217,8 @@ class CasualtyOrderOfLossesTestOnGlobal {
         .targetsToPickFrom(amphibUnits)
         .player(BRITISH)
         .combatValue(
-            CombatValue.buildMainCombatValue(List.of(), amphibUnits, false, data, List.of()))
+            CombatValue.buildMainCombatValue(
+                List.of(), amphibUnits, BattleState.Side.OFFENSE, data, List.of()))
         .battlesite(FRANCE)
         .costs(COST_MAP)
         .data(data)
@@ -292,7 +296,9 @@ class CasualtyOrderOfLossesTestOnGlobal {
     return CasualtyOrderOfLosses.Parameters.builder()
         .targetsToPickFrom(units)
         .player(BRITISH)
-        .combatValue(CombatValue.buildMainCombatValue(List.of(), units, true, data, List.of()))
+        .combatValue(
+            CombatValue.buildMainCombatValue(
+                List.of(), units, BattleState.Side.DEFENSE, data, List.of()))
         .battlesite(FRANCE)
         .costs(COST_MAP)
         .data(data)

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnNapoleonic.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnNapoleonic.java
@@ -11,6 +11,7 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.ArrayList;
@@ -91,7 +92,9 @@ class CasualtyOrderOfLossesTestOnNapoleonic {
     return CasualtyOrderOfLosses.Parameters.builder()
         .targetsToPickFrom(units)
         .player(BRITISH)
-        .combatValue(CombatValue.buildMainCombatValue(List.of(), units, false, data, List.of()))
+        .combatValue(
+            CombatValue.buildMainCombatValue(
+                List.of(), units, BattleState.Side.OFFENSE, data, List.of()))
         .battlesite(NORMANDY)
         .costs(COST_MAP)
         .data(data)

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelectorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelectorTest.java
@@ -24,6 +24,7 @@ import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.delegate.Matches;
+import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
 import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.xml.TestMapGameData;
@@ -86,8 +87,9 @@ class CasualtySelectorTest {
         AaCasualtySelector.getAaCasualties(
                 planes,
                 defendingAa,
-                CombatValue.buildMainCombatValue(defendingAa, planes, false, data, List.of()),
-                CombatValue.buildAaCombatValue(planes, defendingAa, true, data),
+                CombatValue.buildMainCombatValue(
+                    defendingAa, planes, BattleState.Side.OFFENSE, data, List.of()),
+                CombatValue.buildAaCombatValue(planes, defendingAa, BattleState.Side.DEFENSE, data),
                 "",
                 roll,
                 bridge,
@@ -114,8 +116,9 @@ class CasualtySelectorTest {
         AaCasualtySelector.getAaCasualties(
                 planes,
                 defendingAa,
-                CombatValue.buildMainCombatValue(defendingAa, planes, false, data, List.of()),
-                CombatValue.buildAaCombatValue(planes, defendingAa, true, data),
+                CombatValue.buildMainCombatValue(
+                    defendingAa, planes, BattleState.Side.OFFENSE, data, List.of()),
+                CombatValue.buildAaCombatValue(planes, defendingAa, BattleState.Side.DEFENSE, data),
                 "",
                 roll,
                 bridge,
@@ -149,13 +152,17 @@ class CasualtySelectorTest {
             bridge,
             territory("Germany", data),
             CombatValue.buildAaCombatValue(
-                planes, territory("Germany", data).getUnits(), true, bridge.getData()));
+                planes,
+                territory("Germany", data).getUnits(),
+                BattleState.Side.DEFENSE,
+                bridge.getData()));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
                 planes,
                 defendingAa,
-                CombatValue.buildMainCombatValue(defendingAa, planes, false, data, List.of()),
-                CombatValue.buildAaCombatValue(planes, defendingAa, true, data),
+                CombatValue.buildMainCombatValue(
+                    defendingAa, planes, BattleState.Side.OFFENSE, data, List.of()),
+                CombatValue.buildAaCombatValue(planes, defendingAa, BattleState.Side.DEFENSE, data),
                 "",
                 roll,
                 bridge,
@@ -194,14 +201,18 @@ class CasualtySelectorTest {
             bridge,
             territory("Germany", data),
             CombatValue.buildAaCombatValue(
-                planes, territory("Germany", data).getUnits(), true, bridge.getData()));
+                planes,
+                territory("Germany", data).getUnits(),
+                BattleState.Side.DEFENSE,
+                bridge.getData()));
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
                 planes,
                 defendingAa,
-                CombatValue.buildMainCombatValue(defendingAa, planes, false, data, List.of()),
-                CombatValue.buildAaCombatValue(planes, defendingAa, true, data),
+                CombatValue.buildMainCombatValue(
+                    defendingAa, planes, BattleState.Side.OFFENSE, data, List.of()),
+                CombatValue.buildAaCombatValue(planes, defendingAa, BattleState.Side.DEFENSE, data),
                 "",
                 roll,
                 bridge,
@@ -241,13 +252,17 @@ class CasualtySelectorTest {
             bridge,
             territory("Germany", data),
             CombatValue.buildAaCombatValue(
-                planes, territory("Germany", data).getUnits(), true, bridge.getData()));
+                planes,
+                territory("Germany", data).getUnits(),
+                BattleState.Side.DEFENSE,
+                bridge.getData()));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
                 planes,
                 defendingAa,
-                CombatValue.buildMainCombatValue(defendingAa, planes, false, data, List.of()),
-                CombatValue.buildAaCombatValue(planes, defendingAa, true, data),
+                CombatValue.buildMainCombatValue(
+                    defendingAa, planes, BattleState.Side.OFFENSE, data, List.of()),
+                CombatValue.buildAaCombatValue(planes, defendingAa, BattleState.Side.DEFENSE, data),
                 "",
                 roll,
                 bridge,
@@ -287,13 +302,17 @@ class CasualtySelectorTest {
             bridge,
             territory("Germany", data),
             CombatValue.buildAaCombatValue(
-                planes, territory("Germany", data).getUnits(), true, bridge.getData()));
+                planes,
+                territory("Germany", data).getUnits(),
+                BattleState.Side.DEFENSE,
+                bridge.getData()));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
                 planes,
                 defendingAa,
-                CombatValue.buildMainCombatValue(defendingAa, planes, false, data, List.of()),
-                CombatValue.buildAaCombatValue(planes, defendingAa, true, data),
+                CombatValue.buildMainCombatValue(
+                    defendingAa, planes, BattleState.Side.OFFENSE, data, List.of()),
+                CombatValue.buildAaCombatValue(planes, defendingAa, BattleState.Side.DEFENSE, data),
                 "",
                 roll,
                 bridge,
@@ -333,15 +352,19 @@ class CasualtySelectorTest {
             bridge,
             territory("Germany", data),
             CombatValue.buildAaCombatValue(
-                planes, territory("Germany", data).getUnits(), true, bridge.getData()));
+                planes,
+                territory("Germany", data).getUnits(),
+                BattleState.Side.DEFENSE,
+                bridge.getData()));
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
                 planes,
                 defendingAa,
-                CombatValue.buildMainCombatValue(defendingAa, planes, false, data, List.of()),
-                CombatValue.buildAaCombatValue(planes, defendingAa, true, data),
+                CombatValue.buildMainCombatValue(
+                    defendingAa, planes, BattleState.Side.OFFENSE, data, List.of()),
+                CombatValue.buildAaCombatValue(planes, defendingAa, BattleState.Side.DEFENSE, data),
                 "",
                 roll,
                 bridge,
@@ -385,15 +408,19 @@ class CasualtySelectorTest {
             bridge,
             territory("Germany", data),
             CombatValue.buildAaCombatValue(
-                planes, territory("Germany", data).getUnits(), true, bridge.getData()));
+                planes,
+                territory("Germany", data).getUnits(),
+                BattleState.Side.DEFENSE,
+                bridge.getData()));
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
                 planes,
                 defendingAa,
-                CombatValue.buildMainCombatValue(defendingAa, planes, false, data, List.of()),
-                CombatValue.buildAaCombatValue(planes, defendingAa, true, data),
+                CombatValue.buildMainCombatValue(
+                    defendingAa, planes, BattleState.Side.OFFENSE, data, List.of()),
+                CombatValue.buildAaCombatValue(planes, defendingAa, BattleState.Side.DEFENSE, data),
                 "",
                 roll,
                 bridge,
@@ -432,15 +459,19 @@ class CasualtySelectorTest {
             bridge,
             territory("Germany", data),
             CombatValue.buildAaCombatValue(
-                planes, territory("Germany", data).getUnits(), true, bridge.getData()));
+                planes,
+                territory("Germany", data).getUnits(),
+                BattleState.Side.DEFENSE,
+                bridge.getData()));
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
                 planes,
                 defendingAa,
-                CombatValue.buildMainCombatValue(defendingAa, planes, false, data, List.of()),
-                CombatValue.buildAaCombatValue(planes, defendingAa, true, data),
+                CombatValue.buildMainCombatValue(
+                    defendingAa, planes, BattleState.Side.OFFENSE, data, List.of()),
+                CombatValue.buildAaCombatValue(planes, defendingAa, BattleState.Side.DEFENSE, data),
                 "",
                 roll,
                 bridge,

--- a/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/AaDefenseCombatValueTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/AaDefenseCombatValueTest.java
@@ -13,6 +13,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.gameparser.GameParseException;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
+import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -39,7 +40,7 @@ class AaDefenseCombatValueTest {
 
       final Unit supportUnit = unitType.create(1, player, true).get(0);
       final UnitSupportAttachment unitSupportAttachment =
-          givenUnitSupportAttachment(gameData, unitType, "test")
+          givenUnitOffenseSupportAttachment(gameData, unitType, "test")
               .setBonus(2)
               .setPlayers(List.of(player))
               .setUnitType(Set.of(unitType));
@@ -47,11 +48,14 @@ class AaDefenseCombatValueTest {
       final AvailableSupports friendlySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(supportUnit), Set.of(unitSupportAttachment), false, true));
+                  List.of(supportUnit),
+                  Set.of(unitSupportAttachment),
+                  BattleState.Side.OFFENSE,
+                  true));
 
       final Unit enemySupportUnit = unitType.create(1, player, true).get(0);
       final UnitSupportAttachment enemyUnitSupportAttachment =
-          givenUnitSupportAttachment(gameData, unitType, "test2")
+          givenUnitDefenseSupportAttachment(gameData, unitType, "test2")
               .setBonus(-1)
               .setPlayers(List.of(player))
               .setUnitType(Set.of(unitType));
@@ -59,7 +63,10 @@ class AaDefenseCombatValueTest {
       final AvailableSupports enemySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(enemySupportUnit), Set.of(enemyUnitSupportAttachment), false, true));
+                  List.of(enemySupportUnit),
+                  Set.of(enemyUnitSupportAttachment),
+                  BattleState.Side.DEFENSE,
+                  false));
 
       final StrengthCalculator strength =
           AaDefenseCombatValue.builder()
@@ -74,7 +81,7 @@ class AaDefenseCombatValueTest {
           is(4));
     }
 
-    UnitSupportAttachment givenUnitSupportAttachment(
+    UnitSupportAttachment givenUnitOffenseSupportAttachment(
         final GameData gameData, final UnitType unitType, final String name)
         throws GameParseException {
       return new UnitSupportAttachment("rule" + name, unitType, gameData)
@@ -84,6 +91,18 @@ class AaDefenseCombatValueTest {
           .setNumber(1)
           .setSide("offence")
           .setFaction("allied");
+    }
+
+    UnitSupportAttachment givenUnitDefenseSupportAttachment(
+        final GameData gameData, final UnitType unitType, final String name)
+        throws GameParseException {
+      return new UnitSupportAttachment("rule" + name, unitType, gameData)
+          .setBonus(1)
+          .setBonusType("bonus" + name)
+          .setDice("AAstrength")
+          .setNumber(1)
+          .setSide("defence")
+          .setFaction("enemy");
     }
 
     @Test
@@ -100,7 +119,7 @@ class AaDefenseCombatValueTest {
 
       final Unit supportUnit = unitType.create(1, player, true).get(0);
       final UnitSupportAttachment unitSupportAttachment =
-          givenUnitSupportAttachment(gameData, unitType, "test")
+          givenUnitOffenseSupportAttachment(gameData, unitType, "test")
               .setBonus(2)
               .setPlayers(List.of(player))
               .setUnitType(Set.of(unitType));
@@ -108,11 +127,14 @@ class AaDefenseCombatValueTest {
       final AvailableSupports friendlySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(supportUnit), Set.of(unitSupportAttachment), false, true));
+                  List.of(supportUnit),
+                  Set.of(unitSupportAttachment),
+                  BattleState.Side.OFFENSE,
+                  true));
 
       final Unit enemySupportUnit = unitType.create(1, player, true).get(0);
       final UnitSupportAttachment enemyUnitSupportAttachment =
-          givenUnitSupportAttachment(gameData, unitType, "test2")
+          givenUnitDefenseSupportAttachment(gameData, unitType, "test2")
               .setBonus(-1)
               .setPlayers(List.of(player))
               .setUnitType(Set.of(unitType));
@@ -120,7 +142,10 @@ class AaDefenseCombatValueTest {
       final AvailableSupports enemySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(enemySupportUnit), Set.of(enemyUnitSupportAttachment), false, true));
+                  List.of(enemySupportUnit),
+                  Set.of(enemyUnitSupportAttachment),
+                  BattleState.Side.DEFENSE,
+                  false));
 
       final StrengthCalculator strength =
           AaDefenseCombatValue.builder()

--- a/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/AaOffenseCombatValueTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/AaOffenseCombatValueTest.java
@@ -13,6 +13,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.gameparser.GameParseException;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
+import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -39,7 +40,7 @@ class AaOffenseCombatValueTest {
 
       final Unit supportUnit = unitType.create(1, player, true).get(0);
       final UnitSupportAttachment unitSupportAttachment =
-          givenUnitSupportAttachment(gameData, unitType, "test")
+          givenUnitOffenseSupportAttachment(gameData, unitType, "test")
               .setBonus(2)
               .setPlayers(List.of(player))
               .setUnitType(Set.of(unitType));
@@ -47,11 +48,14 @@ class AaOffenseCombatValueTest {
       final AvailableSupports friendlySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(supportUnit), Set.of(unitSupportAttachment), false, true));
+                  List.of(supportUnit),
+                  Set.of(unitSupportAttachment),
+                  BattleState.Side.OFFENSE,
+                  true));
 
       final Unit enemySupportUnit = unitType.create(1, player, true).get(0);
       final UnitSupportAttachment enemyUnitSupportAttachment =
-          givenUnitSupportAttachment(gameData, unitType, "test2")
+          givenUnitDefenseSupportAttachment(gameData, unitType, "test2")
               .setBonus(-1)
               .setPlayers(List.of(player))
               .setUnitType(Set.of(unitType));
@@ -59,7 +63,10 @@ class AaOffenseCombatValueTest {
       final AvailableSupports enemySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(enemySupportUnit), Set.of(enemyUnitSupportAttachment), false, true));
+                  List.of(enemySupportUnit),
+                  Set.of(enemyUnitSupportAttachment),
+                  BattleState.Side.DEFENSE,
+                  false));
 
       final StrengthCalculator strength =
           AaOffenseCombatValue.builder()
@@ -74,7 +81,7 @@ class AaOffenseCombatValueTest {
           is(4));
     }
 
-    UnitSupportAttachment givenUnitSupportAttachment(
+    UnitSupportAttachment givenUnitOffenseSupportAttachment(
         final GameData gameData, final UnitType unitType, final String name)
         throws GameParseException {
       return new UnitSupportAttachment("rule" + name, unitType, gameData)
@@ -84,6 +91,18 @@ class AaOffenseCombatValueTest {
           .setNumber(1)
           .setSide("offence")
           .setFaction("allied");
+    }
+
+    UnitSupportAttachment givenUnitDefenseSupportAttachment(
+        final GameData gameData, final UnitType unitType, final String name)
+        throws GameParseException {
+      return new UnitSupportAttachment("rule" + name, unitType, gameData)
+          .setBonus(1)
+          .setBonusType("bonus" + name)
+          .setDice("AAstrength")
+          .setNumber(1)
+          .setSide("defence")
+          .setFaction("enemy");
     }
 
     @Test
@@ -100,7 +119,7 @@ class AaOffenseCombatValueTest {
 
       final Unit supportUnit = unitType.create(1, player, true).get(0);
       final UnitSupportAttachment unitSupportAttachment =
-          givenUnitSupportAttachment(gameData, unitType, "test")
+          givenUnitOffenseSupportAttachment(gameData, unitType, "test")
               .setBonus(2)
               .setPlayers(List.of(player))
               .setUnitType(Set.of(unitType));
@@ -108,11 +127,14 @@ class AaOffenseCombatValueTest {
       final AvailableSupports friendlySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(supportUnit), Set.of(unitSupportAttachment), false, true));
+                  List.of(supportUnit),
+                  Set.of(unitSupportAttachment),
+                  BattleState.Side.OFFENSE,
+                  true));
 
       final Unit enemySupportUnit = unitType.create(1, player, true).get(0);
       final UnitSupportAttachment enemyUnitSupportAttachment =
-          givenUnitSupportAttachment(gameData, unitType, "test2")
+          givenUnitDefenseSupportAttachment(gameData, unitType, "test2")
               .setBonus(-1)
               .setPlayers(List.of(player))
               .setUnitType(Set.of(unitType));
@@ -120,7 +142,10 @@ class AaOffenseCombatValueTest {
       final AvailableSupports enemySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(enemySupportUnit), Set.of(enemyUnitSupportAttachment), false, true));
+                  List.of(enemySupportUnit),
+                  Set.of(enemyUnitSupportAttachment),
+                  BattleState.Side.DEFENSE,
+                  false));
 
       final StrengthCalculator strength =
           AaOffenseCombatValue.builder()

--- a/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/AaRollTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/AaRollTest.java
@@ -13,6 +13,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.gameparser.GameParseException;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
+import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -43,7 +44,10 @@ class AaRollTest {
     final AvailableSupports friendlySupport =
         AvailableSupports.getSupport(
             new SupportCalculator(
-                List.of(supportUnit), Set.of(unitSupportAttachment), false, true));
+                List.of(supportUnit),
+                Set.of(unitSupportAttachment),
+                BattleState.Side.OFFENSE,
+                true));
 
     final Unit enemySupportUnit = unitType.create(1, player, true).get(0);
     final UnitSupportAttachment enemyUnitSupportAttachment =
@@ -55,7 +59,10 @@ class AaRollTest {
     final AvailableSupports enemySupport =
         AvailableSupports.getSupport(
             new SupportCalculator(
-                List.of(enemySupportUnit), Set.of(enemyUnitSupportAttachment), false, true));
+                List.of(enemySupportUnit),
+                Set.of(enemyUnitSupportAttachment),
+                BattleState.Side.OFFENSE,
+                true));
 
     final AaRoll roll = new AaRoll(friendlySupport, enemySupport);
     assertThat(
@@ -98,7 +105,10 @@ class AaRollTest {
     final AvailableSupports friendlySupport =
         AvailableSupports.getSupport(
             new SupportCalculator(
-                List.of(supportUnit), Set.of(unitSupportAttachment), false, true));
+                List.of(supportUnit),
+                Set.of(unitSupportAttachment),
+                BattleState.Side.OFFENSE,
+                true));
 
     final Unit enemySupportUnit = unitType.create(1, player, true).get(0);
     final UnitSupportAttachment enemyUnitSupportAttachment =
@@ -110,7 +120,10 @@ class AaRollTest {
     final AvailableSupports enemySupport =
         AvailableSupports.getSupport(
             new SupportCalculator(
-                List.of(enemySupportUnit), Set.of(enemyUnitSupportAttachment), false, true));
+                List.of(enemySupportUnit),
+                Set.of(enemyUnitSupportAttachment),
+                BattleState.Side.OFFENSE,
+                true));
 
     final AaRoll roll = new AaRoll(friendlySupport, enemySupport);
     roll.getRoll(unit);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/AvailableSupportsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/AvailableSupportsTest.java
@@ -14,6 +14,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.gameparser.GameParseException;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
+import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -42,7 +43,7 @@ class AvailableSupportsTest {
 
     final AvailableSupports tracker =
         AvailableSupports.getSupport(
-            new SupportCalculator(List.of(unit), List.of(rule), false, false));
+            new SupportCalculator(List.of(unit), List.of(rule), BattleState.Side.OFFENSE, false));
     assertThat("There is only one bonus type", tracker.supportRules.size(), is(1));
     assertThat("The rule only has one support available", tracker.getSupportLeft(rule), is(1));
   }
@@ -75,7 +76,8 @@ class AvailableSupportsTest {
 
     final AvailableSupports tracker =
         AvailableSupports.getSupport(
-            new SupportCalculator(List.of(unit), List.of(rule, rule2), false, false));
+            new SupportCalculator(
+                List.of(unit), List.of(rule, rule2), BattleState.Side.OFFENSE, false));
     assertThat("Rule with players is added", tracker.getSupportLeft(rule), is(1));
     assertThat("Rule without players is not added", tracker.getSupportLeft(rule2), is(0));
   }
@@ -108,7 +110,8 @@ class AvailableSupportsTest {
 
     final AvailableSupports tracker =
         AvailableSupports.getSupport(
-            new SupportCalculator(List.of(unit), List.of(rule, rule2), false, false));
+            new SupportCalculator(
+                List.of(unit), List.of(rule, rule2), BattleState.Side.OFFENSE, false));
     assertThat("Rule with unit types is added", tracker.getSupportLeft(rule), is(1));
     assertThat("Rule without unit types is not added", tracker.getSupportLeft(rule2), is(0));
   }
@@ -141,7 +144,8 @@ class AvailableSupportsTest {
 
     final AvailableSupports tracker =
         AvailableSupports.getSupport(
-            new SupportCalculator(List.of(unit), List.of(rule, rule2), false, false));
+            new SupportCalculator(
+                List.of(unit), List.of(rule, rule2), BattleState.Side.OFFENSE, false));
     assertThat("Rule with unit types is added", tracker.getSupportLeft(rule), is(1));
     assertThat("Rule without unit types is not added", tracker.getSupportLeft(rule2), is(0));
   }
@@ -174,7 +178,8 @@ class AvailableSupportsTest {
 
     final AvailableSupports tracker =
         AvailableSupports.getSupport(
-            new SupportCalculator(List.of(unit), List.of(rule, rule2), false, false));
+            new SupportCalculator(
+                List.of(unit), List.of(rule, rule2), BattleState.Side.OFFENSE, false));
     assertThat("Offence rule has support", tracker.getSupportLeft(rule), is(1));
     assertThat("Defence rule is ignored", tracker.getSupportLeft(rule2), is(0));
   }
@@ -207,7 +212,8 @@ class AvailableSupportsTest {
 
     final AvailableSupports tracker =
         AvailableSupports.getSupport(
-            new SupportCalculator(List.of(unit), List.of(rule, rule2), true, false));
+            new SupportCalculator(
+                List.of(unit), List.of(rule, rule2), BattleState.Side.DEFENSE, false));
     assertThat("Defence rule has support", tracker.getSupportLeft(rule), is(1));
     assertThat("Offence rule is ignored", tracker.getSupportLeft(rule2), is(0));
   }
@@ -240,7 +246,8 @@ class AvailableSupportsTest {
 
     final AvailableSupports tracker =
         AvailableSupports.getSupport(
-            new SupportCalculator(List.of(unit), List.of(rule, rule2), false, false));
+            new SupportCalculator(
+                List.of(unit), List.of(rule, rule2), BattleState.Side.OFFENSE, false));
     assertThat("Enemy rule has support", tracker.getSupportLeft(rule), is(1));
     assertThat("Allied rule is ignored", tracker.getSupportLeft(rule2), is(0));
   }
@@ -273,7 +280,8 @@ class AvailableSupportsTest {
 
     final AvailableSupports tracker =
         AvailableSupports.getSupport(
-            new SupportCalculator(List.of(unit), List.of(rule, rule2), false, true));
+            new SupportCalculator(
+                List.of(unit), List.of(rule, rule2), BattleState.Side.OFFENSE, true));
     assertThat("Allied rule has support", tracker.getSupportLeft(rule), is(1));
     assertThat("Enemy rule is ignored", tracker.getSupportLeft(rule2), is(0));
   }
@@ -308,7 +316,8 @@ class AvailableSupportsTest {
 
     final AvailableSupports tracker =
         AvailableSupports.getSupport(
-            new SupportCalculator(List.of(unit), List.of(rule, rule2), false, true));
+            new SupportCalculator(
+                List.of(unit), List.of(rule, rule2), BattleState.Side.OFFENSE, true));
     assertThat("Rule with a supporter is added", tracker.getSupportLeft(rule), is(1));
     assertThat("Rule without a supporter is ignored", tracker.getSupportLeft(rule2), is(0));
   }
@@ -336,7 +345,7 @@ class AvailableSupportsTest {
 
     final AvailableSupports tracker =
         AvailableSupports.getSupport(
-            new SupportCalculator(List.of(unit), List.of(rule), false, true));
+            new SupportCalculator(List.of(unit), List.of(rule), BattleState.Side.OFFENSE, true));
     assertThat(
         "Rule for improved artillery gives double the support "
             + "when the unit has improved artillery",
@@ -367,7 +376,7 @@ class AvailableSupportsTest {
 
     final AvailableSupports tracker =
         AvailableSupports.getSupport(
-            new SupportCalculator(List.of(unit), List.of(rule), false, true));
+            new SupportCalculator(List.of(unit), List.of(rule), BattleState.Side.OFFENSE, true));
     assertThat(
         "Rule that doesn't use improved artillery doesn't give double the support "
             + "when the unit has improved artillery",
@@ -402,7 +411,10 @@ class AvailableSupportsTest {
     final AvailableSupports tracker =
         AvailableSupports.getSupport(
             new SupportCalculator(
-                List.of(unit, unitWithoutImprovedTechnology), List.of(rule), false, true));
+                List.of(unit, unitWithoutImprovedTechnology),
+                List.of(rule),
+                BattleState.Side.OFFENSE,
+                true));
     assertThat(
         "Unit with improved technology has a value of 2 while the unit without has a value of 1",
         tracker.getSupportLeft(rule),
@@ -439,7 +451,8 @@ class AvailableSupportsTest {
 
     final AvailableSupports tracker =
         AvailableSupports.getSupport(
-            new SupportCalculator(List.of(unit), List.of(rule, rule2), false, false));
+            new SupportCalculator(
+                List.of(unit), List.of(rule, rule2), BattleState.Side.OFFENSE, false));
 
     final AvailableSupports filtered = tracker.filter(UnitSupportAttachment::getRoll);
     assertThat(
@@ -481,7 +494,8 @@ class AvailableSupportsTest {
 
       final AvailableSupports tracker =
           AvailableSupports.getSupport(
-              new SupportCalculator(List.of(supportUnit), List.of(rule), false, false));
+              new SupportCalculator(
+                  List.of(supportUnit), List.of(rule), BattleState.Side.OFFENSE, false));
 
       assertThat("Support unit can give one", tracker.giveSupportToUnit(unit), is(1));
 
@@ -516,7 +530,8 @@ class AvailableSupportsTest {
 
       final AvailableSupports tracker =
           AvailableSupports.getSupport(
-              new SupportCalculator(List.of(supportUnit), List.of(rule), false, false));
+              new SupportCalculator(
+                  List.of(supportUnit), List.of(rule), BattleState.Side.OFFENSE, false));
 
       assertThat("Support unit can give 2", tracker.giveSupportToUnit(unit), is(2));
 
@@ -552,7 +567,8 @@ class AvailableSupportsTest {
 
       final AvailableSupports tracker =
           AvailableSupports.getSupport(
-              new SupportCalculator(List.of(supportUnit), List.of(rule), false, false));
+              new SupportCalculator(
+                  List.of(supportUnit), List.of(rule), BattleState.Side.OFFENSE, false));
 
       // give the support to the first unit
       assertThat("Support unit can give 1", tracker.giveSupportToUnit(unit), is(1));
@@ -590,7 +606,8 @@ class AvailableSupportsTest {
 
       final AvailableSupports tracker =
           AvailableSupports.getSupport(
-              new SupportCalculator(List.of(supportUnit), List.of(rule), false, false));
+              new SupportCalculator(
+                  List.of(supportUnit), List.of(rule), BattleState.Side.OFFENSE, false));
 
       assertThat("Support can give 1", tracker.giveSupportToUnit(unit), is(1));
       assertThat("Support can still give 1 more", tracker.giveSupportToUnit(unit2), is(1));
@@ -629,7 +646,10 @@ class AvailableSupportsTest {
       final AvailableSupports tracker =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(supportUnit, supportUnit2), List.of(rule), false, false));
+                  List.of(supportUnit, supportUnit2),
+                  List.of(rule),
+                  BattleState.Side.OFFENSE,
+                  false));
 
       assertThat("First support unit can support", tracker.giveSupportToUnit(unit), is(1));
       assertThat("Second support unit can support", tracker.giveSupportToUnit(unit2), is(1));
@@ -675,7 +695,10 @@ class AvailableSupportsTest {
       final AvailableSupports tracker =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(supportUnit, supportUnit2), List.of(rule), false, false));
+                  List.of(supportUnit, supportUnit2),
+                  List.of(rule),
+                  BattleState.Side.OFFENSE,
+                  false));
 
       assertThat(
           "All support is given because of stacking", tracker.giveSupportToUnit(unit), is(2));
@@ -722,7 +745,10 @@ class AvailableSupportsTest {
       final AvailableSupports tracker =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(supportUnit, supportUnit2), List.of(rule), false, false));
+                  List.of(supportUnit, supportUnit2),
+                  List.of(rule),
+                  BattleState.Side.OFFENSE,
+                  false));
 
       assertThat(
           "First support unit can fill the entire stack", tracker.giveSupportToUnit(unit), is(2));
@@ -783,7 +809,10 @@ class AvailableSupportsTest {
       final AvailableSupports tracker =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(supportUnit, supportUnit2), List.of(rule, rule2), false, false));
+                  List.of(supportUnit, supportUnit2),
+                  List.of(rule, rule2),
+                  BattleState.Side.OFFENSE,
+                  false));
 
       assertThat("Both support units gave support", tracker.giveSupportToUnit(unit), is(2));
 
@@ -839,7 +868,10 @@ class AvailableSupportsTest {
       final AvailableSupports tracker =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(supportUnit, supportUnit2), List.of(rule, rule2), false, false));
+                  List.of(supportUnit, supportUnit2),
+                  List.of(rule, rule2),
+                  BattleState.Side.OFFENSE,
+                  false));
 
       assertThat(
           "Only the first rule can give its support", tracker.giveSupportToUnit(unit), is(1));
@@ -891,7 +923,10 @@ class AvailableSupportsTest {
       final AvailableSupports tracker =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(supportUnit, supportUnit2), List.of(rule, rule2), false, false));
+                  List.of(supportUnit, supportUnit2),
+                  List.of(rule, rule2),
+                  BattleState.Side.OFFENSE,
+                  false));
 
       assertThat("All support can be given", tracker.giveSupportToUnit(unit), is(2));
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/BombardmentCombatValueTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/BombardmentCombatValueTest.java
@@ -16,6 +16,7 @@ import games.strategy.engine.data.gameparser.GameParseException;
 import games.strategy.triplea.attachments.TerritoryEffectAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
+import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -42,7 +43,7 @@ class BombardmentCombatValueTest {
 
       final Unit supportUnit = unitType.create(1, player, true).get(0);
       final UnitSupportAttachment unitSupportAttachment =
-          givenUnitSupportAttachment(gameData, unitType, "test")
+          givenUnitOffenseSupportAttachment(gameData, unitType, "test")
               .setBonus(3)
               .setPlayers(List.of(player))
               .setUnitType(Set.of(unitType));
@@ -50,11 +51,14 @@ class BombardmentCombatValueTest {
       final AvailableSupports friendlySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(supportUnit), Set.of(unitSupportAttachment), false, true));
+                  List.of(supportUnit),
+                  Set.of(unitSupportAttachment),
+                  BattleState.Side.OFFENSE,
+                  true));
 
       final Unit enemySupportUnit = unitType.create(1, player, true).get(0);
       final UnitSupportAttachment enemyUnitSupportAttachment =
-          givenUnitSupportAttachment(gameData, unitType, "test2")
+          givenUnitDefenseSupportAttachment(gameData, unitType, "test2")
               .setBonus(-2)
               .setPlayers(List.of(player))
               .setUnitType(Set.of(unitType));
@@ -62,7 +66,10 @@ class BombardmentCombatValueTest {
       final AvailableSupports enemySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(enemySupportUnit), Set.of(enemyUnitSupportAttachment), false, true));
+                  List.of(enemySupportUnit),
+                  Set.of(enemyUnitSupportAttachment),
+                  BattleState.Side.DEFENSE,
+                  false));
 
       final TerritoryEffect territoryEffect = new TerritoryEffect("territoryEffect", gameData);
       final TerritoryEffectAttachment territoryEffectAttachment =
@@ -79,7 +86,7 @@ class BombardmentCombatValueTest {
           is(5));
     }
 
-    UnitSupportAttachment givenUnitSupportAttachment(
+    UnitSupportAttachment givenUnitOffenseSupportAttachment(
         final GameData gameData, final UnitType unitType, final String name)
         throws GameParseException {
       return new UnitSupportAttachment("rule" + name, unitType, gameData)
@@ -89,6 +96,18 @@ class BombardmentCombatValueTest {
           .setNumber(1)
           .setSide("offence")
           .setFaction("allied");
+    }
+
+    UnitSupportAttachment givenUnitDefenseSupportAttachment(
+        final GameData gameData, final UnitType unitType, final String name)
+        throws GameParseException {
+      return new UnitSupportAttachment("rule" + name, unitType, gameData)
+          .setBonus(1)
+          .setBonusType("bonus" + name)
+          .setDice("strength")
+          .setNumber(1)
+          .setSide("defence")
+          .setFaction("enemy");
     }
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/MainDefenseCombatValueTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/MainDefenseCombatValueTest.java
@@ -19,6 +19,7 @@ import games.strategy.triplea.attachments.RulesAttachment;
 import games.strategy.triplea.attachments.TerritoryEffectAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
+import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -45,7 +46,7 @@ class MainDefenseCombatValueTest {
 
       final Unit supportUnit = unitType.create(1, player, true).get(0);
       final UnitSupportAttachment unitSupportAttachment =
-          givenUnitSupportAttachment(gameData, unitType, "test")
+          givenUnitOffenseSupportAttachment(gameData, unitType, "test")
               .setBonus(2)
               .setPlayers(List.of(player))
               .setUnitType(Set.of(unitType));
@@ -53,11 +54,14 @@ class MainDefenseCombatValueTest {
       final AvailableSupports friendlySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(supportUnit), Set.of(unitSupportAttachment), false, true));
+                  List.of(supportUnit),
+                  Set.of(unitSupportAttachment),
+                  BattleState.Side.OFFENSE,
+                  true));
 
       final Unit enemySupportUnit = unitType.create(1, player, true).get(0);
       final UnitSupportAttachment enemyUnitSupportAttachment =
-          givenUnitSupportAttachment(gameData, unitType, "test2")
+          givenUnitDefenseSupportAttachment(gameData, unitType, "test2")
               .setBonus(-1)
               .setPlayers(List.of(player))
               .setUnitType(Set.of(unitType));
@@ -65,7 +69,10 @@ class MainDefenseCombatValueTest {
       final AvailableSupports enemySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(enemySupportUnit), Set.of(enemyUnitSupportAttachment), false, true));
+                  List.of(enemySupportUnit),
+                  Set.of(enemyUnitSupportAttachment),
+                  BattleState.Side.DEFENSE,
+                  false));
 
       final MainDefenseCombatValue.MainDefenseRoll roll =
           new MainDefenseCombatValue.MainDefenseRoll(friendlySupport, enemySupport);
@@ -75,7 +82,7 @@ class MainDefenseCombatValueTest {
           is(4));
     }
 
-    UnitSupportAttachment givenUnitSupportAttachment(
+    UnitSupportAttachment givenUnitOffenseSupportAttachment(
         final GameData gameData, final UnitType unitType, final String name)
         throws GameParseException {
       return new UnitSupportAttachment("rule" + name, unitType, gameData)
@@ -85,6 +92,18 @@ class MainDefenseCombatValueTest {
           .setNumber(1)
           .setSide("offence")
           .setFaction("allied");
+    }
+
+    UnitSupportAttachment givenUnitDefenseSupportAttachment(
+        final GameData gameData, final UnitType unitType, final String name)
+        throws GameParseException {
+      return new UnitSupportAttachment("rule" + name, unitType, gameData)
+          .setBonus(1)
+          .setBonusType("bonus" + name)
+          .setDice("roll")
+          .setNumber(1)
+          .setSide("defence")
+          .setFaction("enemy");
     }
 
     @Test
@@ -101,7 +120,7 @@ class MainDefenseCombatValueTest {
 
       final Unit supportUnit = unitType.create(1, player, true).get(0);
       final UnitSupportAttachment unitSupportAttachment =
-          givenUnitSupportAttachment(gameData, unitType, "test")
+          givenUnitOffenseSupportAttachment(gameData, unitType, "test")
               .setBonus(2)
               .setPlayers(List.of(player))
               .setUnitType(Set.of(unitType));
@@ -109,11 +128,14 @@ class MainDefenseCombatValueTest {
       final AvailableSupports friendlySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(supportUnit), Set.of(unitSupportAttachment), false, true));
+                  List.of(supportUnit),
+                  Set.of(unitSupportAttachment),
+                  BattleState.Side.OFFENSE,
+                  true));
 
       final Unit enemySupportUnit = unitType.create(1, player, true).get(0);
       final UnitSupportAttachment enemyUnitSupportAttachment =
-          givenUnitSupportAttachment(gameData, unitType, "test2")
+          givenUnitDefenseSupportAttachment(gameData, unitType, "test2")
               .setBonus(-1)
               .setPlayers(List.of(player))
               .setUnitType(Set.of(unitType));
@@ -121,7 +143,10 @@ class MainDefenseCombatValueTest {
       final AvailableSupports enemySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(enemySupportUnit), Set.of(enemyUnitSupportAttachment), false, true));
+                  List.of(enemySupportUnit),
+                  Set.of(enemyUnitSupportAttachment),
+                  BattleState.Side.DEFENSE,
+                  false));
 
       final MainDefenseCombatValue.MainDefenseRoll roll =
           new MainDefenseCombatValue.MainDefenseRoll(friendlySupport, enemySupport);
@@ -163,7 +188,10 @@ class MainDefenseCombatValueTest {
       final AvailableSupports friendlySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(supportUnit), Set.of(unitSupportAttachment), false, true));
+                  List.of(supportUnit),
+                  Set.of(unitSupportAttachment),
+                  BattleState.Side.OFFENSE,
+                  true));
 
       final Unit enemySupportUnit = unitType.create(1, player, true).get(0);
       final UnitSupportAttachment enemyUnitSupportAttachment =
@@ -175,7 +203,10 @@ class MainDefenseCombatValueTest {
       final AvailableSupports enemySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(enemySupportUnit), Set.of(enemyUnitSupportAttachment), false, true));
+                  List.of(enemySupportUnit),
+                  Set.of(enemyUnitSupportAttachment),
+                  BattleState.Side.OFFENSE,
+                  true));
 
       final TerritoryEffect territoryEffect = new TerritoryEffect("territoryEffect", gameData);
       final TerritoryEffectAttachment territoryEffectAttachment =
@@ -231,7 +262,10 @@ class MainDefenseCombatValueTest {
       final AvailableSupports friendlySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(supportUnit), Set.of(unitSupportAttachment), false, true));
+                  List.of(supportUnit),
+                  Set.of(unitSupportAttachment),
+                  BattleState.Side.OFFENSE,
+                  true));
 
       final Unit enemySupportUnit = unitType.create(1, player, true).get(0);
       final UnitSupportAttachment enemyUnitSupportAttachment =
@@ -243,7 +277,10 @@ class MainDefenseCombatValueTest {
       final AvailableSupports enemySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(enemySupportUnit), Set.of(enemyUnitSupportAttachment), false, true));
+                  List.of(enemySupportUnit),
+                  Set.of(enemyUnitSupportAttachment),
+                  BattleState.Side.OFFENSE,
+                  true));
 
       final TerritoryEffect territoryEffect = new TerritoryEffect("territoryEffect", gameData);
       final TerritoryEffectAttachment territoryEffectAttachment =
@@ -283,7 +320,10 @@ class MainDefenseCombatValueTest {
       final AvailableSupports friendlySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(supportUnit), Set.of(unitSupportAttachment), false, true));
+                  List.of(supportUnit),
+                  Set.of(unitSupportAttachment),
+                  BattleState.Side.OFFENSE,
+                  true));
 
       final Unit enemySupportUnit = unitType.create(1, player, true).get(0);
       final UnitSupportAttachment enemyUnitSupportAttachment =
@@ -295,7 +335,10 @@ class MainDefenseCombatValueTest {
       final AvailableSupports enemySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(enemySupportUnit), Set.of(enemyUnitSupportAttachment), false, true));
+                  List.of(enemySupportUnit),
+                  Set.of(enemyUnitSupportAttachment),
+                  BattleState.Side.OFFENSE,
+                  true));
 
       final MainDefenseCombatValue.MainDefenseStrength strength =
           new MainDefenseCombatValue.MainDefenseStrength(

--- a/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/MainOffenseCombatValueTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/MainOffenseCombatValueTest.java
@@ -16,6 +16,7 @@ import games.strategy.engine.data.gameparser.GameParseException;
 import games.strategy.triplea.attachments.TerritoryEffectAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
+import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -42,7 +43,7 @@ class MainOffenseCombatValueTest {
 
       final Unit supportUnit = unitType.create(1, player, true).get(0);
       final UnitSupportAttachment unitSupportAttachment =
-          givenUnitSupportAttachment(gameData, unitType, "test")
+          givenUnitOffenseSupportAttachment(gameData, unitType, "test")
               .setBonus(2)
               .setPlayers(List.of(player))
               .setUnitType(Set.of(unitType));
@@ -50,11 +51,14 @@ class MainOffenseCombatValueTest {
       final AvailableSupports friendlySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(supportUnit), Set.of(unitSupportAttachment), false, true));
+                  List.of(supportUnit),
+                  Set.of(unitSupportAttachment),
+                  BattleState.Side.OFFENSE,
+                  true));
 
       final Unit enemySupportUnit = unitType.create(1, player, true).get(0);
       final UnitSupportAttachment enemyUnitSupportAttachment =
-          givenUnitSupportAttachment(gameData, unitType, "test2")
+          givenUnitDefenseSupportAttachment(gameData, unitType, "test2")
               .setBonus(-1)
               .setPlayers(List.of(player))
               .setUnitType(Set.of(unitType));
@@ -62,7 +66,10 @@ class MainOffenseCombatValueTest {
       final AvailableSupports enemySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(enemySupportUnit), Set.of(enemyUnitSupportAttachment), false, true));
+                  List.of(enemySupportUnit),
+                  Set.of(enemyUnitSupportAttachment),
+                  BattleState.Side.DEFENSE,
+                  false));
 
       final MainOffenseCombatValue.MainOffenseRoll roll =
           new MainOffenseCombatValue.MainOffenseRoll(friendlySupport, enemySupport);
@@ -72,7 +79,7 @@ class MainOffenseCombatValueTest {
           is(4));
     }
 
-    UnitSupportAttachment givenUnitSupportAttachment(
+    UnitSupportAttachment givenUnitOffenseSupportAttachment(
         final GameData gameData, final UnitType unitType, final String name)
         throws GameParseException {
       return new UnitSupportAttachment("rule" + name, unitType, gameData)
@@ -82,6 +89,18 @@ class MainOffenseCombatValueTest {
           .setNumber(1)
           .setSide("offence")
           .setFaction("allied");
+    }
+
+    UnitSupportAttachment givenUnitDefenseSupportAttachment(
+        final GameData gameData, final UnitType unitType, final String name)
+        throws GameParseException {
+      return new UnitSupportAttachment("rule" + name, unitType, gameData)
+          .setBonus(1)
+          .setBonusType("bonus" + name)
+          .setDice("roll")
+          .setNumber(1)
+          .setSide("defence")
+          .setFaction("enemy");
     }
 
     @Test
@@ -98,7 +117,7 @@ class MainOffenseCombatValueTest {
 
       final Unit supportUnit = unitType.create(1, player, true).get(0);
       final UnitSupportAttachment unitSupportAttachment =
-          givenUnitSupportAttachment(gameData, unitType, "test")
+          givenUnitOffenseSupportAttachment(gameData, unitType, "test")
               .setBonus(2)
               .setPlayers(List.of(player))
               .setUnitType(Set.of(unitType));
@@ -106,11 +125,14 @@ class MainOffenseCombatValueTest {
       final AvailableSupports friendlySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(supportUnit), Set.of(unitSupportAttachment), false, true));
+                  List.of(supportUnit),
+                  Set.of(unitSupportAttachment),
+                  BattleState.Side.OFFENSE,
+                  true));
 
       final Unit enemySupportUnit = unitType.create(1, player, true).get(0);
       final UnitSupportAttachment enemyUnitSupportAttachment =
-          givenUnitSupportAttachment(gameData, unitType, "test2")
+          givenUnitDefenseSupportAttachment(gameData, unitType, "test2")
               .setBonus(-1)
               .setPlayers(List.of(player))
               .setUnitType(Set.of(unitType));
@@ -118,7 +140,10 @@ class MainOffenseCombatValueTest {
       final AvailableSupports enemySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(enemySupportUnit), Set.of(enemyUnitSupportAttachment), false, true));
+                  List.of(enemySupportUnit),
+                  Set.of(enemyUnitSupportAttachment),
+                  BattleState.Side.DEFENSE,
+                  false));
 
       final MainOffenseCombatValue.MainOffenseRoll roll =
           new MainOffenseCombatValue.MainOffenseRoll(friendlySupport, enemySupport);
@@ -160,7 +185,10 @@ class MainOffenseCombatValueTest {
       final AvailableSupports friendlySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(supportUnit), Set.of(unitSupportAttachment), false, true));
+                  List.of(supportUnit),
+                  Set.of(unitSupportAttachment),
+                  BattleState.Side.OFFENSE,
+                  true));
 
       final Unit enemySupportUnit = unitType.create(1, player, true).get(0);
       final UnitSupportAttachment enemyUnitSupportAttachment =
@@ -172,7 +200,10 @@ class MainOffenseCombatValueTest {
       final AvailableSupports enemySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(enemySupportUnit), Set.of(enemyUnitSupportAttachment), false, true));
+                  List.of(enemySupportUnit),
+                  Set.of(enemyUnitSupportAttachment),
+                  BattleState.Side.OFFENSE,
+                  true));
 
       final TerritoryEffect territoryEffect = new TerritoryEffect("territoryEffect", gameData);
       final TerritoryEffectAttachment territoryEffectAttachment =
@@ -265,7 +296,10 @@ class MainOffenseCombatValueTest {
       final AvailableSupports friendlySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(supportUnit), Set.of(unitSupportAttachment), false, true));
+                  List.of(supportUnit),
+                  Set.of(unitSupportAttachment),
+                  BattleState.Side.OFFENSE,
+                  true));
 
       final Unit enemySupportUnit = unitType.create(1, player, true).get(0);
       final UnitSupportAttachment enemyUnitSupportAttachment =
@@ -277,7 +311,10 @@ class MainOffenseCombatValueTest {
       final AvailableSupports enemySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(enemySupportUnit), Set.of(enemyUnitSupportAttachment), false, true));
+                  List.of(enemySupportUnit),
+                  Set.of(enemyUnitSupportAttachment),
+                  BattleState.Side.OFFENSE,
+                  true));
 
       final MainOffenseCombatValue.MainOffenseStrength strength =
           new MainOffenseCombatValue.MainOffenseStrength(

--- a/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRollsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRollsTest.java
@@ -15,6 +15,7 @@ import games.strategy.engine.data.gameparser.GameParseException;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.Die;
+import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.ArrayList;
 import java.util.List;
@@ -780,7 +781,8 @@ class TotalPowerAndTotalRollsTest {
           units.stream()
               .sorted(
                   AaPowerStrengthAndRolls.sortAaHighToLow(
-                      CombatValue.buildAaCombatValue(List.of(), List.of(), false, gameData)))
+                      CombatValue.buildAaCombatValue(
+                          List.of(), List.of(), BattleState.Side.OFFENSE, gameData)))
               .collect(Collectors.toList());
       assertThat(sortedUnits.get(0), is(unit1));
       assertThat(sortedUnits.get(1), is(unit2));
@@ -803,7 +805,8 @@ class TotalPowerAndTotalRollsTest {
           units.stream()
               .sorted(
                   AaPowerStrengthAndRolls.sortAaHighToLow(
-                      CombatValue.buildAaCombatValue(List.of(), List.of(), true, gameData)))
+                      CombatValue.buildAaCombatValue(
+                          List.of(), List.of(), BattleState.Side.DEFENSE, gameData)))
               .collect(Collectors.toList());
       assertThat(sortedUnits.get(0), is(unit5));
       assertThat(sortedUnits.get(1), is(unit3));
@@ -829,7 +832,8 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(unit),
               1,
-              CombatValue.buildAaCombatValue(List.of(), List.of(), false, gameData));
+              CombatValue.buildAaCombatValue(
+                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
 
       assertThat("Dice comes from the unitAttachment", aaPowerAndRolls.getBestDiceSides(), is(8));
     }
@@ -844,7 +848,8 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(unit),
               1,
-              CombatValue.buildAaCombatValue(List.of(), List.of(), true, gameData));
+              CombatValue.buildAaCombatValue(
+                  List.of(), List.of(), BattleState.Side.DEFENSE, gameData));
 
       assertThat("Dice comes from the unitAttachment", aaPowerAndRolls.getBestDiceSides(), is(8));
     }
@@ -868,6 +873,7 @@ class TotalPowerAndTotalRollsTest {
       when(combatValue.getPower()).thenReturn(powerCalculator);
       when(combatValue.getDiceSides(unit)).thenReturn(6);
       when(combatValue.getGameData()).thenReturn(gameData);
+      when(combatValue.getBattleSide()).thenReturn(BattleState.Side.OFFENSE);
       final AaPowerStrengthAndRolls totalPowerAndTotalRolls =
           AaPowerStrengthAndRolls.build(List.of(unit), 1, combatValue);
 
@@ -889,7 +895,8 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(unit, unit2, unit3),
               1,
-              CombatValue.buildAaCombatValue(List.of(), List.of(), false, gameData));
+              CombatValue.buildAaCombatValue(
+                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
 
       assertThat(
           "All have the same dice sides, so take the best strength",
@@ -922,7 +929,8 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(unit, unit2, unit3),
               1,
-              CombatValue.buildAaCombatValue(List.of(), List.of(), false, gameData));
+              CombatValue.buildAaCombatValue(
+                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
 
       assertThat(
           "4 of 4 is better than 2 of 6 and 3 of 5", aaPowerAndRolls.getBestStrength(), is(4));
@@ -955,7 +963,8 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(unit, unit2, unit3),
               1,
-              CombatValue.buildAaCombatValue(List.of(), List.of(), false, gameData));
+              CombatValue.buildAaCombatValue(
+                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
 
       assertThat(
           "3 of 6 is better than 3 of 7 and 3 of 8", aaPowerAndRolls.getBestStrength(), is(3));
@@ -1025,7 +1034,10 @@ class TotalPowerAndTotalRollsTest {
       final AvailableSupports friendlySupport =
           AvailableSupports.getSupport(
               new SupportCalculator(
-                  List.of(supportUnit), List.of(unitSupportAttachment), false, true));
+                  List.of(supportUnit),
+                  List.of(unitSupportAttachment),
+                  BattleState.Side.OFFENSE,
+                  true));
 
       final AaPowerStrengthAndRolls result =
           AaPowerStrengthAndRolls.build(
@@ -1119,7 +1131,7 @@ class TotalPowerAndTotalRollsTest {
               new SupportCalculator(
                   List.of(supportUnit, supportUnit2),
                   List.of(unitSupportAttachment, unitSupportAttachment2),
-                  false,
+                  BattleState.Side.OFFENSE,
                   true));
 
       final PowerStrengthAndRolls result =
@@ -1174,7 +1186,8 @@ class TotalPowerAndTotalRollsTest {
       final PowerStrengthAndRolls powerStrengthAndRolls =
           PowerStrengthAndRolls.build(
               List.of(unit, unit2),
-              CombatValue.buildAaCombatValue(List.of(), List.of(), false, gameData));
+              CombatValue.buildAaCombatValue(
+                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
 
       assertThat(powerStrengthAndRolls.calculateTotalPower(), is(0));
       assertThat(powerStrengthAndRolls.calculateTotalRolls(), is(0));
@@ -1191,7 +1204,8 @@ class TotalPowerAndTotalRollsTest {
       final PowerStrengthAndRolls powerStrengthAndRolls =
           PowerStrengthAndRolls.build(
               List.of(unit, unit2),
-              CombatValue.buildAaCombatValue(List.of(), List.of(), false, gameData));
+              CombatValue.buildAaCombatValue(
+                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
 
       assertThat(powerStrengthAndRolls.calculateTotalPower(), is(5));
       assertThat(powerStrengthAndRolls.calculateTotalRolls(), is(2));
@@ -1208,7 +1222,8 @@ class TotalPowerAndTotalRollsTest {
       final PowerStrengthAndRolls powerStrengthAndRolls =
           PowerStrengthAndRolls.build(
               List.of(unit, unit2),
-              CombatValue.buildAaCombatValue(List.of(), List.of(), false, gameData));
+              CombatValue.buildAaCombatValue(
+                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
 
       assertThat(powerStrengthAndRolls.calculateTotalPower(), is(10));
       assertThat(powerStrengthAndRolls.calculateTotalRolls(), is(4));
@@ -1223,7 +1238,9 @@ class TotalPowerAndTotalRollsTest {
 
       final PowerStrengthAndRolls powerStrengthAndRolls =
           PowerStrengthAndRolls.build(
-              List.of(unit), CombatValue.buildAaCombatValue(List.of(), List.of(), false, gameData));
+              List.of(unit),
+              CombatValue.buildAaCombatValue(
+                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
 
       assertThat(powerStrengthAndRolls.calculateTotalPower(), is(12));
       assertThat(powerStrengthAndRolls.calculateTotalRolls(), is(2));
@@ -1246,7 +1263,8 @@ class TotalPowerAndTotalRollsTest {
       final PowerStrengthAndRolls powerStrengthAndRolls =
           PowerStrengthAndRolls.build(
               List.of(unit),
-              CombatValue.buildMainCombatValue(List.of(), List.of(), false, gameData, List.of()));
+              CombatValue.buildMainCombatValue(
+                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData, List.of()));
 
       assertThat(powerStrengthAndRolls.calculateTotalPower(), is(expectedPower));
       assertThat(powerStrengthAndRolls.calculateTotalRolls(), is(expectedRolls));
@@ -1279,7 +1297,8 @@ class TotalPowerAndTotalRollsTest {
       final PowerStrengthAndRolls powerStrengthAndRolls =
           PowerStrengthAndRolls.build(
               List.of(unit),
-              CombatValue.buildMainCombatValue(List.of(), List.of(), false, gameData, List.of()));
+              CombatValue.buildMainCombatValue(
+                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData, List.of()));
 
       assertThat(powerStrengthAndRolls.calculateTotalPower(), is(expectedPower));
       assertThat(powerStrengthAndRolls.calculateTotalRolls(), is(expectedRolls));
@@ -1299,7 +1318,8 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(unit),
               0,
-              CombatValue.buildAaCombatValue(List.of(), List.of(), false, gameData));
+              CombatValue.buildAaCombatValue(
+                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
 
       assertThat("No targets so no rolls", totalPowerAndTotalRolls.calculateTotalRolls(), is(0));
     }
@@ -1316,7 +1336,8 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(unit, unit2),
               1,
-              CombatValue.buildAaCombatValue(List.of(), List.of(), false, gameData));
+              CombatValue.buildAaCombatValue(
+                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
 
       assertThat(
           "Both units had either zero rolls or zero strength so no total rolls",
@@ -1333,7 +1354,8 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(unit),
               3,
-              CombatValue.buildAaCombatValue(List.of(), List.of(), false, gameData));
+              CombatValue.buildAaCombatValue(
+                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
       assertThat(
           "Infinite unit gets one roll for each target",
           totalPowerAndTotalRolls.calculateTotalRolls(),
@@ -1351,7 +1373,8 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(unit, unit2),
               3,
-              CombatValue.buildAaCombatValue(List.of(), List.of(), false, gameData));
+              CombatValue.buildAaCombatValue(
+                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
       assertThat(
           "Infinite unit gets one roll for each target but no overstacking",
           totalPowerAndTotalRolls.calculateTotalRolls(),
@@ -1369,7 +1392,8 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(unit, unit2),
               3,
-              CombatValue.buildAaCombatValue(List.of(), List.of(), false, gameData));
+              CombatValue.buildAaCombatValue(
+                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
       assertThat(
           "Non infinite and an infinite unit still just hit all the targets once",
           totalPowerAndTotalRolls.calculateTotalRolls(),
@@ -1385,7 +1409,8 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(unit),
               3,
-              CombatValue.buildAaCombatValue(List.of(), List.of(), false, gameData));
+              CombatValue.buildAaCombatValue(
+                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
       assertThat("Unit only has one roll", totalPowerAndTotalRolls.calculateTotalRolls(), is(1));
     }
 
@@ -1400,7 +1425,8 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(unit, unit2),
               3,
-              CombatValue.buildAaCombatValue(List.of(), List.of(), false, gameData));
+              CombatValue.buildAaCombatValue(
+                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
       assertThat(
           "There is only 3 units targets and the units have no overstack so only allow 3",
           totalPowerAndTotalRolls.calculateTotalRolls(),
@@ -1424,7 +1450,8 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(overstackUnit, unit, unit2),
               3,
-              CombatValue.buildAaCombatValue(List.of(), List.of(), false, gameData));
+              CombatValue.buildAaCombatValue(
+                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
 
       assertThat(
           "Infinite gives total attacks equal to number of units (3)"


### PR DESCRIPTION
I changed the battle calculation code to use the BattleState.Side enum instead of a boolean flag.  Outside of the AI code (which I minimally touched), I think I got the majority of places where it used a boolean flag.

## Testing
<!-- Describe any manual testing performed below. -->
A few battles in the UI to make sure things showed up correctly in the Battle UI.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
