### PR TITLE
Remove unnecessary call to CasualtySelector#selectCasualties in StrategicBombingRaidBattle

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
@@ -28,7 +28,6 @@ import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.IExecutable;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.battle.casualty.AaCasualtySelector;
-import games.strategy.triplea.delegate.battle.casualty.CasualtySelector;
 import games.strategy.triplea.delegate.battle.casualty.CasualtySortingUtil;
 import games.strategy.triplea.delegate.data.BattleRecord;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
@@ -580,35 +579,6 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     bridge
         .getDisplayChannelBroadcaster()
         .notifyDice(dice, SELECT_PREFIX + currentTypeAa + CASUALTIES_SUFFIX);
-    final boolean isEditMode = BaseEditDelegate.getEditMode(gameData);
-    final boolean allowMultipleHitsPerUnit =
-        !defendingAa.isEmpty()
-            && defendingAa.stream()
-                .allMatch(Matches.unitAaShotDamageableInsteadOfKillingInstantly());
-    if (isEditMode) {
-      final String text = currentTypeAa + AA_GUNS_FIRE_SUFFIX;
-      return CasualtySelector.selectCasualties(
-          attacker,
-          validAttackingUnitsForThisRoll,
-          CombatValueBuilder.mainCombatValue()
-              .enemyUnits(defendingUnits)
-              .friendlyUnits(attackingUnits)
-              .side(BattleState.Side.OFFENSE)
-              .gameSequence(bridge.getData().getSequence())
-              .supportAttachments(bridge.getData().getUnitTypeList().getSupportRules())
-              .lhtrHeavyBombers(Properties.getLhtrHeavyBombers(bridge.getData().getProperties()))
-              .gameDiceSides(bridge.getData().getDiceSides())
-              .territoryEffects(territoryEffects)
-              .build(),
-          battleSite,
-          bridge,
-          text,
-          null, /* dice */
-          battleId,
-          false, /* head-less */
-          0,
-          allowMultipleHitsPerUnit);
-    }
     final CasualtyDetails casualties =
         AaCasualtySelector.getAaCasualties(
             validAttackingUnitsForThisRoll,


### PR DESCRIPTION
AaCasualtySelector#getAaCasualties will automatically call CasualtySelector#selectCasualties when edit mode is turned on.  So StrategicBombingRaidBattle doesn't need to do that check separately.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
