### PR TITLE
Remove null check for download file version

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
@@ -85,10 +85,8 @@ final class DownloadFile {
             return;
           }
 
-          if (download.getVersion() != null) {
-            new DownloadFileProperties(download.getVersion())
-                .saveForZip(download.getInstallLocation());
-          }
+          new DownloadFileProperties(download.getVersion())
+              .saveForZip(download.getInstallLocation());
 
           downloadListener.downloadComplete(download);
         });


### PR DESCRIPTION
All download file descriptions should have a download version
associated. This removes a null check that would no-op
in creating the version properties file if the version were null.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
