### PR TITLE
Fix integ tests non-determinism, need to set DB data

### DIFF
--- a/lobby-server/src/test/java/org/triplea/modules/moderation/chat/history/GameChatHistoryControllerIntegrationTest.java
+++ b/lobby-server/src/test/java/org/triplea/modules/moderation/chat/history/GameChatHistoryControllerIntegrationTest.java
@@ -1,11 +1,14 @@
 package org.triplea.modules.moderation.chat.history;
 
+import com.github.database.rider.core.api.dataset.DataSet;
 import java.net.URI;
 import org.junit.jupiter.api.Test;
 import org.triplea.http.client.lobby.moderator.ModeratorChatClient;
 import org.triplea.modules.http.AllowedUserRole;
+import org.triplea.modules.http.LobbyServerTest;
 import org.triplea.modules.http.ProtectedEndpointTest;
 
+@DataSet(value = LobbyServerTest.LOBBY_USER_DATASET, useSequenceFiltering = false)
 class GameChatHistoryControllerIntegrationTest extends ProtectedEndpointTest<ModeratorChatClient> {
 
   GameChatHistoryControllerIntegrationTest(final URI localhost) {

--- a/lobby-server/src/test/java/org/triplea/modules/moderation/disconnect/user/DisconnectUserControllerIntegrationTest.java
+++ b/lobby-server/src/test/java/org/triplea/modules/moderation/disconnect/user/DisconnectUserControllerIntegrationTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
+import com.github.database.rider.core.api.dataset.DataSet;
 import java.net.URI;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,8 +12,10 @@ import org.triplea.domain.data.PlayerChatId;
 import org.triplea.http.client.HttpInteractionException;
 import org.triplea.http.client.lobby.moderator.ModeratorChatClient;
 import org.triplea.modules.http.AllowedUserRole;
+import org.triplea.modules.http.LobbyServerTest;
 import org.triplea.modules.http.ProtectedEndpointTest;
 
+@DataSet(value = LobbyServerTest.LOBBY_USER_DATASET, useSequenceFiltering = false)
 class DisconnectUserControllerIntegrationTest extends ProtectedEndpointTest<ModeratorChatClient> {
 
   private static final PlayerChatId CHAT_ID = PlayerChatId.of("chat-id");

--- a/lobby-server/src/test/java/org/triplea/modules/moderation/mute/user/MuteUserControllerIntegrationTest.java
+++ b/lobby-server/src/test/java/org/triplea/modules/moderation/mute/user/MuteUserControllerIntegrationTest.java
@@ -1,12 +1,15 @@
 package org.triplea.modules.moderation.mute.user;
 
+import com.github.database.rider.core.api.dataset.DataSet;
 import java.net.URI;
 import org.junit.jupiter.api.Test;
 import org.triplea.domain.data.PlayerChatId;
 import org.triplea.http.client.lobby.moderator.ModeratorChatClient;
 import org.triplea.modules.http.AllowedUserRole;
+import org.triplea.modules.http.LobbyServerTest;
 import org.triplea.modules.http.ProtectedEndpointTest;
 
+@DataSet(value = LobbyServerTest.LOBBY_USER_DATASET, useSequenceFiltering = false)
 class MuteUserControllerIntegrationTest extends ProtectedEndpointTest<ModeratorChatClient> {
 
   MuteUserControllerIntegrationTest(final URI localhost) {


### PR DESCRIPTION
It is odd these tests were not failing all the time as we do clear data
between tests. This update fixes tests that failed consistently when
run on their own as they were missing a DB-data setup step.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
