### PR TITLE
Improve start-docker-database output colorization

### DIFF
--- a/database/load_sample_data
+++ b/database/load_sample_data
@@ -1,4 +1,9 @@
 #!/bin/bash
 
-echo "Loading sample data"
-psql -h localhost -U lobby_user lobby_db < "$(dirname "$0")/sql/sample_data/lobby_db_sample_data.sql"
+bold="\e[1m"
+bold_green="${bold}\e[32m"
+normal="\e[0m"
+
+echo -e "[${bold_green}Inserting sample data${normal}]"
+psql -h localhost -U lobby_user lobby_db \
+    < "$(dirname "$0")/sql/sample_data/lobby_db_sample_data.sql"

--- a/database/start_docker_db
+++ b/database/start_docker_db
@@ -12,7 +12,7 @@ function main() {
   runDocker
   waitForDatabaseToStart
 
-  echo "Deploying schema to lobby_db"
+  echo -e "[${bold_green}Deploying schemas - running flyway${normal}]"
   pwd
   "$(dirname "$0")/../gradlew" flywayMigrateAll
 


### PR DESCRIPTION
1. Colorize the output texts 'Deploying schema'
and 'Inserting sample data' so that those steps
stand out clearly in the local database startup
output.

2. Improve deploying schema text, we are deploying all
schemas, not just the lobby schema.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots

### Before
![Screenshot from 2020-11-15 11-39-10](https://user-images.githubusercontent.com/12397753/99195033-1a6dfe00-2738-11eb-8666-d26be50c1c64.png)

### After
![Screenshot from 2020-11-15 11-46-03](https://user-images.githubusercontent.com/12397753/99195042-2e196480-2738-11eb-9263-642d00ef9afc.png)


<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
