### PR TITLE
Remove MainFrame 'exit on close' window closed listener

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/ui/MainFrame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/MainFrame.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
-import javax.swing.WindowConstants;
 import org.triplea.swing.JFrameBuilder;
 
 /** Represents the outermost JFrame, maintains the reference to it and controls access. */

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/MainFrame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/MainFrame.java
@@ -34,8 +34,6 @@ public class MainFrame {
 
     LookAndFeelSwingFrameListener.register(mainFrame);
 
-    mainFrame.setDefaultCloseOperation(WindowConstants.EXIT_ON_CLOSE);
-
     final Runnable quitAction =
         () -> {
           quitActions.forEach(Runnable::run);


### PR DESCRIPTION
The exit-on-close assumes there will be no other windows open,
if we are to allow multiple game instances without spawning a new
process we need to avoid a system.exit that would close all windows.
In specific, if we do not spawn a new process for games then there
will be multiple game windows, closing one will render a main frame
which when closed would then invoke a system.exit

Furthermore, the exit-on-close is unnecessary as that preempts
the window closed action that will System.exit if there are no
longer anymore visible windows.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer

Note on line 31:
```
            .windowClosedAction(GameRunner::exitGameIfFinished)
```

Currently that is dead code as the exit system on close will preempt that code and it will not executed. By removing the exist on close we will invoke the 'exitGameIfFinished' and get the same exit behavior without the system.exit.

<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
