### PR TITLE
Unify low luck and normal roll code in DiceRoll

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelector.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelector.java
@@ -105,7 +105,7 @@ public class AaCasualtySelector {
     if (highestAttack < 1) {
       return new CasualtyDetails();
     }
-    final int chosenDiceSize = unitPowerAndRollsMap.getBestDiceSides();
+    final int chosenDiceSize = unitPowerAndRollsMap.getDiceSides();
     final boolean allSameAttackPower = unitPowerAndRollsMap.isSameStrength();
     // multiple HP units need to be counted multiple times:
     final List<Unit> planesList = new ArrayList<>();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaPowerStrengthAndRolls.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AaPowerStrengthAndRolls.java
@@ -35,7 +35,9 @@ import org.triplea.java.collections.CollectionUtils;
 public class AaPowerStrengthAndRolls implements TotalPowerAndTotalRolls {
 
   @Getter int bestStrength;
-  @Getter int bestDiceSides;
+
+  @Getter(onMethod_ = @Override)
+  int diceSides;
 
   CombatValue calculator;
 
@@ -75,7 +77,7 @@ public class AaPowerStrengthAndRolls implements TotalPowerAndTotalRolls {
     }
 
     this.bestStrength = highestStrength;
-    this.bestDiceSides = chosenDiceSides;
+    this.diceSides = chosenDiceSides;
 
     this.activeStrengthAndRolls = calculateActiveStrengthAndRolls();
   }
@@ -159,7 +161,7 @@ public class AaPowerStrengthAndRolls implements TotalPowerAndTotalRolls {
     // dice sides within the same AA firing group isn't supported
     final Optional<Unit> bestInfiniteUnit =
         infiniteAa.stream()
-            .filter(unit -> calculator.getDiceSides(unit) == bestDiceSides)
+            .filter(unit -> calculator.getDiceSides(unit) == diceSides)
             .max(
                 Comparator.comparingInt(
                     unit -> totalStrengthAndTotalRollsByUnit.get(unit).getStrength()));

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/PowerStrengthAndRolls.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/PowerStrengthAndRolls.java
@@ -30,6 +30,9 @@ public class PowerStrengthAndRolls implements TotalPowerAndTotalRolls {
 
   CombatValue calculator;
 
+  @Getter(onMethod_ = @Override)
+  int diceSides;
+
   @Getter(AccessLevel.PUBLIC)
   Map<Unit, UnitPowerStrengthAndRolls> totalStrengthAndTotalRollsByUnit = new HashMap<>();
 
@@ -43,6 +46,7 @@ public class PowerStrengthAndRolls implements TotalPowerAndTotalRolls {
 
   private PowerStrengthAndRolls(final Collection<Unit> units, final CombatValue calculator) {
     this.calculator = calculator;
+    this.diceSides = units.isEmpty() ? 0 : calculator.getDiceSides(units.iterator().next());
     addUnits(units);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRolls.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRolls.java
@@ -13,6 +13,8 @@ public interface TotalPowerAndTotalRolls {
 
   List<Die> getDiceHits(int[] dice);
 
+  int getDiceSides();
+
   int getStrength(Unit unit);
 
   int getRolls(Unit unit);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRollsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/power/calculator/TotalPowerAndTotalRollsTest.java
@@ -822,7 +822,7 @@ class TotalPowerAndTotalRollsTest {
                   .supportAttachments(List.of())
                   .build());
 
-      assertThat("Dice comes from the unitAttachment", aaPowerAndRolls.getBestDiceSides(), is(8));
+      assertThat("Dice comes from the unitAttachment", aaPowerAndRolls.getDiceSides(), is(8));
     }
 
     @Test
@@ -842,7 +842,7 @@ class TotalPowerAndTotalRollsTest {
                   .supportAttachments(List.of())
                   .build());
 
-      assertThat("Dice comes from the unitAttachment", aaPowerAndRolls.getBestDiceSides(), is(8));
+      assertThat("Dice comes from the unitAttachment", aaPowerAndRolls.getDiceSides(), is(8));
     }
 
     @Test
@@ -889,7 +889,7 @@ class TotalPowerAndTotalRollsTest {
 
       assertThat(
           "Unit has a max die side of 4 so that will be used",
-          totalPowerAndTotalRolls.getBestDiceSides(),
+          totalPowerAndTotalRolls.getDiceSides(),
           is(4));
       assertThat(
           "Unit gets 2 support so its best strength is 4",
@@ -958,8 +958,7 @@ class TotalPowerAndTotalRollsTest {
 
       assertThat(
           "4 of 4 is better than 2 of 6 and 3 of 5", aaPowerAndRolls.getBestStrength(), is(4));
-      assertThat(
-          "4 of 4 is better than 2 of 6 and 3 of 5", aaPowerAndRolls.getBestDiceSides(), is(4));
+      assertThat("4 of 4 is better than 2 of 6 and 3 of 5", aaPowerAndRolls.getDiceSides(), is(4));
     }
 
     @Test
@@ -996,8 +995,7 @@ class TotalPowerAndTotalRollsTest {
 
       assertThat(
           "3 of 6 is better than 3 of 7 and 3 of 8", aaPowerAndRolls.getBestStrength(), is(3));
-      assertThat(
-          "3 of 6 is better than 3 of 7 and 3 of 8", aaPowerAndRolls.getBestDiceSides(), is(6));
+      assertThat("3 of 6 is better than 3 of 7 and 3 of 8", aaPowerAndRolls.getDiceSides(), is(6));
     }
   }
 


### PR DESCRIPTION
The AA low luck and normal rolls have the same logic as the non-AA low
luck and normal rolls. The only difference is handling dice sides that
are different from the game state.  So add a getDiceSides method to
TotalPowerAndTotalRolls and unify the code for low luck and normal
rolls.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->
Played HardAI of Global 40 and WAW to test both normal and low luck games.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
