### PR TITLE
StackTraceReportModel - obtain map directory from UiContext instead of ResourceLoader

### DIFF
--- a/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceReportModel.java
+++ b/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceReportModel.java
@@ -1,8 +1,6 @@
 package org.triplea.debug.error.reporting;
 
-import games.strategy.triplea.ResourceLoader;
 import games.strategy.triplea.ui.UiContext;
-import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import javax.annotation.Nonnull;
@@ -35,9 +33,7 @@ class StackTraceReportModel {
         .body(
             ErrorReportBodyFormatter.buildBody(
                 view.readUserDescription(),
-                Optional.ofNullable(UiContext.getResourceLoader())
-                    .map(ResourceLoader::getMapName)
-                    .orElse(null),
+                UiContext.getMapDir(),
                 MemoryUsageReport.getMemory(),
                 stackTraceRecord,
                 engineVersion))


### PR DESCRIPTION
In order to help vacate the dependency on map name from ResourceLoader,
this update removes one such dependency.

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
