### PR TITLE
Move BattleActions#removeCasualties to BattleState#markCasualties

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleActions.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleActions.java
@@ -6,7 +6,6 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.engine.player.Player;
 import games.strategy.triplea.ai.weak.WeakAi;
-import games.strategy.triplea.delegate.battle.MustFightBattle.ReturnFire;
 import java.util.Collection;
 
 /** Actions that can occur in a battle that require interaction with {@link IDelegateBridge} */
@@ -14,19 +13,18 @@ public interface BattleActions {
 
   void clearWaitingToDieAndDamagedChangesInto(IDelegateBridge bridge, BattleState.Side... sides);
 
-  void removeCasualties(
-      Collection<Unit> killed,
-      ReturnFire returnFire,
-      BattleState.Side side,
-      IDelegateBridge bridge);
-
   void endBattle(IBattle.WhoWon whoWon, IDelegateBridge bridge);
 
+  /**
+   * Kills the unit and removes it from the battle
+   *
+   * @param sides the side that the killedUnits are on
+   */
   void remove(
       Collection<Unit> killedUnits,
       IDelegateBridge bridge,
       Territory battleSite,
-      BattleState.Side... side);
+      BattleState.Side... sides);
 
   Territory queryRetreatTerritory(
       BattleState battleState,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
@@ -92,6 +92,16 @@ public interface BattleState {
 
   Collection<Unit> removeNonCombatants(Side side);
 
+  /**
+   * Mark the units that will be dying
+   *
+   * <p>Units that are only damaged should not be passed into this method.
+   *
+   * @param casualties units that are dying
+   * @param side the side the unit are on
+   */
+  void markCasualties(Collection<Unit> casualties, Side side);
+
   Collection<Unit> getBombardingUnits();
 
   GamePlayer getPlayer(Side side);

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/FakeBattleState.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/FakeBattleState.java
@@ -169,6 +169,9 @@ public class FakeBattleState implements BattleState {
   }
 
   @Override
+  public void markCasualties(final Collection<Unit> casualties, final Side side) {}
+
+  @Override
   public List<String> getStepStrings() {
     return List.of();
   }


### PR DESCRIPTION
Remove the code that depends on the bridge to the caller so that
markCasualties can be in the BattleState. The code that depends on the
bridge is old code that will be removed once save compatibility can be
broken.

Modify MustFightBattle#remove to remove the units from the WaitingToDie
lists so that markCasualties can always move the units to the
WaitingToDie list but the caller can then also remove those units if
needed.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->
Played a save from 2.0 that was a sub battle.  Ensured that the ReturnFire was handled correctly.  Units that should return fire were left in the WaitingToDie lists and units that shouldn't return fire were removed from that list.

Played a brand new sub battle to make sure that the current MarkCasualties and ClearFirstStrikeCasualties steps worked correctly together.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
