### PR TITLE
Map version lookup - simplify & move to DownloadedMaps

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/auto/update/UpdatedMapsCheck.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/update/UpdatedMapsCheck.java
@@ -14,11 +14,9 @@ import java.util.List;
 import java.util.Optional;
 import java.util.function.Function;
 import lombok.experimental.UtilityClass;
-import lombok.extern.slf4j.Slf4j;
 import org.triplea.swing.SwingComponents;
 
 @UtilityClass
-@Slf4j
 class UpdatedMapsCheck {
 
   static final int THRESHOLD_DAYS = 7;

--- a/game-core/src/test/java/games/strategy/engine/auto/update/UpdatedMapsCheckTest.java
+++ b/game-core/src/test/java/games/strategy/engine/auto/update/UpdatedMapsCheckTest.java
@@ -2,17 +2,12 @@ package games.strategy.engine.auto.update;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
-import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.mockito.Mockito.verify;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -70,59 +65,5 @@ final class UpdatedMapsCheckTest {
         NOW.minus(UpdatedMapsCheck.THRESHOLD_DAYS - 1, ChronoUnit.DAYS).toEpochMilli(),
         // last check is within a minute of the threshold but not beyond
         NOW.minus(UpdatedMapsCheck.THRESHOLD_DAYS, ChronoUnit.DAYS).plusSeconds(60).toEpochMilli());
-  }
-
-  @Test
-  void shouldSkipCheckWhenNoAvailableDownloadsFound() {
-    final Map<String, Integer> availableMapVersions = Map.of();
-
-    final Collection<String> result =
-        UpdatedMapsCheck.computeOutOfDateMaps(
-            Map.of("installed_map.properties", 1), availableMapVersions);
-
-    assertThat(result, is(empty()));
-  }
-
-  @ParameterizedTest
-  @MethodSource
-  void localMapsNotOutOfDate(final Map<String, Integer> localMaps) {
-    final Map<String, Integer> availableMaps = Map.of("map name", 2);
-
-    final Collection<String> result =
-        UpdatedMapsCheck.computeOutOfDateMaps(localMaps, availableMaps);
-
-    assertThat(result, is(empty()));
-  }
-
-  static List<Map<String, Integer>> localMapsNotOutOfDate() {
-    return List.of(
-        // no local maps
-        Map.of(),
-        // local map is current
-        Map.of("map_name.properties", 2),
-        // local map is more recent
-        Map.of("map_name.properties", 3));
-  }
-
-  @ParameterizedTest
-  @MethodSource
-  void localMapsOutOfDate(final Map<String, Integer> localMaps) {
-    final Map<String, Integer> availableMaps = Map.of("Map Name", 2);
-
-    final Collection<String> result =
-        UpdatedMapsCheck.computeOutOfDateMaps(localMaps, availableMaps);
-
-    assertThat("Version value of available map is greater than local map", result, hasSize(1));
-    assertThat(result.iterator().next(), is("Map Name"));
-  }
-
-  static List<Map<String, Integer>> localMapsOutOfDate() {
-    return List.of(
-        // version is less than 2.0.0 and is '0'
-        Map.of("map_name.zip.properties", 0),
-        // version is less than 2.0.0 and is '1'
-        Map.of("map_name.zip.properties", 1),
-        // alternative spelling of the map zip file with the -master suffix
-        Map.of("map_name-master.zip.properties", 1));
   }
 }


### PR DESCRIPTION
commit f6b9f52566f46a1bf56155d4160b48936149fa04

    Simplify out of date map version lookup
    
    Previously we would compute the mapping of installed maps to versions,
    available maps to versions, then compute the union of these two maps
    and return any maps that had an installed version less than what
    was available.
    
    This update changes that algorithm to instead to iterate over the
    list of available maps, find that map, find the version for that
    map, and if out of date the map is out of date.
    
    Of note, rather than computing a Map of available map names to
    versions, we directly use 'DownloadFileDescription'.

commit 0ffabd1f9bbc40e17e5532f345c114f909b1bcea

    Move method 'getMapVersionByName' to DownloadedMaps.java

commit 95a653800687587c866e3531c2bd82d6f898c884

    Update test cases for out of date map logic

