### PR TITLE
Consolidate map find operations to AvailableGamesList & rename to DownloadedMaps.java

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/AvailableGamesFileSystemReader.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/AvailableGamesFileSystemReader.java
@@ -25,11 +25,11 @@ import org.triplea.io.ZipFileUtil;
  */
 @UtilityClass
 @Slf4j
-public class AvailableGamesFileSystemReader {
+class AvailableGamesFileSystemReader {
 
   private static final String ZIP_EXTENSION = ".zip";
 
-  public static synchronized AvailableGamesList parseMapFiles() {
+  static synchronized AvailableGamesList parseMapFiles() {
     final Set<DefaultGameChooserEntry> entries = new HashSet<>();
     entries.addAll(mapXmlsGameNamesByUri(findAllZippedXmlFiles()));
     entries.addAll(mapXmlsGameNamesByUri(findAllUnZippedXmlFiles()));

--- a/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/AvailableGamesFileSystemReader.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/AvailableGamesFileSystemReader.java
@@ -29,13 +29,13 @@ class AvailableGamesFileSystemReader {
 
   private static final String ZIP_EXTENSION = ".zip";
 
-  static synchronized AvailableGamesList parseMapFiles() {
+  static synchronized DownloadedMaps parseMapFiles() {
     final Set<DefaultGameChooserEntry> entries = new HashSet<>();
     entries.addAll(mapXmlsGameNamesByUri(findAllZippedXmlFiles()));
     entries.addAll(mapXmlsGameNamesByUri(findAllUnZippedXmlFiles()));
     entries.forEach(
         entry -> log.debug("Found game: " + entry.getGameName() + " @ " + entry.getUri()));
-    return new AvailableGamesList(entries);
+    return new DownloadedMaps(entries);
   }
 
   private Collection<DefaultGameChooserEntry> mapXmlsGameNamesByUri(

--- a/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/AvailableGamesList.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/AvailableGamesList.java
@@ -17,6 +17,10 @@ import lombok.AllArgsConstructor;
 public class AvailableGamesList {
   private final Set<DefaultGameChooserEntry> availableGames;
 
+  public static synchronized AvailableGamesList parseMapFiles() {
+    return AvailableGamesFileSystemReader.parseMapFiles();
+  }
+
   public List<String> getSortedGameList() {
     return availableGames.stream()
         .map(DefaultGameChooserEntry::getGameName)

--- a/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/DownloadedMaps.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/DownloadedMaps.java
@@ -1,6 +1,7 @@
 package games.strategy.engine.framework.map.file.system.loader;
 
 import games.strategy.engine.framework.ui.DefaultGameChooserEntry;
+import java.io.File;
 import java.net.URI;
 import java.util.Comparator;
 import java.util.List;
@@ -17,8 +18,21 @@ import lombok.AllArgsConstructor;
 public class AvailableGamesList {
   private final Set<DefaultGameChooserEntry> availableGames;
 
+  /**
+   * Reads the downloaded maps folder contents, parses those contents to find available games, and
+   * returns the list of available games found.
+   */
   public static synchronized AvailableGamesList parseMapFiles() {
     return AvailableGamesFileSystemReader.parseMapFiles();
+  }
+
+  /**
+   * Finds the 'root' of a map folder containing map content files. This will typically be a folder
+   * called something like "downloadedMaps/mapName/map". Returns empty if no map with the given name
+   * is found.
+   */
+  public static Optional<File> findPathToMapFolder(final String mapName) {
+    return FileSystemMapFinder.getPath(mapName);
   }
 
   public List<String> getSortedGameList() {

--- a/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/DownloadedMaps.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/DownloadedMaps.java
@@ -15,14 +15,14 @@ import lombok.AllArgsConstructor;
  * onto their hard drive.
  */
 @AllArgsConstructor
-public class AvailableGamesList {
+public class DownloadedMaps {
   private final Set<DefaultGameChooserEntry> availableGames;
 
   /**
    * Reads the downloaded maps folder contents, parses those contents to find available games, and
    * returns the list of available games found.
    */
-  public static synchronized AvailableGamesList parseMapFiles() {
+  public static synchronized DownloadedMaps parseMapFiles() {
     return AvailableGamesFileSystemReader.parseMapFiles();
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/FileSystemMapFinder.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/FileSystemMapFinder.java
@@ -1,0 +1,93 @@
+package games.strategy.engine.framework.map.file.system.loader;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import games.strategy.engine.ClientFileSystemHelper;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+class FileSystemMapFinder {
+
+  static Optional<File> getPath(final String mapName) {
+    return getCandidatePaths(mapName).stream().filter(File::exists).findAny();
+  }
+
+  private static List<File> getCandidatePaths(final String mapName) {
+    final List<File> candidates = new ArrayList<>();
+    candidates.addAll(
+        getMapDirectoryCandidates(mapName, ClientFileSystemHelper.getUserMapsFolder()));
+    candidates.addAll(getMapZipFileCandidates(mapName, ClientFileSystemHelper.getUserMapsFolder()));
+    return candidates;
+  }
+
+  /**
+   * Returns a list of candidate directories from which the specified map may be loaded.
+   *
+   * <p>The candidate directories are returned in order of preference. That is, a candidate
+   * directory earlier in the list should be preferred to a candidate directory later in the list
+   * assuming they both exist.
+   *
+   * @param mapName The map name; must not be {@code null}.
+   * @return A list of candidate directories; never {@code null}.
+   */
+  @VisibleForTesting
+  static List<File> getMapDirectoryCandidates(final String mapName, final File userMapsFolder) {
+    Preconditions.checkNotNull(mapName);
+
+    final String dirName = File.separator + mapName;
+    final String normalizedMapName = File.separator + normalizeMapName(mapName) + "-master";
+    return List.of(
+        new File(userMapsFolder, dirName + File.separator + "map"),
+        new File(userMapsFolder, dirName),
+        new File(userMapsFolder, normalizedMapName + File.separator + "map"),
+        new File(userMapsFolder, normalizedMapName));
+  }
+
+
+  /**
+   * Returns a list of candidate zip files from which the specified map may be loaded.
+   *
+   * <p>The candidate zip files are returned in order of preference. That is, a candidate file
+   * earlier in the list should be preferred to a candidate file later in the list assuming they
+   * both exist.
+   *
+   * @param mapName The map name; must not be {@code null}.
+   * @return A list of candidate zip files; never {@code null}.
+   */
+  public static List<File> getMapZipFileCandidates(
+      final String mapName, final File userMapsFolder) {
+    Preconditions.checkNotNull(mapName);
+
+    final String normalizedMapName = normalizeMapName(mapName);
+    return List.of(
+        new File(userMapsFolder, mapName + ".zip"),
+        new File(userMapsFolder, normalizedMapName + "-master.zip"),
+        new File(userMapsFolder, normalizedMapName + ".zip"));
+  }
+
+  @VisibleForTesting
+  static String normalizeMapName(final String zipName) {
+    final StringBuilder sb = new StringBuilder();
+    Character lastChar = null;
+
+    final String spacesReplaced = zipName.replace(' ', '_');
+
+    for (final char c : spacesReplaced.toCharArray()) {
+      // break up camel casing
+      if (lastChar != null && Character.isLowerCase(lastChar) && Character.isUpperCase(c)) {
+        sb.append("_");
+      }
+      sb.append(Character.toLowerCase(c));
+      lastChar = c;
+    }
+    return sb.toString();
+  }
+
+
+
+
+}

--- a/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/FileSystemMapFinder.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/FileSystemMapFinder.java
@@ -47,7 +47,6 @@ class FileSystemMapFinder {
         new File(userMapsFolder, normalizedMapName));
   }
 
-
   /**
    * Returns a list of candidate zip files from which the specified map may be loaded.
    *
@@ -86,8 +85,4 @@ class FileSystemMapFinder {
     }
     return sb.toString();
   }
-
-
-
-
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/MapNotFoundException.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/MapNotFoundException.java
@@ -1,9 +1,5 @@
 package games.strategy.engine.framework.startup.launcher;
 
-import java.io.File;
-import java.util.Collection;
-import java.util.stream.Collectors;
-
 /**
  * An unchecked exception indicating the map associated with a save game was not found and must be
  * installed before game play can begin.
@@ -11,15 +7,7 @@ import java.util.stream.Collectors;
 public class MapNotFoundException extends IllegalStateException {
   private static final long serialVersionUID = -1027460394367073991L;
 
-  public MapNotFoundException(final String mapName, final Collection<File> candidatePaths) {
-    super(
-        "Could not find map: "
-            + mapName
-            + "\nTypically this will be because the map is not downloaded."
-            + "\n\nIf you are *sure* you have the map, double check that the"
-            + "\ngame XML can be found under one of the locations listed below"
-            + "\nand the 'mapName' XML attribute in the XML file has the correct name."
-            + "\nSearched these locations:\n"
-            + candidatePaths.stream().map(File::getAbsolutePath).collect(Collectors.joining("\n")));
+  public MapNotFoundException(final String mapName) {
+    super("Could not find map: " + mapName);
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -8,7 +8,7 @@ import games.strategy.engine.data.properties.IEditableProperty;
 import games.strategy.engine.data.properties.PropertiesUi;
 import games.strategy.engine.framework.HeadlessAutoSaveType;
 import games.strategy.engine.framework.map.download.DownloadMapsWindow;
-import games.strategy.engine.framework.map.file.system.loader.AvailableGamesList;
+import games.strategy.engine.framework.map.file.system.loader.DownloadedMaps;
 import games.strategy.engine.framework.startup.mc.ClientModel;
 import games.strategy.engine.framework.startup.ui.FileBackedGamePropertiesCache;
 import games.strategy.engine.framework.startup.ui.IGamePropertiesCache;
@@ -378,13 +378,13 @@ public final class GameSelectorPanel extends JPanel implements Observer {
 
   private void selectGameFile() {
     try {
-      final AvailableGamesList availableGamesList =
+      final DownloadedMaps downloadedMaps =
           BackgroundTaskRunner.runInBackgroundAndReturn(
-              "Loading all available games...", AvailableGamesList::parseMapFiles);
+              "Loading all available games...", DownloadedMaps::parseMapFiles);
 
       GameChooser.chooseGame(
           JOptionPane.getFrameForComponent(this),
-          availableGamesList,
+          downloadedMaps,
           model.getGameName(),
           this::gameSelected);
     } catch (final InterruptedException e) {

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -8,7 +8,6 @@ import games.strategy.engine.data.properties.IEditableProperty;
 import games.strategy.engine.data.properties.PropertiesUi;
 import games.strategy.engine.framework.HeadlessAutoSaveType;
 import games.strategy.engine.framework.map.download.DownloadMapsWindow;
-import games.strategy.engine.framework.map.file.system.loader.AvailableGamesFileSystemReader;
 import games.strategy.engine.framework.map.file.system.loader.AvailableGamesList;
 import games.strategy.engine.framework.startup.mc.ClientModel;
 import games.strategy.engine.framework.startup.ui.FileBackedGamePropertiesCache;
@@ -381,7 +380,7 @@ public final class GameSelectorPanel extends JPanel implements Observer {
     try {
       final AvailableGamesList availableGamesList =
           BackgroundTaskRunner.runInBackgroundAndReturn(
-              "Loading all available games...", AvailableGamesFileSystemReader::parseMapFiles);
+              "Loading all available games...", AvailableGamesList::parseMapFiles);
 
       GameChooser.chooseGame(
           JOptionPane.getFrameForComponent(this),

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
@@ -1,7 +1,7 @@
 package games.strategy.engine.framework.ui;
 
 import games.strategy.engine.data.gameparser.ShallowGameParser;
-import games.strategy.engine.framework.map.file.system.loader.AvailableGamesList;
+import games.strategy.engine.framework.map.file.system.loader.DownloadedMaps;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -53,7 +53,7 @@ public class GameChooser {
    */
   public static void chooseGame(
       final Frame owner,
-      final AvailableGamesList availableGamesList,
+      final DownloadedMaps downloadedMaps,
       final String gameName,
       final Consumer<URI> gameChosenCallback) {
 
@@ -61,7 +61,7 @@ public class GameChooser {
     dialog.setLayout(new BorderLayout());
 
     final DefaultListModel<DefaultGameChooserEntry> gameChooserModel = new DefaultListModel<>();
-    availableGamesList.getSortedGameEntries().forEach(gameChooserModel::addElement);
+    downloadedMaps.getSortedGameEntries().forEach(gameChooserModel::addElement);
 
     final JList<DefaultGameChooserEntry> gameList = new JList<>(gameChooserModel);
     if (gameName == null || gameName.equals("-")) {

--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -4,7 +4,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.map.download.DownloadMapsWindow;
-import games.strategy.engine.framework.map.file.system.loader.AvailableGamesList;
+import games.strategy.engine.framework.map.file.system.loader.DownloadedMaps;
 import games.strategy.engine.framework.startup.launcher.MapNotFoundException;
 import java.awt.Image;
 import java.awt.image.BufferedImage;
@@ -48,7 +48,7 @@ public class ResourceLoader implements Closeable {
     Preconditions.checkNotNull(mapName);
 
     final File mapLocation =
-        AvailableGamesList.findPathToMapFolder(mapName)
+        DownloadedMaps.findPathToMapFolder(mapName)
             .orElseThrow(
                 () -> {
                   SwingComponents.promptUser(

--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -4,6 +4,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.map.download.DownloadMapsWindow;
+import games.strategy.engine.framework.map.file.system.loader.AvailableGamesList;
 import games.strategy.engine.framework.startup.launcher.MapNotFoundException;
 import java.awt.Image;
 import java.awt.image.BufferedImage;
@@ -17,8 +18,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Optional;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipFile;
@@ -49,7 +48,7 @@ public class ResourceLoader implements Closeable {
     Preconditions.checkNotNull(mapName);
 
     final File mapLocation =
-        getPath(mapName)
+        AvailableGamesList.findPathToMapFolder(mapName)
             .orElseThrow(
                 () -> {
                   SwingComponents.promptUser(
@@ -60,7 +59,7 @@ public class ResourceLoader implements Closeable {
                           + "\nOnce the download completes, you may reconnect to this game.",
                       () -> DownloadMapsWindow.showDownloadMapsWindowAndDownload(mapName));
 
-                  return new MapNotFoundException(mapName, getCandidatePaths(mapName));
+                  return new MapNotFoundException(mapName);
                 });
     mapPrefix = getMapPrefix(mapLocation);
 
@@ -141,80 +140,6 @@ public class ResourceLoader implements Closeable {
     }
 
     return Optional.empty();
-  }
-
-  /**
-   * Returns a list of candidate directories from which the specified map may be loaded.
-   *
-   * <p>The candidate directories are returned in order of preference. That is, a candidate
-   * directory earlier in the list should be preferred to a candidate directory later in the list
-   * assuming they both exist.
-   *
-   * @param mapName The map name; must not be {@code null}.
-   * @return A list of candidate directories; never {@code null}.
-   */
-  @VisibleForTesting
-  static List<File> getMapDirectoryCandidates(final String mapName, final File userMapsFolder) {
-    Preconditions.checkNotNull(mapName);
-
-    final String dirName = File.separator + mapName;
-    final String normalizedMapName = File.separator + normalizeMapName(mapName) + "-master";
-    return List.of(
-        new File(userMapsFolder, dirName + File.separator + "map"),
-        new File(userMapsFolder, dirName),
-        new File(userMapsFolder, normalizedMapName + File.separator + "map"),
-        new File(userMapsFolder, normalizedMapName));
-  }
-
-  /**
-   * Returns a list of candidate zip files from which the specified map may be loaded.
-   *
-   * <p>The candidate zip files are returned in order of preference. That is, a candidate file
-   * earlier in the list should be preferred to a candidate file later in the list assuming they
-   * both exist.
-   *
-   * @param mapName The map name; must not be {@code null}.
-   * @return A list of candidate zip files; never {@code null}.
-   */
-  public static List<File> getMapZipFileCandidates(
-      final String mapName, final File userMapsFolder) {
-    Preconditions.checkNotNull(mapName);
-
-    final String normalizedMapName = normalizeMapName(mapName);
-    return List.of(
-        new File(userMapsFolder, mapName + ".zip"),
-        new File(userMapsFolder, normalizedMapName + "-master.zip"),
-        new File(userMapsFolder, normalizedMapName + ".zip"));
-  }
-
-  @VisibleForTesting
-  static String normalizeMapName(final String zipName) {
-    final StringBuilder sb = new StringBuilder();
-    Character lastChar = null;
-
-    final String spacesReplaced = zipName.replace(' ', '_');
-
-    for (final char c : spacesReplaced.toCharArray()) {
-      // break up camel casing
-      if (lastChar != null && Character.isLowerCase(lastChar) && Character.isUpperCase(c)) {
-        sb.append("_");
-      }
-      sb.append(Character.toLowerCase(c));
-      lastChar = c;
-    }
-    return sb.toString();
-  }
-
-  private static Optional<File> getPath(final String mapName) {
-    return getCandidatePaths(mapName).stream().filter(File::exists).findAny();
-  }
-
-  private static List<File> getCandidatePaths(final String mapName) {
-    final List<File> candidates = new ArrayList<>();
-    candidates.addAll(
-        getMapDirectoryCandidates(mapName, ClientFileSystemHelper.getUserMapsFolder()));
-    candidates.addAll(getMapZipFileCandidates(mapName, ClientFileSystemHelper.getUserMapsFolder()));
-    return candidates;
   }
 
   @Override

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -18,7 +18,6 @@ import games.strategy.engine.framework.ArgParser;
 import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.ServerGame;
-import games.strategy.engine.framework.map.file.system.loader.AvailableGamesFileSystemReader;
 import games.strategy.engine.framework.map.file.system.loader.AvailableGamesList;
 import games.strategy.engine.framework.startup.mc.ServerModel;
 import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorModel;
@@ -39,7 +38,7 @@ public class HeadlessGameServer {
   public static final String BOT_GAME_HOST_NAME_PREFIX = "Bot";
   private static HeadlessGameServer instance = null;
 
-  private final AvailableGamesList availableGames = AvailableGamesFileSystemReader.parseMapFiles();
+  private final AvailableGamesList availableGames = AvailableGamesList.parseMapFiles();
   private final GameSelectorModel gameSelectorModel = new GameSelectorModel();
   private final HeadlessServerSetupPanelModel setupPanelModel =
       new HeadlessServerSetupPanelModel(gameSelectorModel);

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -18,7 +18,7 @@ import games.strategy.engine.framework.ArgParser;
 import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.ServerGame;
-import games.strategy.engine.framework.map.file.system.loader.AvailableGamesList;
+import games.strategy.engine.framework.map.file.system.loader.DownloadedMaps;
 import games.strategy.engine.framework.startup.mc.ServerModel;
 import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorModel;
 import games.strategy.triplea.settings.ClientSetting;
@@ -38,7 +38,7 @@ public class HeadlessGameServer {
   public static final String BOT_GAME_HOST_NAME_PREFIX = "Bot";
   private static HeadlessGameServer instance = null;
 
-  private final AvailableGamesList availableGames = AvailableGamesList.parseMapFiles();
+  private final DownloadedMaps availableGames = DownloadedMaps.parseMapFiles();
   private final GameSelectorModel gameSelectorModel = new GameSelectorModel();
   private final HeadlessServerSetupPanelModel setupPanelModel =
       new HeadlessServerSetupPanelModel(gameSelectorModel);

--- a/game-core/src/test/java/games/strategy/engine/framework/map/file/system/loader/FileSystemMapFinderTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/map/file/system/loader/FileSystemMapFinderTest.java
@@ -1,0 +1,66 @@
+package games.strategy.engine.framework.map.file.system.loader;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
+import static org.triplea.io.FileUtils.newFile;
+
+import com.google.common.collect.Maps;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class FileSystemMapFinderTest {
+  private static final File userMapsFolder = newFile("user", "maps");
+
+  @Nested
+  final class GetMapDirectoryCandidatesTest {
+    @Test
+    void getMapDirectoryCandidates() {
+      final List<File> candidates =
+          FileSystemMapFinder.getMapDirectoryCandidates("MapName", userMapsFolder);
+
+      assertThat(candidates, hasSize(4));
+      assertThat(candidates.get(0), is(newFile("user", "maps", "MapName", "map")));
+      assertThat(candidates.get(1), is(newFile("user", "maps", "MapName")));
+      assertThat(candidates.get(2), is(newFile("user", "maps", "map_name-master", "map")));
+      assertThat(candidates.get(3), is(newFile("user", "maps", "map_name-master")));
+    }
+  }
+
+  @Nested
+  final class GetMapZipFileCandidatesTest {
+    @Test
+    void getMapZipFileCandidatesTest() {
+
+      final List<File> candidates =
+          FileSystemMapFinder.getMapZipFileCandidates("MapName", userMapsFolder);
+
+      assertThat(candidates, hasSize(3));
+
+      assertThat(candidates.get(0), is(newFile("user", "maps", "MapName.zip")));
+      assertThat(candidates.get(1), is(newFile("user", "maps", "map_name-master.zip")));
+      assertThat(candidates.get(2), is(newFile("user", "maps", "map_name.zip")));
+    }
+  }
+
+  @Nested
+  final class NormalizeMapNameTest {
+    @Test
+    void shouldNormalizeMapName() {
+      final Map<String, String> testPairs = Maps.newHashMap();
+      testPairs.put("same.zip", "same.zip");
+      testPairs.put("camelCase.zip", "camel_case.zip");
+      testPairs.put("spaces removed.zip", "spaces_removed.zip");
+      testPairs.put("LowerCased.zip", "lower_cased.zip");
+      testPairs.put("LOWER.zip", "lower.zip");
+
+      for (final Map.Entry<String, String> testPair : testPairs.entrySet()) {
+        assertThat(
+            FileSystemMapFinder.normalizeMapName(testPair.getKey()), is(testPair.getValue()));
+      }
+    }
+  }
+}

--- a/game-core/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
@@ -2,16 +2,10 @@ package games.strategy.triplea;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.triplea.io.FileUtils.newFile;
 
-import com.google.common.collect.Maps;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -20,56 +14,6 @@ import org.junit.jupiter.api.io.TempDir;
 
 @SuppressWarnings("InnerClassMayBeStatic")
 final class ResourceLoaderTest {
-  private static final File userMapsFolder = newFile("user", "maps");
-
-  @Nested
-  final class GetMapDirectoryCandidatesTest {
-    @Test
-    void getMapDirectoryCandidates() {
-      final List<File> candidates =
-          ResourceLoader.getMapDirectoryCandidates("MapName", userMapsFolder);
-
-      assertThat(candidates, hasSize(4));
-      assertThat(candidates.get(0), is(newFile("user", "maps", "MapName", "map")));
-      assertThat(candidates.get(1), is(newFile("user", "maps", "MapName")));
-      assertThat(candidates.get(2), is(newFile("user", "maps", "map_name-master", "map")));
-      assertThat(candidates.get(3), is(newFile("user", "maps", "map_name-master")));
-    }
-  }
-
-  @Nested
-  final class GetMapZipFileCandidatesTest {
-    @Test
-    void getMapZipFileCandidatesTest() {
-
-      final List<File> candidates =
-          ResourceLoader.getMapZipFileCandidates("MapName", userMapsFolder);
-
-      assertThat(candidates, hasSize(3));
-
-      assertThat(candidates.get(0), is(newFile("user", "maps", "MapName.zip")));
-      assertThat(candidates.get(1), is(newFile("user", "maps", "map_name-master.zip")));
-      assertThat(candidates.get(2), is(newFile("user", "maps", "map_name.zip")));
-    }
-  }
-
-  @Nested
-  final class NormalizeMapNameTest {
-    @Test
-    void shouldNormalizeMapName() {
-      final Map<String, String> testPairs = Maps.newHashMap();
-      testPairs.put("same.zip", "same.zip");
-      testPairs.put("camelCase.zip", "camel_case.zip");
-      testPairs.put("spaces removed.zip", "spaces_removed.zip");
-      testPairs.put("LowerCased.zip", "lower_cased.zip");
-      testPairs.put("LOWER.zip", "lower.zip");
-
-      for (final Entry<String, String> testPair : testPairs.entrySet()) {
-        assertThat(ResourceLoader.normalizeMapName(testPair.getKey()), is(testPair.getValue()));
-      }
-    }
-  }
-
   @Nested
   final class FindDirectoryTest {
     private static final String TARGET_DIR_NAME = "182c91fa8e";


### PR DESCRIPTION
Mostly moves code around and renames 'AvailalbeGameList' -> 'DownloadedMaps'
Intent is to consolidate the access and logic around accessing map files on disk.
One key part of this update is adding the following API to DownloadedMaps:
```
  public static Optional<File> findPathToMapFolder(final String mapName) {
```
The implementation of the above will shift as we add in a 'map.yml' descriptor file.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing

Did some smoke testing that the available games list looked right and still loaded.
<!-- Describe any manual testing performed below. -->
elp, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
