### PR TITLE
Null player can have no gameData so use unitType to get gameData

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -2395,8 +2395,10 @@ public final class Matches {
             .or(unitTypeIsSupporterOrHasCombatAbility(attack, player))
             .or(unitTypeIsAaForCombatOnly().and(unitTypeIsAaThatCanFireOnRound(battleRound)))
             .or(
-                unitTypeCanBeHitByAaFire(
-                    firingUnits, player.getData().getUnitTypeList(), battleRound));
+                unitType ->
+                    unitTypeCanBeHitByAaFire(
+                            firingUnits, unitType.getData().getUnitTypeList(), battleRound)
+                        .test(unitType));
 
     if (attack) {
       if (!includeAttackersThatCanNotMove) {

--- a/game-core/src/test/java/games/strategy/triplea/delegate/MatchesTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/MatchesTest.java
@@ -279,7 +279,6 @@ final class MatchesTest {
     @BeforeEach
     void setupGameData() {
       gameData = givenGameData().build();
-      when(player.getData()).thenReturn(gameData);
     }
 
     @Test


### PR DESCRIPTION
<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->
A null pointer occurs pretty much anytime a neutral player is attacked.

## Testing
<!-- Describe any manual testing performed below. -->
I noticed this playing a hard ai game.  I thought about giving the null player a valid gamedata but decided to just use the passed in unit type instead.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
