### PR TITLE
Add units in the same change set when their damage is set

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -621,13 +621,14 @@ public class MustFightBattle extends DependentBattle
       }
     }
     if (!unitsToAdd.isEmpty()) {
+      changes.add(
+          ChangeFactory.addUnits(battleSite, unitsToAdd),
+          ChangeFactory.markNoMovementChange(unitsToAdd));
       bridge.addChange(changes);
       remove(unitsToRemove, bridge, battleSite, null);
       final String transcriptText =
           MyFormatter.unitsToText(unitsToAdd) + " added in " + battleSite.getName();
       bridge.getHistoryWriter().addChildToEvent(transcriptText, new ArrayList<>(unitsToAdd));
-      bridge.addChange(ChangeFactory.addUnits(battleSite, unitsToAdd));
-      bridge.addChange(ChangeFactory.markNoMovementChange(unitsToAdd));
       units.addAll(unitsToAdd);
       bridge
           .getDisplayChannelBroadcaster()


### PR DESCRIPTION
If there are unitsToAdd, then those units have been created based on
other units and damage from those other units are transferred to the new
units. The damage change set is currently being sent before the add
units change set. For now, ensure both change sets are sent together.

In the future, need to ensure that the add units change set is sent
first.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->
I noticed this issue when playing a saved game in the middle of a battle that had units changing into other units when they are damaged.  I tested the same saved game with this change and the error didn't show up anymore.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->
This is a regression from the change to UnitDamageReceivedChange but that isn't in a release yet so a release note is not being added.

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
