### PR TITLE
Remove 'version' attribute of XML 'info' tag

### DIFF
--- a/domain-data/src/main/java/org/triplea/domain/data/LobbyGame.java
+++ b/domain-data/src/main/java/org/triplea/domain/data/LobbyGame.java
@@ -26,7 +26,6 @@ public class LobbyGame {
   private Integer playerCount;
   private Integer gameRound;
   private Long epochMilliTimeStarted;
-  private String mapVersion;
   private Boolean passworded;
   private String status;
   @With private String comments;

--- a/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -29,6 +29,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.swing.SwingUtilities;
 import org.triplea.injection.Injections;
 import org.triplea.io.IoUtils;
+import org.triplea.java.RemoveOnNextMajorRelease;
 import org.triplea.util.Tuple;
 import org.triplea.util.Version;
 
@@ -67,7 +68,7 @@ public class GameData implements Serializable, GameState {
   private transient ReadWriteLock readWriteLock = new ReentrantReadWriteLock();
   private transient volatile boolean forceInSwingEventThread = false;
   private String gameName;
-  private Version gameVersion;
+  @RemoveOnNextMajorRelease @Deprecated private Version gameVersion;
   private int diceSides;
   private transient List<TerritoryListener> territoryListeners = new CopyOnWriteArrayList<>();
   private transient List<GameDataChangeListener> dataChangeListeners = new CopyOnWriteArrayList<>();
@@ -293,14 +294,6 @@ public class GameData implements Serializable, GameState {
 
   public IGameLoader getGameLoader() {
     return loader;
-  }
-
-  public void setGameVersion(final Version gameVersion) {
-    this.gameVersion = gameVersion;
-  }
-
-  public Version getGameVersion() {
-    return gameVersion;
   }
 
   @VisibleForTesting

--- a/game-core/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
+++ b/game-core/src/main/java/games/strategy/engine/data/export/GameDataExporter.java
@@ -663,9 +663,6 @@ public class GameDataExporter {
   }
 
   private static Info info(final GameData data) {
-    return Info.builder()
-        .name(data.getGameName())
-        .version(data.getGameVersion().toString())
-        .build();
+    return Info.builder().name(data.getGameName()).build();
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
+++ b/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
@@ -316,7 +316,6 @@ public final class GameParser {
 
   private void parseInfo(final Info info) {
     data.setGameName(info.getName());
-    data.setGameVersion(new Version(info.getVersion()));
   }
 
   private void parseTerritories(

--- a/game-core/src/main/java/games/strategy/engine/framework/message/PlayerListing.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/message/PlayerListing.java
@@ -15,7 +15,6 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.Getter;
-import org.triplea.util.Version;
 
 /**
  * Data from the server indicating what players are available to be taken, and what players are
@@ -35,7 +34,6 @@ public class PlayerListing implements Serializable {
   @Getter private final Map<String, Boolean> playersEnabledListing;
   @Getter private final Map<String, String> localPlayerTypes;
   @Getter private final Collection<String> playersAllowedToBeDisabled;
-  @Getter private final Version gameVersion;
   @Getter private final String gameName;
   @Getter private final String gameRound;
   @Getter private final Map<String, Collection<String>> playerNamesAndAlliancesInTurnOrder;
@@ -43,27 +41,17 @@ public class PlayerListing implements Serializable {
   public PlayerListing(
       final Map<String, Boolean> playersEnabledListing,
       final Map<String, PlayerTypes.Type> localPlayerTypes,
-      final Version gameVersion,
       final String gameName,
       final String gameRound) {
     // we don't need the playerToNode list, the disable-able players, or the alliances list, for a
     // local game
-    this(
-        null,
-        playersEnabledListing,
-        localPlayerTypes,
-        gameVersion,
-        gameName,
-        gameRound,
-        null,
-        null);
+    this(null, playersEnabledListing, localPlayerTypes, gameName, gameRound, null, null);
   }
 
   public PlayerListing(
       final Map<String, String> playerToNodeListing,
       final Map<String, Boolean> playersEnabledListing,
       final Map<String, PlayerTypes.Type> localPlayerTypes,
-      final Version gameVersion,
       final String gameName,
       final String gameRound,
       final Collection<String> playersAllowedToBeDisabled,
@@ -80,7 +68,6 @@ public class PlayerListing implements Serializable {
         localPlayerTypes.entrySet().stream()
             // convert Map<String,PlayerType> -> Map<String,String>
             .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().getLabel()));
-    this.gameVersion = gameVersion;
     this.gameName = gameName;
     this.gameRound = gameRound;
     this.playersAllowedToBeDisabled =

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/LocalLauncher.java
@@ -126,7 +126,6 @@ public class LocalLauncher implements ILauncher {
         new PlayerListing(
             playersEnabled,
             playerTypes,
-            gameSelectorModel.getGameData().getGameVersion(),
             gameSelectorModel.getGameName(),
             gameSelectorModel.getGameRound());
     return new LocalLauncher(

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ClientModel.java
@@ -402,8 +402,7 @@ public class ClientModel implements IMessengerErrorListener {
   }
 
   private void internalPlayerListingChanged(final PlayerListing listing) {
-    gameSelectorModel.clearDataButKeepGameInfo(
-        listing.getGameName(), listing.getGameRound(), listing.getGameVersion().toString());
+    gameSelectorModel.clearDataButKeepGameInfo(listing.getGameName(), listing.getGameRound());
     synchronized (this) {
       playersToNodes = listing.getPlayerToNodeListing();
       playersEnabledListing = listing.getPlayersEnabledListing();

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -80,7 +80,6 @@ import org.triplea.java.Interruptibles;
 import org.triplea.java.concurrency.AsyncRunner;
 import org.triplea.swing.SwingAction;
 import org.triplea.util.ExitStatus;
-import org.triplea.util.Version;
 
 /** Represents a network-aware game server to which multiple clients may connect. */
 @Slf4j
@@ -501,7 +500,6 @@ public class ServerModel extends Observable implements IConnectionChangeListener
             new HashMap<>(),
             new HashMap<>(playersEnabledListing),
             getLocalPlayerTypes(),
-            new Version(0, 0, 0),
             gameSelectorModel.getGameName(),
             gameSelectorModel.getGameRound(),
             new HashSet<>(playersAllowedToBeDisabled),
@@ -511,7 +509,6 @@ public class ServerModel extends Observable implements IConnectionChangeListener
           new HashMap<>(playersToNodeListing),
           new HashMap<>(playersEnabledListing),
           getLocalPlayerTypes(),
-          data.getGameVersion(),
           data.getGameName(),
           data.getSequence().getRound() + "",
           new HashSet<>(playersAllowedToBeDisabled),

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/InGameLobbyWatcher.java
@@ -105,7 +105,6 @@ public class InGameLobbyWatcher {
             .round(gameRound)
             .comment(SystemPropertyReader.gameComments())
             .passworded(passworded)
-            .gameVersion("0")
             .build();
 
     final GamePostingResponse gamePostingResponse =
@@ -212,10 +211,7 @@ public class InGameLobbyWatcher {
   }
 
   private void gameSelectorModelUpdated() {
-    postUpdate(
-        gameDescription
-            .withGameName(gameSelectorModel.getGameName())
-            .withGameVersion(gameSelectorModel.getGameVersion()));
+    postUpdate(gameDescription.withGameName(gameSelectorModel.getGameName()));
   }
 
   public void setGameSelectorModel(@Nullable final GameSelectorModel model) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModel.java
@@ -44,7 +44,6 @@ public class GameSelectorModel extends Observable implements GameSelector {
   private GameData gameData = null;
 
   @Getter private String gameName = "-";
-  @Getter private String gameVersion = "-";
   @Getter private String gameRound = "-";
   @Nullable private String fileName;
   @Getter private boolean canSelect = true;
@@ -154,13 +153,11 @@ public class GameSelectorModel extends Observable implements GameSelector {
    * We don't have a game data (i.e. we are a remote player and the data has not been sent yet), but
    * we still want to display game info.
    */
-  public void clearDataButKeepGameInfo(
-      final String gameName, final String gameRound, final String gameVersion) {
+  public void clearDataButKeepGameInfo(final String gameName, final String gameRound) {
     synchronized (this) {
       gameData = null;
       this.gameName = gameName;
       this.gameRound = gameRound;
-      this.gameVersion = gameVersion;
     }
     notifyObs();
   }
@@ -172,11 +169,10 @@ public class GameSelectorModel extends Observable implements GameSelector {
   public void setGameData(final GameData data) {
     synchronized (this) {
       if (data == null) {
-        gameName = gameRound = gameVersion = "-";
+        gameName = gameRound = "-";
       } else {
         gameName = data.getGameName();
         gameRound = "" + data.getSequence().getRound();
-        gameVersion = data.getGameVersion().toString();
       }
       gameData = data;
     }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -55,7 +55,6 @@ public final class GameSelectorPanel extends JPanel implements Observer {
   private final IGamePropertiesCache gamePropertiesCache = new FileBackedGamePropertiesCache();
   private final Map<String, Object> originalPropertiesMap = new HashMap<>();
   private final JLabel nameText = new JLabel();
-  private final JLabel versionText = new JLabel();
   private final JLabel saveGameText = new JLabel();
   private final JLabel roundText = new JLabel();
   private final JButton loadSavedGame =
@@ -116,10 +115,6 @@ public final class GameSelectorPanel extends JPanel implements Observer {
 
     add(new JLabel("Game Name:"), buildGridCell(0, row, new Insets(0, 10, 3, 5)));
     add(nameText, buildGridCell(1, row, new Insets(0, 0, 3, 0)));
-    row++;
-
-    add(new JLabel("Game Version:"), buildGridCell(0, row, new Insets(0, 10, 3, 5)));
-    add(versionText, buildGridCell(1, row, new Insets(0, 0, 3, 0)));
     row++;
 
     add(new JLabel("Game Round:"), buildGridCell(0, row, new Insets(0, 10, 3, 5)));
@@ -314,7 +309,6 @@ public final class GameSelectorPanel extends JPanel implements Observer {
     SwingAction.invokeNowOrLater(
         () -> {
           nameText.setText(model.getGameName());
-          versionText.setText(model.getGameVersion());
           roundText.setText(model.getGameRound());
           saveGameText.setText(model.getFileName());
 

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbem/PbemSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbem/PbemSetupPanel.java
@@ -241,7 +241,6 @@ public class PbemSetupPanel extends SetupPanel implements Observer {
             null,
             playersEnabled,
             playerTypes,
-            gameSelectorModel.getGameData().getGameVersion(),
             gameSelectorModel.getGameName(),
             gameSelectorModel.getGameRound(),
             null,

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbf/PbfSetupPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbf/PbfSetupPanel.java
@@ -266,7 +266,6 @@ public class PbfSetupPanel extends SetupPanel implements Observer {
             null,
             playersEnabled,
             playerTypes,
-            gameSelectorModel.getGameData().getGameVersion(),
             gameSelectorModel.getGameName(),
             gameSelectorModel.getGameRound(),
             null,

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
@@ -187,10 +187,14 @@ public class GameChooser extends JDialog {
 
     final StringBuilder notes = new StringBuilder();
     notes.append("<h1>").append(shallowParsedGame.getInfo().getName()).append("</h1>");
-    appendListItem(
-        "Number Of Players", shallowParsedGame.getPlayerList().getPlayers().size() + "", notes);
-    appendListItem("Version", shallowParsedGame.getInfo().getVersion() + "", notes);
-    notes.append("<p></p>");
+    notes
+        .append("<b>")
+        .append("Number Of Players")
+        .append("</b>")
+        .append(": ")
+        .append(shallowParsedGame.getPlayerList().getPlayers().size())
+        .append("<br>")
+        .append("<p></p>");
 
     extractGameNotes(shallowParsedGame)
         .ifPresent(

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
@@ -221,9 +221,4 @@ public class GameChooser extends JDialog {
                     .map(PropertyList.Property::getValueProperty)
                     .map(PropertyList.Property.Value::getData));
   }
-
-  private static void appendListItem(
-      final String title, final String value, final StringBuilder builder) {
-    builder.append("<b>").append(title).append("</b>").append(": ").append(value).append("<br>");
-  }
 }

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGamePanel.java
@@ -66,10 +66,6 @@ class LobbyGamePanel extends JPanel {
         .getColumnModel()
         .getColumn(gameTableModel.getColumnIndex(LobbyGameTableModel.Column.P))
         .setPreferredWidth(12);
-    gameTable
-        .getColumnModel()
-        .getColumn(gameTableModel.getColumnIndex(LobbyGameTableModel.Column.GV))
-        .setPreferredWidth(32);
     if (lobbyClient.isModerator()) {
       gameTable
           .getColumnModel()

--- a/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
+++ b/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyGameTableModel.java
@@ -24,7 +24,6 @@ class LobbyGameTableModel extends AbstractTableModel {
   enum Column {
     Host,
     Name,
-    GV,
     Round,
     Players,
     P,
@@ -162,8 +161,6 @@ class LobbyGameTableModel extends AbstractTableModel {
         return description.getPlayerCount();
       case P:
         return (description.getPassworded() ? "*" : "");
-      case GV:
-        return description.getMapVersion();
       case Status:
         // Note, we update status client side to avoid a headless game from reporting
         // a new status when players leave or join. We expect a player count of 0 in

--- a/game-core/src/main/java/games/strategy/engine/posted/game/pbem/PbemMessagePoster.java
+++ b/game-core/src/main/java/games/strategy/engine/posted/game/pbem/PbemMessagePoster.java
@@ -53,13 +53,7 @@ public class PbemMessagePoster implements Serializable {
     this.currentPlayer = currentPlayer;
     this.roundNumber = roundNumber;
     gameProperties = gameData.getProperties();
-    gameNameAndInfo =
-        "TripleA "
-            + title
-            + " for game: "
-            + gameData.getGameName()
-            + ", version: "
-            + gameData.getGameVersion();
+    gameNameAndInfo = "TripleA " + title + " for game: " + gameData.getGameName();
   }
 
   public boolean hasMessengers() {

--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -179,8 +179,6 @@ final class ExportMenu extends JMenu {
       writer.append(Injections.getInstance().getEngineVersion().toString()).println(',');
       writer.append("Game Name: ,");
       writer.append(gameData.getGameName()).println(',');
-      writer.append("Game Version: ,");
-      writer.append(gameData.getGameVersion().toString()).println(',');
       writer.println();
       writer.append("Current Round: ,");
       writer.print(currentRound);

--- a/game-core/src/main/java/org/triplea/lobby/common/GameDescription.java
+++ b/game-core/src/main/java/org/triplea/lobby/common/GameDescription.java
@@ -52,7 +52,6 @@ public class GameDescription implements Serializable {
   @With private final GameStatus status;
   @With private final String comment;
   @With private final boolean passworded;
-  @With private final String gameVersion;
 
   public boolean isBot() {
     return hostedBy.getName().startsWith(HeadlessGameServer.BOT_GAME_HOST_NAME_PREFIX)
@@ -73,7 +72,6 @@ public class GameDescription implements Serializable {
                   lobbyGame.getHostPort()))
           .startDateTime(Instant.ofEpochMilli(lobbyGame.getEpochMilliTimeStarted()))
           .gameName(lobbyGame.getMapName())
-          .gameVersion(lobbyGame.getMapVersion())
           .status(
               Arrays.stream(GameStatus.values())
                   .filter(s -> s.toString().equals(lobbyGame.getStatus()))
@@ -100,7 +98,6 @@ public class GameDescription implements Serializable {
         .hostPort(hostedBy.getPort())
         .epochMilliTimeStarted(startDateTime.toEpochMilli())
         .mapName(gameName)
-        .mapVersion(gameVersion)
         .status(status.toString())
         .passworded(passworded)
         .playerCount(playerCount)

--- a/game-core/src/main/resources/games/strategy/engine/xml/game.dtd
+++ b/game-core/src/main/resources/games/strategy/engine/xml/game.dtd
@@ -6,7 +6,7 @@
 <!ELEMENT info EMPTY>
 <!ATTLIST info
 	name CDATA #REQUIRED
-	version CDATA #REQUIRED
+	version CDATA #IMPLIED
 >
 
 <!-- javaClass must implement the IGameLoader interface -->

--- a/game-core/src/test/java/games/strategy/engine/data/gameparser/GameParserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/gameparser/GameParserTest.java
@@ -43,7 +43,6 @@ final class GameParserTest {
     assertThat(gameData.getDiceSides(), is(notNullValue()));
     assertThat(gameData.getGameLoader(), is(notNullValue()));
     assertThat(gameData.getGameName(), is(notNullValue()));
-    assertThat(gameData.getGameVersion(), is(notNullValue()));
     assertThat(gameData.getHistory().getActivePlayer(), is(notNullValue()));
     assertThat(gameData.getHistory().getLastNode(), is(notNullValue()));
     assertThat(gameData.getMap().getTerritories(), is(notNullValue()));

--- a/game-core/src/test/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModelTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorModelTest.java
@@ -21,11 +21,9 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.triplea.util.Version;
 
 @ExtendWith(MockitoExtension.class)
 class GameSelectorModelTest extends AbstractClientSettingTestCase {
-  private static final String fakeGameVersion = "12.34.56";
   private static final String fakeGameRound = "3";
   private static final String fakeGameName = "_fakeGameName_";
 
@@ -53,7 +51,6 @@ class GameSelectorModelTest extends AbstractClientSettingTestCase {
   private static void assertHasFakeTestData(final GameSelectorModel objectToCheck) {
     assertThat(objectToCheck.getGameName(), is(fakeGameName));
     assertThat(objectToCheck.getGameRound(), is(fakeGameRound));
-    assertThat(objectToCheck.getGameVersion(), is(fakeGameVersion));
   }
 
   @BeforeEach
@@ -88,7 +85,6 @@ class GameSelectorModelTest extends AbstractClientSettingTestCase {
   }
 
   private void prepareMockGameDataExpectations() {
-    when(mockGameData.getGameVersion()).thenReturn(new Version(fakeGameVersion));
     when(mockGameData.getSequence()).thenReturn(mockSequence);
     when(mockSequence.getRound()).thenReturn(Integer.valueOf(fakeGameRound));
     when(mockGameData.getGameName()).thenReturn(fakeGameName);
@@ -109,14 +105,12 @@ class GameSelectorModelTest extends AbstractClientSettingTestCase {
 
     final String newGameName = " 123";
     final String newGameRound = "gameRound xyz";
-    final String newGameVersion = "gameVersion abc";
 
-    testObj.clearDataButKeepGameInfo(newGameName, newGameRound, newGameVersion);
+    testObj.clearDataButKeepGameInfo(newGameName, newGameRound);
     verifyTestObjectObserverUpdateSent();
     assertThat(testObj.getGameData(), nullValue());
     assertThat(testObj.getGameName(), is(newGameName));
     assertThat(testObj.getGameRound(), is(newGameRound));
-    assertThat(testObj.getGameVersion(), is(newGameVersion));
   }
 
   @Test
@@ -155,11 +149,5 @@ class GameSelectorModelTest extends AbstractClientSettingTestCase {
   void testGetGameRound() {
     this.testObjectSetMockGameData();
     assertThat(testObj.getGameRound(), is(fakeGameRound));
-  }
-
-  @Test
-  void testGetGameVersion() {
-    this.testObjectSetMockGameData();
-    assertThat(testObj.getGameVersion(), is(fakeGameVersion));
   }
 }

--- a/game-core/src/test/java/org/triplea/test/TestData.java
+++ b/game-core/src/test/java/org/triplea/test/TestData.java
@@ -15,7 +15,6 @@ public class TestData {
           .playerCount(3)
           .gameRound(1)
           .epochMilliTimeStarted(Instant.now().toEpochMilli())
-          .mapVersion("1")
           .passworded(false)
           .status("Waiting For Players")
           .comments("comments")

--- a/game-core/src/test/resources/Big_World_1942_v3rules.xml
+++ b/game-core/src/test/resources/Big_World_1942_v3rules.xml
@@ -3,7 +3,7 @@
 <!DOCTYPE game SYSTEM "game.dtd">
 
 <game>
-        <info name="Big World : 1942 v3 Rules" version="3.8"/>
+        <info name="Big World : 1942 v3 Rules"/>
         
         <loader javaClass="games.strategy.triplea.TripleA"/>
     

--- a/game-core/src/test/resources/DelegateTest.xml
+++ b/game-core/src/test/resources/DelegateTest.xml
@@ -2,10 +2,7 @@
 <!DOCTYPE game SYSTEM "game.dtd">
 
 <game>
-
-    <info name="delegateTest" version="1" />
-
-
+    <info name="delegateTest"/>
 
     <map>
         <territory name="Afghanistan"/>

--- a/game-core/src/test/resources/GameExample.xml
+++ b/game-core/src/test/resources/GameExample.xml
@@ -2,10 +2,7 @@
 <!DOCTYPE game SYSTEM "game.dtd">
 
 <game>
-
-    <info name="gameExample" version="1.0" />
-
-
+    <info name="gameExample"/>
 
     <map>
         <territory name="canada"/>

--- a/game-core/src/test/resources/Napoleonic_Empires.xml
+++ b/game-core/src/test/resources/Napoleonic_Empires.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE game SYSTEM "game.dtd">
 <game>
-  <info name="Napoleonic Empires" version="4.2.0"/>
+  <info name="Napoleonic Empires"/>
   <loader javaClass="games.strategy.triplea.TripleA"/>
   <triplea minimumVersion="1.9"/>
   <map>

--- a/game-core/src/test/resources/Test.xml
+++ b/game-core/src/test/resources/Test.xml
@@ -2,8 +2,7 @@
 <!DOCTYPE game SYSTEM "game.dtd">
 
 <game>
-
-    <info name="test" version="1.0.0" />
+    <info name="test"/>
 
     <map>
         <territory name="canada"/>

--- a/game-core/src/test/resources/Total_World_War_Dec1941.xml
+++ b/game-core/src/test/resources/Total_World_War_Dec1941.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE game SYSTEM "game.dtd">
 <game>
-  <info name="Total World War: December 1941" version="2.7.7.2"/>
+  <info name="Total World War: December 1941"/>
   <triplea minimumVersion="1.8"/>
   <diceSides value="12"/>
   <variableList>

--- a/game-core/src/test/resources/big_world_1942_test.xml
+++ b/game-core/src/test/resources/big_world_1942_test.xml
@@ -3,7 +3,7 @@
 <!DOCTYPE game SYSTEM "game.dtd">
 
 <game>
-        <info name="Big World : 1942" version="2.5"/>
+        <info name="Big World : 1942"/>
 
         <triplea minimumVersion="1.5"/>
 

--- a/game-core/src/test/resources/iron_blitz_test.xml
+++ b/game-core/src/test/resources/iron_blitz_test.xml
@@ -2,9 +2,7 @@
 <!DOCTYPE game SYSTEM "game.dtd">
 
 <game>
-
-    <info name="Classic: Iron Blitz 3rd Edition Test" version="1.9"/>
-
+    <info name="Classic: Iron Blitz 3rd Edition Test"/>
 
     <triplea minimumVersion="1.6.1"/>
 

--- a/game-core/src/test/resources/lhtr_test.xml
+++ b/game-core/src/test/resources/lhtr_test.xml
@@ -3,8 +3,7 @@
 <!DOCTYPE game SYSTEM "game.dtd">
 
 <game>
-        <info name="World War II Revised LHTR Test" version="1.4"/>
-        
+        <info name="World War II Revised LHTR Test"/>
 
         <map>
                 <!-- Territory Definitions -->

--- a/game-core/src/test/resources/minimap.xml
+++ b/game-core/src/test/resources/minimap.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE game SYSTEM "game.dtd">
 <game>
-    <info name="Minimap" version="1.2"/>
+    <info name="Minimap"/>
     <loader javaClass="games.strategy.triplea.TripleA"/>
     <triplea minimumVersion="1.5"/>
     <map>

--- a/game-core/src/test/resources/pacific_incomplete_test.xml
+++ b/game-core/src/test/resources/pacific_incomplete_test.xml
@@ -12,10 +12,9 @@ Coded by Iron__Cross
 -->
 
 <game>
-    <info name="pacific test" version="1.4"/>
+    <info name="pacific test"/>
 
     <map>
-        
         <!-- Territory Definitions -->
         
         <!-- Australia -->

--- a/game-core/src/test/resources/pact_of_steel_2_test.xml
+++ b/game-core/src/test/resources/pact_of_steel_2_test.xml
@@ -3,7 +3,7 @@
 <!DOCTYPE game SYSTEM "game.dtd">
 
 <game>
-        <info name="Pact of Steel 2 Test" version="3.6"/>
+        <info name="Pact of Steel 2 Test"/>
         <triplea minimumVersion="1.7"/>
         <diceSides value="6"/>
         <map>

--- a/game-core/src/test/resources/revised_test.xml
+++ b/game-core/src/test/resources/revised_test.xml
@@ -3,8 +3,7 @@
 <!DOCTYPE game SYSTEM "game.dtd">
 
 <game>
-        <info name="World War II Revised Test" version="1.4"/>
-        
+        <info name="World War II Revised Test"/>
 
         <map>
                 <!-- Territory Definitions -->

--- a/game-core/src/test/resources/victory_test.xml
+++ b/game-core/src/test/resources/victory_test.xml
@@ -3,8 +3,7 @@
 <!DOCTYPE game SYSTEM "game.dtd">
 
 <game>
-        <info name="victory test" version="3.3"/>
-
+        <info name="victory test"/>
 
         <diceSides value="6"/>
 

--- a/game-core/src/test/resources/ww2_g40_balanced.xml
+++ b/game-core/src/test/resources/ww2_g40_balanced.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE game SYSTEM "game.dtd">
 <game>
-  <info name="World War II G40 Balanced" version="2.0"/>
+  <info name="World War II G40 Balanced"/>
   <triplea minimumVersion="1.8"/>
   <diceSides value="6"/>
   <map>

--- a/game-core/src/test/resources/ww2v3_1941_test.xml
+++ b/game-core/src/test/resources/ww2v3_1941_test.xml
@@ -3,8 +3,7 @@
 <!DOCTYPE game SYSTEM "game.dtd">
 
 <game>
-        <info name="World War II v3 1941 Test" version="1.7"/>
-
+        <info name="World War II v3 1941 Test"/>
 
         <triplea minimumVersion="1.7"/>
 

--- a/game-core/src/test/resources/ww2v3_1942_test.xml
+++ b/game-core/src/test/resources/ww2v3_1942_test.xml
@@ -3,8 +3,7 @@
 <!DOCTYPE game SYSTEM "game.dtd">
 
 <game>
-        <info name="World War II v3 1942 Test" version="1.7"/>
-
+        <info name="World War II v3 1942 Test"/>
 
         <triplea minimumVersion="1.7"/>
 

--- a/lobby-client/src/test/java/org/triplea/http/client/TestData.java
+++ b/lobby-client/src/test/java/org/triplea/http/client/TestData.java
@@ -15,7 +15,6 @@ public class TestData {
           .playerCount(3)
           .gameRound(1)
           .epochMilliTimeStarted(Instant.now().toEpochMilli())
-          .mapVersion("1")
           .passworded(false)
           .status("WAITING_FOR_PLAYERS")
           .comments("comments")

--- a/lobby-server/src/test/java/org/triplea/modules/TestData.java
+++ b/lobby-server/src/test/java/org/triplea/modules/TestData.java
@@ -23,7 +23,6 @@ public class TestData {
           .playerCount(3)
           .gameRound(1)
           .epochMilliTimeStarted(Instant.now().toEpochMilli())
-          .mapVersion("1")
           .passworded(false)
           .status("Waiting For Players")
           .comments("comments")

--- a/map-data/src/main/java/org/triplea/map/data/elements/Info.java
+++ b/map-data/src/main/java/org/triplea/map/data/elements/Info.java
@@ -13,5 +13,4 @@ import org.triplea.generic.xml.reader.annotations.Attribute;
 @AllArgsConstructor
 public class Info {
   @XmlAttribute @Attribute private String name;
-  @XmlAttribute @Attribute private String version;
 }

--- a/map-data/src/test/java/org/triplea/map/data/elements/InfoTest.java
+++ b/map-data/src/test/java/org/triplea/map/data/elements/InfoTest.java
@@ -12,6 +12,5 @@ class InfoTest {
     final Info info = parseMapXml("info.xml").getInfo();
 
     assertThat(info.getName(), is("info-tag-test"));
-    assertThat(info.getVersion(), is("123.xyz"));
   }
 }

--- a/map-data/src/test/resources/info.xml
+++ b/map-data/src/test/resources/info.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <game>
-    <info name="info-tag-test" version="123.xyz"/>
+    <info name="info-tag-test"/>
 </game>

--- a/smoke-testing/src/test/java/games/strategy/engine/data/GameSaveCompatibilityTest.java
+++ b/smoke-testing/src/test/java/games/strategy/engine/data/GameSaveCompatibilityTest.java
@@ -35,7 +35,6 @@ class GameSaveCompatibilityTest {
     assertThat(gameData.getDiceSides(), is(notNullValue()));
     assertThat(gameData.getGameLoader(), is(notNullValue()));
     assertThat(gameData.getGameName(), is(notNullValue()));
-    assertThat(gameData.getGameVersion(), is(notNullValue()));
     assertThat(gameData.getHistory().getActivePlayer(), is(notNullValue()));
     assertThat(gameData.getHistory().getLastNode(), is(notNullValue()));
     assertThat(gameData.getMap().getTerritories(), is(notNullValue()));


### PR DESCRIPTION
The 'map version' is used only for display purposes
leaving players to wonder and determine compatibility
on their own.

Discussion post:
https://forums.triplea-game.org/topic/2524/removing-map-xml-game-version


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
