### PR TITLE
Deprecate AbstractBattle#dependentUnits

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/Unit.java
+++ b/game-core/src/main/java/games/strategy/engine/data/Unit.java
@@ -384,7 +384,8 @@ public class Unit extends GameDataComponent implements DynamicallyModifiable {
    * This is a very slow method because it checks all territories on the map. Try not to use this
    * method if possible.
    *
-   * @return Unmodifiable collection of units that the given transport is transporting.
+   * @return Unmodifiable collection of units that this unit is transporting in the same territory
+   *     it is located in
    */
   public List<Unit> getTransporting() {
     if (Matches.unitCanTransport().test(this) || Matches.unitIsCarrier().test(this)) {
@@ -393,14 +394,19 @@ public class Unit extends GameDataComponent implements DynamicallyModifiable {
       for (final Territory t : getData().getMap()) {
         // find the territory this transport is in
         if (t.getUnitCollection().contains(this)) {
-          return getTransporting(t.getUnitCollection());
+          return getTransporting(t);
         }
       }
     }
     return List.of();
   }
 
-  /** @return Unmodifiable collection of units that the given transport is transporting. */
+  /** @return Unmodifiable collection of units in the territory that this unit is transporting */
+  public List<Unit> getTransporting(final Territory territory) {
+    return getTransporting(territory.getUnitCollection());
+  }
+
+  /** @return Unmodifiable collection of a subset of the units that this unit is transporting */
   public List<Unit> getTransporting(final Collection<Unit> transportedUnitsPossible) {
     // we don't store the units we are transporting
     // rather we look at the transported by property of units

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
@@ -72,12 +72,22 @@ public class TransportTracker {
 
   /**
    * Returns a map of transport -> collection of transported units. This method is identical to
-   * {@link #transporting(Collection)} except that it considers all elements in {@code units} as the
+   * {@link #transporting(Collection)} except that it considers only items in {@code units} as the
    * possible units to transport
    */
   public static Map<Unit, Collection<Unit>> transportingWithAllPossibleUnits(
       final Collection<Unit> units) {
     return transporting(units, transport -> transport.getTransporting(units));
+  }
+
+  /**
+   * Returns a map of transport -> collection of transported units. This method is identical to
+   * {@link #transporting(Collection)} except that it considers only units in {@code territory} as
+   * the possible units to transport
+   */
+  public static Map<Unit, Collection<Unit>> transportingInTerritory(
+      final Collection<Unit> units, final Territory territory) {
+    return transporting(units, transport -> transport.getTransporting(territory));
   }
 
   public static boolean isTransporting(final Unit transport) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/AbstractBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/AbstractBattle.java
@@ -49,11 +49,8 @@ abstract class AbstractBattle implements IBattle {
   boolean isAmphibious = false;
   final BattleType battleType;
   boolean isOver = false;
-  /**
-   * Dependent units, maps unit -> Collection of units, if unit is lost in a battle we are dependent
-   * on then we lose the corresponding collection of units.
-   */
-  final Map<Unit, Collection<Unit>> dependentUnits = new HashMap<>();
+
+  @RemoveOnNextMajorRelease final Map<Unit, Collection<Unit>> dependentUnits = new HashMap<>();
 
   List<Unit> attackingUnits = new ArrayList<>();
   List<Unit> defendingUnits = new ArrayList<>();
@@ -91,22 +88,13 @@ abstract class AbstractBattle implements IBattle {
   @Override
   public Collection<Unit> getDependentUnits(final Collection<Unit> units) {
     return units.stream()
-        .map(this.dependentUnits::get)
-        .filter(Objects::nonNull)
+        .map(unit -> unit.getTransporting(battleSite))
         .flatMap(Collection::stream)
         .collect(Collectors.toUnmodifiableList());
   }
 
   protected Collection<Unit> getUnitsWithDependents(final Collection<Unit> units) {
     return ImmutableList.copyOf(Iterables.concat(units, getDependentUnits(units)));
-  }
-
-  void addDependentTransportingUnits(final Collection<Unit> units) {
-    TransportTracker.transporting(units)
-        .forEach(
-            (unit, transportedUnits) -> {
-              dependentUnits.computeIfAbsent(unit, k -> new ArrayList<>()).addAll(transportedUnits);
-            });
   }
 
   void clearTransportedBy(final IDelegateBridge bridge) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
@@ -112,8 +112,6 @@ public interface BattleState {
 
   Collection<Unit> getDependentUnits(Collection<Unit> units);
 
-  void removeDependentUnits(Collection<Unit> units);
-
   Collection<Unit> getTransportDependents(Collection<Unit> units);
 
   Collection<IBattle> getDependentBattles();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/FinishedBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/FinishedBattle.java
@@ -74,7 +74,6 @@ public class FinishedBattle extends AbstractBattle {
   @Override
   public Change addAttackChange(
       final Route route, final Collection<Unit> units, final Map<Unit, Set<Unit>> targets) {
-    addDependentTransportingUnits(units);
     final Territory attackingFrom = route.getTerritoryBeforeEnd();
     attackingUnits.addAll(units);
     final Collection<Unit> attackingFromMapUnits =
@@ -113,9 +112,6 @@ public class FinishedBattle extends AbstractBattle {
         // do we have any amphibious attacks left?
         isAmphibious = !amphibiousAttackFrom.isEmpty();
       }
-    }
-    for (final Collection<Unit> dependent : dependentUnits.values()) {
-      dependent.removeAll(units);
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/NonFightingBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/NonFightingBattle.java
@@ -13,7 +13,6 @@ import games.strategy.triplea.delegate.data.BattleRecord;
 import games.strategy.triplea.formatter.MyFormatter;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -37,7 +36,6 @@ public class NonFightingBattle extends DependentBattle {
   @Override
   public Change addAttackChange(
       final Route route, final Collection<Unit> units, final Map<Unit, Set<Unit>> targets) {
-    addDependentTransportingUnits(units);
     final Territory attackingFrom = route.getTerritoryBeforeEnd();
     attackingUnits.addAll(units);
     attackingFromMap.computeIfAbsent(attackingFrom, k -> new ArrayList<>()).addAll(units);
@@ -113,9 +111,6 @@ public class NonFightingBattle extends DependentBattle {
         isAmphibious = !getAmphibiousAttackTerritories().isEmpty();
       }
     }
-    for (final Collection<Unit> dependent : dependentUnits.values()) {
-      dependent.removeAll(units);
-    }
   }
 
   @Override
@@ -138,14 +133,6 @@ public class NonFightingBattle extends DependentBattle {
       bridge.getHistoryWriter().addChildToEvent(transcriptText, lost);
       final Change change = ChangeFactory.removeUnits(battleSite, lost);
       bridge.addChange(change);
-    }
-  }
-
-  void addDependentUnits(final Map<Unit, Collection<Unit>> dependencies) {
-    for (final Map.Entry<Unit, Collection<Unit>> entry : dependencies.entrySet()) {
-      dependentUnits
-          .computeIfAbsent(entry.getKey(), k -> new LinkedHashSet<>())
-          .addAll(new ArrayList<>(entry.getValue()));
     }
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/LandParatroopers.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/LandParatroopers.java
@@ -50,8 +50,6 @@ public class LandParatroopers implements BattleStep {
             TransportTracker.unloadAirTransportChange(unit, battleState.getBattleSite(), false));
       }
       bridge.addChange(change);
-
-      battleState.removeDependentUnits(transportsAndParatroopers.airTransports);
     }
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/FakeBattleState.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/FakeBattleState.java
@@ -85,11 +85,6 @@ public class FakeBattleState implements BattleState {
   }
 
   @Override
-  public void removeDependentUnits(final Collection<Unit> units) {
-    // use verify() to check if this method is called
-  }
-
-  @Override
   public Collection<IBattle> getDependentBattles() {
     return new ArrayList<>();
   }

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/LandParatroopersTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/LandParatroopersTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.core.Is.is;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyCollection;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -41,25 +40,25 @@ class LandParatroopersTest {
 
   @Test
   void secondRoundDoesNothing() {
-    final BattleState battleState = spy(givenBattleStateBuilder().battleRound(2).build());
+    final BattleState battleState = givenBattleStateBuilder().battleRound(2).build();
     final LandParatroopers landParatroopers = new LandParatroopers(battleState, battleActions);
 
     assertThat(landParatroopers.getNames(), is(empty()));
 
     landParatroopers.execute(executionStack, delegateBridge);
-    verify(battleState, never()).removeDependentUnits(anyCollection());
+    verify(delegateBridge, never()).addChange(any(Change.class));
   }
 
   @Test
   void waterBattleDoesNothing() {
     final BattleState battleState =
-        spy(givenBattleStateBuilder().battleRound(1).battleSite(givenSeaBattleSite()).build());
+        givenBattleStateBuilder().battleRound(1).battleSite(givenSeaBattleSite()).build();
     final LandParatroopers landParatroopers = new LandParatroopers(battleState, battleActions);
 
     assertThat(landParatroopers.getNames(), is(empty()));
 
     landParatroopers.execute(executionStack, delegateBridge);
-    verify(battleState, never()).removeDependentUnits(anyCollection());
+    verify(delegateBridge, never()).addChange(any(Change.class));
   }
 
   @Test
@@ -69,13 +68,13 @@ class LandParatroopersTest {
     when(attacker.getAttachment(Constants.TECH_ATTACHMENT_NAME)).thenReturn(techAttachment);
     when(techAttachment.getParatroopers()).thenReturn(false);
     final BattleState battleState =
-        spy(givenBattleStateBuilder().battleRound(1).attacker(attacker).build());
+        givenBattleStateBuilder().battleRound(1).attacker(attacker).build();
     final LandParatroopers landParatroopers = new LandParatroopers(battleState, battleActions);
 
     assertThat(landParatroopers.getNames(), is(empty()));
 
     landParatroopers.execute(executionStack, delegateBridge);
-    verify(battleState, never()).removeDependentUnits(anyCollection());
+    verify(delegateBridge, never()).addChange(any(Change.class));
   }
 
   @Test
@@ -107,7 +106,7 @@ class LandParatroopersTest {
     assertThat(landParatroopers.getNames(), is(empty()));
 
     landParatroopers.execute(executionStack, delegateBridge);
-    verify(battleState, never()).removeDependentUnits(anyCollection());
+    verify(delegateBridge, never()).addChange(any(Change.class));
   }
 
   @Test
@@ -141,6 +140,5 @@ class LandParatroopersTest {
 
     landParatroopers.execute(executionStack, delegateBridge);
     verify(delegateBridge).addChange(any(Change.class));
-    verify(battleState).removeDependentUnits(airTransports);
   }
 }


### PR DESCRIPTION
AbstractBattle#dependentUnits appears to have been created back before
the transportBy property came into being. It was used to keep track of
transported units in the battle territory. It handled allied air craft
that couldn't participate, unload units in amphibious assaults, and
other transported units.

This adds a Unit#getTransporting(Territory) method that allows finding
transported units in the specified territory. Now, instead of tracking
the dependents per battle, the battle can instead ask if there are
transported units in the battle site.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->
* Global40 with allied aircraft. Verified both sinking of the carrier and retreating was handled.  The aircraft were destroyed in the former and retreated in the later.
* Global40 with lone transport with transported units into a scrambled zone.  The transport unloaded its cargo before the battle. Verified that the transport was destroyed and that the unloaded units were killed.
* Iron War with paratroopers.  Verified that if the transporting plane was shot down during the AA round, the paratroopers died with it.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->
Are there other transporting situations that I should test for?

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
