### PR TITLE
Decrease number of bots per host from 4 to 5 and bump memory

### DIFF
--- a/infrastructure/ansible/roles/bot/defaults/main.yml
+++ b/infrastructure/ansible/roles/bot/defaults/main.yml
@@ -13,10 +13,10 @@ bot_maps_folder: "{{ bot_folder }}/maps"
 # The URI of the lobby that the bot would connect to.
 bot_lobby_uri: "{{ lobby_uri }}"
 
-bot_max_memory: "176m"
+bot_max_memory: "196m"
 
 # Each bot number matches a bot instance that will be deployed and started.
-bot_numbers: ["01", "02", "03", "04", "05"]
+bot_numbers: ["01", "02", "03", "04" ]
 
 # Bot prefix we expect to be overriden in inventory.
 # We deploy bots to multiple server, to keep the host numbers unique, there is a prefix.


### PR DESCRIPTION
Goal is to avoid unexpected crashes observed in bots.
There does not appear to be any errors in logs.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
