### PR TITLE
Handle some dependent units in translateAttributesToOtherUnits

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/Unit.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Unit.java
@@ -376,7 +376,8 @@ public class Unit extends GameDataComponent implements DynamicallyModifiable {
     disabled = value;
   }
 
-  private void setTransportedBy(final Unit transportedBy) {
+  @VisibleForTesting
+  public void setTransportedBy(final Unit transportedBy) {
     this.transportedBy = transportedBy;
   }
 
@@ -418,7 +419,8 @@ public class Unit extends GameDataComponent implements DynamicallyModifiable {
     return unloaded;
   }
 
-  private void setUnloaded(final List<Unit> unloaded) {
+  @VisibleForTesting
+  public void setUnloaded(final List<Unit> unloaded) {
     if (unloaded == null || unloaded.isEmpty()) {
       this.unloaded = List.of();
     } else {

--- a/game-core/src/test/java/games/strategy/triplea/UnitUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/UnitUtilsTest.java
@@ -130,7 +130,7 @@ class UnitUtilsTest {
     }
 
     @Test
-    void unloadedUnitsAreTransferred() {
+    void unloadedUnitsAreTransferredFromOldUnitToNewUnit() {
       final Unit oldUnit = transport.create(1, player).get(0);
       final List<Unit> newUnits = transport.create(1, player);
 
@@ -191,7 +191,9 @@ class UnitUtilsTest {
       gameData.performChange(changes);
 
       assertThat(
-          "The first new unit should be the new transporter for the units",
+          "Units can only be transported by one unit at a time. So the transported unit "
+              + "should be transferred to one of the new units. Since the new units is a list, the "
+              + "first one will be selected.",
           transportedUnits.get(0).getTransportedBy(),
           is(newUnits.get(0)));
     }

--- a/game-core/src/test/java/games/strategy/triplea/UnitUtilsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/UnitUtilsTest.java
@@ -179,23 +179,26 @@ class UnitUtilsTest {
 
     @Test
     void transportedUnitsAreTransferredToTheFirstNewUnit() {
-      final Unit oldUnit = transport.create(1, player).get(0);
-      seaZone.getUnitCollection().add(oldUnit);
-      final List<Unit> newUnits = transport.create(2, player);
+      final Unit oldTransport = transport.create(1, player).get(0);
+      seaZone.getUnitCollection().add(oldTransport);
+      final Unit newTransport1 = transport.create(1, player).get(0);
+      final Unit newTransport2 = transport.create(1, player).get(0);
 
       final List<Unit> transportedUnits = infantry.create(1, player);
       seaZone.getUnitCollection().addAll(transportedUnits);
-      transportedUnits.get(0).setTransportedBy(oldUnit);
+      transportedUnits.get(0).setTransportedBy(oldTransport);
 
-      final Change changes = UnitUtils.translateAttributesToOtherUnits(oldUnit, newUnits, seaZone);
+      final Change changes =
+          UnitUtils.translateAttributesToOtherUnits(
+              oldTransport, List.of(newTransport1, newTransport2), seaZone);
       gameData.performChange(changes);
 
       assertThat(
           "Units can only be transported by one unit at a time. So the transported unit "
               + "should be transferred to one of the new units. Since the new units is a list, the "
-              + "first one will be selected.",
+              + "first one will be selected and the first one is 'newTransport1'",
           transportedUnits.get(0).getTransportedBy(),
-          is(newUnits.get(0)));
+          is(newTransport1));
     }
   }
 }


### PR DESCRIPTION
Unloaded units and transported units are now transferred from the giving
unit to the receiving unit.  If there is more than one receiving unit,
it will be given to the receiving unit that stream().findFirst()
returns.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->
There are no maps that I can find that have transformed units that transport other units.  So this code shouldn't really be used at this point.  But the point of this change is to allow reworking of the battle unit removal code.

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE-->CHANGE|If a unit is transporting units and it is transformed because of whenCapturedChangesInto, whenHitPointsDamagedChangesInto, or whenHitPointsRepairedChangesInto, then the transported units will be copied to the transformed unit instead of removed.<!--END_RELEASE_NOTE-->
