### PR TITLE
Pass in UnitTypeList in UnitSupportAttachment.get

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -212,6 +212,12 @@ public class GameData implements Serializable, GameState {
     return sequence;
   }
 
+  /**
+   * UnitTypeList is a collection of all of the unit types in the game
+   *
+   * <p>It is a read-only data structure and so doesn't require a lock to read it. It is only
+   * modified during the initial parsing of the game data.
+   */
   @Override
   public UnitTypeList getUnitTypeList() {
     return unitTypeList;

--- a/game-core/src/main/java/games/strategy/engine/data/UnitTypeList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/UnitTypeList.java
@@ -12,7 +12,11 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 
-/** A collection of unit types. */
+/**
+ * A collection of unit types.
+ *
+ * <p>The content of the UnitTypeList doesn't change during a game.
+ */
 public class UnitTypeList extends GameDataComponent implements Iterable<UnitType> {
   private static final long serialVersionUID = 9002927658524651749L;
 
@@ -55,7 +59,7 @@ public class UnitTypeList extends GameDataComponent implements Iterable<UnitType
   public Set<UnitSupportAttachment> getSupportRules() {
     if (supportRules == null) {
       supportRules =
-          UnitSupportAttachment.get(getData()).stream()
+          UnitSupportAttachment.get(this).stream()
               .filter(usa -> (usa.getRoll() || usa.getStrength()))
               .collect(Collectors.toSet());
     }
@@ -70,7 +74,7 @@ public class UnitTypeList extends GameDataComponent implements Iterable<UnitType
   public Set<UnitSupportAttachment> getSupportAaRules() {
     if (supportAaRules == null) {
       supportAaRules =
-          UnitSupportAttachment.get(getData()).stream()
+          UnitSupportAttachment.get(this).stream()
               .filter(usa -> (usa.getAaRoll() || usa.getAaStrength()))
               .collect(Collectors.toSet());
     }

--- a/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/TriggerAttachment.java
@@ -575,7 +575,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
         s[i] = s[i].substring(1);
       }
       boolean found = false;
-      for (final UnitSupportAttachment support : UnitSupportAttachment.get(getData())) {
+      for (final UnitSupportAttachment support :
+          UnitSupportAttachment.get(getData().getUnitTypeList())) {
         if (support.getName().equals(s[i])) {
           found = true;
           if (this.support == null) {
@@ -2190,7 +2191,8 @@ public class TriggerAttachment extends AbstractTriggerAttachment {
       for (final GamePlayer player : t.getPlayers()) {
         for (final String usaString : t.getSupport().keySet()) {
           UnitSupportAttachment usa = null;
-          for (final UnitSupportAttachment support : UnitSupportAttachment.get(data)) {
+          for (final UnitSupportAttachment support :
+              UnitSupportAttachment.get(data.getUnitTypeList())) {
             if (support.getName().equals(usaString)) {
               usa = support;
               break;

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -1479,12 +1479,14 @@ public class UnitAttachment extends DefaultAttachment {
 
   public void setUnitSupportCount(final String s) {
     unitSupportCount = getInt(s);
-    UnitSupportAttachment.setOldSupportCount((UnitType) getAttachedTo(), getData(), s);
+    UnitSupportAttachment.setOldSupportCount(
+        (UnitType) getAttachedTo(), getData().getUnitTypeList(), s);
   }
 
   private void setUnitSupportCount(final Integer s) {
     unitSupportCount = s;
-    UnitSupportAttachment.setOldSupportCount((UnitType) getAttachedTo(), getData(), s.toString());
+    UnitSupportAttachment.setOldSupportCount(
+        (UnitType) getAttachedTo(), getData().getUnitTypeList(), s.toString());
   }
 
   private int getUnitSupportCount() {
@@ -3375,7 +3377,8 @@ public class UnitAttachment extends DefaultAttachment {
     if (supports.size() > 3) {
       tuples.add(Tuple.of("Can Provide Support to Units", ""));
     } else if (!supports.isEmpty()) {
-      final boolean moreThanOneSupportType = UnitSupportAttachment.get(getData()).size() > 1;
+      final boolean moreThanOneSupportType =
+          UnitSupportAttachment.get(getData().getUnitTypeList()).size() > 1;
       for (final UnitSupportAttachment support : supports) {
         if (support.getUnitType() == null || support.getUnitType().isEmpty()) {
           continue;


### PR DESCRIPTION
The UnitTypeList is a read-only data structure. So the lock in
UnitSupportAttachment.get is unneeded.

With the lock removed, UnitSupportAttachment.get can be changed to just
accept the UnitTypeList instead of GameData.

Added comments to UnitTypeList to indicate that it is read-only.  Added
comments to GameData.getUnitTypeList to indicate that the lock isn't
needed for it.  Added comments to UnitSupportAttachment to indicate that
the set of UnitSupportAttachment is immutable.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->
Ran Hard AI of World at War.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->
I noticed this when I was trying to understand UnitTypeList.getSupportRules.  I found it odd that getSupportRules would call UnitSupportAttachment.get and pass in getData() but then UnitSupportAttachment.get would immediately access the UnitTypeList again.

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
