### PR TITLE
Simplify unit scroller behavior

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
@@ -1547,13 +1547,9 @@ public class MovePanel extends AbstractMovePanel {
 
   private void registerKeyBindings(final JFrame frame) {
     SwingKeyBinding.addKeyBinding(
-        frame, KeyCode.SPACE, unitScrollerAction(unitScroller::skipCurrentUnits));
-    SwingKeyBinding.addKeyBinding(
         frame, KeyCode.S, unitScrollerAction(unitScroller::sleepCurrentUnits));
     SwingKeyBinding.addKeyBinding(
-        frame, KeyCode.PERIOD, unitScrollerAction(unitScroller::centerOnNextMovableUnit));
-    SwingKeyBinding.addKeyBinding(
-        frame, KeyCode.COMMA, unitScrollerAction(unitScroller::centerOnPreviousMovableUnit));
+        frame, KeyCode.PERIOD, unitScrollerAction(unitScroller::selectNextMovableUnit));
     SwingKeyBinding.addKeyBinding(frame, KeyCode.F, this::highlightMovableUnits);
     SwingKeyBinding.addKeyBinding(
         frame,

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -120,11 +120,9 @@ public class UnitScroller {
 
     updateMovesLeft();
     clearUnitAvatarArea();
-    // Set last focused area to null so that if we select the next
-    // unit, the units in our previous territory do not become skipped.
-    // This is special for the case when we move units. For example, we select next
-    // unit, with say 2 in a territory, we move one, then if we select next
-    // we do not want the unmoved unit to become skipped.
+    // Units in lastFocusedTerritory become skipped when a player clicks 'next units'.
+    // If moving some units out of a territory, the remaining units should not be skipped
+    // if a player clicks 'next units'.
     lastFocusedTerritory = null;
 
     // remove any moved units from the sleeping units

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScrollerIcon.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScrollerIcon.java
@@ -13,9 +13,7 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 class UnitScrollerIcon implements Supplier<Icon> {
 
-  static final UnitScrollerIcon LEFT_ARROW = new UnitScrollerIcon("left_arrow.png");
   static final UnitScrollerIcon RIGHT_ARROW = new UnitScrollerIcon("right_arrow.png");
-  static final UnitScrollerIcon SKIP = new UnitScrollerIcon("skip.png");
   static final UnitScrollerIcon SLEEP = new UnitScrollerIcon("unit_sleep.png");
   static final UnitScrollerIcon WAKE_ALL = new UnitScrollerIcon("wake_all.png");
 

--- a/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScrollerModel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScrollerModel.java
@@ -24,16 +24,22 @@ class UnitScrollerModel {
       final Collection<Unit> skippedUnits) {
     Preconditions.checkNotNull(t);
 
-    final Predicate<Unit> moveableUnitOwnedByMe =
+    return getPlayerUnitsInTerritory(t, movePhase, player).stream()
+        .filter(Matches.unitHasMovementLeft())
+        .filter(Predicate.not(skippedUnits::contains))
+        .collect(Collectors.toList());
+  }
+
+  static List<Unit> getPlayerUnitsInTerritory(
+      final Territory t, final UnitScroller.MovePhase movePhase, final GamePlayer player) {
+    Preconditions.checkNotNull(t);
+
+    final Predicate<Unit> movableInCurrentPhaseAndOwnedByMe =
         PredicateBuilder.of(Matches.unitIsOwnedBy(player))
-            .and(Matches.unitHasMovementLeft())
-            // if not non combat, cannot move aa units
             .andIf(
                 movePhase == UnitScroller.MovePhase.COMBAT, Matches.unitCanMoveDuringCombatMove())
             .build();
-    final List<Unit> units = t.getUnitCollection().getMatches(moveableUnitOwnedByMe);
-    units.removeAll(skippedUnits);
-    return units;
+    return t.getUnitCollection().getMatches(movableInCurrentPhaseAndOwnedByMe);
   }
 
   static int computeUnitsToMoveCount(


### PR DESCRIPTION
- Update 'next' button to 'skip' and remove the 'skip' button.
The skip button being activated with space bar is bad as that also
clicks the last activated button. For example, if you press '>'
for next unit, then space bar, the 'next unit' button is activated
instead of skip.

- Remove previous button, no longer makes sense if the next button
skips (therefore clicking next and then previous would not go
back to the same unit).

- Show all that can move in the current phase in avatar panel on hover.
It was odd before if you skip units, then hover over the territory
then the avatar panel shows empty while hovering over other
territories shows those units. Without a visual indication that units
are skipped, this is odd behavior.

- Remove auto-selection of capital. Not all maps actually focus
on the current capitol. By removing this default focus the first
time pressing '>' will select units (otherwise we would skip
the currently selected units in capital, but perhaps a player
did not see or realize that these were currently selected).



![Screenshot from 2020-11-25 20-11-12](https://user-images.githubusercontent.com/12397753/100307521-ee822200-2f5a-11eb-9b4f-02a18fcfb4d8.png)

