### PR TITLE
Run unit tests on master for code coverage reports

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,5 @@
 name: Unit Tests
-on: pull_request
+on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,5 +1,8 @@
 name: Unit Tests
-on: [push, pull_request]
+on:
+  push:
+    branches: master
+  pull_request:
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is a partial revert of #8257
The codecov coverage is completely messed up because there no longer are reports from master, so the diff says nothing really making it useless.
This change restores the "old" behaviour for unit tests so that the reports make sense now.

EDIT: actually we only need builds when pushing to master, so I added that in