### PR TITLE
Pass around Collection<TechAdvance> instead of player and tech frontier

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/UnitUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/UnitUtils.java
@@ -12,6 +12,8 @@ import games.strategy.triplea.attachments.TechAbilityAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
+import games.strategy.triplea.delegate.TechAdvance;
+import games.strategy.triplea.delegate.TechTracker;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -46,8 +48,7 @@ public class UnitUtils {
             properties,
             accountForDamage),
         producer,
-        player,
-        technologyFrontier,
+        TechTracker.getCurrentTechAdvances(player, technologyFrontier),
         properties,
         accountForDamage,
         mathMaxZero);
@@ -81,7 +82,12 @@ public class UnitUtils {
     for (final Unit u : factories) {
       final int capacity =
           getHowMuchCanUnitProduce(
-              u, producer, player, technologyFrontier, properties, accountForDamage, false);
+              u,
+              producer,
+              TechTracker.getCurrentTechAdvances(player, technologyFrontier),
+              properties,
+              accountForDamage,
+              false);
       productionPotential.put(u, capacity);
       if (capacity > highestCapacity) {
         highestCapacity = capacity;
@@ -102,8 +108,7 @@ public class UnitUtils {
   public static int getHowMuchCanUnitProduce(
       final Unit unit,
       final Territory producer,
-      final GamePlayer player,
-      final TechnologyFrontier technologyFrontier,
+      final Collection<TechAdvance> techAdvances,
       final GameProperties properties,
       final boolean accountForDamage,
       final boolean mathMaxZero) {
@@ -157,10 +162,9 @@ public class UnitUtils {
     }
     // Increase production if have industrial technology
     if (territoryProduction
-        >= TechAbilityAttachment.getMinimumTerritoryValueForProductionBonus(
-            player, technologyFrontier)) {
-      productionCapacity +=
-          TechAbilityAttachment.getProductionBonus(unit.getType(), player, technologyFrontier);
+        >= TechAbilityAttachment.getMinimumTerritoryValueForProductionBonus(techAdvances)) {
+
+      productionCapacity += TechAbilityAttachment.getProductionBonus(unit.getType(), techAdvances);
     }
     return mathMaxZero ? Math.max(0, productionCapacity) : productionCapacity;
   }

--- a/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -22,6 +22,7 @@ import games.strategy.triplea.ai.AiUtils;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
+import games.strategy.triplea.delegate.TechTracker;
 import games.strategy.triplea.delegate.TransportTracker;
 import games.strategy.triplea.delegate.battle.BattleDelegate;
 import games.strategy.triplea.delegate.data.PlaceableUnits;
@@ -865,8 +866,7 @@ public class WeakAi extends AbstractBuiltInAi {
               UnitUtils.getHowMuchCanUnitProduce(
                   possibleFactoryNeedingRepair,
                   fixTerr,
-                  player,
-                  data.getTechnologyFrontier(),
+                  TechTracker.getCurrentTechAdvances(player, data.getTechnologyFrontier()),
                   data.getProperties(),
                   true,
                   true);
@@ -877,8 +877,7 @@ public class WeakAi extends AbstractBuiltInAi {
             UnitUtils.getHowMuchCanUnitProduce(
                 possibleFactoryNeedingRepair,
                 fixTerr,
-                player,
-                data.getTechnologyFrontier(),
+                TechTracker.getCurrentTechAdvances(player, data.getTechnologyFrontier()),
                 data.getProperties(),
                 true,
                 true);
@@ -910,8 +909,7 @@ public class WeakAi extends AbstractBuiltInAi {
               UnitUtils.getHowMuchCanUnitProduce(
                       capUnit,
                       capUnitTerritory,
-                      player,
-                      data.getTechnologyFrontier(),
+                      TechTracker.getCurrentTechAdvances(player, data.getTechnologyFrontier()),
                       data.getProperties(),
                       false,
                       true)
@@ -963,8 +961,7 @@ public class WeakAi extends AbstractBuiltInAi {
                 UnitUtils.getHowMuchCanUnitProduce(
                         fixUnit,
                         unitsThatCanProduceNeedingRepair.get(fixUnit),
-                        player,
-                        data.getTechnologyFrontier(),
+                        TechTracker.getCurrentTechAdvances(player, data.getTechnologyFrontier()),
                         data.getProperties(),
                         false,
                         true)

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -125,9 +125,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
   static int sumIntegerMap(
       final Function<TechAbilityAttachment, IntegerMap<UnitType>> mapper,
       final UnitType ut,
-      final GamePlayer player,
-      final TechnologyFrontier technologyFrontier) {
-    return TechTracker.getCurrentTechAdvances(player, technologyFrontier).stream()
+      final Collection<TechAdvance> techAdvances) {
+    return techAdvances.stream()
         .map(TechAbilityAttachment::get)
         .filter(Objects::nonNull)
         .map(mapper)
@@ -139,9 +138,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
   static int sumNumbers(
       final ToIntFunction<TechAbilityAttachment> mapper,
       final String attachmentType,
-      final GamePlayer player,
-      final TechnologyFrontier technologyFrontier) {
-    return TechTracker.getCurrentTechAdvances(player, technologyFrontier).stream()
+      final Collection<TechAdvance> techAdvances) {
+    return techAdvances.stream()
         .map(TechAbilityAttachment::get)
         .filter(Objects::nonNull)
         .filter(i -> i.getAttachedTo().toString().equals(attachmentType))
@@ -176,9 +174,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return attackBonus;
   }
 
-  static int getAttackBonus(
-      final UnitType ut, final GamePlayer player, final TechnologyFrontier technologyFrontier) {
-    return sumIntegerMap(TechAbilityAttachment::getAttackBonus, ut, player, technologyFrontier);
+  static int getAttackBonus(final UnitType ut, final Collection<TechAdvance> techAdvances) {
+    return sumIntegerMap(TechAbilityAttachment::getAttackBonus, ut, techAdvances);
   }
 
   private void resetAttackBonus() {
@@ -197,9 +194,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return defenseBonus;
   }
 
-  static int getDefenseBonus(
-      final UnitType ut, final GamePlayer player, final TechnologyFrontier technologyFrontier) {
-    return sumIntegerMap(TechAbilityAttachment::getDefenseBonus, ut, player, technologyFrontier);
+  static int getDefenseBonus(final UnitType ut, final Collection<TechAdvance> techAdvances) {
+    return sumIntegerMap(TechAbilityAttachment::getDefenseBonus, ut, techAdvances);
   }
 
   private void resetDefenseBonus() {
@@ -218,9 +214,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return movementBonus;
   }
 
-  static int getMovementBonus(
-      final UnitType ut, final GamePlayer player, final TechnologyFrontier technologyFrontier) {
-    return sumIntegerMap(TechAbilityAttachment::getMovementBonus, ut, player, technologyFrontier);
+  static int getMovementBonus(final UnitType ut, final Collection<TechAdvance> techAdvances) {
+    return sumIntegerMap(TechAbilityAttachment::getMovementBonus, ut, techAdvances);
   }
 
   private void resetMovementBonus() {
@@ -239,9 +234,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return radarBonus;
   }
 
-  static int getRadarBonus(
-      final UnitType ut, final GamePlayer player, final TechnologyFrontier technologyFrontier) {
-    return sumIntegerMap(TechAbilityAttachment::getRadarBonus, ut, player, technologyFrontier);
+  static int getRadarBonus(final UnitType ut, final Collection<TechAdvance> techAdvances) {
+    return sumIntegerMap(TechAbilityAttachment::getRadarBonus, ut, techAdvances);
   }
 
   private void resetRadarBonus() {
@@ -260,9 +254,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return airAttackBonus;
   }
 
-  static int getAirAttackBonus(
-      final UnitType ut, final GamePlayer player, final TechnologyFrontier technologyFrontier) {
-    return sumIntegerMap(TechAbilityAttachment::getAirAttackBonus, ut, player, technologyFrontier);
+  static int getAirAttackBonus(final UnitType ut, final Collection<TechAdvance> techAdvances) {
+    return sumIntegerMap(TechAbilityAttachment::getAirAttackBonus, ut, techAdvances);
   }
 
   private void resetAirAttackBonus() {
@@ -281,9 +274,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return airDefenseBonus;
   }
 
-  static int getAirDefenseBonus(
-      final UnitType ut, final GamePlayer player, final TechnologyFrontier technologyFrontier) {
-    return sumIntegerMap(TechAbilityAttachment::getAirDefenseBonus, ut, player, technologyFrontier);
+  static int getAirDefenseBonus(final UnitType ut, final Collection<TechAdvance> techAdvances) {
+    return sumIntegerMap(TechAbilityAttachment::getAirDefenseBonus, ut, techAdvances);
   }
 
   private void resetAirDefenseBonus() {
@@ -303,8 +295,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   public static int getProductionBonus(
-      final UnitType ut, final GamePlayer player, final TechnologyFrontier technologyFrontier) {
-    return sumIntegerMap(TechAbilityAttachment::getProductionBonus, ut, player, technologyFrontier);
+      final UnitType ut, final Collection<TechAdvance> techAdvances) {
+    return sumIntegerMap(TechAbilityAttachment::getProductionBonus, ut, techAdvances);
   }
 
   private void resetProductionBonus() {
@@ -326,10 +318,10 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   public static int getMinimumTerritoryValueForProductionBonus(
-      final GamePlayer player, final TechnologyFrontier technologyFrontier) {
+      final Collection<TechAdvance> techAdvances) {
     return Math.max(
         0,
-        TechTracker.getCurrentTechAdvances(player, technologyFrontier).stream()
+        techAdvances.stream()
             .map(TechAbilityAttachment::get)
             .filter(Objects::nonNull)
             .mapToInt(TechAbilityAttachment::getMinimumTerritoryValueForProductionBonus)
@@ -354,12 +346,11 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return repairDiscount;
   }
 
-  public static double getRepairDiscount(
-      final GamePlayer player, final TechnologyFrontier technologyFrontier) {
+  public static double getRepairDiscount(final Collection<TechAdvance> techAdvances) {
     return Math.max(
         0,
         1.0
-            - TechTracker.getCurrentTechAdvances(player, technologyFrontier).stream()
+            - techAdvances.stream()
                 .map(TechAbilityAttachment::get)
                 .filter(Objects::nonNull)
                 .mapToInt(TechAbilityAttachment::getRepairDiscount)
@@ -384,13 +375,9 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return warBondDiceSides;
   }
 
-  public static int getWarBondDiceSides(
-      final GamePlayer player, final TechnologyFrontier technologyFrontier) {
+  public static int getWarBondDiceSides(final Collection<TechAdvance> techAdvances) {
     return sumNumbers(
-        TechAbilityAttachment::getWarBondDiceSides,
-        TechAdvance.TECH_NAME_WAR_BONDS,
-        player,
-        technologyFrontier);
+        TechAbilityAttachment::getWarBondDiceSides, TechAdvance.TECH_NAME_WAR_BONDS, techAdvances);
   }
 
   private void resetWarBondDiceSides() {
@@ -409,13 +396,9 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return warBondDiceNumber;
   }
 
-  public static int getWarBondDiceNumber(
-      final GamePlayer player, final TechnologyFrontier technologyFrontier) {
+  public static int getWarBondDiceNumber(final Collection<TechAdvance> techAdvances) {
     return sumNumbers(
-        TechAbilityAttachment::getWarBondDiceNumber,
-        TechAdvance.TECH_NAME_WAR_BONDS,
-        player,
-        technologyFrontier);
+        TechAbilityAttachment::getWarBondDiceNumber, TechAdvance.TECH_NAME_WAR_BONDS, techAdvances);
   }
 
   private void resetWarBondDiceNumber() {
@@ -439,16 +422,18 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   private static int getRocketDiceNumber(
-      final UnitType ut, final GamePlayer player, final TechnologyFrontier technologyFrontier) {
-    return sumIntegerMap(
-        TechAbilityAttachment::getRocketDiceNumber, ut, player, technologyFrontier);
+      final UnitType ut, final Collection<TechAdvance> techAdvances) {
+    return sumIntegerMap(TechAbilityAttachment::getRocketDiceNumber, ut, techAdvances);
   }
 
   public static int getRocketDiceNumber(
       final Collection<Unit> rockets, final TechnologyFrontier technologyFrontier) {
     int rocketDiceNumber = 0;
     for (final Unit u : rockets) {
-      rocketDiceNumber += getRocketDiceNumber(u.getType(), u.getOwner(), technologyFrontier);
+
+      rocketDiceNumber +=
+          getRocketDiceNumber(
+              u.getType(), TechTracker.getCurrentTechAdvances(u.getOwner(), technologyFrontier));
     }
     return rocketDiceNumber;
   }
@@ -469,13 +454,9 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return rocketDistance;
   }
 
-  public static int getRocketDistance(
-      final GamePlayer player, final TechnologyFrontier technologyFrontier) {
+  public static int getRocketDistance(final Collection<TechAdvance> techAdvances) {
     return sumNumbers(
-        TechAbilityAttachment::getRocketDistance,
-        TechAdvance.TECH_NAME_ROCKETS,
-        player,
-        technologyFrontier);
+        TechAbilityAttachment::getRocketDistance, TechAdvance.TECH_NAME_ROCKETS, techAdvances);
   }
 
   private void resetRocketDistance() {
@@ -494,13 +475,11 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return rocketNumberPerTerritory;
   }
 
-  public static int getRocketNumberPerTerritory(
-      final GamePlayer player, final TechnologyFrontier technologyFrontier) {
+  public static int getRocketNumberPerTerritory(final Collection<TechAdvance> techAdvances) {
     return sumNumbers(
         TechAbilityAttachment::getRocketNumberPerTerritory,
         TechAdvance.TECH_NAME_ROCKETS,
-        player,
-        technologyFrontier);
+        techAdvances);
   }
 
   private void resetRocketNumberPerTerritory() {
@@ -545,10 +524,9 @@ public class TechAbilityAttachment extends DefaultAttachment {
   public static boolean getUnitAbilitiesGained(
       final String filterForAbility,
       final UnitType ut,
-      final GamePlayer player,
-      final TechnologyFrontier technologyFrontier) {
+      final Collection<TechAdvance> techAdvances) {
     Preconditions.checkNotNull(filterForAbility);
-    return TechTracker.getCurrentTechAdvances(player, technologyFrontier).stream()
+    return techAdvances.stream()
         .map(TechAbilityAttachment::get)
         .filter(Objects::nonNull)
         .map(TechAbilityAttachment::getUnitAbilitiesGained)
@@ -591,9 +569,9 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   public static IntegerMap<UnitType> getAirborneCapacity(
-      final GamePlayer player, final TechnologyFrontier technologyFrontier) {
+      final Collection<TechAdvance> techAdvances) {
     final IntegerMap<UnitType> capacityMap = new IntegerMap<>();
-    for (final TechAdvance ta : TechTracker.getCurrentTechAdvances(player, technologyFrontier)) {
+    for (final TechAdvance ta : techAdvances) {
       final TechAbilityAttachment taa = TechAbilityAttachment.get(ta);
       if (taa != null) {
         capacityMap.add(taa.getAirborneCapacity());
@@ -603,10 +581,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   public static int getAirborneCapacity(
-      final Collection<Unit> units,
-      final GamePlayer player,
-      final TechnologyFrontier technologyFrontier) {
-    final IntegerMap<UnitType> capacityMap = getAirborneCapacity(player, technologyFrontier);
+      final Collection<Unit> units, final Collection<TechAdvance> techAdvances) {
+    final IntegerMap<UnitType> capacityMap = getAirborneCapacity(techAdvances);
     int airborneCapacity = 0;
     for (final Unit u : units) {
       airborneCapacity += Math.max(0, (capacityMap.getInt(u.getType()) - u.getLaunched()));
@@ -632,9 +608,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return airborneTypes;
   }
 
-  public static Set<UnitType> getAirborneTypes(
-      final GamePlayer player, final TechnologyFrontier technologyFrontier) {
-    return TechTracker.getCurrentTechAdvances(player, technologyFrontier).stream()
+  public static Set<UnitType> getAirborneTypes(final Collection<TechAdvance> techAdvances) {
+    return techAdvances.stream()
         .map(TechAbilityAttachment::get)
         .filter(Objects::nonNull)
         .map(TechAbilityAttachment::getAirborneTypes)
@@ -658,11 +633,10 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return airborneDistance;
   }
 
-  public static int getAirborneDistance(
-      final GamePlayer player, final TechnologyFrontier technologyFrontier) {
+  public static int getAirborneDistance(final Collection<TechAdvance> techAdvances) {
     return Math.max(
         0,
-        TechTracker.getCurrentTechAdvances(player, technologyFrontier).stream()
+        techAdvances.stream()
             .map(TechAbilityAttachment::get)
             .filter(Objects::nonNull)
             .mapToInt(TechAbilityAttachment::getAirborneDistance)
@@ -687,9 +661,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return airborneBases;
   }
 
-  public static Set<UnitType> getAirborneBases(
-      final GamePlayer player, final TechnologyFrontier technologyFrontier) {
-    return TechTracker.getCurrentTechAdvances(player, technologyFrontier).stream()
+  public static Set<UnitType> getAirborneBases(final Collection<TechAdvance> techAdvances) {
+    return techAdvances.stream()
         .map(TechAbilityAttachment::get)
         .filter(Objects::nonNull)
         .map(TechAbilityAttachment::getAirborneBases)
@@ -728,9 +701,9 @@ public class TechAbilityAttachment extends DefaultAttachment {
    * key.
    */
   public static Map<String, Set<UnitType>> getAirborneTargettedByAa(
-      final GamePlayer player, final TechnologyFrontier technologyFrontier) {
+      final Collection<TechAdvance> techAdvances) {
     final Map<String, Set<UnitType>> airborneTargettedByAa = new HashMap<>();
-    for (final TechAdvance ta : TechTracker.getCurrentTechAdvances(player, technologyFrontier)) {
+    for (final TechAdvance ta : techAdvances) {
       final TechAbilityAttachment taa = TechAbilityAttachment.get(ta);
       if (taa != null) {
         final Map<String, Set<UnitType>> mapAa = taa.getAirborneTargettedByAa();
@@ -763,10 +736,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return attackRollsBonus;
   }
 
-  static int getAttackRollsBonus(
-      final UnitType ut, final GamePlayer player, final TechnologyFrontier technologyFrontier) {
-    return sumIntegerMap(
-        TechAbilityAttachment::getAttackRollsBonus, ut, player, technologyFrontier);
+  static int getAttackRollsBonus(final UnitType ut, final Collection<TechAdvance> techAdvances) {
+    return sumIntegerMap(TechAbilityAttachment::getAttackRollsBonus, ut, techAdvances);
   }
 
   private void resetAttackRollsBonus() {
@@ -785,10 +756,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return defenseRollsBonus;
   }
 
-  static int getDefenseRollsBonus(
-      final UnitType ut, final GamePlayer player, final TechnologyFrontier technologyFrontier) {
-    return sumIntegerMap(
-        TechAbilityAttachment::getDefenseRollsBonus, ut, player, technologyFrontier);
+  static int getDefenseRollsBonus(final UnitType ut, final Collection<TechAdvance> techAdvances) {
+    return sumIntegerMap(TechAbilityAttachment::getDefenseRollsBonus, ut, techAdvances);
   }
 
   private void setBombingBonus(final String value) throws GameParseException {
@@ -803,9 +772,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return bombingBonus;
   }
 
-  public static int getBombingBonus(
-      final UnitType ut, final GamePlayer player, final TechnologyFrontier technologyFrontier) {
-    return sumIntegerMap(TechAbilityAttachment::getBombingBonus, ut, player, technologyFrontier);
+  public static int getBombingBonus(final UnitType ut, final Collection<TechAdvance> techAdvances) {
+    return sumIntegerMap(TechAbilityAttachment::getBombingBonus, ut, techAdvances);
   }
 
   private void resetDefenseRollsBonus() {
@@ -816,9 +784,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     bombingBonus = new IntegerMap<>();
   }
 
-  public static boolean getAllowAirborneForces(
-      final GamePlayer player, final TechnologyFrontier technologyFrontier) {
-    return TechTracker.getCurrentTechAdvances(player, technologyFrontier).stream()
+  public static boolean getAllowAirborneForces(final Collection<TechAdvance> techAdvances) {
+    return techAdvances.stream()
         .map(TechAbilityAttachment::get)
         .filter(Objects::nonNull)
         .anyMatch(TechAbilityAttachment::getAirborneForces);

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -349,13 +349,16 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public int getAirDefense(final GamePlayer player) {
+
     return (Math.min(
         getData().getDiceSides(),
         Math.max(
             0,
             airDefense
                 + TechAbilityAttachment.getAirDefenseBonus(
-                    (UnitType) this.getAttachedTo(), player, getData().getTechnologyFrontier()))));
+                    (UnitType) this.getAttachedTo(),
+                    TechTracker.getCurrentTechAdvances(
+                        player, getData().getTechnologyFrontier())))));
   }
 
   private void resetAirDefense() {
@@ -376,13 +379,16 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public int getAirAttack(final GamePlayer player) {
+
     return (Math.min(
         getData().getDiceSides(),
         Math.max(
             0,
             airAttack
                 + TechAbilityAttachment.getAirAttackBonus(
-                    (UnitType) this.getAttachedTo(), player, getData().getTechnologyFrontier()))));
+                    (UnitType) this.getAttachedTo(),
+                    TechTracker.getCurrentTechAdvances(
+                        player, getData().getTechnologyFrontier())))));
   }
 
   private void resetAirAttack() {
@@ -637,12 +643,12 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public boolean getCanBlitz(final GamePlayer player) {
+
     return canBlitz
         || TechAbilityAttachment.getUnitAbilitiesGained(
             TechAbilityAttachment.ABILITY_CAN_BLITZ,
             (UnitType) this.getAttachedTo(),
-            player,
-            getData().getTechnologyFrontier());
+            TechTracker.getCurrentTechAdvances(player, getData().getTechnologyFrontier()));
   }
 
   private void resetCanBlitz() {
@@ -832,12 +838,12 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public boolean getCanBombard(final GamePlayer player) {
+
     return canBombard
         || TechAbilityAttachment.getUnitAbilitiesGained(
             TechAbilityAttachment.ABILITY_CAN_BOMBARD,
             (UnitType) this.getAttachedTo(),
-            player,
-            getData().getTechnologyFrontier());
+            TechTracker.getCurrentTechAdvances(player, getData().getTechnologyFrontier()));
   }
 
   private void resetCanBombard() {
@@ -1514,11 +1520,13 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public int getMovement(final GamePlayer player) {
+
     return Math.max(
         0,
         movement
             + TechAbilityAttachment.getMovementBonus(
-                (UnitType) this.getAttachedTo(), player, getData().getTechnologyFrontier()));
+                (UnitType) this.getAttachedTo(),
+                TechTracker.getCurrentTechAdvances(player, getData().getTechnologyFrontier())));
   }
 
   private void resetMovement() {
@@ -1543,7 +1551,8 @@ public class UnitAttachment extends DefaultAttachment {
     final int attackValue =
         attack
             + TechAbilityAttachment.getAttackBonus(
-                (UnitType) this.getAttachedTo(), player, getData().getTechnologyFrontier());
+                (UnitType) this.getAttachedTo(),
+                TechTracker.getCurrentTechAdvances(player, getData().getTechnologyFrontier()));
     return Math.min(getData().getDiceSides(), Math.max(0, attackValue));
   }
 
@@ -1566,11 +1575,13 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public int getAttackRolls(final GamePlayer player) {
+
     return Math.max(
         0,
         attackRolls
             + TechAbilityAttachment.getAttackRollsBonus(
-                (UnitType) this.getAttachedTo(), player, getData().getTechnologyFrontier()));
+                (UnitType) this.getAttachedTo(),
+                TechTracker.getCurrentTechAdvances(player, getData().getTechnologyFrontier())));
   }
 
   private void resetAttackRolls() {
@@ -1595,7 +1606,8 @@ public class UnitAttachment extends DefaultAttachment {
     int defenseValue =
         defense
             + TechAbilityAttachment.getDefenseBonus(
-                (UnitType) this.getAttachedTo(), player, getData().getTechnologyFrontier());
+                (UnitType) this.getAttachedTo(),
+                TechTracker.getCurrentTechAdvances(player, getData().getTechnologyFrontier()));
     if (defenseValue > 0 && getIsFirstStrike() && TechTracker.hasSuperSubs(player)) {
       final int bonus = Properties.getSuperSubDefenseBonus(getData().getProperties());
       defenseValue += bonus;
@@ -1626,7 +1638,8 @@ public class UnitAttachment extends DefaultAttachment {
         0,
         defenseRolls
             + TechAbilityAttachment.getDefenseRollsBonus(
-                (UnitType) this.getAttachedTo(), player, getData().getTechnologyFrontier()));
+                (UnitType) this.getAttachedTo(),
+                TechTracker.getCurrentTechAdvances(player, getData().getTechnologyFrontier())));
   }
 
   private void resetDefenseRolls() {
@@ -2199,13 +2212,16 @@ public class UnitAttachment extends DefaultAttachment {
     // TODO: this may cause major problems with Low Luck, if they have diceSides equal to something
     // other than 6, or it
     // does not divide perfectly into attackAAmaxDieSides
+
     return Math.max(
         0,
         Math.min(
             getAttackAaMaxDieSides(),
             attackAa
                 + TechAbilityAttachment.getRadarBonus(
-                    (UnitType) this.getAttachedTo(), player, getData().getTechnologyFrontier())));
+                    (UnitType) this.getAttachedTo(),
+                    TechTracker.getCurrentTechAdvances(
+                        player, getData().getTechnologyFrontier()))));
   }
 
   private void resetAttackAa() {
@@ -2230,13 +2246,16 @@ public class UnitAttachment extends DefaultAttachment {
     // TODO: this may cause major problems with Low Luck, if they have diceSides equal to something
     // other than 6, or it
     // does not divide perfectly into attackAAmaxDieSides
+
     return Math.max(
         0,
         Math.min(
             getOffensiveAttackAaMaxDieSides(),
             offensiveAttackAa
                 + TechAbilityAttachment.getRadarBonus(
-                    (UnitType) this.getAttachedTo(), player, getData().getTechnologyFrontier())));
+                    (UnitType) this.getAttachedTo(),
+                    TechTracker.getCurrentTechAdvances(
+                        player, getData().getTechnologyFrontier()))));
   }
 
   private void resetOffensiveAttackAa() {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
@@ -73,9 +73,10 @@ class AaInMoveUtil implements Serializable {
       return;
     }
     final GamePlayer movingPlayer = movingPlayer(units);
+
     final Map<String, Set<UnitType>> airborneTechTargetsAllowed =
         TechAbilityAttachment.getAirborneTargettedByAa(
-            movingPlayer, getData().getTechnologyFrontier());
+            TechTracker.getCurrentTechAdvances(movingPlayer, getData().getTechnologyFrontier()));
     final List<Unit> defendingAa =
         territory
             .getUnitCollection()
@@ -244,8 +245,10 @@ class AaInMoveUtil implements Serializable {
     // can't rely on player being the unit owner in Edit Mode
     // look at the units being moved to determine allies and enemies
     final GamePlayer movingPlayer = movingPlayer(units);
+
     final Map<String, Set<UnitType>> airborneTechTargetsAllowed =
-        TechAbilityAttachment.getAirborneTargettedByAa(movingPlayer, data.getTechnologyFrontier());
+        TechAbilityAttachment.getAirborneTargettedByAa(
+            TechTracker.getCurrentTechAdvances(movingPlayer, data.getTechnologyFrontier()));
     // don't iterate over the end
     // that will be a battle and handled else where in this tangled mess
     final Predicate<Unit> hasAa =

--- a/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -290,8 +290,13 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate
       final IDelegateBridge delegateBridge,
       final GamePlayer player,
       final TechnologyFrontier technologyFrontier) {
-    final int count = TechAbilityAttachment.getWarBondDiceNumber(player, technologyFrontier);
-    final int sides = TechAbilityAttachment.getWarBondDiceSides(player, technologyFrontier);
+
+    final int count =
+        TechAbilityAttachment.getWarBondDiceNumber(
+            TechTracker.getCurrentTechAdvances(player, technologyFrontier));
+    final int sides =
+        TechAbilityAttachment.getWarBondDiceSides(
+            TechTracker.getCurrentTechAdvances(player, technologyFrontier));
     if (sides <= 0 || count <= 0) {
       return 0;
     }
@@ -315,8 +320,13 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate
       final TechnologyFrontier technologyFrontier,
       final GameMap gameMap,
       final ResourceList resourceList) {
-    final int count = TechAbilityAttachment.getWarBondDiceNumber(player, technologyFrontier);
-    final int sides = TechAbilityAttachment.getWarBondDiceSides(player, technologyFrontier);
+
+    final int count =
+        TechAbilityAttachment.getWarBondDiceNumber(
+            TechTracker.getCurrentTechAdvances(player, technologyFrontier));
+    final int sides =
+        TechAbilityAttachment.getWarBondDiceSides(
+            TechTracker.getCurrentTechAdvances(player, technologyFrontier));
     if (sides <= 0 || count <= 0) {
       return "";
     }
@@ -334,8 +344,13 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate
     // take first one
     GamePlayer giveWarBondsTo = null;
     for (final GamePlayer p : shareWith) {
-      final int diceCount = TechAbilityAttachment.getWarBondDiceNumber(p, technologyFrontier);
-      final int diceSides = TechAbilityAttachment.getWarBondDiceSides(p, technologyFrontier);
+
+      final int diceCount =
+          TechAbilityAttachment.getWarBondDiceNumber(
+              TechTracker.getCurrentTechAdvances(p, technologyFrontier));
+      final int diceSides =
+          TechAbilityAttachment.getWarBondDiceSides(
+              TechTracker.getCurrentTechAdvances(p, technologyFrontier));
       // if both are zero, then it must mean we did not share our war bonds tech with them, even
       // though we are sharing
       // all tech (because they cannot have this tech)

--- a/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -348,8 +348,10 @@ public class PurchaseDelegate extends BaseTripleADelegate
         costs.addMultiple(rule.getCosts(), map.getInt(rule));
       }
     }
+
     final double discount =
-        TechAbilityAttachment.getRepairDiscount(player, getData().getTechnologyFrontier());
+        TechAbilityAttachment.getRepairDiscount(
+            TechTracker.getCurrentTechAdvances(player, getData().getTechnologyFrontier()));
     if (discount != 1.0D) {
       costs.multiplyAllValuesBy(discount);
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -105,7 +105,8 @@ public class RocketsFireHelper implements Serializable {
     for (final Territory attackFrom : getTerritoriesWithRockets(data, player)) {
       final Set<Territory> targets = getTargetsWithinRange(attackFrom, data, player);
       final int maxAttacks =
-          TechAbilityAttachment.getRocketNumberPerTerritory(player, data.getTechnologyFrontier());
+          TechAbilityAttachment.getRocketNumberPerTerritory(
+              TechTracker.getCurrentTechAdvances(player, data.getTechnologyFrontier()));
       for (final Territory t : previouslyAttackedTerritories.keySet()) {
         // negative Rocket Number per Territory == unlimited
         if (maxAttacks >= 0 && maxAttacks <= previouslyAttackedTerritories.get(t)) {
@@ -223,8 +224,10 @@ public class RocketsFireHelper implements Serializable {
 
   private static Set<Territory> getTargetsWithinRange(
       final Territory territory, final GameState data, final GamePlayer player) {
+
     final int maxDistance =
-        TechAbilityAttachment.getRocketDistance(player, data.getTechnologyFrontier());
+        TechAbilityAttachment.getRocketDistance(
+            TechTracker.getCurrentTechAdvances(player, data.getTechnologyFrontier()));
 
     final Set<Territory> hasFactory = new HashSet<>();
     final Predicate<Territory> allowed =
@@ -293,7 +296,7 @@ public class RocketsFireHelper implements Serializable {
       numberOfAttacks =
           Math.min(
               TechAbilityAttachment.getRocketNumberPerTerritory(
-                  player, data.getTechnologyFrontier()),
+                  TechTracker.getCurrentTechAdvances(player, data.getTechnologyFrontier())),
               TechAbilityAttachment.getRocketDiceNumber(rockets, data.getTechnologyFrontier()));
     }
     if (numberOfAttacks <= 0) {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -207,15 +207,19 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
       final GamePlayer player,
       final MoveValidationResult result) {
     final GameData data = player.getData();
-    if (!TechAbilityAttachment.getAllowAirborneForces(player, data.getTechnologyFrontier())) {
+    if (!TechAbilityAttachment.getAllowAirborneForces(
+        TechTracker.getCurrentTechAdvances(player, data.getTechnologyFrontier()))) {
       return result.setErrorReturnResult("Do Not Have Airborne Tech");
     }
     final int airborneDistance =
-        TechAbilityAttachment.getAirborneDistance(player, data.getTechnologyFrontier());
+        TechAbilityAttachment.getAirborneDistance(
+            TechTracker.getCurrentTechAdvances(player, data.getTechnologyFrontier()));
     final Set<UnitType> airborneBases =
-        TechAbilityAttachment.getAirborneBases(player, data.getTechnologyFrontier());
+        TechAbilityAttachment.getAirborneBases(
+            TechTracker.getCurrentTechAdvances(player, data.getTechnologyFrontier()));
     final Set<UnitType> airborneTypes =
-        TechAbilityAttachment.getAirborneTypes(player, data.getTechnologyFrontier());
+        TechAbilityAttachment.getAirborneTypes(
+            TechTracker.getCurrentTechAdvances(player, data.getTechnologyFrontier()));
     if (airborneDistance <= 0 || airborneBases.isEmpty() || airborneTypes.isEmpty()) {
       return result.setErrorReturnResult("Require Airborne Forces And Launch Capacity Tech");
     }
@@ -231,9 +235,10 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
     if (basesAtStart.isEmpty()) {
       return result.setErrorReturnResult("Require Airborne Base At Originating Territory");
     }
+
     final int airborneCapacity =
         TechAbilityAttachment.getAirborneCapacity(
-            basesAtStart, player, data.getTechnologyFrontier());
+            basesAtStart, TechTracker.getCurrentTechAdvances(player, data.getTechnologyFrontier()));
     if (airborneCapacity <= 0) {
       return result.setErrorReturnResult("Airborne Bases Must Have Launch Capacity");
     } else if (airborneCapacity < units.size()) {
@@ -323,7 +328,8 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
   private static Predicate<Unit> getAirborneBaseMatch(
       final GamePlayer player, final GameState data) {
     return getAirborneMatch(
-        TechAbilityAttachment.getAirborneBases(player, data.getTechnologyFrontier()),
+        TechAbilityAttachment.getAirborneBases(
+            TechTracker.getCurrentTechAdvances(player, data.getTechnologyFrontier())),
         data.getRelationshipTracker().getAllies(player, true));
   }
 
@@ -347,7 +353,8 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
       return launchedChange;
     }
     final IntegerMap<UnitType> capacityMap =
-        TechAbilityAttachment.getAirborneCapacity(player, data.getTechnologyFrontier());
+        TechAbilityAttachment.getAirborneCapacity(
+            TechTracker.getCurrentTechAdvances(player, data.getTechnologyFrontier()));
     for (final Unit u : bases) {
       if (newNumberLaunched <= 0) {
         break;
@@ -366,15 +373,19 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
   }
 
   private static boolean allowAirborne(final GamePlayer player, final GameState data) {
-    if (!TechAbilityAttachment.getAllowAirborneForces(player, data.getTechnologyFrontier())) {
+    if (!TechAbilityAttachment.getAllowAirborneForces(
+        TechTracker.getCurrentTechAdvances(player, data.getTechnologyFrontier()))) {
       return false;
     }
     final int airborneDistance =
-        TechAbilityAttachment.getAirborneDistance(player, data.getTechnologyFrontier());
+        TechAbilityAttachment.getAirborneDistance(
+            TechTracker.getCurrentTechAdvances(player, data.getTechnologyFrontier()));
     final Set<UnitType> airborneBases =
-        TechAbilityAttachment.getAirborneBases(player, data.getTechnologyFrontier());
+        TechAbilityAttachment.getAirborneBases(
+            TechTracker.getCurrentTechAdvances(player, data.getTechnologyFrontier()));
     final Set<UnitType> airborneTypes =
-        TechAbilityAttachment.getAirborneTypes(player, data.getTechnologyFrontier());
+        TechAbilityAttachment.getAirborneTypes(
+            TechTracker.getCurrentTechAdvances(player, data.getTechnologyFrontier()));
     if (airborneDistance <= 0 || airborneBases.isEmpty() || airborneTypes.isEmpty()) {
       return false;
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/FireAa.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/FireAa.java
@@ -15,6 +15,7 @@ import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.IExecutable;
 import games.strategy.triplea.delegate.Matches;
+import games.strategy.triplea.delegate.TechTracker;
 import games.strategy.triplea.delegate.battle.MustFightBattle.ReturnFire;
 import games.strategy.triplea.delegate.battle.steps.fire.FireRoundState;
 import games.strategy.triplea.delegate.battle.steps.fire.FiringGroup;
@@ -110,10 +111,12 @@ public class FireAa implements IExecutable {
         final Set<UnitType> validTargetTypes =
             UnitAttachment.get(firingGroup.iterator().next().getType())
                 .getTargetsAa(bridge.getData().getUnitTypeList());
+
         final Set<UnitType> airborneTypesTargeted =
             defending
                 ? TechAbilityAttachment.getAirborneTargettedByAa(
-                        hitPlayer, bridge.getData().getTechnologyFrontier())
+                        TechTracker.getCurrentTechAdvances(
+                            hitPlayer, bridge.getData().getTechnologyFrontier()))
                     .get(aaType)
                 : new HashSet<>();
         final Collection<Unit> validTargets =

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
@@ -27,6 +27,7 @@ import games.strategy.triplea.delegate.Die.DieType;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.IExecutable;
 import games.strategy.triplea.delegate.Matches;
+import games.strategy.triplea.delegate.TechTracker;
 import games.strategy.triplea.delegate.battle.casualty.AaCasualtySelector;
 import games.strategy.triplea.delegate.battle.casualty.CasualtySortingUtil;
 import games.strategy.triplea.delegate.data.BattleRecord;
@@ -91,8 +92,10 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
 
   protected void updateDefendingUnits() {
     // fill in defenders
+
     final Map<String, Set<UnitType>> airborneTechTargetsAllowed =
-        TechAbilityAttachment.getAirborneTargettedByAa(attacker, gameData.getTechnologyFrontier());
+        TechAbilityAttachment.getAirborneTargettedByAa(
+            TechTracker.getCurrentTechAdvances(attacker, gameData.getTechnologyFrontier()));
     final Predicate<Unit> defenders =
         Matches.enemyUnit(attacker, gameData.getRelationshipTracker())
             .and(
@@ -200,8 +203,10 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
     CasualtySortingUtil.sortPreBattle(attackingUnits);
     // TODO: determine if the target has the property, not just any unit with the property
     // isAAforBombingThisUnitOnly
+
     final Map<String, Set<UnitType>> airborneTechTargetsAllowed =
-        TechAbilityAttachment.getAirborneTargettedByAa(attacker, gameData.getTechnologyFrontier());
+        TechAbilityAttachment.getAirborneTargettedByAa(
+            TechTracker.getCurrentTechAdvances(attacker, gameData.getTechnologyFrontier()));
     defendingAa =
         battleSite
             .getUnitCollection()
@@ -455,9 +460,10 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
         final Set<UnitType> targetUnitTypesForThisTypeAa =
             UnitAttachment.get(currentPossibleAa.iterator().next().getType())
                 .getTargetsAa(gameData.getUnitTypeList());
+
         final Set<UnitType> airborneTypesTargetedToo =
             TechAbilityAttachment.getAirborneTargettedByAa(
-                    attacker, gameData.getTechnologyFrontier())
+                    TechTracker.getCurrentTechAdvances(attacker, gameData.getTechnologyFrontier()))
                 .get(currentTypeAa);
         if (determineAttackers) {
           validAttackingUnitsForThisRoll =
@@ -890,14 +896,15 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
             index++;
           }
         }
+
         costThisUnit =
             Math.max(
                 0,
                 (costThisUnit
                     + TechAbilityAttachment.getBombingBonus(
                         attacker.getType(),
-                        attacker.getOwner(),
-                        gameData.getTechnologyFrontier())));
+                        TechTracker.getCurrentTechAdvances(
+                            attacker.getOwner(), gameData.getTechnologyFrontier()))));
         if (limitDamage) {
           costThisUnit = Math.min(costThisUnit, damageLimit);
         }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/FiringGroupSplitterAa.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/FiringGroupSplitterAa.java
@@ -9,6 +9,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.attachments.TechAbilityAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
+import games.strategy.triplea.delegate.TechTracker;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.steps.fire.FiringGroup;
 import java.io.Serializable;
@@ -42,11 +43,13 @@ public class FiringGroupSplitterAa
   @Override
   public List<FiringGroup> apply(final BattleState battleState) {
     // only defense can fire at special airborne units (old "paratroopers")
+
     final Map<String, Set<UnitType>> airborneTechTargetsAllowed =
         side == DEFENSE
             ? TechAbilityAttachment.getAirborneTargettedByAa(
-                battleState.getPlayer(side.getOpposite()),
-                battleState.getGameData().getTechnologyFrontier())
+                TechTracker.getCurrentTechAdvances(
+                    battleState.getPlayer(side.getOpposite()),
+                    battleState.getGameData().getTechnologyFrontier()))
             : Map.of();
 
     final Collection<Unit> aaUnits =

--- a/game-core/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
@@ -13,6 +13,7 @@ import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.TechAbilityAttachment;
 import games.strategy.triplea.delegate.GameStepPropertiesHelper;
 import games.strategy.triplea.delegate.Matches;
+import games.strategy.triplea.delegate.TechTracker;
 import games.strategy.triplea.image.UnitImageFactory.ImageKey;
 import games.strategy.ui.ScrollableTextField;
 import games.strategy.ui.ScrollableTextFieldListener;
@@ -241,8 +242,10 @@ class ProductionRepairPanel extends JPanel {
     for (final Rule current : rules) {
       spent.add(current.getCost(), current.getQuantity());
     }
+
     final double discount =
-        TechAbilityAttachment.getRepairDiscount(gamePlayer, data.getTechnologyFrontier());
+        TechAbilityAttachment.getRepairDiscount(
+            TechTracker.getCurrentTechAdvances(gamePlayer, data.getTechnologyFrontier()));
     if (discount != 1.0D) {
       spent.discount(discount);
     }

--- a/game-core/src/test/java/games/strategy/triplea/attachments/TechAbilityAttachmentTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/attachments/TechAbilityAttachmentTest.java
@@ -1,5 +1,7 @@
 package games.strategy.triplea.attachments;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -12,14 +14,13 @@ import static org.mockito.Mockito.when;
 
 import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.data.GameData;
-import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.NamedAttachable;
-import games.strategy.engine.data.TechnologyFrontier;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.UnitTypeList;
 import games.strategy.engine.data.gameparser.GameParseException;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.delegate.TechAdvance;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -39,17 +40,15 @@ class TechAbilityAttachmentTest {
   private final String name = "Test Name";
   private final String customToString = "CustomToString";
   private final String testUnitType = "someExistentKey";
+  private Collection<TechAdvance> techAdvances;
 
   @BeforeEach
   void setUp() {
     when(attachment.toString()).thenReturn(customToString);
     when(data.getUnitTypeList()).thenReturn(list);
     when(list.getUnitType(testUnitType)).thenReturn(dummyUnitType);
-    final TechnologyFrontier fron = mock(TechnologyFrontier.class);
-    when(data.getTechnologyFrontier()).thenReturn(fron);
     final TechAdvance advance = mock(TechAdvance.class);
-    when(fron.getTechs()).thenReturn(List.of(advance, advance, advance, advance));
-    when(advance.hasTech(any())).thenReturn(Boolean.TRUE);
+    techAdvances = List.of(advance, advance, advance, advance);
     when(advance.getAttachment(Constants.TECH_ABILITY_ATTACHMENT_NAME))
         .thenReturn(attachment, null, attachment, attachment);
   }
@@ -174,9 +173,7 @@ class TechAbilityAttachmentTest {
             new IntegerMap<>(ImmutableMap.of(dummyUnitType, 300)))
         .when(mapper)
         .apply(attachment);
-    final int result =
-        TechAbilityAttachment.sumIntegerMap(
-            mapper, dummyUnitType, mock(GamePlayer.class), data.getTechnologyFrontier());
+    final int result = TechAbilityAttachment.sumIntegerMap(mapper, dummyUnitType, techAdvances);
     assertEquals(319, result);
   }
 
@@ -190,8 +187,7 @@ class TechAbilityAttachmentTest {
               return counter.getAndUpdate(i -> i * -10);
             },
             "NamedAttachable{name=test}",
-            mock(GamePlayer.class),
-            data.getTechnologyFrontier());
-    assertEquals(101, result);
+            techAdvances);
+    assertThat(result, is(101));
   }
 }


### PR DESCRIPTION
Many TechAbilityAttachment methods take a player and a tech frontier and
then convert those into a Collection<TechAdvance>. This commit flips it
so that the Collection<TechAdvance> is passed in instead. The callers
will create the collection with the player and tech frontier.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
