### PR TITLE
Add a RemoveNonCombatantsBeforeAA step at the beginning of the battle

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleState.java
@@ -90,7 +90,10 @@ public interface BattleState {
 
   void retreatUnits(Side side, Collection<Unit> units);
 
-  Collection<Unit> removeNonCombatants(Side side);
+  /**
+   * @param removeAaUnitsThatFireThisRound Should AA units that fire this round be removed or not
+   */
+  Collection<Unit> removeNonCombatants(Side side, boolean removeAaUnitsThatFireThisRound);
 
   /**
    * Mark the units that will be dying

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleStep.java
@@ -44,6 +44,7 @@ import java.util.List;
 public interface BattleStep extends IExecutable {
 
   enum Order {
+    REMOVE_NON_COMBATANTS_INITIAL,
     AA_OFFENSIVE,
     AA_DEFENSIVE,
     AA_REMOVE_CASUALTIES,

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleStep.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattleStep.java
@@ -11,6 +11,7 @@ import games.strategy.triplea.delegate.battle.steps.change.ClearGeneralCasualtie
 import games.strategy.triplea.delegate.battle.steps.change.LandParatroopers;
 import games.strategy.triplea.delegate.battle.steps.change.MarkNoMovementLeft;
 import games.strategy.triplea.delegate.battle.steps.change.RemoveNonCombatants;
+import games.strategy.triplea.delegate.battle.steps.change.RemoveNonCombatantsBeforeAA;
 import games.strategy.triplea.delegate.battle.steps.change.RemoveUnprotectedUnits;
 import games.strategy.triplea.delegate.battle.steps.change.RemoveUnprotectedUnitsGeneral;
 import games.strategy.triplea.delegate.battle.steps.change.suicide.RemoveFirstStrikeSuicide;
@@ -89,6 +90,7 @@ public interface BattleStep extends IExecutable {
 
   static List<BattleStep> getAll(final BattleState battleState, final BattleActions battleActions) {
     return List.of(
+        new RemoveNonCombatantsBeforeAA(battleState, battleActions),
         new OffensiveAaFire(battleState, battleActions),
         new DefensiveAaFire(battleState, battleActions),
         new SubmergeSubsVsOnlyAirStep(battleState, battleActions),

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/RemoveNonCombatants.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/RemoveNonCombatants.java
@@ -13,6 +13,11 @@ import java.util.List;
 import org.triplea.java.ChangeOnNextMajorRelease;
 import org.triplea.java.RemoveOnNextMajorRelease;
 
+/**
+ * Removes non combatants after AA phase
+ *
+ * <p>This also removes AA units that can't fire anymore after this round.
+ */
 public class RemoveNonCombatants implements BattleStep {
 
   private static final long serialVersionUID = 7629566123535773501L;
@@ -44,7 +49,7 @@ public class RemoveNonCombatants implements BattleStep {
   }
 
   private void removeNonCombatants(final BattleState.Side side, final IDelegateBridge bridge) {
-    final Collection<Unit> nonCombatants = battleState.removeNonCombatants(side);
+    final Collection<Unit> nonCombatants = battleState.removeNonCombatants(side, true);
     if (nonCombatants.isEmpty()) {
       return;
     }

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/RemoveNonCombatantsBeforeAA.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/change/RemoveNonCombatantsBeforeAA.java
@@ -1,0 +1,54 @@
+package games.strategy.triplea.delegate.battle.steps.change;
+
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.delegate.ExecutionStack;
+import games.strategy.triplea.delegate.battle.BattleActions;
+import games.strategy.triplea.delegate.battle.BattleState;
+import games.strategy.triplea.delegate.battle.steps.BattleStep;
+import java.util.Collection;
+import java.util.List;
+import lombok.AllArgsConstructor;
+
+/**
+ * Removes non combatants before the AA phase
+ *
+ * <p>This doesn't remove AA units that can fire this round because this occurs before the AA phase
+ * and they still need to fire. This is different from {@link RemoveNonCombatants}.
+ */
+@AllArgsConstructor
+public class RemoveNonCombatantsBeforeAA implements BattleStep {
+
+  private static final long serialVersionUID = 337655823124444148L;
+
+  protected BattleState battleState;
+
+  protected final BattleActions battleActions;
+
+  @Override
+  public List<String> getNames() {
+    return List.of();
+  }
+
+  @Override
+  public Order getOrder() {
+    return Order.REMOVE_NON_COMBATANTS_INITIAL;
+  }
+
+  @Override
+  public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+    removeNonCombatants(BattleState.Side.OFFENSE, bridge);
+    removeNonCombatants(BattleState.Side.DEFENSE, bridge);
+  }
+
+  private void removeNonCombatants(final BattleState.Side side, final IDelegateBridge bridge) {
+    final Collection<Unit> nonCombatants = battleState.removeNonCombatants(side, false);
+    if (nonCombatants.isEmpty()) {
+      return;
+    }
+    bridge
+        .getDisplayChannelBroadcaster()
+        .changedUnitsNotification(
+            battleState.getBattleId(), battleState.getPlayer(side), nonCombatants, null, null);
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/FakeBattleState.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/FakeBattleState.java
@@ -159,7 +159,8 @@ public class FakeBattleState implements BattleState {
   }
 
   @Override
-  public Collection<Unit> removeNonCombatants(final Side side) {
+  public Collection<Unit> removeNonCombatants(
+      final Side side, final boolean removeAaUnitsThatFireThisRound) {
     return List.of();
   }
 

--- a/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/RemoveNonCombatantsTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/change/RemoveNonCombatantsTest.java
@@ -40,10 +40,10 @@ class RemoveNonCombatantsTest {
     when(delegateBridge.getDisplayChannelBroadcaster()).thenReturn(display);
 
     final Collection<Unit> offenseNonCombatants = List.of(mock(Unit.class));
-    when(battleState.removeNonCombatants(BattleState.Side.OFFENSE))
+    when(battleState.removeNonCombatants(BattleState.Side.OFFENSE, true))
         .thenReturn(offenseNonCombatants);
     final Collection<Unit> defenseNonCombatants = List.of(mock(Unit.class));
-    when(battleState.removeNonCombatants(BattleState.Side.DEFENSE))
+    when(battleState.removeNonCombatants(BattleState.Side.DEFENSE, true))
         .thenReturn(defenseNonCombatants);
 
     when(battleState.getPlayer(BattleState.Side.OFFENSE)).thenReturn(attacker);
@@ -69,10 +69,10 @@ class RemoveNonCombatantsTest {
     when(delegateBridge.getDisplayChannelBroadcaster()).thenReturn(display);
 
     final Collection<Unit> offenseNonCombatants = List.of(mock(Unit.class));
-    when(battleState.removeNonCombatants(BattleState.Side.OFFENSE))
+    when(battleState.removeNonCombatants(BattleState.Side.OFFENSE, true))
         .thenReturn(offenseNonCombatants);
     final Collection<Unit> defenseNonCombatants = List.of();
-    when(battleState.removeNonCombatants(BattleState.Side.DEFENSE))
+    when(battleState.removeNonCombatants(BattleState.Side.DEFENSE, true))
         .thenReturn(defenseNonCombatants);
 
     when(battleState.getPlayer(BattleState.Side.OFFENSE)).thenReturn(attacker);
@@ -94,10 +94,10 @@ class RemoveNonCombatantsTest {
     when(delegateBridge.getDisplayChannelBroadcaster()).thenReturn(display);
 
     final Collection<Unit> offenseNonCombatants = List.of();
-    when(battleState.removeNonCombatants(BattleState.Side.OFFENSE))
+    when(battleState.removeNonCombatants(BattleState.Side.OFFENSE, true))
         .thenReturn(offenseNonCombatants);
     final Collection<Unit> defenseNonCombatants = List.of(mock(Unit.class));
-    when(battleState.removeNonCombatants(BattleState.Side.DEFENSE))
+    when(battleState.removeNonCombatants(BattleState.Side.DEFENSE, true))
         .thenReturn(defenseNonCombatants);
 
     when(battleState.getPlayer(BattleState.Side.DEFENSE)).thenReturn(defender);


### PR DESCRIPTION
This step removes all units that can't fire or be fired at during the
upcoming round. It doesn't remove AA units that will fire this round,
unlike RemoveNonCombatants. RemoveNonCombatants is after the AA phase so
it removes AA units that just fired and no longer have any shots.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->
Hard AI World at War

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->
Before this change, it appears that AA units could target "captureableOnEnter" units.  I don't think that is expected behavior.

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|AA units can no longer accidentally hit units that will be captured after the battle is over.<!--END_RELEASE_NOTE-->
