### PR TITLE
Change API on FileSystemAccessStrategy#getMapVersion to avoid conversion to String

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
@@ -17,14 +17,12 @@ import org.triplea.util.Version;
 @Slf4j
 class FileSystemAccessStrategy {
 
-  Optional<Version> getMapVersion(final String mapName) {
-    final File potentialFile = new File(mapName);
-
-    if (!potentialFile.exists()) {
+  Optional<Version> getMapVersion(final File mapFile) {
+    if (!mapFile.exists()) {
       return Optional.empty();
     }
 
-    return DownloadFileProperties.loadForZip(potentialFile).getVersion();
+    return DownloadFileProperties.loadForZip(mapFile).getVersion();
   }
 
   static void remove(

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadList.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadList.java
@@ -28,8 +28,7 @@ class MapDownloadList {
       if (download == null) {
         return;
       }
-      final Optional<Version> mapVersion =
-          strategy.getMapVersion(download.getInstallLocation().getAbsolutePath());
+      final Optional<Version> mapVersion = strategy.getMapVersion(download.getInstallLocation());
 
       if (mapVersion.isPresent()) {
         installed.add(download);

--- a/game-core/src/test/java/games/strategy/engine/framework/map/download/FileSystemAccessStrategyTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/map/download/FileSystemAccessStrategyTest.java
@@ -1,13 +1,13 @@
 package games.strategy.engine.framework.map.download;
 
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
 
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -35,12 +35,11 @@ class FileSystemAccessStrategyTest {
 
   @Test
   void testMapPropertyFileNotFound() {
-    assertThat(testObj.getMapVersion("does_not_exist"), is(Optional.empty()));
+    assertThat(testObj.getMapVersion(new File("does_not_exist")), isEmpty());
   }
 
   @Test
   void testMapFileFound() {
-    assertThat(
-        testObj.getMapVersion(mapFile.getAbsolutePath()), is(Optional.of(new Version(1, 2, 0))));
+    assertThat(testObj.getMapVersion(mapFile), isPresentAndIs(new Version(1, 2, 0)));
   }
 }


### PR DESCRIPTION
The arg to the method is always a file, instead of converting from a file, to
a string (path of the file), back to a file, we can accept the original
File as an argument instead.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
