### PR TITLE
Enemy unit use relationship tracker

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -1853,7 +1853,7 @@ public class ProCombatMoveAi {
 
     for (final Territory t : proData.getMyUnitTerritories()) {
       if (t.isWater()
-          && Matches.territoryHasEnemyUnits(player, data).test(t)
+          && Matches.territoryHasEnemyUnits(player, data.getRelationshipTracker()).test(t)
           && (attackMap.get(t) == null || attackMap.get(t).getUnits().isEmpty())) {
 
         // Move into random adjacent safe sea territory

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -669,7 +669,7 @@ public class ProCombatMoveAi {
               .getNeighbors(
                   t,
                   Matches.territoryIsEnemyNonNeutralAndHasEnemyUnitMatching(
-                      data,
+                      data.getRelationshipTracker(),
                       player,
                       Matches.unitIsLand()
                           .and(Matches.unitIsNotInfrastructure())

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -554,7 +554,8 @@ public class ProCombatMoveAi {
       if (!patd.isCanHold()
           && enemyAttackOptions.getMax(t) != null
           && t.isWater()
-          && !t.getUnitCollection().anyMatch(Matches.enemyUnit(player, data))) {
+          && !t.getUnitCollection()
+              .anyMatch(Matches.enemyUnit(player, data.getRelationshipTracker()))) {
         ProLogger.debug(
             "Removing convoy zone that can't be held: "
                 + t.getName()

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -2321,7 +2321,7 @@ class ProNonCombatMoveAi {
         final int numSeaAttackTerritories =
             CollectionUtils.countMatches(
                 possibleAttackTerritories,
-                Matches.territoryHasEnemySeaUnits(player, data)
+                Matches.territoryHasEnemySeaUnits(player, data.getRelationshipTracker())
                     .and(
                         Matches.territoryHasUnitsThatMatch(
                             Matches.unitHasSubBattleAbilities().negate())));

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/ProTechAi.java
@@ -389,7 +389,7 @@ final class ProTechAi {
     final Predicate<Unit> blitzUnit =
         Matches.unitIsOwnedBy(enemyPlayer).and(Matches.unitCanBlitz()).and(Matches.unitCanMove());
     final Predicate<Territory> validBlitzRoute =
-        Matches.territoryHasNoEnemyUnits(enemyPlayer, data)
+        Matches.territoryHasNoEnemyUnits(enemyPlayer, data.getRelationshipTracker())
             .and(Matches.territoryIsNotImpassableToLandUnits(enemyPlayer, data.getProperties()));
     final List<Route> routes = new ArrayList<>();
     final List<Unit> blitzUnits =

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseTerritory.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseTerritory.java
@@ -53,7 +53,8 @@ public class ProPurchaseTerritory {
       for (final Territory t : data.getMap().getNeighbors(territory, Matches.territoryIsWater())) {
         if (Properties.getWW2V2(data.getProperties())
             || Properties.getUnitPlacementInEnemySeas(data.getProperties())
-            || !t.getUnitCollection().anyMatch(Matches.enemyUnit(player, data))) {
+            || !t.getUnitCollection()
+                .anyMatch(Matches.enemyUnit(player, data.getRelationshipTracker()))) {
           canPlaceTerritories.add(new ProPlaceTerritory(t));
         }
       }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritory.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritory.java
@@ -167,7 +167,9 @@ public class ProTerritory {
 
   public List<Unit> getMaxEnemyDefenders(final GamePlayer player, final GameState data) {
     final List<Unit> defenders =
-        territory.getUnitCollection().getMatches(Matches.enemyUnit(player, data));
+        territory
+            .getUnitCollection()
+            .getMatches(Matches.enemyUnit(player, data.getRelationshipTracker()));
     defenders.addAll(maxScrambleUnits);
     return defenders;
   }

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -1189,7 +1189,7 @@ public class ProTerritoryManager {
             final Set<Territory> myUnitsToLoadTerritories = new HashSet<>();
             if (TransportTracker.isTransporting(myTransportUnit)) {
               units.addAll(TransportTracker.transporting(myTransportUnit));
-            } else if (Matches.territoryHasEnemySeaUnits(player, data)
+            } else if (Matches.territoryHasEnemySeaUnits(player, data.getRelationshipTracker())
                 .negate()
                 .test(currentTerritory)) {
               final Set<Territory> possibleLoadTerritories =

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -252,13 +252,13 @@ public final class ProMatches {
       final GamePlayer player,
       final GameState data,
       final List<Territory> territoriesThatCantBeHeld) {
-    return Matches.territoryHasEnemyUnits(player, data)
+    return Matches.territoryHasEnemyUnits(player, data.getRelationshipTracker())
         .or(Matches.territoryIsInList(territoriesThatCantBeHeld));
   }
 
   public static Predicate<Territory> territoryHasPotentialEnemyUnits(
       final GamePlayer player, final GameState data, final List<GamePlayer> players) {
-    return Matches.territoryHasEnemyUnits(player, data)
+    return Matches.territoryHasEnemyUnits(player, data.getRelationshipTracker())
         .or(Matches.territoryHasUnitsThatMatch(Matches.unitOwnedBy(players)));
   }
 
@@ -273,7 +273,7 @@ public final class ProMatches {
       final GameState data,
       final List<Territory> territoriesThatCantBeHeld) {
     return Matches.isTerritoryEnemyAndNotUnownedWater(player, data)
-        .or(Matches.territoryHasEnemyUnits(player, data))
+        .or(Matches.territoryHasEnemyUnits(player, data.getRelationshipTracker()))
         .or(Matches.territoryIsInList(territoriesThatCantBeHeld));
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -139,7 +139,7 @@ public final class ProMatches {
           && TerritoryEffectHelper.unitKeepsBlitz(u, startTerritory)) {
         final Predicate<Territory> alliedWithNoEnemiesMatch =
             Matches.isTerritoryAllied(player, data.getRelationshipTracker())
-                .and(Matches.territoryHasNoEnemyUnits(player, data));
+                .and(Matches.territoryHasNoEnemyUnits(player, data.getRelationshipTracker()));
         final Predicate<Territory> alliedOrBlitzableMatch =
             alliedWithNoEnemiesMatch.or(territoryIsBlitzable(player, data, u));
         return ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u)
@@ -149,7 +149,7 @@ public final class ProMatches {
       }
       return ProMatches.territoryCanMoveSpecificLandUnit(player, data, isCombatMove, u)
           .and(Matches.isTerritoryAllied(player, data.getRelationshipTracker()))
-          .and(Matches.territoryHasNoEnemyUnits(player, data))
+          .and(Matches.territoryHasNoEnemyUnits(player, data.getRelationshipTracker()))
           .and(Matches.territoryIsInList(enemyTerritories).negate())
           .test(t);
     };
@@ -244,7 +244,7 @@ public final class ProMatches {
               .or(Matches.unitCanBeMovedThroughByEnemies())
               .or(Matches.enemyUnit(player, data.getRelationshipTracker()).negate());
       return t.getUnitCollection().allMatch(subOnly)
-          || Matches.territoryHasNoEnemyUnits(player, data).test(t);
+          || Matches.territoryHasNoEnemyUnits(player, data.getRelationshipTracker()).test(t);
     };
   }
 
@@ -264,7 +264,7 @@ public final class ProMatches {
 
   public static Predicate<Territory> territoryHasNoEnemyUnitsOrCleared(
       final GamePlayer player, final GameState data, final List<Territory> clearedTerritories) {
-    return Matches.territoryHasNoEnemyUnits(player, data)
+    return Matches.territoryHasNoEnemyUnits(player, data.getRelationshipTracker())
         .or(Matches.territoryIsInList(clearedTerritories));
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -72,7 +72,7 @@ public final class ProMatches {
   public static Predicate<Territory> territoryCanMoveAirUnitsAndNoAa(
       final GamePlayer player, final GameState data, final boolean isCombatMove) {
     return ProMatches.territoryCanMoveAirUnits(player, data, isCombatMove)
-        .and(Matches.territoryHasEnemyAaForFlyOver(player, data).negate());
+        .and(Matches.territoryHasEnemyAaForFlyOver(player, data.getRelationshipTracker()).negate());
   }
 
   public static Predicate<Territory> territoryCanMoveSpecificLandUnit(

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -242,7 +242,7 @@ public final class ProMatches {
       final Predicate<Unit> subOnly =
           Matches.unitIsInfrastructure()
               .or(Matches.unitCanBeMovedThroughByEnemies())
-              .or(Matches.enemyUnit(player, data).negate());
+              .or(Matches.enemyUnit(player, data.getRelationshipTracker()).negate());
       return t.getUnitCollection().allMatch(subOnly)
           || Matches.territoryHasNoEnemyUnits(player, data).test(t);
     };
@@ -552,20 +552,21 @@ public final class ProMatches {
   }
 
   public static Predicate<Unit> unitIsEnemyAir(final GamePlayer player, final GameState data) {
-    return Matches.enemyUnit(player, data).and(Matches.unitIsAir());
+    return Matches.enemyUnit(player, data.getRelationshipTracker()).and(Matches.unitIsAir());
   }
 
   public static Predicate<Unit> unitIsEnemyAndNotInfa(
       final GamePlayer player, final GameState data) {
-    return Matches.enemyUnit(player, data).and(Matches.unitIsNotInfrastructure());
+    return Matches.enemyUnit(player, data.getRelationshipTracker())
+        .and(Matches.unitIsNotInfrastructure());
   }
 
   public static Predicate<Unit> unitIsEnemyNotLand(final GamePlayer player, final GameState data) {
-    return Matches.enemyUnit(player, data).and(Matches.unitIsNotLand());
+    return Matches.enemyUnit(player, data.getRelationshipTracker()).and(Matches.unitIsNotLand());
   }
 
   static Predicate<Unit> unitIsEnemyNotNeutral(final GamePlayer player, final GameState data) {
-    return Matches.enemyUnit(player, data).and(unitIsNeutral().negate());
+    return Matches.enemyUnit(player, data.getRelationshipTracker()).and(unitIsNeutral().negate());
   }
 
   private static Predicate<Unit> unitIsNeutral() {

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -200,7 +200,9 @@ public final class ProMoveUtils {
         while (movesLeft >= 0) {
 
           // Load adjacent units if no enemies present in transport territory
-          if (Matches.territoryHasEnemyUnits(player, data).negate().test(transportTerritory)) {
+          if (Matches.territoryHasEnemyUnits(player, data.getRelationshipTracker())
+              .negate()
+              .test(transportTerritory)) {
             final var unitsToRemove = new ArrayList<Unit>();
             for (final Unit amphibUnit : remainingUnitsToLoad) {
               final Territory unitTerritory = proData.getUnitTerritory(amphibUnit);

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProSortMoveOptionsUtils.java
@@ -200,7 +200,8 @@ public final class ProSortMoveOptionsUtils {
     int minPower = Integer.MAX_VALUE;
     for (final Territory t : territories) {
       final List<Unit> defendingUnits =
-          t.getUnitCollection().getMatches(Matches.enemyUnit(player, data));
+          t.getUnitCollection()
+              .getMatches(Matches.enemyUnit(player, data.getRelationshipTracker()));
       final Collection<Unit> attackingUnits = new ArrayList<>(attackMap.get(t).getUnits());
       // Compare the difference in total power when including the unit or not.
       int powerDifference = 0;

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -143,7 +143,8 @@ public final class ProTerritoryValueUtils {
         double nearbyEnemySeaUnitValue = 0;
         final List<Territory> nearbyEnemySeaUnitTerritories =
             CollectionUtils.getMatches(
-                nearbySeaTerritories, Matches.territoryHasEnemyUnits(player, data));
+                nearbySeaTerritories,
+                Matches.territoryHasEnemyUnits(player, data.getRelationshipTracker()));
         for (final Territory nearbyEnemySeaTerritory : nearbyEnemySeaUnitTerritories) {
           final Route route =
               data.getMap()

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/Utils.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/Utils.java
@@ -40,7 +40,8 @@ final class Utils {
                 location,
                 location.isWater() ? Matches.territoryIsWater() : Matches.territoryIsLand())) {
       final List<Unit> enemies =
-          t.getUnitCollection().getMatches(Matches.enemyUnit(location.getOwner(), data));
+          t.getUnitCollection()
+              .getMatches(Matches.enemyUnit(location.getOwner(), data.getRelationshipTracker()));
       strength += AiUtils.strength(enemies, true, location.isWater());
     }
     return strength;

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -320,7 +320,7 @@ public class WeakAi extends AbstractBuiltInAi {
       final GamePlayer player) {
     final Predicate<Territory> routeCond =
         Matches.territoryIsWater()
-            .and(Matches.territoryHasEnemyUnits(player, data).negate())
+            .and(Matches.territoryHasEnemyUnits(player, data.getRelationshipTracker()).negate())
             .and(Matches.territoryHasNonAllowedCanal(player, data).negate());
     Route r = data.getMap().getRoute(start, destination, routeCond);
     if (r == null || r.hasNoSteps() || !routeCond.test(destination)) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -480,7 +480,10 @@ public class WeakAi extends AbstractBuiltInAi {
         @Nullable
         Route newRoute =
             Utils.findNearest(
-                t, Matches.territoryHasEnemyLandUnits(player, data), routeCondition, data);
+                t,
+                Matches.territoryHasEnemyLandUnits(player, data.getRelationshipTracker()),
+                routeCondition,
+                data);
         // move to any enemy territory
         if (newRoute == null) {
           newRoute =
@@ -685,7 +688,10 @@ public class WeakAi extends AbstractBuiltInAi {
             // 2) we can potentially attack another territory
             if (!owned.isWater()
                 && data.getMap()
-                        .getNeighbors(owned, Matches.territoryHasEnemyLandUnits(player, data))
+                        .getNeighbors(
+                            owned,
+                            Matches.territoryHasEnemyLandUnits(
+                                player, data.getRelationshipTracker()))
                         .size()
                     > 1) {
               units = Utils.getUnitsUpToStrength(remainingStrengthNeeded, units);

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -79,7 +79,8 @@ public class WeakAi extends AbstractBuiltInAi {
               && Utils.hasLandRouteToEnemyOwnedCapitol(o, player, data);
         };
     final Predicate<Territory> routeCond =
-        Matches.territoryIsWater().and(Matches.territoryHasNoEnemyUnits(player, data));
+        Matches.territoryIsWater()
+            .and(Matches.territoryHasNoEnemyUnits(player, data.getRelationshipTracker()));
     final @Nullable Route withNoEnemy = Utils.findNearest(ourCapitol, endMatch, routeCond, data);
     if (withNoEnemy != null && withNoEnemy.numberOfSteps() > 0) {
       return withNoEnemy;
@@ -382,7 +383,8 @@ public class WeakAi extends AbstractBuiltInAi {
       return null;
     }
     final Predicate<Territory> routeCondition =
-        Matches.territoryIsWater().and(Matches.territoryHasNoEnemyUnits(player, data));
+        Matches.territoryIsWater()
+            .and(Matches.territoryHasNoEnemyUnits(player, data.getRelationshipTracker()));
     // should select all territories with loaded transports
     final Predicate<Territory> transportOnSea =
         Matches.territoryIsWater().and(Matches.territoryHasLandUnitsOwnedBy(player));

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -712,7 +712,7 @@ public class WeakAi extends AbstractBuiltInAi {
       final GameState data, final GamePlayer player) {
     final Predicate<Territory> enemyFactory =
         Matches.territoryIsEnemyNonNeutralAndHasEnemyUnitMatching(
-            data, player, Matches.unitCanProduceUnitsAndCanBeDamaged());
+            data.getRelationshipTracker(), player, Matches.unitCanProduceUnitsAndCanBeDamaged());
     final Predicate<Unit> ownBomber =
         Matches.unitIsStrategicBomber().and(Matches.unitIsOwnedBy(player));
     final var moves = new ArrayList<MoveDescription>();

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -509,7 +509,7 @@ public class WeakAi extends AbstractBuiltInAi {
         Matches.isTerritoryAllied(player, data.getRelationshipTracker())
             .and(o -> !delegate.getBattleTracker().wasConquered(o));
     final Predicate<Territory> routeCondition =
-        Matches.territoryHasEnemyAaForFlyOver(player, data)
+        Matches.territoryHasEnemyAaForFlyOver(player, data.getRelationshipTracker())
             .negate()
             .and(Matches.territoryIsImpassable().negate());
     final var moves = new ArrayList<MoveDescription>();
@@ -722,7 +722,7 @@ public class WeakAi extends AbstractBuiltInAi {
         continue;
       }
       final Predicate<Territory> routeCond =
-          Matches.territoryHasEnemyAaForFlyOver(player, data).negate();
+          Matches.territoryHasEnemyAaForFlyOver(player, data.getRelationshipTracker()).negate();
       final @Nullable Route bombRoute = Utils.findNearest(t, enemyFactory, routeCond, data);
       if (bombRoute != null) {
         moves.add(new MoveDescription(bombers, bombRoute));

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -339,7 +339,8 @@ public class WeakAi extends AbstractBuiltInAi {
       if (!t.isWater()) {
         continue;
       }
-      if (!t.getUnitCollection().anyMatch(Matches.enemyUnit(player, data))) {
+      if (!t.getUnitCollection()
+          .anyMatch(Matches.enemyUnit(player, data.getRelationshipTracker()))) {
         continue;
       }
       final float enemyStrength = AiUtils.strength(t.getUnits(), false, true);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
@@ -86,7 +86,7 @@ class AaInMoveUtil implements Serializable {
                     Matches.unitIsAaForFlyOverOnly(),
                     1,
                     true,
-                    getData()));
+                    getData().getRelationshipTracker()));
     // comes ordered alphabetically already
     final List<String> aaTypes = UnitAttachment.getAllOfTypeAas(defendingAa);
     // stacks are backwards
@@ -254,7 +254,7 @@ class AaInMoveUtil implements Serializable {
             Matches.unitIsAaForFlyOverOnly(),
             1,
             true,
-            data);
+            data.getRelationshipTracker());
     // AA guns in transports shouldn't be able to fire
     final List<Territory> territoriesWhereAaWillFire = new ArrayList<>();
     for (final Territory current : route.getMiddleSteps()) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -470,7 +470,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate
     if (blockable.isEmpty()) {
       return 0;
     }
-    final Predicate<Unit> enemyUnits = Matches.enemyUnit(player, data);
+    final Predicate<Unit> enemyUnits = Matches.enemyUnit(player, data.getRelationshipTracker());
     int totalLoss = 0;
     final boolean rollDiceForBlockadeDamage =
         Properties.getConvoyBlockadesRollDiceForCost(data.getProperties());

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -704,7 +704,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     if (to.isWater()
         && (!Properties.getWW2V2(getData().getProperties())
             && !Properties.getUnitPlacementInEnemySeas(getData().getProperties()))
-        && to.getUnitCollection().anyMatch(Matches.enemyUnit(player, getData()))) {
+        && to.getUnitCollection()
+            .anyMatch(Matches.enemyUnit(player, getData().getRelationshipTracker()))) {
       return "Cannot place sea units with enemy naval units";
     }
     // make sure there is a factory
@@ -925,7 +926,8 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     if (water
         && (!Properties.getWW2V2(getData().getProperties())
             && !Properties.getUnitPlacementInEnemySeas(getData().getProperties()))
-        && to.getUnitCollection().anyMatch(Matches.enemyUnit(player, getData()))) {
+        && to.getUnitCollection()
+            .anyMatch(Matches.enemyUnit(player, getData().getRelationshipTracker()))) {
       return null;
     }
     final Collection<Unit> units = new ArrayList<>(allUnits);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
@@ -40,7 +40,8 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
     if (to.isWater()) {
       if (units.stream().anyMatch(Matches.unitIsLand())) {
         return "Cant place land units at sea";
-      } else if (to.getUnitCollection().anyMatch(Matches.enemyUnit(player, getData()))) {
+      } else if (to.getUnitCollection()
+          .anyMatch(Matches.enemyUnit(player, getData().getRelationshipTracker()))) {
         return "Cant place in sea zone containing enemy units";
       } else if (!to.getUnitCollection().anyMatch(Matches.unitIsOwnedBy(player))) {
         return "Cant place in sea zone that does not contain a unit owned by you";

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -154,7 +154,8 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
       bridge.addChange(ChangeFactory.changeOwner(units, player, territory));
     } else {
       final Predicate<Unit> enemyNonCom =
-          Matches.unitIsInfrastructure().and(Matches.enemyUnit(player, data));
+          Matches.unitIsInfrastructure()
+              .and(Matches.enemyUnit(player, data.getRelationshipTracker()));
       final Collection<Unit> units = territory.getUnitCollection().getMatches(enemyNonCom);
       // mark no movement for enemy units
       bridge.addChange(ChangeFactory.markNoMovementChange(units));

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1448,10 +1448,9 @@ public final class Matches {
   }
 
   public static Predicate<Territory> territoryHasEnemyLandUnits(
-      final GamePlayer player, final GameState data) {
+      final GamePlayer player, final RelationshipTracker relationshipTracker) {
     return t ->
-        t.getUnitCollection()
-            .anyMatch(enemyUnit(player, data.getRelationshipTracker()).and(unitIsLand()));
+        t.getUnitCollection().anyMatch(enemyUnit(player, relationshipTracker).and(unitIsLand()));
   }
 
   public static Predicate<Territory> territoryHasEnemySeaUnits(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1441,9 +1441,9 @@ public final class Matches {
   }
 
   static Predicate<Territory> territoryHasNonSubmergedEnemyUnits(
-      final GamePlayer player, final GameState data) {
+      final GamePlayer player, final RelationshipTracker relationshipTracker) {
     final Predicate<Unit> match =
-        enemyUnit(player, data.getRelationshipTracker()).and(unitIsSubmerged().negate());
+        enemyUnit(player, relationshipTracker).and(unitIsSubmerged().negate());
     return t -> t.getUnitCollection().anyMatch(match);
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -714,8 +714,8 @@ public final class Matches {
       final Predicate<Unit> typeOfAa,
       final int battleRoundNumber,
       final boolean defending,
-      final GameState data) {
-    return enemyUnit(playerMovingOrAttacking, data.getRelationshipTracker())
+      final RelationshipTracker relationshipTracker) {
+    return enemyUnit(playerMovingOrAttacking, relationshipTracker)
         .and(unitIsBeingTransported().negate())
         .and(
             unitIsAaThatCanHitTheseUnits(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1454,10 +1454,9 @@ public final class Matches {
   }
 
   public static Predicate<Territory> territoryHasEnemySeaUnits(
-      final GamePlayer player, final GameState data) {
+      final GamePlayer player, final RelationshipTracker relationshipTracker) {
     return t ->
-        t.getUnitCollection()
-            .anyMatch(enemyUnit(player, data.getRelationshipTracker()).and(unitIsSea()));
+        t.getUnitCollection().anyMatch(enemyUnit(player, relationshipTracker).and(unitIsSea()));
   }
 
   public static Predicate<Territory> territoryHasEnemyUnits(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -987,12 +987,10 @@ public final class Matches {
   }
 
   public static Predicate<Territory> territoryIsEmptyOfCombatUnits(
-      final GameState data, final GamePlayer player) {
+      final RelationshipTracker relationshipTracker, final GamePlayer player) {
     return t ->
         t.getUnitCollection()
-            .allMatch(
-                unitIsInfrastructure()
-                    .or(enemyUnit(player, data.getRelationshipTracker()).negate()));
+            .allMatch(unitIsInfrastructure().or(enemyUnit(player, relationshipTracker).negate()));
   }
 
   public static Predicate<Territory> territoryIsNeutralButNotWater() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1280,8 +1280,8 @@ public final class Matches {
   }
 
   private static Predicate<Unit> unitIsEnemyAaForFlyOver(
-      final GamePlayer player, final GameState data) {
-    return unitIsAaForFlyOverOnly().and(enemyUnit(player, data.getRelationshipTracker()));
+      final GamePlayer player, final RelationshipTracker relationshipTracker) {
+    return unitIsAaForFlyOverOnly().and(enemyUnit(player, relationshipTracker));
   }
 
   public static Predicate<Unit> unitIsInTerritory(final Territory territory) {
@@ -1425,8 +1425,9 @@ public final class Matches {
   }
 
   public static Predicate<Territory> territoryHasEnemyAaForFlyOver(
-      final GamePlayer player, final GameState data) {
-    return t -> t.getUnitCollection().anyMatch(unitIsEnemyAaForFlyOver(player, data));
+      final GamePlayer player, final RelationshipTracker relationshipTracker) {
+    return t ->
+        t.getUnitCollection().anyMatch(unitIsEnemyAaForFlyOver(player, relationshipTracker));
   }
 
   public static Predicate<Territory> territoryHasNoEnemyUnits(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -907,7 +907,8 @@ public final class Matches {
           return false;
         }
       }
-      return !(contestedDoNotProduce && !territoryHasNoEnemyUnits(player, data).test(t));
+      return !(contestedDoNotProduce
+          && !territoryHasNoEnemyUnits(player, data.getRelationshipTracker()).test(t));
     };
   }
 
@@ -1430,8 +1431,8 @@ public final class Matches {
   }
 
   public static Predicate<Territory> territoryHasNoEnemyUnits(
-      final GamePlayer player, final GameState data) {
-    return t -> !t.getUnitCollection().anyMatch(enemyUnit(player, data.getRelationshipTracker()));
+      final GamePlayer player, final RelationshipTracker relationshipTracker) {
+    return t -> !t.getUnitCollection().anyMatch(enemyUnit(player, relationshipTracker));
   }
 
   public static Predicate<Territory> territoryHasAlliedUnits(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -974,14 +974,15 @@ public final class Matches {
   }
 
   public static Predicate<Territory> territoryIsEnemyNonNeutralAndHasEnemyUnitMatching(
-      final GameState data, final GamePlayer player, final Predicate<Unit> unitMatch) {
+      final RelationshipTracker relationshipTracker,
+      final GamePlayer player,
+      final Predicate<Unit> unitMatch) {
     return t -> {
-      if (!data.getRelationshipTracker().isAtWar(player, t.getOwner())) {
+      if (!relationshipTracker.isAtWar(player, t.getOwner())) {
         return false;
       }
       return !t.getOwner().isNull()
-          && t.getUnitCollection()
-              .anyMatch(enemyUnit(player, data.getRelationshipTracker()).and(unitMatch));
+          && t.getUnitCollection().anyMatch(enemyUnit(player, relationshipTracker).and(unitMatch));
     };
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1460,8 +1460,8 @@ public final class Matches {
   }
 
   public static Predicate<Territory> territoryHasEnemyUnits(
-      final GamePlayer player, final GameState data) {
-    return t -> t.getUnitCollection().anyMatch(enemyUnit(player, data.getRelationshipTracker()));
+      final GamePlayer player, final RelationshipTracker relationshipTracker) {
+    return t -> t.getUnitCollection().anyMatch(enemyUnit(player, relationshipTracker));
   }
 
   public static Predicate<Territory> territoryIsNotUnownedWater() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -336,7 +336,7 @@ public class MovePerformer implements Serializable {
   private static Predicate<Territory> getMustFightThroughMatch(
       final GamePlayer gamePlayer, final GameState data) {
     return Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(gamePlayer, data)
-        .or(Matches.territoryHasNonSubmergedEnemyUnits(gamePlayer, data))
+        .or(Matches.territoryHasNonSubmergedEnemyUnits(gamePlayer, data.getRelationshipTracker()))
         .or(
             Matches.terrIsOwnedByPlayerRelationshipCanTakeOwnedTerrAndPassableAndNotWater(
                 gamePlayer));
@@ -487,7 +487,8 @@ public class MovePerformer implements Serializable {
             && transportedBy != null
             && Matches.unitIsAirTransport().test(transportedBy)
             && GameStepPropertiesHelper.isCombatMove(data)
-            && Matches.territoryHasNonSubmergedEnemyUnits(player, data).test(route.getEnd())) {
+            && Matches.territoryHasNonSubmergedEnemyUnits(player, data.getRelationshipTracker())
+                .test(route.getEnd())) {
           continue;
         }
         // unload the transports

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -180,7 +180,7 @@ public class MovePerformer implements Serializable {
                   route
                       .getEnd()
                       .getUnitCollection()
-                      .getMatches(Matches.enemyUnit(gamePlayer, data));
+                      .getMatches(Matches.enemyUnit(gamePlayer, data.getRelationshipTracker()));
               final Collection<Unit> enemyTargetsTotal =
                   CollectionUtils.getMatches(
                       enemyUnits,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -292,7 +292,8 @@ public class MovePerformer implements Serializable {
                                 gamePlayer)
                             .and(Matches.territoryIsBlitzable(gamePlayer, data)))) {
                   if (Matches.isTerritoryEnemy(gamePlayer, data).test(t)
-                      || Matches.territoryHasEnemyUnits(gamePlayer, data).test(t)) {
+                      || Matches.territoryHasEnemyUnits(gamePlayer, data.getRelationshipTracker())
+                          .test(t)) {
                     continue;
                   }
                   if ((t.equals(route.getEnd())

--- a/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -124,7 +124,8 @@ public class RocketsFireHelper implements Serializable {
         final Collection<Unit> enemyUnits =
             CollectionUtils.getMatches(
                 targetTerritory.getUnitCollection(),
-                Matches.enemyUnit(player, data).and(Matches.unitIsBeingTransported().negate()));
+                Matches.enemyUnit(player, data.getRelationshipTracker())
+                    .and(Matches.unitIsBeingTransported().negate()));
         final Collection<Unit> enemyTargetsTotal =
             CollectionUtils.getMatches(
                 enemyUnits, Matches.unitIsAtMaxDamageOrNotCanBeDamaged(targetTerritory).negate());
@@ -233,7 +234,8 @@ public class RocketsFireHelper implements Serializable {
     final Collection<Territory> possible =
         data.getMap().getNeighbors(territory, maxDistance, allowed);
     final Predicate<Unit> attackableUnits =
-        Matches.enemyUnit(player, data).and(Matches.unitIsBeingTransported().negate());
+        Matches.enemyUnit(player, data.getRelationshipTracker())
+            .and(Matches.unitIsBeingTransported().negate());
     for (final Territory current : possible) {
       final Route route = data.getMap().getRoute(territory, current, allowed);
       if (route != null
@@ -271,7 +273,8 @@ public class RocketsFireHelper implements Serializable {
         attackedTerritory
             .getUnitCollection()
             .getMatches(
-                Matches.enemyUnit(player, data).and(Matches.unitIsBeingTransported().negate()));
+                Matches.enemyUnit(player, data.getRelationshipTracker())
+                    .and(Matches.unitIsBeingTransported().negate()));
     final Collection<Unit> enemyTargetsTotal =
         CollectionUtils.getMatches(
             enemyUnits, Matches.unitIsAtMaxDamageOrNotCanBeDamaged(attackedTerritory).negate());

--- a/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -307,7 +307,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
       }
     } else if (onlyEnemyTerritories
         && !(Matches.isTerritoryEnemyAndNotUnownedWater(player, data).test(end)
-            || Matches.territoryHasEnemyUnits(player, data).test(end))) {
+            || Matches.territoryHasEnemyUnits(player, data.getRelationshipTracker()).test(end))) {
       return result.setErrorReturnResult("Destination Must Be Enemy Or Contain Enemy Units");
     }
     return result;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
@@ -121,7 +121,7 @@ public class UndoableMove extends AbstractUndoableMove {
             final Collection<Unit> enemyTargetsTotal =
                 end.getUnitCollection()
                     .getMatches(
-                        Matches.enemyUnit(bridge.getGamePlayer(), data)
+                        Matches.enemyUnit(bridge.getGamePlayer(), data.getRelationshipTracker())
                             .and(Matches.unitCanBeDamaged())
                             .and(Matches.unitIsBeingTransported().negate()));
             final Collection<Unit> enemyTargets =

--- a/game-core/src/main/java/games/strategy/triplea/delegate/UnitsThatCantFightUtil.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/UnitsThatCantFightUtil.java
@@ -19,7 +19,8 @@ public class UnitsThatCantFightUtil {
 
   Collection<Territory> getTerritoriesWhereUnitsCantFight(final GamePlayer player) {
     final Predicate<Unit> enemyAttackUnits =
-        Matches.enemyUnit(player, gameData).and(Matches.unitCanAttack(player));
+        Matches.enemyUnit(player, gameData.getRelationshipTracker())
+            .and(Matches.unitCanAttack(player));
     final Collection<Territory> cantFight = new ArrayList<>();
     for (final Territory current : gameData.getMap()) {
       final Predicate<Unit> ownedUnitsMatch =

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
@@ -349,7 +349,7 @@ public class AirBattle extends AbstractBattle {
             battleSite
                 .getUnitCollection()
                 .getMatches(
-                    Matches.enemyUnit(bridge.getGamePlayer(), gameData)
+                    Matches.enemyUnit(bridge.getGamePlayer(), gameData.getRelationshipTracker())
                         .and(Matches.unitCanBeDamaged())
                         .and(Matches.unitIsBeingTransported().negate()));
         for (final Unit unit : bombers) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -412,7 +412,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     final Predicate<Unit> seaTranportsOrSubs = seaTransports.or(Matches.unitCanEvade());
     // we want to match all sea zones with our units and enemy units
     final Predicate<Territory> anyTerritoryWithOwnAndEnemy =
-        Matches.territoryHasUnitsOwnedBy(player).and(Matches.territoryHasEnemyUnits(player, data));
+        Matches.territoryHasUnitsOwnedBy(player)
+            .and(Matches.territoryHasEnemyUnits(player, data.getRelationshipTracker()));
     final Predicate<Territory> enemyTerritoryAndOwnUnits =
         Matches.isTerritoryEnemyAndNotUnownedWater(player, data)
             .and(Matches.territoryHasUnitsOwnedBy(player));
@@ -1523,7 +1524,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     canNotLand.addAll(battleTracker.getPendingBattleSites(false));
     canNotLand.addAll(
         CollectionUtils.getMatches(
-            data.getMap().getTerritories(), Matches.territoryHasEnemyUnits(alliedPlayer, data)));
+            data.getMap().getTerritories(),
+            Matches.territoryHasEnemyUnits(alliedPlayer, data.getRelationshipTracker())));
     final Collection<Territory> possibleTerrs =
         new ArrayList<>(
             data.getMap()

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -441,7 +441,9 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
       // add the dependants to the attacking list
       attackingUnits.addAll(dependants);
       final List<Unit> enemyUnits =
-          territory.getUnitCollection().getMatches(Matches.enemyUnit(player, data));
+          territory
+              .getUnitCollection()
+              .getMatches(Matches.enemyUnit(player, data.getRelationshipTracker()));
       final IBattle bombingBattle = battleTracker.getPendingBombingBattle(territory);
       if (bombingBattle != null) {
         // we need to remove any units which are participating in bombing raids
@@ -623,7 +625,9 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     // units
     for (final Territory territory : battleTerritories) {
       final List<Unit> abandonedToUnits =
-          territory.getUnitCollection().getMatches(Matches.enemyUnit(player, data));
+          territory
+              .getUnitCollection()
+              .getMatches(Matches.enemyUnit(player, data.getRelationshipTracker()));
       final GamePlayer abandonedToPlayer = AbstractBattle.findPlayerWithMostUnits(abandonedToUnits);
 
       // now make sure to add any units that must move with these units, so that they get included

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -1100,7 +1100,7 @@ public class BattleTracker implements Serializable {
       site = route.getStart();
     }
     // this will be taken care of by the non fighting battle
-    if (!Matches.territoryHasEnemyUnits(gamePlayer, data).test(site)) {
+    if (!Matches.territoryHasEnemyUnits(gamePlayer, data.getRelationshipTracker()).test(site)) {
       return ChangeFactory.EMPTY_CHANGE;
     }
     // if just an enemy factory &/or AA then no battle

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -433,7 +433,8 @@ public class BattleTracker implements Serializable {
                 Matches.isTerritoryEnemyAndNotUnownedWaterOrImpassableOrRestricted(
                     gamePlayer, data));
     final Predicate<Territory> conquerable =
-        Matches.territoryIsEmptyOfCombatUnits(data, gamePlayer).and(passableLandAndNotRestricted);
+        Matches.territoryIsEmptyOfCombatUnits(data.getRelationshipTracker(), gamePlayer)
+            .and(passableLandAndNotRestricted);
     final Collection<Territory> conquered = new ArrayList<>();
     if (canConquerMiddleSteps) {
       conquered.addAll(route.getMatches(conquerable));

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -918,7 +918,7 @@ public class BattleTracker implements Serializable {
     // destroy any units that should be destroyed on capture
     if (Properties.getUnitsCanBeDestroyedInsteadOfCaptured(data.getProperties())) {
       final Predicate<Unit> enemyToBeDestroyed =
-          Matches.enemyUnit(gamePlayer, data)
+          Matches.enemyUnit(gamePlayer, data.getRelationshipTracker())
               .and(Matches.unitDestroyedWhenCapturedByOrFrom(gamePlayer));
       final Collection<Unit> destroyed =
           territory.getUnitCollection().getMatches(enemyToBeDestroyed);
@@ -956,7 +956,7 @@ public class BattleTracker implements Serializable {
     }
     // destroy any disabled units owned by the enemy that are NOT infrastructure or factories
     final Predicate<Unit> enemyToBeDestroyed =
-        Matches.enemyUnit(gamePlayer, data)
+        Matches.enemyUnit(gamePlayer, data.getRelationshipTracker())
             .and(Matches.unitIsDisabled())
             .and(Matches.unitIsInfrastructure().negate());
     final Collection<Unit> destroyed = territory.getUnitCollection().getMatches(enemyToBeDestroyed);
@@ -973,7 +973,8 @@ public class BattleTracker implements Serializable {
     }
     // take over non combatants
     final Predicate<Unit> enemyNonCom =
-        Matches.enemyUnit(gamePlayer, data).and(Matches.unitIsInfrastructure());
+        Matches.enemyUnit(gamePlayer, data.getRelationshipTracker())
+            .and(Matches.unitIsInfrastructure());
     final Predicate<Unit> willBeCaptured =
         enemyNonCom.or(
             Matches.unitCanBeCapturedOnEnteringToInThisTerritory(
@@ -1104,7 +1105,8 @@ public class BattleTracker implements Serializable {
     }
     // if just an enemy factory &/or AA then no battle
     final Collection<Unit> enemyUnits =
-        CollectionUtils.getMatches(site.getUnits(), Matches.enemyUnit(gamePlayer, data));
+        CollectionUtils.getMatches(
+            site.getUnits(), Matches.enemyUnit(gamePlayer, data.getRelationshipTracker()));
     if (route.getEnd() != null
         && !enemyUnits.isEmpty()
         && enemyUnits.stream().allMatch(Matches.unitIsInfrastructure())) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -148,7 +148,9 @@ public class MustFightBattle extends DependentBattle
       final BattleTracker battleTracker) {
     super(battleSite, attacker, battleTracker, data);
     defendingUnits.addAll(
-        this.battleSite.getUnitCollection().getMatches(Matches.enemyUnit(attacker, data)));
+        this.battleSite
+            .getUnitCollection()
+            .getMatches(Matches.enemyUnit(attacker, data.getRelationshipTracker())));
     maxRounds =
         battleSite.isWater()
             ? Properties.getSeaBattleRounds(data.getProperties())
@@ -158,7 +160,9 @@ public class MustFightBattle extends DependentBattle
   void resetDefendingUnits(final GamePlayer attacker, final GameState data) {
     defendingUnits.clear();
     defendingUnits.addAll(
-        battleSite.getUnitCollection().getMatches(Matches.enemyUnit(attacker, data)));
+        battleSite
+            .getUnitCollection()
+            .getMatches(Matches.enemyUnit(attacker, data.getRelationshipTracker())));
   }
 
   /** Used for head-less battles. */
@@ -300,7 +304,8 @@ public class MustFightBattle extends DependentBattle
       remaining.addAll(
           CollectionUtils.getMatches(
               unitsLeftInTerritory,
-              Matches.unitIsOwnedBy(defender).or(Matches.enemyUnit(attacker, gameData))));
+              Matches.unitIsOwnedBy(defender)
+                  .or(Matches.enemyUnit(attacker, gameData.getRelationshipTracker()))));
     }
     return new ArrayList<>(remaining);
   }
@@ -876,7 +881,7 @@ public class MustFightBattle extends DependentBattle
     // there
     // or if we are moving out of a territory containing enemy units, we cannot retreat back there
     final Predicate<Unit> enemyUnitsThatPreventRetreat =
-        PredicateBuilder.of(Matches.enemyUnit(attacker, gameData))
+        PredicateBuilder.of(Matches.enemyUnit(attacker, gameData.getRelationshipTracker()))
             .and(Matches.unitIsNotInfrastructure())
             .and(Matches.unitIsBeingTransported().negate())
             .and(Matches.unitIsSubmerged().negate())

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
@@ -94,7 +94,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     final Map<String, Set<UnitType>> airborneTechTargetsAllowed =
         TechAbilityAttachment.getAirborneTargettedByAa(attacker, gameData);
     final Predicate<Unit> defenders =
-        Matches.enemyUnit(attacker, gameData)
+        Matches.enemyUnit(attacker, gameData.getRelationshipTracker())
             .and(
                 Matches.unitCanBeDamaged()
                     .or(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
@@ -105,7 +105,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
                             Matches.unitIsAaForBombingThisUnitOnly(),
                             round,
                             true,
-                            gameData)));
+                            gameData.getRelationshipTracker())));
     if (targets.isEmpty()) {
       defendingUnits = CollectionUtils.getMatches(battleSite.getUnits(), defenders);
     } else {
@@ -119,7 +119,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
                   Matches.unitIsAaForBombingThisUnitOnly(),
                   round,
                   true,
-                  gameData));
+                  gameData.getRelationshipTracker()));
       targets.addAll(this.targets.keySet());
       defendingUnits = targets;
     }
@@ -213,7 +213,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
                     Matches.unitIsAaForBombingThisUnitOnly(),
                     round,
                     true,
-                    gameData));
+                    gameData.getRelationshipTracker()));
     aaTypes = UnitAttachment.getAllOfTypeAas(defendingAa);
     // reverse since stacks are in reverse order
     Collections.reverse(aaTypes);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/RemoveUnprotectedUnits.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/RemoveUnprotectedUnits.java
@@ -121,7 +121,7 @@ public class RemoveUnprotectedUnits implements BattleStep {
   private Collection<Unit> getEnemyUnitsThatCanFire(final GamePlayer player) {
     final Predicate<Unit> enemyUnitsMatch =
         Matches.unitIsNotLand()
-            .and(Matches.enemyUnit(player, battleState.getGameData()))
+            .and(Matches.enemyUnit(player, battleState.getGameData().getRelationshipTracker()))
             .and(Matches.unitIsSubmerged().negate())
             .and(Matches.unitCanAttack(player));
     return CollectionUtils.getMatches(battleState.getBattleSite().getUnits(), enemyUnitsMatch);

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/FiringGroupSplitterAa.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/FiringGroupSplitterAa.java
@@ -58,7 +58,7 @@ public class FiringGroupSplitterAa
                 Matches.unitIsAaForCombatOnly(),
                 battleState.getStatus().getRound(),
                 side == DEFENSE,
-                battleState.getGameData()));
+                battleState.getGameData().getRelationshipTracker()));
 
     final List<String> typeAas = UnitAttachment.getAllOfTypeAas(aaUnits);
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreat.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreat.java
@@ -144,7 +144,8 @@ public class DefensiveSubsRetreat implements BattleStep {
         Matches.territoryIsWater()
             .and(
                 Matches.territoryHasNoEnemyUnits(
-                    battleState.getPlayer(DEFENSE), battleState.getGameData()))
+                    battleState.getPlayer(DEFENSE),
+                    battleState.getGameData().getRelationshipTracker()))
             .and(canalMatch);
     return CollectionUtils.getMatches(possible, match);
   }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/AirMovementValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/AirMovementValidator.java
@@ -625,7 +625,10 @@ public final class AirMovementValidator {
 
     // Remove suicide units if combat move and any enemy units at destination
     final Collection<Unit> enemyUnitsAtEnd =
-        route.getEnd().getUnitCollection().getMatches(Matches.enemyUnit(player, player.getData()));
+        route
+            .getEnd()
+            .getUnitCollection()
+            .getMatches(Matches.enemyUnit(player, player.getData().getRelationshipTracker()));
     if (!enemyUnitsAtEnd.isEmpty() && GameStepPropertiesHelper.isCombatMove(player.getData())) {
       ownedAir.removeIf(Matches.unitIsSuicideOnAttack());
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
@@ -1211,7 +1211,8 @@ public class MoveValidator {
           } else if (!AbstractMoveDelegate.getBattleTracker(data).wasConquered(routeEnd)) {
             // this is an unload to a friendly territory
             if (isScramblingOrKamikazeAttacksEnabled
-                || !Matches.territoryIsEmptyOfCombatUnits(data, player).test(routeStart)) {
+                || !Matches.territoryIsEmptyOfCombatUnits(data.getRelationshipTracker(), player)
+                    .test(routeStart)) {
               // Unloading a transport from a sea zone with a battle, to a friendly land territory,
               // during combat move phase, is illegal and in addition to being illegal, it is also
               // causing problems if

--- a/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
@@ -1195,7 +1195,7 @@ public class MoveValidator {
               .and(Matches.unitIsNotTransportButCouldBeCombatTransport());
       for (final Unit transport : transports) {
         if (!isNonCombat) {
-          if (Matches.territoryHasEnemyUnits(player, data).test(routeEnd)
+          if (Matches.territoryHasEnemyUnits(player, data.getRelationshipTracker()).test(routeEnd)
               || Matches.isTerritoryEnemyAndNotUnownedWater(player, data).test(routeEnd)) {
             // this is an amphibious assault
             if (subsPreventUnescortedAmphibAssaults

--- a/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
@@ -1806,7 +1806,8 @@ public class MoveValidator {
             .and(
                 Matches.territoryWasFoughtOver(AbstractMoveDelegate.getBattleTracker(data))
                     .negate());
-    final Predicate<Territory> noEnemyUnits = Matches.territoryHasNoEnemyUnits(player, data);
+    final Predicate<Territory> noEnemyUnits =
+        Matches.territoryHasNoEnemyUnits(player, data.getRelationshipTracker());
     final Predicate<Territory> noAa = Matches.territoryHasEnemyAaForFlyOver(player, data).negate();
     final List<Predicate<Territory>> prioritizedMovePreferences =
         new ArrayList<>(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
@@ -1809,7 +1809,8 @@ public class MoveValidator {
                     .negate());
     final Predicate<Territory> noEnemyUnits =
         Matches.territoryHasNoEnemyUnits(player, data.getRelationshipTracker());
-    final Predicate<Territory> noAa = Matches.territoryHasEnemyAaForFlyOver(player, data).negate();
+    final Predicate<Territory> noAa =
+        Matches.territoryHasEnemyAaForFlyOver(player, data.getRelationshipTracker()).negate();
     final List<Predicate<Territory>> prioritizedMovePreferences =
         new ArrayList<>(
             List.of(

--- a/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/MoveValidator.java
@@ -580,7 +580,9 @@ public class MoveValidator {
     // units that can enter
     // territories with enemy units during NCM
     if (end.getUnitCollection()
-            .anyMatch(Matches.enemyUnit(player, data).and(Matches.unitIsSubmerged().negate()))
+            .anyMatch(
+                Matches.enemyUnit(player, data.getRelationshipTracker())
+                    .and(Matches.unitIsSubmerged().negate()))
         && !onlyIgnoredUnitsOnPath(route, player, false)
         && !(end.isWater() && units.stream().allMatch(Matches.unitIsAir()))
         && !(Properties.getSubsCanEndNonCombatMoveWithEnemies(data.getProperties())
@@ -706,7 +708,9 @@ public class MoveValidator {
     if (!isEditMode) {
 
       // Make sure all units are at least friendly
-      for (final Unit unit : CollectionUtils.getMatches(units, Matches.enemyUnit(player, data))) {
+      for (final Unit unit :
+          CollectionUtils.getMatches(
+              units, Matches.enemyUnit(player, data.getRelationshipTracker()))) {
         result.addDisallowedUnit("Can only move friendly units", unit);
       }
 
@@ -951,7 +955,7 @@ public class MoveValidator {
   private boolean noEnemyUnitsOnPathMiddleSteps(final Route route, final GamePlayer player) {
     final Predicate<Unit> alliedOrNonCombat =
         Matches.unitIsInfrastructure()
-            .or(Matches.enemyUnit(player, data).negate())
+            .or(Matches.enemyUnit(player, data.getRelationshipTracker()).negate())
             .or(Matches.unitIsSubmerged());
     // Submerged units do not interfere with movement
     return route.getMiddleSteps().stream()
@@ -968,11 +972,11 @@ public class MoveValidator {
         Matches.unitIsInfrastructure()
             .or(Matches.unitIsTransportButNotCombatTransport())
             .or(Matches.unitIsLand())
-            .or(Matches.enemyUnit(player, data).negate());
+            .or(Matches.enemyUnit(player, data.getRelationshipTracker()).negate());
     final Predicate<Unit> subOnly =
         Matches.unitIsInfrastructure()
             .or(Matches.unitCanBeMovedThroughByEnemies())
-            .or(Matches.enemyUnit(player, data).negate());
+            .or(Matches.enemyUnit(player, data.getRelationshipTracker()).negate());
     final Predicate<Unit> transportOrSubOnly = transportOnly.or(subOnly);
     final boolean getIgnoreTransportInMovement =
         Properties.getIgnoreTransportInMovement(data.getProperties());
@@ -1004,7 +1008,7 @@ public class MoveValidator {
 
   private boolean enemyDestroyerOnPath(final Route route, final GamePlayer player) {
     final Predicate<Unit> enemyDestroyer =
-        Matches.unitIsDestroyer().and(Matches.enemyUnit(player, data));
+        Matches.unitIsDestroyer().and(Matches.enemyUnit(player, data.getRelationshipTracker()));
     return route.getMiddleSteps().stream()
         .anyMatch(current -> current.getUnitCollection().anyMatch(enemyDestroyer));
   }
@@ -1304,7 +1308,8 @@ public class MoveValidator {
         return result.setErrorReturnResult("Units cannot move before loading onto transports");
       }
       final Predicate<Unit> enemyNonSubmerged =
-          Matches.enemyUnit(player, data).and(Matches.unitIsSubmerged().negate());
+          Matches.enemyUnit(player, data.getRelationshipTracker())
+              .and(Matches.unitIsSubmerged().negate());
       if (!Properties.getUnitsCanLoadInHostileSeaZones(data.getProperties())
           && route.getEnd().getUnitCollection().anyMatch(enemyNonSubmerged)
           && nonParatroopersPresent(player, landAndAir)

--- a/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
@@ -633,7 +633,7 @@ public class MovePanel extends AbstractMovePanel {
           final GamePlayer player = getCurrentPlayer();
           return Matches.territoryHasUnitsOwnedBy(player)
               .negate()
-              .and(Matches.territoryHasEnemyUnits(player, getData()))
+              .and(Matches.territoryHasEnemyUnits(player, getData().getRelationshipTracker()))
               .test(territory);
         }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MoveDelegateTest.java
@@ -841,12 +841,16 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
     // Get the attacking land units that will retreat and their number
     final List<Unit> retreatingLandUnits =
         new ArrayList<>(
-            finlandNorway.getUnitCollection().getMatches(Matches.enemyUnit(germans, gameData)));
+            finlandNorway
+                .getUnitCollection()
+                .getMatches(Matches.enemyUnit(germans, gameData.getRelationshipTracker())));
     final int retreatingLandSizeInt = retreatingLandUnits.size();
     // Get the defending land units that and their number
     final List<Unit> defendingLandUnits =
         new ArrayList<>(
-            finlandNorway.getUnitCollection().getMatches(Matches.enemyUnit(british, gameData)));
+            finlandNorway
+                .getUnitCollection()
+                .getMatches(Matches.enemyUnit(british, gameData.getRelationshipTracker())));
     final int defendingLandSizeInt = defendingLandUnits.size();
     // Set up the battles and the dependent battles
     final IBattle inFinlandNorway =
@@ -918,12 +922,16 @@ class MoveDelegateTest extends AbstractDelegateTestCase {
     // Get the attacking land units that will retreat and their number
     final List<Unit> retreatingLandUnits =
         new ArrayList<>(
-            finlandNorway.getUnitCollection().getMatches(Matches.enemyUnit(germans, gameData)));
+            finlandNorway
+                .getUnitCollection()
+                .getMatches(Matches.enemyUnit(germans, gameData.getRelationshipTracker())));
     final int retreatingLandSizeInt = retreatingLandUnits.size();
     // Get the defending land units that and their number
     final List<Unit> defendingLandUnits =
         new ArrayList<>(
-            finlandNorway.getUnitCollection().getMatches(Matches.enemyUnit(british, gameData)));
+            finlandNorway
+                .getUnitCollection()
+                .getMatches(Matches.enemyUnit(british, gameData.getRelationshipTracker())));
     final int defendingLandSizeInt = defendingLandUnits.size();
     // Set up the battles and the dependent battles
     final IBattle inFinlandNorway =


### PR DESCRIPTION
This updates `Matches.enemyUnit` to use the `RelationshipTracker` instead of `GameState`.  And I updated many of the Matches that just call `enemyUnit` to also use `RelationshipTracker` instead of `GameState`.

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
