### PR TITLE
Remove gameData parameter for the CombatValues

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
@@ -16,7 +16,7 @@ import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator;
 import games.strategy.triplea.delegate.battle.casualty.CasualtyUtil;
-import games.strategy.triplea.delegate.power.calculator.CombatValue;
+import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.delegate.power.calculator.PowerStrengthAndRolls;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -64,22 +64,30 @@ public final class ProBattleUtils {
         new UnitBattleComparator(
                 proData.getUnitValueMap(),
                 data,
-                CombatValue.buildMainCombatValue(
-                    List.of(),
-                    List.of(),
-                    BattleState.Side.OFFENSE,
-                    data,
-                    TerritoryEffectHelper.getEffects(t)))
+                CombatValueBuilder.mainCombatValue()
+                    .enemyUnits(List.of())
+                    .friendlyUnits(List.of())
+                    .side(BattleState.Side.OFFENSE)
+                    .gameSequence(data.getSequence())
+                    .supportAttachments(data.getUnitTypeList().getSupportRules())
+                    .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
+                    .gameDiceSides(data.getDiceSides())
+                    .territoryEffects(TerritoryEffectHelper.getEffects(t))
+                    .build())
             .reversed());
     final int attackPower =
         PowerStrengthAndRolls.build(
                 sortedUnitsList,
-                CombatValue.buildMainCombatValue(
-                    defendingUnits,
-                    sortedUnitsList,
-                    BattleState.Side.OFFENSE,
-                    data,
-                    TerritoryEffectHelper.getEffects(t)))
+                CombatValueBuilder.mainCombatValue()
+                    .enemyUnits(defendingUnits)
+                    .friendlyUnits(sortedUnitsList)
+                    .side(BattleState.Side.OFFENSE)
+                    .gameSequence(data.getSequence())
+                    .supportAttachments(data.getUnitTypeList().getSupportRules())
+                    .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
+                    .gameDiceSides(data.getDiceSides())
+                    .territoryEffects(TerritoryEffectHelper.getEffects(t))
+                    .build())
             .calculateTotalPower();
     final List<Unit> defendersWithHitPoints =
         CollectionUtils.getMatches(defendingUnits, Matches.unitIsInfrastructure().negate());
@@ -157,22 +165,30 @@ public final class ProBattleUtils {
         new UnitBattleComparator(
                 proData.getUnitValueMap(),
                 data,
-                CombatValue.buildMainCombatValue(
-                    List.of(),
-                    List.of(),
-                    attacking ? BattleState.Side.OFFENSE : BattleState.Side.DEFENSE,
-                    data,
-                    TerritoryEffectHelper.getEffects(t)))
+                CombatValueBuilder.mainCombatValue()
+                    .enemyUnits(List.of())
+                    .friendlyUnits(List.of())
+                    .side(attacking ? BattleState.Side.OFFENSE : BattleState.Side.DEFENSE)
+                    .gameSequence(data.getSequence())
+                    .supportAttachments(data.getUnitTypeList().getSupportRules())
+                    .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
+                    .gameDiceSides(data.getDiceSides())
+                    .territoryEffects(TerritoryEffectHelper.getEffects(t))
+                    .build())
             .reversed());
     final int myPower =
         PowerStrengthAndRolls.build(
                 sortedUnitsList,
-                CombatValue.buildMainCombatValue(
-                    enemyUnits,
-                    sortedUnitsList,
-                    attacking ? BattleState.Side.OFFENSE : BattleState.Side.DEFENSE,
-                    data,
-                    TerritoryEffectHelper.getEffects(t)))
+                CombatValueBuilder.mainCombatValue()
+                    .enemyUnits(enemyUnits)
+                    .friendlyUnits(sortedUnitsList)
+                    .side(attacking ? BattleState.Side.OFFENSE : BattleState.Side.DEFENSE)
+                    .gameSequence(data.getSequence())
+                    .supportAttachments(data.getUnitTypeList().getSupportRules())
+                    .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
+                    .gameDiceSides(data.getDiceSides())
+                    .territoryEffects(TerritoryEffectHelper.getEffects(t))
+                    .build())
             .calculateTotalPower();
     return (myPower * 6.0 / data.getDiceSides());
   }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
@@ -6,6 +6,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.Properties;
 import games.strategy.triplea.ai.pro.ProData;
 import games.strategy.triplea.ai.pro.data.ProTerritory;
 import games.strategy.triplea.attachments.UnitAttachment;
@@ -13,7 +14,7 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator;
-import games.strategy.triplea.delegate.power.calculator.CombatValue;
+import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.delegate.power.calculator.PowerStrengthAndRolls;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -205,8 +206,16 @@ public final class ProSortMoveOptionsUtils {
           new UnitBattleComparator(
               proData.getUnitValueMap(),
               data,
-              CombatValue.buildMainCombatValue(
-                  List.of(), List.of(), BattleState.Side.OFFENSE, data, effects));
+              CombatValueBuilder.mainCombatValue()
+                  .enemyUnits(List.of())
+                  .friendlyUnits(List.of())
+                  .side(BattleState.Side.OFFENSE)
+                  .gameSequence(data.getSequence())
+                  .supportAttachments(data.getUnitTypeList().getSupportRules())
+                  .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
+                  .gameDiceSides(data.getDiceSides())
+                  .territoryEffects(effects)
+                  .build());
 
       final List<Unit> defendingUnits =
           t.getUnitCollection().getMatches(Matches.enemyUnit(player, data));
