### PR TITLE
Custom check to use slf4j (disabled)

### DIFF
--- a/.travis/stages/verify/code-convention-checks/check-custom-style
+++ b/.travis/stages/verify/code-convention-checks/check-custom-style
@@ -58,7 +58,7 @@ function displayResult() {
 }
 
 function favorJava9CollectionsApi() {
-  title "Verifying preference to use List.of(), Map.of() and Set.of() compaboldRed to java.util.Collections.*"
+  title "Verifying preference to use List.of(), Map.of() and Set.of() compared to java.util.Collections.*"
   example "instead of 'Collections.singleton(value)', use 'Set.of(value)'"
   local found=0
 

--- a/.travis/stages/verify/code-convention-checks/check-custom-style
+++ b/.travis/stages/verify/code-convention-checks/check-custom-style
@@ -29,7 +29,7 @@ function main() {
   favorJava9CollectionsApi
   #referToCollectionsByInterfaceType
   removeUnusedLogAnnotations
-  preferSlf4jOverJavaLogging  
+  #preferSlf4jOverJavaLogging  
   databaseNamesAreLowerSnakeCase
   databaseTablesAreSingular
   noTabsInSql

--- a/.travis/stages/verify/code-convention-checks/check-custom-style
+++ b/.travis/stages/verify/code-convention-checks/check-custom-style
@@ -29,6 +29,7 @@ function main() {
   favorJava9CollectionsApi
   #referToCollectionsByInterfaceType
   removeUnusedLogAnnotations
+  preferSlf4jOverJavaLogging  
   databaseNamesAreLowerSnakeCase
   databaseTablesAreSingular
   noTabsInSql
@@ -82,16 +83,30 @@ function referToCollectionsByInterfaceType() {
 }
 
 function removeUnusedLogAnnotations() {
-  title "Remove unused lombok @Log and @Slf4j annotations"
+  title "Remove unused lombok @Slf4j annotations"
   local found=0
 
   while read -r file; do
-    if grep -Eq "@Log|@Slf4j" "$file"; then
+    if grep -Eq "@Slf4j" "$file"; then
       if ! grep -Eq "log::|log\." "$file"; then
         echo -e "${bold}$file${normal}"
         found=1
         status=1
       fi
+    fi
+  done <<< "$(cat "$javaFiles")"
+
+  displayResult "$found"
+}
+
+function preferSlf4jOverJavaLogging() {
+  title "Use @Slf4j instead of @Log"
+  local found=0
+
+  while read -r file; do
+    if grep --color=auto -EHn "@Log|^import java.util.log" "$file"; then
+      found=1
+      status=1
     fi
   done <<< "$(cat "$javaFiles")"
 

--- a/.travis/stages/verify/code-convention-checks/check-custom-style
+++ b/.travis/stages/verify/code-convention-checks/check-custom-style
@@ -8,7 +8,7 @@ green="\e[92m"
 blue="\e[34m"
 normal="\e[0m"
 bold="\e[1m"
-blinkingRed="${bold}\e[5m\e[91m"
+boldRed="${bold}\e[91m"
 
 javaFiles=$(mktemp)
 testFiles=$(mktemp)
@@ -51,14 +51,14 @@ function displayResult() {
   if [ "$found" -eq 0 ]; then
     echo -e "${green}[OK]${normal}"
   else
-    echo -e "${blinkingRed}[FIX]${normal}"
+    echo -e "${boldRed}[FIX]${normal}"
   fi
   echo ""
   
 }
 
 function favorJava9CollectionsApi() {
-  title "Verifying preference to use List.of(), Map.of() and Set.of() compared to java.util.Collections.*"
+  title "Verifying preference to use List.of(), Map.of() and Set.of() compaboldRed to java.util.Collections.*"
   example "instead of 'Collections.singleton(value)', use 'Set.of(value)'"
   local found=0
 

--- a/game-headless/src/main/java/org/triplea/game/server/HeadlessGameRunner.java
+++ b/game-headless/src/main/java/org/triplea/game/server/HeadlessGameRunner.java
@@ -23,5 +23,4 @@ public final class HeadlessGameRunner {
         .playerTypes(PlayerTypes.getBuiltInPlayerTypes())
         .build();
   }
-
 }


### PR DESCRIPTION
Adds a custom build check for us to prefer slf4j over java.util.log

commit d9a66569808fb488a2d79d0886d9db637c04116d

    Add custom check to prefer Slf4j over java.util.log

commit 08021d4549a680cfb21aea55719f37a3351e62ae

    change blinking red to solid red

commit ccf540467ed3c28efa4af742e0eee42d73e6c022

    Until java.util.logger references are removed, disable custom check to prefer slf4j


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
