### PR TITLE
Create BombingUnitDamageChange that uses primitives

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/BombingUnitDamageChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/BombingUnitDamageChange.java
@@ -2,11 +2,14 @@ package games.strategy.engine.data;
 
 import java.util.Collections;
 import java.util.Set;
+import org.triplea.java.RemoveOnNextMajorRelease;
 import org.triplea.java.collections.IntegerMap;
 
 /**
  * A game data change that captures the damage caused to a collection of units by a bombing attack.
  */
+@Deprecated
+@RemoveOnNextMajorRelease
 public class BombingUnitDamageChange extends Change {
   private static final long serialVersionUID = -6425858423179501847L;
   private final IntegerMap<Unit> hits;

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/ChangeFactory.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/ChangeFactory.java
@@ -1,6 +1,5 @@
 package games.strategy.engine.data.changefactory;
 
-import games.strategy.engine.data.BombingUnitDamageChange;
 import games.strategy.engine.data.Change;
 import games.strategy.engine.data.ChangeAttachmentChange;
 import games.strategy.engine.data.CompositeChange;
@@ -16,6 +15,7 @@ import games.strategy.engine.data.TechnologyFrontier;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitHitsChange;
+import games.strategy.engine.data.changefactory.units.BombingUnitDamageChange;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.delegate.TechAdvance;
 import games.strategy.triplea.delegate.data.BattleRecords;
@@ -128,8 +128,9 @@ public class ChangeFactory {
   }
 
   /** Must already include existing damage to the unit. This does not add damage, it sets damage. */
-  public static Change bombingUnitDamage(final IntegerMap<Unit> newDamage) {
-    return new BombingUnitDamageChange(newDamage);
+  public static Change bombingUnitDamage(
+      final IntegerMap<Unit> newDamage, final Collection<Territory> territoriesToNotify) {
+    return new BombingUnitDamageChange(newDamage, territoriesToNotify);
   }
 
   public static Change addProductionRule(

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/units/BombingUnitDamageChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/units/BombingUnitDamageChange.java
@@ -1,0 +1,71 @@
+package games.strategy.engine.data.changefactory.units;
+
+import games.strategy.engine.data.Change;
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import java.util.Collection;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.triplea.java.collections.IntegerMap;
+
+/**
+ * A game data change that captures the damage caused to a collection of units by a bombing attack.
+ */
+public class BombingUnitDamageChange extends Change {
+  private static final long serialVersionUID = 7093658184880237574L;
+  private final IntegerMap<String> hits;
+  private final IntegerMap<String> undoHits;
+  private final Collection<String> territoriesToNotify;
+
+  private BombingUnitDamageChange(
+      final IntegerMap<String> hits,
+      final IntegerMap<String> undoHits,
+      final Collection<String> territoriesToNotify) {
+    this.hits = hits;
+    this.undoHits = undoHits;
+    this.territoriesToNotify = territoriesToNotify;
+  }
+
+  public BombingUnitDamageChange(
+      final IntegerMap<Unit> hits, final Collection<Territory> territoriesToNotify) {
+    this.hits = new IntegerMap<>();
+    this.undoHits = new IntegerMap<>();
+    hits.entrySet()
+        .forEach(
+            entry -> {
+              this.hits.put(entry.getKey().getId().toString(), entry.getValue());
+              this.undoHits.put(entry.getKey().getId().toString(), entry.getKey().getUnitDamage());
+            });
+    this.territoriesToNotify =
+        territoriesToNotify.stream().map(Territory::getName).collect(Collectors.toList());
+  }
+
+  @Override
+  protected void perform(final GameData data) {
+    hits.keySet()
+        .forEach(
+            unitId -> {
+              data.getUnits().get(UUID.fromString(unitId)).setUnitDamage(hits.getInt(unitId));
+            });
+    this.territoriesToNotify.forEach(
+        territory -> {
+          data.getMap().getTerritory(territory).notifyChanged();
+        });
+  }
+
+  @Override
+  public Change invert() {
+    return new BombingUnitDamageChange(undoHits, hits, territoriesToNotify);
+  }
+
+  @Override
+  public String toString() {
+    return "Bombing unit damage change. Hits:"
+        + hits
+        + " undoHits:"
+        + undoHits
+        + " territories:"
+        + territoriesToNotify;
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/units/BombingUnitDamageChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/units/BombingUnitDamageChange.java
@@ -7,25 +7,19 @@ import games.strategy.engine.data.Unit;
 import java.util.Collection;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import org.triplea.java.collections.IntegerMap;
 
 /**
  * A game data change that captures the damage caused to a collection of units by a bombing attack.
  */
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class BombingUnitDamageChange extends Change {
   private static final long serialVersionUID = 7093658184880237574L;
   private final IntegerMap<String> hits;
   private final IntegerMap<String> undoHits;
   private final Collection<String> territoriesToNotify;
-
-  private BombingUnitDamageChange(
-      final IntegerMap<String> hits,
-      final IntegerMap<String> undoHits,
-      final Collection<String> territoriesToNotify) {
-    this.hits = hits;
-    this.undoHits = undoHits;
-    this.territoriesToNotify = territoriesToNotify;
-  }
 
   public BombingUnitDamageChange(
       final IntegerMap<Unit> hits, final Collection<Territory> territoriesToNotify) {

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/units/BombingUnitDamageChange.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/units/BombingUnitDamageChange.java
@@ -17,19 +17,25 @@ import org.triplea.java.collections.IntegerMap;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class BombingUnitDamageChange extends Change {
   private static final long serialVersionUID = 7093658184880237574L;
-  private final IntegerMap<String> hits;
-  private final IntegerMap<String> undoHits;
+  private final IntegerMap<String> newDamage;
+  private final IntegerMap<String> oldDamage;
   private final Collection<String> territoriesToNotify;
 
+  /**
+   * @param damage The amount of damage that the unit should have. It is NOT the difference of the
+   *     existing damage and the new damage.
+   * @param territoriesToNotify The territories that contain all the units
+   */
   public BombingUnitDamageChange(
-      final IntegerMap<Unit> hits, final Collection<Territory> territoriesToNotify) {
-    this.hits = new IntegerMap<>();
-    this.undoHits = new IntegerMap<>();
-    hits.entrySet()
+      final IntegerMap<Unit> damage, final Collection<Territory> territoriesToNotify) {
+    this.newDamage = new IntegerMap<>();
+    this.oldDamage = new IntegerMap<>();
+    damage
+        .entrySet()
         .forEach(
             entry -> {
-              this.hits.put(entry.getKey().getId().toString(), entry.getValue());
-              this.undoHits.put(entry.getKey().getId().toString(), entry.getKey().getUnitDamage());
+              this.newDamage.put(entry.getKey().getId().toString(), entry.getValue());
+              this.oldDamage.put(entry.getKey().getId().toString(), entry.getKey().getUnitDamage());
             });
     this.territoriesToNotify =
         territoriesToNotify.stream().map(Territory::getName).collect(Collectors.toList());
@@ -37,10 +43,11 @@ public class BombingUnitDamageChange extends Change {
 
   @Override
   protected void perform(final GameData data) {
-    hits.keySet()
+    newDamage
+        .keySet()
         .forEach(
             unitId -> {
-              data.getUnits().get(UUID.fromString(unitId)).setUnitDamage(hits.getInt(unitId));
+              data.getUnits().get(UUID.fromString(unitId)).setUnitDamage(newDamage.getInt(unitId));
             });
     this.territoriesToNotify.forEach(
         territory -> {
@@ -50,16 +57,6 @@ public class BombingUnitDamageChange extends Change {
 
   @Override
   public Change invert() {
-    return new BombingUnitDamageChange(undoHits, hits, territoriesToNotify);
-  }
-
-  @Override
-  public String toString() {
-    return "Bombing unit damage change. Hits:"
-        + hits
-        + " undoHits:"
-        + undoHits
-        + " territories:"
-        + territoriesToNotify;
+    return new BombingUnitDamageChange(oldDamage, newDamage, territoriesToNotify);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/UnitUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/UnitUtils.java
@@ -197,7 +197,7 @@ public class UnitUtils {
       }
     }
     if (!damageMap.isEmpty()) {
-      changes.add(ChangeFactory.bombingUnitDamage(damageMap));
+      changes.add(ChangeFactory.bombingUnitDamage(damageMap, List.of(t)));
     }
     return changes;
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -283,7 +283,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
             + " owned units to: "
             + MyFormatter.integerUnitMapToString(unitDamageMap, ", ", " = ", false),
         unitsFinal);
-    bridge.addChange(ChangeFactory.bombingUnitDamage(unitDamageMap));
+    bridge.addChange(ChangeFactory.bombingUnitDamage(unitDamageMap, List.of(territory)));
     // territory.notifyChanged();
     return null;
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -28,6 +28,7 @@ import games.strategy.triplea.formatter.MyFormatter;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Map;
@@ -35,6 +36,7 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 
@@ -285,7 +287,13 @@ public class PurchaseDelegate extends BaseTripleADelegate
       }
     }
     if (!damageMap.isEmpty()) {
-      changes.add(ChangeFactory.bombingUnitDamage(damageMap));
+      changes.add(
+          ChangeFactory.bombingUnitDamage(
+              damageMap,
+              bridge.getData().getMap().getTerritories().stream()
+                  .filter(
+                      territory -> !Collections.disjoint(territory.getUnits(), damageMap.keySet()))
+                  .collect(Collectors.toList())));
     }
     // add changes for spent resources
     final String remaining = removeFromPlayer(costs, changes);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -451,7 +451,7 @@ public class RocketsFireHelper implements Serializable {
       // apply the hits to the targets
       final IntegerMap<Unit> damageMap = new IntegerMap<>();
       damageMap.put(unit, totalDamage);
-      bridge.addChange(ChangeFactory.bombingUnitDamage(damageMap));
+      bridge.addChange(ChangeFactory.bombingUnitDamage(damageMap, List.of(attackedTerritory)));
       // attackedTerritory.notifyChanged();
       // in WW2V2, limit rocket attack cost to production value of factory.
     } else if (Properties.getWW2V2(data.getProperties())

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -1051,7 +1051,7 @@ public class BattleTracker implements Serializable {
         damageMap.put(unit, totalDamage);
       }
       if (!damageMap.isEmpty()) {
-        final Change damageChange = ChangeFactory.bombingUnitDamage(damageMap);
+        final Change damageChange = ChangeFactory.bombingUnitDamage(damageMap, List.of(territory));
         bridge.addChange(damageChange);
         if (changeTracker != null) {
           changeTracker.addChange(damageChange);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
@@ -977,7 +977,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
           // apply the hits to the targets
           final IntegerMap<Unit> damageMap = new IntegerMap<>();
           damageMap.put(current, totalDamage);
-          bridge.addChange(ChangeFactory.bombingUnitDamage(damageMap));
+          bridge.addChange(ChangeFactory.bombingUnitDamage(damageMap, List.of(battleSite)));
           bridge
               .getHistoryWriter()
               .addChildToEvent(

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -1774,7 +1774,7 @@ class WW2V3Year41Test {
     // damage a factory
     IntegerMap<Unit> startHits = new IntegerMap<>();
     startHits.put(factory, 1);
-    gameData.performChange(ChangeFactory.bombingUnitDamage(startHits));
+    gameData.performChange(ChangeFactory.bombingUnitDamage(startHits, List.of(germany)));
     assertEquals(1, factory.getUnitDamage());
     RepairRule repair = germans(gameData).getRepairFrontier().getRules().get(0);
     IntegerMap<RepairRule> repairs = new IntegerMap<>();
@@ -1804,7 +1804,7 @@ class WW2V3Year41Test {
     // damage a factory
     startHits = new IntegerMap<>();
     startHits.put(factory, 2);
-    gameData.performChange(ChangeFactory.bombingUnitDamage(startHits));
+    gameData.performChange(ChangeFactory.bombingUnitDamage(startHits, List.of(germany)));
     assertEquals(2, factory.getUnitDamage());
     repair = germans(gameData).getRepairFrontier().getRules().get(0);
     repairs = new IntegerMap<>();
@@ -1833,7 +1833,7 @@ class WW2V3Year41Test {
     // dame a factory
     final IntegerMap<Unit> startHits = new IntegerMap<>();
     startHits.put(factory, 1);
-    gameData.performChange(ChangeFactory.bombingUnitDamage(startHits));
+    gameData.performChange(ChangeFactory.bombingUnitDamage(startHits, List.of(germany)));
     assertEquals(1, factory.getUnitDamage());
     final RepairRule repair = germans(gameData).getRepairFrontier().getRules().get(0);
     final IntegerMap<RepairRule> repairs = new IntegerMap<>();


### PR DESCRIPTION
The old BombingUnitDamageChange is marked as deprecated and will stay
around solely for loading old saves.

The new BombingUnitDamageChange also has been modified to accept the
territory that needs to be notified, instead of looping through all the
game territories during the change process.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->
Conducted a strategic bombing run in WW2 Global 1940.  Verified the change was correctly built.  Verified that it "performed" correctly.  Played till the attacked player could repair the damaged units and verified that the change was correctly built.
## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->
I created a new Change object and marked the other as deprecated.  I think this might be cleaner since the new change object can have a new name and it doesn't need to hold the non-primitive objects.  This definitely breaks forward compatibility but the compatibility check should prevent users from trying to load saves with this new change object in an older version.

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
