### PR TITLE
Move removeNonCombatants to BattleState instead of BattleActions

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleActions.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleActions.java
@@ -12,8 +12,6 @@ import java.util.Collection;
 /** Actions that can occur in a battle that require interaction with {@link IDelegateBridge} */
 public interface BattleActions {
 
-  void removeNonCombatants(IDelegateBridge bridge);
-
   void clearWaitingToDieAndDamagedChangesInto(IDelegateBridge bridge);
 
   void removeCasualties(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
@@ -92,6 +92,8 @@ public interface BattleState {
 
   void retreatUnits(Side side, Collection<Unit> units);
 
+  Collection<Unit> removeNonCombatants(Side side);
+
   Collection<Unit> getBombardingUnits();
 
   GamePlayer getPlayer(Side side);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -1336,29 +1336,27 @@ public class MustFightBattle extends DependentBattle
     };
   }
 
+  /**
+   * Removes non combatants from the requested battle side and returns them
+   *
+   * @return the removed units
+   */
   @Override
-  public void removeNonCombatants(final IDelegateBridge bridge) {
-    final List<Unit> notRemovedDefending =
-        removeNonCombatants(defendingUnits, attackingUnits, false, true);
-    final List<Unit> notRemovedAttacking =
-        removeNonCombatants(attackingUnits, defendingUnits, true, true);
-    final Collection<Unit> toRemoveDefending =
-        CollectionUtils.difference(defendingUnits, notRemovedDefending);
-    final Collection<Unit> toRemoveAttacking =
-        CollectionUtils.difference(attackingUnits, notRemovedAttacking);
-    defendingUnits = notRemovedDefending;
-    attackingUnits = notRemovedAttacking;
-    if (!headless) {
-      if (!toRemoveDefending.isEmpty()) {
-        bridge
-            .getDisplayChannelBroadcaster()
-            .changedUnitsNotification(battleId, defender, toRemoveDefending, null, null);
-      }
-      if (!toRemoveAttacking.isEmpty()) {
-        bridge
-            .getDisplayChannelBroadcaster()
-            .changedUnitsNotification(battleId, attacker, toRemoveAttacking, null, null);
-      }
+  public Collection<Unit> removeNonCombatants(final Side side) {
+    if (side == DEFENSE) {
+      final List<Unit> notRemovedDefending =
+          removeNonCombatants(defendingUnits, attackingUnits, false, true);
+      final Collection<Unit> toRemoveDefending =
+          CollectionUtils.difference(defendingUnits, notRemovedDefending);
+      defendingUnits = notRemovedDefending;
+      return toRemoveDefending;
+    } else {
+      final List<Unit> notRemovedAttacking =
+          removeNonCombatants(attackingUnits, defendingUnits, true, true);
+      final Collection<Unit> toRemoveAttacking =
+          CollectionUtils.difference(attackingUnits, notRemovedAttacking);
+      attackingUnits = notRemovedAttacking;
+      return toRemoveAttacking;
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/RemoveNonCombatants.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/RemoveNonCombatants.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea.delegate.battle.steps.change;
 
+import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleActions;
@@ -7,6 +8,7 @@ import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.steps.BattleStep;
 import java.io.IOException;
 import java.io.ObjectInputStream;
+import java.util.Collection;
 import java.util.List;
 import org.triplea.java.ChangeOnNextMajorRelease;
 import org.triplea.java.RemoveOnNextMajorRelease;
@@ -37,7 +39,19 @@ public class RemoveNonCombatants implements BattleStep {
 
   @Override
   public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-    battleActions.removeNonCombatants(bridge);
+    removeNonCombatants(BattleState.Side.OFFENSE, bridge);
+    removeNonCombatants(BattleState.Side.DEFENSE, bridge);
+  }
+
+  private void removeNonCombatants(final BattleState.Side side, final IDelegateBridge bridge) {
+    final Collection<Unit> nonCombatants = battleState.removeNonCombatants(side);
+    if (nonCombatants.isEmpty()) {
+      return;
+    }
+    bridge
+        .getDisplayChannelBroadcaster()
+        .changedUnitsNotification(
+            battleState.getBattleId(), battleState.getPlayer(side), nonCombatants, null, null);
   }
 
   @RemoveOnNextMajorRelease("battleState will not need to be converted from battleActions")

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/FakeBattleState.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/FakeBattleState.java
@@ -180,6 +180,11 @@ public class FakeBattleState implements BattleState {
   }
 
   @Override
+  public Collection<Unit> removeNonCombatants(final Side side) {
+    return List.of();
+  }
+
+  @Override
   public List<String> getStepStrings() {
     return List.of();
   }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/RemoveNonCombatantsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/RemoveNonCombatantsTest.java
@@ -1,12 +1,21 @@
 package games.strategy.triplea.delegate.battle.steps.change;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.engine.display.IDisplay;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
+import java.util.Collection;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -17,16 +26,88 @@ class RemoveNonCombatantsTest {
 
   @Mock ExecutionStack executionStack;
   @Mock IDelegateBridge delegateBridge;
+  @Mock IDisplay display;
   @Mock BattleState battleState;
   @Mock BattleActions battleActions;
+  @Mock GamePlayer attacker;
+  @Mock GamePlayer defender;
 
   @Test
-  void runs() {
+  void notifiesBothOffenseAndDefenseNonCombat() {
     final RemoveNonCombatants removeNonCombatants =
         new RemoveNonCombatants(battleState, battleActions);
 
+    when(delegateBridge.getDisplayChannelBroadcaster()).thenReturn(display);
+
+    final Collection<Unit> offenseNonCombatants = List.of(mock(Unit.class));
+    when(battleState.removeNonCombatants(BattleState.Side.OFFENSE))
+        .thenReturn(offenseNonCombatants);
+    final Collection<Unit> defenseNonCombatants = List.of(mock(Unit.class));
+    when(battleState.removeNonCombatants(BattleState.Side.DEFENSE))
+        .thenReturn(defenseNonCombatants);
+
+    when(battleState.getPlayer(BattleState.Side.OFFENSE)).thenReturn(attacker);
+    when(battleState.getPlayer(BattleState.Side.DEFENSE)).thenReturn(defender);
+
     removeNonCombatants.execute(executionStack, delegateBridge);
 
-    verify(battleActions).removeNonCombatants(eq(delegateBridge));
+    verify(display, times(2).description("Both offense and defense should be notified"))
+        .changedUnitsNotification(any(), any(), any(), any(), any());
+    verify(display)
+        .changedUnitsNotification(
+            any(), eq(attacker), eq(offenseNonCombatants), eq(null), eq(null));
+    verify(display)
+        .changedUnitsNotification(
+            any(), eq(defender), eq(defenseNonCombatants), eq(null), eq(null));
+  }
+
+  @Test
+  void doesNotNotifyDefenseIfNoDefenseNonCombatants() {
+    final RemoveNonCombatants removeNonCombatants =
+        new RemoveNonCombatants(battleState, battleActions);
+
+    when(delegateBridge.getDisplayChannelBroadcaster()).thenReturn(display);
+
+    final Collection<Unit> offenseNonCombatants = List.of(mock(Unit.class));
+    when(battleState.removeNonCombatants(BattleState.Side.OFFENSE))
+        .thenReturn(offenseNonCombatants);
+    final Collection<Unit> defenseNonCombatants = List.of();
+    when(battleState.removeNonCombatants(BattleState.Side.DEFENSE))
+        .thenReturn(defenseNonCombatants);
+
+    when(battleState.getPlayer(BattleState.Side.OFFENSE)).thenReturn(attacker);
+
+    removeNonCombatants.execute(executionStack, delegateBridge);
+
+    verify(display, times(1).description("Only offense should be notified"))
+        .changedUnitsNotification(any(), any(), any(), any(), any());
+    verify(display)
+        .changedUnitsNotification(
+            any(), eq(attacker), eq(offenseNonCombatants), eq(null), eq(null));
+  }
+
+  @Test
+  void doesNotNotifyOffenseIfNoOffenseNonCombatants() {
+    final RemoveNonCombatants removeNonCombatants =
+        new RemoveNonCombatants(battleState, battleActions);
+
+    when(delegateBridge.getDisplayChannelBroadcaster()).thenReturn(display);
+
+    final Collection<Unit> offenseNonCombatants = List.of();
+    when(battleState.removeNonCombatants(BattleState.Side.OFFENSE))
+        .thenReturn(offenseNonCombatants);
+    final Collection<Unit> defenseNonCombatants = List.of(mock(Unit.class));
+    when(battleState.removeNonCombatants(BattleState.Side.DEFENSE))
+        .thenReturn(defenseNonCombatants);
+
+    when(battleState.getPlayer(BattleState.Side.DEFENSE)).thenReturn(defender);
+
+    removeNonCombatants.execute(executionStack, delegateBridge);
+
+    verify(display, times(1).description("Only defense should be notified"))
+        .changedUnitsNotification(any(), any(), any(), any(), any());
+    verify(display)
+        .changedUnitsNotification(
+            any(), eq(defender), eq(defenseNonCombatants), eq(null), eq(null));
   }
 }


### PR DESCRIPTION
The bridge code has been moved to the RemoveNonCombatants step and
BattleSatte#removeNonCombants returns the list of units removed.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
