### PR TITLE
Remove check to skip downloading already installed maps, this breaks map updates

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -78,8 +78,6 @@ public class DownloadMapsWindow extends JFrame {
       findMap(mapName, allDownloads)
           .ifPresentOrElse(pendingDownloads::add, () -> unknownMapNames.add(mapName));
     }
-    final Collection<String> installedMapNames = removeInstalledDownloads(pendingDownloads);
-
     if (!pendingDownloads.isEmpty()) {
       progressPanel.download(pendingDownloads);
     }
@@ -90,9 +88,8 @@ public class DownloadMapsWindow extends JFrame {
             .map(DownloadFile::getDownload)
             .collect(Collectors.toList()));
 
-    if (!unknownMapNames.isEmpty() || !installedMapNames.isEmpty()) {
-      SwingComponents.newMessageDialog(
-          formatIgnoredPendingMapsMessage(unknownMapNames, installedMapNames));
+    if (!unknownMapNames.isEmpty()) {
+      SwingComponents.newMessageDialog(formatIgnoredPendingMapsMessage(unknownMapNames));
     }
 
     final Optional<String> selectedMapName = pendingDownloadMapNames.stream().findFirst();
@@ -261,19 +258,7 @@ public class DownloadMapsWindow extends JFrame {
     }
   }
 
-  private static Collection<String> removeInstalledDownloads(
-      final Collection<DownloadFileDescription> downloads) {
-    final MapDownloadList mapList = new MapDownloadList(downloads);
-    final Collection<DownloadFileDescription> installedDownloads =
-        downloads.stream().filter(mapList::isInstalled).collect(Collectors.toList());
-    downloads.removeAll(installedDownloads);
-    return installedDownloads.stream()
-        .map(DownloadFileDescription::getMapName)
-        .collect(Collectors.toList());
-  }
-
-  private static String formatIgnoredPendingMapsMessage(
-      final Collection<String> unknownMapNames, final Collection<String> installedMapNames) {
+  private static String formatIgnoredPendingMapsMessage(final Collection<String> unknownMapNames) {
     final StringBuilder sb = new StringBuilder();
     sb.append("<html>");
     sb.append("Some maps were not downloaded.<br>");
@@ -283,16 +268,6 @@ public class DownloadMapsWindow extends JFrame {
       sb.append("Could not find the following map(s):<br>");
       sb.append("<ul>");
       for (final String mapName : unknownMapNames) {
-        sb.append("<li>").append(mapName).append("</li>");
-      }
-      sb.append("</ul>");
-    }
-
-    if (!installedMapNames.isEmpty()) {
-      sb.append("<br>");
-      sb.append("The following map(s) are already installed:<br>");
-      sb.append("<ul>");
-      for (final String mapName : installedMapNames) {
         sb.append("<li>").append(mapName).append("</li>");
       }
       sb.append("</ul>");

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadList.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadList.java
@@ -66,8 +66,4 @@ class MapDownloadList {
       final Collection<DownloadFileDescription> excluded) {
     return outOfDate.stream().filter(not(excluded::contains)).collect(Collectors.toList());
   }
-
-  boolean isInstalled(final DownloadFileDescription download) {
-    return installed.contains(download);
-  }
 }

--- a/game-core/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListTest.java
@@ -126,13 +126,4 @@ class MapDownloadListTest extends AbstractClientSettingTestCase {
 
     assertThat(outOfDate, is(List.of(download2)));
   }
-
-  @Test
-  void testIsInstalled() {
-    when(strategy.getMapVersion(any())).thenReturn(Optional.of(MAP_VERSION));
-    final MapDownloadList testObj = new MapDownloadList(descriptions, strategy);
-
-    assertThat(testObj.isInstalled(TEST_MAP), is(true));
-    assertThat(testObj.isInstalled(newDownloadWithUrl("url1")), is(false));
-  }
 }


### PR DESCRIPTION
When we instantiate a download window with a list of maps to install, these could
be maps that we wish to update. They will be detected as installed, there is logic
that will skip downloading already installed maps, which breaks this flow.

To fix the update map flow, this check for maps that are already installed is removed.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
- Tested as part of: https://github.com/triplea-game/triplea/pull/8493
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Downloading updated maps will now properly update and not report that the map is already installed.<!--END_RELEASE_NOTE-->
