### PR TITLE
Change MustFightBattle#removeUnits to only accept one side

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleActions.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleActions.java
@@ -18,13 +18,13 @@ public interface BattleActions {
   /**
    * Kills the unit and removes it from the battle
    *
-   * @param sides the side that the killedUnits are on
+   * @param side the side that the killedUnits are on
    */
   void removeUnits(
       Collection<Unit> killedUnits,
       IDelegateBridge bridge,
       Territory battleSite,
-      BattleState.Side... sides);
+      BattleState.Side side);
 
   Territory queryRetreatTerritory(
       BattleState battleState,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -557,7 +557,8 @@ public class MustFightBattle extends DependentBattle
             attacker,
             attackingUnits,
             CollectionUtils.getMatches(killedDuringCurrentRound, Matches.unitIsOwnedBy(attacker)),
-            bridge);
+            bridge,
+            side);
       } else {
         removeUnits(defendingWaitingToDie, bridge, battleSite, side);
         defendingWaitingToDie.clear();
@@ -566,7 +567,8 @@ public class MustFightBattle extends DependentBattle
             defendingUnits,
             CollectionUtils.getMatches(
                 killedDuringCurrentRound, Matches.unitIsOwnedBy(attacker).negate()),
-            bridge);
+            bridge,
+            side);
       }
     }
     killedDuringCurrentRound.clear();
@@ -576,7 +578,8 @@ public class MustFightBattle extends DependentBattle
       final GamePlayer player,
       final Collection<Unit> units,
       final Collection<Unit> killedUnits,
-      final IDelegateBridge bridge) {
+      final IDelegateBridge bridge,
+      final Side side) {
     final List<Unit> damagedUnits =
         CollectionUtils.getMatches(
             units,
@@ -609,7 +612,7 @@ public class MustFightBattle extends DependentBattle
           ChangeFactory.addUnits(battleSite, unitsToAdd),
           ChangeFactory.markNoMovementChange(unitsToAdd));
       bridge.addChange(changes);
-      removeUnits(unitsToRemove, bridge, battleSite, OFFENSE, DEFENSE);
+      removeUnits(unitsToRemove, bridge, battleSite, side);
       final String transcriptText =
           MyFormatter.unitsToText(unitsToAdd) + " added in " + battleSite.getName();
       bridge.getHistoryWriter().addChildToEvent(transcriptText, new ArrayList<>(unitsToAdd));
@@ -640,7 +643,7 @@ public class MustFightBattle extends DependentBattle
       final Collection<Unit> killedUnits,
       final IDelegateBridge bridge,
       final Territory battleSite,
-      final Side... sides) {
+      final Side side) {
     if (killedUnits.isEmpty()) {
       return;
     }
@@ -674,14 +677,12 @@ public class MustFightBattle extends DependentBattle
       removeFromDependents(killed, bridge, dependentBattles);
     }
 
-    for (final Side side : sides) {
-      if (side == DEFENSE) {
-        defendingUnits.removeAll(killed);
-        defendingWaitingToDie.removeAll(killed);
-      } else {
-        attackingUnits.removeAll(killed);
-        attackingWaitingToDie.removeAll(killed);
-      }
+    if (side == DEFENSE) {
+      defendingUnits.removeAll(killed);
+      defendingWaitingToDie.removeAll(killed);
+    } else {
+      attackingUnits.removeAll(killed);
+      attackingWaitingToDie.removeAll(killed);
     }
   }
 


### PR DESCRIPTION
There's only one place that calls removeUnits with both sides:
damagedChangeInto. But that can be modified to accept a side, so
removeUnits doesn't need to accept both sides.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
