### PR TITLE
Move unzip map files to be on launch

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/AvailableGamesFileSystemReader.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/AvailableGamesFileSystemReader.java
@@ -26,8 +26,7 @@ class AvailableGamesFileSystemReader {
 
   static synchronized DownloadedMaps parseMapFiles() {
     final List<URI> xmlFiles = findAllGameXmlFiles();
-    final Collection<DefaultGameChooserEntry> gameChooserEntries =
-        mapXmlsGameNamesByUri(xmlFiles);
+    final Collection<DefaultGameChooserEntry> gameChooserEntries = mapXmlsGameNamesByUri(xmlFiles);
     return new DownloadedMaps(gameChooserEntries);
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/DownloadedMaps.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/DownloadedMaps.java
@@ -23,7 +23,6 @@ public class DownloadedMaps {
    * returns the list of available games found.
    */
   public static synchronized DownloadedMaps parseMapFiles() {
-    ZippedMapsExtractor.unzipMapFiles();
     return AvailableGamesFileSystemReader.parseMapFiles();
   }
 

--- a/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/ZippedMapsExtractor.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/ZippedMapsExtractor.java
@@ -11,7 +11,7 @@ import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
-import lombok.experimental.UtilityClass;
+import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.io.FileUtils;
 import org.triplea.io.ZipExtractor;
@@ -22,17 +22,25 @@ import org.triplea.io.ZipExtractor.ZipReadException;
  * Responsible to find downloaded maps and unzip any that are zipped. Any 'bad' map zips that we
  * fail to unzip will be moved into a bad-zip folder.
  */
-@UtilityClass
+@Builder
 @Slf4j
 public class ZippedMapsExtractor {
   private static final String ZIP_EXTENSION = ".zip";
 
   /**
-   * Finds all map zips, extracts them and then removes the original zip. If any zipped files are
-   * found, then the progressIndicator param is invoked with a callback that will execute the unzip
-   * task.
+   * Callback to be invoked if we find any zip files. The task passed to the progress indicator will
+   * be the unzip task.
    */
-  public static void unzipMapFiles(final Consumer<Runnable> progressIndicator) {
+  private final Consumer<Runnable> progressIndicator;
+
+  /** Path to where downloaded maps can be found. */
+  private final Path downloadedMapsFolder;
+
+  /**
+   * Finds all map zips, extracts them and then removes the original zip. If any zipped files are
+   * found, then the progressIndicator is invoked with a callback that will execute the unzip task.
+   */
+  public void unzipMapFiles() {
     final Collection<File> zippedMaps = findAllZippedMapFiles();
     if (zippedMaps.isEmpty()) {
       return;
@@ -66,8 +74,8 @@ public class ZippedMapsExtractor {
                 }));
   }
 
-  private static Collection<File> findAllZippedMapFiles() {
-    return FileUtils.listFiles(ClientFileSystemHelper.getUserMapsFolder()).stream()
+  private Collection<File> findAllZippedMapFiles() {
+    return FileUtils.listFiles(downloadedMapsFolder.toFile()).stream()
         .filter(File::isFile)
         .filter(file -> file.getName().toLowerCase().endsWith(ZIP_EXTENSION))
         .collect(Collectors.toList());
@@ -152,9 +160,8 @@ public class ZippedMapsExtractor {
    * @return Returns the new location of the file, returns an empty if the file move operation
    *     failed.
    */
-  private static Optional<Path> moveBadZip(final File mapZip) {
-    final Path badZipFolder =
-        ClientFileSystemHelper.getUserMapsFolder().toPath().resolve("bad-zips");
+  private Optional<Path> moveBadZip(final File mapZip) {
+    final Path badZipFolder = downloadedMapsFolder.resolve("bad-zips");
     if (!badZipFolder.toFile().mkdirs()) {
       log.error(
           "Unable to create folder: "

--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -393,20 +393,22 @@ public final class GameSelectorPanel extends JPanel implements Observer {
   }
 
   private void gameSelected(final URI gameUri) {
-    try {
-      BackgroundTaskRunner.runInBackground("Loading map...", () -> model.load(gameUri));
-      // warning: NPE check is not to protect against concurrency, another thread could still null
-      // out game data.
-      // The NPE check is to protect against the case where there are errors loading game, in
-      // which case we'll have a null game data.
-      if (model.getGameData() != null) {
-        setOriginalPropertiesMap(model.getGameData());
-        // only for new games, not saved games, we set the default options, and set them only once
-        // (the first time it is loaded)
-        gamePropertiesCache.loadCachedGamePropertiesInto(model.getGameData());
-      }
-    } catch (final InterruptedException e) {
-      Thread.currentThread().interrupt();
-    }
+    BackgroundTaskRunner.runInBackground(
+        "Loading map...",
+        () -> {
+          model.load(gameUri);
+          // warning: NPE check is not to protect against concurrency, another thread could still
+          // null
+          // out game data.
+          // The NPE check is to protect against the case where there are errors loading game, in
+          // which case we'll have a null game data.
+          if (model.getGameData() != null) {
+            setOriginalPropertiesMap(model.getGameData());
+            // only for new games, not saved games, we set the default options, and set them only
+            // once
+            // (the first time it is loaded)
+            gamePropertiesCache.loadCachedGamePropertiesInto(model.getGameData());
+          }
+        });
   }
 }

--- a/game-core/src/main/java/games/strategy/engine/framework/ui/background/BackgroundTaskRunner.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/ui/background/BackgroundTaskRunner.java
@@ -12,7 +12,9 @@ import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
 import lombok.experimental.UtilityClass;
+import org.triplea.java.Interruptibles;
 import org.triplea.java.function.ThrowingSupplier;
+import org.triplea.swing.SwingAction;
 
 /** Provides methods for running tasks in the background to avoid blocking the UI. */
 @UtilityClass
@@ -37,14 +39,19 @@ public final class BackgroundTaskRunner {
    * @throws InterruptedException If the UI thread is interrupted while waiting for the background
    *     action to complete.
    */
-  public static void runInBackground(final String message, final Runnable backgroundAction)
-      throws InterruptedException {
-    runInBackgroundAndReturn(
-        message,
-        () -> {
-          backgroundAction.run();
-          return null;
-        });
+  public static void runInBackground(final String message, final Runnable backgroundAction) {
+    Interruptibles.await(
+        () ->
+            SwingAction.invokeAndWait(
+                () ->
+                    Interruptibles.await(
+                        () ->
+                            runInBackgroundAndReturn(
+                                message,
+                                () -> {
+                                  backgroundAction.run();
+                                  return null;
+                                }))));
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -151,9 +151,7 @@ public class ResourceLoader implements Closeable {
    * @param inputPath2 Same as inputPath but this takes second priority when loading
    */
   public @Nullable URL getResource(final String inputPath, final String inputPath2) {
-    return findResource(inputPath)
-        .or(() -> findResource(inputPath2))
-        .orElse(null);
+    return findResource(inputPath).or(() -> findResource(inputPath2)).orElse(null);
   }
 
   private Optional<URL> findResource(final String searchPath) {

--- a/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
+++ b/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
@@ -776,49 +776,35 @@ final class SelectionComponentFactory {
             .equals(usernameSetting.getValue().map(String::new).orElse(""))) {
           return;
         }
-        try {
-          BackgroundTaskRunner.runInBackground(
-              "Fetching Login Token...",
-              () -> {
-                final NodeBbTokenGenerator tokenGenerator = new NodeBbTokenGenerator(forumUrl);
-                final Optional<Integer> oldUserId = uidSetting.getValue();
-                final Optional<char[]> oldToken = tokenSetting.getValue();
-                if (!usernameField.getText().isBlank()) {
-                  final TokenInfo tokenInfo =
-                      tokenGenerator.generateToken(
-                          usernameField.getText(),
-                          new String(passwordField.getPassword()),
-                          Strings.emptyToNull(otpField.getText()));
-                  context.setValue(uidSetting, tokenInfo.getUserId());
+        BackgroundTaskRunner.runInBackground(
+            "Fetching Login Token...",
+            () -> {
+              final NodeBbTokenGenerator tokenGenerator = new NodeBbTokenGenerator(forumUrl);
+              final Optional<Integer> oldUserId = uidSetting.getValue();
+              final Optional<char[]> oldToken = tokenSetting.getValue();
+              if (!usernameField.getText().isBlank()) {
+                final TokenInfo tokenInfo =
+                    tokenGenerator.generateToken(
+                        usernameField.getText(),
+                        new String(passwordField.getPassword()),
+                        Strings.emptyToNull(otpField.getText()));
+                context.setValue(uidSetting, tokenInfo.getUserId());
 
-                  context.setValue(tokenSetting, tokenInfo.getToken().toCharArray());
+                context.setValue(tokenSetting, tokenInfo.getToken().toCharArray());
 
-                  context.setValue(usernameSetting, usernameField.getText().toCharArray());
-                  // TODO error reporting
-                } else {
-                  context.setValue(usernameSetting, null);
-                  context.setValue(uidSetting, null);
-                  context.setValue(tokenSetting, null);
-                }
+                context.setValue(usernameSetting, usernameField.getText().toCharArray());
+                // TODO error reporting
+              } else {
+                context.setValue(usernameSetting, null);
+                context.setValue(uidSetting, null);
+                context.setValue(tokenSetting, null);
+              }
 
-                oldUserId.ifPresent(
-                    userId ->
-                        oldToken.ifPresent(
-                            token -> tokenGenerator.revokeToken(new String(token), userId)));
-              });
-        } catch (final InterruptedException e) {
-          Thread.currentThread().interrupt();
-        }
-
-        /*final String username = usernameField.getText();
-        context.setValue(uidSetting, username.isEmpty() ? null : username.toCharArray());
-        withSensitiveArray(
-            passwordField::getPassword,
-            password ->
-                context.setValue(
-                    passwordSetting,
-                    (password.length == 0) ? null : password,
-                    SaveContext.ValueSensitivity.SENSITIVE));*/
+              oldUserId.ifPresent(
+                  userId ->
+                      oldToken.ifPresent(
+                          token -> tokenGenerator.revokeToken(new String(token), userId)));
+            });
       }
 
       @Override

--- a/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -19,6 +19,7 @@ import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.ServerGame;
 import games.strategy.engine.framework.map.file.system.loader.DownloadedMaps;
+import games.strategy.engine.framework.map.file.system.loader.ZippedMapsExtractor;
 import games.strategy.engine.framework.startup.mc.ServerModel;
 import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorModel;
 import games.strategy.triplea.settings.ClientSetting;
@@ -279,6 +280,16 @@ public class HeadlessGameServer {
 
     ArgParser.handleCommandLineArgs(args);
     handleHeadlessGameServerArgs();
+    ZippedMapsExtractor.builder()
+        .downloadedMapsFolder(ClientSetting.mapFolderOverride.getValueOrThrow())
+        .progressIndicator(
+            unzipTask -> {
+              log.info("Unzipping map files");
+              unzipTask.run();
+            })
+        .build()
+        .unzipMapFiles();
+
     try {
       new HeadlessGameServer();
     } catch (final Exception e) {

--- a/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
+++ b/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
@@ -8,9 +8,11 @@ import games.strategy.engine.framework.CliProperties;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.lookandfeel.LookAndFeel;
 import games.strategy.engine.framework.map.download.DownloadMapsWindow;
+import games.strategy.engine.framework.map.file.system.loader.ZippedMapsExtractor;
 import games.strategy.engine.framework.startup.ui.PlayerTypes;
 import games.strategy.engine.framework.system.HttpProxy;
 import games.strategy.engine.framework.system.SystemProperties;
+import games.strategy.engine.framework.ui.background.BackgroundTaskRunner;
 import games.strategy.triplea.ai.AiProvider;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.MacOsIntegration;
@@ -96,6 +98,10 @@ public final class HeadedGameRunner {
 
     initializeDesktopIntegrations(args);
     SwingUtilities.invokeLater(ErrorMessage::initialize);
+
+    ZippedMapsExtractor.unzipMapFiles(
+        unzipTask -> BackgroundTaskRunner.runInBackground("Unzipping map files", unzipTask));
+
     GameRunner.start();
   }
 

--- a/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
+++ b/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
@@ -3,6 +3,7 @@ package org.triplea.game.client;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
+import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.ArgParser;
 import games.strategy.engine.framework.CliProperties;
 import games.strategy.engine.framework.GameRunner;
@@ -99,8 +100,12 @@ public final class HeadedGameRunner {
     initializeDesktopIntegrations(args);
     SwingUtilities.invokeLater(ErrorMessage::initialize);
 
-    ZippedMapsExtractor.unzipMapFiles(
-        unzipTask -> BackgroundTaskRunner.runInBackground("Unzipping map files", unzipTask));
+    ZippedMapsExtractor.builder()
+        .downloadedMapsFolder(ClientFileSystemHelper.getUserMapsFolder().toPath())
+        .progressIndicator(
+            unzipTask -> BackgroundTaskRunner.runInBackground("Unzipping map files", unzipTask))
+        .build()
+        .unzipMapFiles();
 
     GameRunner.start();
   }

--- a/game-headless/src/main/java/org/triplea/game/server/HeadlessGameRunner.java
+++ b/game-headless/src/main/java/org/triplea/game/server/HeadlessGameRunner.java
@@ -1,6 +1,5 @@
 package org.triplea.game.server;
 
-import games.strategy.engine.framework.map.file.system.loader.ZippedMapsExtractor;
 import games.strategy.engine.framework.startup.ui.PlayerTypes;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.config.product.ProductVersionReader;
@@ -17,12 +16,6 @@ public final class HeadlessGameRunner {
    */
   public static void main(final String[] args) {
     Injections.init(constructInjections());
-
-    ZippedMapsExtractor.unzipMapFiles(
-        unzipTask -> {
-          log.info("Unzipping map files");
-          unzipTask.run();
-        });
     HeadlessGameServer.start(args);
   }
 

--- a/game-headless/src/main/java/org/triplea/game/server/HeadlessGameRunner.java
+++ b/game-headless/src/main/java/org/triplea/game/server/HeadlessGameRunner.java
@@ -1,10 +1,13 @@
 package org.triplea.game.server;
 
+import games.strategy.engine.framework.map.file.system.loader.ZippedMapsExtractor;
 import games.strategy.engine.framework.startup.ui.PlayerTypes;
+import lombok.extern.slf4j.Slf4j;
 import org.triplea.config.product.ProductVersionReader;
 import org.triplea.injection.Injections;
 
 /** Runs a headless game server. */
+@Slf4j
 public final class HeadlessGameRunner {
   private HeadlessGameRunner() {}
 
@@ -14,6 +17,12 @@ public final class HeadlessGameRunner {
    */
   public static void main(final String[] args) {
     Injections.init(constructInjections());
+
+    ZippedMapsExtractor.unzipMapFiles(
+        unzipTask -> {
+          log.info("Unzipping map files");
+          unzipTask.run();
+        });
     HeadlessGameServer.start(args);
   }
 

--- a/game-headless/src/main/java/org/triplea/game/server/HeadlessGameRunner.java
+++ b/game-headless/src/main/java/org/triplea/game/server/HeadlessGameRunner.java
@@ -1,12 +1,10 @@
 package org.triplea.game.server;
 
 import games.strategy.engine.framework.startup.ui.PlayerTypes;
-import lombok.extern.slf4j.Slf4j;
 import org.triplea.config.product.ProductVersionReader;
 import org.triplea.injection.Injections;
 
 /** Runs a headless game server. */
-@Slf4j
 public final class HeadlessGameRunner {
   private HeadlessGameRunner() {}
 


### PR DESCRIPTION
- Moves time of map unzip to application launch instead of when loading
  available games

- Adds unzip map task to launch of headless game

- Simplify usage of BackgroundTaskRunner by having BackgroundTaskRunner
  deal with threading and catching interrupted exception.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->
- Recommend to review ignoring whitespace changes

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
