### PR TITLE
Fix load-sample-data-script, provide postgres user password

### DIFF
--- a/database/load_sample_data
+++ b/database/load_sample_data
@@ -5,5 +5,7 @@ bold_green="${bold}\e[32m"
 normal="\e[0m"
 
 echo -e "[${bold_green}Inserting sample data${normal}]"
-psql -h localhost -U lobby_user lobby_db \
+
+export PGPASSWORD=postgres
+psql -h localhost -U postgres lobby_db \
     < "$(dirname "$0")/sql/sample_data/lobby_db_sample_data.sql"


### PR DESCRIPTION
The script asked for a password, looks like there is a missing update.
To fix, add a pg-password variable that provides the postgres user
password and log in as the postgres user. After this update
the script runs again.

