### PR TITLE
Correctly detect headless case when building list of players in headless

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -321,7 +321,7 @@ public class ServerModel extends Observable implements IConnectionChangeListener
         playerNamesAndAlliancesInTurnOrder = new LinkedHashMap<>();
         for (final GamePlayer player : data.getPlayerList().getPlayers()) {
           final String name = player.getName();
-          if (!HeadlessGameServer.headless()) {
+          if (HeadlessGameServer.headless()) {
             if (player.getIsDisabled()) {
               playersToNodeListing.put(name, messengers.getLocalNode().getName());
               localPlayerTypes.put(name, PlayerTypes.WEAK_AI);


### PR DESCRIPTION
Commit 443d3662c69b8bfaaaa5bb1e6a7e93a9da55fd6e had a small typo when it
converted "ui == null" to "HeadlessGameServer.headless()". It added a
'!' to one of the conversions which forced all factions in a headless bot
to be the weak ai. You couldn't select a faction to play.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->
You can't actually test this until https://github.com/triplea-game/triplea/pull/8485 is merged.  I tested it by going back to commit 443d3662c69b8bfaaaa5bb1e6a7e93a9da55fd6e and fixing it there.  I had discovered that the issue occurred between commit 6c91f4985 and commit 443d3662c (the commit in between doesn't build).

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
