### PR TITLE
Pass GameMap instead of GameData for TerritoryAttachment methods

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -566,7 +566,6 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer {
     if (getPlayerBridge().isGameOver()) {
       return;
     }
-    final GameData data = getGameData();
     // play a sound for this phase
     final IAbstractForumPosterDelegate endTurnDelegate;
     try {
@@ -581,7 +580,8 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer {
       throw new IllegalStateException(errorContext, e);
     }
     if (!soundPlayedAlreadyEndTurn
-        && TerritoryAttachment.doWeHaveEnoughCapitalsToProduce(this.getGamePlayer(), data)) {
+        && TerritoryAttachment.doWeHaveEnoughCapitalsToProduce(
+            this.getGamePlayer(), getGameData().getMap())) {
       // do not play if we are reloading a savegame from pbem (gets annoying)
       if (!endTurnDelegate.getHasPostedTurnSummary()) {
         ClipPlayer.play(SoundPath.CLIP_PHASE_END_TURN, this.getGamePlayer());

--- a/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AbstractAi.java
@@ -340,7 +340,7 @@ public abstract class AbstractAi extends AbstractBasePlayer {
             unitChoices.stream().anyMatch(Matches.unitCanProduceUnits().negate());
         final Predicate<Unit> ownedFactories =
             Matches.unitCanProduceUnits().and(Matches.unitIsOwnedBy(me));
-        final List<Territory> capitals = TerritoryAttachment.getAllCapitals(me, data);
+        final List<Territory> capitals = TerritoryAttachment.getAllCapitals(me, data.getMap());
         final List<Territory> test = new ArrayList<>(capitals);
         test.retainAll(territoryChoices);
         final List<Territory> territoriesWithFactories =
@@ -422,7 +422,7 @@ public abstract class AbstractAi extends AbstractBasePlayer {
         }
       } else {
         // pick a not owned territory if possible
-        final List<Territory> capitals = TerritoryAttachment.getAllCapitals(me, data);
+        final List<Territory> capitals = TerritoryAttachment.getAllCapitals(me, data.getMap());
         final List<Territory> test = new ArrayList<>(capitals);
         test.retainAll(notOwned);
         if (!test.isEmpty()) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProData.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProData.java
@@ -69,7 +69,8 @@ public final class ProData {
       winPercentage = 90;
       minWinPercentage = 65;
     }
-    myCapital = TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
+    myCapital =
+        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data.getMap());
     myUnitTerritories =
         CollectionUtils.getMatches(
             data.getMap().getTerritories(), Matches.territoryHasUnitsOwnedBy(player));

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProRetreatAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProRetreatAi.java
@@ -102,7 +102,7 @@ class ProRetreatAi {
       Territory retreatTerritory = null;
       double maxStrength = Double.NEGATIVE_INFINITY;
       final Territory myCapital =
-          TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
+          TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data.getMap());
       for (final Territory t : possibleTerritories) {
         if (t.equals(myCapital)) {
           retreatTerritory = t;

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
@@ -42,7 +42,7 @@ final class ProTechAi {
       return;
     }
     final Territory myCapitol =
-        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
+        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data.getMap());
     final float enemyStrength = getStrengthOfPotentialAttackers(myCapitol, data, player);
     float myStrength =
         (myCapitol == null || myCapitol.getUnitCollection() == null)

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -199,7 +199,8 @@ public class ProTerritoryManager {
           // Make sure allies' capital isn't next to territory
           final GamePlayer alliedPlayer = alliedUnits.iterator().next().getOwner();
           final Territory capital =
-              TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(alliedPlayer, data);
+              TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(
+                  alliedPlayer, data.getMap());
           if (capital != null && !data.getMap().getNeighbors(capital).contains(t)) {
 
             // Get max enemy defenders

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
@@ -232,7 +232,7 @@ public final class ProSimulateTurnUtils {
     if (ta != null
         && ta.getCapital() != null
         && terrOrigOwner != null
-        && TerritoryAttachment.getAllCapitals(terrOrigOwner, data).contains(t)
+        && TerritoryAttachment.getAllCapitals(terrOrigOwner, data.getMap()).contains(t)
         && relationshipTracker.isAllied(terrOrigOwner, player)) {
 
       // Give capital and any allied territories back to original owner

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
@@ -135,7 +135,8 @@ public final class ProUtils {
     final List<Territory> enemyCapitals = new ArrayList<>();
     final List<GamePlayer> enemyPlayers = getEnemyPlayers(player);
     for (final GamePlayer otherPlayer : enemyPlayers) {
-      enemyCapitals.addAll(TerritoryAttachment.getAllCurrentlyOwnedCapitals(otherPlayer, data));
+      enemyCapitals.addAll(
+          TerritoryAttachment.getAllCurrentlyOwnedCapitals(otherPlayer, data.getMap()));
     }
     enemyCapitals.retainAll(
         CollectionUtils.getMatches(
@@ -153,7 +154,8 @@ public final class ProUtils {
     final List<Territory> capitals = new ArrayList<>();
     final List<GamePlayer> players = getAlliedPlayers(player);
     for (final GamePlayer alliedPlayer : players) {
-      capitals.addAll(TerritoryAttachment.getAllCurrentlyOwnedCapitals(alliedPlayer, data));
+      capitals.addAll(
+          TerritoryAttachment.getAllCurrentlyOwnedCapitals(alliedPlayer, data.getMap()));
     }
     capitals.retainAll(
         CollectionUtils.getMatches(

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/Utils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/Utils.java
@@ -69,7 +69,7 @@ final class Utils {
     for (final GamePlayer player :
         CollectionUtils.getMatches(data.getPlayerList().getPlayers(), Matches.isAtWar(us, data))) {
       for (final Territory capital :
-          TerritoryAttachment.getAllCurrentlyOwnedCapitals(player, data)) {
+          TerritoryAttachment.getAllCurrentlyOwnedCapitals(player, data.getMap())) {
         if (data.getMap().getDistance(t, capital, Matches.territoryIsLand()) != -1) {
           return true;
         }

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -65,7 +65,7 @@ public class WeakAi extends AbstractAi {
       return null;
     }
     final Territory ourCapitol =
-        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
+        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data.getMap());
     if (ourCapitol == null) {
       return null;
     }
@@ -94,7 +94,7 @@ public class WeakAi extends AbstractAi {
 
   private static boolean isAmphibAttack(final GamePlayer player, final GameData data) {
     final Territory capitol =
-        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
+        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data.getMap());
     // we dont own our own capitol
     if (capitol == null || !capitol.getOwner().equals(player)) {
       return false;
@@ -156,7 +156,7 @@ public class WeakAi extends AbstractAi {
       return List.of();
     }
     final Territory capitol =
-        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
+        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data.getMap());
     if (capitol == null || !capitol.getOwner().equals(player)) {
       return List.of();
     }
@@ -449,7 +449,8 @@ public class WeakAi extends AbstractAi {
       // find the nearest enemy owned capital
       for (final GamePlayer otherPlayer : data.getPlayerList().getPlayers()) {
         final Territory capitol =
-            TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(otherPlayer, data);
+            TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(
+                otherPlayer, data.getMap());
         if (capitol != null
             && !data.getRelationshipTracker().isAllied(player, capitol.getOwner())) {
           final Route route = data.getMap().getRoute(t, capitol, moveThrough);
@@ -803,7 +804,7 @@ public class WeakAi extends AbstractAi {
     final int totalPu = player.getResources().getQuantity(pus);
     int leftToSpend = totalPu;
     final @Nullable Territory capitol =
-        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
+        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data.getMap());
     final List<ProductionRule> rules = player.getProductionFrontier().getRules();
     final IntegerMap<ProductionRule> purchase = new IntegerMap<>();
     final List<RepairRule> repairRules;
@@ -1043,7 +1044,7 @@ public class WeakAi extends AbstractAi {
       return;
     }
     final @Nullable Territory capitol =
-        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data);
+        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data.getMap());
     if (capitol != null) {
       // place in capitol first
       placeAllWeCanOn(data, capitol, placeDelegate, player);

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -277,7 +277,7 @@ public class TerritoryAttachment extends DefaultAttachment {
     return capital != null;
   }
 
-  public String getCapital() {
+  public @Nullable String getCapital() {
     return capital;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -7,6 +7,7 @@ import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
 import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GameMap;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.MutableProperty;
 import games.strategy.engine.data.Resource;
@@ -61,10 +62,11 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   public static boolean doWeHaveEnoughCapitalsToProduce(
-      final GamePlayer player, final GameData data) {
-    final List<Territory> capitalsListOriginal = TerritoryAttachment.getAllCapitals(player, data);
+      final GamePlayer player, final GameMap gameMap) {
+    final List<Territory> capitalsListOriginal =
+        TerritoryAttachment.getAllCapitals(player, gameMap);
     final List<Territory> capitalsListOwned =
-        TerritoryAttachment.getAllCurrentlyOwnedCapitals(player, data);
+        TerritoryAttachment.getAllCurrentlyOwnedCapitals(player, gameMap);
     final PlayerAttachment pa = PlayerAttachment.get(player);
 
     if (pa == null) {
@@ -78,19 +80,15 @@ public class TerritoryAttachment extends DefaultAttachment {
    * we find that we don't own. If a capital has no neighbor connections, it will be sent last.
    */
   public static @Nullable Territory getFirstOwnedCapitalOrFirstUnownedCapital(
-      final GamePlayer player, final GameData data) {
+      final GamePlayer player, final GameMap gameMap) {
     final List<Territory> capitals = new ArrayList<>();
     final List<Territory> noNeighborCapitals = new ArrayList<>();
-    for (final Territory current : data.getMap().getTerritories()) {
+    for (final Territory current : gameMap.getTerritories()) {
       final TerritoryAttachment ta = TerritoryAttachment.get(current);
       if (ta != null && ta.getCapital() != null) {
-        final GamePlayer whoseCapital = data.getPlayerList().getPlayerId(ta.getCapital());
-        if (whoseCapital == null) {
-          throw new IllegalStateException("Invalid capital for player name:" + ta.getCapital());
-        }
-        if (player.equals(whoseCapital)) {
+        if (player.getName().equals(ta.getCapital())) {
           if (player.equals(current.getOwner())) {
-            if (!data.getMap().getNeighbors(current).isEmpty()) {
+            if (!gameMap.getNeighbors(current).isEmpty()) {
               return current;
             }
             noNeighborCapitals.add(current);
@@ -114,16 +112,12 @@ public class TerritoryAttachment extends DefaultAttachment {
   }
 
   /** will return empty list if none controlled, never returns null. */
-  public static List<Territory> getAllCapitals(final GamePlayer player, final GameData data) {
+  public static List<Territory> getAllCapitals(final GamePlayer player, final GameMap gameMap) {
     final List<Territory> capitals = new ArrayList<>();
-    for (final Territory current : data.getMap().getTerritories()) {
+    for (final Territory current : gameMap.getTerritories()) {
       final TerritoryAttachment ta = TerritoryAttachment.get(current);
       if (ta != null && ta.getCapital() != null) {
-        final GamePlayer whoseCapital = data.getPlayerList().getPlayerId(ta.getCapital());
-        if (whoseCapital == null) {
-          throw new IllegalStateException("Invalid capital for player name:" + ta.getCapital());
-        }
-        if (player.equals(whoseCapital)) {
+        if (player.getName().equals(ta.getCapital())) {
           capitals.add(current);
         }
       }
@@ -140,16 +134,12 @@ public class TerritoryAttachment extends DefaultAttachment {
 
   /** will return empty list if none controlled, never returns null. */
   public static List<Territory> getAllCurrentlyOwnedCapitals(
-      final GamePlayer player, final GameData data) {
+      final GamePlayer player, final GameMap gameMap) {
     final List<Territory> capitals = new ArrayList<>();
-    for (final Territory current : data.getMap().getTerritories()) {
+    for (final Territory current : gameMap.getTerritories()) {
       final TerritoryAttachment ta = TerritoryAttachment.get(current);
       if (ta != null && ta.getCapital() != null) {
-        final GamePlayer whoseCapital = data.getPlayerList().getPlayerId(ta.getCapital());
-        if (whoseCapital == null) {
-          throw new IllegalStateException("Invalid capital for player name:" + ta.getCapital());
-        }
-        if (player.equals(whoseCapital) && player.equals(current.getOwner())) {
+        if (player.getName().equals(ta.getCapital()) && player.equals(current.getOwner())) {
           capitals.add(current);
         }
       }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -51,8 +51,8 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate
   private boolean needToInitialize = true;
   private boolean hasPostedTurnSummary = false;
 
-  private static boolean canPlayerCollectIncome(final GamePlayer player, final GameData data) {
-    return TerritoryAttachment.doWeHaveEnoughCapitalsToProduce(player, data);
+  private static boolean canPlayerCollectIncome(final GamePlayer player, final GameMap gameMap) {
+    return TerritoryAttachment.doWeHaveEnoughCapitalsToProduce(player, gameMap);
   }
 
   /**
@@ -100,7 +100,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate
     hasPostedTurnSummary = false;
     final PlayerAttachment pa = PlayerAttachment.get(player);
     // can't collect unless you own your own capital
-    if (!canPlayerCollectIncome(player, data)) {
+    if (!canPlayerCollectIncome(player, data.getMap())) {
       endTurnReport.append(rollWarBondsForFriends(bridge, player, data));
       // we do not collect any income this turn
     } else {
@@ -328,7 +328,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate
       // if both are zero, then it must mean we did not share our war bonds tech with them, even
       // though we are sharing
       // all tech (because they cannot have this tech)
-      if (diceSides <= 0 && diceCount <= 0 && canPlayerCollectIncome(p, data)) {
+      if (diceSides <= 0 && diceCount <= 0 && canPlayerCollectIncome(p, data.getMap())) {
         giveWarBondsTo = p;
         break;
       }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -814,7 +814,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       return "Too many constructions in " + to.getName();
     }
     final List<Territory> capitalsListOwned =
-        TerritoryAttachment.getAllCurrentlyOwnedCapitals(player, getData());
+        TerritoryAttachment.getAllCurrentlyOwnedCapitals(player, getData().getMap());
     if (!capitalsListOwned.contains(to) && isPlacementInCapitalRestricted(player)) {
       return "Cannot place these units outside of the capital";
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -147,23 +147,23 @@ public class EndRoundDelegate extends BaseTripleADelegate {
     }
     // Quick check to see who still owns their own capital
     final boolean russia =
-        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(russians, data)
+        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(russians, data.getMap())
             .getOwner()
             .equals(russians);
     final boolean germany =
-        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(germans, data)
+        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(germans, data.getMap())
             .getOwner()
             .equals(germans);
     final boolean britain =
-        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(british, data)
+        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(british, data.getMap())
             .getOwner()
             .equals(british);
     final boolean japan =
-        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(japanese, data)
+        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(japanese, data.getMap())
             .getOwner()
             .equals(japanese);
     final boolean america =
-        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(americans, data)
+        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(americans, data.getMap())
             .getOwner()
             .equals(americans);
     int count = 0;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1611,7 +1611,8 @@ public final class Matches {
         boolean atLeastOnePlayerOwnsCapital = false;
         for (final GamePlayer player : players) {
           final boolean ownCapital =
-              TerritoryAttachment.doWeHaveEnoughCapitalsToProduce(player, damagedUnit.getData());
+              TerritoryAttachment.doWeHaveEnoughCapitalsToProduce(
+                  player, damagedUnit.getData().getMap());
           atLeastOnePlayerOwnsCapital = atLeastOnePlayerOwnsCapital || ownCapital;
           if (!ownCapital && territoryOfRepairUnit.getOwner().equals(player)) {
             return false;
@@ -1624,7 +1625,7 @@ public final class Matches {
 
         // Damaged units can only be repaired by facilities if the unit owner controls their capital
         if (!TerritoryAttachment.doWeHaveEnoughCapitalsToProduce(
-            damagedUnit.getOwner(), damagedUnit.getData())) {
+            damagedUnit.getOwner(), damagedUnit.getData().getMap())) {
           return false;
         }
       }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -134,7 +134,7 @@ public class PurchaseDelegate extends BaseTripleADelegate
     }
     // if my capital is captured, I can't produce, but I may have PUs if I captured someone else's
     // capital
-    return TerritoryAttachment.doWeHaveEnoughCapitalsToProduce(player, getData());
+    return TerritoryAttachment.doWeHaveEnoughCapitalsToProduce(player, getData().getMap());
   }
 
   protected boolean canWePurchaseOrRepair() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TechnologyDelegate.java
@@ -125,7 +125,7 @@ public class TechnologyDelegate extends BaseTripleADelegate implements ITechDele
     if (!Properties.getTechDevelopment(getData().getProperties())) {
       return false;
     }
-    if (!TerritoryAttachment.doWeHaveEnoughCapitalsToProduce(player, getData())) {
+    if (!TerritoryAttachment.doWeHaveEnoughCapitalsToProduce(player, getData().getMap())) {
       return false;
     }
     if (Properties.getWW2V3TechModel(getData().getProperties())) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/TwoIfBySeaEndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/TwoIfBySeaEndTurnDelegate.java
@@ -24,11 +24,11 @@ public class TwoIfBySeaEndTurnDelegate extends AbstractEndTurnDelegate {
     final GamePlayer japanese = playerList.getPlayerId(Constants.PLAYER_NAME_JAPANESE);
     // Quick check to see who still owns their own capital
     final boolean britain =
-        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(british, data)
+        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(british, data.getMap())
             .getOwner()
             .equals(british);
     final boolean japan =
-        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(japanese, data)
+        TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(japanese, data.getMap())
             .getOwner()
             .equals(japanese);
     if (!gameOver) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -684,7 +684,7 @@ public class BattleTracker implements Serializable {
       final PlayerAttachment pa = PlayerAttachment.get(gamePlayer);
       final PlayerAttachment paWhoseCapital = PlayerAttachment.get(whoseCapital);
       final List<Territory> capitalsList =
-          TerritoryAttachment.getAllCurrentlyOwnedCapitals(whoseCapital, data);
+          TerritoryAttachment.getAllCurrentlyOwnedCapitals(whoseCapital, data.getMap());
       // we are losing one right now, so it is < not <=
       if (paWhoseCapital != null && paWhoseCapital.getRetainCapitalNumber() < capitalsList.size()) {
         // do nothing, we keep our money since we still control enough capitals
@@ -765,12 +765,13 @@ public class BattleTracker implements Serializable {
         && relationshipTracker.isAllied(terrOrigOwner, gamePlayer)
         && !terrOrigOwner.equals(territory.getOwner())) {
       final List<Territory> capitalsListOwned =
-          TerritoryAttachment.getAllCurrentlyOwnedCapitals(terrOrigOwner, data);
+          TerritoryAttachment.getAllCurrentlyOwnedCapitals(terrOrigOwner, data.getMap());
       if (!capitalsListOwned.isEmpty()) {
         newOwner = terrOrigOwner;
       } else {
         newOwner = gamePlayer;
-        for (final Territory current : TerritoryAttachment.getAllCapitals(terrOrigOwner, data)) {
+        for (final Territory current :
+            TerritoryAttachment.getAllCapitals(terrOrigOwner, data.getMap())) {
           if (territory.equals(current) || current.getOwner().equals(GamePlayer.NULL_PLAYERID)) {
             // if a neutral controls our capital, our territories get liberated (ie: china in ww2v3)
             newOwner = terrOrigOwner;
@@ -855,7 +856,7 @@ public class BattleTracker implements Serializable {
     if (isTerritoryOwnerAnEnemy
         && terrOrigOwner != null
         && ta.getCapital() != null
-        && TerritoryAttachment.getAllCapitals(terrOrigOwner, data).contains(territory)
+        && TerritoryAttachment.getAllCapitals(terrOrigOwner, data.getMap()).contains(territory)
         && relationshipTracker.isAllied(terrOrigOwner, gamePlayer)) {
       // if it is give it back to the original owner
       final Collection<Territory> originallyOwned =

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1938,7 +1938,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
                     try {
                       mapPanel.centerOn(
                           TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(
-                              player, data));
+                              player, data.getMap()));
                     } finally {
                       data.releaseReadLock();
                     }


### PR DESCRIPTION
The four static methods in TerritoryAttachment that are related with
capitals don't need the entire GameData. They only need the GameMap.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->
I came across this while looking at the AI code.

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
