### PR TITLE
Unify non-lowluck dice hit calculations

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaPowerStrengthAndRolls.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaPowerStrengthAndRolls.java
@@ -259,6 +259,7 @@ public class AaPowerStrengthAndRolls implements TotalPowerAndTotalRolls {
    * @param dice Rolled Dice numbers from bridge with size equal to getTotalRolls
    * @return A list of Dice
    */
+  @Override
   public List<Die> getDiceHits(final int[] dice) {
     final Deque<Integer> diceQueue =
         IntStream.of(dice).boxed().collect(Collectors.toCollection(ArrayDeque::new));
@@ -267,14 +268,15 @@ public class AaPowerStrengthAndRolls implements TotalPowerAndTotalRolls {
         .flatMap(
             unitPowerStrengthAndRolls -> {
               final int strength = unitPowerStrengthAndRolls.getStrength();
-              final int diceValue = diceQueue.removeFirst();
               return IntStream.range(0, unitPowerStrengthAndRolls.getRolls())
                   .mapToObj(
-                      rollNumber ->
-                          new Die(
-                              diceValue,
-                              strength,
-                              diceValue < strength ? Die.DieType.HIT : Die.DieType.MISS));
+                      rollNumber -> {
+                        final int diceValue = diceQueue.removeFirst();
+                        return new Die(
+                            diceValue,
+                            strength,
+                            diceValue < strength ? Die.DieType.HIT : Die.DieType.MISS);
+                      });
             })
         .collect(Collectors.toList());
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/PowerStrengthAndRolls.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/PowerStrengthAndRolls.java
@@ -1,10 +1,17 @@
 package games.strategy.triplea.delegate.power.calculator;
 
 import games.strategy.engine.data.Unit;
+import games.strategy.triplea.delegate.Die;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Value;
@@ -25,6 +32,8 @@ public class PowerStrengthAndRolls implements TotalPowerAndTotalRolls {
 
   @Getter(AccessLevel.PUBLIC)
   Map<Unit, UnitPowerStrengthAndRolls> totalStrengthAndTotalRollsByUnit = new HashMap<>();
+
+  List<UnitPowerStrengthAndRolls> sortedStrengthAndRolls = new ArrayList<>();
 
   @Getter(AccessLevel.PUBLIC)
   Map<Unit, IntegerMap<Unit>> unitSupportPowerMap = new HashMap<>();
@@ -64,8 +73,7 @@ public class PowerStrengthAndRolls implements TotalPowerAndTotalRolls {
         strength = 0;
         rolls = 0;
       }
-      totalStrengthAndTotalRollsByUnit.put(
-          unit,
+      final UnitPowerStrengthAndRolls data =
           UnitPowerStrengthAndRolls.builder()
               .strength(strength)
               .rolls(rolls)
@@ -73,7 +81,9 @@ public class PowerStrengthAndRolls implements TotalPowerAndTotalRolls {
               .powerCalculator(powerCalculator)
               .diceSides(calculator.getDiceSides(unit))
               .chooseBestRoll(calculator.chooseBestRoll(unit))
-              .build());
+              .build();
+      totalStrengthAndTotalRollsByUnit.put(unit, data);
+      sortedStrengthAndRolls.add(data);
     }
 
     strengthCalculator
@@ -90,6 +100,67 @@ public class PowerStrengthAndRolls implements TotalPowerAndTotalRolls {
                 unitSupportRollsMap
                     .computeIfAbsent(supporter, (newSupport) -> new IntegerMap<>())
                     .add(supportedUnits));
+  }
+
+  /**
+   * @param dice Rolled Dice numbers from bridge with size equal to getTotalRolls
+   * @return A list of Dice
+   */
+  @Override
+  public List<Die> getDiceHits(final int[] dice) {
+    final Deque<Integer> diceQueue =
+        IntStream.of(dice).boxed().collect(Collectors.toCollection(ArrayDeque::new));
+
+    return sortedStrengthAndRolls.stream()
+        .flatMap(
+            unitPowerStrengthAndRolls -> {
+              if (unitPowerStrengthAndRolls.getChooseBestRoll()) {
+                return getDiceForChooseBestRoll(diceQueue, unitPowerStrengthAndRolls);
+              } else {
+                return getDiceForAllRolls(diceQueue, unitPowerStrengthAndRolls);
+              }
+            })
+        .collect(Collectors.toList());
+  }
+
+  private Stream<Die> getDiceForChooseBestRoll(
+      final Deque<Integer> diceQueue, final UnitPowerStrengthAndRolls unitPowerStrengthAndRolls) {
+    final List<Integer> diceRolls = new ArrayList<>();
+    int bestRoll = unitPowerStrengthAndRolls.getDiceSides();
+    int bestRollIndex = 0;
+    for (int i = 0; i < unitPowerStrengthAndRolls.getRolls(); i++) {
+      final int die = diceQueue.remove();
+      diceRolls.add(die);
+      if (die < bestRoll) {
+        bestRoll = die;
+        bestRollIndex = i;
+      }
+    }
+
+    final int diceHitIndex = bestRollIndex;
+
+    final int strength = unitPowerStrengthAndRolls.getStrength();
+    return IntStream.range(0, unitPowerStrengthAndRolls.getRolls())
+        .mapToObj(
+            rollNumber ->
+                new Die(
+                    diceRolls.get(rollNumber),
+                    strength,
+                    rollNumber == diceHitIndex
+                        ? diceRolls.get(rollNumber) < strength ? Die.DieType.HIT : Die.DieType.MISS
+                        : Die.DieType.IGNORED));
+  }
+
+  private Stream<Die> getDiceForAllRolls(
+      final Deque<Integer> diceQueue, final UnitPowerStrengthAndRolls unitPowerStrengthAndRolls) {
+    final int strength = unitPowerStrengthAndRolls.getStrength();
+    return IntStream.range(0, unitPowerStrengthAndRolls.getRolls())
+        .mapToObj(
+            rollNumber -> {
+              final int diceValue = diceQueue.removeFirst();
+              return new Die(
+                  diceValue, strength, diceValue < strength ? Die.DieType.HIT : Die.DieType.MISS);
+            });
   }
 
   @Override

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRolls.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRolls.java
@@ -1,6 +1,8 @@
 package games.strategy.triplea.delegate.power.calculator;
 
 import games.strategy.engine.data.Unit;
+import games.strategy.triplea.delegate.Die;
+import java.util.List;
 
 public interface TotalPowerAndTotalRolls {
   int calculateTotalPower();
@@ -8,6 +10,8 @@ public interface TotalPowerAndTotalRolls {
   int calculateTotalRolls();
 
   boolean hasStrengthOrRolls();
+
+  List<Die> getDiceHits(int[] dice);
 
   int getStrength(Unit unit);
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/DiceRollTest.java
@@ -1010,8 +1010,8 @@ class DiceRollTest {
                 .gameDiceSides(testDelegateBridge.getData().getDiceSides())
                 .territoryEffects(TerritoryEffectHelper.getEffects(germany))
                 .build());
-    assertThat(dice.getRolls(4).get(0).getType(), is(Die.DieType.HIT));
-    assertThat(dice.getRolls(4).get(1).getType(), is(Die.DieType.IGNORED));
+    assertThat(dice.getRolls(4).get(0).getType(), is(Die.DieType.IGNORED));
+    assertThat(dice.getRolls(4).get(1).getType(), is(Die.DieType.HIT));
     assertThat(dice.getHits(), is(1));
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/PowerStrengthAndRollsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/PowerStrengthAndRollsTest.java
@@ -1,0 +1,153 @@
+package games.strategy.triplea.delegate.power.calculator;
+
+import static games.strategy.triplea.Constants.UNIT_ATTACHMENT_NAME;
+import static games.strategy.triplea.delegate.battle.steps.MockGameData.givenGameData;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.GameSequence;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.attachments.UnitAttachment;
+import games.strategy.triplea.delegate.Die;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PowerStrengthAndRollsTest {
+
+  @Mock GamePlayer owner;
+
+  private Unit givenUnit(final String name, final GameData gameData) {
+    return givenUnit(givenUnitType(name, gameData));
+  }
+
+  private Unit givenUnit(final UnitType unitType) {
+    return unitType.create(1, owner, true).get(0);
+  }
+
+  private UnitType givenUnitType(final String name, final GameData gameData) {
+    final UnitType unitType = new UnitType(name + "Type", gameData);
+    final UnitAttachment unitAttachment =
+        new UnitAttachment(name + "Attachment", unitType, gameData);
+    unitType.addAttachment(UNIT_ATTACHMENT_NAME, unitAttachment);
+    return unitType;
+  }
+
+  private PowerStrengthAndRolls givenPowerStrengthAndRolls(final List<Unit> units) {
+    final List<Unit> sortedUnits = new ArrayList<>(units);
+    sortedUnits.sort(
+        Comparator.comparingInt(unit -> unit.getUnitAttachment().getAttack(unit.getOwner())));
+    Collections.reverse(sortedUnits);
+    return PowerStrengthAndRolls.build(
+        sortedUnits,
+        MainOffenseCombatValue.builder()
+            .gameSequence(mock(GameSequence.class))
+            .gameDiceSides(6)
+            .lhtrHeavyBombers(false)
+            .rollSupportFromFriends(AvailableSupports.EMPTY_RESULT)
+            .rollSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
+            .strengthSupportFromFriends(AvailableSupports.EMPTY_RESULT)
+            .strengthSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
+            .territoryEffects(List.of())
+            .friendUnits(sortedUnits)
+            .enemyUnits(List.of())
+            .build());
+  }
+
+  @Nested
+  class GetDiceHits {
+    @Test
+    void threeUnitsWithDifferentPowers() {
+      final GameData gameData = givenGameData().withDiceSides(6).build();
+      final Unit unit1 = givenUnit("test", gameData);
+      unit1.getUnitAttachment().setAttack(2).setAttackRolls(1);
+      final Unit unit2 = givenUnit("test2", gameData);
+      unit2.getUnitAttachment().setAttack(3).setAttackRolls(1);
+      final Unit unit3 = givenUnit("test3", gameData);
+      unit3.getUnitAttachment().setAttack(4).setAttackRolls(1);
+      final List<Unit> units = List.of(unit1, unit2, unit3);
+
+      final PowerStrengthAndRolls result = givenPowerStrengthAndRolls(units);
+      final int[] dice = {0, 5, 2};
+      final List<Die> diceHits = result.getDiceHits(dice);
+
+      assertThat(
+          "Unit3 rolls first and hits with 0, unit2 rolls second and misses with 5, unit1 rolls"
+              + "last and misses with 2",
+          diceHits,
+          is(
+              List.of(
+                  new Die(0, 4, Die.DieType.HIT),
+                  new Die(5, 3, Die.DieType.MISS),
+                  new Die(2, 2, Die.DieType.MISS))));
+    }
+
+    @Test
+    void unitHasMultipleRolls() {
+      final GameData gameData = givenGameData().withDiceSides(6).build();
+      final Unit unit1 = givenUnit("test", gameData);
+      unit1.getUnitAttachment().setAttack(2).setAttackRolls(2);
+      final Unit unit2 = givenUnit("test2", gameData);
+      unit2.getUnitAttachment().setAttack(3).setAttackRolls(2);
+      final Unit unit3 = givenUnit("test3", gameData);
+      unit3.getUnitAttachment().setAttack(4).setAttackRolls(2);
+      final List<Unit> units = List.of(unit1, unit2, unit3);
+
+      final PowerStrengthAndRolls result = givenPowerStrengthAndRolls(units);
+      final int[] dice = {0, 5, 2, 1, 4, 3};
+      final List<Die> diceHits = result.getDiceHits(dice);
+
+      assertThat(
+          "Unit3 rolls first twice, unit2 rolls second twice, and unit 3 rolls last twice",
+          diceHits,
+          is(
+              List.of(
+                  new Die(0, 4, Die.DieType.HIT),
+                  new Die(5, 4, Die.DieType.MISS),
+                  new Die(2, 3, Die.DieType.HIT),
+                  new Die(1, 3, Die.DieType.HIT),
+                  new Die(4, 2, Die.DieType.MISS),
+                  new Die(3, 2, Die.DieType.MISS))));
+    }
+
+    @Test
+    void unitHasMultipleRollsButCanOnlyChooseBest() {
+      final GameData gameData = givenGameData().withDiceSides(6).build();
+      final Unit unit1 = givenUnit("test", gameData);
+      unit1.getUnitAttachment().setAttack(2).setAttackRolls(2).setChooseBestRoll(true);
+      final Unit unit2 = givenUnit("test2", gameData);
+      unit2.getUnitAttachment().setAttack(3).setAttackRolls(2).setChooseBestRoll(true);
+      final Unit unit3 = givenUnit("test3", gameData);
+      unit3.getUnitAttachment().setAttack(4).setAttackRolls(2).setChooseBestRoll(true);
+      final List<Unit> units = List.of(unit1, unit2, unit3);
+
+      final PowerStrengthAndRolls result = givenPowerStrengthAndRolls(units);
+      final int[] dice = {0, 5, 2, 1, 4, 3};
+      final List<Die> diceHits = result.getDiceHits(dice);
+
+      assertThat(
+          "Unit3 rolls first twice, unit2 rolls second twice, and unit 3 rolls last twice. "
+              + "The best of each pair of rolls is used and the other is IGNORED.",
+          diceHits,
+          is(
+              List.of(
+                  new Die(0, 4, Die.DieType.HIT),
+                  new Die(5, 4, Die.DieType.IGNORED),
+                  new Die(2, 3, Die.DieType.IGNORED),
+                  new Die(1, 3, Die.DieType.HIT),
+                  new Die(4, 2, Die.DieType.IGNORED),
+                  new Die(3, 2, Die.DieType.MISS))));
+    }
+  }
+}


### PR DESCRIPTION
Add getDiceHits to the TotalPowerAndTotalRolls interface. Given an array
of integers (random dice rolls), it will return a list of Die with the
rolled number and whether it was a hit or not.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->
Ran both low luck, normal, and lhtr battles and checked that the dice were correctly shown and calculated.  Also ran a hard AI for a few battles.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
