### PR TITLE
Remove redundant call to 'MainFrame#show'

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/ui/MainFrame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/MainFrame.java
@@ -47,7 +47,6 @@ public class MainFrame {
     mainFrame.pack();
 
     setupPanelModel.setUi(mainFrame);
-    show();
   }
 
   public static void buildMainFrame(


### PR DESCRIPTION
The code that builds the main frame will invoke show for us.
