### PR TITLE
CodeClimate: Increase file line count and cognitive complexity thresholds

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -9,10 +9,13 @@ checks:
       threshold: 5
   method-complexity:
     config:
-      threshold: 7
+      threshold: 25 
   method-lines:
     config:
       threshold: 50
+  file-lines:
+    config:
+      threshold: 1000
   similar-code:
     config:
       threshold: 80


### PR DESCRIPTION
This update sets the threshold values for line count and cognitive
complexity to be relatively extreme values. This is to avoid
false positives with either metric such that if the metric fails
we can really pay attention to it and have it flag the cases where
we really would want a fix.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
