### PR TITLE
Fix SLF4J logging outputs

### DIFF
--- a/game-core/src/main/java/org/triplea/debug/Slf4jLogMessageUploader.java
+++ b/game-core/src/main/java/org/triplea/debug/Slf4jLogMessageUploader.java
@@ -1,5 +1,6 @@
 package org.triplea.debug;
 
+import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
 
@@ -11,6 +12,8 @@ import ch.qos.logback.core.AppenderBase;
 public class Slf4jLogMessageUploader extends AppenderBase<ILoggingEvent> {
   @Override
   protected void append(final ILoggingEvent eventObject) {
-    ErrorMessage.show(LoggerRecordAdapter.fromLogbackEvent(eventObject));
+    if (eventObject.getLevel().isGreaterOrEqual(Level.WARN)) {
+      ErrorMessage.show(LoggerRecordAdapter.fromLogbackEvent(eventObject));
+    }
   }
 }

--- a/game-headed/src/main/resources/logback.xml
+++ b/game-headed/src/main/resources/logback.xml
@@ -1,6 +1,14 @@
 <configuration>
     <appender name="swingMessage" class="org.triplea.debug.Slf4jLogMessageUploader"/>
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n
+            </Pattern>
+        </layout>
+    </appender>
     <root level="info">
         <appender-ref ref="swingMessage"/>
+        <appender-ref ref="console"/>
     </root>
 </configuration>


### PR DESCRIPTION
After this update 'WARN' or higher slf4j logging will open
an error report window (similar to current behavior for
java.util.logger) and all slf4j logging will go to console.

Previously we were missing the threshold check and 'info'
messages opened an error window.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
