### PR TITLE
Move some matches to use relationshiptracker instead of game state

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -558,7 +558,7 @@ class ProNonCombatMoveAi {
             data.getMap().getNeighbors(t, Matches.territoryIsLand());
         for (final Territory neighbor : landNeighbors) {
           double neighborProduction = TerritoryAttachment.getProduction(neighbor);
-          if (Matches.isTerritoryAllied(player, data).test(neighbor)) {
+          if (Matches.isTerritoryAllied(player, data.getRelationshipTracker()).test(neighbor)) {
             neighborProduction = 0.1 * neighborProduction;
           }
           neighborValue += neighborProduction;

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
@@ -238,7 +238,9 @@ final class ProTechAi {
               availOther += other;
             }
             final Set<Territory> transNeighbors =
-                data.getMap().getNeighbors(t4, Matches.isTerritoryAllied(enemyPlayer, data));
+                data.getMap()
+                    .getNeighbors(
+                        t4, Matches.isTerritoryAllied(enemyPlayer, data.getRelationshipTracker()));
             for (final Territory transNeighbor : transNeighbors) {
               final List<Unit> transUnits =
                   transNeighbor.getUnitCollection().getMatches(enemyTransportable);
@@ -504,7 +506,7 @@ final class ProTechAi {
           q.add(neighbor);
           distance.put(neighbor, distance.getInt(current) + 1);
           if (lz == null
-              && Matches.isTerritoryAllied(player, data).test(neighbor)
+              && Matches.isTerritoryAllied(player, data.getRelationshipTracker()).test(neighbor)
               && !neighbor.isWater()) {
             lz = neighbor;
           }
@@ -593,7 +595,7 @@ final class ProTechAi {
     final List<Territory> territories = new ArrayList<>();
     final List<Territory> checkList = getExactNeighbors(check, data);
     for (final Territory t : checkList) {
-      if (Matches.isTerritoryAllied(player, data).test(t)
+      if (Matches.isTerritoryAllied(player, data.getRelationshipTracker()).test(t)
           && Matches.territoryIsNotImpassableToLandUnits(player, data.getProperties()).test(t)) {
         territories.add(t);
       }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -669,7 +669,7 @@ public class ProTerritoryManager {
         moveMap,
         unitMoveMap,
         landRoutesMap,
-        Matches.isTerritoryAllied(player, data),
+        Matches.isTerritoryAllied(player, data.getRelationshipTracker()),
         new ArrayList<>(),
         clearedTerritories,
         false,
@@ -695,7 +695,7 @@ public class ProTerritoryManager {
         moveMap,
         transportMapList,
         landRoutesMap,
-        Matches.isTerritoryAllied(player, data),
+        Matches.isTerritoryAllied(player, data.getRelationshipTracker()),
         false,
         isCheckingEnemyAttacks,
         false);
@@ -710,7 +710,8 @@ public class ProTerritoryManager {
     final List<Map<Territory, ProTerritory>> enemyMoveMaps = new ArrayList<>();
     final List<Territory> clearedTerritories =
         CollectionUtils.getMatches(
-            data.getMap().getTerritories(), Matches.isTerritoryAllied(player, data));
+            data.getMap().getTerritories(),
+            Matches.isTerritoryAllied(player, data.getRelationshipTracker()));
 
     // Loop through each enemy to determine the maximum number of enemy units that can defend each
     // territory

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -1002,7 +1002,8 @@ public class ProTerritoryManager {
         }
       }
       for (final Territory t : data.getMap().getTerritories()) {
-        if (t.getUnitCollection().anyMatch(Matches.unitIsAlliedCarrier(player, data))) {
+        if (t.getUnitCollection()
+            .anyMatch(Matches.unitIsAlliedCarrier(player, data.getRelationshipTracker()))) {
           possibleCarrierTerritories.add(t);
         }
       }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
@@ -241,7 +241,8 @@ public final class ProSimulateTurnUtils {
           OriginalOwnerTracker.getOriginallyOwned(data, terrOrigOwner);
       final List<Territory> friendlyTerritories =
           CollectionUtils.getMatches(
-              originallyOwned, Matches.isTerritoryAllied(terrOrigOwner, data));
+              originallyOwned,
+              Matches.isTerritoryAllied(terrOrigOwner, data.getRelationshipTracker()));
       friendlyTerritories.add(t);
       for (final Territory item : friendlyTerritories) {
         if (item.getOwner().equals(terrOrigOwner)) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -122,7 +122,7 @@ public final class ProMatches {
 
   public static Predicate<Territory> territoryCanMoveLandUnitsAndIsAllied(
       final GamePlayer player, final GameState data) {
-    return Matches.isTerritoryAllied(player, data)
+    return Matches.isTerritoryAllied(player, data.getRelationshipTracker())
         .and(territoryCanMoveLandUnits(player, data, false));
   }
 
@@ -138,7 +138,7 @@ public final class ProMatches {
           && Matches.unitCanBlitz().test(u)
           && TerritoryEffectHelper.unitKeepsBlitz(u, startTerritory)) {
         final Predicate<Territory> alliedWithNoEnemiesMatch =
-            Matches.isTerritoryAllied(player, data)
+            Matches.isTerritoryAllied(player, data.getRelationshipTracker())
                 .and(Matches.territoryHasNoEnemyUnits(player, data));
         final Predicate<Territory> alliedOrBlitzableMatch =
             alliedWithNoEnemiesMatch.or(territoryIsBlitzable(player, data, u));
@@ -148,7 +148,7 @@ public final class ProMatches {
             .test(t);
       }
       return ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u)
-          .and(Matches.isTerritoryAllied(player, data))
+          .and(Matches.isTerritoryAllied(player, data.getRelationshipTracker()))
           .and(Matches.territoryHasNoEnemyUnits(player, data))
           .and(Matches.territoryIsInList(enemyTerritories).negate())
           .test(t);
@@ -164,12 +164,13 @@ public final class ProMatches {
       final List<Territory> blockedTerritories,
       final List<Territory> clearedTerritories) {
     Predicate<Territory> alliedMatch =
-        Matches.isTerritoryAllied(player, data).or(Matches.territoryIsInList(clearedTerritories));
+        Matches.isTerritoryAllied(player, data.getRelationshipTracker())
+            .or(Matches.territoryIsInList(clearedTerritories));
     if (isCombatMove
         && Matches.unitCanBlitz().test(u)
         && TerritoryEffectHelper.unitKeepsBlitz(u, startTerritory)) {
       alliedMatch =
-          Matches.isTerritoryAllied(player, data)
+          Matches.isTerritoryAllied(player, data.getRelationshipTracker())
               .or(Matches.territoryIsInList(clearedTerritories))
               .or(territoryIsBlitzable(player, data, u));
     }
@@ -342,7 +343,7 @@ public final class ProMatches {
       final GamePlayer player, final GameState data) {
     final Predicate<Unit> infraFactoryMatch =
         Matches.unitCanProduceUnits().and(Matches.unitIsInfrastructure());
-    return Matches.isTerritoryAllied(player, data)
+    return Matches.isTerritoryAllied(player, data.getRelationshipTracker())
         .and(Matches.territoryIsLand())
         .and(Matches.territoryHasUnitsThatMatch(infraFactoryMatch));
   }
@@ -370,7 +371,8 @@ public final class ProMatches {
   static Predicate<Territory> territoryIsAlliedLandAndHasNoEnemyNeighbors(
       final GamePlayer player, final GameState data) {
     final Predicate<Territory> alliedLand =
-        territoryCanMoveLandUnits(player, data, false).and(Matches.isTerritoryAllied(player, data));
+        territoryCanMoveLandUnits(player, data, false)
+            .and(Matches.isTerritoryAllied(player, data.getRelationshipTracker()));
     final Predicate<Territory> hasNoEnemyNeighbors =
         Matches.territoryHasNeighborMatching(
                 data, ProMatches.territoryIsEnemyNotNeutralLand(player, data))
@@ -406,7 +408,9 @@ public final class ProMatches {
   public static Predicate<Territory> territoryIsEnemyNotNeutralOrAllied(
       final GamePlayer player, final GameState data) {
     return territoryIsEnemyNotNeutralLand(player, data)
-        .or(Matches.territoryIsLand().and(Matches.isTerritoryAllied(player, data)));
+        .or(
+            Matches.territoryIsLand()
+                .and(Matches.isTerritoryAllied(player, data.getRelationshipTracker())));
   }
 
   public static Predicate<Territory> territoryIsEnemyOrCantBeHeld(

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -161,7 +161,7 @@ public final class ProTerritoryValueUtils {
             nearbyEnemySeaUnitValue +=
                 nearbyEnemySeaTerritory
                         .getUnitCollection()
-                        .countMatches(Matches.unitIsEnemyOf(data, player))
+                        .countMatches(Matches.unitIsEnemyOf(data.getRelationshipTracker(), player))
                     / Math.pow(2, distance);
           }
         }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
@@ -162,7 +162,8 @@ public final class ProUtils {
         CollectionUtils.getMatches(
             capitals, Matches.territoryIsNotImpassableToLandUnits(player, data.getProperties())));
     capitals.retainAll(
-        CollectionUtils.getMatches(capitals, Matches.isTerritoryAllied(player, data)));
+        CollectionUtils.getMatches(
+            capitals, Matches.isTerritoryAllied(player, data.getRelationshipTracker())));
     return capitals;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -500,7 +500,7 @@ public class WeakAi extends AbstractBuiltInAi {
     // this works because we are on the server
     final BattleDelegate delegate = DelegateFinder.battleDelegate(data);
     final Predicate<Territory> canLand =
-        Matches.isTerritoryAllied(player, data)
+        Matches.isTerritoryAllied(player, data.getRelationshipTracker())
             .and(o -> !delegate.getBattleTracker().wasConquered(o));
     final Predicate<Territory> routeCondition =
         Matches.territoryHasEnemyAaForFlyOver(player, data)

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AirThatCantLandUtil.java
@@ -46,7 +46,9 @@ public class AirThatCantLandUtil {
       final Collection<Unit> air = current.getUnitCollection().getMatches(ownedAir);
       final boolean hasNeighboringFriendlyFactory =
           map.getNeighbors(
-                      current, Matches.territoryHasAlliedIsFactoryOrCanProduceUnits(data, player))
+                      current,
+                      Matches.territoryHasAlliedIsFactoryOrCanProduceUnits(
+                          data.getRelationshipTracker(), player))
                   .size()
               > 0;
       final boolean skip =

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -966,9 +966,9 @@ public final class Matches {
   }
 
   static Predicate<Territory> territoryHasAlliedIsFactoryOrCanProduceUnits(
-      final GameState data, final GamePlayer player) {
+      final RelationshipTracker relationshipTracker, final GamePlayer player) {
     return t ->
-        isTerritoryAllied(player, data.getRelationshipTracker()).test(t)
+        isTerritoryAllied(player, relationshipTracker).test(t)
             && t.getUnitCollection().anyMatch(unitCanProduceUnits());
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -245,8 +245,9 @@ public final class Matches {
     return unit -> UnitAttachment.get(unit.getType()).getDefense(unit.getOwner()) >= defendValue;
   }
 
-  public static Predicate<Unit> unitIsEnemyOf(final GameState data, final GamePlayer player) {
-    return unit -> data.getRelationshipTracker().isAtWar(unit.getOwner(), player);
+  public static Predicate<Unit> unitIsEnemyOf(
+      final RelationshipTracker relationshipTracker, final GamePlayer player) {
+    return unit -> relationshipTracker.isAtWar(unit.getOwner(), player);
   }
 
   public static Predicate<Unit> unitIsNotSea() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -968,7 +968,7 @@ public final class Matches {
   static Predicate<Territory> territoryHasAlliedIsFactoryOrCanProduceUnits(
       final GameState data, final GamePlayer player) {
     return t ->
-        isTerritoryAllied(player, data).test(t)
+        isTerritoryAllied(player, data.getRelationshipTracker()).test(t)
             && t.getUnitCollection().anyMatch(unitCanProduceUnits());
   }
 
@@ -1244,8 +1244,8 @@ public final class Matches {
   }
 
   public static Predicate<Territory> isTerritoryAllied(
-      final GamePlayer player, final GameState data) {
-    return t -> data.getRelationshipTracker().isAllied(player, t.getOwner());
+      final GamePlayer player, final RelationshipTracker relationshipTracker) {
+    return t -> relationshipTracker.isAllied(player, t.getOwner());
   }
 
   public static Predicate<Territory> isTerritoryOwnedBy(final GamePlayer player) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -558,10 +558,11 @@ public final class Matches {
     return t -> t.getUnitCollection().anyMatch(unitIsOwnedBy(player).and(unitIsCarrier()));
   }
 
-  public static Predicate<Unit> unitIsAlliedCarrier(final GamePlayer player, final GameState data) {
+  public static Predicate<Unit> unitIsAlliedCarrier(
+      final GamePlayer player, final RelationshipTracker relationshipTracker) {
     return unit ->
         UnitAttachment.get(unit.getType()).getCarrierCapacity() != -1
-            && data.getRelationshipTracker().isAllied(player, unit.getOwner());
+            && relationshipTracker.isAllied(player, unit.getOwner());
   }
 
   public static Predicate<Unit> unitCanBeTransported() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -387,7 +387,9 @@ public class MovePerformer implements Serializable {
         && GameStepPropertiesHelper.isNonCombatMove(data, false)
         && routeEnd
             .getUnitCollection()
-            .anyMatch(Matches.unitIsEnemyOf(data, gamePlayer).and(Matches.unitIsDestroyer()))) {
+            .anyMatch(
+                Matches.unitIsEnemyOf(data.getRelationshipTracker(), gamePlayer)
+                    .and(Matches.unitIsDestroyer()))) {
       // if we are allowed to have our subs enter any sea zone with enemies during noncombat, we
       // want to make sure we
       // can't keep moving them if there is an enemy destroyer there

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
@@ -841,7 +841,7 @@ public class AirBattle extends AbstractBattle {
   public static Predicate<Unit> defendingGroundSeaBattleInterceptors(
       final GamePlayer attacker, final GameState data) {
     return PredicateBuilder.of(Matches.unitCanAirBattle())
-        .and(Matches.unitIsEnemyOf(data, attacker))
+        .and(Matches.unitIsEnemyOf(data.getRelationshipTracker(), attacker))
         .and(Matches.unitWasInAirBattle().negate())
         .andIf(
             !Properties.getCanScrambleIntoAirBattles(data.getProperties()),
@@ -857,14 +857,14 @@ public class AirBattle extends AbstractBattle {
       final Territory territory, final GamePlayer attacker, final GameState data) {
     final Predicate<Unit> canIntercept =
         PredicateBuilder.of(Matches.unitCanIntercept())
-            .and(Matches.unitIsEnemyOf(data, attacker))
+            .and(Matches.unitIsEnemyOf(data.getRelationshipTracker(), attacker))
             .and(Matches.unitWasInAirBattle().negate())
             .andIf(
                 !Properties.getCanScrambleIntoAirBattles(data.getProperties()),
                 Matches.unitWasScrambled().negate())
             .build();
     final Predicate<Unit> airbasesCanIntercept =
-        Matches.unitIsEnemyOf(data, attacker)
+        Matches.unitIsEnemyOf(data.getRelationshipTracker(), attacker)
             .and(Matches.unitIsAirBase())
             .and(Matches.unitIsNotDisabled())
             .and(Matches.unitIsBeingTransported().negate());

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -647,7 +647,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
               .map(Unit::getOwner)
               .map(
                   p ->
-                      Matches.unitIsEnemyOf(data, p)
+                      Matches.unitIsEnemyOf(data.getRelationshipTracker(), p)
                           .and(Matches.unitIsNotAir())
                           .and(Matches.unitIsNotInfrastructure()))
               .map(territory.getUnitCollection()::getMatches)

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -1557,7 +1557,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
               CollectionUtils.getMatches(
                   possibleTerrs,
                   Matches.territoryHasUnitsThatMatch(
-                          Matches.unitIsAlliedCarrier(alliedPlayer, data))
+                          Matches.unitIsAlliedCarrier(alliedPlayer, data.getRelationshipTracker()))
                       .and(Matches.territoryIsWater())));
       availableWater.removeAll(battleTracker.getPendingBattleSites(false));
       // simple calculation, either we can take all the air, or we can't, nothing in the middle
@@ -1567,7 +1567,9 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         final Territory t = waterIter.next();
         int carrierCapacity =
             AirMovementValidator.carrierCapacity(
-                t.getUnitCollection().getMatches(Matches.unitIsAlliedCarrier(alliedPlayer, data)),
+                t.getUnitCollection()
+                    .getMatches(
+                        Matches.unitIsAlliedCarrier(alliedPlayer, data.getRelationshipTracker())),
                 t);
         if (!t.equals(currentTerr)) {
           carrierCapacity -=

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -939,7 +939,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         Territory landingTerr = null;
         final String historyText;
         if (!mustReturnToBase
-            || !Matches.isTerritoryAllied(u.getOwner(), data).test(u.getOriginatedFrom())) {
+            || !Matches.isTerritoryAllied(u.getOwner(), data.getRelationshipTracker())
+                .test(u.getOriginatedFrom())) {
           final Collection<Territory> possible =
               whereCanAirLand(u, t, u.getOwner(), data, battleTracker, carrierCostOfCurrentTerr);
           if (possible.size() > 1) {
@@ -1547,7 +1548,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         new HashSet<>(
             CollectionUtils.getMatches(
                 possibleTerrs,
-                Matches.isTerritoryAllied(alliedPlayer, data).and(Matches.territoryIsLand())));
+                Matches.isTerritoryAllied(alliedPlayer, data.getRelationshipTracker())
+                    .and(Matches.territoryIsLand())));
     availableLand.removeAll(canNotLand);
     final Set<Territory> whereCanLand = new HashSet<>(availableLand);
     // now for carrier-air-landing validation

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -598,7 +598,8 @@ public class BattleTracker implements Serializable {
         final GamePlayer convoyOwner = convoy.getOwner();
         if (relationshipTracker.isAllied(gamePlayer, convoyOwner)) {
           if (CollectionUtils.getMatches(
-                      cta.getConvoyAttached(), Matches.isTerritoryAllied(convoyOwner, data))
+                      cta.getConvoyAttached(),
+                      Matches.isTerritoryAllied(convoyOwner, data.getRelationshipTracker()))
                   .size()
               <= 0) {
             bridge
@@ -614,7 +615,8 @@ public class BattleTracker implements Serializable {
           }
         } else if (relationshipTracker.isAtWar(gamePlayer, convoyOwner)
             && CollectionUtils.getMatches(
-                        cta.getConvoyAttached(), Matches.isTerritoryAllied(convoyOwner, data))
+                        cta.getConvoyAttached(),
+                        Matches.isTerritoryAllied(convoyOwner, data.getRelationshipTracker()))
                     .size()
                 == 1) {
           bridge
@@ -868,7 +870,8 @@ public class BattleTracker implements Serializable {
           OriginalOwnerTracker.getOriginallyOwned(data, terrOrigOwner);
       final List<Territory> friendlyTerritories =
           CollectionUtils.getMatches(
-              originallyOwned, Matches.isTerritoryAllied(terrOrigOwner, data));
+              originallyOwned,
+              Matches.isTerritoryAllied(terrOrigOwner, data.getRelationshipTracker()));
       // give back the factories as well.
       for (final Territory item : friendlyTerritories) {
         if (item.getOwner().equals(terrOrigOwner)) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -140,7 +140,9 @@ public class BattleTracker implements Serializable {
   public boolean didAllThesePlayersJustGoToWarThisTurn(
       final GamePlayer p1, final Collection<Unit> enemyUnits, final GameState data) {
     final Set<GamePlayer> enemies = new HashSet<>();
-    for (final Unit u : CollectionUtils.getMatches(enemyUnits, Matches.unitIsEnemyOf(data, p1))) {
+    for (final Unit u :
+        CollectionUtils.getMatches(
+            enemyUnits, Matches.unitIsEnemyOf(data.getRelationshipTracker(), p1))) {
       enemies.add(u.getOwner());
     }
     for (final GamePlayer e : enemies) {
@@ -831,7 +833,9 @@ public class BattleTracker implements Serializable {
     // TODO: see if necessary
     if (territory
         .getUnitCollection()
-        .anyMatch(Matches.unitIsEnemyOf(data, gamePlayer).and(Matches.unitCanBeDamaged()))) {
+        .anyMatch(
+            Matches.unitIsEnemyOf(data.getRelationshipTracker(), gamePlayer)
+                .and(Matches.unitCanBeDamaged()))) {
       final IBattle bombingBattle = getPendingBombingBattle(territory);
       if (bombingBattle != null) {
         final BattleResults results = new BattleResults(bombingBattle, WhoWon.DRAW, data);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/ScrambleLogic.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/ScrambleLogic.java
@@ -57,7 +57,7 @@ public class ScrambleLogic {
     this.territoriesWithBattles = territoriesWithBattles;
     this.battleTracker = battleTracker;
     this.airbaseThatCanScramblePredicate =
-        Matches.unitIsEnemyOf(data, player)
+        Matches.unitIsEnemyOf(data.getRelationshipTracker(), player)
             .and(Matches.unitIsAirBase())
             .and(Matches.unitIsNotDisabled())
             .and(Matches.unitIsBeingTransported().negate());
@@ -66,7 +66,7 @@ public class ScrambleLogic {
             .and(
                 Matches.territoryHasUnitsThatMatch(
                     Matches.unitCanScramble()
-                        .and(Matches.unitIsEnemyOf(data, player))
+                        .and(Matches.unitIsEnemyOf(data.getRelationshipTracker(), player))
                         .and(Matches.unitIsNotDisabled())))
             .and(Matches.territoryHasUnitsThatMatch(airbaseThatCanScramblePredicate))
             .andIf(
@@ -168,7 +168,7 @@ public class ScrambleLogic {
       return Map.of();
     }
     final Predicate<Unit> unitCanScramble =
-        Matches.unitIsEnemyOf(data, player)
+        Matches.unitIsEnemyOf(data.getRelationshipTracker(), player)
             .and(Matches.unitCanScramble())
             .and(Matches.unitIsNotDisabled())
             .and(Matches.unitWasScrambled().negate());

--- a/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
@@ -796,7 +796,8 @@ public class MoveValidator {
     for (final Territory t : route.getSteps()) {
       final Collection<Unit> unitsAllowedSoFar = new ArrayList<>();
       if (Matches.isTerritoryEnemyAndNotUnownedWater(player, data).test(t)
-          || t.getUnitCollection().anyMatch(Matches.unitIsEnemyOf(data, player))) {
+          || t.getUnitCollection()
+              .anyMatch(Matches.unitIsEnemyOf(data.getRelationshipTracker(), player))) {
         for (final Unit unit : unitsWithStackingLimits) {
           final UnitType ut = unit.getType();
           int maxAllowed =
@@ -1182,7 +1183,8 @@ public class MoveValidator {
       final boolean subsPreventUnescortedAmphibAssaults =
           Properties.getSubmarinesPreventUnescortedAmphibiousAssaults(data.getProperties());
       final Predicate<Unit> enemySubMatch =
-          Matches.unitIsEnemyOf(data, player).and(Matches.unitCanBeMovedThroughByEnemies());
+          Matches.unitIsEnemyOf(data.getRelationshipTracker(), player)
+              .and(Matches.unitCanBeMovedThroughByEnemies());
       final Predicate<Unit> ownedSeaNonTransportMatch =
           Matches.unitIsOwnedBy(player)
               .and(Matches.unitIsSea())


### PR DESCRIPTION
This modifies a few of the Matches methods to take just the `RelationshipTracker` instead of the full `GameState`/`GameData`.

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
