### PR TITLE
Put the allied air transportedBy code in the same place

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -2089,17 +2089,15 @@ public final class Matches {
         .and(
             unit -> {
               final int currentDamage = unit.getHits();
-              final List<Tuple<Tuple<Integer, Integer>, Tuple<String, String>>>
-                  whenCombatDamagedList = UnitAttachment.get(unit.getType()).getWhenCombatDamaged();
-              for (final Tuple<Tuple<Integer, Integer>, Tuple<String, String>> key :
-                  whenCombatDamagedList) {
-                final String effect = key.getSecond().getFirst();
-                if (!effect.equals(filterForEffect)) {
+              final List<UnitAttachment.WhenCombatDamaged> whenCombatDamagedList =
+                  UnitAttachment.get(unit.getType()).getWhenCombatDamaged();
+              for (final UnitAttachment.WhenCombatDamaged key : whenCombatDamagedList) {
+                if (!key.getEffect().equals(filterForEffect)) {
                   continue;
                 }
-                final int damagedFrom = key.getFirst().getFirst();
-                final int damagedTo = key.getFirst().getSecond();
-                if (currentDamage >= damagedFrom && currentDamage <= damagedTo) {
+                final int damagedMin = key.getDamageMin();
+                final int damagedMax = key.getDamageMax();
+                if (currentDamage >= damagedMin && currentDamage <= damagedMax) {
                   return true;
                 }
               }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/MoveDelegate.java
@@ -351,7 +351,7 @@ public class MoveDelegate extends AbstractMoveDelegate {
             .and(Matches.unitIsCarrier())
             .and(
                 Matches.unitHasWhenCombatDamagedEffect(
-                    UnitAttachment.UNITSMAYNOTLEAVEALLIEDCARRIER));
+                    UnitAttachment.UNITS_MAY_NOT_LEAVE_ALLIED_CARRIER));
     final Predicate<Unit> ownedFightersMatch =
         Matches.unitIsOwnedBy(player)
             .and(Matches.unitIsAir())
@@ -505,7 +505,8 @@ public class MoveDelegate extends AbstractMoveDelegate {
     final Collection<Unit> damagedCarriers =
         CollectionUtils.getMatches(
             fullyRepaired.keySet(),
-            Matches.unitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLEAVEALLIEDCARRIER));
+            Matches.unitHasWhenCombatDamagedEffect(
+                UnitAttachment.UNITS_MAY_NOT_LEAVE_ALLIED_CARRIER));
 
     // now cycle through those now-repaired carriers, and remove allied air from being dependent
     final CompositeChange clearAlliedAir = new CompositeChange();

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -234,24 +234,11 @@ public class MustFightBattle extends DependentBattle
     if (!Properties.getAlliedAirIndependent(gameData.getProperties())) {
       // allied air can not participate in the battle so set transportedBy on each allied air unit
       // and remove them from the attacking units
-      MoveValidator.carrierMustMoveWith(units, units, gameData.getRelationshipTracker(), attacker)
-          .forEach(
-              (carrier, dependencies) -> {
-                final UnitAttachment ua = UnitAttachment.get(carrier.getType());
-                if (ua.getCarrierCapacity() == -1) {
-                  return;
-                }
-
-                dependencies.stream()
-                    .filter(Matches.unitIsAir())
-                    .forEach(
-                        fighter -> {
-                          change.add(
-                              ChangeFactory.unitPropertyChange(
-                                  fighter, carrier, Unit.TRANSPORTED_BY));
-                          this.attackingUnits.remove(fighter);
-                        });
-              });
+      final TransportTracker.AlliedAirTransportChange alliedAirTransportChange =
+          TransportTracker.markTransportedByForAlliedAirOnCarrier(
+              units, gameData.getRelationshipTracker(), attacker);
+      change.add(alliedAirTransportChange.getChange());
+      this.attackingUnits.removeAll(alliedAirTransportChange.getAlliedAir());
     }
     // mark units with no movement for all but air
     Collection<Unit> nonAir = CollectionUtils.getMatches(attackingUnits, Matches.unitIsNotAir());

--- a/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/AirMovementValidator.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/AirMovementValidator.java
@@ -810,7 +810,8 @@ public final class AirMovementValidator {
       if (Matches.unitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLANDONCARRIER)
           .test(unit)) {
         // and we must check to make sure we let any allied air that are cargo stay here
-        if (Matches.unitHasWhenCombatDamagedEffect(UnitAttachment.UNITSMAYNOTLEAVEALLIEDCARRIER)
+        if (Matches.unitHasWhenCombatDamagedEffect(
+                UnitAttachment.UNITS_MAY_NOT_LEAVE_ALLIED_CARRIER)
             .test(unit)) {
           int cargo = 0;
           final Collection<Unit> airCargo =


### PR DESCRIPTION
Allied air was getting the transportedBy flag in MustFightBattle but
having it cleared in TransportTracker.  This moves the code in
MustFightBattle to TransportTracker so that it is in the same place.

Also, creates a value class for whenCombatDamaged to replace the Tuple
of Tuples.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->
Played a game with allied air on a carrier and checked that it was marked as transported still.
## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
