### PR TITLE
Rework the auto low luck casualty selection

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelector.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelector.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea.delegate.battle.casualty;
 
+import com.google.common.collect.Lists;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
@@ -18,9 +19,10 @@ import games.strategy.triplea.delegate.power.calculator.AaPowerStrengthAndRolls;
 import games.strategy.triplea.delegate.power.calculator.CombatValue;
 import games.strategy.triplea.util.UnitCategory;
 import games.strategy.triplea.util.UnitSeparator;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
+import java.util.Deque;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -28,9 +30,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
+import lombok.Value;
 import lombok.experimental.UtilityClass;
-import org.triplea.util.Tuple;
 
 @UtilityClass
 public class AaCasualtySelector {
@@ -78,13 +79,10 @@ public class AaCasualtySelector {
         AaPowerStrengthAndRolls.build(defendingAa, planes.size(), aaCombatValueCalculator);
     final List<Unit> availableTargets = calculateAvailableTargets(planes, allowMultipleHitsPerUnit);
 
-    if (Properties.getLowLuck(data.getProperties())
-        || Properties.getLowLuckAaOnly(data.getProperties())) {
-      return getLowLuckAaCasualties(
-          availableTargets, unitPowerAndRollsMap, dice, bridge, allowMultipleHitsPerUnit);
-    }
-
-    return calculateAaCasualties(availableTargets, unitPowerAndRollsMap, dice, bridge);
+    return Properties.getLowLuck(data.getProperties())
+            || Properties.getLowLuckAaOnly(data.getProperties())
+        ? getLowLuckAaCasualties(availableTargets, unitPowerAndRollsMap, dice, bridge)
+        : calculateRolledAaCasualties(availableTargets, unitPowerAndRollsMap, dice, bridge);
   }
 
   /**
@@ -114,265 +112,209 @@ public class AaCasualtySelector {
       final List<Unit> availableTargets,
       final AaPowerStrengthAndRolls unitPowerAndRollsMap,
       final DiceRoll dice,
-      final IDelegateBridge bridge,
-      final boolean allowMultipleHitsPerUnit) {
+      final IDelegateBridge bridge) {
 
-    int hitsLeft = dice.getHits();
+    final LowLuckTargetGroups targetGroups =
+        createGuaranteedLowLuckHitGroups(availableTargets, dice, unitPowerAndRollsMap);
 
-    // if we can damage units, do it now
-    final CasualtyDetails finalCasualtyDetails = new CasualtyDetails();
-    final int highestAttack = unitPowerAndRollsMap.getBestStrength();
-    if (highestAttack < 1) {
-      return new CasualtyDetails();
+    if (targetGroups.guaranteedHitGroups.isEmpty()) {
+      // it is not possible to separate the targets into guaranteed hit groups so randomly choose
+      // the targets instead
+      return buildCasualtyDetails(
+          availableTargets, findRandomTargets(availableTargets, bridge, dice.getHits()));
     }
-    final int chosenDiceSize = unitPowerAndRollsMap.getDiceSides();
-    final boolean allSameAttackPower = unitPowerAndRollsMap.isSameStrength();
-    // multiple HP units need to be counted multiple times:
-    // killing the air by groups does not work if the the attack power is different for some of the
-    // rolls
-    // also, killing by groups does not work if some of the aa guns have 'MayOverStackAA' and we
-    // have more hits than the
-    // total number of groups (including the remainder group)
-    // (when i mean, 'does not work', i mean that it is no longer a mathematically fair way to find
-    // casualties)
-    // find group size (if no groups, do dice sides)
-    final int groupSize;
-    if (allSameAttackPower) {
-      groupSize = chosenDiceSize / highestAttack;
+
+    if (dice.getHits() >= targetGroups.guaranteedHitGroups.size()) {
+      // there are enough hits to take one unit from each guaranteed hit group
+      final List<Unit> hitTargetIndices = new ArrayList<>();
+      for (final List<Unit> group : targetGroups.guaranteedHitGroups) {
+        hitTargetIndices.add(group.get(0));
+      }
+
+      // if there are more hits than groups, the extra hits come out of the remainderUnits
+      final int remainderHits = dice.getHits() - targetGroups.guaranteedHitGroups.size();
+      if (remainderHits > 0) {
+        if (remainderHits == targetGroups.remainderUnits.size()) {
+          hitTargetIndices.addAll(targetGroups.remainderUnits);
+        } else {
+          // randomly pull out units from the remainder group
+          hitTargetIndices.addAll(
+              findRandomTargets(targetGroups.remainderUnits, bridge, remainderHits));
+        }
+      }
+      return buildCasualtyDetails(availableTargets, hitTargetIndices);
     } else {
-      groupSize = chosenDiceSize;
-    }
-    final int numberOfGroupsByDiceSides =
-        (int) Math.ceil((double) availableTargets.size() / (double) groupSize);
-    final boolean tooManyHitsToDoGroups = hitsLeft > numberOfGroupsByDiceSides;
-    if (!allSameAttackPower || tooManyHitsToDoGroups || chosenDiceSize % highestAttack != 0) {
-      // we have too many hits, so just pick randomly
-      return calculateAaCasualties(availableTargets, unitPowerAndRollsMap, dice, bridge);
-    }
+      // There is somehow more guaranteed hit groups than hits. This currently only happens
+      // with multi hp targets and damageable AA shots.
 
-    // if we have a group of 6 fighters and 2 bombers, and dicesides is 6, and attack was 1, then we
-    // would want 1
-    // fighter to die for sure. this is what group size is for.
-    // if the attack is greater than 1 though, and all use the same attack power, then the group
-    // size can be smaller
-    // (ie: attack is 2, and we have 3 fighters and 2 bombers, we would want 1 fighter to die for
-    // sure).
-    // categorize with groupSize
-    final Tuple<List<List<Unit>>, List<Unit>> airSplit =
-        categorizeLowLuckAirUnits(availableTargets, groupSize);
-    // the non rolling air units
-    // if we are less hits than the number of groups, OR we have equal hits to number of groups but
-    // we also have a
-    // remainder that is equal to or greater than group size,
-    // THEN we need to make sure to pick randomly, and include the remainder group. (reason we do
-    // not do this with any
-    // remainder size, is because we might have missed the dice roll to hit the remainder)
-    if (hitsLeft
-        < (airSplit.getFirst().size()
-            + ((int) Math.ceil((double) airSplit.getSecond().size() / (double) groupSize)))) {
-      // fewer hits than groups
-      final List<Unit> tempPossibleHitUnits = new ArrayList<>();
-      for (final List<Unit> group : airSplit.getFirst()) {
-        tempPossibleHitUnits.add(group.get(0));
+      // pull out one unit from each guaranteed hit and then randomly pick the hits from those
+      final List<Unit> guaranteedHitUnits = new ArrayList<>();
+      for (final List<Unit> group : targetGroups.guaranteedHitGroups) {
+        guaranteedHitUnits.add(group.get(0));
       }
-      if (!airSplit.getSecond().isEmpty()) {
-        // if we have a remainder group, we need to add some of them into the mix
-        // but we have to do so randomly
-        final List<Unit> remainders = new ArrayList<>(airSplit.getSecond());
-        if (remainders.size() == 1) {
-          tempPossibleHitUnits.add(remainders.remove(0));
-        } else {
-          final int numberOfRemainderGroups =
-              (int) Math.ceil((double) remainders.size() / (double) groupSize);
-          final int[] randomRemainder =
-              bridge.getRandom(
-                  remainders.size(),
-                  numberOfRemainderGroups,
-                  null,
-                  DiceType.ENGINE,
-                  "Deciding which planes should die due to AA fire");
-          int pos2 = 0;
-          for (final int element : randomRemainder) {
-            pos2 += element;
-            tempPossibleHitUnits.add(remainders.remove(pos2 % remainders.size()));
-          }
-        }
-      }
-      final int[] hitRandom =
-          bridge.getRandom(
-              tempPossibleHitUnits.size(),
-              hitsLeft,
-              null,
-              DiceType.ENGINE,
-              "Deciding which planes should die due to AA fire");
-      // now we find the
-      int pos = 0;
-      for (final int element : hitRandom) {
-        pos += element;
-        final Unit unitHit = tempPossibleHitUnits.remove(pos % tempPossibleHitUnits.size());
-        if (allowMultipleHitsPerUnit
-            && (Collections.frequency(finalCasualtyDetails.getDamaged(), unitHit)
-                < (getTotalHitpointsLeft(unitHit) - 1))) {
-          finalCasualtyDetails.addToDamaged(unitHit);
-        } else {
-          finalCasualtyDetails.addToKilled(unitHit);
-        }
-      }
-    } else {
-      // kill one in every group
-      for (final List<Unit> group : airSplit.getFirst()) {
-        final Unit unitHit = group.get(0);
-        if (allowMultipleHitsPerUnit
-            && (Collections.frequency(finalCasualtyDetails.getDamaged(), unitHit)
-                < (getTotalHitpointsLeft(unitHit) - 1))) {
-          finalCasualtyDetails.addToDamaged(unitHit);
-        } else {
-          finalCasualtyDetails.addToKilled(unitHit);
-        }
-        hitsLeft--;
-      }
-      // for any hits left over...
-      if (hitsLeft == airSplit.getSecond().size()) {
-        for (final Unit unitHit : airSplit.getSecond()) {
-          if (allowMultipleHitsPerUnit
-              && (Collections.frequency(finalCasualtyDetails.getDamaged(), unitHit)
-                  < (getTotalHitpointsLeft(unitHit) - 1))) {
-            finalCasualtyDetails.addToDamaged(unitHit);
-          } else {
-            finalCasualtyDetails.addToKilled(unitHit);
-          }
-        }
-      } else if (hitsLeft != 0) {
-        // the remainder
-        // roll all at once to prevent frequent random calls, important for pbem games
-        final int[] hitRandom =
-            bridge.getRandom(
-                airSplit.getSecond().size(),
-                hitsLeft,
-                null,
-                DiceType.ENGINE,
-                "Deciding which planes should die due to AA fire");
-        int pos = 0;
-        for (final int element : hitRandom) {
-          pos += element;
-          final Unit unitHit = airSplit.getSecond().remove(pos % airSplit.getSecond().size());
-          if (allowMultipleHitsPerUnit
-              && (Collections.frequency(finalCasualtyDetails.getDamaged(), unitHit)
-                  < (getTotalHitpointsLeft(unitHit) - 1))) {
-            finalCasualtyDetails.addToDamaged(unitHit);
-          } else {
-            finalCasualtyDetails.addToKilled(unitHit);
-          }
-        }
-      }
-    }
 
-    // double check
-    if (finalCasualtyDetails.size() != dice.getHits()) {
-      throw new IllegalStateException(
-          "wrong number of casualties, expected:" + dice + " but got: " + finalCasualtyDetails);
+      return buildCasualtyDetails(
+          availableTargets, findRandomTargets(guaranteedHitUnits, bridge, dice.getHits()));
     }
-    return finalCasualtyDetails;
   }
 
-  private static CasualtyDetails calculateAaCasualties(
+  /**
+   * Categorize the units and then split them up into groups of guaranteeHitGroupSize
+   *
+   * <p>Any group less than guaranteeHitGroupSize is added to the remainderUnits
+   */
+  private static LowLuckTargetGroups createGuaranteedLowLuckHitGroups(
+      final Collection<Unit> targets,
+      final DiceRoll diceRoll,
+      final AaPowerStrengthAndRolls unitPowerAndRollsMap) {
+
+    final int guaranteeHitGroupSize =
+        calculateGuaranteeLowLuckHitGroupSize(targets, diceRoll, unitPowerAndRollsMap);
+
+    final Collection<UnitCategory> groupedTargets =
+        UnitSeparator.categorize(targets, null, false, true);
+    final List<List<Unit>> guaranteedHitGroups = new ArrayList<>();
+    final List<Unit> remainderUnits = new ArrayList<>();
+    for (final UnitCategory uc : groupedTargets) {
+      final Deque<List<Unit>> guaranteedGroups =
+          new ArrayDeque<>(Lists.partition(uc.getUnits(), guaranteeHitGroupSize));
+      final List<Unit> lastGroup = guaranteedGroups.peekLast();
+      // if the last group isn't the right size, put those units in the remainder list
+      if (lastGroup != null && lastGroup.size() != guaranteeHitGroupSize) {
+        guaranteedGroups.removeLast();
+        remainderUnits.addAll(lastGroup);
+      }
+      guaranteedHitGroups.addAll(guaranteedGroups);
+    }
+    return LowLuckTargetGroups.of(guaranteedHitGroups, remainderUnits);
+  }
+
+  @Value(staticConstructor = "of")
+  private static class LowLuckTargetGroups {
+    List<List<Unit>> guaranteedHitGroups;
+    List<Unit> remainderUnits;
+  }
+
+  /**
+   * Calculate the number of targets that guarantee a hit in a low luck dice roll
+   *
+   * <p>In low luck, the number of hits = (power / dice sides). If the strength for all of the aa
+   * units is the same, then the number of hits = (strength * targetCount / diceSides). To find out
+   * how big a group is needed to get a guaranteed hit, re-order the equation to be (targetCount /
+   * hits) = (diceSides / strength). So, for every (diceSides / strength) targets, there is one
+   * guaranteed hit.
+   *
+   * @return 0 if not possible to split up the targets into guaranteed hit groups or > 0 for the
+   *     size that guarantees a hit
+   */
+  private static int calculateGuaranteeLowLuckHitGroupSize(
+      final Collection<Unit> availableTargets,
+      final DiceRoll diceRoll,
+      final AaPowerStrengthAndRolls unitPowerAndRollsMap) {
+    final int bestStrength = unitPowerAndRollsMap.getBestStrength();
+    final int chosenDiceSize = unitPowerAndRollsMap.getDiceSides();
+
+    final boolean hasOverstackHits =
+        diceRoll.getHits()
+            > Math.ceil(
+                (double) (bestStrength * availableTargets.size()) / (double) chosenDiceSize);
+
+    // if the aa units aren't the same strength, then it isn't possible to calculate the target
+    // count for a guaranteed hit because different strengths have different target counts.
+    if (!unitPowerAndRollsMap.isSameStrength()
+        // if there are more hits than (strength * targetCount / diceSides), then there must have
+        // been overstack AA and that messes up the target count.
+        || hasOverstackHits
+        // if the best strength isn't a factor of chosenDiceSize, then the target count will be
+        // fractional which doesn't work
+        || chosenDiceSize % bestStrength != 0) {
+      return 0;
+    }
+
+    return chosenDiceSize / bestStrength;
+  }
+
+  /** Select a random set of targets out of availableTargets */
+  private static Collection<Unit> findRandomTargets(
+      final List<Unit> availableTargets, final IDelegateBridge bridge, final int hits) {
+    final int[] hitRandom =
+        bridge.getRandom(
+            availableTargets.size(),
+            hits,
+            null,
+            DiceType.ENGINE,
+            "Deciding which planes should die due to AA fire");
+    // turn the random numbers into a unique set of targets
+    final Set<Integer> hitTargets = new HashSet<>();
+    int index = 0;
+    for (final int randomIndex : hitRandom) {
+      index = (index + randomIndex) % availableTargets.size();
+      while (hitTargets.contains(index)) {
+        index = (index + 1) % availableTargets.size();
+      }
+      hitTargets.add(index);
+    }
+    return hitTargets.stream().map(availableTargets::get).collect(Collectors.toList());
+  }
+
+  private static CasualtyDetails buildCasualtyDetails(
+      final List<Unit> availableTargets, final Collection<Unit> hitTargets) {
+    final Map<Unit, Long> unitHp =
+        availableTargets.stream()
+            .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
+
+    final CasualtyDetails casualtyDetails = new CasualtyDetails();
+    for (final Unit hitTarget : hitTargets) {
+      final Unit unit = availableTargets.get(availableTargets.indexOf(hitTarget));
+      unitHp.computeIfPresent(
+          unit,
+          (unitKey, hp) -> {
+            if (hp > 1) {
+              casualtyDetails.addToDamaged(unit);
+            } else {
+              casualtyDetails.addToKilled(unit);
+            }
+            return hp - 1;
+          });
+    }
+    return casualtyDetails;
+  }
+
+  private static CasualtyDetails calculateRolledAaCasualties(
       final List<Unit> availableTargets,
       final AaPowerStrengthAndRolls unitPowerAndRollsMap,
       final DiceRoll dice,
       final IDelegateBridge bridge) {
 
-    final CasualtyDetails finalCasualtyDetails = new CasualtyDetails();
     final int hits = dice.getHits();
-    final Set<Integer> hitTargets;
+    final Collection<Unit> hitTargets;
     if (unitPowerAndRollsMap.calculateTotalRolls() == availableTargets.size()
         && hits < availableTargets.size()) {
       // there is a roll for every target but not enough hits to kill all of the targets
       // so no need to get a random set of units since all units will either have a hit
       // or miss roll
-      final List<Die> rolls = dice.getRolls();
-      hitTargets = new HashSet<>();
-      for (int i = 0; i < rolls.size(); i++) {
-        if (rolls.get(i).getType() == DieType.HIT) {
-          hitTargets.add(i);
-        }
-      }
+      hitTargets = findRolledTargets(availableTargets, dice);
     } else if (hits < availableTargets.size()) {
       // there isn't a roll for every target so need to randomly pick the target for each hit
-      final int[] hitRandom =
-          bridge.getRandom(
-              availableTargets.size(),
-              hits,
-              null,
-              DiceType.ENGINE,
-              "Deciding which planes should die due to AA fire");
-      // turn the random numbers into a unique set of targets
-      hitTargets = new HashSet<>();
-      int index = 0;
-      for (final int randomIndex : hitRandom) {
-        index = (index + randomIndex) % availableTargets.size();
-        while (hitTargets.contains(index)) {
-          index = (index + 1) % availableTargets.size();
-        }
-        hitTargets.add(index);
-      }
+      hitTargets = findRandomTargets(availableTargets, bridge, hits);
     } else {
       // all targets were hit so add them all
-      hitTargets = IntStream.range(0, availableTargets.size()).boxed().collect(Collectors.toSet());
+      hitTargets = availableTargets;
     }
 
-    final Map<Unit, Long> unitHp =
-        availableTargets.stream()
-            .collect(Collectors.groupingBy(Function.identity(), Collectors.counting()));
-
-    for (final Integer hitTarget : hitTargets) {
-      final Unit unit = availableTargets.get(hitTarget);
-      unitHp.computeIfPresent(
-          unit,
-          (unitKey, hp) -> {
-            if (hp > 1) {
-              finalCasualtyDetails.addToDamaged(unit);
-            } else {
-              finalCasualtyDetails.addToKilled(unit);
-            }
-            return hp - 1;
-          });
-    }
-    return finalCasualtyDetails;
+    return buildCasualtyDetails(availableTargets, hitTargets);
   }
 
-  /**
-   * http://triplea.sourceforge.net/mywiki/Forum#nabble-td4658925%7Ca4658925 returns two lists, the
-   * first list is the air units that can be evenly divided into groups of 3 or 6 (depending on
-   * radar) the second list is all the air units that do not fit in the first list
-   */
-  private static Tuple<List<List<Unit>>, List<Unit>> categorizeLowLuckAirUnits(
-      final Collection<Unit> units, final int groupSize) {
-    final Collection<UnitCategory> categorizedAir =
-        UnitSeparator.categorize(units, null, false, true);
-    final List<List<Unit>> groupsOfSize = new ArrayList<>();
-    final List<Unit> toRoll = new ArrayList<>();
-    for (final UnitCategory uc : categorizedAir) {
-      final int remainder = uc.getUnits().size() % groupSize;
-      final int splitPosition = uc.getUnits().size() - remainder;
-      final List<Unit> group = new ArrayList<>(uc.getUnits().subList(0, splitPosition));
-      if (!group.isEmpty()) {
-        for (int i = 0; i < splitPosition; i += groupSize) {
-          final List<Unit> miniGroup = new ArrayList<>(uc.getUnits().subList(i, i + groupSize));
-          if (!miniGroup.isEmpty()) {
-            groupsOfSize.add(miniGroup);
-          }
-        }
+  /** Find the targets that were hit by a dice roll */
+  private static Collection<Unit> findRolledTargets(
+      final List<Unit> availableTargets, final DiceRoll dice) {
+    final List<Die> rolls = dice.getRolls();
+    final List<Unit> hitTargets = new ArrayList<>();
+    for (int i = 0; i < rolls.size(); i++) {
+      if (rolls.get(i).getType() == DieType.HIT) {
+        hitTargets.add(availableTargets.get(i));
       }
-      toRoll.addAll(uc.getUnits().subList(splitPosition, uc.getUnits().size()));
     }
-    return Tuple.of(groupsOfSize, toRoll);
-  }
-
-  private static int getTotalHitpointsLeft(final Unit unit) {
-    if (unit == null) {
-      return 0;
-    }
-    final UnitAttachment ua = UnitAttachment.get(unit.getType());
-    return ua.getHitPoints() - unit.getHits();
+    return hitTargets;
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/LowLuckTargetGroups.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/LowLuckTargetGroups.java
@@ -1,0 +1,110 @@
+package games.strategy.triplea.delegate.battle.casualty;
+
+import com.google.common.collect.Lists;
+import games.strategy.engine.data.Unit;
+import games.strategy.triplea.delegate.DiceRoll;
+import games.strategy.triplea.delegate.power.calculator.AaPowerStrengthAndRolls;
+import games.strategy.triplea.util.UnitCategory;
+import games.strategy.triplea.util.UnitSeparator;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Deque;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.Value;
+
+@Value
+class LowLuckTargetGroups {
+  List<List<Unit>> guaranteedHitGroups;
+  List<Unit> remainderUnits;
+
+  /**
+   * Categorize the units and then split them up into groups of guaranteeHitGroupSize. See {@link
+   * LowLuckTargetGroups#calculateGuaranteeLowLuckHitGroupSize(Collection, DiceRoll,
+   * AaPowerStrengthAndRolls)}
+   *
+   * <p>Any group less than guaranteeHitGroupSize is added to the remainderUnits
+   */
+  LowLuckTargetGroups(
+      final Collection<Unit> targets,
+      final DiceRoll diceRoll,
+      final AaPowerStrengthAndRolls unitPowerAndRollsMap) {
+
+    final int guaranteeHitGroupSize =
+        calculateGuaranteeLowLuckHitGroupSize(targets, diceRoll, unitPowerAndRollsMap);
+
+    this.guaranteedHitGroups = new ArrayList<>();
+    this.remainderUnits = new ArrayList<>();
+    if (guaranteeHitGroupSize == 0) {
+      // it isn't possible to create guaranteed hit groups so all the units are put in the remainder
+      this.remainderUnits.addAll(targets);
+      return;
+    }
+
+    final Collection<UnitCategory> groupedTargets =
+        UnitSeparator.categorize(targets, null, false, true);
+    for (final UnitCategory uc : groupedTargets) {
+      final Deque<List<Unit>> guaranteedGroups =
+          new ArrayDeque<>(Lists.partition(uc.getUnits(), guaranteeHitGroupSize));
+      if (guaranteedGroups.isEmpty()) {
+        continue;
+      }
+      final List<Unit> lastGroup = guaranteedGroups.peekLast();
+      // if the last group isn't the right size, put those units in the remainder list
+      if (lastGroup.size() != guaranteeHitGroupSize) {
+        final List<Unit> groupOfRemainderUnits = guaranteedGroups.removeLast();
+        this.remainderUnits.addAll(groupOfRemainderUnits);
+      }
+      this.guaranteedHitGroups.addAll(guaranteedGroups);
+    }
+  }
+
+  /**
+   * Calculate the number of targets that guarantee a hit in a low luck dice roll
+   *
+   * <p>In low luck, the number of hits = (power / dice sides). If the strength for all of the aa
+   * units is the same, then the number of hits = (strength * targetCount / diceSides). To find out
+   * how big a group is needed to get a guaranteed hit, re-order the equation to be (targetCount /
+   * hits) = (diceSides / strength). So, for every (diceSides / strength) targets, there is one
+   * guaranteed hit.
+   *
+   * @return 0 if not possible to split up the targets into guaranteed hit groups or > 0 for the
+   *     size that guarantees a hit
+   */
+  private static int calculateGuaranteeLowLuckHitGroupSize(
+      final Collection<Unit> availableTargets,
+      final DiceRoll diceRoll,
+      final AaPowerStrengthAndRolls unitPowerAndRollsMap) {
+    final int bestStrength = unitPowerAndRollsMap.getBestStrength();
+    final int chosenDiceSize = unitPowerAndRollsMap.getDiceSides();
+
+    // if the aa units aren't the same strength, then it isn't possible to calculate the target
+    // count for a guaranteed hit because different strengths have different target counts.
+    if (!unitPowerAndRollsMap.isSameStrength()
+        // if there are more hits than (strength * targetCount / diceSides), then there must have
+        // been AA that can fire multiple times at a single target (overstackAA) and that messes up
+        // the target count.
+        || (diceRoll.getHits()
+            > Math.ceil(
+                (double) (bestStrength * availableTargets.size()) / (double) chosenDiceSize))
+        // if the best strength isn't a factor of chosenDiceSize, then the target count will be
+        // fractional which doesn't work
+        || chosenDiceSize % bestStrength != 0) {
+      return 0;
+    }
+
+    return chosenDiceSize / bestStrength;
+  }
+
+  boolean hasGuaranteedGroups() {
+    return !guaranteedHitGroups.isEmpty();
+  }
+
+  /** Grab one unit from each of the guaranteed hit groups */
+  List<Unit> getGuaranteedHits() {
+    return guaranteedHitGroups.stream()
+        .map(hitGroup -> hitGroup.get(0))
+        .collect(Collectors.toList());
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -354,8 +354,10 @@ class WW2V3Year41Test {
                 territory("Germany", gameData))
             .getKilled();
     assertEquals(2, casualties.size());
-    thenGetRandomShouldHaveBeenCalled(bridge, times(3));
-    // should be 1 fighter and 2 bombers
+    // random should not have been called during getAaCasualties so the number of times
+    // should stay at 1
+    thenGetRandomShouldHaveBeenCalled(bridge, times(1));
+    // should be 1 fighter and 1 bomber
     assertEquals(1, CollectionUtils.countMatches(casualties, Matches.unitIsStrategicBomber()));
     assertEquals(
         1, CollectionUtils.countMatches(casualties, Matches.unitIsStrategicBomber().negate()));

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelectorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelectorTest.java
@@ -529,7 +529,7 @@ class AaCasualtySelectorTest {
                   .build());
 
       return new DiceRoll(
-          new int[0],
+          new int[] {5},
           strengthAndRolls.calculateTotalPower() / strengthAndRolls.getDiceSides(),
           1,
           false);
@@ -549,7 +549,7 @@ class AaCasualtySelectorTest {
                   .build());
 
       return new DiceRoll(
-          new int[0],
+          new int[] {0},
           strengthAndRolls.calculateTotalPower() / strengthAndRolls.getDiceSides() + 1,
           1,
           false);
@@ -612,11 +612,9 @@ class AaCasualtySelectorTest {
 
       assertThat(details.getKilled(), hasSize(1));
       assertThat(
-          "The otherPlaneUnitType is killed because it's unitType is sorted before planeUnitType "
-              + "(it sorts by unit type name) and there are 3 of them and the random selection was "
-              + "for the second unit in the list.",
+          "The 2nd plane was randomly selected and it is a planeUnitType.",
           details.getKilled().stream().map(Unit::getType).collect(Collectors.toList()),
-          containsInAnyOrder(otherPlaneUnitType));
+          containsInAnyOrder(planeUnitType));
 
       assertThat(
           "The planes have 1 hp so there can't be damaged planes",
@@ -740,11 +738,9 @@ class AaCasualtySelectorTest {
 
       assertThat(details.getKilled(), hasSize(1));
       assertThat(
-          "The otherPlaneUnitType is killed because it's unitType is sorted before planeUnitType "
-              + "(it sorts by unit type name) and there are 3 of them and the random selection was "
-              + "for the second unit in the list.",
+          "The 2nd plane was randomly selected and it is a planeUnitType.",
           details.getKilled().stream().map(Unit::getType).collect(Collectors.toList()),
-          containsInAnyOrder(otherPlaneUnitType));
+          containsInAnyOrder(planeUnitType));
 
       assertThat(
           "The planes have 1 hp so there can't be damaged planes",
@@ -754,9 +750,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void oneTypeOfPlaneWithRemainderOverDiceSidesButNotExtraHit() {
-
-      // need to randomly pick a plane to kill
-      whenGetRandom(bridge).thenAnswer(withValues(1));
 
       final List<Unit> planes = planeUnitType.createTemp(8, hitPlayer);
       final List<Unit> aaUnits = aaUnitType.createTemp(1, aaPlayer);
@@ -783,11 +776,6 @@ class AaCasualtySelectorTest {
 
     @Test
     void twoTypesOfPlanesAndBothHaveRemainderOverDiceSidesButNotExtraHit() {
-
-      // need to pick one plane out of the remainder list and then randomly pick two planes out of
-      // the final list. This behavior should probably be changed to just take one unit from each
-      // group.
-      whenGetRandom(bridge).thenAnswer(withValues(1)).thenAnswer(withValues(0, 0));
 
       final List<Unit> planes = planeUnitType.createTemp(8, hitPlayer);
       planes.addAll(otherPlaneUnitType.createTemp(8, hitPlayer));
@@ -823,9 +811,8 @@ class AaCasualtySelectorTest {
     @Test
     void twoTypesOfPlanesAndTogetherHaveRemainderOverDiceSidesButNotExtraHit() {
 
-      // need to randomly pick 2 planes out of the remainder and then pick 1 plane out of those
-      // 2 planes to actually kill
-      whenGetRandom(bridge).thenAnswer(withValues(1, 1)).thenAnswer(withValues(1));
+      // need to randomly pick 1 planes out of the remainder to kill
+      whenGetRandom(bridge).thenAnswer(withValues(1));
 
       final List<Unit> planes = planeUnitType.createTemp(4, hitPlayer);
       planes.addAll(otherPlaneUnitType.createTemp(4, hitPlayer));
@@ -846,11 +833,9 @@ class AaCasualtySelectorTest {
 
       assertThat(details.getKilled(), hasSize(1));
       assertThat(
-          "The 2nd and 4th plane were picked in the list and the fourth plane was finally "
-              + "finished. Since otherPlaneUnitType is sorted before planeUnitType, its 4 planes "
-              + "were in the list first and so the 2nd and 4th plane were both otherPlaneUnitType.",
+          "The 2nd plane was randomly selected and it is planeUnitType.",
           details.getKilled().stream().map(Unit::getType).collect(Collectors.toList()),
-          containsInAnyOrder(otherPlaneUnitType));
+          containsInAnyOrder(planeUnitType));
 
       assertThat(
           "The planes have 1 hp so there can't be damaged planes",
@@ -1008,9 +993,9 @@ class AaCasualtySelectorTest {
 
       assertThat(details.getKilled(), hasSize(2));
       assertThat(
-          "The 2nd and 4th plane were 'randomly' selected and they are both otherPlaneUnitType.",
+          "The 2nd and 4th plane were randomly selected and they are both planeUnitType.",
           details.getKilled().stream().map(Unit::getType).collect(Collectors.toList()),
-          containsInAnyOrder(otherPlaneUnitType, otherPlaneUnitType));
+          containsInAnyOrder(planeUnitType, planeUnitType));
 
       assertThat(
           "The planes have 1 hp so there can't be damaged planes",
@@ -1022,7 +1007,7 @@ class AaCasualtySelectorTest {
     void twoTypesOfPlanesAndTogetherHaveRemainderOf1AndWithExtraHit() {
 
       // need to randomly pick 2 planes to kill
-      whenGetRandom(bridge).thenAnswer(withValues(1, 1));
+      whenGetRandom(bridge).thenAnswer(withValues(1, 2));
 
       final List<Unit> planes = planeUnitType.createTemp(4, hitPlayer);
       planes.addAll(otherPlaneUnitType.createTemp(3, hitPlayer));
@@ -1043,10 +1028,9 @@ class AaCasualtySelectorTest {
 
       assertThat(details.getKilled(), hasSize(2));
       assertThat(
-          "The 2nd and 4th plane were 'randomly' selected and the 2nd is otherPlaneUnitType "
-              + "while the 4th is planeUnitType.",
+          "The 2nd and 4th plane were randomly selected and both are planeUnitType.",
           details.getKilled().stream().map(Unit::getType).collect(Collectors.toList()),
-          containsInAnyOrder(otherPlaneUnitType, planeUnitType));
+          containsInAnyOrder(planeUnitType, planeUnitType));
 
       assertThat(
           "The planes have 1 hp so there can't be damaged planes",

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelectorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/AaCasualtySelectorTest.java
@@ -59,7 +59,7 @@ class AaCasualtySelectorTest {
       hits += (shots[i] ? 1 : 0);
     }
 
-    return new DiceRoll(diceRolls, hits, 1, false, null);
+    return new DiceRoll(diceRolls, hits, 1, false, "");
   }
 
   private CombatValue givenAaCombatValue() {
@@ -533,7 +533,7 @@ class AaCasualtySelectorTest {
           strengthAndRolls.calculateTotalPower() / strengthAndRolls.getDiceSides(),
           1,
           false,
-          null);
+          "");
     }
 
     private DiceRoll givenLowLuckDiceRollWithExtraHit(
@@ -554,7 +554,7 @@ class AaCasualtySelectorTest {
           strengthAndRolls.calculateTotalPower() / strengthAndRolls.getDiceSides() + 1,
           1,
           false,
-          null);
+          "");
     }
 
     @Test

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelectorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelectorTest.java
@@ -278,10 +278,9 @@ class CasualtySelectorTest {
     assertEquals(2, casualties.size());
     // two extra rolls to pick which units are hit
     thenGetRandomShouldHaveBeenCalled(bridge, times(2));
-    // should be 1 fighter and 1 bomber
-    assertEquals(0, CollectionUtils.countMatches(casualties, Matches.unitIsStrategicBomber()));
+    assertEquals(2, CollectionUtils.countMatches(casualties, Matches.unitIsStrategicBomber()));
     assertEquals(
-        2, CollectionUtils.countMatches(casualties, Matches.unitIsStrategicBomber().negate()));
+        0, CollectionUtils.countMatches(casualties, Matches.unitIsStrategicBomber().negate()));
   }
 
   @Test
@@ -540,7 +539,7 @@ class CasualtySelectorTest {
                 territory("Germany", data))
             .getKilled();
     assertEquals(2, casualties.size());
-    thenGetRandomShouldHaveBeenCalled(bridge, times(3));
+    thenGetRandomShouldHaveBeenCalled(bridge, times(1));
     // should be 1 fighter and 1 bomber
     assertEquals(1, CollectionUtils.countMatches(casualties, Matches.unitIsStrategicBomber()));
     assertEquals(


### PR DESCRIPTION
Rewrite the old comments to fit better with how the game now works. When
this was first worked on, all AA were infinite, the dice sides was
always 6, and AA only had a strength of 1 or 2.

The new logic is a little different from the old logic. The old logic
used a little more randomness than the new logic.  But that randomness
doesn't appear to improve the functionality so it was removed.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->
Ran Hard AI of Warcraft and TWW

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
