### PR TITLE
Rename ChangeAttachmentChange and use primitives 

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/Attachable.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Attachable.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.data;
 
+import games.strategy.engine.data.changefactory.serializers.PrimitiveNamedAttachable;
 import java.util.Map;
 
 /**
@@ -16,4 +17,6 @@ public interface Attachable {
   IAttachment getAttachment(String key);
 
   Map<String, IAttachment> getAttachments();
+
+  PrimitiveNamedAttachable getPrimitiveForm();
 }

--- a/game-core/src/main/java/games/strategy/engine/data/NamedAttachable.java
+++ b/game-core/src/main/java/games/strategy/engine/data/NamedAttachable.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.data;
 
+import games.strategy.engine.data.changefactory.serializers.PrimitiveNamedAttachable;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -33,5 +34,10 @@ public class NamedAttachable extends DefaultNamed implements Attachable {
   @Override
   public void removeAttachment(final String keyString) {
     attachments.remove(keyString);
+  }
+
+  @Override
+  public PrimitiveNamedAttachable getPrimitiveForm() {
+    return new PrimitiveNamedAttachable(this);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/changefactory/serializers/PrimitiveNamedAttachable.java
+++ b/game-core/src/main/java/games/strategy/engine/data/changefactory/serializers/PrimitiveNamedAttachable.java
@@ -1,0 +1,85 @@
+package games.strategy.engine.data.changefactory.serializers;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Named;
+import games.strategy.engine.data.NamedAttachable;
+import games.strategy.engine.data.RelationshipType;
+import games.strategy.engine.data.Resource;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.TerritoryEffect;
+import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.delegate.TechAdvance;
+import java.io.Serializable;
+
+/**
+ * Serializes NamedAttachments into a primitive form that can be deserialized with access to
+ * GameData
+ */
+public class PrimitiveNamedAttachable implements Serializable {
+  private static final long serialVersionUID = 740501183336843321L;
+
+  private final String name;
+  private final GameType type;
+
+  public PrimitiveNamedAttachable(final NamedAttachable named) {
+    name = named.getName();
+    if (named instanceof GamePlayer) {
+      type = GameType.PLAYERID;
+    } else if (named instanceof Territory) {
+      type = GameType.TERRITORY;
+    } else if (named instanceof UnitType) {
+      type = GameType.UNITTYPE;
+    } else if (named instanceof RelationshipType) {
+      type = GameType.RELATIONSHIPTYPE;
+    } else if (named instanceof Resource) {
+      type = GameType.RESOURCE;
+    } else if (named instanceof TerritoryEffect) {
+      type = GameType.TERRITORYEFFECT;
+    } else if (named instanceof TechAdvance) {
+      type = GameType.TECHADVANCE;
+    } else {
+      throw new IllegalArgumentException("Wrong type:" + named);
+    }
+  }
+
+  enum GameType {
+    PLAYERID,
+    UNITTYPE,
+    TERRITORY,
+    RELATIONSHIPTYPE,
+    RESOURCE,
+    TERRITORYEFFECT,
+    TECHADVANCE
+  }
+
+  public Named getReference(final GameData data) {
+    checkNotNull(data);
+
+    data.acquireReadLock();
+    try {
+      switch (type) {
+        case PLAYERID:
+          return data.getPlayerList().getPlayerId(name);
+        case TERRITORY:
+          return data.getMap().getTerritory(name);
+        case UNITTYPE:
+          return data.getUnitTypeList().getUnitType(name);
+        case RELATIONSHIPTYPE:
+          return data.getRelationshipTypeList().getRelationshipType(name);
+        case RESOURCE:
+          return data.getResourceList().getResource(name);
+        case TERRITORYEFFECT:
+          return data.getTerritoryEffectList().get(name);
+        case TECHADVANCE:
+          return data.getTechnologyFrontier().getAdvanceByName(name);
+        default:
+          throw new IllegalStateException("Unknown type: " + type);
+      }
+    } finally {
+      data.releaseReadLock();
+    }
+  }
+}


### PR DESCRIPTION
ChangeAttachmentChange was renamed to AttachmentPropertyChange.

ChangeAttachmentChange stores an Attachable object. This is an
interface and didn't have an easy way to turn it into a primitive. A new
method getPrimitiveForm has been added that will generate an
PrimitiveAttachable. The PrimitiveAttachable can be easily serialized
and can deserialize with the help of the GameData object.

The PrimitiveAttachable is based off of GameObjectStreamData.

<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->
I played Fast AI of Wacraft Heroes and TWW.  I believe they use lots of triggers and that is where a lot of ChangeAttachmentChanges are used.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
