### PR TITLE
Add the player types to the headless Injections

### DIFF
--- a/game-headless/build.gradle
+++ b/game-headless/build.gradle
@@ -11,6 +11,7 @@ description = 'TripleA Headless Game Server'
 mainClassName = 'org.triplea.game.server.HeadlessGameRunner'
 
 dependencies {
+    implementation project(":ai")
     implementation project(':game-core')
     implementation project(':java-extras')
 }

--- a/game-headless/src/main/java/org/triplea/game/server/HeadlessGameRunner.java
+++ b/game-headless/src/main/java/org/triplea/game/server/HeadlessGameRunner.java
@@ -1,13 +1,10 @@
 package org.triplea.game.server;
 
 import games.strategy.engine.framework.startup.ui.PlayerTypes;
-import games.strategy.triplea.ai.AiProvider;
 import java.util.Collection;
 import java.util.List;
-import java.util.ServiceLoader;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import java.util.stream.StreamSupport;
 import org.triplea.ai.does.nothing.DoesNothingAiProvider;
 import org.triplea.config.product.ProductVersionReader;
 import org.triplea.injection.Injections;
@@ -35,10 +32,7 @@ public final class HeadlessGameRunner {
   private static Collection<PlayerTypes.Type> gatherPlayerTypes() {
     return Stream.of(
             PlayerTypes.getBuiltInPlayerTypes(),
-            List.of(new PlayerTypes.AiType(new DoesNothingAiProvider())),
-            StreamSupport.stream(ServiceLoader.load(AiProvider.class).spliterator(), false)
-                .map(PlayerTypes.AiType::new)
-                .collect(Collectors.toSet()))
+            List.of(new PlayerTypes.AiType(new DoesNothingAiProvider())))
         .flatMap(Collection::stream)
         .collect(Collectors.toList());
   }

--- a/game-headless/src/main/java/org/triplea/game/server/HeadlessGameRunner.java
+++ b/game-headless/src/main/java/org/triplea/game/server/HeadlessGameRunner.java
@@ -1,5 +1,14 @@
 package org.triplea.game.server;
 
+import games.strategy.engine.framework.startup.ui.PlayerTypes;
+import games.strategy.triplea.ai.AiProvider;
+import java.util.Collection;
+import java.util.List;
+import java.util.ServiceLoader;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+import org.triplea.ai.does.nothing.DoesNothingAiProvider;
 import org.triplea.config.product.ProductVersionReader;
 import org.triplea.injection.Injections;
 
@@ -17,6 +26,20 @@ public final class HeadlessGameRunner {
   }
 
   private static Injections constructInjections() {
-    return Injections.builder().engineVersion(new ProductVersionReader().getVersion()).build();
+    return Injections.builder()
+        .engineVersion(new ProductVersionReader().getVersion())
+        .playerTypes(gatherPlayerTypes())
+        .build();
+  }
+
+  private static Collection<PlayerTypes.Type> gatherPlayerTypes() {
+    return Stream.of(
+            PlayerTypes.getBuiltInPlayerTypes(),
+            List.of(new PlayerTypes.AiType(new DoesNothingAiProvider())),
+            StreamSupport.stream(ServiceLoader.load(AiProvider.class).spliterator(), false)
+                .map(PlayerTypes.AiType::new)
+                .collect(Collectors.toSet()))
+        .flatMap(Collection::stream)
+        .collect(Collectors.toList());
   }
 }

--- a/game-headless/src/main/java/org/triplea/game/server/HeadlessGameRunner.java
+++ b/game-headless/src/main/java/org/triplea/game/server/HeadlessGameRunner.java
@@ -1,7 +1,6 @@
 package org.triplea.game.server;
 
 import games.strategy.engine.framework.startup.ui.PlayerTypes;
-import java.util.Collection;
 import org.triplea.config.product.ProductVersionReader;
 import org.triplea.injection.Injections;
 
@@ -21,11 +20,8 @@ public final class HeadlessGameRunner {
   private static Injections constructInjections() {
     return Injections.builder()
         .engineVersion(new ProductVersionReader().getVersion())
-        .playerTypes(gatherPlayerTypes())
+        .playerTypes(PlayerTypes.getBuiltInPlayerTypes())
         .build();
   }
 
-  private static Collection<PlayerTypes.Type> gatherPlayerTypes() {
-    return PlayerTypes.getBuiltInPlayerTypes();
-  }
 }

--- a/game-headless/src/main/java/org/triplea/game/server/HeadlessGameRunner.java
+++ b/game-headless/src/main/java/org/triplea/game/server/HeadlessGameRunner.java
@@ -2,10 +2,6 @@ package org.triplea.game.server;
 
 import games.strategy.engine.framework.startup.ui.PlayerTypes;
 import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import org.triplea.ai.does.nothing.DoesNothingAiProvider;
 import org.triplea.config.product.ProductVersionReader;
 import org.triplea.injection.Injections;
 
@@ -30,10 +26,6 @@ public final class HeadlessGameRunner {
   }
 
   private static Collection<PlayerTypes.Type> gatherPlayerTypes() {
-    return Stream.of(
-            PlayerTypes.getBuiltInPlayerTypes(),
-            List.of(new PlayerTypes.AiType(new DoesNothingAiProvider())))
-        .flatMap(Collection::stream)
-        .collect(Collectors.toList());
+    return PlayerTypes.getBuiltInPlayerTypes();
   }
 }


### PR DESCRIPTION
<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->
Started a headless game bot, started lobby, started headed game.  Connected to the local lobby and connected to the headless game.  Before this change, it would throw errors about unknown player types.  Now it works.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->
I don't generally play in the lobby but it feels like the headless bots have changed behavior.  Now, when I loaded the bot, it immediately started the game with all players using the AI.  I reverted the code to before the introduction of the "ai" project and it still is acting like that.  I'm going to look back further to see if there is a change in behavior.  But that would be fixed in a different PR, if there is a fix needed.

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
