### PR TITLE
Use a value object to combine the rolls and strength in power calculation

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaPowerStrengthAndRolls.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaPowerStrengthAndRolls.java
@@ -106,17 +106,12 @@ public class AaPowerStrengthAndRolls implements TotalPowerAndTotalRolls {
     final RollCalculator rollCalculator = calculator.getRoll();
     final PowerCalculator powerCalculator = calculator.getPower();
     for (final Unit unit : units) {
-      int strength = strengthCalculator.getStrength(unit).getValue();
-      int rolls = rollCalculator.getRoll(unit).getValue();
-      if (rolls == 0 || strength == 0) {
-        strength = 0;
-        rolls = 0;
-      }
       totalStrengthAndTotalRollsByUnit.put(
           unit,
           UnitPowerStrengthAndRolls.builder()
-              .strength(strength)
-              .rolls(rolls)
+              .strengthAndRolls(
+                  UnitPowerStrengthAndRolls.StrengthAndRolls.of(
+                      strengthCalculator.getStrength(unit), rollCalculator.getRoll(unit)))
               .power(powerCalculator.getValue(unit))
               .powerCalculator(powerCalculator)
               .diceSides(calculator.getDiceSides(unit))
@@ -235,8 +230,7 @@ public class AaPowerStrengthAndRolls implements TotalPowerAndTotalRolls {
       if (activeUnits.contains(mapEntry.getKey())) {
         continue;
       }
-      totalStrengthAndTotalRollsByUnit.put(
-          mapEntry.getKey(), mapEntry.getValue().toBuilder().rolls(0).strength(0).power(0).build());
+      totalStrengthAndTotalRollsByUnit.put(mapEntry.getKey(), mapEntry.getValue().toZero());
     }
 
     return activeStrengthAndRolls;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/PowerCalculator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/PowerCalculator.java
@@ -27,8 +27,8 @@ public class PowerCalculator {
     return getValue(
         chooseBestRoll.apply(unit),
         getDiceSides.apply(unit),
-        strengthCalculator.getStrength(unit).getValue(),
-        rollCalculator.getRoll(unit).getValue());
+        strengthCalculator.getStrength(unit),
+        rollCalculator.getRoll(unit));
   }
 
   /**
@@ -41,24 +41,26 @@ public class PowerCalculator {
   int getValue(
       final boolean chooseBestRoll,
       final int diceSides,
-      final int unitStrength,
-      final int unitRolls) {
-    if (unitStrength <= 0 || unitRolls <= 0) {
+      final StrengthValue unitStrength,
+      final RollValue unitRolls) {
+    if (unitStrength.isZero() || unitRolls.isZero()) {
       return 0;
     }
     // Bonus is normally 1 for most games
     final int extraRollBonus = Math.max(1, diceSides / 6);
 
     int totalPower = 0;
-    if (unitRolls == 1) {
-      totalPower += unitStrength;
+    if (unitRolls.getValue() == 1) {
+      totalPower += unitStrength.getValue();
     } else {
       if (chooseBestRoll) {
         // chooseBestRoll doesn't really make sense in LL. So instead,
         // we will just add +1 onto the power to simulate the gains of having the best die picked.
-        totalPower += Math.min(unitStrength + extraRollBonus * (unitRolls - 1), diceSides);
+        totalPower +=
+            Math.min(
+                unitStrength.getValue() + extraRollBonus * (unitRolls.getValue() - 1), diceSides);
       } else {
-        totalPower += unitRolls * unitStrength;
+        totalPower += unitRolls.getValue() * unitStrength.getValue();
       }
     }
     return totalPower;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/PowerStrengthAndRolls.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/PowerStrengthAndRolls.java
@@ -89,16 +89,11 @@ public class PowerStrengthAndRolls implements TotalPowerAndTotalRolls {
     final RollCalculator rollCalculator = calculator.getRoll();
     final PowerCalculator powerCalculator = calculator.getPower();
     for (final Unit unit : units) {
-      int strength = strengthCalculator.getStrength(unit).getValue();
-      int rolls = rollCalculator.getRoll(unit).getValue();
-      if (rolls == 0 || strength == 0) {
-        strength = 0;
-        rolls = 0;
-      }
       final UnitPowerStrengthAndRolls data =
           UnitPowerStrengthAndRolls.builder()
-              .strength(strength)
-              .rolls(rolls)
+              .strengthAndRolls(
+                  UnitPowerStrengthAndRolls.StrengthAndRolls.of(
+                      strengthCalculator.getStrength(unit), rollCalculator.getRoll(unit)))
               .power(powerCalculator.getValue(unit))
               .powerCalculator(powerCalculator)
               .diceSides(calculator.getDiceSides(unit))

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/RollValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/RollValue.java
@@ -20,6 +20,10 @@ class RollValue {
     return RollValue.of(value, value == -1);
   }
 
+  RollValue toValue(final int value) {
+    return RollValue.of(value, false);
+  }
+
   RollValue add(final int extraValue) {
     return isInfinite ? this : RollValue.of(value + extraValue, false);
   }
@@ -27,5 +31,9 @@ class RollValue {
   int getValue() {
     // rolls don't have a maximum
     return isInfinite ? -1 : Math.max(0, value);
+  }
+
+  boolean isZero() {
+    return value == 0;
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/StrengthValue.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/StrengthValue.java
@@ -20,7 +20,15 @@ class StrengthValue {
     return StrengthValue.of(diceSides, value + extraValue);
   }
 
+  StrengthValue toValue(final int value) {
+    return StrengthValue.of(diceSides, value);
+  }
+
   int getValue() {
     return Math.min(Math.max(value, 0), diceSides);
+  }
+
+  boolean isZero() {
+    return value == 0;
   }
 }


### PR DESCRIPTION
Rolls and strength values are intertwined with each other when dealing
with power calculation.  If one is zero, then the other is zero. Instead
of keeping track of these details in the callers, the StrengthAndRolls
value object will ensure it.

Also, pass around the RollValue and StrengthValue as much as possible so
that it can be type checked and the information they store can be kept
through changes.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
