### PR TITLE
Add a way to clear the execution stack

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/ExecutionStack.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/ExecutionStack.java
@@ -51,4 +51,8 @@ public class ExecutionStack implements Serializable {
   public boolean isEmpty() {
     return deque.isEmpty();
   }
+
+  public void clear() {
+    deque.clear();
+  }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
@@ -64,7 +64,12 @@ public interface BattleState {
   class BattleStatus {
     int round;
     int maxRounds;
+
+    @RemoveOnNextMajorRelease(
+        "The ExecutionStack is now being cleared when the battle is over so later battle steps will"
+            + "no longer run and they don't need to check isOver anymore.")
     boolean isOver;
+
     boolean isAmphibious;
     boolean isHeadless;
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEnd.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEnd.java
@@ -54,12 +54,15 @@ public class CheckGeneralBattleEnd implements BattleStep {
   public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
     if (hasSideLost(OFFENSE)) {
       battleActions.endBattle(IBattle.WhoWon.DEFENDER, bridge);
+      stack.clear();
 
     } else if (hasSideLost(DEFENSE)) {
       battleActions.endBattle(IBattle.WhoWon.ATTACKER, bridge);
+      stack.clear();
 
     } else if (isStalemate() && !canAttackerRetreatInStalemate()) {
       battleActions.endBattle(IBattle.WhoWon.DRAW, bridge);
+      stack.clear();
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEndOld.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckGeneralBattleEndOld.java
@@ -27,17 +27,21 @@ public class CheckGeneralBattleEndOld extends CheckGeneralBattleEnd {
   public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
     if (hasSideLost(OFFENSE)) {
       getBattleActions().endBattle(IBattle.WhoWon.DEFENDER, bridge);
+      stack.clear();
 
     } else if (hasSideLost(DEFENSE)) {
       new RemoveUnprotectedUnits(getBattleState(), getBattleActions())
           .removeUnprotectedUnits(bridge, DEFENSE);
       getBattleActions().endBattle(IBattle.WhoWon.ATTACKER, bridge);
+      stack.clear();
 
     } else if (isStalemate()) {
       if (canAttackerRetreatInStalemate()) {
-        new OffensiveGeneralRetreat(getBattleState(), getBattleActions()).retreatUnits(bridge);
+        new OffensiveGeneralRetreat(getBattleState(), getBattleActions())
+            .retreatUnits(stack, bridge);
       }
       getBattleActions().endBattle(IBattle.WhoWon.DRAW, bridge);
+      stack.clear();
     }
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckStalemateBattleEnd.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/CheckStalemateBattleEnd.java
@@ -29,6 +29,7 @@ public class CheckStalemateBattleEnd extends CheckGeneralBattleEnd {
   public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
     if (!getBattleState().getStatus().isOver() && isStalemate()) {
       getBattleActions().endBattle(IBattle.WhoWon.DRAW, bridge);
+      stack.clear();
     }
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreat.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreat.java
@@ -102,6 +102,7 @@ public class DefensiveSubsRetreat implements BattleStep {
             .side(DEFENSE)
             .bridge(bridge)
             .units(unitsToRetreat)
+            .executionStack(stack)
             .build(),
         retreatTerritories,
         getName());

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveGeneralRetreat.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveGeneralRetreat.java
@@ -87,11 +87,11 @@ public class OffensiveGeneralRetreat implements BattleStep {
 
   @Override
   public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-    retreatUnits(bridge);
+    retreatUnits(stack, bridge);
   }
 
   @RemoveOnNextMajorRelease("This doesn't need to be public in the next major release")
-  public void retreatUnits(final IDelegateBridge bridge) {
+  public void retreatUnits(final ExecutionStack stack, final IDelegateBridge bridge) {
     if (battleState.getStatus().isOver()) {
       return;
     }
@@ -119,7 +119,7 @@ public class OffensiveGeneralRetreat implements BattleStep {
               getQueryText(retreater.getRetreatType()));
 
       if (retreatTo != null) {
-        retreat(bridge, retreater, retreatTo);
+        retreat(stack, bridge, retreater, retreatTo);
       }
     }
   }
@@ -146,7 +146,10 @@ public class OffensiveGeneralRetreat implements BattleStep {
   }
 
   private void retreat(
-      final IDelegateBridge bridge, final Retreater retreater, final Territory retreatTo) {
+      final ExecutionStack stack,
+      final IDelegateBridge bridge,
+      final Retreater retreater,
+      final Territory retreatTo) {
     final Collection<Unit> retreatUnits = retreater.getRetreatUnits();
 
     SoundUtils.playRetreatType(
@@ -166,6 +169,7 @@ public class OffensiveGeneralRetreat implements BattleStep {
 
     if (battleState.filterUnits(ALIVE, OFFENSE).isEmpty()) {
       battleActions.endBattle(IBattle.WhoWon.DEFENDER, bridge);
+      stack.clear();
     } else {
       bridge.getDisplayChannelBroadcaster().notifyRetreat(battleState.getBattleId(), retreatUnits);
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveSubsRetreat.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveSubsRetreat.java
@@ -88,6 +88,7 @@ public class OffensiveSubsRetreat implements BattleStep {
             .side(OFFENSE)
             .bridge(bridge)
             .units(unitsToRetreat)
+            .executionStack(stack)
             .build(),
         Properties.getSubmersibleSubs(battleState.getGameData().getProperties())
             ? List.of(battleState.getBattleSite())

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/sub/SubmergeSubsVsOnlyAirStep.java
@@ -66,6 +66,7 @@ public class SubmergeSubsVsOnlyAirStep implements BattleStep {
                     battleState.filterUnits(ALIVE, submergingSide), canNotBeTargetedByAllMatch))
             .side(submergingSide)
             .bridge(bridge)
+            .executionStack(stack)
             .build());
   }
 


### PR DESCRIPTION
When a battle is over, the execution stack can be cleared. The remaining
steps don't need to run.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->
Added a breakpoint to battle steps and ensured that it was not executing them.  Also ensured that battles still worked.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
