### PR TITLE
Bump installer JRE bundle version from 11.0.6+10 to 11.0.9.1+1

### DIFF
--- a/game-headed/build.install4j
+++ b/game-headed/build.install4j
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<install4j version="8.0.7" transformSequenceNumber="8">
+<install4j version="8.0.9" transformSequenceNumber="8">
   <directoryPresets config=".triplea-root" />
   <application name="TripleA" applicationId="5251-3669-9623-1649" mediaDir="build/releases" mediaFilePattern="${compiler:sys.fullName}_${compiler:sys.version}_${compiler:sys.platform}" compression="9" lzmaCompression="true" pack200Compression="true" createChecksums="false" shortName="TripleA" publisher="TripleA Developer Team" publisherWeb="https://triplea-game.org" version="${compiler:sys.version}" allPathsRelative="true" autoSave="true" convertDotsToUnderscores="false" macVolumeId="af9346379363d40e" javaMinVersion="11" jdkMode="jdk">
-    <jreBundles jdkProviderId="AdoptOpenJDK" release="openjdk11/jdk-11.0.6+10" />
+    <jreBundles jdkProviderId="AdoptOpenJDK" release="openjdk11/jdk-11.0.9.1+1" />
   </application>
   <files>
     <mountPoints>


### PR DESCRIPTION
The previously specified version is no longer available with install4j version 8.0.9


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer

This update was made by:
- downloading the latest install4j 
- opening install4j
- opening the install4j config file found in the triplea folder
- selected a new JRE bundle using the dots icon present in the UI:
![Screenshot from 2020-12-04 23-23-31](https://user-images.githubusercontent.com/12397753/101236642-cb0c5500-3687-11eb-95a5-157e30c5efc4.png)
- finally clicked 'save project' in the UI and then examined the config file differences that were made, commit and pushed.
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
