### PR TITLE
Rename collapsible panel titles

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/PlacementUnitsCollapsiblePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PlacementUnitsCollapsiblePanel.java
@@ -23,7 +23,7 @@ class PlacementUnitsCollapsiblePanel {
     unitsToPlacePanel =
         new SimpleUnitPanel(
             uiContext, SimpleUnitPanel.Style.SMALL_ICONS_WRAPPED_WITH_LABEL_WHEN_EMPTY);
-    panel = new CollapsiblePanel(unitsToPlacePanel, "Purchased Units");
+    panel = new CollapsiblePanel(unitsToPlacePanel, "Placements");
     panel.setVisible(false);
     gameData.addGameDataEventListener(GameDataEvent.GAME_STEP_CHANGED, this::updateStep);
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -150,7 +150,7 @@ public class UnitScroller {
               movesLeft = movesLeft();
               SwingUtilities.invokeLater(
                   () -> {
-                    panel.setTitle("Units To Move: " + movesLeft);
+                    panel.setTitle("Active Units: " + movesLeft);
 
                     if (movesLeft == 0) {
                       clearUnitAvatarArea();


### PR DESCRIPTION
'Purchased Units' -> 'Placements': Helps beter match the phase
and what the units are.

'Units to move' -> 'Active Units': Less wordy and better
describes what the units are within the panel.


![Screenshot from 2020-11-25 18-55-40](https://user-images.githubusercontent.com/12397753/100302749-d9ec5c80-2f4f-11eb-8d52-592d958ea2dc.png)

