### PR TITLE
Project#20 - Add ClientNetworkBridge to IDelegateBridge, enable websocket send and receive API

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/delegate/DefaultDelegateBridge.java
+++ b/game-core/src/main/java/games/strategy/engine/delegate/DefaultDelegateBridge.java
@@ -15,30 +15,22 @@ import games.strategy.engine.player.Player;
 import games.strategy.engine.random.IRandomSource;
 import games.strategy.engine.random.IRandomStats.DiceType;
 import games.strategy.engine.random.RandomStats;
+import games.strategy.net.websocket.ClientNetworkBridge;
 import java.util.Properties;
+import lombok.RequiredArgsConstructor;
+import org.triplea.http.client.web.socket.messages.WebSocketMessage;
 import org.triplea.sound.ISound;
 
 /** Default implementation of DelegateBridge. */
+@RequiredArgsConstructor
 public class DefaultDelegateBridge implements IDelegateBridge {
   private final GameData gameData;
   private final IGame game;
   private final IDelegateHistoryWriter historyWriter;
   private final RandomStats randomStats;
   private final DelegateExecutionManager delegateExecutionManager;
+  private final ClientNetworkBridge clientNetworkBridge;
   private IRandomSource randomSource;
-
-  public DefaultDelegateBridge(
-      final GameData data,
-      final IGame game,
-      final IDelegateHistoryWriter historyWriter,
-      final RandomStats randomStats,
-      final DelegateExecutionManager delegateExecutionManager) {
-    gameData = data;
-    this.game = game;
-    this.historyWriter = historyWriter;
-    this.randomStats = randomStats;
-    this.delegateExecutionManager = delegateExecutionManager;
-  }
 
   @Override
   public GameData getData() {
@@ -158,5 +150,10 @@ public class DefaultDelegateBridge implements IDelegateBridge {
   @Override
   public void stopGameSequence() {
     ((ServerGame) game).stopGameSequence();
+  }
+
+  @Override
+  public void sendMessage(final WebSocketMessage webSocketMessage) {
+    clientNetworkBridge.sendMessage(webSocketMessage);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/delegate/IDelegateBridge.java
+++ b/game-core/src/main/java/games/strategy/engine/delegate/IDelegateBridge.java
@@ -8,6 +8,7 @@ import games.strategy.engine.history.IDelegateHistoryWriter;
 import games.strategy.engine.player.Player;
 import games.strategy.engine.random.IRandomStats.DiceType;
 import java.util.Properties;
+import org.triplea.http.client.web.socket.messages.WebSocketMessage;
 import org.triplea.sound.ISound;
 
 /**
@@ -91,4 +92,6 @@ public interface IDelegateBridge {
   void enterDelegateExecution();
 
   GameData getData();
+
+  void sendMessage(WebSocketMessage webSocketMessage);
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/AbstractGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/AbstractGame.java
@@ -12,6 +12,7 @@ import games.strategy.engine.player.Player;
 import games.strategy.engine.vault.Vault;
 import games.strategy.net.INode;
 import games.strategy.net.Messengers;
+import games.strategy.net.websocket.ClientNetworkBridge;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -38,6 +39,12 @@ public abstract class AbstractGame implements IGame {
   final Map<GamePlayer, Player> gamePlayers = new HashMap<>();
   final PlayerManager playerManager;
 
+  // TODO: Project#20 - clientNetworkBridge will be used for Websocket network bridge.
+  //   Usages will basically be to add listeners to map message types to methods calls.
+  //   The mapped method calls will replace the existing RMI-style based network code.
+  @SuppressWarnings({"FieldCanBeLocal", "unused"})
+  private final ClientNetworkBridge clientNetworkBridge;
+
   @Nullable private IDisplay display;
   @Nullable private ISound sound;
 
@@ -45,9 +52,11 @@ public abstract class AbstractGame implements IGame {
       final GameData data,
       final Set<Player> gamePlayers,
       final Map<String, INode> remotePlayerMapping,
-      final Messengers messengers) {
+      final Messengers messengers,
+      final ClientNetworkBridge clientNetworkBridge) {
     gameData = data;
     this.messengers = messengers;
+    this.clientNetworkBridge = clientNetworkBridge;
     vault = new Vault(messengers);
     final Map<String, INode> allPlayers = new HashMap<>(remotePlayerMapping);
     for (final Player player : gamePlayers) {

--- a/game-core/src/main/java/games/strategy/engine/framework/ClientGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ClientGame.java
@@ -12,6 +12,7 @@ import games.strategy.engine.random.IRemoteRandom;
 import games.strategy.engine.random.RemoteRandom;
 import games.strategy.net.INode;
 import games.strategy.net.Messengers;
+import games.strategy.net.websocket.ClientNetworkBridge;
 import games.strategy.triplea.delegate.battle.casualty.CasualtySelector;
 import java.io.File;
 import java.io.FileOutputStream;
@@ -29,8 +30,9 @@ public class ClientGame extends AbstractGame {
       final GameData data,
       final Set<Player> gamePlayers,
       final Map<String, INode> remotePlayerMapping,
-      final Messengers messengers) {
-    super(data, gamePlayers, remotePlayerMapping, messengers);
+      final Messengers messengers,
+      final ClientNetworkBridge clientNetworkBridge) {
+    super(data, gamePlayers, remotePlayerMapping, messengers, clientNetworkBridge);
     gameModifiedChannel =
         new IGameModifiedChannel() {
           @Override

--- a/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ServerGame.java
@@ -37,6 +37,7 @@ import games.strategy.engine.random.PlainRandomSource;
 import games.strategy.engine.random.RandomStats;
 import games.strategy.net.INode;
 import games.strategy.net.Messengers;
+import games.strategy.net.websocket.ClientNetworkBridge;
 import games.strategy.triplea.TripleAPlayer;
 import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.settings.ClientSetting;
@@ -68,6 +69,8 @@ public class ServerGame extends AbstractGame {
   private InGameLobbyWatcherWrapper inGameLobbyWatcher;
   private boolean needToInitialize = true;
   private final LaunchAction launchAction;
+  private final ClientNetworkBridge clientNetworkBridge;
+
   /**
    * When the delegate execution is stopped, we countdown on this latch to prevent the
    * startgame(...) method from returning.
@@ -81,8 +84,10 @@ public class ServerGame extends AbstractGame {
       final Set<Player> localPlayers,
       final Map<String, INode> remotePlayerMapping,
       final Messengers messengers,
+      final ClientNetworkBridge clientNetworkBridge,
       final LaunchAction launchAction) {
-    super(data, localPlayers, remotePlayerMapping, messengers);
+    super(data, localPlayers, remotePlayerMapping, messengers, clientNetworkBridge);
+    this.clientNetworkBridge = clientNetworkBridge;
     this.launchAction = launchAction;
     gameModifiedChannel =
         new IGameModifiedChannel() {
@@ -469,7 +474,8 @@ public class ServerGame extends AbstractGame {
               this,
               new DelegateHistoryWriter(messengers),
               randomStats,
-              delegateExecutionManager);
+              delegateExecutionManager,
+              clientNetworkBridge);
       if (delegateRandomSource == null) {
         delegateRandomSource =
             (IRandomSource)
@@ -495,7 +501,8 @@ public class ServerGame extends AbstractGame {
             this,
             new DelegateHistoryWriter(messengers),
             randomStats,
-            delegateExecutionManager);
+            delegateExecutionManager,
+            clientNetworkBridge);
     if (delegateRandomSource == null) {
       delegateRandomSource =
           (IRandomSource)

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
@@ -12,6 +12,7 @@ import games.strategy.engine.random.IRandomSource;
 import games.strategy.engine.random.PlainRandomSource;
 import games.strategy.net.LocalNoOpMessenger;
 import games.strategy.net.Messengers;
+import games.strategy.net.websocket.ClientNetworkBridge;
 import java.awt.Component;
 import java.util.Collection;
 import java.util.HashMap;
@@ -63,7 +64,13 @@ public class LocalLauncher implements ILauncher {
       final Set<Player> gamePlayers =
           gameData.getGameLoader().newPlayers(playerListing.getLocalPlayerTypeMap());
       final ServerGame game =
-          new ServerGame(gameData, gamePlayers, new HashMap<>(), messengers, launchAction);
+          new ServerGame(
+              gameData,
+              gamePlayers,
+              new HashMap<>(),
+              messengers,
+              ClientNetworkBridge.NO_OP_SENDER,
+              launchAction);
       game.setRandomSource(randomSource);
       gameData.getGameLoader().startGame(game, gamePlayers, launchAction, null);
       return Optional.of(game);

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -16,6 +16,7 @@ import games.strategy.engine.player.Player;
 import games.strategy.engine.random.CryptoRandomSource;
 import games.strategy.net.INode;
 import games.strategy.net.Messengers;
+import games.strategy.net.websocket.ClientNetworkBridge;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.triplea.settings.ClientSetting;
 import java.io.File;
@@ -118,8 +119,19 @@ public class ServerLauncher implements ILauncher {
       final byte[] gameDataAsBytes = gameData.toBytes();
       final Set<Player> localPlayerSet =
           gameData.getGameLoader().newPlayers(playerListing.getLocalPlayerTypeMap());
+
+      // TODO: Project#20 - if feature flag is toggled, start game relay server
+      //   and use a real ClientNetworkingBridge
+      final ClientNetworkBridge clientNetworkBridge = ClientNetworkBridge.NO_OP_SENDER;
+
       serverGame =
-          new ServerGame(gameData, localPlayerSet, remotePlayers, messengers, launchAction);
+          new ServerGame(
+              gameData,
+              localPlayerSet,
+              remotePlayers,
+              messengers,
+              clientNetworkBridge,
+              launchAction);
       serverGame.setInGameLobbyWatcher(inGameLobbyWatcher);
       launchAction.onLaunch(serverGame);
       // tell the clients to start, later we will wait for them to all signal that they are ready.

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -37,6 +37,7 @@ import games.strategy.net.IClientMessenger;
 import games.strategy.net.IMessengerErrorListener;
 import games.strategy.net.INode;
 import games.strategy.net.Messengers;
+import games.strategy.net.websocket.ClientNetworkBridge;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.triplea.settings.ClientSetting;
 import java.awt.Component;
@@ -83,6 +84,7 @@ public class ClientModel implements IMessengerErrorListener {
   private IRemoteModelListener listener = IRemoteModelListener.NULL_LISTENER;
   private Messengers messengers;
   private IClientMessenger messenger;
+  private ClientNetworkBridge clientNetworkBridge;
   private Component ui;
   private ChatPanel chatPanel;
   private ClientGame game;
@@ -233,6 +235,8 @@ public class ClientModel implements IMessengerErrorListener {
               props,
               objectStreamFactory,
               new ClientLogin(this.ui, Injections.getInstance().getEngineVersion()));
+      // TODO: Project#20 replace no-op sender with a real sender.
+      clientNetworkBridge = ClientNetworkBridge.NO_OP_SENDER;
     } catch (final CouldNotLogInException e) {
       EventThreadJOptionPane.showMessageDialog(this.ui, e.getMessage());
       return false;
@@ -346,7 +350,7 @@ public class ClientModel implements IMessengerErrorListener {
             .filter(e -> e.getValue().equals(messenger.getLocalNode().getName()))
             .collect(Collectors.toMap(Map.Entry::getKey, e -> PlayerType.CLIENT_PLAYER));
     final Set<Player> playerSet = data.getGameLoader().newPlayers(playerMapping);
-    game = new ClientGame(data, playerSet, players, messengers);
+    game = new ClientGame(data, playerSet, players, messengers, clientNetworkBridge);
     new Thread(
             () -> {
               SwingUtilities.invokeLater(

--- a/game-core/src/main/java/games/strategy/net/websocket/ClientNetworkBridge.java
+++ b/game-core/src/main/java/games/strategy/net/websocket/ClientNetworkBridge.java
@@ -1,0 +1,34 @@
+package games.strategy.net.websocket;
+
+import java.util.function.Consumer;
+import org.triplea.http.client.web.socket.messages.MessageType;
+import org.triplea.http.client.web.socket.messages.WebSocketMessage;
+
+/**
+ * Main interface for sending and receiving game network messages from a game-relay-server. Of note,
+ * a client should expect to receive any messages it sends. To trigger actions, a client should send
+ * the action message and then allow for the message receiving code to handle the received message
+ * and trigger the action. The game-relay-server will distribute the same message to all other
+ * clients who will then invoke similar actions.
+ *
+ * <p>Messages are sent and received as JSON and the data object used to send messages should use
+ * primitive value types to the greatest extent possible. This allows us more flexibility to change
+ * data structure and object names without needing to change the JSON paylaod that is sent over the
+ * wire.
+ */
+public interface ClientNetworkBridge {
+  ClientNetworkBridge NO_OP_SENDER =
+      new ClientNetworkBridge() {
+        @Override
+        public void sendMessage(final WebSocketMessage webSocketMessage) {}
+
+        @Override
+        public <T extends WebSocketMessage> void addListener(
+            final MessageType<T> messageType, final Consumer<T> messageConsumer) {}
+      };
+
+  void sendMessage(WebSocketMessage webSocketMessage);
+
+  <T extends WebSocketMessage> void addListener(
+      MessageType<T> messageType, Consumer<T> messageConsumer);
+}

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProDummyDelegateBridge.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProDummyDelegateBridge.java
@@ -14,6 +14,7 @@ import games.strategy.engine.random.PlainRandomSource;
 import games.strategy.triplea.ai.pro.AbstractProAi;
 import games.strategy.triplea.ui.display.HeadlessDisplay;
 import java.util.Properties;
+import org.triplea.http.client.web.socket.messages.WebSocketMessage;
 import org.triplea.sound.HeadlessSoundChannel;
 import org.triplea.sound.ISound;
 
@@ -42,6 +43,9 @@ public class ProDummyDelegateBridge implements IDelegateBridge {
   public GameData getData() {
     return gameData;
   }
+
+  @Override
+  public void sendMessage(final WebSocketMessage webSocketMessage) {}
 
   @Override
   public void leaveDelegateExecution() {}

--- a/game-core/src/main/java/games/strategy/triplea/delegate/GameDelegateBridge.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/GameDelegateBridge.java
@@ -9,6 +9,7 @@ import games.strategy.engine.history.IDelegateHistoryWriter;
 import games.strategy.engine.player.Player;
 import games.strategy.engine.random.IRandomStats.DiceType;
 import java.util.Properties;
+import org.triplea.http.client.web.socket.messages.WebSocketMessage;
 import org.triplea.sound.ISound;
 
 /** TripleA implementation of DelegateBridge. */
@@ -24,6 +25,11 @@ public class GameDelegateBridge implements IDelegateBridge {
   @Override
   public GameData getData() {
     return bridge.getData();
+  }
+
+  @Override
+  public void sendMessage(final WebSocketMessage webSocketMessage) {
+    bridge.sendMessage(webSocketMessage);
   }
 
   /** Return our custom historyWriter instead of the default one. */

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyDelegateBridge.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyDelegateBridge.java
@@ -17,6 +17,7 @@ import games.strategy.triplea.delegate.battle.MustFightBattle;
 import games.strategy.triplea.ui.display.HeadlessDisplay;
 import java.util.List;
 import java.util.Properties;
+import org.triplea.http.client.web.socket.messages.WebSocketMessage;
 import org.triplea.sound.HeadlessSoundChannel;
 import org.triplea.sound.ISound;
 
@@ -73,6 +74,9 @@ public class DummyDelegateBridge implements IDelegateBridge {
   public GameData getData() {
     return gameData;
   }
+
+  @Override
+  public void sendMessage(final WebSocketMessage webSocketMessage) {}
 
   @Override
   public void leaveDelegateExecution() {}

--- a/game-core/src/main/java/games/strategy/triplea/ui/ObjectiveDummyDelegateBridge.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ObjectiveDummyDelegateBridge.java
@@ -26,6 +26,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
+import org.triplea.http.client.web.socket.messages.WebSocketMessage;
 import org.triplea.sound.HeadlessSoundChannel;
 import org.triplea.sound.ISound;
 import org.triplea.util.Tuple;
@@ -48,6 +49,9 @@ public class ObjectiveDummyDelegateBridge implements IDelegateBridge {
   public GameData getData() {
     return gameData;
   }
+
+  @Override
+  public void sendMessage(final WebSocketMessage webSocketMessage) {}
 
   @Override
   public void leaveDelegateExecution() {}


### PR DESCRIPTION
- We add a new interface ClientNetworkBridge that will be the main interface for sending
websocket network messages. We can also use this to register listeners to listen for
network messages and invoke the existing network APIs.

The key design difference will be after receving a network message we will know, based
on message type, which method to invoke and the message will contain the method arguments.
This would replace the way methods are invoked previously via remote method calls.

This update only adds the needed API and wires the ClientNetworkBridge to where it will
be needed, but it is not yet used (future commits will build on this)


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->
