### PR TITLE
Create DamageUnitsHistoryChange for damaging units

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/history/change/HistoryChangeFactory.java
+++ b/game-core/src/main/java/games/strategy/engine/history/change/HistoryChangeFactory.java
@@ -2,10 +2,12 @@ package games.strategy.engine.history.change;
 
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
+import games.strategy.engine.history.change.units.DamageUnitsHistoryChange;
 import games.strategy.engine.history.change.units.RemoveUnitsHistoryChange;
 import games.strategy.engine.history.change.units.TransformDamagedUnitsHistoryChange;
 import java.util.Collection;
 import lombok.experimental.UtilityClass;
+import org.triplea.java.collections.IntegerMap;
 
 @UtilityClass
 public class HistoryChangeFactory {
@@ -24,5 +26,10 @@ public class HistoryChangeFactory {
       final Territory location, final Collection<Unit> killedUnits, final String aaType) {
     return new RemoveUnitsHistoryChange(
         location, killedUnits, "${units} killed by " + aaType + " in ${territory}");
+  }
+
+  public DamageUnitsHistoryChange damageUnits(
+      final Territory location, final IntegerMap<Unit> damagedUnits) {
+    return new DamageUnitsHistoryChange(location, damagedUnits);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/history/change/units/DamageUnitsHistoryChange.java
+++ b/game-core/src/main/java/games/strategy/engine/history/change/units/DamageUnitsHistoryChange.java
@@ -1,0 +1,55 @@
+package games.strategy.engine.history.change.units;
+
+import games.strategy.engine.data.Change;
+import games.strategy.engine.data.CompositeChange;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.changefactory.ChangeFactory;
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.engine.history.change.HistoryChange;
+import games.strategy.triplea.formatter.MyFormatter;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.experimental.FieldDefaults;
+import org.triplea.java.collections.IntegerMap;
+
+/** Sets the amount of damage that units have received in a territory */
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+@Getter
+@EqualsAndHashCode
+public class DamageUnitsHistoryChange implements HistoryChange {
+
+  CompositeChange change = new CompositeChange();
+  Territory location;
+  IntegerMap<Unit> damageToUnits;
+
+  public DamageUnitsHistoryChange(final Territory location, final IntegerMap<Unit> damagedUnits) {
+    this.location = location;
+
+    // add together the amount of new damage with the existing damage
+    this.damageToUnits = new IntegerMap<>(damagedUnits);
+    damageToUnits.keySet().forEach(unit -> damageToUnits.add(unit, unit.getHits()));
+  }
+
+  @Override
+  public void perform(final IDelegateBridge bridge) {
+    final Change damageUnitsChange = ChangeFactory.unitsHit(damageToUnits, List.of(location));
+
+    this.change.add(damageUnitsChange);
+    bridge.addChange(this.change);
+
+    bridge
+        .getHistoryWriter()
+        .addChildToEvent(
+            "Units damaged: " + MyFormatter.unitsToText(damageToUnits.keySet()),
+            new ArrayList<>(damageToUnits.keySet()));
+  }
+
+  @Override
+  public Change invert() {
+    return this.change.invert();
+  }
+}


### PR DESCRIPTION
<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->
Hard AI of World At War
## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE-->CHANGE|If a kamikaze strike kills a unit that is transporting other units (or just unloaded units to another territory), the transported units and unloaded units are now killed along with the unit that was originally hit by the kamikaze strike.<!--END_RELEASE_NOTE-->
