### PR TITLE
Update map versions for maps that have been updated to have relative links

### DIFF
--- a/triplea_maps.yaml
+++ b/triplea_maps.yaml
@@ -178,7 +178,7 @@
 - mapName: Civil War
   mapCategory: BEST
   url: https://github.com/triplea-maps/civil_war/archive/master.zip
-  version: 7
+  version: 8
   img: https://cloud.githubusercontent.com/assets/12397753/18229195/05ef3d68-7224-11e6-9698-f21923d51858.png
   description: |
     <br>Civil_War
@@ -521,7 +521,7 @@
 - mapName: Big World 2
   mapCategory: GOOD
   url: https://github.com/triplea-maps/big_world_2/archive/master.zip
-  version: 1
+  version: 2
   img: https://raw.githubusercontent.com/triplea-maps/big_world_2/master/description/TripleA_big_world2_mini.png
   description: |
     <br>Version 6.1.2, last update 2015.1.2 for engine 1.8.0.5
@@ -886,7 +886,7 @@
 - mapName: Pacific Challenge
   mapCategory: GOOD
   url: https://github.com/triplea-maps/pacific_challenge/archive/master.zip
-  version: 2
+  version: 3
   img: https://raw.githubusercontent.com/triplea-maps/pacific_challenge/master/description/TripleA_pacific_challenge_mini.png
   description: |
     <br>
@@ -930,7 +930,7 @@
     <br>
 - mapName: NWO Variants
   url: https://github.com/triplea-maps/nwo_variants/archive/master.zip
-  version: 2
+  version: 3
   img: https://raw.githubusercontent.com/triplea-maps/nwo_variants/master/description/TripleA_new_world_order_mini.png
   description: |
     <br>
@@ -1819,7 +1819,7 @@
 - mapName: Elemental Forces
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/elemental_forces/archive/master.zip
-  version: 1
+  version: 2
   img: https://raw.githubusercontent.com/triplea-maps/elemental_forces/master/description/TripleA_elemental_forces_mini.png
   description: |
     <br>
@@ -1862,7 +1862,7 @@
 - mapName: New World Order 1915Lebowski
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/new_world_order1915lebowski/archive/master.zip
-  version: 3
+  version: 4
   img: https://raw.githubusercontent.com/triplea-maps/new_world_order1915lebowski/master/description/TripleA_nwo_1915_lebowski_mini.png
   description: |
     <br>


### PR DESCRIPTION
The engine has logic to find the filename of an image link and to
make that filename relative. This is overly complex as the link
could just be relative to begin with.

Various maps have been updated to remove the ignored preceding part
of an image link to just be relative, eg:
{http://sourceforge/path/img.png -> img.png}


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
