### PR TITLE
Lobby close exits program

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -153,7 +153,7 @@ public final class GameRunner {
     ProcessRunnerUtil.exec(commands);
   }
 
-  public static void exitGameIfFinished() {
+  public static void exitGameIfNoWindowsVisible() {
     SwingUtilities.invokeLater(
         () -> {
           final boolean allFramesClosed =

--- a/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -154,6 +154,8 @@ public final class GameRunner {
   }
 
   public static void exitGameIfNoWindowsVisible() {
+    // Invoke later to add this check to the end of the event dispatcher queue
+    // and allow any potential in-flight 'setVisible' invocations to execute first.
     SwingUtilities.invokeLater(
         () -> {
           final boolean allFramesClosed =

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/MainFrame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/MainFrame.java
@@ -28,7 +28,7 @@ public class MainFrame {
     mainFrame =
         JFrameBuilder.builder()
             .title("TripleA")
-            .windowClosedAction(GameRunner::exitGameIfFinished)
+            .windowClosedAction(GameRunner::exitGameIfNoWindowsVisible)
             .build();
     BackgroundTaskRunner.setMainFrame(mainFrame);
 

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -148,7 +148,7 @@ public class LobbyFrame extends JFrame implements QuitHandler {
     new Thread(
             () -> {
               GameRunner.showMainFrame();
-              GameRunner.exitGameIfFinished();
+              GameRunner.exitGameIfNoWindowsVisible();
             })
         .start();
     return true;

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -27,6 +27,7 @@ import org.triplea.domain.data.ChatParticipant;
 import org.triplea.live.servers.ServerProperties;
 import org.triplea.swing.DialogBuilder;
 import org.triplea.swing.JFrameBuilder;
+import org.triplea.swing.SwingComponents;
 
 /** The top-level frame window for the lobby client UI. */
 public class LobbyFrame extends JFrame implements QuitHandler {
@@ -39,6 +40,7 @@ public class LobbyFrame extends JFrame implements QuitHandler {
   public LobbyFrame(final LobbyClient lobbyClient, final ServerProperties serverProperties) {
     super("TripleA Lobby");
     setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
+    SwingComponents.addWindowClosedListener(this, GameRunner::exitGameIfNoWindowsVisible);
     setIconImage(JFrameBuilder.getGameIcon());
     this.lobbyClient = lobbyClient;
     setJMenuBar(new LobbyMenu(this));
@@ -145,12 +147,6 @@ public class LobbyFrame extends JFrame implements QuitHandler {
     dispose();
     chatTransmitter.disconnect();
     tableModel.shutdown();
-    new Thread(
-            () -> {
-              GameRunner.showMainFrame();
-              GameRunner.exitGameIfNoWindowsVisible();
-            })
-        .start();
     return true;
   }
 }


### PR DESCRIPTION
commit 27cf9488f5ae149981ac34853d21579db5b9cab0

    Rename method 'exitGameIfFinished' -> 'exitGameIfNoWindowsVisible'

commit 8461b3b570d1b7a2ece0d0782d27c05f8261a44c

    Change close lobby behavior to close the application if no further windows are open.
    
    Previously closing the lobby window would open the 'main frame', now instead
    it'll close the application so long as no other windows are open.

commit b4d02bf99e54654c83d7dd7615e5beee30a4d0cd

    Add explanatory comments on why 'invokeLater' when checking if all windows closed


## Testing
- manually verified closing lobby window now exits the app so long as other windows within the same process are not open

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
