### PR TITLE
Also check for illegal arg exception when writing download properties…

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileProperties.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileProperties.java
@@ -42,7 +42,7 @@ public class DownloadFileProperties {
   void saveForZip(final File zipFile) {
     try (OutputStream fos = new FileOutputStream(fromZip(zipFile))) {
       props.store(fos, null);
-    } catch (final IOException e) {
+    } catch (final IllegalArgumentException | IOException e) {
       log.error("Failed to write property file to: " + fromZip(zipFile).getAbsolutePath(), e);
     }
   }


### PR DESCRIPTION
… file

We can get the exception if we try to write a non-String data type.
This update adds IllegalArgumentException to a catch block to handle
such cases and give a better error messages (intended for developers)


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
