### PR TITLE
Websocket Networking [Preview]

### DIFF
--- a/game-core/build.gradle
+++ b/game-core/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation project(":http-clients")
     implementation project(":java-extras")
     implementation project(":lobby-client")
+    implementation project(":game-relay-server")
     implementation project(":map-data")
     implementation project(":maps-server-client")
     implementation project(":swing-lib")

--- a/game-core/src/main/java/games/strategy/engine/framework/AbstractGame.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/AbstractGame.java
@@ -39,12 +39,7 @@ public abstract class AbstractGame implements IGame {
   final Map<GamePlayer, Player> gamePlayers = new HashMap<>();
   final PlayerManager playerManager;
 
-  // TODO: Project#20 - clientNetworkBridge will be used for Websocket network bridge.
-  //   Usages will basically be to add listeners to map message types to methods calls.
-  //   The mapped method calls will replace the existing RMI-style based network code.
-  @SuppressWarnings({"FieldCanBeLocal", "unused"})
   private final ClientNetworkBridge clientNetworkBridge;
-
   @Nullable private IDisplay display;
   @Nullable private ISound sound;
 
@@ -120,6 +115,21 @@ public abstract class AbstractGame implements IGame {
     }
     if (display != null) {
       messengers.registerChannelSubscriber(display, getDisplayChannel());
+
+      clientNetworkBridge.addListener(
+          IDisplay.BombingResultsMessage.TYPE, message -> message.accept(display));
+      clientNetworkBridge.addListener(
+          IDisplay.NotifyRetreatMessage.TYPE,
+          message -> message.accept(display, gameData.getPlayerList()));
+      clientNetworkBridge.addListener(
+          IDisplay.NotifyUnitsRetreatingMessage.TYPE,
+          message -> message.accept(display, gameData.getUnits()));
+      clientNetworkBridge.addListener(
+          IDisplay.NotifyDiceMessage.TYPE, message -> message.accept(display));
+      clientNetworkBridge.addListener(
+          IDisplay.DisplayShutdownMessage.TYPE, message -> message.accept(display));
+      clientNetworkBridge.addListener(
+          IDisplay.GoToBattleStepMessage.TYPE, message -> message.accept(display));
     }
     this.display = display;
   }

--- a/game-core/src/main/java/games/strategy/net/websocket/WebsocketNetworkBridge.java
+++ b/game-core/src/main/java/games/strategy/net/websocket/WebsocketNetworkBridge.java
@@ -1,0 +1,42 @@
+package games.strategy.net.websocket;
+
+import games.strategy.triplea.settings.ClientSetting;
+import java.net.URI;
+import java.util.function.Consumer;
+import lombok.extern.java.Log;
+import org.triplea.http.client.web.socket.GenericWebSocketClient;
+import org.triplea.http.client.web.socket.messages.MessageType;
+import org.triplea.http.client.web.socket.messages.WebSocketMessage;
+
+@Log
+public class WebsocketNetworkBridge implements ClientNetworkBridge {
+  private GenericWebSocketClient genericWebSocketClient;
+
+  public WebsocketNetworkBridge(final URI serverUri) {
+    if (ClientSetting.useWebsocketNetwork.getValue().orElse(false)) {
+      genericWebSocketClient =
+          GenericWebSocketClient.builder()
+              .websocketUri(serverUri)
+              .errorHandler(log::warning)
+              .build();
+
+      log.info("Connecting to game server: " + serverUri);
+      genericWebSocketClient.connect();
+    }
+  }
+
+  @Override
+  public void sendMessage(final WebSocketMessage webSocketMessage) {
+    if (ClientSetting.useWebsocketNetwork.getValue().orElse(false)) {
+      genericWebSocketClient.sendMessage(webSocketMessage);
+    }
+  }
+
+  @Override
+  public <T extends WebSocketMessage> void addListener(
+      final MessageType<T> messageType, final Consumer<T> messageConsumer) {
+    if (ClientSetting.useWebsocketNetwork.getValue().orElse(false)) {
+      genericWebSocketClient.addListener(messageType, messageConsumer);
+    }
+  }
+}

--- a/game-core/src/main/java/games/strategy/triplea/TripleA.java
+++ b/game-core/src/main/java/games/strategy/triplea/TripleA.java
@@ -58,6 +58,7 @@ public class TripleA implements IGameLoader {
         ((ServerGame) game).addDelegateMessenger(delegate);
       }
     }
+
     final LocalPlayers localPlayers = new LocalPlayers(players);
     game.setDisplay(launchAction.startGame(localPlayers, game, players, chat));
     game.setSoundChannel(launchAction.getSoundChannel(localPlayers));

--- a/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProDummyDelegateBridge.java
+++ b/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProDummyDelegateBridge.java
@@ -45,7 +45,9 @@ public class ProDummyDelegateBridge implements IDelegateBridge {
   }
 
   @Override
