### PR TITLE
Remove code to 'warm up crypto random source'

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -168,7 +168,6 @@ public class ServerLauncher implements ILauncher {
       isLaunching = false;
       abortLaunch = testShouldWeAbort();
       if (!abortLaunch) {
-        warmUpCryptoRandomSource();
         log.info("Launching game - starting game delegates.");
         serverGame.startGame();
       } else {
@@ -218,23 +217,6 @@ public class ServerLauncher implements ILauncher {
       log.info("Game Status: Waiting For Players");
       inGameLobbyWatcher.setGameStatus(GameDescription.GameStatus.WAITING_FOR_PLAYERS, null);
     }
-  }
-
-  private void warmUpCryptoRandomSource() {
-    // the first roll takes a while, initialize here in the background so that the user doesn't
-    // notice
-    new Thread(
-            () -> {
-              try {
-                serverGame
-                    .getRandomSource()
-                    .getRandom(gameData.getDiceSides(), 2, "Warming up crypto random source");
-              } catch (final RuntimeException e) {
-                log.log(Level.SEVERE, "Failed to warm up crypto random source", e);
-              }
-            },
-            "Warming up crypto random source")
-        .start();
   }
 
   public void addObserver(


### PR DESCRIPTION
The commentary code states warming up the crypto random
source takes a long time. Measuring the runtime on a bot
and local hosted game, it takes either nano seconds
or runs under 100ms.

We have errors in the logs about this action, and it
does not seem to clearly meet the stated performance
objective as the invocation is quite fast.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
