### PR TITLE
Unify the first strike clear casualty step with the others

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleActions.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleActions.java
@@ -12,7 +12,7 @@ import java.util.Collection;
 /** Actions that can occur in a battle that require interaction with {@link IDelegateBridge} */
 public interface BattleActions {
 
-  void clearWaitingToDieAndDamagedChangesInto(IDelegateBridge bridge);
+  void clearWaitingToDieAndDamagedChangesInto(IDelegateBridge bridge, BattleState.Side... sides);
 
   void removeCasualties(
       Collection<Unit> killed,
@@ -27,12 +27,6 @@ public interface BattleActions {
       IDelegateBridge bridge,
       Territory battleSite,
       BattleState.Side... side);
-
-  void damagedChangeInto(
-      GamePlayer player,
-      Collection<Unit> units,
-      Collection<Unit> killedUnits,
-      IDelegateBridge bridge);
 
   Territory queryRetreatTerritory(
       BattleState battleState,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
@@ -88,8 +88,6 @@ public interface BattleState {
 
   Collection<Unit> filterUnits(UnitBattleFilter status, Side... sides);
 
-  void clearWaitingToDie(Side... sides);
-
   void retreatUnits(Side side, Collection<Unit> units);
 
   Collection<Unit> removeNonCombatants(Side side);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -114,8 +114,7 @@ public class MustFightBattle extends DependentBattle
   // keep track of all the units that die this round to see if they change into another unit
   private final List<Unit> killedDuringCurrentRound = new ArrayList<>();
   // Our current execution state, we keep a stack of executables, this allows us to save our state
-  // and resume while in
-  // the middle of a battle.
+  // and resume while in the middle of a battle.
   private final ExecutionStack stack = new ExecutionStack();
 
   @Getter(onMethod = @__({@Override}))
@@ -436,22 +435,6 @@ public class MustFightBattle extends DependentBattle
   }
 
   @Override
-  public void clearWaitingToDie(final Side... sides) {
-    for (final Side side : sides) {
-      switch (side) {
-        case OFFENSE:
-          attackingWaitingToDie.clear();
-          break;
-        case DEFENSE:
-          defendingWaitingToDie.clear();
-          break;
-        default:
-          break;
-      }
-    }
-  }
-
-  @Override
   public void retreatUnits(final Side side, final Collection<Unit> retreatingUnits) {
     final Collection<Unit> units = side == DEFENSE ? defendingUnits : attackingUnits;
     final Collection<Unit> unitsRetreated =
@@ -538,7 +521,7 @@ public class MustFightBattle extends DependentBattle
   }
 
   private void endBattle(final IDelegateBridge bridge) {
-    clearWaitingToDieAndDamagedChangesInto(bridge);
+    clearWaitingToDieAndDamagedChangesInto(bridge, OFFENSE, DEFENSE);
     isOver = true;
     battleTracker.removeBattle(this, bridge.getData());
 
@@ -559,29 +542,32 @@ public class MustFightBattle extends DependentBattle
   }
 
   @Override
-  public void clearWaitingToDieAndDamagedChangesInto(final IDelegateBridge bridge) {
-    final Collection<Unit> unitsToRemove = new ArrayList<>();
-    unitsToRemove.addAll(attackingWaitingToDie);
-    unitsToRemove.addAll(defendingWaitingToDie);
-    remove(unitsToRemove, bridge, battleSite, OFFENSE, DEFENSE);
-    defendingWaitingToDie.clear();
-    attackingWaitingToDie.clear();
-    damagedChangeInto(
-        attacker,
-        attackingUnits,
-        CollectionUtils.getMatches(killedDuringCurrentRound, Matches.unitIsOwnedBy(attacker)),
-        bridge);
-    damagedChangeInto(
-        defender,
-        defendingUnits,
-        CollectionUtils.getMatches(
-            killedDuringCurrentRound, Matches.unitIsOwnedBy(attacker).negate()),
-        bridge);
+  public void clearWaitingToDieAndDamagedChangesInto(
+      final IDelegateBridge bridge, final BattleState.Side... sides) {
+    for (final Side side : sides) {
+      if (side == OFFENSE) {
+        remove(attackingWaitingToDie, bridge, battleSite, side);
+        attackingWaitingToDie.clear();
+        damagedChangeInto(
+            attacker,
+            attackingUnits,
+            CollectionUtils.getMatches(killedDuringCurrentRound, Matches.unitIsOwnedBy(attacker)),
+            bridge);
+      } else {
+        remove(defendingWaitingToDie, bridge, battleSite, side);
+        defendingWaitingToDie.clear();
+        damagedChangeInto(
+            defender,
+            defendingUnits,
+            CollectionUtils.getMatches(
+                killedDuringCurrentRound, Matches.unitIsOwnedBy(attacker).negate()),
+            bridge);
+      }
+    }
     killedDuringCurrentRound.clear();
   }
 
-  @Override
-  public void damagedChangeInto(
+  private void damagedChangeInto(
       final GamePlayer player,
       final Collection<Unit> units,
       final Collection<Unit> killedUnits,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/ClearAaCasualties.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/ClearAaCasualties.java
@@ -28,6 +28,7 @@ public class ClearAaCasualties implements BattleStep {
 
   @Override
   public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-    battleActions.clearWaitingToDieAndDamagedChangesInto(bridge);
+    battleActions.clearWaitingToDieAndDamagedChangesInto(
+        bridge, BattleState.Side.OFFENSE, BattleState.Side.DEFENSE);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/ClearGeneralCasualties.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/ClearGeneralCasualties.java
@@ -30,6 +30,7 @@ public class ClearGeneralCasualties implements BattleStep {
 
   @Override
   public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-    battleActions.clearWaitingToDieAndDamagedChangesInto(bridge);
+    battleActions.clearWaitingToDieAndDamagedChangesInto(
+        bridge, BattleState.Side.OFFENSE, BattleState.Side.DEFENSE);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/ClearFirstStrikeCasualties.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/ClearFirstStrikeCasualties.java
@@ -3,11 +3,9 @@ package games.strategy.triplea.delegate.battle.steps.fire.firststrike;
 import static games.strategy.triplea.delegate.battle.BattleState.Side.DEFENSE;
 import static games.strategy.triplea.delegate.battle.BattleState.Side.OFFENSE;
 import static games.strategy.triplea.delegate.battle.BattleState.UnitBattleFilter.ALIVE;
-import static games.strategy.triplea.delegate.battle.BattleState.UnitBattleFilter.CASUALTY;
 import static games.strategy.triplea.delegate.battle.BattleStepStrings.REMOVE_SNEAK_ATTACK_CASUALTIES;
 
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.ExecutionStack;
@@ -16,9 +14,9 @@ import games.strategy.triplea.delegate.battle.BattleActions;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.steps.BattleStep;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Set;
 
 public class ClearFirstStrikeCasualties implements BattleStep {
 
@@ -91,19 +89,11 @@ public class ClearFirstStrikeCasualties implements BattleStep {
       return;
     }
 
-    final EnumSet<BattleState.Side> sidesToClear = getSidesToClear();
-    final Collection<Unit> unitsToRemove =
-        new ArrayList<>(
-            battleState.filterUnits(CASUALTY, sidesToClear.toArray(new BattleState.Side[0])));
-    battleActions.remove(
-        unitsToRemove,
-        bridge,
-        battleState.getBattleSite(),
-        sidesToClear.toArray(new BattleState.Side[0]));
-    battleState.clearWaitingToDie(sidesToClear.toArray(new BattleState.Side[0]));
+    battleActions.clearWaitingToDieAndDamagedChangesInto(
+        bridge, getSidesToClear().toArray(new BattleState.Side[0]));
   }
 
-  private EnumSet<BattleState.Side> getSidesToClear() {
+  private Set<BattleState.Side> getSidesToClear() {
     if (Properties.getWW2V2(battleState.getGameData().getProperties())) {
       // WWW2V2 subs always fire in a surprise attack phase even if their casualties will
       // be able to fire back.

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/FakeBattleState.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/FakeBattleState.java
@@ -159,22 +159,6 @@ public class FakeBattleState implements BattleState {
   }
 
   @Override
-  public void clearWaitingToDie(final Side... sides) {
-    for (final Side side : sides) {
-      switch (side) {
-        case OFFENSE:
-          attackingWaitingToDie.clear();
-          break;
-        case DEFENSE:
-          defendingWaitingToDie.clear();
-          break;
-        default:
-          break;
-      }
-    }
-  }
-
-  @Override
   public void retreatUnits(final Side side, final Collection<Unit> units) {
     retreatUnits.addAll(units);
   }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/ClearAaCasualtiesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/ClearAaCasualtiesTest.java
@@ -1,5 +1,7 @@
 package games.strategy.triplea.delegate.battle.steps.change;
 
+import static games.strategy.triplea.delegate.battle.BattleState.Side.DEFENSE;
+import static games.strategy.triplea.delegate.battle.BattleState.Side.OFFENSE;
 import static games.strategy.triplea.delegate.battle.FakeBattleState.givenBattleStateBuilder;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -26,6 +28,7 @@ class ClearAaCasualtiesTest {
 
     clearAaCasualties.execute(executionStack, delegateBridge);
 
-    verify(battleActions).clearWaitingToDieAndDamagedChangesInto(eq(delegateBridge));
+    verify(battleActions)
+        .clearWaitingToDieAndDamagedChangesInto(eq(delegateBridge), eq(OFFENSE), eq(DEFENSE));
   }
 }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/ClearFirstStrikeCasualtiesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/fire/firststrike/ClearFirstStrikeCasualtiesTest.java
@@ -2,16 +2,12 @@ package games.strategy.triplea.delegate.battle.steps.fire.firststrike;
 
 import static games.strategy.triplea.delegate.battle.BattleState.Side.DEFENSE;
 import static games.strategy.triplea.delegate.battle.BattleState.Side.OFFENSE;
-import static games.strategy.triplea.delegate.battle.BattleState.UnitBattleFilter.CASUALTY;
 import static games.strategy.triplea.delegate.battle.steps.fire.firststrike.BattleStateBuilder.givenBattleState;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 
 import games.strategy.engine.delegate.IDelegateBridge;
@@ -38,8 +34,7 @@ class ClearFirstStrikeCasualtiesTest {
   @MethodSource
   void getStep(final List<BattleStateVariation> parameters, final List<BattleState.Side> sides) {
 
-    final BattleState battleState = spy(givenBattleState(parameters));
-    lenient().doNothing().when(battleState).clearWaitingToDie(any());
+    final BattleState battleState = givenBattleState(parameters);
 
     final ClearFirstStrikeCasualties clearFirstStrikeCasualties =
         new ClearFirstStrikeCasualties(battleState, battleActions);
@@ -51,20 +46,16 @@ class ClearFirstStrikeCasualtiesTest {
     switch (sides.size()) {
       case 0:
       default:
-        verify(battleState, never()).filterUnits(eq(CASUALTY), any());
-        verify(battleState, never()).clearWaitingToDie(any());
-        verify(battleActions, never()).remove(anyCollection(), eq(delegateBridge), any());
+        verify(battleActions, never()).clearWaitingToDieAndDamagedChangesInto(any(), any());
         break;
       case 1:
-        verify(battleState).filterUnits(CASUALTY, sides.get(0));
-        verify(battleState).clearWaitingToDie(eq(sides.get(0)));
-        verify(battleActions).remove(anyCollection(), eq(delegateBridge), any(), eq(sides.get(0)));
+        verify(battleActions)
+            .clearWaitingToDieAndDamagedChangesInto(eq(delegateBridge), eq(sides.get(0)));
         break;
       case 2:
-        verify(battleState).filterUnits(CASUALTY, sides.get(0), sides.get(1));
-        verify(battleState).clearWaitingToDie(eq(sides.get(0)), eq(sides.get(1)));
         verify(battleActions)
-            .remove(anyCollection(), eq(delegateBridge), any(), eq(sides.get(0)), eq(sides.get(1)));
+            .clearWaitingToDieAndDamagedChangesInto(
+                eq(delegateBridge), eq(sides.get(0)), eq(sides.get(1)));
         break;
     }
   }


### PR DESCRIPTION
The first strike clear casualty step had a copy of the logic in
clearWaitingToDieAndDamagedChangesInto because that the first strike
clear logic needs to be able to clear just one side. This modifies
clearWaitingToDieAndDamagedChangesInto so that sides have to be passed
in.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
