### PR TITLE
Reword "units to place" text -> "purchased units"

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/PlacementUnitsCollapsiblePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PlacementUnitsCollapsiblePanel.java
@@ -23,7 +23,7 @@ class PlacementUnitsCollapsiblePanel {
     unitsToPlacePanel =
         new SimpleUnitPanel(
             uiContext, SimpleUnitPanel.Style.SMALL_ICONS_WRAPPED_WITH_LABEL_WHEN_EMPTY);
-    panel = new CollapsiblePanel(unitsToPlacePanel, "Units To Place");
+    panel = new CollapsiblePanel(unitsToPlacePanel, "Purchased Units");
     panel.setVisible(false);
     gameData.addGameDataEventListener(GameDataEvent.GAME_STEP_CHANGED, this::updateStep);
   }


### PR DESCRIPTION
"Units to place" is confusing as the verb tense makes it
sound like it is an immediate action occuring during the
current phase. Considering the 'placement units panel'
appears in all phases except the placements, it's confusing.

Even worse, the 'units to place' text appears next to
'units to move', the latter is an immediate action that
is occurring during the current phase, the former is a
future action (confusing).

"Purchased Units" is direct and is usually semantically correct
on most games (arguably in others, the purchase price was zero
for some units, hence still semantically correct).


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->
![Screenshot from 2020-11-22 00-46-37](https://user-images.githubusercontent.com/12397753/99899217-5df6c980-2c5c-11eb-9783-8b798c2f4aca.png)


## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
