### PR TITLE
Convert map download version to be an integer rather than a 'Version'

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
@@ -24,7 +24,7 @@ public final class DownloadFileDescription {
   @EqualsAndHashCode.Include private final String url;
   private final String description;
   private final String mapName;
-  private final Version version;
+  private final Integer version;
   private final DownloadType downloadType;
   private final MapCategory mapCategory;
   private final String img;
@@ -69,7 +69,7 @@ public final class DownloadFileDescription {
         .url(mapDownloadListing.getUrl())
         .description(mapDownloadListing.getDescription())
         .mapName(mapDownloadListing.getMapName())
-        .version(new Version(mapDownloadListing.getVersion()))
+        .version(new Version(mapDownloadListing.getVersion()).getMajor())
         .downloadType(DownloadType.MAP)
         .mapCategory(MapCategory.fromString(mapDownloadListing.getMapCategory()))
         .img(mapDownloadListing.getPreviewImage())
@@ -82,7 +82,7 @@ public final class DownloadFileDescription {
         .url(skin.getUrl())
         .description(skin.getDescription())
         .mapName(skin.getSkinName())
-        .version(new Version(skin.getVersion()))
+        .version(new Version(skin.getVersion()).getMajor())
         .downloadType(DownloadType.MAP_SKIN)
         .mapCategory(MapCategory.fromString(mapCategory))
         .img(skin.getPreviewImageUrl())

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
@@ -12,7 +12,6 @@ import lombok.experimental.UtilityClass;
 import org.snakeyaml.engine.v2.api.Load;
 import org.snakeyaml.engine.v2.api.LoadSettings;
 import org.snakeyaml.engine.v2.exceptions.YamlEngineException;
-import org.triplea.util.Version;
 
 /**
  * Utility class to parse an available map list file config file - used to determine which maps are
@@ -53,8 +52,7 @@ final class DownloadFileParser {
                   (String) checkNotNull(yaml.get(Tags.description.toString()));
               final String mapName = (String) checkNotNull(yaml.get(Tags.mapName.toString()));
 
-              final Version version =
-                  new Version(checkNotNull((Integer) yaml.get(Tags.version.toString())), 0, 0);
+              final Integer version = (Integer) yaml.get(Tags.version.toString());
               final DownloadFileDescription.DownloadType downloadType =
                   optEnum(
                       yaml,

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileProperties.java
@@ -19,8 +19,8 @@ public class DownloadFileProperties {
   static final String VERSION_PROPERTY = "map.version";
   private final Properties props = new Properties();
 
-  DownloadFileProperties(final Version mapVersion) {
-    props.put(VERSION_PROPERTY, mapVersion.toString());
+  DownloadFileProperties(final Integer mapVersion) {
+    props.put(VERSION_PROPERTY, String.valueOf(mapVersion));
   }
 
   static DownloadFileProperties loadForZip(final File zipFile) {
@@ -51,7 +51,9 @@ public class DownloadFileProperties {
     return new File(zipFile.getAbsolutePath() + ".properties");
   }
 
-  public Optional<Version> getVersion() {
-    return Optional.ofNullable(props.getProperty(VERSION_PROPERTY)).map(Version::new);
+  public Optional<Integer> getVersion() {
+    return Optional.ofNullable(props.getProperty(VERSION_PROPERTY))
+        .map(Version::new)
+        .map(Version::getMajor);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/FileSystemAccessStrategy.java
@@ -11,12 +11,11 @@ import javax.swing.DefaultListModel;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.java.Interruptibles;
 import org.triplea.swing.SwingComponents;
-import org.triplea.util.Version;
 
 @Slf4j
 class FileSystemAccessStrategy {
 
-  Optional<Version> getMapVersion(final File mapFile) {
+  Optional<Integer> getMapVersion(final File mapFile) {
     if (!mapFile.exists()) {
       return Optional.empty();
     }

--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadList.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadList.java
@@ -8,7 +8,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
-import org.triplea.util.Version;
 
 class MapDownloadList {
 
@@ -28,12 +27,11 @@ class MapDownloadList {
       if (download == null) {
         return;
       }
-      final Optional<Version> mapVersion = strategy.getMapVersion(download.getInstallLocation());
+      final Optional<Integer> mapVersion = strategy.getMapVersion(download.getInstallLocation());
 
       if (mapVersion.isPresent()) {
         installed.add(download);
-        if (download.getVersion() != null
-            && download.getVersion().isGreaterThan(mapVersion.get())) {
+        if (download.getVersion() != null && download.getVersion() > mapVersion.get()) {
           outOfDate.add(download);
         }
       } else {

--- a/game-core/src/test/java/games/strategy/engine/auto/update/UpdatedMapsCheckTest.java
+++ b/game-core/src/test/java/games/strategy/engine/auto/update/UpdatedMapsCheckTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.triplea.util.Version;
 
 @SuppressWarnings("unused")
 @ExtendWith(MockitoExtension.class)
@@ -75,19 +74,19 @@ final class UpdatedMapsCheckTest {
 
   @Test
   void shouldSkipCheckWhenNoAvailableDownloadsFound() {
-    final Map<String, Version> availableMapVersions = Map.of();
+    final Map<String, Integer> availableMapVersions = Map.of();
 
     final Collection<String> result =
         UpdatedMapsCheck.computeOutOfDateMaps(
-            Map.of("installed_map.properties", new Version(1, 0, 0)), availableMapVersions);
+            Map.of("installed_map.properties", 1), availableMapVersions);
 
     assertThat(result, is(empty()));
   }
 
   @ParameterizedTest
   @MethodSource
-  void localMapsNotOutOfDate(final Map<String, Version> localMaps) {
-    final Map<String, Version> availableMaps = Map.of("map name", new Version(2, 0, 0));
+  void localMapsNotOutOfDate(final Map<String, Integer> localMaps) {
+    final Map<String, Integer> availableMaps = Map.of("map name", 2);
 
     final Collection<String> result =
         UpdatedMapsCheck.computeOutOfDateMaps(localMaps, availableMaps);
@@ -95,20 +94,20 @@ final class UpdatedMapsCheckTest {
     assertThat(result, is(empty()));
   }
 
-  static List<Map<String, Version>> localMapsNotOutOfDate() {
+  static List<Map<String, Integer>> localMapsNotOutOfDate() {
     return List.of(
         // no local maps
         Map.of(),
         // local map is current
-        Map.of("map_name.properties", new Version(2, 0, 0)),
+        Map.of("map_name.properties", 2),
         // local map is more recent
-        Map.of("map_name.properties", new Version(3, 0, 0)));
+        Map.of("map_name.properties", 3));
   }
 
   @ParameterizedTest
   @MethodSource
-  void localMapsOutOfDate(final Map<String, Version> localMaps) {
-    final Map<String, Version> availableMaps = Map.of("Map Name", new Version(2, 0, 0));
+  void localMapsOutOfDate(final Map<String, Integer> localMaps) {
+    final Map<String, Integer> availableMaps = Map.of("Map Name", 2);
 
     final Collection<String> result =
         UpdatedMapsCheck.computeOutOfDateMaps(localMaps, availableMaps);
@@ -117,13 +116,13 @@ final class UpdatedMapsCheckTest {
     assertThat(result.iterator().next(), is("Map Name"));
   }
 
-  static List<Map<String, Version>> localMapsOutOfDate() {
+  static List<Map<String, Integer>> localMapsOutOfDate() {
     return List.of(
         // version is less than 2.0.0 and is '0'
-        Map.of("map_name.zip.properties", new Version(0, 0, 0)),
+        Map.of("map_name.zip.properties", 0),
         // version is less than 2.0.0 and is '1'
-        Map.of("map_name.zip.properties", new Version(1, 0, 0)),
+        Map.of("map_name.zip.properties", 1),
         // alternative spelling of the map zip file with the -master suffix
-        Map.of("map_name-master.zip.properties", new Version(1, 0, 0)));
+        Map.of("map_name-master.zip.properties", 1));
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadFileDescriptionTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadFileDescriptionTest.java
@@ -9,7 +9,6 @@ import java.io.File;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.triplea.util.Version;
 
 class DownloadFileDescriptionTest extends AbstractClientSettingTestCase {
   @Test
@@ -19,7 +18,7 @@ class DownloadFileDescriptionTest extends AbstractClientSettingTestCase {
             "",
             "",
             "",
-            new Version(0, 0, 0),
+            0,
             DownloadFileDescription.DownloadType.MAP,
             DownloadFileDescription.MapCategory.EXPERIMENTAL,
             "");
@@ -33,7 +32,7 @@ class DownloadFileDescriptionTest extends AbstractClientSettingTestCase {
             "",
             "",
             "",
-            new Version(0, 0, 0),
+            0,
             DownloadFileDescription.DownloadType.MAP_SKIN,
             DownloadFileDescription.MapCategory.EXPERIMENTAL,
             "");
@@ -47,7 +46,7 @@ class DownloadFileDescriptionTest extends AbstractClientSettingTestCase {
             "",
             "",
             "",
-            new Version(0, 0, 0),
+            0,
             DownloadFileDescription.DownloadType.MAP_TOOL,
             DownloadFileDescription.MapCategory.EXPERIMENTAL,
             "");
@@ -62,7 +61,7 @@ class DownloadFileDescriptionTest extends AbstractClientSettingTestCase {
             "",
             "",
             mapName,
-            new Version(0, 0, 0),
+            0,
             DownloadFileDescription.DownloadType.MAP,
             DownloadFileDescription.MapCategory.EXPERIMENTAL,
             "");
@@ -76,7 +75,7 @@ class DownloadFileDescriptionTest extends AbstractClientSettingTestCase {
             "",
             "",
             "",
-            new Version(0, 0, 0),
+            0,
             DownloadFileDescription.DownloadType.MAP,
             DownloadFileDescription.MapCategory.BEST,
             "");
@@ -110,7 +109,7 @@ class DownloadFileDescriptionTest extends AbstractClientSettingTestCase {
         inputUrl,
         "",
         "",
-        new Version(0, 0, 0),
+        0,
         DownloadFileDescription.DownloadType.MAP,
         DownloadFileDescription.MapCategory.EXPERIMENTAL,
         "");
@@ -140,7 +139,7 @@ class DownloadFileDescriptionTest extends AbstractClientSettingTestCase {
             inputUrl,
             "",
             mapName,
-            new Version(0, 0, 0),
+            0,
             DownloadFileDescription.DownloadType.MAP,
             DownloadFileDescription.MapCategory.EXPERIMENTAL,
             "");

--- a/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadFileTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadFileTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.mock;
 
 import games.strategy.engine.framework.map.download.DownloadFile.DownloadState;
 import org.junit.jupiter.api.Test;
-import org.triplea.util.Version;
 
 class DownloadFileTest {
   @Test
@@ -16,7 +15,7 @@ class DownloadFileTest {
             "url",
             "description",
             "mapName",
-            new Version(0, 0, 0),
+            0,
             DownloadFileDescription.DownloadType.MAP,
             DownloadFileDescription.MapCategory.BEST,
             "");

--- a/game-core/src/test/java/games/strategy/engine/framework/map/download/FileSystemAccessStrategyTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/map/download/FileSystemAccessStrategyTest.java
@@ -11,7 +11,6 @@ import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
-import org.triplea.util.Version;
 
 /**
  * For transition reasons we use a DownloadFileProperties to read a properties file for each map
@@ -40,6 +39,6 @@ class FileSystemAccessStrategyTest {
 
   @Test
   void testMapFileFound() {
-    assertThat(testObj.getMapVersion(mapFile), isPresentAndIs(new Version(1, 2, 0)));
+    assertThat(testObj.getMapVersion(mapFile), isPresentAndIs(1));
   }
 }

--- a/game-core/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/map/download/MapDownloadListTest.java
@@ -2,6 +2,8 @@ package games.strategy.engine.framework.map.download;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
@@ -14,13 +16,12 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.triplea.util.Version;
 
 @ExtendWith(MockitoExtension.class)
 class MapDownloadListTest extends AbstractClientSettingTestCase {
   private static final String MAP_NAME = "new_test_order";
-  private static final Version MAP_VERSION = new Version(10, 10, 0);
-  private static final Version lowVersion = new Version(0, 0, 0);
+  private static final int MAP_VERSION = 10;
+  private static final int lowVersion = 0;
 
   private static final DownloadFileDescription TEST_MAP =
       new DownloadFileDescription(
@@ -44,16 +45,11 @@ class MapDownloadListTest extends AbstractClientSettingTestCase {
   @Test
   void testAvailable() {
     when(strategy.getMapVersion(any())).thenReturn(Optional.empty());
-    final MapDownloadList testObj = new MapDownloadList(descriptions, strategy);
+    final MapDownloadList mapDownloadList = new MapDownloadList(descriptions, strategy);
 
-    final List<DownloadFileDescription> available = testObj.getAvailable();
-    assertThat(available.size(), is(1));
-
-    final List<DownloadFileDescription> installed = testObj.getInstalled();
-    assertThat(installed.size(), is(0));
-
-    final List<DownloadFileDescription> outOfDate = testObj.getOutOfDate();
-    assertThat(outOfDate.size(), is(0));
+    assertThat(mapDownloadList.getAvailable(), hasSize(1));
+    assertThat(mapDownloadList.getInstalled(), is(empty()));
+    assertThat(mapDownloadList.getOutOfDate(), is(empty()));
   }
 
   @Test
@@ -62,11 +58,11 @@ class MapDownloadListTest extends AbstractClientSettingTestCase {
     final DownloadFileDescription download1 = newDownloadWithUrl("url1");
     final DownloadFileDescription download2 = newDownloadWithUrl("url2");
     final DownloadFileDescription download3 = newDownloadWithUrl("url3");
-    final MapDownloadList testObj =
+    final MapDownloadList mapDownloadList =
         new MapDownloadList(List.of(download1, download2, download3), strategy);
 
     final List<DownloadFileDescription> available =
-        testObj.getAvailableExcluding(List.of(download1, download3));
+        mapDownloadList.getAvailableExcluding(List.of(download1, download3));
 
     assertThat(available, is(List.of(download2)));
   }
@@ -75,7 +71,7 @@ class MapDownloadListTest extends AbstractClientSettingTestCase {
     return new DownloadFileDescription(
         url,
         "description",
-        "mapName",
+        "mapName" + url,
         MAP_VERSION,
         DownloadFileDescription.DownloadType.MAP,
         DownloadFileDescription.MapCategory.BEST,
@@ -85,31 +81,21 @@ class MapDownloadListTest extends AbstractClientSettingTestCase {
   @Test
   void testInstalled() {
     when(strategy.getMapVersion(any())).thenReturn(Optional.of(MAP_VERSION));
-    final MapDownloadList testObj = new MapDownloadList(descriptions, strategy);
+    final MapDownloadList mapDownloadList = new MapDownloadList(descriptions, strategy);
 
-    final List<DownloadFileDescription> available = testObj.getAvailable();
-    assertThat(available.size(), is(0));
-
-    final List<DownloadFileDescription> installed = testObj.getInstalled();
-    assertThat(installed.size(), is(1));
-
-    final List<DownloadFileDescription> outOfDate = testObj.getOutOfDate();
-    assertThat(outOfDate.size(), is(0));
+    assertThat(mapDownloadList.getAvailable(), is(empty()));
+    assertThat(mapDownloadList.getInstalled(), hasSize(1));
+    assertThat(mapDownloadList.getOutOfDate(), is(empty()));
   }
 
   @Test
   void testOutOfDate() {
     when(strategy.getMapVersion(any())).thenReturn(Optional.of(lowVersion));
-    final MapDownloadList testObj = new MapDownloadList(descriptions, strategy);
+    final MapDownloadList mapDownloadList = new MapDownloadList(descriptions, strategy);
 
-    final List<DownloadFileDescription> available = testObj.getAvailable();
-    assertThat(available.size(), is(0));
-
-    final List<DownloadFileDescription> installed = testObj.getInstalled();
-    assertThat(installed.size(), is(1));
-
-    final List<DownloadFileDescription> outOfDate = testObj.getOutOfDate();
-    assertThat(outOfDate.size(), is(1));
+    assertThat(mapDownloadList.getAvailable(), is(empty()));
+    assertThat(mapDownloadList.getInstalled(), hasSize(1));
+    assertThat(mapDownloadList.getOutOfDate(), hasSize(1));
   }
 
   @Test
@@ -118,11 +104,11 @@ class MapDownloadListTest extends AbstractClientSettingTestCase {
     final DownloadFileDescription download1 = newDownloadWithUrl("url1");
     final DownloadFileDescription download2 = newDownloadWithUrl("url2");
     final DownloadFileDescription download3 = newDownloadWithUrl("url3");
-    final MapDownloadList testObj =
+    final MapDownloadList mapDownloadList =
         new MapDownloadList(List.of(download1, download2, download3), strategy);
 
     final List<DownloadFileDescription> outOfDate =
-        testObj.getOutOfDateExcluding(List.of(download1, download3));
+        mapDownloadList.getOutOfDateExcluding(List.of(download1, download3));
 
     assertThat(outOfDate, is(List.of(download2)));
   }


### PR DESCRIPTION
The map download version is just a single number, this update converts
the data type that we are parse it into from a 'Version' object to
instead be an 'Integer' object.

