### PR TITLE
Move the unit sorting into PowerStrengthAndRolls for unification

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -956,7 +956,7 @@ public class ProCombatMoveAi {
             final List<Unit> attackingUnits = patd.getUnits();
             final List<Unit> defendingUnits = patd.getMaxEnemyDefenders(player, data);
             final boolean isOverwhelmingWin =
-                ProBattleUtils.checkForOverwhelmingWin(proData, t, attackingUnits, defendingUnits);
+                ProBattleUtils.checkForOverwhelmingWin(t, attackingUnits, defendingUnits);
             final boolean hasAa = defendingUnits.stream().anyMatch(Matches.unitIsAaForAnything());
             if (!hasAa && !isOverwhelmingWin) {
               minWinPercentage = result.getWinPercentage();
@@ -995,7 +995,7 @@ public class ProCombatMoveAi {
             final List<Unit> attackingUnits = patd.getUnits();
             final List<Unit> defendingUnits = patd.getMaxEnemyDefenders(player, data);
             final boolean isOverwhelmingWin =
-                ProBattleUtils.checkForOverwhelmingWin(proData, t, attackingUnits, defendingUnits);
+                ProBattleUtils.checkForOverwhelmingWin(t, attackingUnits, defendingUnits);
             if (!isOverwhelmingWin && result.getBattleRounds() > 2) {
               minWinTerritory = t;
               break;
@@ -1383,7 +1383,7 @@ public class ProCombatMoveAi {
             final boolean hasNoDefenders =
                 defendingUnits.stream().noneMatch(ProMatches.unitIsEnemyAndNotInfa(player, data));
             final boolean isOverwhelmingWin =
-                ProBattleUtils.checkForOverwhelmingWin(proData, t, patd.getUnits(), defendingUnits);
+                ProBattleUtils.checkForOverwhelmingWin(t, patd.getUnits(), defendingUnits);
             final boolean hasAa = defendingUnits.stream().anyMatch(Matches.unitIsAaForAnything());
             if (!hasNoDefenders
                 && !isOverwhelmingWin
@@ -1454,7 +1454,7 @@ public class ProCombatMoveAi {
             final boolean hasNoDefenders =
                 defendingUnits.stream().noneMatch(ProMatches.unitIsEnemyAndNotInfa(player, data));
             final boolean isOverwhelmingWin =
-                ProBattleUtils.checkForOverwhelmingWin(proData, t, patd.getUnits(), defendingUnits);
+                ProBattleUtils.checkForOverwhelmingWin(t, patd.getUnits(), defendingUnits);
             final boolean hasAa = defendingUnits.stream().anyMatch(Matches.unitIsAaForAnything());
             if (!isAirUnit
                 || (!hasNoDefenders

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProRetreatAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProRetreatAi.java
@@ -110,7 +110,6 @@ class ProRetreatAi {
         }
         final double strength =
             ProBattleUtils.estimateStrength(
-                proData,
                 t,
                 t.getUnitCollection().getMatches(Matches.isUnitAllied(player, data)),
                 new ArrayList<>(),

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProScrambleAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProScrambleAi.java
@@ -76,7 +76,7 @@ class ProScrambleAi {
             Comparator.<Unit>comparingDouble(
                     o ->
                         ProBattleUtils.estimateStrength(
-                            proData, scrambleTo, List.of(o), new ArrayList<>(), false))
+                            scrambleTo, List.of(o), new ArrayList<>(), false))
                 .reversed());
         canScrambleAir = canScrambleAir.subList(0, maxCanScramble);
       }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProOtherMoveOptions.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProOtherMoveOptions.java
@@ -88,11 +88,11 @@ public class ProOtherMoveOptions {
           if (!maxUnits.isEmpty()) {
             maxStrength =
                 ProBattleUtils.estimateStrength(
-                    proData, t, new ArrayList<>(maxUnits), new ArrayList<>(), isAttacker);
+                    t, new ArrayList<>(maxUnits), new ArrayList<>(), isAttacker);
           }
           final double currentStrength =
               ProBattleUtils.estimateStrength(
-                  proData, t, new ArrayList<>(currentUnits), new ArrayList<>(), isAttacker);
+                  t, new ArrayList<>(currentUnits), new ArrayList<>(), isAttacker);
           final boolean currentHasLandUnits = currentUnits.stream().anyMatch(Matches.unitIsLand());
           final boolean maxHasLandUnits = maxUnits.stream().anyMatch(Matches.unitIsLand());
           if ((currentHasLandUnits

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -392,8 +392,7 @@ public class ProTerritoryManager {
               .sorted(
                   Comparator.<Unit>comparingDouble(
                           unit ->
-                              ProBattleUtils.estimateStrength(
-                                  proData, to, List.of(unit), List.of(), false))
+                              ProBattleUtils.estimateStrength(to, List.of(unit), List.of(), false))
                       .reversed())
               .limit(maxCanScramble)
               .forEachOrdered(addTo::add);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProBattleUtils.java
@@ -14,7 +14,6 @@ import games.strategy.triplea.ai.pro.logging.ProLogger;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.delegate.battle.BattleState;
-import games.strategy.triplea.delegate.battle.UnitBattleComparator;
 import games.strategy.triplea.delegate.battle.casualty.CasualtyUtil;
 import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.delegate.power.calculator.PowerStrengthAndRolls;
@@ -42,7 +41,6 @@ public final class ProBattleUtils {
    * or within a single round of combat.
    */
   public static boolean checkForOverwhelmingWin(
-      final ProData proData,
       final Territory t,
       final Collection<Unit> attackingUnits,
       final Collection<Unit> defendingUnits) {
@@ -53,34 +51,18 @@ public final class ProBattleUtils {
     }
 
     // Check that defender has at least 1 power
-    final double power = estimatePower(proData, t, defendingUnits, attackingUnits, false);
+    final double power = estimatePower(t, defendingUnits, attackingUnits, false);
     if (power == 0 && !attackingUnits.isEmpty()) {
       return true;
     }
 
     // Determine if enough attack power to win in 1 round
-    final List<Unit> sortedUnitsList = new ArrayList<>(attackingUnits);
-    sortedUnitsList.sort(
-        new UnitBattleComparator(
-                proData.getUnitValueMap(),
-                data,
-                CombatValueBuilder.mainCombatValue()
-                    .enemyUnits(List.of())
-                    .friendlyUnits(List.of())
-                    .side(BattleState.Side.OFFENSE)
-                    .gameSequence(data.getSequence())
-                    .supportAttachments(data.getUnitTypeList().getSupportRules())
-                    .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
-                    .gameDiceSides(data.getDiceSides())
-                    .territoryEffects(TerritoryEffectHelper.getEffects(t))
-                    .build())
-            .reversed());
     final int attackPower =
         PowerStrengthAndRolls.build(
-                sortedUnitsList,
+                attackingUnits,
                 CombatValueBuilder.mainCombatValue()
                     .enemyUnits(defendingUnits)
-                    .friendlyUnits(sortedUnitsList)
+                    .friendlyUnits(attackingUnits)
                     .side(BattleState.Side.OFFENSE)
                     .gameSequence(data.getSequence())
                     .supportAttachments(data.getUnitTypeList().getSupportRules())
@@ -109,17 +91,15 @@ public final class ProBattleUtils {
       final Collection<Unit> defendingUnits) {
 
     if (attackingUnits.stream().allMatch(Matches.unitIsInfrastructure())
-        || estimatePower(proData, t, attackingUnits, defendingUnits, true) <= 0) {
+        || estimatePower(t, attackingUnits, defendingUnits, true) <= 0) {
       return 0;
     }
     if (defendingUnits.stream().allMatch(Matches.unitIsInfrastructure())
-        || estimatePower(proData, t, defendingUnits, attackingUnits, false) <= 0) {
+        || estimatePower(t, defendingUnits, attackingUnits, false) <= 0) {
       return 99999;
     }
-    final double attackerStrength =
-        estimateStrength(proData, t, attackingUnits, defendingUnits, true);
-    final double defenderStrength =
-        estimateStrength(proData, t, defendingUnits, attackingUnits, false);
+    final double attackerStrength = estimateStrength(t, attackingUnits, defendingUnits, true);
+    final double defenderStrength = estimateStrength(t, defendingUnits, attackingUnits, false);
     return ((attackerStrength - defenderStrength) / Math.pow(defenderStrength, 0.85) * 50 + 50);
   }
 
@@ -129,7 +109,6 @@ public final class ProBattleUtils {
    * @return The larger the result, the stronger {@code myUnits} are relative to {@code enemyUnits}.
    */
   public static double estimateStrength(
-      final ProData proData,
       final Territory t,
       final Collection<Unit> myUnits,
       final Collection<Unit> enemyUnits,
@@ -145,12 +124,11 @@ public final class ProBattleUtils {
               unitsThatCanFight, Matches.unitIsTransportButNotCombatTransport().negate());
     }
     final int myHitPoints = CasualtyUtil.getTotalHitpointsLeft(unitsThatCanFight);
-    final double myPower = estimatePower(proData, t, myUnits, enemyUnits, attacking);
+    final double myPower = estimatePower(t, myUnits, enemyUnits, attacking);
     return (2.0 * myHitPoints) + myPower;
   }
 
   private static double estimatePower(
-      final ProData proData,
       final Territory t,
       final Collection<Unit> myUnits,
       final Collection<Unit> enemyUnits,
@@ -160,28 +138,12 @@ public final class ProBattleUtils {
     final List<Unit> unitsThatCanFight =
         CollectionUtils.getMatches(
             myUnits, Matches.unitCanBeInBattle(attacking, !t.isWater(), 1, true));
-    final List<Unit> sortedUnitsList = new ArrayList<>(unitsThatCanFight);
-    sortedUnitsList.sort(
-        new UnitBattleComparator(
-                proData.getUnitValueMap(),
-                data,
-                CombatValueBuilder.mainCombatValue()
-                    .enemyUnits(List.of())
-                    .friendlyUnits(List.of())
-                    .side(attacking ? BattleState.Side.OFFENSE : BattleState.Side.DEFENSE)
-                    .gameSequence(data.getSequence())
-                    .supportAttachments(data.getUnitTypeList().getSupportRules())
-                    .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
-                    .gameDiceSides(data.getDiceSides())
-                    .territoryEffects(TerritoryEffectHelper.getEffects(t))
-                    .build())
-            .reversed());
     final int myPower =
         PowerStrengthAndRolls.build(
-                sortedUnitsList,
+                unitsThatCanFight,
                 CombatValueBuilder.mainCombatValue()
                     .enemyUnits(enemyUnits)
-                    .friendlyUnits(sortedUnitsList)
+                    .friendlyUnits(unitsThatCanFight)
                     .side(attacking ? BattleState.Side.OFFENSE : BattleState.Side.DEFENSE)
                     .gameSequence(data.getSequence())
                     .supportAttachments(data.getUnitTypeList().getSupportRules())

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
@@ -3,7 +3,6 @@ package games.strategy.triplea.ai.pro.util;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
-import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Properties;
@@ -13,7 +12,6 @@ import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.delegate.battle.BattleState;
-import games.strategy.triplea.delegate.battle.UnitBattleComparator;
 import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.delegate.power.calculator.PowerStrengthAndRolls;
 import java.util.ArrayList;
@@ -24,7 +22,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
-import org.triplea.java.collections.CollectionUtils;
 
 /** Pro AI attack options utilities. */
 public final class ProSortMoveOptionsUtils {
@@ -201,45 +198,28 @@ public final class ProSortMoveOptionsUtils {
 
     int minPower = Integer.MAX_VALUE;
     for (final Territory t : territories) {
-      final Collection<TerritoryEffect> effects = TerritoryEffectHelper.getEffects(t);
-      final UnitBattleComparator comparator =
-          new UnitBattleComparator(
-              proData.getUnitValueMap(),
-              data,
-              CombatValueBuilder.mainCombatValue()
-                  .enemyUnits(List.of())
-                  .friendlyUnits(List.of())
-                  .side(BattleState.Side.OFFENSE)
-                  .gameSequence(data.getSequence())
-                  .supportAttachments(data.getUnitTypeList().getSupportRules())
-                  .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
-                  .gameDiceSides(data.getDiceSides())
-                  .territoryEffects(effects)
-                  .build());
-
       final List<Unit> defendingUnits =
           t.getUnitCollection().getMatches(Matches.enemyUnit(player, data));
-      final Collection<Unit> sortedUnits =
-          CollectionUtils.createSortedCollection(attackMap.get(t).getUnits(), comparator);
+      final Collection<Unit> attackingUnits = attackMap.get(t).getUnits();
       // Compare the difference in total power when including the unit or not.
       int powerDifference = 0;
       for (final boolean includeUnit : new boolean[] {false, true}) {
         if (includeUnit) {
-          sortedUnits.add(unit);
+          attackingUnits.add(unit);
         }
         powerDifference +=
             (includeUnit ? 1 : -1)
                 * PowerStrengthAndRolls.build(
-                        sortedUnits,
+                        attackingUnits,
                         CombatValueBuilder.mainCombatValue()
                             .enemyUnits(defendingUnits)
-                            .friendlyUnits(sortedUnits)
+                            .friendlyUnits(attackingUnits)
                             .side(BattleState.Side.OFFENSE)
                             .gameSequence(data.getSequence())
                             .supportAttachments(data.getUnitTypeList().getSupportRules())
                             .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
                             .gameDiceSides(data.getDiceSides())
-                            .territoryEffects(effects)
+                            .territoryEffects(TerritoryEffectHelper.getEffects(t))
                             .build())
                     .calculateTotalPower();
       }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -38,7 +38,7 @@ public final class ProTerritoryValueUtils {
     if (ProUtils.isNeutralLand(t)) {
       final double strength =
           ProBattleUtils.estimateStrength(
-              proData, t, new ArrayList<>(t.getUnits()), new ArrayList<>(), false);
+              t, new ArrayList<>(t.getUnits()), new ArrayList<>(), false);
 
       // Estimate TUV swing as number of casualties * cost
       final double tuvSwing = -(strength / 8) * proData.getMinCostPerHitPoint();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/UnitBattleComparator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/UnitBattleComparator.java
@@ -36,21 +36,6 @@ public class UnitBattleComparator implements Comparator<Unit> {
   public UnitBattleComparator(
       final IntegerMap<UnitType> costs,
       final GameData data,
-      final CombatValue combatValueCalculator) {
-    this(costs, data, combatValueCalculator, false, false);
-  }
-
-  public UnitBattleComparator(
-      final IntegerMap<UnitType> costs,
-      final GameData data,
-      final CombatValue combatValueCalculator,
-      final boolean bonus) {
-    this(costs, data, combatValueCalculator, bonus, false);
-  }
-
-  public UnitBattleComparator(
-      final IntegerMap<UnitType> costs,
-      final GameData data,
       final CombatValue combatValueCalculator,
       final boolean bonus,
       final boolean ignorePrimaryPower) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLosses.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtyOrderOfLosses.java
@@ -100,7 +100,7 @@ class CasualtyOrderOfLosses {
             true,
             true);
     final PowerStrengthAndRolls unitPowerAndRolls =
-        PowerStrengthAndRolls.build(sortedUnitsList, parameters.combatValue);
+        PowerStrengthAndRolls.buildWithPreSortedUnits(sortedUnitsList, parameters.combatValue);
 
     final Map<Unit, IntegerMap<Unit>> unitSupportPowerMap =
         unitPowerAndRolls.getUnitSupportPowerMap();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
@@ -276,17 +276,8 @@ public class CasualtySelector {
       final boolean allowMultipleHitsPerUnit) {
     final CasualtyList defaultCasualtySelection = new CasualtyList();
     // Sort units by power and cost in ascending order
-    final List<Unit> sorted;
-    sorted =
-        CasualtyOrderOfLosses.sortUnitsForCasualtiesWithSupport(
-            CasualtyOrderOfLosses.Parameters.builder()
-                .targetsToPickFrom(targetsToPickFrom)
-                .player(player)
-                .combatValue(combatValue)
-                .battlesite(battlesite)
-                .costs(costs)
-                .data(data)
-                .build());
+    final List<Unit> sorted =
+        getCasualtyOrderOfLoss(targetsToPickFrom, player, combatValue, battlesite, costs, data);
     // Remove two hit bb's selecting them first for default casualties
     int numSelectedCasualties = 0;
     if (allowMultipleHitsPerUnit) {
@@ -314,6 +305,24 @@ public class CasualtySelector {
       numSelectedCasualties++;
     }
     return Tuple.of(defaultCasualtySelection, sorted);
+  }
+
+  public static List<Unit> getCasualtyOrderOfLoss(
+      final Collection<Unit> targetsToPickFrom,
+      final GamePlayer player,
+      final CombatValue combatValue,
+      final Territory battlesite,
+      final IntegerMap<UnitType> costs,
+      final GameData data) {
+    return CasualtyOrderOfLosses.sortUnitsForCasualtiesWithSupport(
+        CasualtyOrderOfLosses.Parameters.builder()
+            .targetsToPickFrom(targetsToPickFrom)
+            .player(player)
+            .combatValue(combatValue)
+            .battlesite(battlesite)
+            .costs(costs)
+            .data(data)
+            .build());
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEnd.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEnd.java
@@ -75,7 +75,7 @@ public class CheckGeneralBattleEnd implements BattleStep {
   }
 
   private boolean hasNoStrengthOrRolls(final BattleState.Side side) {
-    return !PowerStrengthAndRolls.build(
+    return !PowerStrengthAndRolls.buildWithPreSortedUnits(
             battleState.filterUnits(ALIVE, side),
             CombatValueBuilder.mainCombatValue()
                 .enemyUnits(battleState.filterUnits(ALIVE, side.getOpposite()))

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/CombatValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/CombatValue.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.delegate.power.calculator;
 import games.strategy.engine.data.Unit;
 import games.strategy.triplea.delegate.battle.BattleState;
 import java.util.Collection;
+import java.util.Comparator;
 
 public interface CombatValue {
 
@@ -12,6 +13,22 @@ public interface CombatValue {
 
   default PowerCalculator getPower() {
     return new PowerCalculator(getStrength(), getRoll(), this::chooseBestRoll, this::getDiceSides);
+  }
+
+  /**
+   * Sorts units from high strength to low strength
+   *
+   * <p>Takes into account different dice sides. A unit with strength 2 and dice sides 2 will be
+   * sorted high than a unit with strength 3 and dice sides of 6.
+   */
+  default Comparator<Unit> unitComparator() {
+    // unit support is stateful which would mess up the sort calculations so remove unit supports
+    final StrengthCalculator strengthCalculator = this.buildWithNoUnitSupports().getStrength();
+    return Comparator.<Unit, Boolean>comparing(
+            unit -> strengthCalculator.getStrength(unit).getValue() == 0)
+        .thenComparingDouble(
+            unit ->
+                -strengthCalculator.getStrength(unit).getValue() / (float) this.getDiceSides(unit));
   }
 
   int getDiceSides(Unit unit);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/PowerStrengthAndRolls.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/PowerStrengthAndRolls.java
@@ -47,10 +47,26 @@ public class PowerStrengthAndRolls implements TotalPowerAndTotalRolls {
   }
 
   /**
-   * Returns the power (strength) and rolls for each of the specified units.
+   * Builds a PowerStrengthAndRolls that calculates the power, strength, and roll for each unit
    *
-   * @param unitsGettingPowerFor should be sorted from weakest to strongest, before the method is
+   * @param unitsGettingPowerFor should be sorted from strongest to weakest, before the method is
    *     called, for the actual battle.
+   */
+  public static PowerStrengthAndRolls buildWithPreSortedUnits(
+      final Collection<Unit> unitsGettingPowerFor, final CombatValue calculator) {
+
+    if (unitsGettingPowerFor == null || unitsGettingPowerFor.isEmpty()) {
+      return new PowerStrengthAndRolls(List.of(), calculator);
+    }
+
+    return new PowerStrengthAndRolls(unitsGettingPowerFor, calculator);
+  }
+
+  /**
+   * Builds a PowerStrengthAndRolls that calculates the power, strength, and roll for each unit
+   *
+   * @param unitsGettingPowerFor does not need to be sorted
+   * @param calculator calculates the value of offense or defense
    */
   public static PowerStrengthAndRolls build(
       final Collection<Unit> unitsGettingPowerFor, final CombatValue calculator) {
@@ -59,7 +75,13 @@ public class PowerStrengthAndRolls implements TotalPowerAndTotalRolls {
       return new PowerStrengthAndRolls(List.of(), calculator);
     }
 
-    return new PowerStrengthAndRolls(unitsGettingPowerFor, calculator);
+    // First, sort units strongest to weakest without support so that later, the support is given
+    // to the best units first
+    return new PowerStrengthAndRolls(
+        unitsGettingPowerFor.stream()
+            .sorted(calculator.unitComparator())
+            .collect(Collectors.toList()),
+        calculator);
   }
 
   private void addUnits(final Collection<Unit> units) {

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -6,7 +6,6 @@ import games.strategy.engine.data.MutableProperty;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
-import games.strategy.engine.data.UnitType;
 import games.strategy.engine.framework.ui.background.WaitDialog;
 import games.strategy.engine.history.History;
 import games.strategy.triplea.Properties;
@@ -14,7 +13,6 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
 import games.strategy.triplea.delegate.battle.BattleDelegate;
 import games.strategy.triplea.delegate.battle.BattleState;
-import games.strategy.triplea.delegate.battle.UnitBattleComparator;
 import games.strategy.triplea.delegate.battle.casualty.CasualtyUtil;
 import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.delegate.power.calculator.PowerStrengthAndRolls;
@@ -54,7 +52,6 @@ import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingUtilities;
 import lombok.extern.java.Log;
 import org.triplea.java.collections.CollectionUtils;
-import org.triplea.java.collections.IntegerMap;
 import org.triplea.swing.IntTextField;
 import org.triplea.swing.SwingComponents;
 
@@ -1419,22 +1416,6 @@ class BattleCalculatorPanel extends JPanel {
       attackerUnitsTotalHitpoints.setText("HP: " + attackHitPoints);
       defenderUnitsTotalHitpoints.setText("HP: " + defenseHitPoints);
       final Collection<TerritoryEffect> territoryEffects = getTerritoryEffects();
-      final IntegerMap<UnitType> costs = TuvUtils.getCostsForTuv(getAttacker(), data);
-      attackers.sort(
-          new UnitBattleComparator(
-                  costs,
-                  data,
-                  CombatValueBuilder.mainCombatValue()
-                      .enemyUnits(List.of())
-                      .friendlyUnits(List.of())
-                      .side(BattleState.Side.OFFENSE)
-                      .gameSequence(data.getSequence())
-                      .supportAttachments(data.getUnitTypeList().getSupportRules())
-                      .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(data.getProperties()))
-                      .gameDiceSides(data.getDiceSides())
-                      .territoryEffects(territoryEffects)
-                      .build())
-              .reversed());
       if (isAmphibiousBattle()) {
         attackers.stream()
             .filter(Matches.unitIsLand())

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -872,7 +872,6 @@ public class BattleDisplay extends JPanel {
         columns.add(i, new ArrayList<>());
       }
       final List<Unit> units = new ArrayList<>(this.units);
-      DiceRoll.sortByStrength(units, side);
       final TotalPowerAndTotalRolls unitPowerAndRollsMap;
       final boolean isAirPreBattleOrPreRaid = battleType.isAirBattle();
       gameData.acquireReadLock();

--- a/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -699,7 +699,8 @@ class EditPanel extends ActionPanel {
                             .gameDiceSides(getData().getDiceSides())
                             .territoryEffects(List.of())
                             .build(),
-                        true)
+                        true,
+                        false)
                     .reversed());
             // unit mapped to <max, min, current>
             final Map<Unit, Triple<Integer, Integer, Integer>> currentDamageMap = new HashMap<>();
@@ -786,7 +787,8 @@ class EditPanel extends ActionPanel {
                             .gameDiceSides(getData().getDiceSides())
                             .territoryEffects(List.of())
                             .build(),
-                        true)
+                        true,
+                        false)
                     .reversed());
             // unit mapped to <max, min, current>
             final Map<Unit, Triple<Integer, Integer, Integer>> currentDamageMap = new HashMap<>();

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -865,8 +865,8 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
     final List<Unit> defendList = transport.create(1, germans);
     final List<Unit> defendSub = submarine.create(1, germans);
     defendList.addAll(defendSub);
-    // fire the defending transport then the submarine (both miss)
-    whenGetRandom(bridge).thenAnswer(withValues(1, 2));
+    // fire the defending submarine then the transport (both miss)
+    whenGetRandom(bridge).thenAnswer(withValues(2, 1));
     // Execute the battle and verify no hits
     final DiceRoll roll =
         DiceRoll.rollDice(
@@ -1009,8 +1009,8 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
     final List<Unit> defendList = transport.create(1, germans);
     final List<Unit> defendSub = submarine.create(1, germans);
     defendList.addAll(defendSub);
-    // fire the defending transport then the submarine (both miss)
-    whenGetRandom(bridge).thenAnswer(withValues(1, 2));
+    // fire the defending submarine then the transport (both miss)
+    whenGetRandom(bridge).thenAnswer(withValues(2, 1));
     // Execute the battle and verify no hits
     final DiceRoll roll =
         DiceRoll.rollDice(

--- a/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/PowerStrengthAndRollsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/PowerStrengthAndRollsTest.java
@@ -13,9 +13,6 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Die;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -45,12 +42,8 @@ class PowerStrengthAndRollsTest {
   }
 
   private PowerStrengthAndRolls givenPowerStrengthAndRolls(final List<Unit> units) {
-    final List<Unit> sortedUnits = new ArrayList<>(units);
-    sortedUnits.sort(
-        Comparator.comparingInt(unit -> unit.getUnitAttachment().getAttack(unit.getOwner())));
-    Collections.reverse(sortedUnits);
     return PowerStrengthAndRolls.build(
-        sortedUnits,
+        units,
         MainOffenseCombatValue.builder()
             .gameSequence(mock(GameSequence.class))
             .gameDiceSides(6)
@@ -60,7 +53,7 @@ class PowerStrengthAndRollsTest {
             .strengthSupportFromFriends(AvailableSupports.EMPTY_RESULT)
             .strengthSupportFromEnemies(AvailableSupports.EMPTY_RESULT)
             .territoryEffects(List.of())
-            .friendUnits(sortedUnits)
+            .friendUnits(units)
             .enemyUnits(List.of())
             .build());
   }


### PR DESCRIPTION
Instead of preceeding each call to PowerStrengthAndRolls.build() with
their own unique sorting logic, the sorting logic is now inside of
build() so that it is uniform.  There is a buildWithPreSortedUnits() to
allow the rare case where the sort is either not needed or requires
special logic.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->
Played a few battles with Hard AI

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
