### PR TITLE
Update github workflow actions to only execute on PR

### DIFF
--- a/.github/workflows/auto-format.yml
+++ b/.github/workflows/auto-format.yml
@@ -1,5 +1,5 @@
 name: Spotless Formatting
-on: [push, pull_request]
+on: pull_request
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-links.yml
+++ b/.github/workflows/check-links.yml
@@ -1,5 +1,5 @@
 name: Check Links are Valid
-on: [push, pull_request]
+on:  pull_request
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-yaml-syntax.yml
+++ b/.github/workflows/check-yaml-syntax.yml
@@ -1,5 +1,5 @@
 name: Check YAML Formatting
-on: [push, pull_request]
+on: pull_request
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/checkstyle.yml
+++ b/.github/workflows/checkstyle.yml
@@ -1,5 +1,5 @@
 name: Checkstyle
-on: [push, pull_request]
+on: pull_request
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/code-convention-checks.yml
+++ b/.github/workflows/code-convention-checks.yml
@@ -1,5 +1,5 @@
 name: Code Convention Checks
-on: [push, pull_request]
+on: pull_request
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/compatibility-tests.yml
+++ b/.github/workflows/compatibility-tests.yml
@@ -1,5 +1,5 @@
 name: Compatibility Tests
-on: [push]
+on: pull_request
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,5 +1,5 @@
 name: Integration Tests
-on: [push]
+on: pull_request
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/pmd-checks.yml
+++ b/.github/workflows/pmd-checks.yml
@@ -1,5 +1,5 @@
 name: PMD Checks
-on: [push, pull_request]
+on: pull_request
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,5 +1,5 @@
 name: Smoke Tests
-on: [pull_request]
+on: pull_request
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,5 @@
 name: Unit Tests
-on: [push, pull_request]
+on: pull_request
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/verify-test-structure.yml
+++ b/.github/workflows/verify-test-structure.yml
@@ -1,5 +1,5 @@
 name: Verify testing structure
-on: [push, pull_request]
+on: pull_request
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Do not build on pushes to branches & PRs, just PRs.
If pushing to the main repo, we get a double build which
uses up unnecessary github action minutes.