@@ -222,8 +231,16 @@ public final class ProSortMoveOptionsUtils {
             (includeUnit ? 1 : -1)
                 * PowerStrengthAndRolls.build(
                         sortedUnits,
-                        CombatValue.buildMainCombatValue(
-                            defendingUnits, sortedUnits, BattleState.Side.OFFENSE, data, effects))
+                        CombatValueBuilder.mainCombatValue()
+                            .enemyUnits(defendingUnits)
+                            .friendlyUnits(sortedUnits)
+                            .side(BattleState.Side.OFFENSE)
+                            .gameSequence(data.getSequence())
+                            .supportAttachments(data.getUnitTypeList().getSupportRules())
+                            .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
+                            .gameDiceSides(data.getDiceSides())
+                            .territoryEffects(effects)
+                            .build())
                     .calculateTotalPower();
       }
       if (powerDifference < minPower) {

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -2246,10 +2246,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public int getAttackAaMaxDieSides() {
-    if (attackAaMaxDieSides < 0) {
-      return getData().getDiceSides();
-    }
-    return attackAaMaxDieSides;
+    return attackAaMaxDieSides > 0 ? attackAaMaxDieSides : getData().getDiceSides();
   }
 
   private void resetAttackAaMaxDieSides() {
@@ -2267,10 +2264,9 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public int getOffensiveAttackAaMaxDieSides() {
-    if (offensiveAttackAaMaxDieSides < 0) {
-      return getData().getDiceSides();
-    }
-    return offensiveAttackAaMaxDieSides;
+    return offensiveAttackAaMaxDieSides > 0
+        ? offensiveAttackAaMaxDieSides
+        : getData().getDiceSides();
   }
 
   private void resetOffensiveAttackAaMaxDieSides() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
@@ -16,7 +16,7 @@ import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.BattleTracker;
 import games.strategy.triplea.delegate.battle.casualty.AaCasualtySelector;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
-import games.strategy.triplea.delegate.power.calculator.CombatValue;
+import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.formatter.MyFormatter;
 import java.io.Serializable;
 import java.util.ArrayList;
@@ -329,14 +329,22 @@ class AaInMoveUtil implements Serializable {
         AaCasualtySelector.getAaCasualties(
             validTargetedUnitsForThisRoll,
             defendingAa,
-            CombatValue.buildMainCombatValue(
-                allEnemyUnits,
-                allFriendlyUnits,
-                BattleState.Side.OFFENSE,
-                bridge.getData(),
-                TerritoryEffectHelper.getEffects(territory)),
-            CombatValue.buildAaCombatValue(
-                allFriendlyUnits, allEnemyUnits, BattleState.Side.DEFENSE, bridge.getData()),
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(allEnemyUnits)
+                .friendlyUnits(allFriendlyUnits)
+                .side(BattleState.Side.OFFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(TerritoryEffectHelper.getEffects(territory))
+                .build(),
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(allFriendlyUnits)
+                .friendlyUnits(allEnemyUnits)
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build(),
             "Select "
                 + dice.getHits()
                 + " casualties from "

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -15,6 +15,7 @@ import games.strategy.triplea.delegate.Die.DieType;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.power.calculator.AaPowerStrengthAndRolls;
 import games.strategy.triplea.delegate.power.calculator.CombatValue;
+import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.delegate.power.calculator.PowerStrengthAndRolls;
 import games.strategy.triplea.delegate.power.calculator.TotalPowerAndTotalRolls;
 import games.strategy.triplea.formatter.MyFormatter;
@@ -90,7 +91,12 @@ public class DiceRoll implements Externalizable {
         aaUnits,
         bridge,
         location,
-        CombatValue.buildAaCombatValue(List.of(), List.of(), side, bridge.getData()));
+        CombatValueBuilder.aaCombatValue()
+            .enemyUnits(List.of())
+            .friendlyUnits(List.of())
+            .side(side)
+            .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+            .build());
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
@@ -22,7 +22,7 @@ import games.strategy.triplea.delegate.battle.casualty.CasualtySelector;
 import games.strategy.triplea.delegate.battle.casualty.CasualtySortingUtil;
 import games.strategy.triplea.delegate.data.BattleRecord;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
-import games.strategy.triplea.delegate.power.calculator.CombatValue;
+import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.util.TuvUtils;
 import java.util.ArrayList;
@@ -696,8 +696,12 @@ public class AirBattle extends AbstractBattle {
                       attacker,
                       bridge,
                       "Attackers Fire, ",
-                      CombatValue.buildAirBattleCombatValue(
-                          BattleState.Side.OFFENSE, bridge.getData()));
+                      CombatValueBuilder.airBattleCombatValue()
+                          .side(BattleState.Side.OFFENSE)
+                          .lhtrHeavyBombers(
+                              Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                          .gameDiceSides(bridge.getData().getDiceSides())
+                          .build());
             }
           };
       final IExecutable calculateCasualties =
@@ -710,12 +714,17 @@ public class AirBattle extends AbstractBattle {
                   CasualtySelector.selectCasualties(
                       defender,
                       defendingUnits,
-                      CombatValue.buildMainCombatValue(
-                          attackingUnits,
-                          defendingUnits,
-                          BattleState.Side.DEFENSE,
-                          bridge.getData(),
-                          List.of()),
+                      CombatValueBuilder.mainCombatValue()
+                          .enemyUnits(attackingUnits)
+                          .friendlyUnits(defendingUnits)
+                          .side(BattleState.Side.DEFENSE)
+                          .gameSequence(bridge.getData().getSequence())
+                          .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                          .lhtrHeavyBombers(
+                              Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                          .gameDiceSides(bridge.getData().getDiceSides())
+                          .territoryEffects(List.of())
+                          .build(),
                       battleSite,
                       bridge,
                       ATTACKERS_FIRE,
@@ -767,8 +776,12 @@ public class AirBattle extends AbstractBattle {
                       defender,
                       bridge,
                       "Defenders Fire, ",
-                      CombatValue.buildAirBattleCombatValue(
-                          BattleState.Side.DEFENSE, bridge.getData()));
+                      CombatValueBuilder.airBattleCombatValue()
+                          .side(BattleState.Side.DEFENSE)
+                          .lhtrHeavyBombers(
+                              Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                          .gameDiceSides(bridge.getData().getDiceSides())
+                          .build());
             }
           };
       final IExecutable calculateCasualties =
@@ -781,12 +794,17 @@ public class AirBattle extends AbstractBattle {
                   CasualtySelector.selectCasualties(
                       attacker,
                       attackingUnits,
-                      CombatValue.buildMainCombatValue(
-                          defendingUnits,
-                          attackingUnits,
-                          BattleState.Side.OFFENSE,
-                          bridge.getData(),
-                          List.of()),
+                      CombatValueBuilder.mainCombatValue()
+                          .enemyUnits(defendingUnits)
+                          .friendlyUnits(attackingUnits)
+                          .side(BattleState.Side.OFFENSE)
+                          .gameSequence(bridge.getData().getSequence())
+                          .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                          .lhtrHeavyBombers(
+                              Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                          .gameDiceSides(bridge.getData().getDiceSides())
+                          .territoryEffects(List.of())
+                          .build(),
                       battleSite,
                       bridge,
                       DEFENDERS_FIRE,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
@@ -32,7 +32,7 @@ import games.strategy.triplea.delegate.battle.casualty.CasualtySelector;
 import games.strategy.triplea.delegate.battle.casualty.CasualtySortingUtil;
 import games.strategy.triplea.delegate.data.BattleRecord;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
-import games.strategy.triplea.delegate.power.calculator.CombatValue;
+import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.util.TuvUtils;
 import java.util.ArrayList;
@@ -590,12 +590,16 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
       return CasualtySelector.selectCasualties(
           attacker,
           validAttackingUnitsForThisRoll,
-          CombatValue.buildMainCombatValue(
-              defendingUnits,
-              attackingUnits,
-              BattleState.Side.OFFENSE,
-              bridge.getData(),
-              territoryEffects),
+          CombatValueBuilder.mainCombatValue()
+              .enemyUnits(defendingUnits)
+              .friendlyUnits(attackingUnits)
+              .side(BattleState.Side.OFFENSE)
+              .gameSequence(bridge.getData().getSequence())
+              .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+              .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+              .gameDiceSides(bridge.getData().getDiceSides())
+              .territoryEffects(territoryEffects)
+              .build(),
           battleSite,
           bridge,
           text,
@@ -609,14 +613,22 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
         AaCasualtySelector.getAaCasualties(
             validAttackingUnitsForThisRoll,
             defendingAa,
-            CombatValue.buildMainCombatValue(
-                defendingUnits,
-                attackingUnits,
-                BattleState.Side.OFFENSE,
-                bridge.getData(),
-                territoryEffects),
-            CombatValue.buildAaCombatValue(
-                attackingUnits, defendingUnits, BattleState.Side.DEFENSE, bridge.getData()),
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(defendingUnits)
+                .friendlyUnits(attackingUnits)
+                .side(BattleState.Side.OFFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(territoryEffects)
+                .build(),
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(attackingUnits)
+                .friendlyUnits(defendingUnits)
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build(),
             "Hits from " + currentTypeAa + ", ",
             dice,
             bridge,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEnd.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEnd.java
@@ -6,6 +6,7 @@ import static games.strategy.triplea.delegate.battle.BattleState.UnitBattleFilte
 
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.Matches;
@@ -15,7 +16,7 @@ import games.strategy.triplea.delegate.battle.IBattle;
 import games.strategy.triplea.delegate.battle.steps.BattleStep;
 import games.strategy.triplea.delegate.battle.steps.RetreatChecks;
 import games.strategy.triplea.delegate.battle.steps.fire.general.FiringGroupSplitterGeneral;
-import games.strategy.triplea.delegate.power.calculator.CombatValue;
+import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.delegate.power.calculator.PowerStrengthAndRolls;
 import java.util.List;
 import java.util.Objects;
@@ -76,12 +77,17 @@ public class CheckGeneralBattleEnd implements BattleStep {
   private boolean hasNoStrengthOrRolls(final BattleState.Side side) {
     return !PowerStrengthAndRolls.build(
             battleState.filterUnits(ALIVE, side),
-            CombatValue.buildMainCombatValue(
-                battleState.filterUnits(ALIVE, side.getOpposite()),
-                battleState.filterUnits(ALIVE, side),
-                side,
-                battleState.getGameData(),
-                battleState.getTerritoryEffects()))
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(battleState.filterUnits(ALIVE, side.getOpposite()))
+                .friendlyUnits(battleState.filterUnits(ALIVE, side))
+                .side(side)
+                .gameSequence(battleState.getGameData().getSequence())
+                .supportAttachments(battleState.getGameData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(
+                    Properties.getLhtrHeavyBombers(battleState.getGameData().getProperties()))
+                .gameDiceSides(battleState.getGameData().getDiceSides())
+                .territoryEffects(battleState.getTerritoryEffects())
+                .build())
         .hasStrengthOrRolls();
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/MainDiceRoller.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/MainDiceRoller.java
@@ -3,8 +3,9 @@ package games.strategy.triplea.delegate.battle.steps.fire;
 import static games.strategy.triplea.delegate.battle.BattleState.UnitBattleFilter.ALIVE;
 
 import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.DiceRoll;
-import games.strategy.triplea.delegate.power.calculator.CombatValue;
+import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import java.util.function.BiFunction;
 
 /** Rolls dice for normal (basically, anything that isn't AA) dice requests */
@@ -21,11 +22,17 @@ public class MainDiceRoller implements BiFunction<IDelegateBridge, RollDiceStep,
             step.getBattleState().getPlayer(step.getSide()),
             step.getBattleState().getBattleSite(),
             step.getBattleState().getStatus().getRound()),
-        CombatValue.buildMainCombatValue(
-            step.getBattleState().filterUnits(ALIVE, step.getSide().getOpposite()),
-            step.getBattleState().filterUnits(ALIVE, step.getSide()),
-            step.getSide(),
-            step.getBattleState().getGameData(),
-            step.getBattleState().getTerritoryEffects()));
+        CombatValueBuilder.mainCombatValue()
+            .enemyUnits(step.getBattleState().filterUnits(ALIVE, step.getSide().getOpposite()))
+            .friendlyUnits(step.getBattleState().filterUnits(ALIVE, step.getSide()))
+            .side(step.getSide())
+            .gameSequence(step.getBattleState().getGameData().getSequence())
+            .supportAttachments(
+                step.getBattleState().getGameData().getUnitTypeList().getSupportRules())
+            .lhtrHeavyBombers(
+                Properties.getLhtrHeavyBombers(step.getBattleState().getGameData().getProperties()))
+            .gameDiceSides(step.getBattleState().getGameData().getDiceSides())
+            .territoryEffects(step.getBattleState().getTerritoryEffects())
+            .build());
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/NavalBombardment.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/NavalBombardment.java
@@ -16,7 +16,7 @@ import games.strategy.triplea.delegate.battle.MustFightBattle;
 import games.strategy.triplea.delegate.battle.casualty.CasualtySelector;
 import games.strategy.triplea.delegate.battle.steps.BattleStep;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
-import games.strategy.triplea.delegate.power.calculator.CombatValue;
+import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -113,11 +113,17 @@ public class NavalBombardment implements BattleStep {
               step.getBattleState().getPlayer(step.getSide()),
               step.getBattleState().getBattleSite(),
               step.getBattleState().getStatus().getRound()),
-          CombatValue.buildBombardmentCombatValue(
-              step.getBattleState().filterUnits(ALIVE, step.getSide().getOpposite()),
-              step.getBattleState().filterUnits(ALIVE, step.getSide()),
-              step.getBattleState().getGameData(),
-              step.getBattleState().getTerritoryEffects()));
+          CombatValueBuilder.navalBombardmentCombatValue()
+              .enemyUnits(step.getBattleState().filterUnits(ALIVE, step.getSide().getOpposite()))
+              .friendlyUnits(step.getBattleState().filterUnits(ALIVE, step.getSide()))
+              .supportAttachments(
+                  step.getBattleState().getGameData().getUnitTypeList().getSupportRules())
+              .lhtrHeavyBombers(
+                  Properties.getLhtrHeavyBombers(
+                      step.getBattleState().getGameData().getProperties()))
+              .gameDiceSides(step.getBattleState().getGameData().getDiceSides())
+              .territoryEffects(step.getBattleState().getTerritoryEffects())
+              .build());
     }
   }
 
@@ -129,11 +135,17 @@ public class NavalBombardment implements BattleStep {
       return CasualtySelector.selectCasualties(
           step.getBattleState().getPlayer(step.getSide().getOpposite()),
           step.getFiringGroup().getTargetUnits(),
-          CombatValue.buildBombardmentCombatValue(
-              step.getBattleState().filterUnits(ALIVE, step.getSide()),
-              step.getBattleState().filterUnits(ALIVE, step.getSide().getOpposite()),
-              step.getBattleState().getGameData(),
-              step.getBattleState().getTerritoryEffects()),
+          CombatValueBuilder.navalBombardmentCombatValue()
+              .enemyUnits(step.getBattleState().filterUnits(ALIVE, step.getSide()))
+              .friendlyUnits(step.getBattleState().filterUnits(ALIVE, step.getSide().getOpposite()))
+              .supportAttachments(
+                  step.getBattleState().getGameData().getUnitTypeList().getSupportRules())
+              .lhtrHeavyBombers(
+                  Properties.getLhtrHeavyBombers(
+                      step.getBattleState().getGameData().getProperties()))
+              .gameDiceSides(step.getBattleState().getGameData().getDiceSides())
+              .territoryEffects(step.getBattleState().getTerritoryEffects())
+              .build(),
           step.getBattleState().getBattleSite(),
           bridge,
           "Hits from " + step.getFiringGroup().getDisplayName() + ", ",

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/SelectMainBattleCasualties.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/SelectMainBattleCasualties.java
@@ -12,7 +12,7 @@ import games.strategy.triplea.delegate.BaseEditDelegate;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.battle.casualty.CasualtySelector;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
-import games.strategy.triplea.delegate.power.calculator.CombatValue;
+import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -153,12 +153,19 @@ public class SelectMainBattleCasualties
       return CasualtySelector.selectCasualties(
           step.getBattleState().getPlayer(step.getSide().getOpposite()),
           targetsToPickFrom,
-          CombatValue.buildMainCombatValue(
-              step.getBattleState().filterUnits(ALIVE, step.getSide()),
-              step.getBattleState().filterUnits(ALIVE, step.getSide().getOpposite()),
-              step.getSide().getOpposite(),
-              step.getBattleState().getGameData(),
-              step.getBattleState().getTerritoryEffects()),
+          CombatValueBuilder.mainCombatValue()
+              .enemyUnits(step.getBattleState().filterUnits(ALIVE, step.getSide()))
+              .friendlyUnits(step.getBattleState().filterUnits(ALIVE, step.getSide().getOpposite()))
+              .side(step.getSide().getOpposite())
+              .gameSequence(step.getBattleState().getGameData().getSequence())
+              .supportAttachments(
+                  step.getBattleState().getGameData().getUnitTypeList().getSupportRules())
+              .lhtrHeavyBombers(
+                  Properties.getLhtrHeavyBombers(
+                      step.getBattleState().getGameData().getProperties()))
+              .gameDiceSides(step.getBattleState().getGameData().getDiceSides())
+              .territoryEffects(step.getBattleState().getTerritoryEffects())
+              .build(),
           step.getBattleState().getBattleSite(),
           bridge,
           "Hits from " + step.getFiringGroup().getDisplayName() + ", ",

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaDefenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaDefenseCombatValue.java
@@ -1,8 +1,6 @@
 package games.strategy.triplea.delegate.power.calculator;
 
-import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Unit;
-import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.Collection;
 import java.util.List;
@@ -26,37 +24,35 @@ import org.triplea.java.collections.IntegerMap;
 @Getter(AccessLevel.NONE)
 class AaDefenseCombatValue implements CombatValue {
 
-  @Getter(onMethod = @__({@Override}))
-  @NonNull
-  GameData gameData;
+  @NonNull AvailableSupports strengthSupportFromFriends;
+  @NonNull AvailableSupports strengthSupportFromEnemies;
+  @NonNull AvailableSupports rollSupportFromFriends;
+  @NonNull AvailableSupports rollSupportFromEnemies;
 
-  @NonNull AvailableSupports supportFromFriends;
-  @NonNull AvailableSupports supportFromEnemies;
-
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = @Override)
   @NonNull
   @Builder.Default
   Collection<Unit> friendUnits = List.of();
 
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = @Override)
   @NonNull
   @Builder.Default
   Collection<Unit> enemyUnits = List.of();
 
   @Override
   public RollCalculator getRoll() {
-    return new AaRoll(supportFromFriends, supportFromEnemies);
+    return new AaRoll(rollSupportFromFriends.copy(), rollSupportFromEnemies.copy());
   }
 
   @Override
   public StrengthCalculator getStrength() {
-    return new AaDefenseStrength(this, supportFromFriends, supportFromEnemies);
+    return new AaDefenseStrength(
+        this, strengthSupportFromFriends.copy(), strengthSupportFromEnemies.copy());
   }
 
   @Override
   public int getDiceSides(final Unit unit) {
-    final int diceSides = unit.getUnitAttachment().getAttackAaMaxDieSides();
-    return diceSides < 1 ? gameData.getDiceSides() : diceSides;
+    return unit.getUnitAttachment().getAttackAaMaxDieSides();
   }
 
   @Override
@@ -72,9 +68,10 @@ class AaDefenseCombatValue implements CombatValue {
   @Override
   public CombatValue buildWithNoUnitSupports() {
     return AaDefenseCombatValue.builder()
-        .gameData(gameData)
-        .supportFromFriends(AvailableSupports.EMPTY_RESULT)
-        .supportFromEnemies(AvailableSupports.EMPTY_RESULT)
+        .rollSupportFromFriends(AvailableSupports.EMPTY_RESULT)
+        .rollSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
+        .strengthSupportFromFriends(AvailableSupports.EMPTY_RESULT)
+        .strengthSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
         .friendUnits(List.of())
         .enemyUnits(List.of())
         .build();
@@ -83,9 +80,10 @@ class AaDefenseCombatValue implements CombatValue {
   @Override
   public CombatValue buildOppositeCombatValue() {
     return AaOffenseCombatValue.builder()
-        .gameData(gameData)
-        .supportFromFriends(supportFromEnemies)
-        .supportFromEnemies(supportFromFriends)
+        .rollSupportFromFriends(rollSupportFromEnemies)
+        .rollSupportFromEnemies(rollSupportFromFriends)
+        .strengthSupportFromFriends(strengthSupportFromEnemies)
+        .strengthSupportFromEnemies(strengthSupportFromFriends)
         .friendUnits(enemyUnits)
         .enemyUnits(friendUnits)
         .build();
@@ -97,15 +95,6 @@ class AaDefenseCombatValue implements CombatValue {
     AaDefenseCombatValue calculator;
     AvailableSupports supportFromFriends;
     AvailableSupports supportFromEnemies;
-
-    AaDefenseStrength(
-        final AaDefenseCombatValue calculator,
-        final AvailableSupports supportFromFriends,
-        final AvailableSupports supportFromEnemies) {
-      this.calculator = calculator;
-      this.supportFromFriends = supportFromFriends.filter(UnitSupportAttachment::getAaStrength);
-      this.supportFromEnemies = supportFromEnemies.filter(UnitSupportAttachment::getAaStrength);
-    }
 
     @Override
     public StrengthValue getStrength(final Unit unit) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaOffenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaOffenseCombatValue.java
@@ -1,8 +1,6 @@
 package games.strategy.triplea.delegate.power.calculator;
 
-import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Unit;
-import games.strategy.triplea.attachments.UnitSupportAttachment;
 import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.Collection;
 import java.util.List;
@@ -26,37 +24,35 @@ import org.triplea.java.collections.IntegerMap;
 @Getter(AccessLevel.NONE)
 class AaOffenseCombatValue implements CombatValue {
 
-  @Getter(onMethod = @__({@Override}))
-  @NonNull
-  GameData gameData;
+  @NonNull AvailableSupports strengthSupportFromFriends;
+  @NonNull AvailableSupports strengthSupportFromEnemies;
+  @NonNull AvailableSupports rollSupportFromFriends;
+  @NonNull AvailableSupports rollSupportFromEnemies;
 
-  @NonNull AvailableSupports supportFromFriends;
-  @NonNull AvailableSupports supportFromEnemies;
-
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = @Override)
   @NonNull
   @Builder.Default
   Collection<Unit> friendUnits = List.of();
 
-  @Getter(onMethod = @__({@Override}))
+  @Getter(onMethod_ = @Override)
   @NonNull
   @Builder.Default
   Collection<Unit> enemyUnits = List.of();
 
   @Override
   public RollCalculator getRoll() {
-    return new AaRoll(supportFromFriends, supportFromEnemies);
+    return new AaRoll(rollSupportFromFriends.copy(), rollSupportFromEnemies.copy());
   }
 
   @Override
   public StrengthCalculator getStrength() {
-    return new AaOffenseStrength(this, supportFromFriends, supportFromEnemies);
+    return new AaOffenseStrength(
+        this, strengthSupportFromFriends.copy(), strengthSupportFromEnemies.copy());
   }
 
   @Override
   public int getDiceSides(final Unit unit) {
-    final int diceSides = unit.getUnitAttachment().getOffensiveAttackAaMaxDieSides();
-    return diceSides < 1 ? gameData.getDiceSides() : diceSides;
+    return unit.getUnitAttachment().getOffensiveAttackAaMaxDieSides();
   }
 
   @Override
@@ -72,9 +68,10 @@ class AaOffenseCombatValue implements CombatValue {
   @Override
   public CombatValue buildWithNoUnitSupports() {
     return AaOffenseCombatValue.builder()
-        .gameData(gameData)
-        .supportFromFriends(AvailableSupports.EMPTY_RESULT)
-        .supportFromEnemies(AvailableSupports.EMPTY_RESULT)
+        .rollSupportFromFriends(AvailableSupports.EMPTY_RESULT)
+        .rollSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
+        .strengthSupportFromFriends(AvailableSupports.EMPTY_RESULT)
+        .strengthSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
         .friendUnits(List.of())
         .enemyUnits(List.of())
         .build();
@@ -83,9 +80,10 @@ class AaOffenseCombatValue implements CombatValue {
   @Override
   public CombatValue buildOppositeCombatValue() {
     return AaDefenseCombatValue.builder()
-        .gameData(gameData)
-        .supportFromFriends(supportFromEnemies)
-        .supportFromEnemies(supportFromFriends)
+        .rollSupportFromFriends(rollSupportFromEnemies)
+        .rollSupportFromEnemies(rollSupportFromFriends)
+        .strengthSupportFromFriends(strengthSupportFromEnemies)
+        .strengthSupportFromEnemies(strengthSupportFromFriends)
         .friendUnits(enemyUnits)
         .enemyUnits(friendUnits)
         .build();
@@ -97,15 +95,6 @@ class AaOffenseCombatValue implements CombatValue {
     AaOffenseCombatValue calculator;
     AvailableSupports supportFromFriends;
     AvailableSupports supportFromEnemies;
-
-    AaOffenseStrength(
-        final AaOffenseCombatValue calculator,
-        final AvailableSupports supportFromFriends,
-        final AvailableSupports supportFromEnemies) {
-      this.calculator = calculator;
-      this.supportFromFriends = supportFromFriends.filter(UnitSupportAttachment::getAaStrength);
-      this.supportFromEnemies = supportFromEnemies.filter(UnitSupportAttachment::getAaStrength);
-    }
 
     @Override
     public StrengthValue getStrength(final Unit unit) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaPowerStrengthAndRolls.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaPowerStrengthAndRolls.java
@@ -1,7 +1,6 @@
 package games.strategy.triplea.delegate.power.calculator;
 
 import com.google.common.annotations.VisibleForTesting;
-import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.delegate.Die;
 import games.strategy.triplea.delegate.Matches;
@@ -40,7 +39,6 @@ public class AaPowerStrengthAndRolls implements TotalPowerAndTotalRolls {
   @Getter int bestDiceSides;
 
   CombatValue calculator;
-  GameData gameData;
 
   Map<Unit, UnitPowerStrengthAndRolls> totalStrengthAndTotalRollsByUnit = new HashMap<>();
 
@@ -57,17 +55,13 @@ public class AaPowerStrengthAndRolls implements TotalPowerAndTotalRolls {
   List<UnitPowerStrengthAndRolls> activeStrengthAndRolls;
 
   private AaPowerStrengthAndRolls(
-      final GameData gameData,
-      final Collection<Unit> units,
-      final int targetCount,
-      final CombatValue calculator) {
-    this.gameData = gameData;
+      final Collection<Unit> units, final int targetCount, final CombatValue calculator) {
     this.calculator = calculator;
     this.targetCount = targetCount;
     addUnits(units);
 
     int highestStrength = 0;
-    int chosenDiceSides = gameData.getDiceSides();
+    int chosenDiceSides = 100;
     for (final Map.Entry<Unit, UnitPowerStrengthAndRolls> unitStrengthAndRolls :
         totalStrengthAndTotalRollsByUnit.entrySet()) {
       final Unit u = unitStrengthAndRolls.getKey();
@@ -91,21 +85,20 @@ public class AaPowerStrengthAndRolls implements TotalPowerAndTotalRolls {
       final Collection<Unit> aaUnits, final int targetCount, final CombatValue calculator) {
 
     if (aaUnits == null || aaUnits.isEmpty()) {
-      return new AaPowerStrengthAndRolls(
-          calculator.getGameData(), List.of(), targetCount, calculator);
+      return new AaPowerStrengthAndRolls(List.of(), targetCount, calculator);
     }
     // First, sort units strongest to weakest without support so that later, the support is given
     // to the best units first
     return new AaPowerStrengthAndRolls(
-        calculator.getGameData(),
         aaUnits.stream()
             .sorted(
                 sortAaHighToLow(
-                    CombatValue.buildAaCombatValue(
-                        List.of(),
-                        List.of(),
-                        calculator.getBattleSide(),
-                        calculator.getGameData())))
+                    CombatValueBuilder.aaCombatValue()
+                        .enemyUnits(List.of())
+                        .friendlyUnits(List.of())
+                        .side(calculator.getBattleSide())
+                        .supportAttachments(List.of())
+                        .build()))
             .collect(Collectors.toList()),
         targetCount,
         calculator);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaRoll.java
@@ -1,7 +1,6 @@
 package games.strategy.triplea.delegate.power.calculator;
 
 import games.strategy.engine.data.Unit;
-import games.strategy.triplea.attachments.UnitSupportAttachment;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -17,11 +16,6 @@ class AaRoll implements RollCalculator {
 
   AvailableSupports supportFromFriends;
   AvailableSupports supportFromEnemies;
-
-  AaRoll(final AvailableSupports supportFromFriends, final AvailableSupports supportFromEnemies) {
-    this.supportFromFriends = supportFromFriends.filter(UnitSupportAttachment::getAaRoll);
-    this.supportFromEnemies = supportFromEnemies.filter(UnitSupportAttachment::getAaRoll);
-  }
 
   @Override
   public RollValue getRoll(final Unit unit) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AirBattleDefenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AirBattleDefenseCombatValue.java
@@ -1,8 +1,6 @@
 package games.strategy.triplea.delegate.power.calculator;
 
-import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Unit;
-import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.Collection;
 import java.util.List;
@@ -21,14 +19,21 @@ import org.triplea.java.collections.IntegerMap;
  */
 @Builder
 @Value
-@Getter(onMethod_ = @Override)
 class AirBattleDefenseCombatValue implements CombatValue {
 
-  @NonNull GameData gameData;
+  @NonNull Integer gameDiceSides;
 
-  @NonNull @Builder.Default Collection<Unit> friendUnits = List.of();
+  @NonNull Boolean lhtrHeavyBombers;
 
-  @NonNull @Builder.Default Collection<Unit> enemyUnits = List.of();
+  @Getter(onMethod_ = @Override)
+  @NonNull
+  @Builder.Default
+  Collection<Unit> friendUnits = List.of();
+
+  @Getter(onMethod_ = @Override)
+  @NonNull
+  @Builder.Default
+  Collection<Unit> enemyUnits = List.of();
 
   @Override
   public RollCalculator getRoll() {
@@ -37,7 +42,7 @@ class AirBattleDefenseCombatValue implements CombatValue {
 
   @Override
   public StrengthCalculator getStrength() {
-    return new AirBattleDefenseStrength(gameData.getDiceSides());
+    return new AirBattleDefenseStrength(gameDiceSides);
   }
 
   @Override
@@ -47,23 +52,28 @@ class AirBattleDefenseCombatValue implements CombatValue {
 
   @Override
   public int getDiceSides(final Unit unit) {
-    return gameData.getDiceSides();
+    return gameDiceSides;
   }
 
   @Override
   public boolean chooseBestRoll(final Unit unit) {
-    return Properties.getLhtrHeavyBombers(gameData.getProperties())
-        || unit.getUnitAttachment().getChooseBestRoll();
+    return lhtrHeavyBombers || unit.getUnitAttachment().getChooseBestRoll();
   }
 
   @Override
   public CombatValue buildWithNoUnitSupports() {
-    return AirBattleDefenseCombatValue.builder().gameData(gameData).build();
+    return AirBattleDefenseCombatValue.builder()
+        .gameDiceSides(gameDiceSides)
+        .lhtrHeavyBombers(lhtrHeavyBombers)
+        .build();
   }
 
   @Override
   public CombatValue buildOppositeCombatValue() {
-    return AirBattleOffenseCombatValue.builder().gameData(gameData).build();
+    return AirBattleOffenseCombatValue.builder()
+        .gameDiceSides(gameDiceSides)
+        .lhtrHeavyBombers(lhtrHeavyBombers)
+        .build();
   }
 
   @Value

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AirBattleOffenseCombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AirBattleOffenseCombatValue.java
@@ -1,8 +1,6 @@
 package games.strategy.triplea.delegate.power.calculator;
 
-import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Unit;
-import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.Collection;
 import java.util.List;
@@ -21,14 +19,21 @@ import org.triplea.java.collections.IntegerMap;
  */
 @Builder
 @Value
-@Getter(onMethod_ = @Override)
 class AirBattleOffenseCombatValue implements CombatValue {
 
-  @NonNull GameData gameData;
+  @NonNull Integer gameDiceSides;
 
-  @NonNull @Builder.Default Collection<Unit> friendUnits = List.of();
+  @NonNull Boolean lhtrHeavyBombers;
 
-  @NonNull @Builder.Default Collection<Unit> enemyUnits = List.of();
+  @Getter(onMethod_ = @Override)
+  @NonNull
+  @Builder.Default
+  Collection<Unit> friendUnits = List.of();
+
+  @Getter(onMethod_ = @Override)
+  @NonNull
+  @Builder.Default
+  Collection<Unit> enemyUnits = List.of();
 
   @Override
   public RollCalculator getRoll() {
@@ -37,7 +42,7 @@ class AirBattleOffenseCombatValue implements CombatValue {
 
   @Override
   public StrengthCalculator getStrength() {
-    return new AirBattleOffenseStrength(gameData.getDiceSides());
+    return new AirBattleOffenseStrength(gameDiceSides);
   }
 
   @Override
@@ -47,23 +52,28 @@ class AirBattleOffenseCombatValue implements CombatValue {
 
   @Override
   public int getDiceSides(final Unit unit) {
-    return gameData.getDiceSides();
+    return gameDiceSides;
   }
 
   @Override
   public boolean chooseBestRoll(final Unit unit) {
-    return Properties.getLhtrHeavyBombers(gameData.getProperties())
-        || unit.getUnitAttachment().getChooseBestRoll();
+    return lhtrHeavyBombers || unit.getUnitAttachment().getChooseBestRoll();
   }
 
   @Override
   public CombatValue buildWithNoUnitSupports() {
-    return AirBattleOffenseCombatValue.builder().gameData(gameData).build();
+    return AirBattleOffenseCombatValue.builder()
+        .gameDiceSides(gameDiceSides)
+        .lhtrHeavyBombers(lhtrHeavyBombers)
+        .build();
   }
 
   @Override
   public CombatValue buildOppositeCombatValue() {
-    return AirBattleDefenseCombatValue.builder().gameData(gameData).build();
+    return AirBattleDefenseCombatValue.builder()
+        .gameDiceSides(gameDiceSides)
+        .lhtrHeavyBombers(lhtrHeavyBombers)
+        .build();
   }
 
   @Value

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AvailableSupports.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AvailableSupports.java
@@ -64,6 +64,11 @@ class AvailableSupports {
         .build();
   }
 
+  /** Constructs a copied version of this */
+  AvailableSupports copy() {
+    return filter(support -> true);
+  }
+
   /** Constructs a filtered version of this */
   AvailableSupports filter(final Predicate<UnitSupportAttachment> ruleFilter) {
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/CombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/CombatValue.java
@@ -1,7 +1,5 @@
 package games.strategy.triplea.delegate.power.calculator;
 
-import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.Collection;
@@ -13,8 +11,7 @@ public interface CombatValue {
   StrengthCalculator getStrength();
 
   default PowerCalculator getPower() {
-    return new PowerCalculator(
-        getGameData(), getStrength(), getRoll(), this::chooseBestRoll, this::getDiceSides);
+    return new PowerCalculator(getStrength(), getRoll(), this::chooseBestRoll, this::getDiceSides);
   }
 
   int getDiceSides(Unit unit);
@@ -23,8 +20,6 @@ public interface CombatValue {
 
   boolean chooseBestRoll(Unit unit);
 
-  GameData getGameData();
-
   Collection<Unit> getFriendUnits();
 
   Collection<Unit> getEnemyUnits();
@@ -32,131 +27,4 @@ public interface CombatValue {
   CombatValue buildWithNoUnitSupports();
 
   CombatValue buildOppositeCombatValue();
-
-  static CombatValue buildMainCombatValue(
-      final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie,
-      final Collection<Unit> allFriendlyUnitsAliveOrWaitingToDie,
-      final BattleState.Side side,
-      final GameData gameData,
-      final Collection<TerritoryEffect> territoryEffects) {
-
-    // Get all friendly supports
-    final AvailableSupports supportFromFriends =
-        AvailableSupports.getSortedSupport(
-            new SupportCalculator(
-                allFriendlyUnitsAliveOrWaitingToDie,
-                gameData.getUnitTypeList().getSupportRules(),
-                side,
-                true));
-
-    // Get all enemy supports
-    final AvailableSupports supportFromEnemies =
-        AvailableSupports.getSortedSupport(
-            new SupportCalculator(
-                allEnemyUnitsAliveOrWaitingToDie,
-                gameData.getUnitTypeList().getSupportRules(),
-                side.getOpposite(),
-                false));
-
-    return side == BattleState.Side.DEFENSE
-        ? MainDefenseCombatValue.builder()
-            .gameData(gameData)
-            .supportFromFriends(supportFromFriends)
-            .supportFromEnemies(supportFromEnemies)
-            .friendUnits(allFriendlyUnitsAliveOrWaitingToDie)
-            .enemyUnits(allEnemyUnitsAliveOrWaitingToDie)
-            .territoryEffects(territoryEffects)
-            .build()
-        : MainOffenseCombatValue.builder()
-            .gameData(gameData)
-            .supportFromFriends(supportFromFriends)
-            .supportFromEnemies(supportFromEnemies)
-            .friendUnits(allFriendlyUnitsAliveOrWaitingToDie)
-            .enemyUnits(allEnemyUnitsAliveOrWaitingToDie)
-            .territoryEffects(territoryEffects)
-            .build();
-  }
-
-  static CombatValue buildAaCombatValue(
-      final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie,
-      final Collection<Unit> allFriendlyUnitsAliveOrWaitingToDie,
-      final BattleState.Side side,
-      final GameData gameData) {
-
-    // Get all friendly supports
-    final AvailableSupports supportFromFriends =
-        AvailableSupports.getSortedSupport(
-            new SupportCalculator(
-                allFriendlyUnitsAliveOrWaitingToDie, //
-                gameData.getUnitTypeList().getSupportAaRules(),
-                side,
-                true));
-
-    // Get all enemy supports
-    final AvailableSupports supportFromEnemies =
-        AvailableSupports.getSortedSupport(
-            new SupportCalculator(
-                allEnemyUnitsAliveOrWaitingToDie, //
-                gameData.getUnitTypeList().getSupportAaRules(),
-                side.getOpposite(),
-                false));
-
-    return side == BattleState.Side.DEFENSE
-        ? AaDefenseCombatValue.builder()
-            .gameData(gameData)
-            .supportFromFriends(supportFromFriends)
-            .supportFromEnemies(supportFromEnemies)
-            .friendUnits(allFriendlyUnitsAliveOrWaitingToDie)
-            .enemyUnits(allEnemyUnitsAliveOrWaitingToDie)
-            .build()
-        : AaOffenseCombatValue.builder()
-            .gameData(gameData)
-            .supportFromFriends(supportFromFriends)
-            .supportFromEnemies(supportFromEnemies)
-            .friendUnits(allFriendlyUnitsAliveOrWaitingToDie)
-            .enemyUnits(allEnemyUnitsAliveOrWaitingToDie)
-            .build();
-  }
-
-  static CombatValue buildBombardmentCombatValue(
-      final Collection<Unit> allEnemyUnitsAliveOrWaitingToDie,
-      final Collection<Unit> allFriendlyUnitsAliveOrWaitingToDie,
-      final GameData gameData,
-      final Collection<TerritoryEffect> territoryEffects) {
-
-    // Get all friendly supports
-    final AvailableSupports supportFromFriends =
-        AvailableSupports.getSortedSupport(
-            new SupportCalculator(
-                allFriendlyUnitsAliveOrWaitingToDie,
-                gameData.getUnitTypeList().getSupportRules(),
-                BattleState.Side.OFFENSE,
-                true));
-
-    // Get all enemy supports
-    final AvailableSupports supportFromEnemies =
-        AvailableSupports.getSortedSupport(
-            new SupportCalculator(
-                allEnemyUnitsAliveOrWaitingToDie,
-                gameData.getUnitTypeList().getSupportRules(),
-                BattleState.Side.DEFENSE,
-                false));
-
-    return BombardmentCombatValue.builder()
-        .gameData(gameData)
-        .supportFromFriends(supportFromFriends)
-        .supportFromEnemies(supportFromEnemies)
-        .friendUnits(allFriendlyUnitsAliveOrWaitingToDie)
-        .enemyUnits(allEnemyUnitsAliveOrWaitingToDie)
-        .territoryEffects(territoryEffects)
-        .build();
-  }
-
-  static CombatValue buildAirBattleCombatValue(
-      final BattleState.Side side, final GameData gameData) {
-
-    return side == BattleState.Side.DEFENSE
-        ? AirBattleDefenseCombatValue.builder().gameData(gameData).build()
-        : AirBattleOffenseCombatValue.builder().gameData(gameData).build();
-  }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/CombatValueBuilder.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/CombatValueBuilder.java
@@ -1,0 +1,164 @@
+package games.strategy.triplea.delegate.power.calculator;
+
+import games.strategy.engine.data.GameSequence;
+import games.strategy.engine.data.TerritoryEffect;
+import games.strategy.engine.data.Unit;
+import games.strategy.triplea.attachments.UnitSupportAttachment;
+import games.strategy.triplea.delegate.battle.BattleState;
+import java.util.Collection;
+import lombok.Builder;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class CombatValueBuilder {
+
+  @Builder(builderMethodName = "mainCombatValue", builderClassName = "MainBuilder")
+  static CombatValue buildMainCombatValue(
+      final Collection<Unit> enemyUnits,
+      final Collection<Unit> friendlyUnits,
+      final BattleState.Side side,
+      final GameSequence gameSequence,
+      final Collection<UnitSupportAttachment> supportAttachments,
+      final boolean lhtrHeavyBombers,
+      final int gameDiceSides,
+      final Collection<TerritoryEffect> territoryEffects) {
+
+    // Get all friendly supports
+    final AvailableSupports supportFromFriends =
+        AvailableSupports.getSortedSupport(
+            new SupportCalculator(friendlyUnits, supportAttachments, side, true));
+
+    // Get all enemy supports
+    final AvailableSupports supportFromEnemies =
+        AvailableSupports.getSortedSupport(
+            new SupportCalculator(enemyUnits, supportAttachments, side.getOpposite(), false));
+
+    return side == BattleState.Side.DEFENSE
+        ? MainDefenseCombatValue.builder()
+            .gameSequence(gameSequence)
+            .gameDiceSides(gameDiceSides)
+            .lhtrHeavyBombers(lhtrHeavyBombers)
+            .strengthSupportFromFriends(
+                supportFromFriends.filter(UnitSupportAttachment::getStrength))
+            .strengthSupportFromEnemies(
+                supportFromEnemies.filter(UnitSupportAttachment::getStrength))
+            .rollSupportFromFriends(supportFromFriends.filter(UnitSupportAttachment::getRoll))
+            .rollSupportFromEnemies(supportFromEnemies.filter(UnitSupportAttachment::getRoll))
+            .friendUnits(friendlyUnits)
+            .enemyUnits(enemyUnits)
+            .territoryEffects(territoryEffects)
+            .build()
+        : MainOffenseCombatValue.builder()
+            .gameSequence(gameSequence)
+            .gameDiceSides(gameDiceSides)
+            .lhtrHeavyBombers(lhtrHeavyBombers)
+            .strengthSupportFromFriends(
+                supportFromFriends.filter(UnitSupportAttachment::getStrength))
+            .strengthSupportFromEnemies(
+                supportFromEnemies.filter(UnitSupportAttachment::getStrength))
+            .rollSupportFromFriends(supportFromFriends.filter(UnitSupportAttachment::getRoll))
+            .rollSupportFromEnemies(supportFromEnemies.filter(UnitSupportAttachment::getRoll))
+            .friendUnits(friendlyUnits)
+            .enemyUnits(enemyUnits)
+            .territoryEffects(territoryEffects)
+            .build();
+  }
+
+  @Builder(builderMethodName = "aaCombatValue", builderClassName = "AaBuilder")
+  static CombatValue buildAaCombatValue(
+      final Collection<Unit> enemyUnits,
+      final Collection<Unit> friendlyUnits,
+      final BattleState.Side side,
+      final Collection<UnitSupportAttachment> supportAttachments) {
+
+    // Get all friendly supports
+    final AvailableSupports supportFromFriends =
+        AvailableSupports.getSortedSupport(
+            new SupportCalculator(
+                friendlyUnits, //
+                supportAttachments,
+                side,
+                true));
+
+    // Get all enemy supports
+    final AvailableSupports supportFromEnemies =
+        AvailableSupports.getSortedSupport(
+            new SupportCalculator(
+                enemyUnits, //
+                supportAttachments,
+                side.getOpposite(),
+                false));
+
+    return side == BattleState.Side.DEFENSE
+        ? AaDefenseCombatValue.builder()
+            .strengthSupportFromFriends(
+                supportFromFriends.filter(UnitSupportAttachment::getAaStrength))
+            .strengthSupportFromEnemies(
+                supportFromEnemies.filter(UnitSupportAttachment::getAaStrength))
+            .rollSupportFromFriends(supportFromFriends.filter(UnitSupportAttachment::getAaRoll))
+            .rollSupportFromEnemies(supportFromEnemies.filter(UnitSupportAttachment::getAaRoll))
+            .friendUnits(friendlyUnits)
+            .enemyUnits(enemyUnits)
+            .build()
+        : AaOffenseCombatValue.builder()
+            .strengthSupportFromFriends(
+                supportFromFriends.filter(UnitSupportAttachment::getAaStrength))
+            .strengthSupportFromEnemies(
+                supportFromEnemies.filter(UnitSupportAttachment::getAaStrength))
+            .rollSupportFromFriends(supportFromFriends.filter(UnitSupportAttachment::getRoll))
+            .rollSupportFromEnemies(supportFromEnemies.filter(UnitSupportAttachment::getRoll))
+            .friendUnits(friendlyUnits)
+            .enemyUnits(enemyUnits)
+            .build();
+  }
+
+  @Builder(
+      builderMethodName = "navalBombardmentCombatValue",
+      builderClassName = "NavalBombardmentBuilder")
+  static CombatValue buildBombardmentCombatValue(
+      final Collection<Unit> enemyUnits,
+      final Collection<Unit> friendlyUnits,
+      final Collection<UnitSupportAttachment> supportAttachments,
+      final boolean lhtrHeavyBombers,
+      final int gameDiceSides,
+      final Collection<TerritoryEffect> territoryEffects) {
+
+    // Get all friendly supports
+    final AvailableSupports supportFromFriends =
+        AvailableSupports.getSortedSupport(
+            new SupportCalculator(
+                friendlyUnits, supportAttachments, BattleState.Side.OFFENSE, true));
+
+    // Get all enemy supports
+    final AvailableSupports supportFromEnemies =
+        AvailableSupports.getSortedSupport(
+            new SupportCalculator(enemyUnits, supportAttachments, BattleState.Side.DEFENSE, false));
+
+    return BombardmentCombatValue.builder()
+        .gameDiceSides(gameDiceSides)
+        .lhtrHeavyBombers(lhtrHeavyBombers)
+        .strengthSupportFromFriends(supportFromFriends.filter(UnitSupportAttachment::getStrength))
+        .strengthSupportFromEnemies(supportFromEnemies.filter(UnitSupportAttachment::getStrength))
+        .rollSupportFromFriends(supportFromFriends.filter(UnitSupportAttachment::getRoll))
+        .rollSupportFromEnemies(supportFromEnemies.filter(UnitSupportAttachment::getRoll))
+        .friendUnits(friendlyUnits)
+        .enemyUnits(enemyUnits)
+        .territoryEffects(territoryEffects)
+        .build();
+  }
+
+  @Builder(builderMethodName = "airBattleCombatValue", builderClassName = "AirBattleBuilder")
+  static CombatValue buildAirBattleCombatValue(
+      final BattleState.Side side, final boolean lhtrHeavyBombers, final int gameDiceSides) {
+
+    return side == BattleState.Side.DEFENSE
+        ? AirBattleDefenseCombatValue.builder()
+            .gameDiceSides(gameDiceSides)
+            .lhtrHeavyBombers(lhtrHeavyBombers)
+            .build()
+        : AirBattleOffenseCombatValue.builder()
+            .gameDiceSides(gameDiceSides)
+            .lhtrHeavyBombers(lhtrHeavyBombers)
+            .build();
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/PowerCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/PowerCalculator.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.delegate.power.calculator;
 
-import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Unit;
 import java.util.function.Function;
 import lombok.AccessLevel;
@@ -19,7 +18,6 @@ import lombok.Value;
 @AllArgsConstructor
 public class PowerCalculator {
 
-  GameData gameData;
   StrengthCalculator strengthCalculator;
   RollCalculator rollCalculator;
   Function<Unit, Boolean> chooseBestRoll;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/PowerStrengthAndRolls.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/PowerStrengthAndRolls.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.delegate.power.calculator;
 
-import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Unit;
 import java.util.Collection;
 import java.util.HashMap;
@@ -23,7 +22,6 @@ import org.triplea.java.collections.IntegerMap;
 public class PowerStrengthAndRolls implements TotalPowerAndTotalRolls {
 
   CombatValue calculator;
-  GameData gameData;
 
   @Getter(AccessLevel.PUBLIC)
   Map<Unit, UnitPowerStrengthAndRolls> totalStrengthAndTotalRollsByUnit = new HashMap<>();
@@ -34,9 +32,7 @@ public class PowerStrengthAndRolls implements TotalPowerAndTotalRolls {
   @Getter(AccessLevel.PUBLIC)
   Map<Unit, IntegerMap<Unit>> unitSupportRollsMap = new HashMap<>();
 
-  private PowerStrengthAndRolls(
-      final GameData gameData, final Collection<Unit> units, final CombatValue calculator) {
-    this.gameData = gameData;
+  private PowerStrengthAndRolls(final Collection<Unit> units, final CombatValue calculator) {
     this.calculator = calculator;
     addUnits(units);
   }
@@ -51,10 +47,10 @@ public class PowerStrengthAndRolls implements TotalPowerAndTotalRolls {
       final Collection<Unit> unitsGettingPowerFor, final CombatValue calculator) {
 
     if (unitsGettingPowerFor == null || unitsGettingPowerFor.isEmpty()) {
-      return new PowerStrengthAndRolls(calculator.getGameData(), List.of(), calculator);
+      return new PowerStrengthAndRolls(List.of(), calculator);
     }
 
-    return new PowerStrengthAndRolls(calculator.getGameData(), unitsGettingPowerFor, calculator);
+    return new PowerStrengthAndRolls(unitsGettingPowerFor, calculator);
   }
 
   private void addUnits(final Collection<Unit> units) {

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -16,7 +16,7 @@ import games.strategy.triplea.delegate.battle.BattleDelegate;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator;
 import games.strategy.triplea.delegate.battle.casualty.CasualtyUtil;
-import games.strategy.triplea.delegate.power.calculator.CombatValue;
+import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.delegate.power.calculator.PowerStrengthAndRolls;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.UiContext;
@@ -1424,8 +1424,16 @@ class BattleCalculatorPanel extends JPanel {
           new UnitBattleComparator(
                   costs,
                   data,
-                  CombatValue.buildMainCombatValue(
-                      List.of(), List.of(), BattleState.Side.OFFENSE, data, territoryEffects))
+                  CombatValueBuilder.mainCombatValue()
+                      .enemyUnits(List.of())
+                      .friendlyUnits(List.of())
+                      .side(BattleState.Side.OFFENSE)
+                      .gameSequence(data.getSequence())
+                      .supportAttachments(data.getUnitTypeList().getSupportRules())
+                      .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
+                      .gameDiceSides(data.getDiceSides())
+                      .territoryEffects(territoryEffects)
+                      .build())
               .reversed());
       if (isAmphibiousBattle()) {
         attackers.stream()
@@ -1446,15 +1454,31 @@ class BattleCalculatorPanel extends JPanel {
       final int attackPower =
           PowerStrengthAndRolls.build(
                   attackers,
-                  CombatValue.buildMainCombatValue(
-                      defenders, attackers, BattleState.Side.OFFENSE, data, territoryEffects))
+                  CombatValueBuilder.mainCombatValue()
+                      .enemyUnits(defenders)
+                      .friendlyUnits(attackers)
+                      .side(BattleState.Side.OFFENSE)
+                      .gameSequence(data.getSequence())
+                      .supportAttachments(data.getUnitTypeList().getSupportRules())
+                      .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
+                      .gameDiceSides(data.getDiceSides())
+                      .territoryEffects(territoryEffects)
+                      .build())
               .calculateTotalPower();
       // defender is never amphibious
       final int defensePower =
           PowerStrengthAndRolls.build(
                   defenders,
-                  CombatValue.buildMainCombatValue(
-                      attackers, defenders, BattleState.Side.DEFENSE, data, territoryEffects))
+                  CombatValueBuilder.mainCombatValue()
+                      .enemyUnits(attackers)
+                      .friendlyUnits(defenders)
+                      .side(BattleState.Side.DEFENSE)
+                      .gameSequence(data.getSequence())
+                      .supportAttachments(data.getUnitTypeList().getSupportRules())
+                      .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
+                      .gameDiceSides(data.getDiceSides())
+                      .territoryEffects(territoryEffects)
+                      .build())
               .calculateTotalPower();
       attackerUnitsTotalPower.setText("Power: " + attackPower);
       defenderUnitsTotalPower.setText("Power: " + defensePower);

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -10,6 +10,7 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.BaseEditDelegate;
 import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.delegate.Die;
@@ -21,6 +22,7 @@ import games.strategy.triplea.delegate.battle.casualty.CasualtyUtil;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
 import games.strategy.triplea.delegate.data.CasualtyList;
 import games.strategy.triplea.delegate.power.calculator.CombatValue;
+import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.delegate.power.calculator.PowerStrengthAndRolls;
 import games.strategy.triplea.delegate.power.calculator.TotalPowerAndTotalRolls;
 import games.strategy.triplea.settings.ClientSetting;
@@ -877,15 +879,24 @@ public class BattleDisplay extends JPanel {
       try {
         final CombatValue combatValue;
         if (isAirPreBattleOrPreRaid) {
-          combatValue = CombatValue.buildAirBattleCombatValue(side, gameData);
+          combatValue =
+              CombatValueBuilder.airBattleCombatValue()
+                  .side(BattleState.Side.DEFENSE)
+                  .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(gameData.getProperties()))
+                  .gameDiceSides(gameData.getDiceSides())
+                  .build();
         } else {
           combatValue =
-              CombatValue.buildMainCombatValue(
-                  new ArrayList<>(enemyBattleModel.getUnits()),
-                  units,
-                  side,
-                  gameData,
-                  territoryEffects);
+              CombatValueBuilder.mainCombatValue()
+                  .enemyUnits(new ArrayList<>(enemyBattleModel.getUnits()))
+                  .friendlyUnits(units)
+                  .side(side)
+                  .gameSequence(gameData.getSequence())
+                  .supportAttachments(gameData.getUnitTypeList().getSupportRules())
+                  .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(gameData.getProperties()))
+                  .gameDiceSides(gameData.getDiceSides())
+                  .territoryEffects(territoryEffects)
+                  .build();
         }
         unitPowerAndRollsMap = PowerStrengthAndRolls.build(units, combatValue);
       } finally {

--- a/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -22,7 +22,7 @@ import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.UnitBattleComparator;
 import games.strategy.triplea.delegate.data.MustMoveWithDetails;
 import games.strategy.triplea.delegate.move.validation.MoveValidator;
-import games.strategy.triplea.delegate.power.calculator.CombatValue;
+import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.formatter.MyFormatter;
 import games.strategy.triplea.ui.panels.map.MapPanel;
 import games.strategy.triplea.ui.panels.map.MapSelectionListener;
@@ -688,8 +688,17 @@ class EditPanel extends ActionPanel {
                 new UnitBattleComparator(
                         TuvUtils.getCostsForTuv(player, getData()),
                         getData(),
-                        CombatValue.buildMainCombatValue(
-                            List.of(), List.of(), BattleState.Side.OFFENSE, getData(), List.of()),
+                        CombatValueBuilder.mainCombatValue()
+                            .enemyUnits(List.of())
+                            .friendlyUnits(List.of())
+                            .side(BattleState.Side.OFFENSE)
+                            .gameSequence(getData().getSequence())
+                            .supportAttachments(getData().getUnitTypeList().getSupportRules())
+                            .lhtrHeavyBombers(
+                                Properties.getLhtrHeavyBombers(getData().getProperties()))
+                            .gameDiceSides(getData().getDiceSides())
+                            .territoryEffects(List.of())
+                            .build(),
                         true)
                     .reversed());
             // unit mapped to <max, min, current>
@@ -766,8 +775,17 @@ class EditPanel extends ActionPanel {
                 new UnitBattleComparator(
                         TuvUtils.getCostsForTuv(player, getData()),
                         getData(),
-                        CombatValue.buildMainCombatValue(
-                            List.of(), List.of(), BattleState.Side.OFFENSE, getData(), List.of()),
+                        CombatValueBuilder.mainCombatValue()
+                            .enemyUnits(List.of())
+                            .friendlyUnits(List.of())
+                            .side(BattleState.Side.OFFENSE)
+                            .gameSequence(getData().getSequence())
+                            .supportAttachments(getData().getUnitTypeList().getSupportRules())
+                            .lhtrHeavyBombers(
+                                Properties.getLhtrHeavyBombers(getData().getProperties()))
+                            .gameDiceSides(getData().getDiceSides())
+                            .territoryEffects(List.of())
+                            .build(),
                         true)
                     .reversed());
             // unit mapped to <max, min, current>

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -59,7 +59,7 @@ import games.strategy.triplea.delegate.battle.UnitBattleComparator;
 import games.strategy.triplea.delegate.data.FightBattleDetails;
 import games.strategy.triplea.delegate.data.TechResults;
 import games.strategy.triplea.delegate.data.TechRoll;
-import games.strategy.triplea.delegate.power.calculator.CombatValue;
+import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.delegate.remote.IEditDelegate;
 import games.strategy.triplea.delegate.remote.IPoliticsDelegate;
 import games.strategy.triplea.delegate.remote.IUserActionDelegate;
@@ -1427,12 +1427,16 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
                 new UnitBattleComparator(
                         TuvUtils.getCostsForTuv(units.get(0).getOwner(), data),
                         data,
-                        CombatValue.buildMainCombatValue(
-                            List.of(),
-                            List.of(),
-                            BattleState.Side.OFFENSE,
-                            data,
-                            TerritoryEffectHelper.getEffects(entry.getKey())),
+                        CombatValueBuilder.mainCombatValue()
+                            .enemyUnits(List.of())
+                            .friendlyUnits(List.of())
+                            .side(BattleState.Side.OFFENSE)
+                            .gameSequence(data.getSequence())
+                            .supportAttachments(data.getUnitTypeList().getSupportRules())
+                            .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
+                            .gameDiceSides(data.getDiceSides())
+                            .territoryEffects(TerritoryEffectHelper.getEffects(entry.getKey()))
+                            .build(),
                         true)
                     .reversed());
             possibleUnitsToAttackStringForm.put(entry.getKey().getName(), units);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -21,11 +21,12 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Constants;
+import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.StrategicBombingRaidBattle;
-import games.strategy.triplea.delegate.power.calculator.CombatValue;
+import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.math.BigDecimal;
 import java.util.Collection;
@@ -57,8 +58,16 @@ class DiceRollTest {
             russians,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(), infantry, BattleState.Side.DEFENSE, bridge.getData(), territoryEffects));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(infantry)
+                .side(BattleState.Side.DEFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(territoryEffects)
+                .build());
     assertThat(roll.getHits(), is(1));
     // infantry
     final DiceRoll roll2 =
@@ -67,8 +76,16 @@ class DiceRollTest {
             russians,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(), infantry, BattleState.Side.DEFENSE, bridge.getData(), territoryEffects));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(infantry)
+                .side(BattleState.Side.DEFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(territoryEffects)
+                .build());
     assertThat(roll2.getHits(), is(0));
     // infantry attacks
     final DiceRoll roll3 =
@@ -77,8 +94,16 @@ class DiceRollTest {
             russians,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(), infantry, BattleState.Side.OFFENSE, bridge.getData(), territoryEffects));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(infantry)
+                .side(BattleState.Side.OFFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(territoryEffects)
+                .build());
     assertThat(roll3.getHits(), is(1));
     // infantry attack
     final DiceRoll roll4 =
@@ -87,8 +112,16 @@ class DiceRollTest {
             russians,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(), infantry, BattleState.Side.OFFENSE, bridge.getData(), territoryEffects));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(infantry)
+                .side(BattleState.Side.OFFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(territoryEffects)
+                .build());
     assertThat(roll4.getHits(), is(0));
   }
 
@@ -114,8 +147,16 @@ class DiceRollTest {
             russians,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(), infantry, BattleState.Side.DEFENSE, bridge.getData(), territoryEffects));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(infantry)
+                .side(BattleState.Side.DEFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(territoryEffects)
+                .build());
     assertThat(roll.getHits(), is(1));
     // infantry
     final DiceRoll roll2 =
@@ -124,8 +165,16 @@ class DiceRollTest {
             russians,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(), infantry, BattleState.Side.DEFENSE, bridge.getData(), territoryEffects));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(infantry)
+                .side(BattleState.Side.DEFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(territoryEffects)
+                .build());
     assertThat(roll2.getHits(), is(0));
     // infantry attacks
     final DiceRoll roll3 =
@@ -134,8 +183,16 @@ class DiceRollTest {
             russians,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(), infantry, BattleState.Side.OFFENSE, bridge.getData(), territoryEffects));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(infantry)
+                .side(BattleState.Side.OFFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(territoryEffects)
+                .build());
     assertThat(roll3.getHits(), is(1));
     // infantry attack
     final DiceRoll roll4 =
@@ -144,8 +201,16 @@ class DiceRollTest {
             russians,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(), infantry, BattleState.Side.OFFENSE, bridge.getData(), territoryEffects));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(infantry)
+                .side(BattleState.Side.OFFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(territoryEffects)
+                .build());
     assertThat(roll4.getHits(), is(0));
   }
 
@@ -167,12 +232,16 @@ class DiceRollTest {
             russians,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                units,
-                BattleState.Side.OFFENSE,
-                bridge.getData(),
-                TerritoryEffectHelper.getEffects(westRussia)));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(units)
+                .side(BattleState.Side.OFFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(TerritoryEffectHelper.getEffects(westRussia))
+                .build());
     assertThat(roll.getHits(), is(2));
   }
 
@@ -201,12 +270,16 @@ class DiceRollTest {
             russians,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                units,
-                BattleState.Side.OFFENSE,
-                bridge.getData(),
-                TerritoryEffectHelper.getEffects(westRussia)));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(units)
+                .side(BattleState.Side.OFFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(TerritoryEffectHelper.getEffects(westRussia))
+                .build());
     assertThat(roll.getHits(), is(3));
   }
 
@@ -225,12 +298,16 @@ class DiceRollTest {
             russians,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                units,
-                BattleState.Side.DEFENSE,
-                bridge.getData(),
-                TerritoryEffectHelper.getEffects(westRussia)));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(units)
+                .side(BattleState.Side.DEFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(TerritoryEffectHelper.getEffects(westRussia))
+                .build());
     assertThat(roll.getHits(), is(1));
     thenGetRandomShouldHaveBeenCalled(bridge, never());
   }
@@ -262,12 +339,16 @@ class DiceRollTest {
             americans,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                attackers,
-                BattleState.Side.OFFENSE,
-                bridge.getData(),
-                TerritoryEffectHelper.getEffects(algeria)));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(attackers)
+                .side(BattleState.Side.OFFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(TerritoryEffectHelper.getEffects(algeria))
+                .build());
     assertThat(roll.getHits(), is(1));
   }
 
@@ -298,12 +379,16 @@ class DiceRollTest {
             americans,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                attackers,
-                BattleState.Side.OFFENSE,
-                bridge.getData(),
-                TerritoryEffectHelper.getEffects(algeria)));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(attackers)
+                .side(BattleState.Side.OFFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(TerritoryEffectHelper.getEffects(algeria))
+                .build());
     assertThat(roll.getHits(), is(1));
     thenGetRandomShouldHaveBeenCalled(bridge, never());
   }
@@ -335,12 +420,16 @@ class DiceRollTest {
             americans,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                attackers,
-                BattleState.Side.OFFENSE,
-                bridge.getData(),
-                TerritoryEffectHelper.getEffects(algeria)));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(attackers)
+                .side(BattleState.Side.OFFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(TerritoryEffectHelper.getEffects(algeria))
+                .build());
     assertThat(roll.getHits(), is(0));
   }
 
@@ -364,8 +453,12 @@ class DiceRollTest {
             aaGunList,
             bridge,
             westRussia,
-            CombatValue.buildAaCombatValue(
-                bombers, aaGunList, BattleState.Side.DEFENSE, bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(bombers)
+                .friendlyUnits(aaGunList)
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     assertThat(hit.getHits(), is(1));
     // aa misses
     final DiceRoll miss =
@@ -374,8 +467,12 @@ class DiceRollTest {
             aaGunList,
             bridge,
             westRussia,
-            CombatValue.buildAaCombatValue(
-                bombers, aaGunList, BattleState.Side.DEFENSE, bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(bombers)
+                .friendlyUnits(aaGunList)
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     assertThat(miss.getHits(), is(0));
   }
 
@@ -405,8 +502,12 @@ class DiceRollTest {
             aaGunList,
             bridge,
             westRussia,
-            CombatValue.buildAaCombatValue(
-                fighterList, aaGunList, BattleState.Side.DEFENSE, bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(fighterList)
+                .friendlyUnits(aaGunList)
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     assertThat(hit.getHits(), is(1));
     // aa misses
     final DiceRoll miss =
@@ -419,8 +520,12 @@ class DiceRollTest {
             aaGunList,
             bridge,
             westRussia,
-            CombatValue.buildAaCombatValue(
-                fighterList, aaGunList, BattleState.Side.DEFENSE, bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(fighterList)
+                .friendlyUnits(aaGunList)
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     assertThat(miss.getHits(), is(0));
     // 6 bombers, 1 should hit, and nothing should be rolled
     fighterList = fighterType.create(6, russians);
@@ -434,8 +539,12 @@ class DiceRollTest {
             aaGunList,
             bridge,
             westRussia,
-            CombatValue.buildAaCombatValue(
-                fighterList, aaGunList, BattleState.Side.DEFENSE, bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(fighterList)
+                .friendlyUnits(aaGunList)
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     assertThat(hitNoRoll.getHits(), is(1));
     thenGetRandomShouldHaveBeenCalled(bridge, times(2));
   }
@@ -464,8 +573,12 @@ class DiceRollTest {
             aaGunList,
             bridge,
             westRussia,
-            CombatValue.buildAaCombatValue(
-                fighterList, aaGunList, BattleState.Side.DEFENSE, bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(fighterList)
+                .friendlyUnits(aaGunList)
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     assertThat(hit.getHits(), is(1));
     thenGetRandomShouldHaveBeenCalled(bridge, never());
   }
@@ -498,8 +611,12 @@ class DiceRollTest {
             aaGunList,
             bridge,
             finnland,
-            CombatValue.buildAaCombatValue(
-                fighterList, aaGunList, BattleState.Side.DEFENSE, bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(fighterList)
+                .friendlyUnits(aaGunList)
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     assertThat(hit.getHits(), is(1));
     // aa misses
     final DiceRoll miss =
@@ -512,8 +629,12 @@ class DiceRollTest {
             aaGunList,
             bridge,
             finnland,
-            CombatValue.buildAaCombatValue(
-                fighterList, aaGunList, BattleState.Side.DEFENSE, bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(fighterList)
+                .friendlyUnits(aaGunList)
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     assertThat(miss.getHits(), is(0));
     // 6 bombers, 2 should hit, and nothing should be rolled
     fighterList = fighterType.create(6, russians);
@@ -527,8 +648,12 @@ class DiceRollTest {
             aaGunList,
             bridge,
             finnland,
-            CombatValue.buildAaCombatValue(
-                fighterList, aaGunList, BattleState.Side.DEFENSE, bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(fighterList)
+                .friendlyUnits(aaGunList)
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     assertThat(hitNoRoll.getHits(), is(2));
     thenGetRandomShouldHaveBeenCalled(bridge, times(2));
   }
@@ -564,8 +689,12 @@ class DiceRollTest {
             atGuns,
             bridge,
             westernFrance,
-            CombatValue.buildAaCombatValue(
-                targets, atGuns, BattleState.Side.DEFENSE, bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(targets)
+                .friendlyUnits(atGuns)
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     assertThat(hit.getHits(), is(1));
     final DiceRoll miss =
         DiceRoll.rollAa(
@@ -573,8 +702,12 @@ class DiceRollTest {
             atGuns,
             bridge,
             westernFrance,
-            CombatValue.buildAaCombatValue(
-                targets, atGuns, BattleState.Side.DEFENSE, bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(targets)
+                .friendlyUnits(atGuns)
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     assertThat(miss.getHits(), is(0));
 
     // 1 AT gun + 1 AT support (AT support is a unit that provides +2 AA strength for 3 units)
@@ -585,8 +718,12 @@ class DiceRollTest {
             atGuns,
             bridge,
             westernFrance,
-            CombatValue.buildAaCombatValue(
-                targets, supportUnits, BattleState.Side.DEFENSE, bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(targets)
+                .friendlyUnits(supportUnits)
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     assertThat(hitWithSupport.getHits(), is(1));
     final DiceRoll missWithSupport =
         DiceRoll.rollAa(
@@ -594,8 +731,12 @@ class DiceRollTest {
             atGuns,
             bridge,
             westernFrance,
-            CombatValue.buildAaCombatValue(
-                targets, supportUnits, BattleState.Side.DEFENSE, bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(targets)
+                .friendlyUnits(supportUnits)
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     assertThat(missWithSupport.getHits(), is(0));
 
     // 2 AT guns + 1 AT support
@@ -606,8 +747,12 @@ class DiceRollTest {
             atGuns,
             bridge,
             westernFrance,
-            CombatValue.buildAaCombatValue(
-                targets, supportUnits, BattleState.Side.DEFENSE, bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(targets)
+                .friendlyUnits(supportUnits)
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     assertThat(hitWith2AtAndSupport.getHits(), is(1));
     final DiceRoll missWith2AtAndSupport =
         DiceRoll.rollAa(
@@ -615,8 +760,12 @@ class DiceRollTest {
             atGuns,
             bridge,
             westernFrance,
-            CombatValue.buildAaCombatValue(
-                targets, supportUnits, BattleState.Side.DEFENSE, bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(targets)
+                .friendlyUnits(supportUnits)
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     assertThat(missWith2AtAndSupport.getHits(), is(0));
 
     // 2 AT guns + 1 AT support + 1 enemy AT counter (AT counter is a unit that provides -10 AA
@@ -630,8 +779,12 @@ class DiceRollTest {
             atGuns,
             bridge,
             westernFrance,
-            CombatValue.buildAaCombatValue(
-                enemySupportUnits, supportUnits, BattleState.Side.DEFENSE, bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(enemySupportUnits)
+                .friendlyUnits(supportUnits)
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     assertThat(missWith2AtAndSupportAndEnemySupport.getHits(), is(0));
 
     // 4 AT guns + 1 AT support + 1 enemy AT counter
@@ -643,8 +796,12 @@ class DiceRollTest {
             atGuns,
             bridge,
             westernFrance,
-            CombatValue.buildAaCombatValue(
-                enemySupportUnits, supportUnits, BattleState.Side.DEFENSE, bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(enemySupportUnits)
+                .friendlyUnits(supportUnits)
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     assertThat(hitWith4AtAndSupportAndEnemySupport.getHits(), is(1));
     final DiceRoll missWith4AtAndSupportAndEnemySupport =
         DiceRoll.rollAa(
@@ -652,8 +809,12 @@ class DiceRollTest {
             atGuns,
             bridge,
             westernFrance,
-            CombatValue.buildAaCombatValue(
-                enemySupportUnits, supportUnits, BattleState.Side.DEFENSE, bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(enemySupportUnits)
+                .friendlyUnits(supportUnits)
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     assertThat(missWith4AtAndSupportAndEnemySupport.getHits(), is(0));
 
     thenGetRandomShouldHaveBeenCalled(bridge, times(8));
@@ -682,12 +843,18 @@ class DiceRollTest {
             british,
             testDelegateBridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                bombers,
-                BattleState.Side.OFFENSE,
-                testDelegateBridge.getData(),
-                TerritoryEffectHelper.getEffects(germany)));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(bombers)
+                .side(BattleState.Side.OFFENSE)
+                .gameSequence(testDelegateBridge.getData().getSequence())
+                .supportAttachments(
+                    testDelegateBridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(
+                    Properties.getLhtrHeavyBombers(testDelegateBridge.getData().getProperties()))
+                .gameDiceSides(testDelegateBridge.getData().getDiceSides())
+                .territoryEffects(TerritoryEffectHelper.getEffects(germany))
+                .build());
     assertThat(dice.getRolls(4).get(0).getType(), is(Die.DieType.HIT));
     assertThat(dice.getRolls(4).get(1).getType(), is(Die.DieType.HIT));
   }
@@ -715,12 +882,18 @@ class DiceRollTest {
             british,
             testDelegateBridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                bombers,
-                BattleState.Side.DEFENSE,
-                testDelegateBridge.getData(),
-                TerritoryEffectHelper.getEffects(germany)));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(bombers)
+                .side(BattleState.Side.DEFENSE)
+                .gameSequence(testDelegateBridge.getData().getSequence())
+                .supportAttachments(
+                    testDelegateBridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(
+                    Properties.getLhtrHeavyBombers(testDelegateBridge.getData().getProperties()))
+                .gameDiceSides(testDelegateBridge.getData().getDiceSides())
+                .territoryEffects(TerritoryEffectHelper.getEffects(germany))
+                .build());
     assertThat(dice.getRolls(1).size(), is(1));
     assertThat(dice.getRolls(1).get(0).getType(), is(Die.DieType.HIT));
   }
@@ -744,12 +917,18 @@ class DiceRollTest {
             british,
             testDelegateBridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                bombers,
-                BattleState.Side.DEFENSE,
-                testDelegateBridge.getData(),
-                TerritoryEffectHelper.getEffects(germany)));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(bombers)
+                .side(BattleState.Side.DEFENSE)
+                .gameSequence(testDelegateBridge.getData().getSequence())
+                .supportAttachments(
+                    testDelegateBridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(
+                    Properties.getLhtrHeavyBombers(testDelegateBridge.getData().getProperties()))
+                .gameDiceSides(testDelegateBridge.getData().getDiceSides())
+                .territoryEffects(TerritoryEffectHelper.getEffects(germany))
+                .build());
 
     assertThat(dice.getRolls(1).size(), is(1));
     assertThat(dice.getRolls(1).get(0).getType(), is(Die.DieType.HIT));
@@ -778,12 +957,18 @@ class DiceRollTest {
             british,
             testDelegateBridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                bombers,
-                BattleState.Side.OFFENSE,
-                testDelegateBridge.getData(),
-                TerritoryEffectHelper.getEffects(germany)));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(bombers)
+                .side(BattleState.Side.OFFENSE)
+                .gameSequence(testDelegateBridge.getData().getSequence())
+                .supportAttachments(
+                    testDelegateBridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(
+                    Properties.getLhtrHeavyBombers(testDelegateBridge.getData().getProperties()))
+                .gameDiceSides(testDelegateBridge.getData().getDiceSides())
+                .territoryEffects(TerritoryEffectHelper.getEffects(germany))
+                .build());
 
     assertThat(dice.getRolls(4).get(0).getType(), is(Die.DieType.HIT));
     assertThat(dice.getRolls(4).get(1).getType(), is(Die.DieType.IGNORED));
@@ -813,12 +998,18 @@ class DiceRollTest {
             british,
             testDelegateBridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                bombers,
-                BattleState.Side.OFFENSE,
-                testDelegateBridge.getData(),
-                TerritoryEffectHelper.getEffects(germany)));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(bombers)
+                .side(BattleState.Side.OFFENSE)
+                .gameSequence(testDelegateBridge.getData().getSequence())
+                .supportAttachments(
+                    testDelegateBridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(
+                    Properties.getLhtrHeavyBombers(testDelegateBridge.getData().getProperties()))
+                .gameDiceSides(testDelegateBridge.getData().getDiceSides())
+                .territoryEffects(TerritoryEffectHelper.getEffects(germany))
+                .build());
     assertThat(dice.getRolls(4).get(0).getType(), is(Die.DieType.HIT));
     assertThat(dice.getRolls(4).get(1).getType(), is(Die.DieType.IGNORED));
     assertThat(dice.getHits(), is(1));
@@ -847,12 +1038,18 @@ class DiceRollTest {
             british,
             testDelegateBridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                bombers,
-                BattleState.Side.DEFENSE,
-                testDelegateBridge.getData(),
-                TerritoryEffectHelper.getEffects(germany)));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(bombers)
+                .side(BattleState.Side.DEFENSE)
+                .gameSequence(testDelegateBridge.getData().getSequence())
+                .supportAttachments(
+                    testDelegateBridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(
+                    Properties.getLhtrHeavyBombers(testDelegateBridge.getData().getProperties()))
+                .gameDiceSides(testDelegateBridge.getData().getDiceSides())
+                .territoryEffects(TerritoryEffectHelper.getEffects(germany))
+                .build());
     assertThat(dice.getRolls(1).size(), is(2));
     assertThat(dice.getHits(), is(1));
     assertThat(dice.getRolls(1).get(0).getType(), is(Die.DieType.HIT));

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -21,13 +21,14 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.BattleTracker;
 import games.strategy.triplea.delegate.battle.IBattle;
 import games.strategy.triplea.delegate.battle.steps.retreat.OffensiveGeneralRetreat;
-import games.strategy.triplea.delegate.power.calculator.CombatValue;
+import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.util.TransportUtils;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -446,12 +447,16 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
             russians,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                attackList,
-                BattleState.Side.OFFENSE,
-                bridge.getData(),
-                TerritoryEffectHelper.getEffects(balticSeaZone)));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(attackList)
+                .side(BattleState.Side.OFFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(TerritoryEffectHelper.getEffects(balticSeaZone))
+                .build());
     assertEquals(2, roll.getHits());
     advanceToStep(bridge, "russianNonCombatMove");
     // Test the move
@@ -869,12 +874,16 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
             germans,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                defendList,
-                BattleState.Side.DEFENSE,
-                bridge.getData(),
-                TerritoryEffectHelper.getEffects(balticSeaZone)));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(defendList)
+                .side(BattleState.Side.DEFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(TerritoryEffectHelper.getEffects(balticSeaZone))
+                .build());
     assertEquals(0, roll.getHits());
     // Get total number of units in Finland before the retreat
     final int preCountInt = finlandNorway.getUnitCollection().size();
@@ -942,12 +951,16 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
             germans,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                defendList,
-                BattleState.Side.DEFENSE,
-                bridge.getData(),
-                TerritoryEffectHelper.getEffects(balticSeaZone)));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(defendList)
+                .side(BattleState.Side.DEFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(TerritoryEffectHelper.getEffects(balticSeaZone))
+                .build());
     assertEquals(1, roll.getHits());
     // Get total number of units in Finland before the retreat
     final int preCountInt = finlandNorway.getUnitCollection().size();
@@ -1005,12 +1018,16 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
             germans,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                defendList,
-                BattleState.Side.DEFENSE,
-                bridge.getData(),
-                TerritoryEffectHelper.getEffects(balticSeaZone)));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(defendList)
+                .side(BattleState.Side.DEFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(TerritoryEffectHelper.getEffects(balticSeaZone))
+                .build());
     assertEquals(0, roll.getHits());
     // Get total number of units in Finland before the retreat
     final int preCountInt = karelia.getUnitCollection().size();
@@ -1068,12 +1085,16 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
             germans,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                defendList,
-                BattleState.Side.DEFENSE,
-                bridge.getData(),
-                TerritoryEffectHelper.getEffects(balticSeaZone)));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(defendList)
+                .side(BattleState.Side.DEFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(TerritoryEffectHelper.getEffects(balticSeaZone))
+                .build());
     assertEquals(1, roll.getHits());
     // Get total number of units in Finland before the retreat
     final int preCountInt = karelia.getUnitCollection().size();

--- a/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
@@ -16,8 +16,9 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Constants;
+import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.battle.BattleState;
-import games.strategy.triplea.delegate.power.calculator.CombatValue;
+import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.Collection;
 import java.util.List;
@@ -112,12 +113,16 @@ class PacificTest extends AbstractDelegateTestCase {
             americans,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                infantryUs,
-                BattleState.Side.DEFENSE,
-                bridge.getData(),
-                territoryEffects));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(infantryUs)
+                .side(BattleState.Side.DEFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(territoryEffects)
+                .build());
     assertEquals(1, roll.getHits());
     // Defending US marines
     final List<Unit> marineUs = marine.create(1, americans);
@@ -127,8 +132,16 @@ class PacificTest extends AbstractDelegateTestCase {
             americans,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(), marineUs, BattleState.Side.DEFENSE, bridge.getData(), territoryEffects));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(marineUs)
+                .side(BattleState.Side.DEFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(territoryEffects)
+                .build());
     assertEquals(1, roll.getHits());
     // Chinese units
     // Defending Chinese infantry
@@ -139,12 +152,16 @@ class PacificTest extends AbstractDelegateTestCase {
             chinese,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                infantryChina,
-                BattleState.Side.DEFENSE,
-                bridge.getData(),
-                territoryEffects));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(infantryChina)
+                .side(BattleState.Side.DEFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(territoryEffects)
+                .build());
     assertEquals(1, roll.getHits());
   }
 
@@ -172,12 +189,16 @@ class PacificTest extends AbstractDelegateTestCase {
             americans,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                infantryUs,
-                BattleState.Side.DEFENSE,
-                bridge.getData(),
-                territoryEffects));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(infantryUs)
+                .side(BattleState.Side.DEFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(territoryEffects)
+                .build());
     assertEquals(0, roll.getHits());
     // Defending US marines
     final List<Unit> marineUs = marine.create(1, americans);
@@ -187,8 +208,16 @@ class PacificTest extends AbstractDelegateTestCase {
             americans,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(), marineUs, BattleState.Side.DEFENSE, bridge.getData(), territoryEffects));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(marineUs)
+                .side(BattleState.Side.DEFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(territoryEffects)
+                .build());
     assertEquals(0, roll.getHits());
     // Chinese units
     // Defending Chinese infantry
@@ -199,12 +228,16 @@ class PacificTest extends AbstractDelegateTestCase {
             chinese,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                infantryChina,
-                BattleState.Side.DEFENSE,
-                bridge.getData(),
-                territoryEffects));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(infantryChina)
+                .side(BattleState.Side.DEFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(territoryEffects)
+                .build());
     assertEquals(1, roll.getHits());
     // Defending US infantry
     roll =
@@ -213,12 +246,16 @@ class PacificTest extends AbstractDelegateTestCase {
             americans,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                infantryUs,
-                BattleState.Side.DEFENSE,
-                bridge.getData(),
-                territoryEffects));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(infantryUs)
+                .side(BattleState.Side.DEFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(territoryEffects)
+                .build());
     assertEquals(1, roll.getHits());
     // Defending US marines
     roll =
@@ -227,8 +264,16 @@ class PacificTest extends AbstractDelegateTestCase {
             americans,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(), marineUs, BattleState.Side.DEFENSE, bridge.getData(), territoryEffects));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(marineUs)
+                .side(BattleState.Side.DEFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(territoryEffects)
+                .build());
     assertEquals(1, roll.getHits());
     // Chinese units
     // Defending Chinese infantry
@@ -238,12 +283,16 @@ class PacificTest extends AbstractDelegateTestCase {
             chinese,
             bridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                infantryChina,
-                BattleState.Side.DEFENSE,
-                bridge.getData(),
-                territoryEffects));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(infantryChina)
+                .side(BattleState.Side.DEFENSE)
+                .gameSequence(bridge.getData().getSequence())
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
+                .gameDiceSides(bridge.getData().getDiceSides())
+                .territoryEffects(territoryEffects)
+                .build());
     assertEquals(1, roll.getHits());
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -67,6 +67,7 @@ import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.data.gameparser.GameParseException;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Constants;
+import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
@@ -81,7 +82,7 @@ import games.strategy.triplea.delegate.data.MoveValidationResult;
 import games.strategy.triplea.delegate.data.PlaceableUnits;
 import games.strategy.triplea.delegate.data.TechResults;
 import games.strategy.triplea.delegate.move.validation.MoveValidator;
-import games.strategy.triplea.delegate.power.calculator.CombatValue;
+import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.delegate.remote.IAbstractPlaceDelegate;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.ArrayList;
@@ -174,19 +175,32 @@ class WW2V3Year41Test {
             defendingAa,
             bridge,
             territory("Germany", gameData),
-            CombatValue.buildAaCombatValue(
-                planes,
-                territory("Germany", gameData).getUnits(),
-                BattleState.Side.DEFENSE,
-                bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(planes)
+                .friendlyUnits(territory("Germany", gameData).getUnits())
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
                 planes,
                 defendingAa,
-                CombatValue.buildMainCombatValue(
-                    defendingAa, planes, BattleState.Side.OFFENSE, gameData, List.of()),
-                CombatValue.buildAaCombatValue(
-                    planes, defendingAa, BattleState.Side.DEFENSE, gameData),
+                CombatValueBuilder.mainCombatValue()
+                    .enemyUnits(defendingAa)
+                    .friendlyUnits(planes)
+                    .side(BattleState.Side.OFFENSE)
+                    .gameSequence(gameData.getSequence())
+                    .supportAttachments(gameData.getUnitTypeList().getSupportRules())
+                    .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(gameData.getProperties()))
+                    .gameDiceSides(gameData.getDiceSides())
+                    .territoryEffects(List.of())
+                    .build(),
+                CombatValueBuilder.aaCombatValue()
+                    .enemyUnits(planes)
+                    .friendlyUnits(defendingAa)
+                    .side(BattleState.Side.DEFENSE)
+                    .supportAttachments(gameData.getUnitTypeList().getSupportAaRules())
+                    .build(),
                 "",
                 roll,
                 bridge,
@@ -230,21 +244,34 @@ class WW2V3Year41Test {
             defendingAa,
             bridge,
             territory("Germany", gameData),
-            CombatValue.buildAaCombatValue(
-                planes,
-                territory("Germany", gameData).getUnits(),
-                BattleState.Side.DEFENSE,
-                bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(planes)
+                .friendlyUnits(territory("Germany", gameData).getUnits())
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
                 planes,
                 defendingAa,
-                CombatValue.buildMainCombatValue(
-                    defendingAa, planes, BattleState.Side.OFFENSE, gameData, List.of()),
-                CombatValue.buildAaCombatValue(
-                    planes, defendingAa, BattleState.Side.DEFENSE, gameData),
+                CombatValueBuilder.mainCombatValue()
+                    .enemyUnits(defendingAa)
+                    .friendlyUnits(planes)
+                    .side(BattleState.Side.OFFENSE)
+                    .gameSequence(gameData.getSequence())
+                    .supportAttachments(gameData.getUnitTypeList().getSupportRules())
+                    .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(gameData.getProperties()))
+                    .gameDiceSides(gameData.getDiceSides())
+                    .territoryEffects(List.of())
+                    .build(),
+                CombatValueBuilder.aaCombatValue()
+                    .enemyUnits(planes)
+                    .friendlyUnits(defendingAa)
+                    .side(BattleState.Side.DEFENSE)
+                    .supportAttachments(gameData.getUnitTypeList().getSupportAaRules())
+                    .build(),
                 "",
                 roll,
                 bridge,
@@ -290,11 +317,12 @@ class WW2V3Year41Test {
             defendingAa,
             bridge,
             territory("Germany", gameData),
-            CombatValue.buildAaCombatValue(
-                planes,
-                territory("Germany", gameData).getUnits(),
-                BattleState.Side.DEFENSE,
-                bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(planes)
+                .friendlyUnits(territory("Germany", gameData).getUnits())
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     assertEquals(2, roll.getHits());
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
@@ -302,10 +330,22 @@ class WW2V3Year41Test {
         AaCasualtySelector.getAaCasualties(
                 planes,
                 defendingAa,
-                CombatValue.buildMainCombatValue(
-                    defendingAa, planes, BattleState.Side.OFFENSE, gameData, List.of()),
-                CombatValue.buildAaCombatValue(
-                    planes, defendingAa, BattleState.Side.DEFENSE, gameData),
+                CombatValueBuilder.mainCombatValue()
+                    .enemyUnits(defendingAa)
+                    .friendlyUnits(planes)
+                    .side(BattleState.Side.OFFENSE)
+                    .gameSequence(gameData.getSequence())
+                    .supportAttachments(gameData.getUnitTypeList().getSupportRules())
+                    .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(gameData.getProperties()))
+                    .gameDiceSides(gameData.getDiceSides())
+                    .territoryEffects(List.of())
+                    .build(),
+                CombatValueBuilder.aaCombatValue()
+                    .enemyUnits(planes)
+                    .friendlyUnits(defendingAa)
+                    .side(BattleState.Side.DEFENSE)
+                    .supportAttachments(gameData.getUnitTypeList().getSupportAaRules())
+                    .build(),
                 "",
                 roll,
                 bridge,
@@ -701,12 +741,17 @@ class WW2V3Year41Test {
             germans,
             delegateBridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                germanFighter,
-                BattleState.Side.OFFENSE,
-                delegateBridge.getData(),
-                territoryEffects));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(germanFighter)
+                .side(BattleState.Side.OFFENSE)
+                .gameSequence(delegateBridge.getData().getSequence())
+                .supportAttachments(delegateBridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(
+                    Properties.getLhtrHeavyBombers(delegateBridge.getData().getProperties()))
+                .gameDiceSides(delegateBridge.getData().getDiceSides())
+                .territoryEffects(territoryEffects)
+                .build());
     assertEquals(1, roll1.getHits());
     // Defending fighter
     final DiceRoll roll2 =
@@ -715,12 +760,17 @@ class WW2V3Year41Test {
             germans,
             delegateBridge,
             "",
-            CombatValue.buildMainCombatValue(
-                List.of(),
-                germanFighter,
-                BattleState.Side.DEFENSE,
-                delegateBridge.getData(),
-                territoryEffects));
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(germanFighter)
+                .side(BattleState.Side.DEFENSE)
+                .gameSequence(delegateBridge.getData().getSequence())
+                .supportAttachments(delegateBridge.getData().getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(
+                    Properties.getLhtrHeavyBombers(delegateBridge.getData().getProperties()))
+                .gameDiceSides(delegateBridge.getData().getDiceSides())
+                .territoryEffects(territoryEffects)
+                .build());
     assertEquals(0, roll2.getHits());
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTest.java
@@ -9,12 +9,13 @@ import static org.mockito.Mockito.when;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.GameSequence;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.UnitTypeList;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.battle.BattleState;
-import games.strategy.triplea.delegate.power.calculator.CombatValue;
+import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
@@ -68,7 +69,6 @@ class CasualtyOrderOfLossesTest {
   }
 
   private CasualtyOrderOfLosses.Parameters withFakeParameters() {
-    when(gameData.getUnitTypeList()).thenReturn(unitTypeList);
     final GamePlayer player = mock(GamePlayer.class);
     when(player.getName()).thenReturn("player");
     final Territory territory = mock(Territory.class);
@@ -77,8 +77,16 @@ class CasualtyOrderOfLossesTest {
         .targetsToPickFrom(List.of())
         .player(player)
         .combatValue(
-            CombatValue.buildMainCombatValue(
-                List.of(), List.of(), BattleState.Side.OFFENSE, gameData, List.of()))
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(List.of())
+                .side(BattleState.Side.OFFENSE)
+                .gameSequence(mock(GameSequence.class))
+                .supportAttachments(List.of())
+                .lhtrHeavyBombers(false)
+                .gameDiceSides(gameData.getDiceSides())
+                .territoryEffects(List.of())
+                .build())
         .battlesite(territory)
         .costs(IntegerMap.of(Map.of()))
         .data(gameData)

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnBigWorldV3.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnBigWorldV3.java
@@ -6,9 +6,10 @@ import static org.hamcrest.core.Is.is;
 
 import games.strategy.engine.data.MutableProperty;
 import games.strategy.engine.data.Unit;
+import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.ImprovedArtillerySupportAdvance;
 import games.strategy.triplea.delegate.battle.BattleState;
-import games.strategy.triplea.delegate.power.calculator.CombatValue;
+import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.xml.TestDataBigWorld1942V3;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -64,8 +65,16 @@ class CasualtyOrderOfLossesTestOnBigWorldV3 {
         .targetsToPickFrom(amphibUnits)
         .player(testData.british)
         .combatValue(
-            CombatValue.buildMainCombatValue(
-                List.of(), amphibUnits, BattleState.Side.OFFENSE, testData.gameData, List.of()))
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(amphibUnits)
+                .side(BattleState.Side.OFFENSE)
+                .gameSequence(testData.gameData.getSequence())
+                .supportAttachments(testData.gameData.getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(testData.gameData.getProperties()))
+                .gameDiceSides(testData.gameData.getDiceSides())
+                .territoryEffects(List.of())
+                .build())
         .battlesite(testData.france)
         .costs(testData.costMap)
         .data(testData.gameData)
@@ -192,12 +201,17 @@ class CasualtyOrderOfLossesTestOnBigWorldV3 {
                 .targetsToPickFrom(attackingUnits)
                 .player(testData.british)
                 .combatValue(
-                    CombatValue.buildMainCombatValue(
-                        List.of(),
-                        attackingUnits,
-                        BattleState.Side.OFFENSE,
-                        testData.gameData,
-                        List.of()))
+                    CombatValueBuilder.mainCombatValue()
+                        .enemyUnits(List.of())
+                        .friendlyUnits(attackingUnits)
+                        .side(BattleState.Side.OFFENSE)
+                        .gameSequence(testData.gameData.getSequence())
+                        .supportAttachments(testData.gameData.getUnitTypeList().getSupportRules())
+                        .lhtrHeavyBombers(
+                            Properties.getLhtrHeavyBombers(testData.gameData.getProperties()))
+                        .gameDiceSides(testData.gameData.getDiceSides())
+                        .territoryEffects(List.of())
+                        .build())
                 .battlesite(testData.france)
                 .costs(testData.costMap)
                 .data(testData.gameData)
@@ -244,12 +258,17 @@ class CasualtyOrderOfLossesTestOnBigWorldV3 {
                 .targetsToPickFrom(attackingUnits)
                 .player(testData.british)
                 .combatValue(
-                    CombatValue.buildMainCombatValue(
-                        List.of(),
-                        attackingUnits,
-                        BattleState.Side.OFFENSE,
-                        testData.gameData,
-                        List.of()))
+                    CombatValueBuilder.mainCombatValue()
+                        .enemyUnits(List.of())
+                        .friendlyUnits(attackingUnits)
+                        .side(BattleState.Side.OFFENSE)
+                        .gameSequence(testData.gameData.getSequence())
+                        .supportAttachments(testData.gameData.getUnitTypeList().getSupportRules())
+                        .lhtrHeavyBombers(
+                            Properties.getLhtrHeavyBombers(testData.gameData.getProperties()))
+                        .gameDiceSides(testData.gameData.getDiceSides())
+                        .territoryEffects(List.of())
+                        .build())
                 .battlesite(testData.france)
                 .costs(testData.costMap)
                 .data(testData.gameData)
@@ -267,12 +286,17 @@ class CasualtyOrderOfLossesTestOnBigWorldV3 {
                 .targetsToPickFrom(attackingUnits.subList(0, 3))
                 .player(testData.british)
                 .combatValue(
-                    CombatValue.buildMainCombatValue(
-                        List.of(),
-                        attackingUnits.subList(0, 3),
-                        BattleState.Side.OFFENSE,
-                        testData.gameData,
-                        List.of()))
+                    CombatValueBuilder.mainCombatValue()
+                        .enemyUnits(List.of())
+                        .friendlyUnits(attackingUnits.subList(0, 3))
+                        .side(BattleState.Side.OFFENSE)
+                        .gameSequence(testData.gameData.getSequence())
+                        .supportAttachments(testData.gameData.getUnitTypeList().getSupportRules())
+                        .lhtrHeavyBombers(
+                            Properties.getLhtrHeavyBombers(testData.gameData.getProperties()))
+                        .gameDiceSides(testData.gameData.getDiceSides())
+                        .territoryEffects(List.of())
+                        .build())
                 .battlesite(testData.france)
                 .costs(testData.costMap)
                 .data(testData.gameData)

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnGlobal.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnGlobal.java
@@ -13,12 +13,13 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.delegate.HeavyBomberAdvance;
 import games.strategy.triplea.delegate.ImprovedArtillerySupportAdvance;
 import games.strategy.triplea.delegate.TechAdvance;
 import games.strategy.triplea.delegate.battle.BattleState;
-import games.strategy.triplea.delegate.power.calculator.CombatValue;
+import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -134,8 +135,16 @@ class CasualtyOrderOfLossesTestOnGlobal {
         .targetsToPickFrom(units)
         .player(BRITISH)
         .combatValue(
-            CombatValue.buildMainCombatValue(
-                List.of(), units, BattleState.Side.OFFENSE, data, List.of()))
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(units)
+                .side(BattleState.Side.OFFENSE)
+                .gameSequence(data.getSequence())
+                .supportAttachments(data.getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
+                .gameDiceSides(data.getDiceSides())
+                .territoryEffects(List.of())
+                .build())
         .battlesite(FRANCE)
         .costs(COST_MAP)
         .data(data)
@@ -217,8 +226,16 @@ class CasualtyOrderOfLossesTestOnGlobal {
         .targetsToPickFrom(amphibUnits)
         .player(BRITISH)
         .combatValue(
-            CombatValue.buildMainCombatValue(
-                List.of(), amphibUnits, BattleState.Side.OFFENSE, data, List.of()))
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(amphibUnits)
+                .side(BattleState.Side.OFFENSE)
+                .gameSequence(data.getSequence())
+                .supportAttachments(data.getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
+                .gameDiceSides(data.getDiceSides())
+                .territoryEffects(List.of())
+                .build())
         .battlesite(FRANCE)
         .costs(COST_MAP)
         .data(data)
@@ -297,8 +314,16 @@ class CasualtyOrderOfLossesTestOnGlobal {
         .targetsToPickFrom(units)
         .player(BRITISH)
         .combatValue(
-            CombatValue.buildMainCombatValue(
-                List.of(), units, BattleState.Side.DEFENSE, data, List.of()))
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(units)
+                .side(BattleState.Side.DEFENSE)
+                .gameSequence(data.getSequence())
+                .supportAttachments(data.getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
+                .gameDiceSides(data.getDiceSides())
+                .territoryEffects(List.of())
+                .build())
         .battlesite(FRANCE)
         .costs(COST_MAP)
         .data(data)

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnNapoleonic.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLossesTestOnNapoleonic.java
@@ -11,8 +11,9 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.battle.BattleState;
-import games.strategy.triplea.delegate.power.calculator.CombatValue;
+import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -93,8 +94,16 @@ class CasualtyOrderOfLossesTestOnNapoleonic {
         .targetsToPickFrom(units)
         .player(BRITISH)
         .combatValue(
-            CombatValue.buildMainCombatValue(
-                List.of(), units, BattleState.Side.OFFENSE, data, List.of()))
+            CombatValueBuilder.mainCombatValue()
+                .enemyUnits(List.of())
+                .friendlyUnits(units)
+                .side(BattleState.Side.OFFENSE)
+                .gameSequence(data.getSequence())
+                .supportAttachments(data.getUnitTypeList().getSupportRules())
+                .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
+                .gameDiceSides(data.getDiceSides())
+                .territoryEffects(List.of())
+                .build())
         .battlesite(NORMANDY)
         .costs(COST_MAP)
         .data(data)

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelectorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelectorTest.java
@@ -21,12 +21,13 @@ import static org.mockito.Mockito.when;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
-import games.strategy.triplea.delegate.power.calculator.CombatValue;
+import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -87,9 +88,22 @@ class CasualtySelectorTest {
         AaCasualtySelector.getAaCasualties(
                 planes,
                 defendingAa,
-                CombatValue.buildMainCombatValue(
-                    defendingAa, planes, BattleState.Side.OFFENSE, data, List.of()),
-                CombatValue.buildAaCombatValue(planes, defendingAa, BattleState.Side.DEFENSE, data),
+                CombatValueBuilder.mainCombatValue()
+                    .enemyUnits(defendingAa)
+                    .friendlyUnits(planes)
+                    .side(BattleState.Side.OFFENSE)
+                    .gameSequence(data.getSequence())
+                    .supportAttachments(data.getUnitTypeList().getSupportRules())
+                    .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
+                    .gameDiceSides(data.getDiceSides())
+                    .territoryEffects(List.of())
+                    .build(),
+                CombatValueBuilder.aaCombatValue()
+                    .enemyUnits(planes)
+                    .friendlyUnits(defendingAa)
+                    .side(BattleState.Side.DEFENSE)
+                    .supportAttachments(data.getUnitTypeList().getSupportAaRules())
+                    .build(),
                 "",
                 roll,
                 bridge,
@@ -116,9 +130,22 @@ class CasualtySelectorTest {
         AaCasualtySelector.getAaCasualties(
                 planes,
                 defendingAa,
-                CombatValue.buildMainCombatValue(
-                    defendingAa, planes, BattleState.Side.OFFENSE, data, List.of()),
-                CombatValue.buildAaCombatValue(planes, defendingAa, BattleState.Side.DEFENSE, data),
+                CombatValueBuilder.mainCombatValue()
+                    .enemyUnits(defendingAa)
+                    .friendlyUnits(planes)
+                    .side(BattleState.Side.OFFENSE)
+                    .gameSequence(data.getSequence())
+                    .supportAttachments(data.getUnitTypeList().getSupportRules())
+                    .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
+                    .gameDiceSides(data.getDiceSides())
+                    .territoryEffects(List.of())
+                    .build(),
+                CombatValueBuilder.aaCombatValue()
+                    .enemyUnits(planes)
+                    .friendlyUnits(defendingAa)
+                    .side(BattleState.Side.DEFENSE)
+                    .supportAttachments(data.getUnitTypeList().getSupportAaRules())
+                    .build(),
                 "",
                 roll,
                 bridge,
@@ -151,18 +178,32 @@ class CasualtySelectorTest {
             defendingAa,
             bridge,
             territory("Germany", data),
-            CombatValue.buildAaCombatValue(
-                planes,
-                territory("Germany", data).getUnits(),
-                BattleState.Side.DEFENSE,
-                bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(planes)
+                .friendlyUnits(territory("Germany", data).getUnits())
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
                 planes,
                 defendingAa,
-                CombatValue.buildMainCombatValue(
-                    defendingAa, planes, BattleState.Side.OFFENSE, data, List.of()),
-                CombatValue.buildAaCombatValue(planes, defendingAa, BattleState.Side.DEFENSE, data),
+                CombatValueBuilder.mainCombatValue()
+                    .enemyUnits(defendingAa)
+                    .friendlyUnits(planes)
+                    .side(BattleState.Side.OFFENSE)
+                    .gameSequence(data.getSequence())
+                    .supportAttachments(data.getUnitTypeList().getSupportRules())
+                    .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
+                    .gameDiceSides(data.getDiceSides())
+                    .territoryEffects(List.of())
+                    .build(),
+                CombatValueBuilder.aaCombatValue()
+                    .enemyUnits(planes)
+                    .friendlyUnits(defendingAa)
+                    .side(BattleState.Side.DEFENSE)
+                    .supportAttachments(data.getUnitTypeList().getSupportAaRules())
+                    .build(),
                 "",
                 roll,
                 bridge,
@@ -200,19 +241,33 @@ class CasualtySelectorTest {
             defendingAa,
             bridge,
             territory("Germany", data),
-            CombatValue.buildAaCombatValue(
-                planes,
-                territory("Germany", data).getUnits(),
-                BattleState.Side.DEFENSE,
-                bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(planes)
+                .friendlyUnits(territory("Germany", data).getUnits())
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
                 planes,
                 defendingAa,
-                CombatValue.buildMainCombatValue(
-                    defendingAa, planes, BattleState.Side.OFFENSE, data, List.of()),
-                CombatValue.buildAaCombatValue(planes, defendingAa, BattleState.Side.DEFENSE, data),
+                CombatValueBuilder.mainCombatValue()
+                    .enemyUnits(defendingAa)
+                    .friendlyUnits(planes)
+                    .side(BattleState.Side.OFFENSE)
+                    .gameSequence(data.getSequence())
+                    .supportAttachments(data.getUnitTypeList().getSupportRules())
+                    .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
+                    .gameDiceSides(data.getDiceSides())
+                    .territoryEffects(List.of())
+                    .build(),
+                CombatValueBuilder.aaCombatValue()
+                    .enemyUnits(planes)
+                    .friendlyUnits(defendingAa)
+                    .side(BattleState.Side.DEFENSE)
+                    .supportAttachments(data.getUnitTypeList().getSupportAaRules())
+                    .build(),
                 "",
                 roll,
                 bridge,
@@ -251,18 +306,32 @@ class CasualtySelectorTest {
             defendingAa,
             bridge,
             territory("Germany", data),
-            CombatValue.buildAaCombatValue(
-                planes,
-                territory("Germany", data).getUnits(),
-                BattleState.Side.DEFENSE,
-                bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(planes)
+                .friendlyUnits(territory("Germany", data).getUnits())
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
                 planes,
                 defendingAa,
-                CombatValue.buildMainCombatValue(
-                    defendingAa, planes, BattleState.Side.OFFENSE, data, List.of()),
-                CombatValue.buildAaCombatValue(planes, defendingAa, BattleState.Side.DEFENSE, data),
+                CombatValueBuilder.mainCombatValue()
+                    .enemyUnits(defendingAa)
+                    .friendlyUnits(planes)
+                    .side(BattleState.Side.OFFENSE)
+                    .gameSequence(data.getSequence())
+                    .supportAttachments(data.getUnitTypeList().getSupportRules())
+                    .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
+                    .gameDiceSides(data.getDiceSides())
+                    .territoryEffects(List.of())
+                    .build(),
+                CombatValueBuilder.aaCombatValue()
+                    .enemyUnits(planes)
+                    .friendlyUnits(defendingAa)
+                    .side(BattleState.Side.DEFENSE)
+                    .supportAttachments(data.getUnitTypeList().getSupportAaRules())
+                    .build(),
                 "",
                 roll,
                 bridge,
@@ -301,18 +370,32 @@ class CasualtySelectorTest {
             defendingAa,
             bridge,
             territory("Germany", data),
-            CombatValue.buildAaCombatValue(
-                planes,
-                territory("Germany", data).getUnits(),
-                BattleState.Side.DEFENSE,
-                bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(planes)
+                .friendlyUnits(territory("Germany", data).getUnits())
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
                 planes,
                 defendingAa,
-                CombatValue.buildMainCombatValue(
-                    defendingAa, planes, BattleState.Side.OFFENSE, data, List.of()),
-                CombatValue.buildAaCombatValue(planes, defendingAa, BattleState.Side.DEFENSE, data),
+                CombatValueBuilder.mainCombatValue()
+                    .enemyUnits(defendingAa)
+                    .friendlyUnits(planes)
+                    .side(BattleState.Side.OFFENSE)
+                    .gameSequence(data.getSequence())
+                    .supportAttachments(data.getUnitTypeList().getSupportRules())
+                    .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
+                    .gameDiceSides(data.getDiceSides())
+                    .territoryEffects(List.of())
+                    .build(),
+                CombatValueBuilder.aaCombatValue()
+                    .enemyUnits(planes)
+                    .friendlyUnits(defendingAa)
+                    .side(BattleState.Side.DEFENSE)
+                    .supportAttachments(data.getUnitTypeList().getSupportAaRules())
+                    .build(),
                 "",
                 roll,
                 bridge,
@@ -351,20 +434,34 @@ class CasualtySelectorTest {
             defendingAa,
             bridge,
             territory("Germany", data),
-            CombatValue.buildAaCombatValue(
-                planes,
-                territory("Germany", data).getUnits(),
-                BattleState.Side.DEFENSE,
-                bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(planes)
+                .friendlyUnits(territory("Germany", data).getUnits())
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
                 planes,
                 defendingAa,
-                CombatValue.buildMainCombatValue(
-                    defendingAa, planes, BattleState.Side.OFFENSE, data, List.of()),
-                CombatValue.buildAaCombatValue(planes, defendingAa, BattleState.Side.DEFENSE, data),
+                CombatValueBuilder.mainCombatValue()
+                    .enemyUnits(defendingAa)
+                    .friendlyUnits(planes)
+                    .side(BattleState.Side.OFFENSE)
+                    .gameSequence(data.getSequence())
+                    .supportAttachments(data.getUnitTypeList().getSupportRules())
+                    .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
+                    .gameDiceSides(data.getDiceSides())
+                    .territoryEffects(List.of())
+                    .build(),
+                CombatValueBuilder.aaCombatValue()
+                    .enemyUnits(planes)
+                    .friendlyUnits(defendingAa)
+                    .side(BattleState.Side.DEFENSE)
+                    .supportAttachments(data.getUnitTypeList().getSupportAaRules())
+                    .build(),
                 "",
                 roll,
                 bridge,
@@ -407,20 +504,34 @@ class CasualtySelectorTest {
             defendingAa,
             bridge,
             territory("Germany", data),
-            CombatValue.buildAaCombatValue(
-                planes,
-                territory("Germany", data).getUnits(),
-                BattleState.Side.DEFENSE,
-                bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(planes)
+                .friendlyUnits(territory("Germany", data).getUnits())
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
                 planes,
                 defendingAa,
-                CombatValue.buildMainCombatValue(
-                    defendingAa, planes, BattleState.Side.OFFENSE, data, List.of()),
-                CombatValue.buildAaCombatValue(planes, defendingAa, BattleState.Side.DEFENSE, data),
+                CombatValueBuilder.mainCombatValue()
+                    .enemyUnits(defendingAa)
+                    .friendlyUnits(planes)
+                    .side(BattleState.Side.OFFENSE)
+                    .gameSequence(data.getSequence())
+                    .supportAttachments(data.getUnitTypeList().getSupportRules())
+                    .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
+                    .gameDiceSides(data.getDiceSides())
+                    .territoryEffects(List.of())
+                    .build(),
+                CombatValueBuilder.aaCombatValue()
+                    .enemyUnits(planes)
+                    .friendlyUnits(defendingAa)
+                    .side(BattleState.Side.DEFENSE)
+                    .supportAttachments(data.getUnitTypeList().getSupportAaRules())
+                    .build(),
                 "",
                 roll,
                 bridge,
@@ -458,20 +569,34 @@ class CasualtySelectorTest {
             defendingAa,
             bridge,
             territory("Germany", data),
-            CombatValue.buildAaCombatValue(
-                planes,
-                territory("Germany", data).getUnits(),
-                BattleState.Side.DEFENSE,
-                bridge.getData()));
+            CombatValueBuilder.aaCombatValue()
+                .enemyUnits(planes)
+                .friendlyUnits(territory("Germany", data).getUnits())
+                .side(BattleState.Side.DEFENSE)
+                .supportAttachments(bridge.getData().getUnitTypeList().getSupportAaRules())
+                .build());
     // make sure we rolled once
     thenGetRandomShouldHaveBeenCalled(bridge, times(1));
     final Collection<Unit> casualties =
         AaCasualtySelector.getAaCasualties(
                 planes,
                 defendingAa,
-                CombatValue.buildMainCombatValue(
-                    defendingAa, planes, BattleState.Side.OFFENSE, data, List.of()),
-                CombatValue.buildAaCombatValue(planes, defendingAa, BattleState.Side.DEFENSE, data),
+                CombatValueBuilder.mainCombatValue()
+                    .enemyUnits(defendingAa)
+                    .friendlyUnits(planes)
+                    .side(BattleState.Side.OFFENSE)
+                    .gameSequence(data.getSequence())
+                    .supportAttachments(data.getUnitTypeList().getSupportRules())
+                    .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
+                    .gameDiceSides(data.getDiceSides())
+                    .territoryEffects(List.of())
+                    .build(),
+                CombatValueBuilder.aaCombatValue()
+                    .enemyUnits(planes)
+                    .friendlyUnits(defendingAa)
+                    .side(BattleState.Side.DEFENSE)
+                    .supportAttachments(data.getUnitTypeList().getSupportAaRules())
+                    .build(),
                 "",
                 roll,
                 bridge,

--- a/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/AaDefenseCombatValueTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/AaDefenseCombatValueTest.java
@@ -70,9 +70,10 @@ class AaDefenseCombatValueTest {
 
       final StrengthCalculator strength =
           AaDefenseCombatValue.builder()
-              .gameData(gameData)
-              .supportFromFriends(friendlySupport)
-              .supportFromEnemies(enemySupport)
+              .strengthSupportFromFriends(friendlySupport)
+              .strengthSupportFromEnemies(enemySupport)
+              .rollSupportFromFriends(AvailableSupports.EMPTY_RESULT)
+              .rollSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
               .build()
               .getStrength();
       assertThat(
@@ -149,9 +150,10 @@ class AaDefenseCombatValueTest {
 
       final StrengthCalculator strength =
           AaDefenseCombatValue.builder()
-              .gameData(gameData)
-              .supportFromFriends(friendlySupport)
-              .supportFromEnemies(enemySupport)
+              .strengthSupportFromFriends(friendlySupport)
+              .strengthSupportFromEnemies(enemySupport)
+              .rollSupportFromFriends(AvailableSupports.EMPTY_RESULT)
+              .rollSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
               .build()
               .getStrength();
       strength.getStrength(unit);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/AaOffenseCombatValueTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/AaOffenseCombatValueTest.java
@@ -70,9 +70,10 @@ class AaOffenseCombatValueTest {
 
       final StrengthCalculator strength =
           AaOffenseCombatValue.builder()
-              .gameData(gameData)
-              .supportFromFriends(friendlySupport)
-              .supportFromEnemies(enemySupport)
+              .strengthSupportFromFriends(friendlySupport)
+              .strengthSupportFromEnemies(enemySupport)
+              .rollSupportFromFriends(AvailableSupports.EMPTY_RESULT)
+              .rollSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
               .build()
               .getStrength();
       assertThat(
@@ -149,9 +150,10 @@ class AaOffenseCombatValueTest {
 
       final StrengthCalculator strength =
           AaOffenseCombatValue.builder()
-              .gameData(gameData)
-              .supportFromFriends(friendlySupport)
-              .supportFromEnemies(enemySupport)
+              .strengthSupportFromFriends(friendlySupport)
+              .strengthSupportFromEnemies(enemySupport)
+              .rollSupportFromFriends(AvailableSupports.EMPTY_RESULT)
+              .rollSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
               .build()
               .getStrength();
       strength.getStrength(unit);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/AaPowerStrengthAndRollsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/AaPowerStrengthAndRollsTest.java
@@ -42,14 +42,15 @@ class AaPowerStrengthAndRollsTest {
   class GetRolls {
 
     private AaPowerStrengthAndRolls givenAaPowerStrengthAndRolls(
-        final GameData gameData, final List<Unit> units, final int numValidTargets) {
+        final List<Unit> units, final int numValidTargets) {
       return AaPowerStrengthAndRolls.build(
           units,
           numValidTargets,
           AaOffenseCombatValue.builder()
-              .gameData(gameData)
-              .supportFromFriends(AvailableSupports.EMPTY_RESULT)
-              .supportFromEnemies(AvailableSupports.EMPTY_RESULT)
+              .rollSupportFromFriends(AvailableSupports.EMPTY_RESULT)
+              .rollSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
+              .strengthSupportFromFriends(AvailableSupports.EMPTY_RESULT)
+              .strengthSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
               .build());
     }
 
@@ -60,7 +61,7 @@ class AaPowerStrengthAndRollsTest {
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(1);
       final List<Unit> units = List.of(unit);
 
-      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(gameData, units, 2);
+      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(units, 2);
 
       assertThat("Unit has 1 roll and there are is least 1 target", result.getRolls(unit), is(1));
     }
@@ -72,7 +73,7 @@ class AaPowerStrengthAndRollsTest {
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(3);
       final List<Unit> units = List.of(unit);
 
-      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(gameData, units, 2);
+      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(units, 2);
 
       assertThat("Unit has 3 rolls but only 2 targets", result.getRolls(unit), is(2));
     }
@@ -87,7 +88,7 @@ class AaPowerStrengthAndRollsTest {
 
       final List<Unit> units = List.of(unit1, unit2);
 
-      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(gameData, units, 4);
+      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(units, 4);
 
       assertThat("Unit1 has 1 roll and there is 4 targets", result.getRolls(unit1), is(1));
       assertThat("Unit2 has 1 roll and there is 4 targets", result.getRolls(unit2), is(1));
@@ -103,7 +104,7 @@ class AaPowerStrengthAndRollsTest {
 
       final List<Unit> units = List.of(unit1, unit2);
 
-      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(gameData, units, 3);
+      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(units, 3);
 
       assertThat(
           "Unit2 has higher strength so can use both its rolls", result.getRolls(unit2), is(2));
@@ -122,7 +123,7 @@ class AaPowerStrengthAndRollsTest {
 
       final List<Unit> units = List.of(unit1, unit2, unit3);
 
-      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(gameData, units, 3);
+      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(units, 3);
 
       assertThat(
           "Unit2 has higher strength so can use both its rolls", result.getRolls(unit2), is(2));
@@ -137,7 +138,7 @@ class AaPowerStrengthAndRollsTest {
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(-1);
       final List<Unit> units = List.of(unit);
 
-      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(gameData, units, 4);
+      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(units, 4);
 
       assertThat("Infinite unit can roll for all targets", result.getRolls(unit), is(4));
     }
@@ -151,7 +152,7 @@ class AaPowerStrengthAndRollsTest {
       unit2.getUnitAttachment().setOffensiveAttackAa(3).setMaxAaAttacks(-1);
       final List<Unit> units = List.of(unit1, unit2);
 
-      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(gameData, units, 4);
+      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(units, 4);
 
       assertThat(
           "Unit2 is stronger so it rolls for all the targets", result.getRolls(unit2), is(4));
@@ -160,7 +161,7 @@ class AaPowerStrengthAndRollsTest {
 
     @Test
     void twoAaWithInfiniteWithDifferentDice() {
-      final GameData gameData = givenGameData().withDiceSides(6).build();
+      final GameData gameData = givenGameData().build();
       final Unit unit1 = givenUnit("test", gameData);
       unit1
           .getUnitAttachment()
@@ -175,7 +176,7 @@ class AaPowerStrengthAndRollsTest {
           .setOffensiveAttackAaMaxDieSides(8);
       final List<Unit> units = List.of(unit1, unit2);
 
-      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(gameData, units, 4);
+      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(units, 4);
 
       assertThat(
           "2 of 4 is better than 3 of 8 so unit1 rolls for all targets",
@@ -193,7 +194,7 @@ class AaPowerStrengthAndRollsTest {
       unit2.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(-1);
       final List<Unit> units = List.of(unit1, unit2);
 
-      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(gameData, units, 4);
+      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(units, 4);
 
       assertThat(
           "Unit1 is equal power to the infinite unit2 so it doesn't roll",
@@ -211,7 +212,7 @@ class AaPowerStrengthAndRollsTest {
       unit2.getUnitAttachment().setOffensiveAttackAa(3).setMaxAaAttacks(-1);
       final List<Unit> units = List.of(unit1, unit2);
 
-      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(gameData, units, 4);
+      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(units, 4);
 
       assertThat(
           "Unit1 is weaker than the infinite unit2 so it doesn't roll",
@@ -229,7 +230,7 @@ class AaPowerStrengthAndRollsTest {
       unit2.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(-1);
       final List<Unit> units = List.of(unit1, unit2);
 
-      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(gameData, units, 4);
+      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(units, 4);
 
       assertThat(
           "Unit1 is stronger than the infinite unit2 so it rolls once",
@@ -246,7 +247,7 @@ class AaPowerStrengthAndRollsTest {
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(5).setMayOverStackAa(true);
       final List<Unit> units = List.of(unit);
 
-      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(gameData, units, 4);
+      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(units, 4);
 
       assertThat(
           "Overstack always uses all of its rolls even if there are not enough targets",
@@ -261,7 +262,7 @@ class AaPowerStrengthAndRollsTest {
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(-1).setMayOverStackAa(true);
       final List<Unit> units = List.of(unit);
 
-      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(gameData, units, 2);
+      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(units, 2);
 
       assertThat(
           "Overstack makes no sense on an infinite unit so it only rolls for all the targets",
@@ -278,7 +279,7 @@ class AaPowerStrengthAndRollsTest {
       unit2.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(2).setMayOverStackAa(true);
       final List<Unit> units = List.of(unit1, unit2);
 
-      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(gameData, units, 4);
+      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(units, 4);
 
       assertThat(
           "Unit1 is infinite so it rolls for all the targets", result.getRolls(unit1), is(4));
@@ -294,7 +295,7 @@ class AaPowerStrengthAndRollsTest {
       unit2.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(2).setMayOverStackAa(true);
       final List<Unit> units = List.of(unit1, unit2);
 
-      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(gameData, units, 4);
+      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(units, 4);
 
       assertThat("Unit1 has two rolls and there are 4 targets", result.getRolls(unit1), is(2));
       assertThat("Unit2 is overstack so it just uses all its rolls", result.getRolls(unit2), is(2));
@@ -311,7 +312,7 @@ class AaPowerStrengthAndRollsTest {
       unit3.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(2).setMayOverStackAa(true);
       final List<Unit> units = List.of(unit1, unit2, unit3);
 
-      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(gameData, units, 4);
+      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(units, 4);
 
       assertThat(
           "Unit1 is infinite and equal strength as the non-infinite so it rolls for all targets",
@@ -335,7 +336,7 @@ class AaPowerStrengthAndRollsTest {
       unit3.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(2).setMayOverStackAa(true);
       final List<Unit> units = List.of(unit1, unit2, unit3);
 
-      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(gameData, units, 4);
+      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(units, 4);
 
       assertThat(
           "Unit1 is infinite and weaker than the non infinite, so it only rolls for 2 targets",
@@ -359,7 +360,7 @@ class AaPowerStrengthAndRollsTest {
       unit3.getUnitAttachment().setOffensiveAttackAa(4).setMaxAaAttacks(2).setMayOverStackAa(true);
       final List<Unit> units = List.of(unit1, unit2, unit3);
 
-      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(gameData, units, 4);
+      final AaPowerStrengthAndRolls result = givenAaPowerStrengthAndRolls(units, 4);
 
       assertThat(
           "Unit1 is infinite and stronger than the non infinite, so it rolls for all targets",

--- a/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/BombardmentCombatValueTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/BombardmentCombatValueTest.java
@@ -79,7 +79,7 @@ class BombardmentCombatValueTest {
 
       final BombardmentCombatValue.BombardmentStrength strength =
           new BombardmentCombatValue.BombardmentStrength(
-              gameData, friendlySupport, enemySupport, List.of(territoryEffect));
+              6, List.of(territoryEffect), friendlySupport, enemySupport);
       assertThat(
           "Strength starts at 3, friendly adds 3, enemy removes 2, territory adds 1: total 5",
           strength.getStrength(unit).getValue(),

--- a/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/MainDefenseCombatValueTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/MainDefenseCombatValueTest.java
@@ -216,7 +216,7 @@ class MainDefenseCombatValueTest {
 
       final MainDefenseCombatValue.MainDefenseStrength strength =
           new MainDefenseCombatValue.MainDefenseStrength(
-              gameData, friendlySupport, enemySupport, List.of(territoryEffect));
+              gameData.getSequence(), 6, List.of(territoryEffect), friendlySupport, enemySupport);
       assertThat(
           "Strength starts at 3, friendly adds 3, enemy removes 2, territory adds 1: total 5",
           strength.getStrength(unit).getValue(),
@@ -290,7 +290,7 @@ class MainDefenseCombatValueTest {
 
       final MainDefenseCombatValue.MainDefenseStrength strength =
           new MainDefenseCombatValue.MainDefenseStrength(
-              gameData, friendlySupport, enemySupport, List.of(territoryEffect));
+              gameData.getSequence(), 6, List.of(territoryEffect), friendlySupport, enemySupport);
       assertThat(
           "Strength is limited to 1, friendly is not used, "
               + "enemy removes 2, territory adds 3: total 1",
@@ -342,7 +342,7 @@ class MainDefenseCombatValueTest {
 
       final MainDefenseCombatValue.MainDefenseStrength strength =
           new MainDefenseCombatValue.MainDefenseStrength(
-              gameData, friendlySupport, enemySupport, List.of());
+              gameData.getSequence(), 6, List.of(), friendlySupport, enemySupport);
       strength.getStrength(unit);
       assertThat(
           "Friendly gave 2 and enemy gave -1",

--- a/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/MainOffenseCombatValueTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/MainOffenseCombatValueTest.java
@@ -213,7 +213,7 @@ class MainOffenseCombatValueTest {
 
       final MainOffenseCombatValue.MainOffenseStrength strength =
           new MainOffenseCombatValue.MainOffenseStrength(
-              gameData, friendlySupport, enemySupport, List.of(territoryEffect));
+              6, List.of(territoryEffect), friendlySupport, enemySupport);
       assertThat(
           "Strength starts at 3, friendly adds 3, enemy removes 2, territory adds 1: total 5",
           strength.getStrength(unit).getValue(),
@@ -246,7 +246,7 @@ class MainOffenseCombatValueTest {
 
       final MainOffenseCombatValue.MainOffenseStrength strength =
           new MainOffenseCombatValue.MainOffenseStrength(
-              gameData, AvailableSupports.EMPTY_RESULT, AvailableSupports.EMPTY_RESULT, List.of());
+              6, List.of(), AvailableSupports.EMPTY_RESULT, AvailableSupports.EMPTY_RESULT);
       assertThat(
           "Strength starts at 3, marine adds 1: total 4",
           strength.getStrength(unit).getValue(),
@@ -267,7 +267,7 @@ class MainOffenseCombatValueTest {
 
       final MainOffenseCombatValue.MainOffenseStrength strength =
           new MainOffenseCombatValue.MainOffenseStrength(
-              gameData, AvailableSupports.EMPTY_RESULT, AvailableSupports.EMPTY_RESULT, List.of());
+              6, List.of(), AvailableSupports.EMPTY_RESULT, AvailableSupports.EMPTY_RESULT);
       assertThat(
           "Strength starts at 3 and marine is not added: total 3",
           strength.getStrength(unit).getValue(),
@@ -318,7 +318,7 @@ class MainOffenseCombatValueTest {
 
       final MainOffenseCombatValue.MainOffenseStrength strength =
           new MainOffenseCombatValue.MainOffenseStrength(
-              gameData, friendlySupport, enemySupport, List.of());
+              6, List.of(), friendlySupport, enemySupport);
       strength.getStrength(unit);
       assertThat(
           "Friendly gave 2 and enemy gave -1",

--- a/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRollsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRollsTest.java
@@ -80,8 +80,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit);
       final List<Die> sortedDie = new ArrayList<>();
 
-      final AaPowerStrengthAndRolls result =
-          whenGetPowerHitsResult(gameData, units, sortedDie, 1, 4);
+      final AaPowerStrengthAndRolls result = whenGetPowerHitsResult(units, sortedDie, 1, 4);
 
       assertThat(
           "Total Power equals the single unit's strength", result.calculateTotalPower(), is(2));
@@ -90,7 +89,6 @@ class TotalPowerAndTotalRollsTest {
     }
 
     private AaPowerStrengthAndRolls whenGetPowerHitsResult(
-        final GameData gameData,
         final List<Unit> units,
         final List<Die> sortedDie,
         final int dieHit,
@@ -100,9 +98,10 @@ class TotalPowerAndTotalRollsTest {
               units,
               numValidTargets,
               AaOffenseCombatValue.builder()
-                  .gameData(gameData)
-                  .supportFromFriends(AvailableSupports.EMPTY_RESULT)
-                  .supportFromEnemies(AvailableSupports.EMPTY_RESULT)
+                  .rollSupportFromFriends(AvailableSupports.EMPTY_RESULT)
+                  .rollSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
+                  .strengthSupportFromFriends(AvailableSupports.EMPTY_RESULT)
+                  .strengthSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
                   .build());
 
       final int totalRolls = unitPowerAndRollsMap.calculateTotalRolls();
@@ -123,7 +122,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit);
       final List<Die> sortedDie = new ArrayList<>();
 
-      whenGetPowerHitsResult(gameData, units, sortedDie, 6, 4);
+      whenGetPowerHitsResult(units, sortedDie, 6, 4);
 
       assertThat(
           "The strength was 2 but the dice rolled a 6 so it was a miss",
@@ -139,8 +138,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit);
       final List<Die> sortedDie = new ArrayList<>();
 
-      final AaPowerStrengthAndRolls result =
-          whenGetPowerHitsResult(gameData, units, sortedDie, 1, 4);
+      final AaPowerStrengthAndRolls result = whenGetPowerHitsResult(units, sortedDie, 1, 4);
 
       assertThat(
           "2 strength in 2 rolls equals total power of 4", result.calculateTotalPower(), is(4));
@@ -157,8 +155,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit);
       final List<Die> sortedDie = new ArrayList<>();
 
-      final AaPowerStrengthAndRolls result =
-          whenGetPowerHitsResult(gameData, units, sortedDie, 1, 2);
+      final AaPowerStrengthAndRolls result = whenGetPowerHitsResult(units, sortedDie, 1, 2);
 
       assertThat(
           "Unit has 3 rolls but only 2 targets, so 2 rolls of 2 strength = 4",
@@ -179,8 +176,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit, unit2);
       final List<Die> sortedDie = new ArrayList<>();
 
-      final AaPowerStrengthAndRolls result =
-          whenGetPowerHitsResult(gameData, units, sortedDie, 1, 4);
+      final AaPowerStrengthAndRolls result = whenGetPowerHitsResult(units, sortedDie, 1, 4);
 
       assertThat("2 strength + 2 strength is 4", result.calculateTotalPower(), is(4));
       assertThat("Both units have the same strength", result.isSameStrength(), is(true));
@@ -199,8 +195,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit, unit2);
       final List<Die> sortedDie = new ArrayList<>();
 
-      final AaPowerStrengthAndRolls result =
-          whenGetPowerHitsResult(gameData, units, sortedDie, 1, 4);
+      final AaPowerStrengthAndRolls result = whenGetPowerHitsResult(units, sortedDie, 1, 4);
 
       assertThat("2 strength + 3 strength is 5", result.calculateTotalPower(), is(5));
       assertThat("Both units have different strength values", result.isSameStrength(), is(false));
@@ -219,8 +214,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit, unit2);
       final List<Die> sortedDie = new ArrayList<>();
 
-      final AaPowerStrengthAndRolls result =
-          whenGetPowerHitsResult(gameData, units, sortedDie, 1, 3);
+      final AaPowerStrengthAndRolls result = whenGetPowerHitsResult(units, sortedDie, 1, 3);
 
       assertThat(
           "The second unit has higher strength so it rolls both "
@@ -247,7 +241,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit, unit2);
       final List<Die> sortedDie = new ArrayList<>();
 
-      whenGetPowerHitsResult(gameData, units, sortedDie, 2, 4);
+      whenGetPowerHitsResult(units, sortedDie, 2, 4);
 
       assertThat(
           "The dice is a 2 so the first unit hits (with a strength of 3) "
@@ -265,8 +259,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit);
       final List<Die> sortedDie = new ArrayList<>();
 
-      final AaPowerStrengthAndRolls result =
-          whenGetPowerHitsResult(gameData, units, sortedDie, 1, 4);
+      final AaPowerStrengthAndRolls result = whenGetPowerHitsResult(units, sortedDie, 1, 4);
 
       assertThat(
           "Infinite strength of 2 is multiplied by the rolls so 8",
@@ -293,8 +286,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit, unit2);
       final List<Die> sortedDie = new ArrayList<>();
 
-      final AaPowerStrengthAndRolls result =
-          whenGetPowerHitsResult(gameData, units, sortedDie, 1, 4);
+      final AaPowerStrengthAndRolls result = whenGetPowerHitsResult(units, sortedDie, 1, 4);
 
       assertThat(
           "Two infinite units are equal to one infinite unit", result.calculateTotalPower(), is(8));
@@ -322,8 +314,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit, unit2);
       final List<Die> sortedDie = new ArrayList<>();
 
-      final AaPowerStrengthAndRolls result =
-          whenGetPowerHitsResult(gameData, units, sortedDie, 1, 4);
+      final AaPowerStrengthAndRolls result = whenGetPowerHitsResult(units, sortedDie, 1, 4);
 
       assertThat(
           "The strongest infinite unit is used for all targets",
@@ -345,7 +336,7 @@ class TotalPowerAndTotalRollsTest {
 
     @Test
     void twoAaWithInfiniteWithDifferentDice() {
-      final GameData gameData = givenGameData().withDiceSides(6).build();
+      final GameData gameData = givenGameData().build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment()
           .setOffensiveAttackAa(2)
@@ -360,8 +351,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit, unit2);
       final List<Die> sortedDie = new ArrayList<>();
 
-      final AaPowerStrengthAndRolls result =
-          whenGetPowerHitsResult(gameData, units, sortedDie, 1, 4);
+      final AaPowerStrengthAndRolls result = whenGetPowerHitsResult(units, sortedDie, 1, 4);
 
       assertThat(
           "2 of 4 is better than 3 of 8 so the 2 strength is used for all targets",
@@ -392,8 +382,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit, unit2);
       final List<Die> sortedDie = new ArrayList<>();
 
-      final AaPowerStrengthAndRolls result =
-          whenGetPowerHitsResult(gameData, units, sortedDie, 1, 4);
+      final AaPowerStrengthAndRolls result = whenGetPowerHitsResult(units, sortedDie, 1, 4);
 
       assertThat(
           "Both units have strength 2 so the power is 2 * 4 (rolls) = 8",
@@ -420,8 +409,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit, unit2);
       final List<Die> sortedDie = new ArrayList<>();
 
-      final AaPowerStrengthAndRolls result =
-          whenGetPowerHitsResult(gameData, units, sortedDie, 1, 4);
+      final AaPowerStrengthAndRolls result = whenGetPowerHitsResult(units, sortedDie, 1, 4);
 
       assertThat(
           "The non infinite unit is not used so the power is 3 (strength) * 4 (roll)",
@@ -452,8 +440,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit, unit2);
       final List<Die> sortedDie = new ArrayList<>();
 
-      final AaPowerStrengthAndRolls result =
-          whenGetPowerHitsResult(gameData, units, sortedDie, 1, 4);
+      final AaPowerStrengthAndRolls result = whenGetPowerHitsResult(units, sortedDie, 1, 4);
 
       assertThat(
           "The non infinite unit is used once so 3 + 2 * 3", result.calculateTotalPower(), is(9));
@@ -480,8 +467,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit);
       final List<Die> sortedDie = new ArrayList<>();
 
-      final AaPowerStrengthAndRolls result =
-          whenGetPowerHitsResult(gameData, units, sortedDie, 1, 4);
+      final AaPowerStrengthAndRolls result = whenGetPowerHitsResult(units, sortedDie, 1, 4);
 
       assertThat("2 rolls with 2 strength is 4 power", result.calculateTotalPower(), is(4));
       assertThat("Only one unit, so only one strength", result.isSameStrength(), is(true));
@@ -497,8 +483,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit);
       final List<Die> sortedDie = new ArrayList<>();
 
-      final AaPowerStrengthAndRolls result =
-          whenGetPowerHitsResult(gameData, units, sortedDie, 1, 4);
+      final AaPowerStrengthAndRolls result = whenGetPowerHitsResult(units, sortedDie, 1, 4);
 
       assertThat(
           "Unit has 5 rolls with 2 strength and can overstack, so 5 * 2",
@@ -524,8 +509,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit);
       final List<Die> sortedDie = new ArrayList<>();
 
-      final AaPowerStrengthAndRolls result =
-          whenGetPowerHitsResult(gameData, units, sortedDie, 1, 2);
+      final AaPowerStrengthAndRolls result = whenGetPowerHitsResult(units, sortedDie, 1, 2);
 
       assertThat(
           "Overstack makes no sense on an infinite unit. "
@@ -547,8 +531,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit, unit2);
       final List<Die> sortedDie = new ArrayList<>();
 
-      final AaPowerStrengthAndRolls result =
-          whenGetPowerHitsResult(gameData, units, sortedDie, 1, 4);
+      final AaPowerStrengthAndRolls result = whenGetPowerHitsResult(units, sortedDie, 1, 4);
 
       assertThat(
           "Infinite unit hits all 4, overstack unit adds 2 more: 6 (roll) * 2 (strength)",
@@ -578,8 +561,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit, unit2);
       final List<Die> sortedDie = new ArrayList<>();
 
-      final AaPowerStrengthAndRolls result =
-          whenGetPowerHitsResult(gameData, units, sortedDie, 1, 4);
+      final AaPowerStrengthAndRolls result = whenGetPowerHitsResult(units, sortedDie, 1, 4);
 
       assertThat(
           "Infinite unit hits all 4 with strength 2, "
@@ -610,8 +592,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit, unit2);
       final List<Die> sortedDie = new ArrayList<>();
 
-      final AaPowerStrengthAndRolls result =
-          whenGetPowerHitsResult(gameData, units, sortedDie, 1, 4);
+      final AaPowerStrengthAndRolls result = whenGetPowerHitsResult(units, sortedDie, 1, 4);
 
       assertThat(result.calculateTotalPower(), is(8));
       assertThat(result.isSameStrength(), is(true));
@@ -636,8 +617,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit, unit2);
       final List<Die> sortedDie = new ArrayList<>();
 
-      final AaPowerStrengthAndRolls result =
-          whenGetPowerHitsResult(gameData, units, sortedDie, 1, 4);
+      final AaPowerStrengthAndRolls result = whenGetPowerHitsResult(units, sortedDie, 1, 4);
 
       assertThat(result.calculateTotalPower(), is(10));
       assertThat(result.isSameStrength(), is(false));
@@ -664,8 +644,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit, unit2, unit3);
       final List<Die> sortedDie = new ArrayList<>();
 
-      final AaPowerStrengthAndRolls result =
-          whenGetPowerHitsResult(gameData, units, sortedDie, 1, 4);
+      final AaPowerStrengthAndRolls result = whenGetPowerHitsResult(units, sortedDie, 1, 4);
 
       assertThat(result.calculateTotalPower(), is(12));
       assertThat(result.isSameStrength(), is(true));
@@ -694,8 +673,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit, unit2, unit3);
       final List<Die> sortedDie = new ArrayList<>();
 
-      final AaPowerStrengthAndRolls result =
-          whenGetPowerHitsResult(gameData, units, sortedDie, 1, 4);
+      final AaPowerStrengthAndRolls result = whenGetPowerHitsResult(units, sortedDie, 1, 4);
 
       assertThat(result.calculateTotalPower(), is(18));
       assertThat(result.isSameStrength(), is(false));
@@ -724,8 +702,7 @@ class TotalPowerAndTotalRollsTest {
       final List<Unit> units = List.of(unit, unit2, unit3);
       final List<Die> sortedDie = new ArrayList<>();
 
-      final AaPowerStrengthAndRolls result =
-          whenGetPowerHitsResult(gameData, units, sortedDie, 1, 4);
+      final AaPowerStrengthAndRolls result = whenGetPowerHitsResult(units, sortedDie, 1, 4);
 
       assertThat(result.calculateTotalPower(), is(20));
       assertThat(result.isSameStrength(), is(false));
@@ -781,8 +758,12 @@ class TotalPowerAndTotalRollsTest {
           units.stream()
               .sorted(
                   AaPowerStrengthAndRolls.sortAaHighToLow(
-                      CombatValue.buildAaCombatValue(
-                          List.of(), List.of(), BattleState.Side.OFFENSE, gameData)))
+                      CombatValueBuilder.aaCombatValue()
+                          .enemyUnits(List.of())
+                          .friendlyUnits(List.of())
+                          .side(BattleState.Side.OFFENSE)
+                          .supportAttachments(List.of())
+                          .build()))
               .collect(Collectors.toList());
       assertThat(sortedUnits.get(0), is(unit1));
       assertThat(sortedUnits.get(1), is(unit2));
@@ -805,8 +786,12 @@ class TotalPowerAndTotalRollsTest {
           units.stream()
               .sorted(
                   AaPowerStrengthAndRolls.sortAaHighToLow(
-                      CombatValue.buildAaCombatValue(
-                          List.of(), List.of(), BattleState.Side.DEFENSE, gameData)))
+                      CombatValueBuilder.aaCombatValue()
+                          .enemyUnits(List.of())
+                          .friendlyUnits(List.of())
+                          .side(BattleState.Side.DEFENSE)
+                          .supportAttachments(List.of())
+                          .build()))
               .collect(Collectors.toList());
       assertThat(sortedUnits.get(0), is(unit5));
       assertThat(sortedUnits.get(1), is(unit3));
@@ -821,7 +806,7 @@ class TotalPowerAndTotalRollsTest {
 
     @Test
     void singleUnitWithCustomDice() {
-      final GameData gameData = givenGameData().withDiceSides(6).build();
+      final GameData gameData = givenGameData().build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment()
           .setOffensiveAttackAa(2)
@@ -832,15 +817,19 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(unit),
               1,
-              CombatValue.buildAaCombatValue(
-                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
+              CombatValueBuilder.aaCombatValue()
+                  .enemyUnits(List.of())
+                  .friendlyUnits(List.of())
+                  .side(BattleState.Side.OFFENSE)
+                  .supportAttachments(List.of())
+                  .build());
 
       assertThat("Dice comes from the unitAttachment", aaPowerAndRolls.getBestDiceSides(), is(8));
     }
 
     @Test
     void singleDefensiveUnitWithCustomDice() {
-      final GameData gameData = givenGameData().withDiceSides(6).build();
+      final GameData gameData = givenGameData().build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setAttackAa(2).setMaxAaAttacks(1).setAttackAaMaxDieSides(8);
 
@@ -848,15 +837,19 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(unit),
               1,
-              CombatValue.buildAaCombatValue(
-                  List.of(), List.of(), BattleState.Side.DEFENSE, gameData));
+              CombatValueBuilder.aaCombatValue()
+                  .enemyUnits(List.of())
+                  .friendlyUnits(List.of())
+                  .side(BattleState.Side.DEFENSE)
+                  .supportAttachments(List.of())
+                  .build());
 
       assertThat("Dice comes from the unitAttachment", aaPowerAndRolls.getBestDiceSides(), is(8));
     }
 
     @Test
     void singleUnitWithSupport() {
-      final GameData gameData = givenGameData().withDiceSides(6).build();
+      final GameData gameData = givenGameData().build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setOffensiveAttackAa(2).setMaxAaAttacks(1);
 
@@ -868,11 +861,9 @@ class TotalPowerAndTotalRollsTest {
       when(strengthCalculator.getStrength(unit)).thenReturn(StrengthValue.of(6, 3));
       when(combatValue.getStrength()).thenReturn(strengthCalculator);
       final PowerCalculator powerCalculator =
-          new PowerCalculator(
-              gameData, strengthCalculator, rollCalculator, (unit1) -> true, (unit1) -> 6);
+          new PowerCalculator(strengthCalculator, rollCalculator, (unit1) -> true, (unit1) -> 6);
       when(combatValue.getPower()).thenReturn(powerCalculator);
       when(combatValue.getDiceSides(unit)).thenReturn(6);
-      when(combatValue.getGameData()).thenReturn(gameData);
       when(combatValue.getBattleSide()).thenReturn(BattleState.Side.OFFENSE);
       final AaPowerStrengthAndRolls totalPowerAndTotalRolls =
           AaPowerStrengthAndRolls.build(List.of(unit), 1, combatValue);
@@ -895,8 +886,12 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(unit, unit2, unit3),
               1,
-              CombatValue.buildAaCombatValue(
-                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
+              CombatValueBuilder.aaCombatValue()
+                  .enemyUnits(List.of())
+                  .friendlyUnits(List.of())
+                  .side(BattleState.Side.OFFENSE)
+                  .supportAttachments(List.of())
+                  .build());
 
       assertThat(
           "All have the same dice sides, so take the best strength",
@@ -906,7 +901,7 @@ class TotalPowerAndTotalRollsTest {
 
     @Test
     void multipleUnitsWithDifferentDice() {
-      final GameData gameData = givenGameData().withDiceSides(6).build();
+      final GameData gameData = givenGameData().build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment()
           .setOffensiveAttackAa(2)
@@ -929,8 +924,12 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(unit, unit2, unit3),
               1,
-              CombatValue.buildAaCombatValue(
-                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
+              CombatValueBuilder.aaCombatValue()
+                  .enemyUnits(List.of())
+                  .friendlyUnits(List.of())
+                  .side(BattleState.Side.OFFENSE)
+                  .supportAttachments(List.of())
+                  .build());
 
       assertThat(
           "4 of 4 is better than 2 of 6 and 3 of 5", aaPowerAndRolls.getBestStrength(), is(4));
@@ -940,7 +939,7 @@ class TotalPowerAndTotalRollsTest {
 
     @Test
     void multipleUnitsWithDifferentDice2() {
-      final GameData gameData = givenGameData().withDiceSides(6).build();
+      final GameData gameData = givenGameData().build();
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment()
           .setOffensiveAttackAa(3)
@@ -963,8 +962,12 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(unit, unit2, unit3),
               1,
-              CombatValue.buildAaCombatValue(
-                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
+              CombatValueBuilder.aaCombatValue()
+                  .enemyUnits(List.of())
+                  .friendlyUnits(List.of())
+                  .side(BattleState.Side.OFFENSE)
+                  .supportAttachments(List.of())
+                  .build());
 
       assertThat(
           "3 of 6 is better than 3 of 7 and 3 of 8", aaPowerAndRolls.getBestStrength(), is(3));
@@ -987,9 +990,10 @@ class TotalPowerAndTotalRollsTest {
               List.of(unit),
               1,
               AaOffenseCombatValue.builder()
-                  .gameData(gameData)
-                  .supportFromFriends(AvailableSupports.EMPTY_RESULT)
-                  .supportFromEnemies(AvailableSupports.EMPTY_RESULT)
+                  .rollSupportFromFriends(AvailableSupports.EMPTY_RESULT)
+                  .rollSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
+                  .strengthSupportFromFriends(AvailableSupports.EMPTY_RESULT)
+                  .strengthSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
                   .build());
 
       assertThat(result.getStrength(unit), is(0));
@@ -1006,9 +1010,10 @@ class TotalPowerAndTotalRollsTest {
               List.of(unit),
               1,
               AaOffenseCombatValue.builder()
-                  .gameData(gameData)
-                  .supportFromFriends(AvailableSupports.EMPTY_RESULT)
-                  .supportFromEnemies(AvailableSupports.EMPTY_RESULT)
+                  .rollSupportFromFriends(AvailableSupports.EMPTY_RESULT)
+                  .rollSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
+                  .strengthSupportFromFriends(AvailableSupports.EMPTY_RESULT)
+                  .strengthSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
                   .build());
 
       assertThat(result.getRolls(unit), is(0));
@@ -1031,22 +1036,25 @@ class TotalPowerAndTotalRollsTest {
               .setUnitType(
                   Set.of(strongUnit.getType(), weakUnit.getType(), lessWeakUnit.getType()));
 
-      final AvailableSupports friendlySupport =
+      final AvailableSupports rollSupportFromFriends =
           AvailableSupports.getSupport(
               new SupportCalculator(
                   List.of(supportUnit),
                   List.of(unitSupportAttachment),
                   BattleState.Side.OFFENSE,
                   true));
+      final AvailableSupports strengthSupportFromFriends =
+          rollSupportFromFriends.filter(UnitSupportAttachment::getAaStrength);
 
       final AaPowerStrengthAndRolls result =
           AaPowerStrengthAndRolls.build(
               List.of(weakUnit, strongUnit, lessWeakUnit),
               4,
               AaOffenseCombatValue.builder()
-                  .gameData(gameData)
-                  .supportFromFriends(friendlySupport)
-                  .supportFromEnemies(AvailableSupports.EMPTY_RESULT)
+                  .rollSupportFromFriends(rollSupportFromFriends)
+                  .rollSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
+                  .strengthSupportFromFriends(strengthSupportFromFriends)
+                  .strengthSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
                   .build());
 
       assertThat(
@@ -1076,9 +1084,13 @@ class TotalPowerAndTotalRollsTest {
           PowerStrengthAndRolls.build(
               List.of(unit),
               MainOffenseCombatValue.builder()
-                  .gameData(gameData)
-                  .supportFromFriends(AvailableSupports.EMPTY_RESULT)
-                  .supportFromEnemies(AvailableSupports.EMPTY_RESULT)
+                  .gameSequence(gameData.getSequence())
+                  .gameDiceSides(6)
+                  .lhtrHeavyBombers(false)
+                  .rollSupportFromFriends(AvailableSupports.EMPTY_RESULT)
+                  .rollSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
+                  .strengthSupportFromFriends(AvailableSupports.EMPTY_RESULT)
+                  .strengthSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
                   .territoryEffects(List.of())
                   .build());
 
@@ -1095,9 +1107,13 @@ class TotalPowerAndTotalRollsTest {
           PowerStrengthAndRolls.build(
               List.of(unit),
               MainOffenseCombatValue.builder()
-                  .gameData(gameData)
-                  .supportFromFriends(AvailableSupports.EMPTY_RESULT)
-                  .supportFromEnemies(AvailableSupports.EMPTY_RESULT)
+                  .gameSequence(gameData.getSequence())
+                  .gameDiceSides(6)
+                  .lhtrHeavyBombers(false)
+                  .rollSupportFromFriends(AvailableSupports.EMPTY_RESULT)
+                  .rollSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
+                  .strengthSupportFromFriends(AvailableSupports.EMPTY_RESULT)
+                  .strengthSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
                   .territoryEffects(List.of())
                   .build());
       assertThat(result.getRolls(unit), is(0));
@@ -1126,30 +1142,36 @@ class TotalPowerAndTotalRollsTest {
               .setBonus(1)
               .setUnitType(Set.of(unit.getType()));
 
-      final AvailableSupports friendlySupport =
+      final AvailableSupports rollSupportFromFriends =
           AvailableSupports.getSupport(
               new SupportCalculator(
                   List.of(supportUnit, supportUnit2),
                   List.of(unitSupportAttachment, unitSupportAttachment2),
                   BattleState.Side.OFFENSE,
                   true));
+      final AvailableSupports strengthSupportFromFriends =
+          rollSupportFromFriends.filter(UnitSupportAttachment::getStrength);
 
       final PowerStrengthAndRolls result =
           PowerStrengthAndRolls.build(
               List.of(unit, otherSupportedUnit, nonSupportedUnit),
               MainOffenseCombatValue.builder()
-                  .gameData(gameData)
-                  .supportFromFriends(friendlySupport)
-                  .supportFromEnemies(AvailableSupports.EMPTY_RESULT)
+                  .gameSequence(gameData.getSequence())
+                  .gameDiceSides(6)
+                  .lhtrHeavyBombers(false)
+                  .rollSupportFromFriends(rollSupportFromFriends)
+                  .rollSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
+                  .strengthSupportFromFriends(strengthSupportFromFriends)
+                  .strengthSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
                   .territoryEffects(List.of())
                   .build());
 
       assertThat("First should have both support", result.getStrength(unit), is(3));
       assertThat("First should have both support", result.getRolls(unit), is(3));
-      assertThat("second should have one support", result.getStrength(otherSupportedUnit), is(2));
-      assertThat("second should have one support", result.getRolls(otherSupportedUnit), is(2));
-      assertThat("last should have no support", result.getStrength(nonSupportedUnit), is(1));
-      assertThat("last should have no support", result.getRolls(nonSupportedUnit), is(1));
+      assertThat("Second should have one support", result.getStrength(otherSupportedUnit), is(2));
+      assertThat("Second should have one support", result.getRolls(otherSupportedUnit), is(2));
+      assertThat("Last should have no support", result.getStrength(nonSupportedUnit), is(1));
+      assertThat("Last should have no support", result.getRolls(nonSupportedUnit), is(1));
 
       assertThat(
           "First support unit supported two, the second supported one",
@@ -1186,8 +1208,12 @@ class TotalPowerAndTotalRollsTest {
       final PowerStrengthAndRolls powerStrengthAndRolls =
           PowerStrengthAndRolls.build(
               List.of(unit, unit2),
-              CombatValue.buildAaCombatValue(
-                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
+              CombatValueBuilder.aaCombatValue()
+                  .enemyUnits(List.of())
+                  .friendlyUnits(List.of())
+                  .side(BattleState.Side.OFFENSE)
+                  .supportAttachments(List.of())
+                  .build());
 
       assertThat(powerStrengthAndRolls.calculateTotalPower(), is(0));
       assertThat(powerStrengthAndRolls.calculateTotalRolls(), is(0));
@@ -1204,8 +1230,12 @@ class TotalPowerAndTotalRollsTest {
       final PowerStrengthAndRolls powerStrengthAndRolls =
           PowerStrengthAndRolls.build(
               List.of(unit, unit2),
-              CombatValue.buildAaCombatValue(
-                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
+              CombatValueBuilder.aaCombatValue()
+                  .enemyUnits(List.of())
+                  .friendlyUnits(List.of())
+                  .side(BattleState.Side.OFFENSE)
+                  .supportAttachments(List.of())
+                  .build());
 
       assertThat(powerStrengthAndRolls.calculateTotalPower(), is(5));
       assertThat(powerStrengthAndRolls.calculateTotalRolls(), is(2));
@@ -1222,8 +1252,12 @@ class TotalPowerAndTotalRollsTest {
       final PowerStrengthAndRolls powerStrengthAndRolls =
           PowerStrengthAndRolls.build(
               List.of(unit, unit2),
-              CombatValue.buildAaCombatValue(
-                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
+              CombatValueBuilder.aaCombatValue()
+                  .enemyUnits(List.of())
+                  .friendlyUnits(List.of())
+                  .side(BattleState.Side.OFFENSE)
+                  .supportAttachments(List.of())
+                  .build());
 
       assertThat(powerStrengthAndRolls.calculateTotalPower(), is(10));
       assertThat(powerStrengthAndRolls.calculateTotalRolls(), is(4));
@@ -1239,8 +1273,12 @@ class TotalPowerAndTotalRollsTest {
       final PowerStrengthAndRolls powerStrengthAndRolls =
           PowerStrengthAndRolls.build(
               List.of(unit),
-              CombatValue.buildAaCombatValue(
-                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
+              CombatValueBuilder.aaCombatValue()
+                  .enemyUnits(List.of())
+                  .friendlyUnits(List.of())
+                  .side(BattleState.Side.OFFENSE)
+                  .supportAttachments(List.of())
+                  .build());
 
       assertThat(powerStrengthAndRolls.calculateTotalPower(), is(12));
       assertThat(powerStrengthAndRolls.calculateTotalRolls(), is(2));
@@ -1254,8 +1292,7 @@ class TotalPowerAndTotalRollsTest {
         final int diceSides,
         final int expectedPower,
         final int expectedRolls) {
-      final GameData gameData =
-          givenGameData().withDiceSides(diceSides).withLhtrHeavyBombers(true).build();
+      final GameData gameData = givenGameData().withDiceSides(diceSides).build();
 
       final Unit unit = givenUnit("test", gameData);
       unit.getUnitAttachment().setAttack(strength).setAttackRolls(rolls);
@@ -1263,8 +1300,16 @@ class TotalPowerAndTotalRollsTest {
       final PowerStrengthAndRolls powerStrengthAndRolls =
           PowerStrengthAndRolls.build(
               List.of(unit),
-              CombatValue.buildMainCombatValue(
-                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData, List.of()));
+              CombatValueBuilder.mainCombatValue()
+                  .enemyUnits(List.of())
+                  .friendlyUnits(List.of())
+                  .side(BattleState.Side.OFFENSE)
+                  .gameSequence(gameData.getSequence())
+                  .supportAttachments(gameData.getUnitTypeList().getSupportRules())
+                  .lhtrHeavyBombers(true)
+                  .gameDiceSides(diceSides)
+                  .territoryEffects(List.of())
+                  .build());
 
       assertThat(powerStrengthAndRolls.calculateTotalPower(), is(expectedPower));
       assertThat(powerStrengthAndRolls.calculateTotalRolls(), is(expectedRolls));
@@ -1297,8 +1342,16 @@ class TotalPowerAndTotalRollsTest {
       final PowerStrengthAndRolls powerStrengthAndRolls =
           PowerStrengthAndRolls.build(
               List.of(unit),
-              CombatValue.buildMainCombatValue(
-                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData, List.of()));
+              CombatValueBuilder.mainCombatValue()
+                  .enemyUnits(List.of())
+                  .friendlyUnits(List.of())
+                  .side(BattleState.Side.OFFENSE)
+                  .gameSequence(gameData.getSequence())
+                  .supportAttachments(gameData.getUnitTypeList().getSupportRules())
+                  .lhtrHeavyBombers(false)
+                  .gameDiceSides(diceSides)
+                  .territoryEffects(List.of())
+                  .build());
 
       assertThat(powerStrengthAndRolls.calculateTotalPower(), is(expectedPower));
       assertThat(powerStrengthAndRolls.calculateTotalRolls(), is(expectedRolls));
@@ -1318,8 +1371,12 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(unit),
               0,
-              CombatValue.buildAaCombatValue(
-                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
+              CombatValueBuilder.aaCombatValue()
+                  .enemyUnits(List.of())
+                  .friendlyUnits(List.of())
+                  .side(BattleState.Side.OFFENSE)
+                  .supportAttachments(List.of())
+                  .build());
 
       assertThat("No targets so no rolls", totalPowerAndTotalRolls.calculateTotalRolls(), is(0));
     }
@@ -1336,8 +1393,12 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(unit, unit2),
               1,
-              CombatValue.buildAaCombatValue(
-                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
+              CombatValueBuilder.aaCombatValue()
+                  .enemyUnits(List.of())
+                  .friendlyUnits(List.of())
+                  .side(BattleState.Side.OFFENSE)
+                  .supportAttachments(List.of())
+                  .build());
 
       assertThat(
           "Both units had either zero rolls or zero strength so no total rolls",
@@ -1354,8 +1415,12 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(unit),
               3,
-              CombatValue.buildAaCombatValue(
-                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
+              CombatValueBuilder.aaCombatValue()
+                  .enemyUnits(List.of())
+                  .friendlyUnits(List.of())
+                  .side(BattleState.Side.OFFENSE)
+                  .supportAttachments(List.of())
+                  .build());
       assertThat(
           "Infinite unit gets one roll for each target",
           totalPowerAndTotalRolls.calculateTotalRolls(),
@@ -1373,8 +1438,12 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(unit, unit2),
               3,
-              CombatValue.buildAaCombatValue(
-                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
+              CombatValueBuilder.aaCombatValue()
+                  .enemyUnits(List.of())
+                  .friendlyUnits(List.of())
+                  .side(BattleState.Side.OFFENSE)
+                  .supportAttachments(List.of())
+                  .build());
       assertThat(
           "Infinite unit gets one roll for each target but no overstacking",
           totalPowerAndTotalRolls.calculateTotalRolls(),
@@ -1392,8 +1461,12 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(unit, unit2),
               3,
-              CombatValue.buildAaCombatValue(
-                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
+              CombatValueBuilder.aaCombatValue()
+                  .enemyUnits(List.of())
+                  .friendlyUnits(List.of())
+                  .side(BattleState.Side.OFFENSE)
+                  .supportAttachments(List.of())
+                  .build());
       assertThat(
           "Non infinite and an infinite unit still just hit all the targets once",
           totalPowerAndTotalRolls.calculateTotalRolls(),
@@ -1409,8 +1482,12 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(unit),
               3,
-              CombatValue.buildAaCombatValue(
-                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
+              CombatValueBuilder.aaCombatValue()
+                  .enemyUnits(List.of())
+                  .friendlyUnits(List.of())
+                  .side(BattleState.Side.OFFENSE)
+                  .supportAttachments(List.of())
+                  .build());
       assertThat("Unit only has one roll", totalPowerAndTotalRolls.calculateTotalRolls(), is(1));
     }
 
@@ -1425,8 +1502,12 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(unit, unit2),
               3,
-              CombatValue.buildAaCombatValue(
-                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
+              CombatValueBuilder.aaCombatValue()
+                  .enemyUnits(List.of())
+                  .friendlyUnits(List.of())
+                  .side(BattleState.Side.OFFENSE)
+                  .supportAttachments(List.of())
+                  .build());
       assertThat(
           "There is only 3 units targets and the units have no overstack so only allow 3",
           totalPowerAndTotalRolls.calculateTotalRolls(),
@@ -1450,8 +1531,12 @@ class TotalPowerAndTotalRollsTest {
           AaPowerStrengthAndRolls.build(
               List.of(overstackUnit, unit, unit2),
               3,
-              CombatValue.buildAaCombatValue(
-                  List.of(), List.of(), BattleState.Side.OFFENSE, gameData));
+              CombatValueBuilder.aaCombatValue()
+                  .enemyUnits(List.of())
+                  .friendlyUnits(List.of())
+                  .side(BattleState.Side.OFFENSE)
+                  .supportAttachments(List.of())
+                  .build());
 
       assertThat(
           "Infinite gives total attacks equal to number of units (3)"


### PR DESCRIPTION
Removes the `GameData` from `CombatValue`.  Instead, the pieces needed are passed in.  I also changed it to builders because the number of parameters increased quite a bit.

## Testing
<!-- Describe any manual testing performed below. -->
Hard AI run of World At War in a round 10+

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