-  public void sendMessage(final WebSocketMessage webSocketMessage) {}
+  public void sendMessage(final WebSocketMessage webSocketMessage) {
+
+  }
 
   @Override
   public void leaveDelegateExecution() {}

--- a/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/DiceRoll.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
+import lombok.Getter;
 
 /**
  * Used to store information about a dice roll.
@@ -34,6 +35,7 @@ import java.util.stream.Collectors;
  */
 public class DiceRoll implements Externalizable {
   private static final long serialVersionUID = -1167204061937566271L;
+  @Getter
   private List<Die> rolls;
   // this does not need to match the Die with isHit true since for low luck we get many hits with
   // few dice
@@ -67,7 +69,7 @@ public class DiceRoll implements Externalizable {
   // only for externalizable
   public DiceRoll() {}
 
-  private DiceRoll(final List<Die> dice, final int hits, final double expectedHits) {
+  public DiceRoll(final List<Die> dice, final int hits, final double expectedHits) {
     rolls = new ArrayList<>(dice);
     this.hits = hits;
     this.expectedHits = expectedHits;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/Die.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/Die.java
@@ -2,10 +2,12 @@ package games.strategy.triplea.delegate;
 
 import java.io.Serializable;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 /** A single roll of a die. */
+@Builder
 @AllArgsConstructor
 @EqualsAndHashCode
 @Getter

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
@@ -24,6 +24,7 @@ import games.strategy.triplea.delegate.data.BattleRecord;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
 import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import games.strategy.triplea.formatter.MyFormatter;
+import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.util.TuvUtils;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -502,7 +503,12 @@ public class AirBattle extends AbstractBattle {
     final GamePlayer retreatingPlayer = defender ? this.defender : attacker;
     final String text = retreatingPlayer.getName() + " retreat?";
     final String step = defender ? DEFENDERS_WITHDRAW : ATTACKERS_WITHDRAW;
-    bridge.getDisplayChannelBroadcaster().gotoBattleStep(battleId, step);
+
+    if (ClientSetting.useWebsocketNetwork.getValue().orElse(false)) {
+      bridge.sendMessage(new IDisplay.GoToBattleStepMessage(battleId.toString(), step));
+    } else {
+      bridge.getDisplayChannelBroadcaster().gotoBattleStep(battleId, step);
+    }
     final Territory retreatTo =
         getRemote(retreatingPlayer, bridge)
             .retreatQuery(battleId, false, battleSite, availableTerritories, text);
@@ -524,9 +530,19 @@ public class AirBattle extends AbstractBattle {
       final String messageShort = retreatingPlayer.getName() + " retreats";
       final String messageLong =
           retreatingPlayer.getName() + " retreats all units to " + retreatTo.getName();
-      bridge
-          .getDisplayChannelBroadcaster()
-          .notifyRetreat(messageShort, messageLong, step, retreatingPlayer);
+      if (ClientSetting.useWebsocketNetwork.getValue().orElse(false)) {
+        bridge.sendMessage(
+            IDisplay.NotifyRetreatMessage.builder()
+                .shortMessage(messageShort)
+                .message(messageLong)
+                .step(step)
+                .retreatingPlayerName(retreatingPlayer.getName())
+                .build());
+      } else {
+        bridge
+            .getDisplayChannelBroadcaster()
+            .notifyRetreat(messageShort, messageLong, step, retreatingPlayer);
+      }
     }
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/SelectCasualties.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/SelectCasualties.java
@@ -6,11 +6,13 @@ import static games.strategy.triplea.delegate.battle.BattleStepStrings.SELECT_PR
 import static games.strategy.triplea.delegate.battle.BattleStepStrings.UNITS;
 
 import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.engine.display.IDisplay;
 import games.strategy.triplea.delegate.ExecutionStack;
 import games.strategy.triplea.delegate.battle.BattleDelegate;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.battle.steps.BattleStep;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
+import games.strategy.triplea.settings.ClientSetting;
 import java.util.List;
 import java.util.function.BiFunction;
 import lombok.Getter;
@@ -54,13 +56,20 @@ public class SelectCasualties implements BattleStep {
 
   @Override
   public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
-
-    bridge
-        .getDisplayChannelBroadcaster()
-        .notifyDice(
-            fireRoundState.getDice(),
-            MarkCasualties.getPossibleOldNameForNotifyingBattleDisplay(
-                battleState, firingGroup, side, getName()));
+    if (ClientSetting.useWebsocketNetwork.getValue().orElse(false)) {
+      bridge.sendMessage(
+          new IDisplay.NotifyDiceMessage(
+              fireRoundState.getDice(),
+              MarkCasualties.getPossibleOldNameForNotifyingBattleDisplay(
+                  battleState, firingGroup, side, getName())));
+    } else {
+      bridge
+          .getDisplayChannelBroadcaster()
+          .notifyDice(
+              fireRoundState.getDice(),
+              MarkCasualties.getPossibleOldNameForNotifyingBattleDisplay(
+                  battleState, firingGroup, side, getName()));
+    }
 
     final CasualtyDetails details = selectCasualties.apply(bridge, this);
 

--- a/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyDelegateBridge.java
+++ b/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyDelegateBridge.java
@@ -76,7 +76,9 @@ public class DummyDelegateBridge implements IDelegateBridge {
   }
 
   @Override
-  public void sendMessage(final WebSocketMessage webSocketMessage) {}
+  public void sendMessage(final WebSocketMessage webSocketMessage) {
+
+  }
 
   @Override
   public void leaveDelegateExecution() {}

--- a/game-core/src/main/java/org/triplea/debug/Slf4jLogMessageUploader.java
+++ b/game-core/src/main/java/org/triplea/debug/Slf4jLogMessageUploader.java
@@ -1,5 +1,6 @@
 package org.triplea.debug;
 
+import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.AppenderBase;
 
@@ -11,6 +12,8 @@ import ch.qos.logback.core.AppenderBase;
 public class Slf4jLogMessageUploader extends AppenderBase<ILoggingEvent> {
   @Override
   protected void append(final ILoggingEvent eventObject) {
-    ErrorMessage.show(LoggerRecordAdapter.fromLogbackEvent(eventObject));
+    if (eventObject.getLevel().isGreaterOrEqual(Level.WARN)) {
+      ErrorMessage.show(LoggerRecordAdapter.fromLogbackEvent(eventObject));
+    }
   }
 }

--- a/game-relay-server/src/main/java/org/triplea/game/server/GameRelayServer.java
+++ b/game-relay-server/src/main/java/org/triplea/game/server/GameRelayServer.java
@@ -1,5 +1,6 @@
 package org.triplea.game.server;
 
+import java.net.URI;
 import lombok.extern.java.Log;
 import org.triplea.web.socket.StandaloneWebsocketServer;
 import org.triplea.web.socket.WebSocketMessagingBus;
@@ -12,6 +13,11 @@ import org.triplea.web.socket.WebSocketMessagingBus;
 @Log
 public class GameRelayServer {
   private final StandaloneWebsocketServer standaloneWebsocketServer;
+  private final int port;
+
+  public static URI createLocalhostConnectionUri(final int port) {
+    return URI.create("ws://localhost:" + port);
+  }
 
   /**
    * Constructs and starts the game relay server.
@@ -19,9 +25,13 @@ public class GameRelayServer {
    * @param port The local host port that the relay server will open and use to accept connections.
    */
   public GameRelayServer(final int port) {
+    this.port = port;
     final WebSocketMessagingBus webSocketMessagingBus = new WebSocketMessagingBus();
     webSocketMessagingBus.addMessageListener(webSocketMessagingBus::broadcastMessageEnvelope);
     standaloneWebsocketServer = new StandaloneWebsocketServer(webSocketMessagingBus, port);
+  }
+
+  public void start() {
     standaloneWebsocketServer.start();
     log.info("Game Relay Server started on port: " + port);
   }

--- a/game-relay-server/src/test/java/org/triplea/game/server/GameRelayServerTest.java
+++ b/game-relay-server/src/test/java/org/triplea/game/server/GameRelayServerTest.java
@@ -11,6 +11,7 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.awaitility.Awaitility;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.triplea.http.client.web.socket.GenericWebSocketClient;
@@ -27,6 +28,11 @@ class GameRelayServerTest {
   private static final int port = 6000 + ((int) (Math.random() * 1000));
   private static final URI SERVER_URI = URI.create("ws://localhost:" + port);
   private static final GameRelayServer gameRelayServer = new GameRelayServer(port);
+
+  @BeforeAll
+  static void startServer() {
+    gameRelayServer.start();
+  }
 
   @AfterAll
   static void stopServer() {


### PR DESCRIPTION
A working example and a *rough* preview of replacing java socket networking with websocket networking.

Only the overall design & approach should be previewed at this time.

The pattern for replacing the socket calls is as follows:
- for a RMI method, create a value object that extends WebsocketMessage that encapsulated those parameters
- ensure that the message value object is specific to networking message, no game objects should be re-used here and preference is given to using primitive data types where possible
- register the websocket message with a handler, eg:
 ```
      clientNetworkBridge.addListener(
          IDisplay.BombingResultsMessage.TYPE, message -> message.accept(display));
```
- instead of invoking the RMI method endpoint, create the message object and send it


This update already creates a socket relay server, which puts us on a path where the game-host is separate and is not also a game-client itself.