### PR TITLE
Add download test files dependency to integTest

### DIFF
--- a/smoke-testing/build.gradle
+++ b/smoke-testing/build.gradle
@@ -20,6 +20,7 @@ shadowJar {
     archiveClassifier.set ''
 }
 
+tasks.integTest.dependsOn("downloadXmls", "downloadSaveGames")
 tasks.test.dependsOn("downloadXmls", "downloadSaveGames")
 
 task downloadXmls {


### PR DESCRIPTION
Running './gradlew integTest' on its own fails due to missing resources.
This update adds the download test data assets task as a prerequisite
to 'integTest', previously it was so just for the 'test' task.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
