### PR TITLE
Unify how step names are detected

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameStep.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameStep.java
@@ -165,15 +165,51 @@ public class GameStep extends GameDataComponent {
         || name.endsWith("NonCombatMove");
   }
 
-  public static boolean isPurchaseOrBidStep(final String stepName) {
-    return stepName.endsWith("Bid") || isPurchase(stepName);
+  public static boolean isTechStep(final String stepName) {
+    return stepName.endsWith("Tech");
   }
 
-  public static boolean isPurchase(final String stepName) {
+  public static boolean isMoveStep(final String stepName) {
+    return stepName.endsWith("Move");
+  }
+
+  public static boolean isNonCombatMoveStep(final String stepName) {
+    return stepName.endsWith("NonCombatMove");
+  }
+
+  public static boolean isBattleStep(final String stepName) {
+    return stepName.endsWith("Battle");
+  }
+
+  public static boolean isPoliticsStep(final String stepName) {
+    return stepName.endsWith("Politics");
+  }
+
+  public static boolean isUserActionsStep(final String stepName) {
+    return stepName.endsWith("UserActions");
+  }
+
+  public static boolean isEndTurnStep(final String stepName) {
+    return stepName.endsWith("EndTurn");
+  }
+
+  public static boolean isPurchaseOrBidStep(final String stepName) {
+    return isBidStep(stepName) || isPurchaseStep(stepName);
+  }
+
+  public static boolean isPurchaseStep(final String stepName) {
     return stepName.endsWith("Purchase");
+  }
+
+  public static boolean isBidStep(final String stepName) {
+    return stepName.endsWith("Bid");
   }
 
   public static boolean isPlaceStep(final String stepName) {
     return stepName.endsWith("Place");
+  }
+
+  public static boolean isTechActivationStep(final String stepName) {
+    return stepName.endsWith("TechActivation");
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleAPlayer.java
@@ -131,7 +131,7 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer {
     ui.requiredTurnSeries(this.getGamePlayer());
     enableEditModeMenu();
     boolean badStep = false;
-    if (name.endsWith("Tech")) {
+    if (GameStep.isTechStep(name)) {
       tech();
     } else if (GameStep.isPurchaseOrBidStep(name)) {
       purchase(GameStepPropertiesHelper.isBid(getGameData()));
@@ -139,22 +139,22 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer {
         ui.waitForMoveForumPoster(this.getGamePlayer(), getPlayerBridge());
         // TODO only do forum post if there is a combat
       }
-    } else if (name.endsWith("Move")) {
+    } else if (GameStep.isMoveStep(name)) {
       final boolean nonCombat = GameStepPropertiesHelper.isNonCombatMove(getGameData(), false);
       move(nonCombat, name);
       if (!nonCombat) {
         ui.waitForMoveForumPoster(this.getGamePlayer(), getPlayerBridge());
         // TODO only do forum post if there is a combat
       }
-    } else if (name.endsWith("Battle")) {
+    } else if (GameStep.isBattleStep(name)) {
       battle();
     } else if (GameStep.isPlaceStep(name)) {
       place();
-    } else if (name.endsWith("Politics")) {
+    } else if (GameStep.isPoliticsStep(name)) {
       politics(true);
-    } else if (name.endsWith("UserActions")) {
+    } else if (GameStep.isUserActionsStep(name)) {
       userActions(true);
-    } else if (name.endsWith("EndTurn")) {
+    } else if (GameStep.isEndTurnStep(name)) {
       endTurn();
       // reset our sounds
       soundPlayedAlreadyCombatMove = false;
@@ -165,7 +165,7 @@ public abstract class TripleAPlayer extends AbstractHumanPlayer {
       soundPlayedAlreadyEndTurn = false;
       soundPlayedAlreadyPlacement = false;
     } else {
-      badStep = !name.endsWith("TechActivation");
+      badStep = !GameStep.isTechActivationStep(name);
     }
     disableEditModeMenu();
     if (badStep) {

--- a/game-core/src/main/java/games/strategy/triplea/ai/AbstractBuiltInAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/AbstractBuiltInAi.java
@@ -3,6 +3,7 @@ package games.strategy.triplea.ai;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.GameState;
+import games.strategy.engine.data.GameStep;
 import games.strategy.engine.data.Resource;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
@@ -13,6 +14,7 @@ import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.DelegateFinder;
 import games.strategy.triplea.delegate.DiceRoll;
+import games.strategy.triplea.delegate.GameStepPropertiesHelper;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.PoliticsDelegate;
 import games.strategy.triplea.delegate.battle.IBattle.BattleType;
@@ -494,35 +496,35 @@ public abstract class AbstractBuiltInAi extends AbstractBasePlayer {
   public final void start(final String name) {
     super.start(name);
     final GamePlayer gamePlayer = this.getGamePlayer();
-    if (name.endsWith("Bid")) {
+    if (GameStep.isBidStep(name)) {
       final IPurchaseDelegate purchaseDelegate =
           (IPurchaseDelegate) getPlayerBridge().getRemoteDelegate();
       final String propertyName = gamePlayer.getName() + " bid";
       final int bidAmount = getGameData().getProperties().get(propertyName, 0);
       purchase(true, bidAmount, purchaseDelegate, getGameData(), gamePlayer);
-    } else if (name.endsWith("Purchase")) {
+    } else if (GameStep.isPurchaseStep(name)) {
       final IPurchaseDelegate purchaseDelegate =
           (IPurchaseDelegate) getPlayerBridge().getRemoteDelegate();
       final Resource pus = getGameData().getResourceList().getResource(Constants.PUS);
       final int leftToSpend = gamePlayer.getResources().getQuantity(pus);
       purchase(false, leftToSpend, purchaseDelegate, getGameData(), gamePlayer);
-    } else if (name.endsWith("Tech")) {
+    } else if (GameStep.isTechStep(name)) {
       final ITechDelegate techDelegate = (ITechDelegate) getPlayerBridge().getRemoteDelegate();
       tech(techDelegate, getGameData(), gamePlayer);
-    } else if (name.endsWith("Move")) {
+    } else if (GameStep.isMoveStep(name)) {
       final IMoveDelegate moveDel = (IMoveDelegate) getPlayerBridge().getRemoteDelegate();
-      if (!name.endsWith("AirborneCombatMove")) {
-        move(name.endsWith("NonCombatMove"), moveDel, getGameData(), gamePlayer);
+      if (!GameStepPropertiesHelper.isAirborneMove(getGameData())) {
+        move(GameStep.isNonCombatMoveStep(name), moveDel, getGameData(), gamePlayer);
       }
-    } else if (name.endsWith("Battle")) {
+    } else if (GameStep.isBattleStep(name)) {
       battle((IBattleDelegate) getPlayerBridge().getRemoteDelegate());
-    } else if (name.endsWith("Politics")) {
+    } else if (GameStep.isPoliticsStep(name)) {
       politicalActions();
-    } else if (name.endsWith("Place")) {
+    } else if (GameStep.isPlaceStep(name)) {
       final IAbstractPlaceDelegate placeDel =
           (IAbstractPlaceDelegate) getPlayerBridge().getRemoteDelegate();
-      place(name.contains("Bid"), placeDel, getGameData(), gamePlayer);
-    } else if (name.endsWith("EndTurn")) {
+      place(GameStep.isBidStep(name), placeDel, getGameData(), gamePlayer);
+    } else if (GameStep.isEndTurnStep(name)) {
       endTurn((IAbstractForumPosterDelegate) getPlayerBridge().getRemoteDelegate(), gamePlayer);
     }
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/PlacementUnitsCollapsiblePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/PlacementUnitsCollapsiblePanel.java
@@ -67,7 +67,7 @@ class PlacementUnitsCollapsiblePanel {
         return false;
       }
 
-      if (GameStep.isPurchase(previousStep.getName())) {
+      if (GameStep.isPurchaseStep(previousStep.getName())) {
         return true;
       }
     }


### PR DESCRIPTION
GameStep had most of the steps already so this adds the remainder. Also,
this updates TripleAPlayer and AbstractBuiltInAi to use the GameStep
methods that they weren't using before.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->
Played Global40 Fast AI

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->
There is already a `GameStep` object but it isn't available in the `start` method because the step name is passed between server and clients.  But I think we should change `start` to be a final method and have it turn the step name into a `GameStep` object and then call an abstract protected method (named something like `runStep`, `runPhase`, `startStep`).  Then this new protected method would have a `GameStep` object and it could have an enum part of it to indicate which step it is.  This would probably also allow merging some code in `GameStep` and `GameStepPropertiesHelper`.

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
