### PR TITLE
Rename 'map options' and 'select map' to 'game options'

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/network/ui/ChangeGameOptionsClientAction.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/network/ui/ChangeGameOptionsClientAction.java
@@ -46,7 +46,7 @@ public class ChangeGameOptionsClientAction extends AbstractAction {
       final String cancel = "Cancel";
       pane.setOptions(new Object[] {ok, cancel});
       final JDialog window =
-          pane.createDialog(JOptionPane.getFrameForComponent(parent), "Map Options");
+          pane.createDialog(JOptionPane.getFrameForComponent(parent), "Game Options");
       window.setVisible(true);
       final Object buttonPressed = pane.getValue();
       if (buttonPressed != null && !buttonPressed.equals(cancel)) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -65,14 +65,14 @@ public final class GameSelectorPanel extends JPanel implements Observer {
           .build();
   private final JButton loadNewGame =
       new JButtonBuilder()
-          .title("Select Map")
+          .title("Select Game")
           .toolTip(
               "<html>Select a game from all the maps/games that come with TripleA, "
                   + "<br>and the ones you have downloaded.</html>")
           .build();
   private final JButton mapOptions =
       new JButtonBuilder()
-          .title("Map Options")
+          .title("Game Options")
           .toolTip(
               "<html>Set options for the currently selected game, <br>such as enabling/disabling "
                   + "Low Luck, or Technology, etc.</html>")
@@ -286,7 +286,7 @@ public final class GameSelectorPanel extends JPanel implements Observer {
     final String makeDefault = "Make Default";
     final String reset = "Reset";
     pane.setOptions(new Object[] {ok, makeDefault, reset, cancel});
-    final JDialog window = pane.createDialog(JOptionPane.getFrameForComponent(this), "Map Options");
+    final JDialog window = pane.createDialog(JOptionPane.getFrameForComponent(this), "Game Options");
     window.setVisible(true);
     final Object buttonPressed = pane.getValue();
     if (buttonPressed == null || buttonPressed.equals(cancel)) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -114,11 +114,11 @@ public final class GameSelectorPanel extends JPanel implements Observer {
         buildGridCell(1, row, new Insets(0, 0, 3, 0)));
     row++;
 
-    add(new JLabel("Map Name:"), buildGridCell(0, row, new Insets(0, 10, 3, 5)));
+    add(new JLabel("Game Name:"), buildGridCell(0, row, new Insets(0, 10, 3, 5)));
     add(nameText, buildGridCell(1, row, new Insets(0, 0, 3, 0)));
     row++;
 
-    add(new JLabel("Map Version:"), buildGridCell(0, row, new Insets(0, 10, 3, 5)));
+    add(new JLabel("Game Version:"), buildGridCell(0, row, new Insets(0, 10, 3, 5)));
     add(versionText, buildGridCell(1, row, new Insets(0, 0, 3, 0)));
     row++;
 

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -286,7 +286,8 @@ public final class GameSelectorPanel extends JPanel implements Observer {
     final String makeDefault = "Make Default";
     final String reset = "Reset";
     pane.setOptions(new Object[] {ok, makeDefault, reset, cancel});
-    final JDialog window = pane.createDialog(JOptionPane.getFrameForComponent(this), "Game Options");
+    final JDialog window =
+        pane.createDialog(JOptionPane.getFrameForComponent(this), "Game Options");
     window.setVisible(true);
     final Object buttonPressed = pane.getValue();
     if (buttonPressed == null || buttonPressed.equals(cancel)) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -115,11 +115,11 @@ final class GameMenu extends JMenu {
   private void addGameOptionsMenu() {
     if (!gameData.getProperties().getEditableProperties().isEmpty()) {
       add(SwingAction.of(
-              "Map Options",
+              "Game Options",
               e -> {
                 final PropertiesUi ui =
                     new PropertiesUi(gameData.getProperties().getEditableProperties(), false);
-                JOptionPane.showMessageDialog(frame, ui, "Map Options", JOptionPane.PLAIN_MESSAGE);
+                JOptionPane.showMessageDialog(frame, ui, "Game Options", JOptionPane.PLAIN_MESSAGE);
               }))
           .setMnemonic(KeyEvent.VK_O);
     }


### PR DESCRIPTION
'Game' is more fitting in our vernacular to refer to a specific
game XML while a map is a collection of games and graphics.

![Screenshot from 2020-11-25 18-58-43](https://user-images.githubusercontent.com/12397753/100303028-77479080-2f50-11eb-86ec-3df4ac2821ec.png)
