### PR TITLE
Create a new Unit instance instead of the instance that was sent across the wire

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameObjectInputStream.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameObjectInputStream.java
@@ -1,6 +1,7 @@
 package games.strategy.engine.data;
 
 import games.strategy.engine.framework.GameObjectStreamFactory;
+import games.strategy.triplea.settings.ClientSetting;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
@@ -45,8 +46,14 @@ public class GameObjectInputStream extends ObjectInputStream {
       if (local != null) {
         return local;
       }
-      getData().getUnits().put(unit);
-      return unit;
+      final Unit newLocal;
+      if (ClientSetting.showBetaFeatures.getValueOrThrow()) {
+        newLocal = new Unit(unit.getId(), unit.getType(), unit.getOwner(), unit.getData());
+      } else {
+        newLocal = unit;
+      }
+      dataSource.getData().getUnits().put(newLocal);
+      return newLocal;
     } finally {
       dataSource.getData().releaseReadLock();
     }

--- a/game-core/src/main/java/games/strategy/engine/data/GameObjectInputStream.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameObjectInputStream.java
@@ -47,7 +47,7 @@ public class GameObjectInputStream extends ObjectInputStream {
         return local;
       }
       final Unit newLocal;
-      if (ClientSetting.showBetaFeatures.getValueOrThrow()) {
+      if (ClientSetting.showSerializeFeatures.getValueOrThrow()) {
         newLocal = new Unit(unit.getId(), unit.getType(), unit.getOwner(), unit.getData());
       } else {
         newLocal = unit;

--- a/game-core/src/main/java/games/strategy/engine/data/Unit.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Unit.java
@@ -105,6 +105,13 @@ public class Unit extends GameDataComponent implements DynamicallyModifiable {
     setOwner(owner);
   }
 
+  public Unit(final UUID uuid, final UnitType type, final GamePlayer owner, final GameData data) {
+    super(data);
+    this.id = uuid;
+    this.type = checkNotNull(type);
+    setOwner(owner);
+  }
+
   public UnitAttachment getUnitAttachment() {
     return (UnitAttachment) type.getAttachment("unitAttachment");
   }

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -128,6 +128,8 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
       new BooleanClientSetting("SHOW_BATTLES_WHEN_OBSERVING", true);
   public static final ClientSetting<Boolean> showBetaFeatures =
       new BooleanClientSetting("SHOW_BETA_FEATURES");
+  public static final ClientSetting<Boolean> showSerializeFeatures =
+      new BooleanClientSetting("SHOW_SERIALIZE_FEATURES");
   public static final ClientSetting<Boolean> useMapsServerBetaFeature =
       new BooleanClientSetting("USE_MAPS_SERVER_BETA_FEATURES");
   public static final BooleanClientSetting showChatTimeSettings =

--- a/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -245,6 +245,19 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
     }
   },
 
+  SHOW_SERIALIZE_FEATURES_BINDING(
+      "Use New Serialization",
+      SettingType.TESTING,
+      "Toggles whether to use the new serialization mechanisms. This mechanism is still "
+          + "under development and potentially may break saved games and network games.\n"
+          + " All players in the same game must have it set to the same value."
+          + "Restart to fully activate") {
+    @Override
+    public SelectionComponent<JComponent> newSelectionComponent() {
+      return booleanRadioButtons(ClientSetting.showSerializeFeatures);
+    }
+  },
+
   USE_MAPS_SERVER_BETA_FEATURE(
       "Use Maps Server (Beta)",
       SettingType.TESTING,


### PR DESCRIPTION
Currently, if the Unit doesn't exist in the local GameData, it copies the Unit that is being deserialized.  With the idea in #7710, this needs to be changed so that the unit isn't copied.

I've put this change behind the beta flag because I'm not exactly sure what possible issues this could cause.  It is possible that there is some behavior of the game that depends on new Units being copied with their current state.  I played a simple networked game and only saw new units being transferred as part of unit purchase but I'm fairly certain there are other situations (such as units switching sides, units transforming, etc).

Once this is released, we need to ask people to turn on the beta flag and then test out network games on maps.

<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE-->CHANGE|Unit objects are no longer copied between networked game instances. This is behind the beta flag as there might be situations where the game assumes that the unit's state (such as amphibious, submerged, damage, etc) will be copied without going through change objects.<!--END_RELEASE_NOTE-->
