### PR TITLE
Ensure the player name in the step definition is valid

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
@@ -555,6 +555,16 @@ public final class GameParser {
     for (final GamePlay.Sequence.Step current : stepList) {
       final IDelegate delegate = getDelegate(current.getDelegate());
       final GamePlayer player = getPlayerIdOptional(current.getPlayer()).orElse(null);
+      if (player == null && current.getPlayer() != null && !current.getPlayer().isBlank()) {
+        log.log(
+            Level.SEVERE,
+            "The step "
+                + current.getName()
+                + " wants a player with the name of '"
+                + current.getPlayer()
+                + "' but that player can not be found. "
+                + "Make sure the player's name is spelled correctly.");
+      }
       final String name = current.getName();
       String displayName = null;
       final Properties stepProperties = parseStepProperties(current.getStepProperties());


### PR DESCRIPTION
<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->
Fixes #8214

## Testing
<!-- Describe any manual testing performed below. -->
I started a game using the map from #8214 and verified the error was shown correctly.
I started a game from a few other maps and verified that an error didn't occur.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->
It is possible that other released maps might show this error.  I didn't check every map.  But when those errors come in, they should be easily fixed.

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE-->CHANGE|Invalid player names in a step definition will now cause an error to be shown when the map is first loaded.<!--END_RELEASE_NOTE-->
