### PR TITLE
Update help menus, add open console and submit bug report

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/LobbyMenu.java
@@ -82,9 +82,17 @@ public final class LobbyMenu extends JMenuBar {
                 'U',
                 () -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.USER_GUIDE))
             .addMenuItem(
-                "TripleA Forum",
+                "Vew Forums",
                 'F',
                 () -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.TRIPLEA_FORUM))
+            .addMenuItem(
+                "Send Bug Report",
+                'B',
+                () -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_ISSUES))
+            .addMenuItem(
+                "Open Debug Console", //
+                'C',
+                () -> ClientSetting.showConsole.setValueAndFlush(true))
             .build());
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/HelpMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/HelpMenu.java
@@ -2,6 +2,7 @@ package games.strategy.triplea.ui.menubar.help;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.triplea.UrlConstants;
+import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.UiContext;
 import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
@@ -18,6 +19,9 @@ public final class HelpMenu {
       SwingAction.of(
           "Send Bug Report",
           e -> SwingComponents.newOpenUrlConfirmationDialog(UrlConstants.GITHUB_ISSUES));
+
+  private static final Action openDebugConsole =
+      SwingAction.of("Open Debug Console", e -> ClientSetting.showConsole.setValueAndFlush(true));
 
   private static final Action gameLicenseMenu =
       SwingAction.of(
@@ -45,6 +49,8 @@ public final class HelpMenu {
     menu.addSeparator();
 
     menu.add(gameLicenseMenu).setMnemonic(KeyEvent.VK_I);
+
+    menu.add(openDebugConsole).setMnemonic(KeyEvent.VK_C);
 
     menu.add(bugReportMenu).setMnemonic(KeyEvent.VK_B);
 


### PR DESCRIPTION
1. Update the in-game help menu to have a 'show debug console' option.

2. Update the lobby help menu to be similar to the in-game menu
with both a 'submit bug report' and a 'show debug console' option.

The goal with this update is to make it a bit easier to open the
help console, currently the only way to do so is from the game
settings window.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE-->UPDATE|Submit bug report menu item now available in lobby 'help' menu. 'Show debug console' is also now available in the help menu.<!--END_RELEASE_NOTE-->
