### PR TITLE
Fix potential NPE when clicking 'ctrl+A' to add units to battle calc

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorDialog.java
@@ -107,7 +107,7 @@ public class BattleCalculatorDialog extends JDialog {
   }
 
   public static void addDefenders(final Territory t) {
-    if (instances.isEmpty()) {
+    if (instances.isEmpty() || t == null) {
       return;
     }
     final BattleCalculatorDialog currentDialog = instances.get(instances.size() - 1);


### PR DESCRIPTION
Clicking around on map with 'ctrl+A' can encounter a NPE due
to null 'current territory'


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Fix potential NullPointerException message when pressing 'ctrl+a' to add units to battle calculator<!--END_RELEASE_NOTE-->
