### PR TITLE
Add BattlePhaseList, BattlePhase, and UnitAbilities

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/data/battle/phase/BattlePhase.java
+++ b/game-core/src/main/java/games/strategy/engine/data/battle/phase/BattlePhase.java
@@ -12,6 +12,12 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Value;
 
+/**
+ * A phase in the battle
+ *
+ * <p>Each phase has a list of abilities that indicate what unit types are allowed to do during the
+ * phase. All of the abilities occur "simultaneously".
+ */
 @Value
 public class BattlePhase {
   String name;

--- a/game-core/src/main/java/games/strategy/engine/data/battle/phase/BattlePhase.java
+++ b/game-core/src/main/java/games/strategy/engine/data/battle/phase/BattlePhase.java
@@ -35,7 +35,8 @@ public class BattlePhase {
   }
 
   /**
-   * Adds the unit ability or finds an existing equal ability and merges the onUnitTypes
+   * Adds the unit ability or finds an existing equal ability and merges the {@link
+   * CombatUnitAbility#attachedUnitTypes}
    *
    * @return The passed in unitAbility if it is new or the existing unitAbility
    */

--- a/game-core/src/main/java/games/strategy/engine/data/battle/phase/BattlePhase.java
+++ b/game-core/src/main/java/games/strategy/engine/data/battle/phase/BattlePhase.java
@@ -1,0 +1,55 @@
+package games.strategy.engine.data.battle.phase;
+
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.unit.ability.CombatUnitAbility;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.Value;
+
+@Value
+public class BattlePhase {
+  String name;
+  int order;
+
+  @Getter(AccessLevel.NONE)
+  Map<GamePlayer, Collection<CombatUnitAbility>> abilities = new HashMap<>();
+
+  public Collection<CombatUnitAbility> getAbilities(final GamePlayer player) {
+    return abilities.getOrDefault(player, List.of());
+  }
+
+  public void clearAbilities() {
+    abilities.clear();
+  }
+
+  /**
+   * Adds the unit ability or finds an existing equal ability and merges the onUnitTypes
+   *
+   * @return The passed in unitAbility if it is new or the existing unitAbility
+   */
+  public CombatUnitAbility addAbilityOrMergeAttached(
+      final GamePlayer player, final CombatUnitAbility unitAbility) {
+    final Optional<CombatUnitAbility> duplicateAbility =
+        abilities.computeIfAbsent(player, p -> new ArrayList<>()).stream()
+            .filter(unitAbility::canMergeAttachedUnitTypes)
+            .findFirst();
+    if (duplicateAbility.isPresent()) {
+      // this ability already exists so combine the unit types that have this ability
+      duplicateAbility.get().mergeAttachedUnitTypes(unitAbility);
+      return duplicateAbility.get();
+    } else {
+      abilities.get(player).add(unitAbility);
+      return unitAbility;
+    }
+  }
+
+  public void addAbility(final GamePlayer player, final CombatUnitAbility unitAbility) {
+    abilities.computeIfAbsent(player, p -> new ArrayList<>()).add(unitAbility);
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/data/battle/phase/BattlePhaseList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/battle/phase/BattlePhaseList.java
@@ -9,6 +9,11 @@ import java.util.Map;
 import java.util.Optional;
 import lombok.Getter;
 
+/**
+ * Stores all of the {@link BattlePhase}s that will be used during a battle
+ *
+ * <p>Also stores the {@link ConvertUnitAbility} that can be used during the battle.
+ */
 @Getter
 public class BattlePhaseList {
 

--- a/game-core/src/main/java/games/strategy/engine/data/battle/phase/BattlePhaseList.java
+++ b/game-core/src/main/java/games/strategy/engine/data/battle/phase/BattlePhaseList.java
@@ -1,0 +1,58 @@
+package games.strategy.engine.data.battle.phase;
+
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.unit.ability.ConvertUnitAbility;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import lombok.Getter;
+
+@Getter
+public class BattlePhaseList {
+
+  public static final String DEFAULT_AA_PHASE = "AA";
+  public static final String DEFAULT_BOMBARD_PHASE = "Bombard";
+  public static final String DEFAULT_FIRST_STRIKE_PHASE = "First Strike";
+  public static final String DEFAULT_GENERAL_PHASE = "General";
+
+  private final Collection<BattlePhase> phases = new ArrayList<>();
+
+  private final Map<GamePlayer, Collection<ConvertUnitAbility>> convertAbilities = new HashMap<>();
+
+  public BattlePhaseList() {
+    phases.add(new BattlePhase(DEFAULT_AA_PHASE, 100));
+    phases.add(new BattlePhase(DEFAULT_BOMBARD_PHASE, 200));
+    phases.add(new BattlePhase(DEFAULT_FIRST_STRIKE_PHASE, 300));
+    phases.add(new BattlePhase(DEFAULT_GENERAL_PHASE, 400));
+  }
+
+  public Optional<BattlePhase> getPhase(final String name) {
+    return phases.stream().filter(phase -> phase.getName().equals(name)).findFirst();
+  }
+
+  public ConvertUnitAbility addAbilityOrMergeAttached(
+      final GamePlayer player, final ConvertUnitAbility convertUnitAbility) {
+    final Optional<ConvertUnitAbility> duplicateAbility =
+        convertAbilities.computeIfAbsent(player, p -> new ArrayList<>()).stream()
+            .filter(convertUnitAbility::canMergeAttachedUnitTypes)
+            .findFirst();
+    if (duplicateAbility.isPresent()) {
+      // this ability already exists so combine the unit types that have this ability
+      duplicateAbility.get().mergeAttachedUnitTypes(convertUnitAbility);
+      return duplicateAbility.get();
+    } else {
+      convertAbilities.get(player).add(convertUnitAbility);
+      return convertUnitAbility;
+    }
+  }
+
+  public void addAbility(final GamePlayer player, final ConvertUnitAbility convertUnitAbility) {
+    convertAbilities.computeIfAbsent(player, p -> new ArrayList<>()).add(convertUnitAbility);
+  }
+
+  public void clearConvertAbilities() {
+    convertAbilities.clear();
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/CombatUnitAbility.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/CombatUnitAbility.java
@@ -45,8 +45,8 @@ public class CombatUnitAbility {
   @Builder.Default
   Collection<BattleState.Side> sides = List.of(BattleState.Side.OFFENSE, BattleState.Side.DEFENSE);
 
-  /** How many combat rounds this ability can be used. -1 means unlimited */
-  @Builder.Default int round = -1;
+  /** How many combat rounds this ability can be used */
+  @Builder.Default int round = Integer.MAX_VALUE;
 
   /**
    * Can the casualties return fire after the battle phase that this UnitAbility is active?

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/CombatUnitAbility.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/CombatUnitAbility.java
@@ -1,0 +1,106 @@
+package games.strategy.engine.data.unit.ability;
+
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.delegate.battle.BattleState;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.experimental.FieldDefaults;
+import lombok.experimental.NonFinal;
+
+/** Unit Ability for combat situations */
+@Data
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+@Builder(toBuilder = true)
+public class CombatUnitAbility {
+
+  enum DiceType {
+    // Use AA dice (attackAA, offensiveAttackAA)
+    AA,
+    // Use bombard dice (bombard or attack if bombard is empty)
+    BOMBARD,
+    // Use normal dice (attack, defense)
+    NORMAL
+  }
+
+  /** The name of this unit ability that will be shown in the Battle UI */
+  @NonNull String name;
+
+  /** The unit types that have this ability */
+  @NonFinal Collection<UnitType> attachedUnitTypes;
+
+  /** The unit types that can be targeted */
+  @NonNull Collection<UnitType> targets;
+
+  /** The type of dice that will be rolled. */
+  @Builder.Default DiceType diceType = DiceType.NORMAL;
+
+  /** The side(s) that the unit needs to be on to use the ability */
+  @Builder.Default
+  Collection<BattleState.Side> sides = List.of(BattleState.Side.OFFENSE, BattleState.Side.DEFENSE);
+
+  /** How many combat rounds this ability can be used. -1 means unlimited */
+  @Builder.Default int round = -1;
+
+  /**
+   * Can the casualties return fire after the battle phase that this UnitAbility is active?
+   *
+   * <p>Casualties that are created in the battle phase where this UnitAbility is active can always
+   * return fire since they are firing simultaneously
+   */
+  @Builder.Default boolean returnFire = true;
+
+  /** Will these units commit suicide when they have a hit? */
+  @Builder.Default boolean suicideOnHit = false;
+
+  public boolean isTarget(final Unit unit) {
+    return targets.contains(unit.getType());
+  }
+
+  public boolean isSide(final BattleState.Side side) {
+    return sides.contains(side);
+  }
+
+  public boolean isRound(final int round) {
+    return this.round == -1 || this.round <= round;
+  }
+
+  /**
+   * Can the attachedTo from "other" be combined with this?
+   *
+   * <p>This is only used to merge auto created CombatUnitAbilities.
+   *
+   * <p>The name is not important in deciding whether the attachedTo can be combined.
+   *
+   * <p>The attachedTo is only important if this is an suicideOnHit ability. By ensuring that each
+   * CombatUnitAbility is unique per suicideOnHit unitType, this simplifies the logic to determine
+   * which unit should suicide after a hit.
+   */
+  public boolean canMergeAttachedUnitTypes(final CombatUnitAbility other) {
+    // build a new CombatUnitAbility based off of other but with this CombatUnitAbility's name
+    // and attachedUnitTypes (if not suicideOnHit) as they are not relevant for merging.
+    return equals(
+        other.toBuilder()
+            .name(this.name)
+            .attachedUnitTypes(suicideOnHit ? other.attachedUnitTypes : this.attachedUnitTypes)
+            .build());
+  }
+
+  /**
+   * Merges the attachedUnitTypes from the unitAbility with this attachedUnitTypes
+   *
+   * <p>This is only used to merge auto created CombatUnitAbilities.
+   */
+  public void mergeAttachedUnitTypes(final CombatUnitAbility unitAbility) {
+    this.attachedUnitTypes =
+        Stream.of(this.attachedUnitTypes, unitAbility.attachedUnitTypes)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/CombatUnitAbility.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/CombatUnitAbility.java
@@ -48,14 +48,12 @@ public class CombatUnitAbility {
 
   public static final CombatUnitAbility EMPTY = CombatUnitAbility.builder().name("Empty").build();
 
+  /** Which {@link games.strategy.triplea.delegate.power.calculator.CombatValue} should be used */
   @Value
-  static class DiceType {
-    // Use AA dice (attackAA, offensiveAttackAA)
-    static final DiceType AA = new DiceType("AA");
-    // Use bombard dice (bombard or attack if bombard is empty)
-    static final DiceType BOMBARD = new DiceType("BOMBARD");
-    // Use normal dice (attack, defense)
-    static final DiceType NORMAL = new DiceType("NORMAL");
+  static class CombatValueType {
+    static final CombatValueType AA = new CombatValueType("AA");
+    static final CombatValueType BOMBARD = new CombatValueType("BOMBARD");
+    static final CombatValueType NORMAL = new CombatValueType("NORMAL");
 
     String type;
   }
@@ -78,7 +76,7 @@ public class CombatUnitAbility {
   @Builder.Default Collection<UnitType> targets = List.of();
 
   /** The type of dice that will be rolled. */
-  @Builder.Default DiceType diceType = DiceType.NORMAL;
+  @Builder.Default CombatValueType combatValueType = CombatValueType.NORMAL;
 
   /** The side(s) that the unit needs to be on to use the ability */
   @Builder.Default

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/CombatUnitAbility.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/CombatUnitAbility.java
@@ -14,7 +14,32 @@ import lombok.NonNull;
 import lombok.experimental.FieldDefaults;
 import lombok.experimental.NonFinal;
 
-/** Unit Ability for combat situations */
+/**
+ * Unit Ability for targeting and causing damage to units
+ *
+ * <p>A unit ability indicates what targets a unit type has, what dice it should roll, whether its
+ * casualties can return fire in a later {@link
+ * games.strategy.engine.data.battle.phase.BattlePhase}.
+ *
+ * <p>Some examples of what this does cover are:
+ *
+ * <ul>
+ *   <li>Instant Kill for a Submarine: It would use the NORMAL dice type, its targets would be sea
+ *       units, and casualties would not return fire.
+ *   <li>Land Mines Explosion: It would use the NORMAL dice type, its targets would be land based,
+ *       it would commit suicide, and the casualties would return fire.
+ *   <li>Depth Charges for Destroyer: It would use the AA dice type, its targets would be
+ *       submarines, and the casualties would return fire.
+ * </ul>
+ *
+ * Some examples of what this doesn't cover are:
+ *
+ * <ul>
+ *   <li>The ability to blitz
+ *   <li>The ability to retreat during a battle
+ *   <li>The ability to create new units
+ * </ul>
+ */
 @Data
 @FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
 @Builder(toBuilder = true)

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/CombatUnitAbility.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/CombatUnitAbility.java
@@ -7,10 +7,10 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nonnull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NonNull;
 import lombok.experimental.FieldDefaults;
 import lombok.experimental.NonFinal;
 
@@ -57,7 +57,7 @@ public class CombatUnitAbility {
   }
 
   /** The name of this unit ability that will be shown in the Battle UI */
-  @NonNull String name;
+  @Nonnull String name;
 
   /** The unit types that have this ability */
   @Builder.Default @NonFinal Collection<UnitType> attachedUnitTypes = List.of();

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/CombatUnitAbility.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/CombatUnitAbility.java
@@ -11,6 +11,7 @@ import javax.annotation.Nonnull;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
+import lombok.Value;
 import lombok.experimental.FieldDefaults;
 import lombok.experimental.NonFinal;
 
@@ -47,13 +48,16 @@ public class CombatUnitAbility {
 
   public static final CombatUnitAbility EMPTY = CombatUnitAbility.builder().name("Empty").build();
 
-  enum DiceType {
+  @Value
+  static class DiceType {
     // Use AA dice (attackAA, offensiveAttackAA)
-    AA,
+    static final DiceType AA = new DiceType("AA");
     // Use bombard dice (bombard or attack if bombard is empty)
-    BOMBARD,
+    static final DiceType BOMBARD = new DiceType("BOMBARD");
     // Use normal dice (attack, defense)
-    NORMAL
+    static final DiceType NORMAL = new DiceType("NORMAL");
+
+    String type;
   }
 
   enum Suicide {

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/CombatUnitAbility.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/CombatUnitAbility.java
@@ -56,8 +56,21 @@ public class CombatUnitAbility {
    */
   @Builder.Default boolean returnFire = true;
 
-  /** Will these units commit suicide when they have a hit? */
-  @Builder.Default boolean suicideOnHit = false;
+  /**
+   * Does this unit commit suicide after it has fired a shot?
+   *
+   * <p>Whether the shot hit or not doesn't matter.
+   *
+   * <p>It can commit suicide as a defensive unit, offensive unit, or both.
+   */
+  @Builder.Default Collection<BattleState.Side> commitSuicide = List.of();
+
+  /**
+   * Does this unit commit suicide after it has successfully hit a target?
+   *
+   * <p>It can commit suicide as a defensive unit, offensive unit, or both.
+   */
+  @Builder.Default Collection<BattleState.Side> commitSuicideAfterSuccessfulHit = List.of();
 
   public boolean isTarget(final Unit unit) {
     return targets.contains(unit.getType());
@@ -76,20 +89,13 @@ public class CombatUnitAbility {
    *
    * <p>This is only used to merge auto created CombatUnitAbilities.
    *
-   * <p>The name is not important in deciding whether the attachedTo can be combined.
-   *
-   * <p>The attachedTo is only important if this is an suicideOnHit ability. By ensuring that each
-   * CombatUnitAbility is unique per suicideOnHit unitType, this simplifies the logic to determine
-   * which unit should suicide after a hit.
+   * <p>CombatUnitAbility with different names and attachedUnitTypes can still be merged together so
+   * the equals need to ignore those two attributes. But equals normally still needs to check the
+   * equality of names and attachedUnitTypes so don't modify the equals method itself.
    */
   public boolean canMergeAttachedUnitTypes(final CombatUnitAbility other) {
-    // build a new CombatUnitAbility based off of other but with this CombatUnitAbility's name
-    // and attachedUnitTypes (if not suicideOnHit) as they are not relevant for merging.
     return equals(
-        other.toBuilder()
-            .name(this.name)
-            .attachedUnitTypes(suicideOnHit ? other.attachedUnitTypes : this.attachedUnitTypes)
-            .build());
+        other.toBuilder().name(this.name).attachedUnitTypes(this.attachedUnitTypes).build());
   }
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/CombatUnitAbility.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/CombatUnitAbility.java
@@ -20,6 +20,8 @@ import lombok.experimental.NonFinal;
 @Builder(toBuilder = true)
 public class CombatUnitAbility {
 
+  public static final CombatUnitAbility EMPTY = CombatUnitAbility.builder().name("Empty").build();
+
   enum DiceType {
     // Use AA dice (attackAA, offensiveAttackAA)
     AA,
@@ -33,10 +35,10 @@ public class CombatUnitAbility {
   @NonNull String name;
 
   /** The unit types that have this ability */
-  @NonFinal Collection<UnitType> attachedUnitTypes;
+  @Builder.Default @NonFinal Collection<UnitType> attachedUnitTypes = List.of();
 
   /** The unit types that can be targeted */
-  @NonNull Collection<UnitType> targets;
+  @Builder.Default Collection<UnitType> targets = List.of();
 
   /** The type of dice that will be rolled. */
   @Builder.Default DiceType diceType = DiceType.NORMAL;

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/CombatUnitAbility.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/CombatUnitAbility.java
@@ -48,16 +48,6 @@ public class CombatUnitAbility {
 
   public static final CombatUnitAbility EMPTY = CombatUnitAbility.builder().name("Empty").build();
 
-  /** Which {@link games.strategy.triplea.delegate.power.calculator.CombatValue} should be used */
-  @Value
-  static class CombatValueType {
-    static final CombatValueType AA = new CombatValueType("AA");
-    static final CombatValueType BOMBARD = new CombatValueType("BOMBARD");
-    static final CombatValueType NORMAL = new CombatValueType("NORMAL");
-
-    String type;
-  }
-
   enum Suicide {
     NONE,
     /** Commit suicide after the units fire? */
@@ -97,6 +87,16 @@ public class CombatUnitAbility {
   @Builder.Default Suicide suicideOnOffense = Suicide.NONE;
   /** When should this unit commit suicide on defense */
   @Builder.Default Suicide suicideOnDefense = Suicide.NONE;
+
+  /** Which {@link games.strategy.triplea.delegate.power.calculator.CombatValue} should be used */
+  @Value
+  static class CombatValueType {
+    static final CombatValueType AA = new CombatValueType("AA");
+    static final CombatValueType BOMBARD = new CombatValueType("BOMBARD");
+    static final CombatValueType NORMAL = new CombatValueType("NORMAL");
+
+    String type;
+  }
 
   public boolean isTarget(final Unit unit) {
     return targets.contains(unit.getType());

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/CombatUnitAbility.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/CombatUnitAbility.java
@@ -62,8 +62,10 @@ public class CombatUnitAbility {
 
   enum Suicide {
     NONE,
-    ALWAYS,
-    ONLY_ON_HIT,
+    /** Commit suicide after the units fire? */
+    AFTER_FIRE,
+    /** Commit suicide after the units actually hit a target? */
+    AFTER_HIT,
   }
 
   /** The name of this unit ability that will be shown in the Battle UI */

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/CombatUnitAbility.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/CombatUnitAbility.java
@@ -56,6 +56,12 @@ public class CombatUnitAbility {
     NORMAL
   }
 
+  enum Suicide {
+    NONE,
+    ALWAYS,
+    ONLY_ON_HIT,
+  }
+
   /** The name of this unit ability that will be shown in the Battle UI */
   @Nonnull String name;
 
@@ -83,21 +89,10 @@ public class CombatUnitAbility {
    */
   @Builder.Default boolean returnFire = true;
 
-  /**
-   * Does this unit commit suicide after it has fired a shot?
-   *
-   * <p>Whether the shot hit or not doesn't matter.
-   *
-   * <p>It can commit suicide as a defensive unit, offensive unit, or both.
-   */
-  @Builder.Default Collection<BattleState.Side> commitSuicide = List.of();
-
-  /**
-   * Does this unit commit suicide after it has successfully hit a target?
-   *
-   * <p>It can commit suicide as a defensive unit, offensive unit, or both.
-   */
-  @Builder.Default Collection<BattleState.Side> commitSuicideAfterSuccessfulHit = List.of();
+  /** When should this unit commit suicide on offense */
+  @Builder.Default Suicide suicideOnOffense = Suicide.NONE;
+  /** When should this unit commit suicide on defense */
+  @Builder.Default Suicide suicideOnDefense = Suicide.NONE;
 
   public boolean isTarget(final Unit unit) {
     return targets.contains(unit.getType());

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/ConvertUnitAbility.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/ConvertUnitAbility.java
@@ -33,7 +33,7 @@ public class ConvertUnitAbility {
   /** The unitAbility that will be converted */
   @NonNull CombatUnitAbility from;
 
-  /** If to is null, then this just removes the "from" UnitAbility */
+  /** If null, then this just removes the "from" UnitAbility */
   CombatUnitAbility to;
 
   /**

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/ConvertUnitAbility.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/ConvertUnitAbility.java
@@ -41,11 +41,11 @@ public class ConvertUnitAbility {
    *
    * <p>This is only used to merge auto created ConvertUnitAbilities.
    *
-   * <p>The name and attachedTo is not important in deciding whether the attachedTo can be combined.
+   * <p>ConvertUnitAbilities with different names and attachedUnitTypes can still be merged together
+   * so the equals need to ignore those two attributes. But equals normally still needs to check the
+   * equality of names and attachedUnitTypes so don't modify the equals method itself.
    */
   public boolean canMergeAttachedUnitTypes(final ConvertUnitAbility other) {
-    // build a new ConvertUnitAbility based off of other but with this ConvertUnitAbility's name
-    // and attachedUnitTypes as they are not relevant for merging.
     return equals(
         other.toBuilder().name(this.name).attachedUnitTypes(this.attachedUnitTypes).build());
   }

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/ConvertUnitAbility.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/ConvertUnitAbility.java
@@ -18,9 +18,9 @@ import lombok.experimental.NonFinal;
 @Builder(toBuilder = true)
 public class ConvertUnitAbility {
 
-  enum Faction {
-    ALLIED,
-    ENEMY
+  enum Team {
+    FRIENDLY,
+    FOE
   }
 
   @Nonnull String name;
@@ -28,7 +28,7 @@ public class ConvertUnitAbility {
   @NonFinal Collection<UnitType> attachedUnitTypes;
 
   /** Does this affect enemy and/or allied units */
-  @Builder.Default Collection<Faction> factions = List.of(Faction.ENEMY);
+  @Builder.Default Collection<Team> teams = List.of(Team.FOE);
 
   /** The unitAbility that will be converted */
   @Nonnull CombatUnitAbility from;

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/ConvertUnitAbility.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/ConvertUnitAbility.java
@@ -6,7 +6,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
@@ -34,8 +33,8 @@ public class ConvertUnitAbility {
   /** The unitAbility that will be converted */
   @Nonnull CombatUnitAbility from;
 
-  /** If null, then this just removes the "from" UnitAbility */
-  @Nullable CombatUnitAbility to;
+  /** The unitAbility that will replace the "from" unitAbility */
+  @Builder.Default CombatUnitAbility to = CombatUnitAbility.EMPTY;
 
   /**
    * Can the attachedTo from "other" be combined with this?

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/ConvertUnitAbility.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/ConvertUnitAbility.java
@@ -5,10 +5,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NonNull;
 import lombok.experimental.FieldDefaults;
 import lombok.experimental.NonFinal;
 
@@ -23,7 +24,7 @@ public class ConvertUnitAbility {
     ENEMY
   }
 
-  @NonNull String name;
+  @Nonnull String name;
   /** The unit types that have this ability */
   @NonFinal Collection<UnitType> attachedUnitTypes;
 
@@ -31,10 +32,10 @@ public class ConvertUnitAbility {
   @Builder.Default Collection<Faction> factions = List.of(Faction.ENEMY);
 
   /** The unitAbility that will be converted */
-  @NonNull CombatUnitAbility from;
+  @Nonnull CombatUnitAbility from;
 
   /** If null, then this just removes the "from" UnitAbility */
-  CombatUnitAbility to;
+  @Nullable CombatUnitAbility to;
 
   /**
    * Can the attachedTo from "other" be combined with this?

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/ConvertUnitAbility.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/ConvertUnitAbility.java
@@ -1,0 +1,64 @@
+package games.strategy.engine.data.unit.ability;
+
+import games.strategy.engine.data.UnitType;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.experimental.FieldDefaults;
+import lombok.experimental.NonFinal;
+
+/** Unit Ability to convert CombatUnitAbilities into other CombatUnitAbilities or into nothing */
+@Data
+@FieldDefaults(makeFinal = true, level = AccessLevel.PRIVATE)
+@Builder(toBuilder = true)
+public class ConvertUnitAbility {
+
+  enum Faction {
+    ALLIED,
+    ENEMY
+  }
+
+  @NonNull String name;
+  /** The unit types that have this ability */
+  @NonFinal Collection<UnitType> attachedUnitTypes;
+
+  /** Does this affect enemy and/or allied units */
+  @Builder.Default Collection<Faction> factions = List.of(Faction.ENEMY);
+
+  /** The unitAbility that will be converted */
+  @NonNull CombatUnitAbility from;
+
+  /** If to is null, then this just removes the "from" UnitAbility */
+  CombatUnitAbility to;
+
+  /**
+   * Can the attachedTo from "other" be combined with this?
+   *
+   * <p>This is only used to merge auto created ConvertUnitAbilities.
+   *
+   * <p>The name and attachedTo is not important in deciding whether the attachedTo can be combined.
+   */
+  public boolean canMergeAttachedUnitTypes(final ConvertUnitAbility other) {
+    // build a new ConvertUnitAbility based off of other but with this ConvertUnitAbility's name
+    // and attachedUnitTypes as they are not relevant for merging.
+    return equals(
+        other.toBuilder().name(this.name).attachedUnitTypes(this.attachedUnitTypes).build());
+  }
+
+  /**
+   * Merges the attachedUnitTypes from the unitAbility with this attachedUnitTypes
+   *
+   * <p>This is only used to merge auto created ConvertUnitAbilities.
+   */
+  public void mergeAttachedUnitTypes(final ConvertUnitAbility unitAbility) {
+    this.attachedUnitTypes =
+        Stream.of(this.attachedUnitTypes, unitAbility.attachedUnitTypes)
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/UnitAbilityFactory.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/UnitAbilityFactory.java
@@ -176,7 +176,8 @@ public class UnitAbilityFactory {
                         : unitAttachment.getMaxRoundsAa())
                 .targets(aaTargets.get(unitAttachment.getTypeAa()))
                 .returnFire(false)
-                .suicideOnHit(UnitAttachment.get(unitType).getIsSuicideOnHit())
+                .commitSuicideAfterSuccessfulHit(getCommitSuicideOnHitSides(unitType))
+                .commitSuicide(getCommitSuicideSides(unitType))
                 .build(),
             player,
             BattlePhaseList.DEFAULT_AA_PHASE);
@@ -199,6 +200,24 @@ public class UnitAbilityFactory {
             .orElseThrow(
                 () -> new IllegalArgumentException("The phase " + phaseName + " doesn't exist"));
     return battlePhase.addAbilityOrMergeAttached(player, combatUnitAbility);
+  }
+
+  private static Collection<BattleState.Side> getCommitSuicideOnHitSides(final UnitType unitType) {
+    return UnitAttachment.get(unitType).getIsSuicideOnHit()
+        ? List.of(BattleState.Side.OFFENSE, BattleState.Side.DEFENSE)
+        : List.of();
+  }
+
+  private static Collection<BattleState.Side> getCommitSuicideSides(final UnitType unitType) {
+    final Collection<BattleState.Side> commitSuicideSides = new ArrayList<>();
+    final UnitAttachment unitAttachment = UnitAttachment.get(unitType);
+    if (unitAttachment.getIsSuicideOnAttack()) {
+      commitSuicideSides.add(BattleState.Side.OFFENSE);
+    }
+    if (unitAttachment.getIsSuicideOnDefense()) {
+      commitSuicideSides.add(BattleState.Side.DEFENSE);
+    }
+    return commitSuicideSides;
   }
 
   private static ConvertUnitAbility createWillNotFireIfPresentAbilities(
@@ -286,7 +305,8 @@ public class UnitAbilityFactory {
                 .sides(sides)
                 .targets(getTargetsWithDestroyer(unitTypeList, unitType))
                 .returnFire(!isFirstStrike)
-                .suicideOnHit(UnitAttachment.get(unitType).getIsSuicideOnHit())
+                .commitSuicideAfterSuccessfulHit(getCommitSuicideOnHitSides(unitType))
+                .commitSuicide(getCommitSuicideSides(unitType))
                 .build(),
             player,
             isFirstStrike
@@ -308,7 +328,8 @@ public class UnitAbilityFactory {
                   .sides(sides)
                   .targets(getTargetsWithoutDestroyer(unitTypeList, unitType))
                   .returnFire(!isFirstStrike)
-                  .suicideOnHit(UnitAttachment.get(unitType).getIsSuicideOnHit())
+                  .commitSuicideAfterSuccessfulHit(getCommitSuicideOnHitSides(unitType))
+                  .commitSuicide(getCommitSuicideSides(unitType))
                   .build(),
               player,
               isFirstStrike

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/UnitAbilityFactory.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/UnitAbilityFactory.java
@@ -170,7 +170,10 @@ public class UnitAbilityFactory {
                 .attachedUnitTypes(List.of(unitType))
                 .diceType(CombatUnitAbility.DiceType.AA)
                 .sides(sides)
-                .round(unitAttachment.getMaxRoundsAa())
+                .round(
+                    unitAttachment.getMaxRoundsAa() == -1
+                        ? Integer.MAX_VALUE
+                        : unitAttachment.getMaxRoundsAa())
                 .targets(aaTargets.get(unitAttachment.getTypeAa()))
                 .returnFire(false)
                 .suicideOnHit(UnitAttachment.get(unitType).getIsSuicideOnHit())

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/UnitAbilityFactory.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/UnitAbilityFactory.java
@@ -1,0 +1,432 @@
+package games.strategy.engine.data.unit.ability;
+
+import static games.strategy.triplea.delegate.battle.BattleStepStrings.FIRST_STRIKE_UNITS;
+import static games.strategy.triplea.delegate.battle.BattleStepStrings.NAVAL_BOMBARD;
+import static games.strategy.triplea.delegate.battle.BattleStepStrings.UNITS;
+
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.PlayerList;
+import games.strategy.engine.data.UnitType;
+import games.strategy.engine.data.UnitTypeList;
+import games.strategy.engine.data.battle.phase.BattlePhase;
+import games.strategy.engine.data.battle.phase.BattlePhaseList;
+import games.strategy.engine.data.properties.GameProperties;
+import games.strategy.triplea.Properties;
+import games.strategy.triplea.attachments.UnitAttachment;
+import games.strategy.triplea.delegate.battle.BattleState;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import lombok.experimental.UtilityClass;
+
+/**
+ * Auto-generates unit abilities from deprecated unit options
+ *
+ * <p>If a map defines the unit abilities, then this should not be used.
+ */
+@UtilityClass
+public class UnitAbilityFactory {
+
+  private static final String WILL_NOT_FIRE_AA_ABILITY_PREFIX = "willNotFireAa";
+
+  /**
+   * Tracks the typeAa and their targetsAa
+   *
+   * <p>The typeAa and their targetsAa is copied on every single unitAttachment. This means that a
+   * map maker might have different targetsAa in the same typeAa. But that is a typo since the
+   * engine only uses the first targetsAa that it finds. This map keeps track of the typeAa and
+   * targetsAa separately from the unitAttachment so that there is a central place to find them.
+   */
+  private static final Map<String, Collection<UnitType>> aaTargets = new HashMap<>();
+
+  /**
+   * Tracks what unit types a specific unit type can not target without an ally destroyer present
+   *
+   * <p>The deprecated property canNotBeTargetedBy was used to determine if a unit could be targeted
+   * depending on the presence of an isDestroyer. This means that canNotBeTargetedBy is structured
+   * as targeted unit -> firing units. But unitAbilities are structured as firing unit -> targeted
+   * units.
+   *
+   * <p>This map is used to invert that data set at the beginning so that it can be easily looked up
+   * later
+   */
+  private static final Map<UnitType, Collection<UnitType>> unitCanNotTargetWithoutDestroyer =
+      new HashMap<>();
+
+  /**
+   * Create the default unit abilities at the beginning of the battle step
+   *
+   * <p>This needs to be called once at the beginning of each battle step. All the battles in the
+   * battle step will use the same unit abilities but technology and triggers can change the
+   * properties that this depends on so subsequent battle steps may have different unit abilities.
+   */
+  public static void generate(
+      final PlayerList playerList,
+      final UnitTypeList unitTypeList,
+      final BattlePhaseList battlePhaseList,
+      final GameProperties properties) {
+
+    // clear out the existing unit abilities so that they can be rebuilt
+    clearExistingUnitAbilities(battlePhaseList);
+
+    // set up some helper maps
+    initializeTargetsAa(unitTypeList);
+    initializeCanNotTargetWithoutDestroyer(unitTypeList);
+
+    // create unique unit abilities for each player
+    playerList.forEach(
+        player -> {
+          generatePerPlayer(unitTypeList, battlePhaseList, properties, player);
+        });
+  }
+
+  private static void clearExistingUnitAbilities(final BattlePhaseList battlePhaseList) {
+    battlePhaseList.clearConvertAbilities();
+    battlePhaseList.getPhases().forEach(BattlePhase::clearAbilities);
+  }
+
+  private static void initializeTargetsAa(final UnitTypeList unitTypeList) {
+    aaTargets.clear();
+    unitTypeList.stream()
+        .map(UnitAttachment::get)
+        .forEach(
+            unitAttachment ->
+                aaTargets.putIfAbsent(
+                    unitAttachment.getTypeAa(), unitAttachment.getTargetsAa(unitTypeList)));
+  }
+
+  private static void initializeCanNotTargetWithoutDestroyer(final UnitTypeList unitTypeList) {
+    unitCanNotTargetWithoutDestroyer.clear();
+    unitTypeList.stream()
+        .filter(
+            Predicate.not(
+                unitType -> UnitAttachment.get(unitType).getCanNotBeTargetedBy().isEmpty()))
+        .forEach(
+            unitType ->
+                UnitAttachment.get(unitType)
+                    .getCanNotBeTargetedBy()
+                    .forEach(
+                        firingUnitType ->
+                            unitCanNotTargetWithoutDestroyer
+                                .computeIfAbsent(firingUnitType, u -> new ArrayList<>())
+                                .add(unitType)));
+  }
+
+  /**
+   * Create the default unit abilities at the beginning of the battle step for each player
+   *
+   * <p>Since a player can have different tech advances, the unit abilities can be unique per player
+   */
+  private static void generatePerPlayer(
+      final UnitTypeList unitTypeList,
+      final BattlePhaseList battlePhaseList,
+      final GameProperties properties,
+      final GamePlayer player) {
+    unitTypeList.stream()
+        .forEach(
+            unitType ->
+                generatePerPlayerAndUnit(
+                    unitTypeList, battlePhaseList, properties, player, unitType));
+
+    createBombardUnitAbilities(unitTypeList, battlePhaseList, properties, player);
+  }
+
+  private static void generatePerPlayerAndUnit(
+      final UnitTypeList unitTypeList,
+      final BattlePhaseList battlePhaseList,
+      final GameProperties properties,
+      final GamePlayer player,
+      final UnitType unitType) {
+    final UnitAttachment unitAttachment = UnitAttachment.get(unitType);
+    if (unitAttachment.getIsAaForCombatOnly()) {
+      createAaUnitAbilities(battlePhaseList, player, unitType);
+    }
+    createUnitAbilities(unitTypeList, battlePhaseList, properties, player, unitType);
+  }
+
+  private static void createAaUnitAbilities(
+      final BattlePhaseList battlePhaseList, final GamePlayer player, final UnitType unitType) {
+    final UnitAttachment unitAttachment = UnitAttachment.get(unitType);
+    final Collection<BattleState.Side> sides = new ArrayList<>();
+    if (unitAttachment.getOffensiveAttackAa(player) > 0 && unitAttachment.getMaxAaAttacks() != 0) {
+      sides.add(BattleState.Side.OFFENSE);
+    }
+    if (unitAttachment.getAttackAa(player) > 0 && unitAttachment.getMaxAaAttacks() != 0) {
+      sides.add(BattleState.Side.DEFENSE);
+    }
+    if (sides.isEmpty()) {
+      return;
+    }
+
+    final CombatUnitAbility ability =
+        addAbility(
+            battlePhaseList,
+            CombatUnitAbility.builder()
+                .name(unitAttachment.getTypeAa())
+                .attachedUnitTypes(List.of(unitType))
+                .diceType(CombatUnitAbility.DiceType.AA)
+                .sides(sides)
+                .round(unitAttachment.getMaxRoundsAa())
+                .targets(aaTargets.get(unitAttachment.getTypeAa()))
+                .returnFire(false)
+                .suicideOnHit(UnitAttachment.get(unitType).getIsSuicideOnHit())
+                .build(),
+            player,
+            BattlePhaseList.DEFAULT_AA_PHASE);
+
+    unitAttachment.getWillNotFireIfPresent().stream()
+        .map(
+            unitTypeThatPreventsFiring ->
+                createWillNotFireIfPresentAbilities(unitTypeThatPreventsFiring, ability))
+        .forEach(antiAbility -> addConvertAbility(battlePhaseList, antiAbility, player));
+  }
+
+  private static CombatUnitAbility addAbility(
+      final BattlePhaseList battlePhaseList,
+      final CombatUnitAbility combatUnitAbility,
+      final GamePlayer player,
+      final String phaseName) {
+    final BattlePhase battlePhase =
+        battlePhaseList
+            .getPhase(phaseName)
+            .orElseThrow(
+                () -> new IllegalArgumentException("The phase " + phaseName + " doesn't exist"));
+    return battlePhase.addAbilityOrMergeAttached(player, combatUnitAbility);
+  }
+
+  private static ConvertUnitAbility createWillNotFireIfPresentAbilities(
+      final UnitType unitTypeThatPreventsFiring, final CombatUnitAbility ability) {
+    return ConvertUnitAbility.builder()
+        .name(WILL_NOT_FIRE_AA_ABILITY_PREFIX + " " + ability.getName())
+        .attachedUnitTypes(List.of(unitTypeThatPreventsFiring))
+        .factions(List.of(ConvertUnitAbility.Faction.ENEMY))
+        .from(ability)
+        .build();
+  }
+
+  private static void addConvertAbility(
+      final BattlePhaseList battlePhaseList,
+      final ConvertUnitAbility unitAbility,
+      final GamePlayer player) {
+    battlePhaseList.addAbilityOrMergeAttached(player, unitAbility);
+  }
+
+  private static void createUnitAbilities(
+      final UnitTypeList unitTypeList,
+      final BattlePhaseList battlePhaseList,
+      final GameProperties properties,
+      final GamePlayer player,
+      final UnitType unitType) {
+    final UnitAttachment unitAttachment = UnitAttachment.get(unitType);
+    final Collection<BattleState.Side> sides = new ArrayList<>();
+    if (unitAttachment.getAttack(player) > 0) {
+      sides.add(BattleState.Side.OFFENSE);
+    }
+    if (unitAttachment.getDefense(player) > 0) {
+      if (unitAttachment.getIsFirstStrike()
+          && !Properties.getDefendingSubsSneakAttack(properties)) {
+        // if the defending sub doesn't have sneak attack, then it needs to have a defensive general
+        // ability instead
+        createUnitAbilities(
+            unitTypeList,
+            battlePhaseList,
+            properties,
+            player,
+            unitType,
+            List.of(BattleState.Side.DEFENSE),
+            false);
+      } else {
+        sides.add(BattleState.Side.DEFENSE);
+      }
+    }
+    if (sides.isEmpty()) {
+      return;
+    }
+
+    createUnitAbilities(
+        unitTypeList,
+        battlePhaseList,
+        properties,
+        player,
+        unitType,
+        sides,
+        unitAttachment.getIsFirstStrike());
+  }
+
+  private static void createUnitAbilities(
+      final UnitTypeList unitTypeList,
+      final BattlePhaseList battlePhaseList,
+      final GameProperties properties,
+      final GamePlayer player,
+      final UnitType unitType,
+      final Collection<BattleState.Side> sides,
+      final boolean isFirstStrike) {
+    // if the unit needs a destroyer present to target things, then two abilities will be created.
+    // one ability will target everything but will not be attached to this unit and the other
+    // ability will only target the units that don't need a destroyer present. The destroyer will
+    // gain a convertUnitAbility so that this unit can have its ability converted when the destroyer
+    // is present
+    final boolean needsDestroyerToTarget =
+        !unitCanNotTargetWithoutDestroyer.getOrDefault(unitType, List.of()).isEmpty();
+
+    final CombatUnitAbility ability =
+        addAbility(
+            battlePhaseList,
+            CombatUnitAbility.builder()
+                .name((isFirstStrike ? FIRST_STRIKE_UNITS : UNITS))
+                .attachedUnitTypes(needsDestroyerToTarget ? List.of() : List.of(unitType))
+                .diceType(CombatUnitAbility.DiceType.NORMAL)
+                .sides(sides)
+                .targets(getTargetsWithDestroyer(unitTypeList, unitType))
+                .returnFire(!isFirstStrike)
+                .suicideOnHit(UnitAttachment.get(unitType).getIsSuicideOnHit())
+                .build(),
+            player,
+            isFirstStrike
+                ? BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE
+                : BattlePhaseList.DEFAULT_GENERAL_PHASE);
+
+    if (isFirstStrike) {
+      createAntiFirstStrikeAbility(unitTypeList, battlePhaseList, properties, ability, player);
+    }
+
+    if (needsDestroyerToTarget) {
+      final CombatUnitAbility abilityWithoutDestroyer =
+          addAbility(
+              battlePhaseList,
+              CombatUnitAbility.builder()
+                  .name((isFirstStrike ? FIRST_STRIKE_UNITS : UNITS) + " without destroyer")
+                  .attachedUnitTypes(List.of(unitType))
+                  .diceType(CombatUnitAbility.DiceType.NORMAL)
+                  .sides(sides)
+                  .targets(getTargetsWithoutDestroyer(unitTypeList, unitType))
+                  .returnFire(!isFirstStrike)
+                  .suicideOnHit(UnitAttachment.get(unitType).getIsSuicideOnHit())
+                  .build(),
+              player,
+              isFirstStrike
+                  ? BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE
+                  : BattlePhaseList.DEFAULT_GENERAL_PHASE);
+
+      battlePhaseList.addAbilityOrMergeAttached(
+          player,
+          ConvertUnitAbility.builder()
+              .name("allow " + unitType.getName() + " to hit more units")
+              .attachedUnitTypes(getIsDestroyerUnitTypes(unitTypeList))
+              .factions(List.of(ConvertUnitAbility.Faction.ALLIED))
+              .from(abilityWithoutDestroyer)
+              .to(ability)
+              .build());
+
+      if (isFirstStrike) {
+        createAntiFirstStrikeAbility(
+            unitTypeList, battlePhaseList, properties, abilityWithoutDestroyer, player);
+      }
+    }
+  }
+
+  private static List<UnitType> getTargetsWithDestroyer(
+      final UnitTypeList unitTypeList, final UnitType unitType) {
+    return unitTypeList.stream()
+        .filter(
+            Predicate.not(
+                possibleTarget ->
+                    UnitAttachment.get(unitType).getCanNotTarget().contains(possibleTarget)))
+        .filter(isNotInfrastructure())
+        .collect(Collectors.toList());
+  }
+
+  private static List<UnitType> getTargetsWithoutDestroyer(
+      final UnitTypeList unitTypeList, final UnitType unitType) {
+    return getTargetsWithDestroyer(unitTypeList, unitType).stream()
+        .filter(
+            Predicate.not(
+                possibleTarget ->
+                    unitCanNotTargetWithoutDestroyer
+                        .computeIfAbsent(unitType, k -> List.of())
+                        .contains(possibleTarget)))
+        .collect(Collectors.toList());
+  }
+
+  private static Predicate<UnitType> isNotInfrastructure() {
+    return Predicate.not(
+        possibleTarget -> UnitAttachment.get(possibleTarget).getIsInfrastructure());
+  }
+
+  private static void createAntiFirstStrikeAbility(
+      final UnitTypeList unitTypeList,
+      final BattlePhaseList battlePhaseList,
+      final GameProperties properties,
+      final CombatUnitAbility unitAbility,
+      final GamePlayer player) {
+    if (getIsDestroyerUnitTypes(unitTypeList).isEmpty()) {
+      return;
+    }
+
+    final CombatUnitAbility unitAbilityWithReturnFire =
+        addAbility(
+            battlePhaseList,
+            unitAbility.toBuilder().attachedUnitTypes(List.of()).returnFire(true).build(),
+            player,
+            Properties.getWW2V2(properties)
+                ? BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE
+                : BattlePhaseList.DEFAULT_GENERAL_PHASE);
+
+    battlePhaseList.addAbilityOrMergeAttached(
+        player,
+        ConvertUnitAbility.builder()
+            .name("neutralize first strike ability")
+            .attachedUnitTypes(getIsDestroyerUnitTypes(unitTypeList))
+            .factions(List.of(ConvertUnitAbility.Faction.ENEMY))
+            .from(unitAbility)
+            .to(unitAbilityWithReturnFire)
+            .build());
+  }
+
+  private static Collection<UnitType> getIsDestroyerUnitTypes(final UnitTypeList unitTypeList) {
+    return unitTypeList.stream()
+        .filter(unitType -> UnitAttachment.get(unitType).getIsDestroyer())
+        .collect(Collectors.toList());
+  }
+
+  private static void createBombardUnitAbilities(
+      final UnitTypeList unitTypeList,
+      final BattlePhaseList battlePhaseList,
+      final GameProperties properties,
+      final GamePlayer player) {
+
+    if (getCanBombardUnitTypes(unitTypeList, player).isEmpty()) {
+      return;
+    }
+
+    battlePhaseList
+        .getPhase(BattlePhaseList.DEFAULT_BOMBARD_PHASE)
+        .ifPresent(
+            phase ->
+                phase.addAbilityOrMergeAttached(
+                    player,
+                    CombatUnitAbility.builder()
+                        .name(NAVAL_BOMBARD)
+                        .attachedUnitTypes(getCanBombardUnitTypes(unitTypeList, player))
+                        .diceType(CombatUnitAbility.DiceType.BOMBARD)
+                        .round(1)
+                        .returnFire(Properties.getNavalBombardCasualtiesReturnFire(properties))
+                        .targets(getBombardTargetUnitTypes(unitTypeList))
+                        .build()));
+  }
+
+  private static List<UnitType> getCanBombardUnitTypes(
+      final UnitTypeList unitTypeList, final GamePlayer player) {
+    return unitTypeList.stream()
+        .filter(unitType -> UnitAttachment.get(unitType).getCanBombard(player))
+        .collect(Collectors.toList());
+  }
+
+  private static Collection<UnitType> getBombardTargetUnitTypes(final UnitTypeList unitTypeList) {
+    return unitTypeList.stream().filter(isNotInfrastructure()).collect(Collectors.toList());
+  }
+}

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/UnitAbilityFactory.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/UnitAbilityFactory.java
@@ -201,7 +201,14 @@ public class UnitAbilityFactory {
         battlePhaseList
             .getPhase(phaseName)
             .orElseThrow(
-                () -> new IllegalArgumentException("The phase " + phaseName + " doesn't exist"));
+                () ->
+                    new IllegalArgumentException(
+                        "The phase "
+                            + phaseName
+                            + " doesn't exist. Existing phases are: "
+                            + battlePhaseList.getPhases().stream()
+                                .map(BattlePhase::getName)
+                                .collect(Collectors.joining(", "))));
     return battlePhase.addAbilityOrMergeAttached(player, combatUnitAbility);
   }
 

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/UnitAbilityFactory.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/UnitAbilityFactory.java
@@ -211,9 +211,9 @@ public class UnitAbilityFactory {
     if (side == BattleState.Side.OFFENSE
         ? unitAttachment.getIsSuicideOnAttack()
         : unitAttachment.getIsSuicideOnDefense()) {
-      return CombatUnitAbility.Suicide.ALWAYS;
+      return CombatUnitAbility.Suicide.AFTER_FIRE;
     } else if (unitAttachment.getIsSuicideOnHit()) {
-      return CombatUnitAbility.Suicide.ONLY_ON_HIT;
+      return CombatUnitAbility.Suicide.AFTER_HIT;
     } else {
       return CombatUnitAbility.Suicide.NONE;
     }

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/UnitAbilityFactory.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/UnitAbilityFactory.java
@@ -179,8 +179,8 @@ public class UnitAbilityFactory {
                         : unitAttachment.getMaxRoundsAa())
                 .targets(parameters.aaTargets.get(unitAttachment.getTypeAa()))
                 .returnFire(false)
-                .commitSuicideAfterSuccessfulHit(getCommitSuicideOnHitSides(unitType))
-                .commitSuicide(getCommitSuicideSides(unitType))
+                .suicideOnOffense(calculateSuicideType(unitType, BattleState.Side.OFFENSE))
+                .suicideOnDefense(calculateSuicideType(unitType, BattleState.Side.DEFENSE))
                 .build(),
             player,
             BattlePhaseList.DEFAULT_AA_PHASE);
@@ -205,22 +205,18 @@ public class UnitAbilityFactory {
     return battlePhase.addAbilityOrMergeAttached(player, combatUnitAbility);
   }
 
-  private static Collection<BattleState.Side> getCommitSuicideOnHitSides(final UnitType unitType) {
-    return UnitAttachment.get(unitType).getIsSuicideOnHit()
-        ? List.of(BattleState.Side.OFFENSE, BattleState.Side.DEFENSE)
-        : List.of();
-  }
-
-  private static Collection<BattleState.Side> getCommitSuicideSides(final UnitType unitType) {
-    final Collection<BattleState.Side> commitSuicideSides = new ArrayList<>();
+  private static CombatUnitAbility.Suicide calculateSuicideType(
+      final UnitType unitType, final BattleState.Side side) {
     final UnitAttachment unitAttachment = UnitAttachment.get(unitType);
-    if (unitAttachment.getIsSuicideOnAttack()) {
-      commitSuicideSides.add(BattleState.Side.OFFENSE);
+    if (side == BattleState.Side.OFFENSE
+        ? unitAttachment.getIsSuicideOnAttack()
+        : unitAttachment.getIsSuicideOnDefense()) {
+      return CombatUnitAbility.Suicide.ALWAYS;
+    } else if (unitAttachment.getIsSuicideOnHit()) {
+      return CombatUnitAbility.Suicide.ONLY_ON_HIT;
+    } else {
+      return CombatUnitAbility.Suicide.NONE;
     }
-    if (unitAttachment.getIsSuicideOnDefense()) {
-      commitSuicideSides.add(BattleState.Side.DEFENSE);
-    }
-    return commitSuicideSides;
   }
 
   private static ConvertUnitAbility createWillNotFireIfPresentAbilities(
@@ -288,8 +284,8 @@ public class UnitAbilityFactory {
                 .sides(sides)
                 .targets(getTargetsWithDestroyer(parameters.unitTypeList, unitType))
                 .returnFire(!isFirstStrike)
-                .commitSuicideAfterSuccessfulHit(getCommitSuicideOnHitSides(unitType))
-                .commitSuicide(getCommitSuicideSides(unitType))
+                .suicideOnOffense(calculateSuicideType(unitType, BattleState.Side.OFFENSE))
+                .suicideOnDefense(calculateSuicideType(unitType, BattleState.Side.DEFENSE))
                 .build(),
             player,
             isFirstStrike
@@ -311,8 +307,8 @@ public class UnitAbilityFactory {
                   .sides(sides)
                   .targets(getTargetsWithoutDestroyer(parameters, unitType))
                   .returnFire(!isFirstStrike)
-                  .commitSuicideAfterSuccessfulHit(getCommitSuicideOnHitSides(unitType))
-                  .commitSuicide(getCommitSuicideSides(unitType))
+                  .suicideOnOffense(calculateSuicideType(unitType, BattleState.Side.OFFENSE))
+                  .suicideOnDefense(calculateSuicideType(unitType, BattleState.Side.DEFENSE))
                   .build(),
               player,
               isFirstStrike

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/UnitAbilityFactory.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/UnitAbilityFactory.java
@@ -228,7 +228,7 @@ public class UnitAbilityFactory {
     return ConvertUnitAbility.builder()
         .name(WILL_NOT_FIRE_AA_ABILITY_PREFIX + " " + ability.getName())
         .attachedUnitTypes(List.of(unitTypeThatPreventsFiring))
-        .factions(List.of(ConvertUnitAbility.Faction.ENEMY))
+        .teams(List.of(ConvertUnitAbility.Team.FOE))
         .from(ability)
         .build();
   }
@@ -324,7 +324,7 @@ public class UnitAbilityFactory {
           ConvertUnitAbility.builder()
               .name("allow " + unitType.getName() + " to hit more units")
               .attachedUnitTypes(getIsDestroyerUnitTypes(parameters.unitTypeList))
-              .factions(List.of(ConvertUnitAbility.Faction.ALLIED))
+              .teams(List.of(ConvertUnitAbility.Team.FRIENDLY))
               .from(abilityWithoutDestroyer)
               .to(ability)
               .build());
@@ -384,7 +384,7 @@ public class UnitAbilityFactory {
         ConvertUnitAbility.builder()
             .name("neutralize first strike ability")
             .attachedUnitTypes(getIsDestroyerUnitTypes(parameters.unitTypeList))
-            .factions(List.of(ConvertUnitAbility.Faction.ENEMY))
+            .teams(List.of(ConvertUnitAbility.Team.FOE))
             .from(unitAbility)
             .to(unitAbilityWithReturnFire)
             .build());

--- a/game-core/src/main/java/games/strategy/engine/data/unit/ability/UnitAbilityFactory.java
+++ b/game-core/src/main/java/games/strategy/engine/data/unit/ability/UnitAbilityFactory.java
@@ -171,7 +171,7 @@ public class UnitAbilityFactory {
             CombatUnitAbility.builder()
                 .name(unitAttachment.getTypeAa())
                 .attachedUnitTypes(List.of(unitType))
-                .diceType(CombatUnitAbility.DiceType.AA)
+                .combatValueType(CombatUnitAbility.CombatValueType.AA)
                 .sides(sides)
                 .round(
                     unitAttachment.getMaxRoundsAa() == -1
@@ -280,7 +280,7 @@ public class UnitAbilityFactory {
             CombatUnitAbility.builder()
                 .name((isFirstStrike ? FIRST_STRIKE_UNITS : UNITS))
                 .attachedUnitTypes(needsDestroyerToTarget ? List.of() : List.of(unitType))
-                .diceType(CombatUnitAbility.DiceType.NORMAL)
+                .combatValueType(CombatUnitAbility.CombatValueType.NORMAL)
                 .sides(sides)
                 .targets(getTargetsWithDestroyer(parameters.unitTypeList, unitType))
                 .returnFire(!isFirstStrike)
@@ -303,7 +303,7 @@ public class UnitAbilityFactory {
               CombatUnitAbility.builder()
                   .name((isFirstStrike ? FIRST_STRIKE_UNITS : UNITS) + " without destroyer")
                   .attachedUnitTypes(List.of(unitType))
-                  .diceType(CombatUnitAbility.DiceType.NORMAL)
+                  .combatValueType(CombatUnitAbility.CombatValueType.NORMAL)
                   .sides(sides)
                   .targets(getTargetsWithoutDestroyer(parameters, unitType))
                   .returnFire(!isFirstStrike)
@@ -409,7 +409,7 @@ public class UnitAbilityFactory {
                     CombatUnitAbility.builder()
                         .name(NAVAL_BOMBARD)
                         .attachedUnitTypes(getCanBombardUnitTypes(parameters.unitTypeList, player))
-                        .diceType(CombatUnitAbility.DiceType.BOMBARD)
+                        .combatValueType(CombatUnitAbility.CombatValueType.BOMBARD)
                         .round(1)
                         .returnFire(
                             Properties.getNavalBombardCasualtiesReturnFire(parameters.properties))

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -662,7 +662,8 @@ public class UnitAttachment extends DefaultAttachment {
     setIsSub(getBool(s));
   }
 
-  private void setIsSub(final Boolean s) {
+  @VisibleForTesting
+  public void setIsSub(final Boolean s) {
     isSub = true;
     if (s) {
       canNotTarget = null;
@@ -760,7 +761,8 @@ public class UnitAttachment extends DefaultAttachment {
     }
   }
 
-  private void setCanNotBeTargetedBy(final Set<UnitType> value) {
+  @VisibleForTesting
+  public void setCanNotBeTargetedBy(final Set<UnitType> value) {
     canNotBeTargetedBy = value;
   }
 
@@ -816,7 +818,8 @@ public class UnitAttachment extends DefaultAttachment {
     isDestroyer = getBool(s);
   }
 
-  private void setIsDestroyer(final Boolean s) {
+  @VisibleForTesting
+  public void setIsDestroyer(final Boolean s) {
     isDestroyer = s;
   }
 
@@ -832,7 +835,8 @@ public class UnitAttachment extends DefaultAttachment {
     canBombard = getBool(s);
   }
 
-  private void setCanBombard(final Boolean s) {
+  @VisibleForTesting
+  public void setCanBombard(final Boolean s) {
     canBombard = s;
   }
 
@@ -2470,7 +2474,8 @@ public class UnitAttachment extends DefaultAttachment {
     isRocket = false;
   }
 
-  private void setTypeAa(final String s) {
+  @VisibleForTesting
+  public void setTypeAa(final String s) {
     typeAa = s;
   }
 
@@ -2545,7 +2550,8 @@ public class UnitAttachment extends DefaultAttachment {
     }
   }
 
-  private void setWillNotFireIfPresent(final Set<UnitType> value) {
+  @VisibleForTesting
+  public void setWillNotFireIfPresent(final Set<UnitType> value) {
     willNotFireIfPresent = value;
   }
 

--- a/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -682,7 +682,8 @@ public class UnitAttachment extends DefaultAttachment {
     return canEvade || isSub;
   }
 
-  private void setIsFirstStrike(final Boolean s) {
+  @VisibleForTesting
+  public void setIsFirstStrike(final Boolean s) {
     isFirstStrike = s;
   }
 
@@ -1854,7 +1855,8 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   @Deprecated
-  private void setIsSuicide(final Boolean s) {
+  @VisibleForTesting
+  public void setIsSuicide(final Boolean s) {
     isSuicide = true;
     if (s) {
       canNotTarget = null;
@@ -1868,7 +1870,8 @@ public class UnitAttachment extends DefaultAttachment {
     return isSuicide || isSuicideOnAttack || isSuicideOnDefense;
   }
 
-  private void setIsSuicideOnAttack(final Boolean s) {
+  @VisibleForTesting
+  public void setIsSuicideOnAttack(final Boolean s) {
     isSuicideOnAttack = s;
   }
 
@@ -1876,7 +1879,8 @@ public class UnitAttachment extends DefaultAttachment {
     return isSuicideOnAttack || isSuicide;
   }
 
-  private void setIsSuicideOnDefense(final Boolean s) {
+  @VisibleForTesting
+  public void setIsSuicideOnDefense(final Boolean s) {
     isSuicideOnDefense = s;
   }
 

--- a/game-core/src/test/java/games/strategy/engine/data/unit/ability/UnitAbilityFactoryTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/unit/ability/UnitAbilityFactoryTest.java
@@ -1,0 +1,1312 @@
+package games.strategy.engine.data.unit.ability;
+
+import static games.strategy.triplea.Constants.DEFENDING_SUBS_SNEAK_ATTACK;
+import static games.strategy.triplea.Constants.NAVAL_BOMBARD_CASUALTIES_RETURN_FIRE;
+import static games.strategy.triplea.Constants.UNIT_ATTACHMENT_NAME;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+import static org.mockito.Mockito.mock;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.PlayerList;
+import games.strategy.engine.data.UnitType;
+import games.strategy.engine.data.UnitTypeList;
+import games.strategy.engine.data.battle.phase.BattlePhaseList;
+import games.strategy.engine.data.properties.GameProperties;
+import games.strategy.triplea.attachments.UnitAttachment;
+import games.strategy.triplea.delegate.battle.BattleState;
+import games.strategy.triplea.delegate.battle.steps.MockGameData;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class UnitAbilityFactoryTest {
+
+  private GameData gameData;
+  private PlayerList playerList;
+  private GamePlayer player;
+  private UnitTypeList unitTypeList;
+  private UnitType unitType;
+  private UnitAttachment unitAttachment;
+  private BattlePhaseList battlePhaseList;
+
+  @BeforeEach
+  void setup() {
+    gameData = MockGameData.givenGameData().withDiceSides(6).build();
+
+    playerList = new PlayerList(gameData);
+    player = new GamePlayer("player", gameData);
+    playerList.addPlayerId(new GamePlayer("player", gameData));
+
+    unitType = new UnitType("basic", gameData);
+    unitAttachment = new UnitAttachment("basic", unitType, gameData);
+    unitType.addAttachment(UNIT_ATTACHMENT_NAME, unitAttachment);
+
+    unitTypeList = new UnitTypeList(gameData);
+    unitTypeList.addUnitType(unitType);
+
+    battlePhaseList = new BattlePhaseList();
+  }
+
+  @Test
+  void unitWithNoAbilities() {
+
+    UnitAbilityFactory.generate(
+        playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+    assertThat(
+        "Unit has no AA abilities", getAbilities(BattlePhaseList.DEFAULT_AA_PHASE), is(empty()));
+    assertThat(
+        "Unit has no Bombard abilities",
+        getAbilities(BattlePhaseList.DEFAULT_BOMBARD_PHASE),
+        is(empty()));
+    assertThat(
+        "Unit has no First Strike abilities",
+        getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE),
+        is(empty()));
+    assertThat(
+        "Unit has no general fight abilities",
+        getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
+        is(empty()));
+  }
+
+  private Collection<CombatUnitAbility> getAbilities(final String phaseName) {
+    return battlePhaseList.getPhase(phaseName).get().getAbilities(player);
+  }
+
+  @Nested
+  class Normal {
+
+    @Nested
+    class NonFirstStrike {
+
+      @Test
+      void unitWithOnlyNormalOffenseAbilities() {
+        unitAttachment.setAttack(1);
+
+        UnitAbilityFactory.generate(
+            playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+        assertThat(
+            "Unit has no AA abilities",
+            getAbilities(BattlePhaseList.DEFAULT_AA_PHASE),
+            is(empty()));
+        assertThat(
+            "Unit has no Bombard abilities",
+            getAbilities(BattlePhaseList.DEFAULT_BOMBARD_PHASE),
+            is(empty()));
+        assertThat(
+            "Unit has no First Strike abilities",
+            getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE),
+            is(empty()));
+        assertThat(
+            "Unit has attack abilities",
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
+            hasSize(1));
+
+        final CombatUnitAbility unitAbility =
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE).iterator().next();
+        assertThat(
+            "unitAbility is attached to the unit type",
+            unitAbility.getAttachedUnitTypes(),
+            is(List.of(unitType)));
+        assertThat(
+            "unitAbility is only for attacking",
+            unitAbility.getSides(),
+            is(List.of(BattleState.Side.OFFENSE)));
+      }
+
+      @Test
+      void unitWithOnlyNormalDefenseAbilities() {
+        unitAttachment.setDefense(1);
+
+        UnitAbilityFactory.generate(
+            playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+        assertThat(
+            "Unit has no AA abilities",
+            getAbilities(BattlePhaseList.DEFAULT_AA_PHASE),
+            is(empty()));
+        assertThat(
+            "Unit has no Bombard abilities",
+            getAbilities(BattlePhaseList.DEFAULT_BOMBARD_PHASE),
+            is(empty()));
+        assertThat(
+            "Unit has no First Strike abilities",
+            getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE),
+            is(empty()));
+        assertThat(
+            "Unit has defense abilities",
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
+            hasSize(1));
+
+        final CombatUnitAbility unitAbility =
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE).iterator().next();
+        assertThat(
+            "unitAbility is attached to the unit type",
+            unitAbility.getAttachedUnitTypes(),
+            is(List.of(unitType)));
+        assertThat(
+            "unitAbility is only for defending",
+            unitAbility.getSides(),
+            is(List.of(BattleState.Side.DEFENSE)));
+      }
+
+      @Test
+      void twoUnitTypesWithSamePropertiesHaveCommonAbility() {
+        unitAttachment.setAttack(1);
+
+        final UnitType otherUnitType = new UnitType("other", gameData);
+        final UnitAttachment otherUnitAttachment =
+            new UnitAttachment("other", otherUnitType, gameData);
+        otherUnitType.addAttachment(UNIT_ATTACHMENT_NAME, otherUnitAttachment);
+        otherUnitAttachment.setAttack(1);
+        unitTypeList.addUnitType(otherUnitType);
+
+        UnitAbilityFactory.generate(
+            playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+        assertThat(
+            "Both unitTypes should have the same ability",
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
+            hasSize(1));
+
+        final CombatUnitAbility unitAbility =
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE).iterator().next();
+        assertThat(
+            "unitAbility is attached to both of the unit types",
+            unitAbility.getAttachedUnitTypes(),
+            is(List.of(unitType, otherUnitType)));
+      }
+
+      @Test
+      void unitTargetsAllButInfrastructure() {
+        unitAttachment.setAttack(1);
+        unitAttachment.setDefense(1);
+
+        final UnitType infrastructureUnitType = new UnitType("infrastructure", gameData);
+        final UnitAttachment infrastructureUnitAttachment =
+            new UnitAttachment("infrastructure", infrastructureUnitType, gameData);
+        infrastructureUnitType.addAttachment(UNIT_ATTACHMENT_NAME, infrastructureUnitAttachment);
+        infrastructureUnitAttachment.setIsInfrastructure(true);
+        unitTypeList.addUnitType(infrastructureUnitType);
+
+        final UnitType otherUnitType = new UnitType("other", gameData);
+        final UnitAttachment otherUnitAttachment =
+            new UnitAttachment("other", otherUnitType, gameData);
+        otherUnitType.addAttachment(UNIT_ATTACHMENT_NAME, otherUnitAttachment);
+        unitTypeList.addUnitType(otherUnitType);
+
+        UnitAbilityFactory.generate(
+            playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+        final CombatUnitAbility unitAbility =
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE).iterator().next();
+        assertThat(
+            "All non infrastructure unit types, including itself, are possible targets",
+            unitAbility.getTargets(),
+            is(List.of(unitType, otherUnitType)));
+      }
+
+      @Test
+      void unitCanNotTarget() {
+        unitAttachment.setAttack(1);
+        unitAttachment.setDefense(1);
+
+        final UnitType canNotTargetUnitType = new UnitType("canNotTarget", gameData);
+        final UnitAttachment canNotTargetUnitAttachment =
+            new UnitAttachment("canNotTarget", canNotTargetUnitType, gameData);
+        canNotTargetUnitType.addAttachment(UNIT_ATTACHMENT_NAME, canNotTargetUnitAttachment);
+        unitTypeList.addUnitType(canNotTargetUnitType);
+
+        unitAttachment.setCanNotTarget(Set.of(canNotTargetUnitType));
+
+        final UnitType otherUnitType = new UnitType("other", gameData);
+        final UnitAttachment otherUnitAttachment =
+            new UnitAttachment("other", otherUnitType, gameData);
+        otherUnitType.addAttachment(UNIT_ATTACHMENT_NAME, otherUnitAttachment);
+        unitTypeList.addUnitType(otherUnitType);
+
+        UnitAbilityFactory.generate(
+            playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+        final CombatUnitAbility unitAbility =
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE).iterator().next();
+        assertThat(
+            "The canNotTargetUnitType is listed in the units canNotTarget property so it should "
+                + "not be in the target list",
+            unitAbility.getTargets(),
+            is(List.of(unitType, otherUnitType)));
+      }
+
+      @Test
+      void twoUnitTypesWithSameCanNotTargetHaveCommonAbility() {
+        final UnitType canNotTarget1 = new UnitType("canNotTarget1", gameData);
+        final UnitAttachment canNotTarget1Attachment =
+            new UnitAttachment("canNotTarget1", canNotTarget1, gameData);
+        canNotTarget1.addAttachment(UNIT_ATTACHMENT_NAME, canNotTarget1Attachment);
+        unitTypeList.addUnitType(canNotTarget1);
+
+        unitAttachment.setAttack(1);
+        unitAttachment.setCanNotTarget(Set.of(canNotTarget1));
+
+        final UnitType otherUnitType = new UnitType("other", gameData);
+        final UnitAttachment otherUnitAttachment =
+            new UnitAttachment("other", otherUnitType, gameData);
+        otherUnitType.addAttachment(UNIT_ATTACHMENT_NAME, otherUnitAttachment);
+        otherUnitAttachment.setAttack(1);
+        otherUnitAttachment.setCanNotTarget(Set.of(canNotTarget1));
+        unitTypeList.addUnitType(otherUnitType);
+
+        UnitAbilityFactory.generate(
+            playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+        assertThat(
+            "Both unitTypes have the same ability",
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
+            hasSize(1));
+
+        final CombatUnitAbility unitAbility =
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE).iterator().next();
+        assertThat(
+            "The ability should be attached to both unit types",
+            unitAbility.getAttachedUnitTypes(),
+            is(List.of(unitType, otherUnitType)));
+      }
+
+      @Test
+      void suicideOnHitUnitsDoNotCombineAbilities() {
+        unitAttachment.setAttack(1);
+        unitAttachment.setIsSuicideOnHit(true);
+
+        final UnitType otherSuicideUnitType = new UnitType("otherSuicide", gameData);
+        final UnitAttachment otherSuicideUnitAttachment =
+            new UnitAttachment("otherSuicide", otherSuicideUnitType, gameData);
+        otherSuicideUnitType.addAttachment(UNIT_ATTACHMENT_NAME, otherSuicideUnitAttachment);
+        otherSuicideUnitAttachment.setAttack(1);
+        otherSuicideUnitAttachment.setIsSuicideOnHit(true);
+        unitTypeList.addUnitType(otherSuicideUnitType);
+
+        UnitAbilityFactory.generate(
+            playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+        assertThat(
+            "Even though both unitTypes have the same properties, they have their own ability "
+                + "because they are suicideOnHit",
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
+            hasSize(2));
+
+        assertThat(
+            "Both unit abilities should have only 1 attached unit type",
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE).stream()
+                .filter(combatUnitAbility -> combatUnitAbility.getAttachedUnitTypes().size() == 1)
+                .collect(Collectors.toList()),
+            hasSize(2));
+
+        assertThat(
+            "One unit ability should be attached to unitType",
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE).stream()
+                .filter(
+                    combatUnitAbility ->
+                        combatUnitAbility.getAttachedUnitTypes().contains(unitType))
+                .collect(Collectors.toList()),
+            hasSize(1));
+
+        assertThat(
+            "One unit ability should be attached to otherSuicideUnitType",
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE).stream()
+                .filter(
+                    combatUnitAbility ->
+                        combatUnitAbility.getAttachedUnitTypes().contains(otherSuicideUnitType))
+                .collect(Collectors.toList()),
+            hasSize(1));
+      }
+
+      @Test
+      void twoUnitTypesWithDifferentCanNotTargetGetDifferentAbilities() {
+        final UnitType canNotTarget1 = new UnitType("canNotTarget1", gameData);
+        final UnitAttachment canNotTarget1Attachment =
+            new UnitAttachment("canNotTarget1", canNotTarget1, gameData);
+        canNotTarget1.addAttachment(UNIT_ATTACHMENT_NAME, canNotTarget1Attachment);
+        unitTypeList.addUnitType(canNotTarget1);
+
+        final UnitType canNotTarget2 = new UnitType("canNotTarget2", gameData);
+        final UnitAttachment canNotTarget2Attachment =
+            new UnitAttachment("canNotTarget2", canNotTarget2, gameData);
+        canNotTarget2.addAttachment(UNIT_ATTACHMENT_NAME, canNotTarget2Attachment);
+        unitTypeList.addUnitType(canNotTarget2);
+
+        unitAttachment.setAttack(1);
+        unitAttachment.setCanNotTarget(Set.of(canNotTarget1));
+
+        final UnitType otherUnitType = new UnitType("other", gameData);
+        final UnitAttachment otherUnitAttachment =
+            new UnitAttachment("other", otherUnitType, gameData);
+        otherUnitType.addAttachment(UNIT_ATTACHMENT_NAME, otherUnitAttachment);
+        otherUnitAttachment.setAttack(1);
+        otherUnitAttachment.setCanNotTarget(Set.of(canNotTarget2));
+        unitTypeList.addUnitType(otherUnitType);
+
+        UnitAbilityFactory.generate(
+            playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+        assertThat(
+            "Both unitTypes should have their own ability",
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
+            hasSize(2));
+
+        assertThat(
+            "Both unit abilities should have only 1 attached unit type",
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE).stream()
+                .filter(combatUnitAbility -> combatUnitAbility.getAttachedUnitTypes().size() == 1)
+                .collect(Collectors.toList()),
+            hasSize(2));
+
+        assertThat(
+            "One unit ability should be attached to unitType",
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE).stream()
+                .filter(
+                    combatUnitAbility ->
+                        combatUnitAbility.getAttachedUnitTypes().contains(unitType))
+                .collect(Collectors.toList()),
+            hasSize(1));
+
+        assertThat(
+            "One unit ability should be attached to otherUnitType",
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE).stream()
+                .filter(
+                    combatUnitAbility ->
+                        combatUnitAbility.getAttachedUnitTypes().contains(otherUnitType))
+                .collect(Collectors.toList()),
+            hasSize(1));
+      }
+
+      @Test
+      void unitIsListedInCanNotBeTargetedBy() {
+        unitAttachment.setAttack(1);
+        unitAttachment.setDefense(1);
+
+        final UnitType canNotTargetUnitType = new UnitType("canNotTarget", gameData);
+        final UnitAttachment canNotTargetUnitAttachment =
+            new UnitAttachment("canNotTarget", canNotTargetUnitType, gameData);
+        canNotTargetUnitType.addAttachment(UNIT_ATTACHMENT_NAME, canNotTargetUnitAttachment);
+        canNotTargetUnitAttachment.setCanNotBeTargetedBy(Set.of(unitType));
+        unitTypeList.addUnitType(canNotTargetUnitType);
+
+        final UnitType destroyerUnitType = new UnitType("destroyer", gameData);
+        final UnitAttachment destroyerUnitAttachment =
+            new UnitAttachment("destroyer", destroyerUnitType, gameData);
+        destroyerUnitType.addAttachment(UNIT_ATTACHMENT_NAME, destroyerUnitAttachment);
+        destroyerUnitAttachment.setIsDestroyer(true);
+        unitTypeList.addUnitType(destroyerUnitType);
+
+        UnitAbilityFactory.generate(
+            playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+        assertThat(
+            "Unit has an ability without a destroyer present and another ability with the "
+                + "destroyer present to allow it to hit the canNotTargetUnitType",
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
+            hasSize(2));
+
+        assertThat(
+            "Destroyer has convertUnitType",
+            battlePhaseList.getConvertAbilities().get(player),
+            hasSize(1));
+
+        final ConvertUnitAbility convertUnitAbility =
+            battlePhaseList.getConvertAbilities().get(player).iterator().next();
+
+        assertThat(
+            "Both of the abilities in the convertUnitAbility should be in the general phase",
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
+            hasItems(convertUnitAbility.getFrom(), convertUnitAbility.getTo()));
+
+        final CombatUnitAbility initialAbility = convertUnitAbility.getFrom();
+
+        assertThat(
+            "The initial ability should be attached to the unit type",
+            initialAbility.getAttachedUnitTypes(),
+            is(List.of(unitType)));
+        assertThat(
+            "The initial ability doesn't allow targeting the canNotTargetUnitType",
+            initialAbility.getTargets(),
+            is(List.of(unitType, destroyerUnitType)));
+
+        final CombatUnitAbility finalAbility = convertUnitAbility.getTo();
+        assertThat(
+            "The final ability is not initially attached to the unit type",
+            finalAbility.getAttachedUnitTypes(),
+            is(empty()));
+        assertThat(
+            "The final ability does allow targeting the canNotTargetUnitType",
+            finalAbility.getTargets(),
+            is(List.of(unitType, canNotTargetUnitType, destroyerUnitType)));
+      }
+
+      @Test
+      void unitIsListedInCanNotBeTargetedByAndHasCanNotTarget() {
+        unitAttachment.setAttack(1);
+        unitAttachment.setDefense(1);
+
+        final UnitType canNotTargetUnitType = new UnitType("canNotTarget", gameData);
+        final UnitAttachment canNotTargetUnitAttachment =
+            new UnitAttachment("canNotTarget", canNotTargetUnitType, gameData);
+        canNotTargetUnitType.addAttachment(UNIT_ATTACHMENT_NAME, canNotTargetUnitAttachment);
+        canNotTargetUnitAttachment.setCanNotBeTargetedBy(Set.of(unitType));
+        unitTypeList.addUnitType(canNotTargetUnitType);
+
+        final UnitType destroyerUnitType = new UnitType("destroyer", gameData);
+        final UnitAttachment destroyerUnitAttachment =
+            new UnitAttachment("destroyer", destroyerUnitType, gameData);
+        destroyerUnitType.addAttachment(UNIT_ATTACHMENT_NAME, destroyerUnitAttachment);
+        destroyerUnitAttachment.setIsDestroyer(true);
+        unitTypeList.addUnitType(destroyerUnitType);
+        unitAttachment.setCanNotTarget(Set.of(destroyerUnitType));
+
+        UnitAbilityFactory.generate(
+            playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+        final ConvertUnitAbility convertUnitAbility =
+            battlePhaseList.getConvertAbilities().get(player).iterator().next();
+
+        final CombatUnitAbility initialAbility = convertUnitAbility.getFrom();
+
+        assertThat(
+            "The initial ability doesn't allow targeting the canNotTargetUnitType and the "
+                + "destroyerUnitType",
+            initialAbility.getTargets(),
+            is(List.of(unitType)));
+
+        final CombatUnitAbility finalAbility = convertUnitAbility.getTo();
+        assertThat(
+            "The final ability does allow targeting the canNotTargetUnitType but the "
+                + "destroyerUnitType is still not allowed",
+            finalAbility.getTargets(),
+            is(List.of(unitType, canNotTargetUnitType)));
+      }
+    }
+
+    @Nested
+    class FirstStrike {
+
+      @Test
+      void unitWithIsSub() {
+        unitAttachment.setIsSub(true);
+        unitAttachment.setAttack(1);
+        unitAttachment.setDefense(1);
+
+        final GameProperties properties = new GameProperties(gameData);
+        properties.set(DEFENDING_SUBS_SNEAK_ATTACK, true);
+
+        UnitAbilityFactory.generate(playerList, unitTypeList, battlePhaseList, properties);
+
+        assertThat(
+            "Unit has no AA abilities",
+            getAbilities(BattlePhaseList.DEFAULT_AA_PHASE),
+            is(empty()));
+        assertThat(
+            "Unit has no Bombard abilities",
+            getAbilities(BattlePhaseList.DEFAULT_BOMBARD_PHASE),
+            is(empty()));
+        assertThat(
+            "Unit has First Strike abilities",
+            getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE),
+            hasSize(1));
+        assertThat(
+            "Unit has no General abilities",
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
+            is(empty()));
+      }
+
+      @Test
+      void unitWithIsSubWithDefendingSubsSneakAttackTrue() {
+        unitAttachment.setIsSub(true);
+        unitAttachment.setAttack(1);
+        unitAttachment.setDefense(1);
+
+        final GameProperties properties = new GameProperties(gameData);
+        properties.set(DEFENDING_SUBS_SNEAK_ATTACK, true);
+
+        UnitAbilityFactory.generate(playerList, unitTypeList, battlePhaseList, properties);
+
+        assertThat(
+            "Unit has First Strike abilities",
+            getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE),
+            hasSize(1));
+
+        final CombatUnitAbility unitAbility =
+            getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE).iterator().next();
+        assertThat("isSub doesn't allow return fire", unitAbility.isReturnFire(), is(false));
+        assertThat(
+            "isSub's ability is on both sides because DEFENDING_SUBS_SNEAK_ATTACK is true",
+            unitAbility.getSides(),
+            is(List.of(BattleState.Side.OFFENSE, BattleState.Side.DEFENSE)));
+        assertThat(
+            "isSub's ability is attached to it",
+            unitAbility.getAttachedUnitTypes(),
+            is(List.of(unitType)));
+      }
+
+      @Test
+      void unitWithIsSubWithDefendingSubsSneakAttackFalse() {
+        unitAttachment.setIsSub(true);
+        unitAttachment.setAttack(1);
+        unitAttachment.setDefense(1);
+
+        final GameProperties properties = new GameProperties(gameData);
+        properties.set(DEFENDING_SUBS_SNEAK_ATTACK, false);
+
+        UnitAbilityFactory.generate(playerList, unitTypeList, battlePhaseList, properties);
+
+        assertThat(
+            "Unit has First Strike abilities on offense",
+            getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE),
+            hasSize(1));
+
+        assertThat(
+            "Unit has General abilities on defense",
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
+            hasSize(1));
+
+        final CombatUnitAbility offenseUnitAbility =
+            getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE).iterator().next();
+        assertThat(
+            "isSub's first strike ability doesn't allow return fire",
+            offenseUnitAbility.isReturnFire(),
+            is(false));
+        assertThat(
+            "isSub's first strike ability is only on offense side because "
+                + "DEFENDING_SUBS_SNEAK_ATTACK is false",
+            offenseUnitAbility.getSides(),
+            is(List.of(BattleState.Side.OFFENSE)));
+        assertThat(
+            "isSub's first strike ability is attached to it",
+            offenseUnitAbility.getAttachedUnitTypes(),
+            is(List.of(unitType)));
+
+        final CombatUnitAbility defenseUnitAbility =
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE).iterator().next();
+        assertThat(
+            "isSub's general ability does allow return fire",
+            defenseUnitAbility.isReturnFire(),
+            is(true));
+        assertThat(
+            "isSub's general ability is only on defense sides",
+            defenseUnitAbility.getSides(),
+            is(List.of(BattleState.Side.DEFENSE)));
+        assertThat(
+            "isSub's general ability is attached to it",
+            defenseUnitAbility.getAttachedUnitTypes(),
+            is(List.of(unitType)));
+      }
+
+      @Test
+      void unitWithIsSubButIsDestroyerMissing() {
+        unitAttachment.setIsSub(true);
+        unitAttachment.setAttack(1);
+        unitAttachment.setDefense(1);
+
+        final GameProperties properties = new GameProperties(gameData);
+        properties.set(DEFENDING_SUBS_SNEAK_ATTACK, true);
+
+        UnitAbilityFactory.generate(playerList, unitTypeList, battlePhaseList, properties);
+
+        assertThat(
+            "Unit has First Strike abilities",
+            getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE),
+            hasSize(1));
+        assertThat(
+            "Unit has no General abilities because isDestroyer is not present",
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
+            is(empty()));
+
+        final CombatUnitAbility unitAbility =
+            getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE).iterator().next();
+        assertThat("isSub doesn't allow return fire", unitAbility.isReturnFire(), is(false));
+        assertThat(
+            "isSub's ability is on both sides because DEFENDING_SUBS_SNEAK_ATTACK is true",
+            unitAbility.getSides(),
+            is(List.of(BattleState.Side.OFFENSE, BattleState.Side.DEFENSE)));
+
+        assertThat(
+            "isSub triggers isFirstStrike which generally needs a convert ability but there "
+                + "isn't an isDestroyer unit type so the convert ability is not created.",
+            battlePhaseList.getConvertAbilities().get(player),
+            is(nullValue()));
+      }
+
+      @Test
+      void unitWithIsSubAndIsDestroyerExists() {
+        unitAttachment.setIsSub(true);
+        unitAttachment.setAttack(1);
+        unitAttachment.setDefense(1);
+
+        final UnitType destroyerUnitType = new UnitType("destroyer", gameData);
+        final UnitAttachment destroyerUnitAttachment =
+            new UnitAttachment("destroyer", destroyerUnitType, gameData);
+        destroyerUnitType.addAttachment(UNIT_ATTACHMENT_NAME, destroyerUnitAttachment);
+        destroyerUnitAttachment.setIsDestroyer(true);
+        unitTypeList.addUnitType(destroyerUnitType);
+
+        final GameProperties properties = new GameProperties(gameData);
+        properties.set(DEFENDING_SUBS_SNEAK_ATTACK, true);
+
+        UnitAbilityFactory.generate(playerList, unitTypeList, battlePhaseList, properties);
+
+        assertThat(
+            "Unit has First Strike abilities",
+            getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE),
+            hasSize(1));
+        assertThat(
+            "Unit has General abilities because the isDestroyer can convert its first strike "
+                + "unitAbility",
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
+            hasSize(1));
+
+        final CombatUnitAbility firstStrikeAbility =
+            getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE).iterator().next();
+        final CombatUnitAbility generalAbility =
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE).iterator().next();
+        assertThat(
+            "The first strike ability is attached to the isSub",
+            firstStrikeAbility.getAttachedUnitTypes(),
+            is(List.of(unitType)));
+        assertThat(
+            "The general ability is not attached to anything yet since it is attached when "
+                + "the convert ability runs during the battle.",
+            generalAbility.getAttachedUnitTypes(),
+            is(empty()));
+
+        assertThat(
+            "A convert ability needs to exist to convert the first strike to general",
+            battlePhaseList.getConvertAbilities().get(player),
+            hasSize(1));
+        final ConvertUnitAbility convertUnitAbility =
+            battlePhaseList.getConvertAbilities().get(player).iterator().next();
+        assertThat(convertUnitAbility.getFrom(), is(firstStrikeAbility));
+        assertThat(convertUnitAbility.getTo(), is(generalAbility));
+      }
+
+      @Test
+      void unitIsSubAndIsListedInCanNotBeTargetedBy() {
+        unitAttachment.setAttack(1);
+        unitAttachment.setDefense(1);
+        unitAttachment.setIsSub(true);
+
+        final UnitType canNotTargetUnitType = new UnitType("canNotTarget", gameData);
+        final UnitAttachment canNotTargetUnitAttachment =
+            new UnitAttachment("canNotTarget", canNotTargetUnitType, gameData);
+        canNotTargetUnitType.addAttachment(UNIT_ATTACHMENT_NAME, canNotTargetUnitAttachment);
+        canNotTargetUnitAttachment.setCanNotBeTargetedBy(Set.of(unitType));
+        unitTypeList.addUnitType(canNotTargetUnitType);
+
+        final UnitType destroyerUnitType = new UnitType("destroyer", gameData);
+        final UnitAttachment destroyerUnitAttachment =
+            new UnitAttachment("destroyer", destroyerUnitType, gameData);
+        destroyerUnitType.addAttachment(UNIT_ATTACHMENT_NAME, destroyerUnitAttachment);
+        destroyerUnitAttachment.setIsDestroyer(true);
+        unitTypeList.addUnitType(destroyerUnitType);
+
+        final GameProperties properties = new GameProperties(gameData);
+        properties.set(DEFENDING_SUBS_SNEAK_ATTACK, true);
+
+        UnitAbilityFactory.generate(playerList, unitTypeList, battlePhaseList, properties);
+
+        assertThat(
+            "Unit has a first strike ability without a friendly destroyer present and another "
+                + "ability with a friendly destroyer present to allow it to hit the "
+                + "canNotTargetUnitType",
+            getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE),
+            hasSize(2));
+
+        assertThat(
+            "When an enemy destroyer is present, the unit has a general ability without a "
+                + "friendly destroyer present and another ability with a friendly destroyer "
+                + "present to allow it to hit the canNotTargetUnitType",
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
+            hasSize(2));
+
+        assertThat(
+            "Friendly destroyer has a convert ability to allow the sub to hit the canNotTarget "
+                + "unit. Enemy destroyers have two convert abilities to negate the sub in either "
+                + "case",
+            battlePhaseList.getConvertAbilities().get(player),
+            hasSize(3));
+
+        final ConvertUnitAbility friendlyConvertUnitAbility =
+            battlePhaseList.getConvertAbilities().get(player).stream()
+                .filter(
+                    unitAbility ->
+                        unitAbility.getFactions().contains(ConvertUnitAbility.Faction.ALLIED))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(
+            "Both of the abilities in the friendlyConvertUnitAbility should be in the first "
+                + "strike phase since the friendly isDestroyer doesn't negate the first strike",
+            getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE),
+            hasItems(friendlyConvertUnitAbility.getFrom(), friendlyConvertUnitAbility.getTo()));
+
+        final List<ConvertUnitAbility> enemyUnitAbilities =
+            battlePhaseList.getConvertAbilities().get(player).stream()
+                .filter(
+                    unitAbility ->
+                        unitAbility.getFactions().contains(ConvertUnitAbility.Faction.ENEMY))
+                .collect(Collectors.toList());
+
+        final ConvertUnitAbility enemyConvertUnitAbilityWhenFriendlyDestroyerPresent =
+            enemyUnitAbilities.stream()
+                .filter(
+                    unitAbility ->
+                        unitAbility.getFrom().getTargets().contains(canNotTargetUnitType))
+                .findFirst()
+                .orElseThrow();
+
+        final ConvertUnitAbility enemyConvertUnitAbilityWhenFriendlyDestroyerNotPresent =
+            enemyUnitAbilities.stream()
+                .filter(
+                    Predicate.not(
+                        unitAbility ->
+                            unitAbility.getFrom().getTargets().contains(canNotTargetUnitType)))
+                .findFirst()
+                .orElseThrow();
+
+        assertThat(
+            "The to unitAbilities in both of the convert are in the general phase",
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
+            hasItems(
+                enemyConvertUnitAbilityWhenFriendlyDestroyerNotPresent.getTo(),
+                enemyConvertUnitAbilityWhenFriendlyDestroyerPresent.getTo()));
+
+        assertThat(
+            "The from unitAbilities in both of the convert are in the first strike phase",
+            getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE),
+            hasItems(
+                enemyConvertUnitAbilityWhenFriendlyDestroyerNotPresent.getFrom(),
+                enemyConvertUnitAbilityWhenFriendlyDestroyerPresent.getFrom()));
+      }
+    }
+  }
+
+  @Nested
+  class Aa {
+
+    @Test
+    void unitWithOnlyAaOffenseAbilities() {
+      unitAttachment.setOffensiveAttackAa(1);
+      unitAttachment.setIsAaForCombatOnly(true);
+
+      UnitAbilityFactory.generate(
+          playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+      assertThat(
+          "Unit has offense AA abilities",
+          getAbilities(BattlePhaseList.DEFAULT_AA_PHASE),
+          hasSize(1));
+      assertThat(
+          "Unit has no Bombard abilities",
+          getAbilities(BattlePhaseList.DEFAULT_BOMBARD_PHASE),
+          is(empty()));
+      assertThat(
+          "Unit has no First Strike abilities",
+          getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE),
+          is(empty()));
+      assertThat(
+          "Unit has no General abilities",
+          getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
+          is(empty()));
+    }
+
+    @Test
+    void unitWithOnlyAaDefenseAbilities() {
+      unitAttachment.setAttackAa(1);
+      unitAttachment.setIsAaForCombatOnly(true);
+
+      UnitAbilityFactory.generate(
+          playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+      assertThat(
+          "Unit has defense AA abilities",
+          getAbilities(BattlePhaseList.DEFAULT_AA_PHASE),
+          hasSize(1));
+      assertThat(
+          "Unit has no Bombard abilities",
+          getAbilities(BattlePhaseList.DEFAULT_BOMBARD_PHASE),
+          is(empty()));
+      assertThat(
+          "Unit has no First Strike abilities",
+          getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE),
+          is(empty()));
+      assertThat(
+          "Unit has no General abilities",
+          getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
+          is(empty()));
+    }
+
+    @Test
+    void unitWithOnlyAaAbilitiesButNotForCombat() {
+      unitAttachment.setOffensiveAttackAa(1);
+      unitAttachment.setAttackAa(1);
+      unitAttachment.setIsAaForCombatOnly(false);
+
+      UnitAbilityFactory.generate(
+          playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+      assertThat(
+          "Unit has not for AA combat so has no AA abilities",
+          getAbilities(BattlePhaseList.DEFAULT_AA_PHASE),
+          is(empty()));
+      assertThat(
+          "Unit has no Bombard abilities",
+          getAbilities(BattlePhaseList.DEFAULT_BOMBARD_PHASE),
+          is(empty()));
+      assertThat(
+          "Unit has no First Strike abilities",
+          getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE),
+          is(empty()));
+      assertThat(
+          "Unit has no General abilities",
+          getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
+          is(empty()));
+    }
+
+    @Test
+    void unitWithOnlyAaOffenseAbilitiesButNoRolls() {
+      unitAttachment.setOffensiveAttackAa(1);
+      unitAttachment.setMaxAaAttacks(0);
+      unitAttachment.setIsAaForCombatOnly(true);
+
+      UnitAbilityFactory.generate(
+          playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+      assertThat(
+          "Unit has no AA rolls so doesn't have an AA ability",
+          getAbilities(BattlePhaseList.DEFAULT_AA_PHASE),
+          is(empty()));
+      assertThat(
+          "Unit has no Bombard abilities",
+          getAbilities(BattlePhaseList.DEFAULT_BOMBARD_PHASE),
+          is(empty()));
+      assertThat(
+          "Unit has no First Strike abilities",
+          getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE),
+          is(empty()));
+      assertThat(
+          "Unit has no General abilities",
+          getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
+          is(empty()));
+    }
+
+    @Test
+    void unitWithOnlyAaDefenseAbilitiesButNoRolls() {
+      unitAttachment.setAttackAa(1);
+      unitAttachment.setMaxAaAttacks(0);
+      unitAttachment.setIsAaForCombatOnly(true);
+
+      UnitAbilityFactory.generate(
+          playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+      assertThat(
+          "Unit has no AA rolls so doesn't have an AA ability",
+          getAbilities(BattlePhaseList.DEFAULT_AA_PHASE),
+          is(empty()));
+      assertThat(
+          "Unit has no Bombard abilities",
+          getAbilities(BattlePhaseList.DEFAULT_BOMBARD_PHASE),
+          is(empty()));
+      assertThat(
+          "Unit has no First Strike abilities",
+          getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE),
+          is(empty()));
+      assertThat(
+          "Unit has no General abilities",
+          getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
+          is(empty()));
+    }
+
+    @Test
+    void unitWithMaxRounds() {
+      unitAttachment.setAttackAa(1);
+      unitAttachment.setIsAaForCombatOnly(true);
+      unitAttachment.setMaxRoundsAa(10);
+
+      UnitAbilityFactory.generate(
+          playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+      final CombatUnitAbility ability =
+          getAbilities(BattlePhaseList.DEFAULT_AA_PHASE).iterator().next();
+      assertThat(ability.getRound(), is(10));
+    }
+
+    @Test
+    void unitTargetsAa() {
+      unitAttachment.setAttackAa(1);
+      unitAttachment.setIsAaForCombatOnly(true);
+      unitAttachment.setTargetsAa(Set.of(mock(UnitType.class), mock(UnitType.class)));
+
+      UnitAbilityFactory.generate(
+          playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+      final CombatUnitAbility ability =
+          getAbilities(BattlePhaseList.DEFAULT_AA_PHASE).iterator().next();
+      assertThat(ability.getTargets(), is(unitAttachment.getTargetsAa(unitTypeList)));
+    }
+
+    @Test
+    void twoUnitsWithSameTargetsAa() {
+      final Set<UnitType> targets = Set.of(mock(UnitType.class), mock(UnitType.class));
+      unitAttachment.setAttackAa(1);
+      unitAttachment.setIsAaForCombatOnly(true);
+      unitAttachment.setTargetsAa(targets);
+      unitAttachment.setTypeAa("test");
+
+      final UnitType otherUnitType = new UnitType("other", gameData);
+      final UnitAttachment otherUnitAttachment =
+          new UnitAttachment("other", otherUnitType, gameData);
+      otherUnitType.addAttachment(UNIT_ATTACHMENT_NAME, otherUnitAttachment);
+      otherUnitAttachment.setAttackAa(1);
+      otherUnitAttachment.setIsAaForCombatOnly(true);
+      otherUnitAttachment.setTargetsAa(targets);
+      otherUnitAttachment.setTypeAa("test");
+      unitTypeList.addUnitType(otherUnitType);
+
+      UnitAbilityFactory.generate(
+          playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+      assertThat(
+          "Only one ability should be created since both units have the same typeAa",
+          getAbilities(BattlePhaseList.DEFAULT_AA_PHASE),
+          hasSize(1));
+
+      final CombatUnitAbility ability =
+          getAbilities(BattlePhaseList.DEFAULT_AA_PHASE).iterator().next();
+      assertThat(
+          "Both of the unit types in the typeAa should be on this ability",
+          ability.getAttachedUnitTypes(),
+          is(List.of(unitType, otherUnitType)));
+    }
+
+    @Test
+    void twoUnitsWithSameTypeAaButDifferentTargetsAa() {
+      final String typeAa = "TypeAA";
+      final Set<UnitType> targets1 = Set.of(mock(UnitType.class), mock(UnitType.class));
+      unitAttachment.setAttackAa(1);
+      unitAttachment.setIsAaForCombatOnly(true);
+      unitAttachment.setTargetsAa(targets1);
+      unitAttachment.setTypeAa(typeAa);
+
+      final UnitType otherUnitType = new UnitType("other", gameData);
+      final UnitAttachment otherUnitAttachment =
+          new UnitAttachment("other", otherUnitType, gameData);
+      otherUnitType.addAttachment(UNIT_ATTACHMENT_NAME, otherUnitAttachment);
+      final Set<UnitType> targets2 = Set.of(mock(UnitType.class), mock(UnitType.class));
+      otherUnitAttachment.setAttackAa(1);
+      otherUnitAttachment.setIsAaForCombatOnly(true);
+      otherUnitAttachment.setTargetsAa(targets2);
+      otherUnitAttachment.setTypeAa(typeAa);
+      unitTypeList.addUnitType(otherUnitType);
+
+      UnitAbilityFactory.generate(
+          playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+      assertThat(
+          "Even though the targetsAa are different, both units have the same typeAa. So the engine "
+              + "assumes that it was a typo and will create one ability using the targetsAa from "
+              + "only one of the units. This targetsAa is generally the first one it sees.",
+          getAbilities(BattlePhaseList.DEFAULT_AA_PHASE),
+          hasSize(1));
+
+      final CombatUnitAbility ability =
+          getAbilities(BattlePhaseList.DEFAULT_AA_PHASE).iterator().next();
+      assertThat(
+          "Both of the unit types in the typeAa should be on this ability",
+          ability.getAttachedUnitTypes(),
+          is(List.of(unitType, otherUnitType)));
+      assertThat(
+          "The unit ability should have just one of the targetsAa. In this test, that happens "
+              + "to be the first set.",
+          ability.getTargets(),
+          is(targets1));
+    }
+
+    @Test
+    void suicideOnHitUnitsDoNotCombineAbilities() {
+      final Set<UnitType> targets = Set.of(mock(UnitType.class), mock(UnitType.class));
+      unitAttachment.setAttackAa(1);
+      unitAttachment.setIsAaForCombatOnly(true);
+      unitAttachment.setTargetsAa(targets);
+      unitAttachment.setTypeAa("test");
+      unitAttachment.setIsSuicideOnHit(true);
+
+      final UnitType otherSuicideUnitType = new UnitType("otherSuicide", gameData);
+      final UnitAttachment otherSuicideUnitAttachment =
+          new UnitAttachment("otherSuicide", otherSuicideUnitType, gameData);
+      otherSuicideUnitType.addAttachment(UNIT_ATTACHMENT_NAME, otherSuicideUnitAttachment);
+      otherSuicideUnitAttachment.setAttackAa(1);
+      otherSuicideUnitAttachment.setIsAaForCombatOnly(true);
+      otherSuicideUnitAttachment.setTargetsAa(targets);
+      otherSuicideUnitAttachment.setTypeAa("test");
+      otherSuicideUnitAttachment.setIsSuicideOnHit(true);
+      unitTypeList.addUnitType(otherSuicideUnitType);
+
+      UnitAbilityFactory.generate(
+          playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+      assertThat(
+          "Each unit type should have its own ability since they are suicideOnHit",
+          getAbilities(BattlePhaseList.DEFAULT_AA_PHASE),
+          hasSize(2));
+
+      assertThat(
+          "Both unit abilities should have only 1 attached unit type",
+          getAbilities(BattlePhaseList.DEFAULT_AA_PHASE).stream()
+              .filter(combatUnitAbility -> combatUnitAbility.getAttachedUnitTypes().size() == 1)
+              .collect(Collectors.toList()),
+          hasSize(2));
+
+      assertThat(
+          "One unit ability should be attached to unitType",
+          getAbilities(BattlePhaseList.DEFAULT_AA_PHASE).stream()
+              .filter(
+                  combatUnitAbility -> combatUnitAbility.getAttachedUnitTypes().contains(unitType))
+              .collect(Collectors.toList()),
+          hasSize(1));
+
+      assertThat(
+          "One unit ability should be attached to otherSuicideUnitType",
+          getAbilities(BattlePhaseList.DEFAULT_AA_PHASE).stream()
+              .filter(
+                  combatUnitAbility ->
+                      combatUnitAbility.getAttachedUnitTypes().contains(otherSuicideUnitType))
+              .collect(Collectors.toList()),
+          hasSize(1));
+    }
+
+    @Test
+    void unitWithWillNotFire() {
+      unitAttachment.setAttackAa(1);
+      unitAttachment.setIsAaForCombatOnly(true);
+
+      final UnitType preventsFiringUnitType = mock(UnitType.class);
+      unitAttachment.setWillNotFireIfPresent(Set.of(preventsFiringUnitType));
+
+      UnitAbilityFactory.generate(
+          playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+      assertThat(
+          "A convert ability needs to exist so that the preventsFiringUnitType can negate the "
+              + "AA attack",
+          battlePhaseList.getConvertAbilities().get(player),
+          hasSize(1));
+      final ConvertUnitAbility convertUnitAbility =
+          battlePhaseList.getConvertAbilities().get(player).iterator().next();
+      final CombatUnitAbility unitAbility =
+          getAbilities(BattlePhaseList.DEFAULT_AA_PHASE).iterator().next();
+      assertThat(
+          "The convert ability needs to reference the AA ability",
+          convertUnitAbility.getFrom(),
+          is(unitAbility));
+      assertThat(
+          "The convert ability is removing the AA ability so there is no To ability",
+          convertUnitAbility.getTo(),
+          nullValue());
+      assertThat(
+          "The convert ability should be on the preventsFiringUnitType",
+          convertUnitAbility.getAttachedUnitTypes(),
+          is(List.of(preventsFiringUnitType)));
+      assertThat(
+          "The preventsFiringUnitType is preventing an enemy AA unit",
+          convertUnitAbility.getFactions(),
+          is(List.of(ConvertUnitAbility.Faction.ENEMY)));
+    }
+
+    @Test
+    void twoUnitWithWillNotFireInTheSameTypeAa() {
+
+      final Set<UnitType> preventsFiringUnitTypes = Set.of(mock(UnitType.class));
+      final Set<UnitType> targets = Set.of(mock(UnitType.class), mock(UnitType.class));
+
+      unitAttachment.setWillNotFireIfPresent(preventsFiringUnitTypes);
+      unitAttachment.setAttackAa(1);
+      unitAttachment.setIsAaForCombatOnly(true);
+      unitAttachment.setTargetsAa(targets);
+      unitAttachment.setTypeAa("test");
+
+      final UnitType otherUnitType = new UnitType("other", gameData);
+      final UnitAttachment otherUnitAttachment =
+          new UnitAttachment("other", otherUnitType, gameData);
+      otherUnitType.addAttachment(UNIT_ATTACHMENT_NAME, otherUnitAttachment);
+      otherUnitAttachment.setWillNotFireIfPresent(preventsFiringUnitTypes);
+      otherUnitAttachment.setAttackAa(1);
+      otherUnitAttachment.setIsAaForCombatOnly(true);
+      otherUnitAttachment.setTargetsAa(targets);
+      otherUnitAttachment.setTypeAa("test");
+      unitTypeList.addUnitType(otherUnitType);
+
+      UnitAbilityFactory.generate(
+          playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+      assertThat(
+          "A convert ability needs to exist so that the preventsFiringUnitType can negate the "
+              + "AA attack. Only one is needed as both of the firing unit types have the same "
+              + "typeAa",
+          battlePhaseList.getConvertAbilities().get(player),
+          hasSize(1));
+      final ConvertUnitAbility convertUnitAbility =
+          battlePhaseList.getConvertAbilities().get(player).iterator().next();
+      final CombatUnitAbility unitAbility =
+          getAbilities(BattlePhaseList.DEFAULT_AA_PHASE).iterator().next();
+      assertThat(
+          "The convert ability needs to reference the AA ability",
+          convertUnitAbility.getFrom(),
+          is(unitAbility));
+    }
+
+    @Test
+    void twoUnitWithWillNotFireInDifferentTypeAa() {
+
+      final Set<UnitType> preventsFiringUnitTypes = Set.of(mock(UnitType.class));
+
+      unitAttachment.setWillNotFireIfPresent(preventsFiringUnitTypes);
+      unitAttachment.setAttackAa(1);
+      unitAttachment.setIsAaForCombatOnly(true);
+      unitAttachment.setTargetsAa(Set.of(mock(UnitType.class)));
+      unitAttachment.setTypeAa("test");
+
+      final UnitType otherUnitType = new UnitType("other", gameData);
+      final UnitAttachment otherUnitAttachment =
+          new UnitAttachment("other", otherUnitType, gameData);
+      otherUnitType.addAttachment(UNIT_ATTACHMENT_NAME, otherUnitAttachment);
+      otherUnitAttachment.setWillNotFireIfPresent(preventsFiringUnitTypes);
+      otherUnitAttachment.setAttackAa(1);
+      otherUnitAttachment.setIsAaForCombatOnly(true);
+      otherUnitAttachment.setTargetsAa(Set.of(mock(UnitType.class)));
+      otherUnitAttachment.setTypeAa("test2");
+      unitTypeList.addUnitType(otherUnitType);
+
+      UnitAbilityFactory.generate(
+          playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+      assertThat(
+          "A convert ability needs to exist so that the preventsFiringUnitType can negate the "
+              + "AA attack. Two are needed; one for each of the typeAa",
+          battlePhaseList.getConvertAbilities().get(player),
+          hasSize(2));
+      final Collection<ConvertUnitAbility> convertUnitAbilities =
+          battlePhaseList.getConvertAbilities().get(player);
+      final List<CombatUnitAbility> unitAbilities =
+          new ArrayList<>(getAbilities(BattlePhaseList.DEFAULT_AA_PHASE));
+
+      assertThat(
+          "One of the convert abilities needs to reference the first unit ability",
+          convertUnitAbilities.stream()
+              .filter(
+                  convertUnitAbility -> convertUnitAbility.getFrom().equals(unitAbilities.get(0)))
+              .collect(Collectors.toList()),
+          hasSize(1));
+      assertThat(
+          "One of the convert abilities needs to reference the second unit ability",
+          convertUnitAbilities.stream()
+              .filter(
+                  convertUnitAbility -> convertUnitAbility.getFrom().equals(unitAbilities.get(1)))
+              .collect(Collectors.toList()),
+          hasSize(1));
+    }
+  }
+
+  @Nested
+  class Bombard {
+
+    @Test
+    void unitWithOnlyBombardAbilities() {
+      unitAttachment.setCanBombard(true);
+
+      UnitAbilityFactory.generate(
+          playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+      assertThat(
+          "Unit has no AA rolls so doesn't have an AA ability",
+          getAbilities(BattlePhaseList.DEFAULT_AA_PHASE),
+          is(empty()));
+      assertThat(
+          "Unit has Bombard abilities",
+          getAbilities(BattlePhaseList.DEFAULT_BOMBARD_PHASE),
+          hasSize(1));
+      assertThat(
+          "Unit has no First Strike abilities",
+          getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE),
+          is(empty()));
+      assertThat(
+          "Unit has no General abilities",
+          getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
+          is(empty()));
+    }
+
+    @Test
+    void twoUnitsWithBombardMakeOnlyOneAbility() {
+      unitAttachment.setCanBombard(true);
+
+      final UnitType unitType2 = new UnitType("other", gameData);
+      final UnitAttachment unitAttachment2 = new UnitAttachment("other", unitType2, gameData);
+      unitType2.addAttachment(UNIT_ATTACHMENT_NAME, unitAttachment2);
+      unitAttachment2.setCanBombard(true);
+
+      unitTypeList.addUnitType(unitType2);
+
+      UnitAbilityFactory.generate(
+          playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+      assertThat(
+          "Only one Bombard ability should be created",
+          getAbilities(BattlePhaseList.DEFAULT_BOMBARD_PHASE),
+          hasSize(1));
+
+      final CombatUnitAbility ability =
+          getAbilities(BattlePhaseList.DEFAULT_BOMBARD_PHASE).iterator().next();
+      assertThat(
+          "Both unit types should be on the ability",
+          ability.getAttachedUnitTypes(),
+          is(List.of(unitType, unitType2)));
+    }
+
+    @Test
+    void bombardReturnFireIsTrueIfPropertyIsTrue() {
+      unitAttachment.setCanBombard(true);
+
+      final GameProperties gameProperties = new GameProperties(gameData);
+      gameProperties.set(NAVAL_BOMBARD_CASUALTIES_RETURN_FIRE, true);
+
+      UnitAbilityFactory.generate(playerList, unitTypeList, battlePhaseList, gameProperties);
+
+      final CombatUnitAbility ability =
+          getAbilities(BattlePhaseList.DEFAULT_BOMBARD_PHASE).iterator().next();
+      assertThat(ability.isReturnFire(), is(true));
+    }
+
+    @Test
+    void bombardReturnFireIsFalseIfPropertyIsFalse() {
+      unitAttachment.setCanBombard(true);
+
+      final GameProperties gameProperties = new GameProperties(gameData);
+      gameProperties.set(NAVAL_BOMBARD_CASUALTIES_RETURN_FIRE, false);
+
+      UnitAbilityFactory.generate(playerList, unitTypeList, battlePhaseList, gameProperties);
+
+      final CombatUnitAbility ability =
+          getAbilities(BattlePhaseList.DEFAULT_BOMBARD_PHASE).iterator().next();
+      assertThat(ability.isReturnFire(), is(false));
+    }
+  }
+}

--- a/game-core/src/test/java/games/strategy/engine/data/unit/ability/UnitAbilityFactoryTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/unit/ability/UnitAbilityFactoryTest.java
@@ -181,11 +181,11 @@ class UnitAbilityFactoryTest {
         assertThat(
             "isSuicideOnHit translates ONLY_ON_HIT for offense",
             unitAbility.getSuicideOnOffense(),
-            is(CombatUnitAbility.Suicide.ONLY_ON_HIT));
+            is(CombatUnitAbility.Suicide.AFTER_HIT));
         assertThat(
             "isSuicideOnHit translates ONLY_ON_HIT for defense",
             unitAbility.getSuicideOnDefense(),
-            is(CombatUnitAbility.Suicide.ONLY_ON_HIT));
+            is(CombatUnitAbility.Suicide.AFTER_HIT));
       }
 
       @Test
@@ -206,7 +206,7 @@ class UnitAbilityFactoryTest {
         assertThat(
             "isSuicideOnAttack translates into suicide on offense ALWAYS",
             unitAbility.getSuicideOnOffense(),
-            is(CombatUnitAbility.Suicide.ALWAYS));
+            is(CombatUnitAbility.Suicide.AFTER_FIRE));
         assertThat(
             "isSuicideOnAttack should not cause suicide on defense to have anything",
             unitAbility.getSuicideOnDefense(),
@@ -231,7 +231,7 @@ class UnitAbilityFactoryTest {
         assertThat(
             "isSuicideOnDefense translates into suicide on defense ALWAYS",
             unitAbility.getSuicideOnDefense(),
-            is(CombatUnitAbility.Suicide.ALWAYS));
+            is(CombatUnitAbility.Suicide.AFTER_FIRE));
         assertThat(
             "isSuicideOnDefense should not cause suicide on offense to have anything",
             unitAbility.getSuicideOnOffense(),
@@ -252,11 +252,11 @@ class UnitAbilityFactoryTest {
         assertThat(
             "isSuicideOnAttack supersedes isSuicideOnHit so offense is ALWAYS",
             unitAbility.getSuicideOnOffense(),
-            is(CombatUnitAbility.Suicide.ALWAYS));
+            is(CombatUnitAbility.Suicide.AFTER_FIRE));
         assertThat(
             "isSuicideOnHit is by itself on defense so it is ONLY_ON_HIT",
             unitAbility.getSuicideOnDefense(),
-            is(CombatUnitAbility.Suicide.ONLY_ON_HIT));
+            is(CombatUnitAbility.Suicide.AFTER_HIT));
       }
 
       @Test
@@ -581,11 +581,11 @@ class UnitAbilityFactoryTest {
         assertThat(
             "isSuicideOnHit translates ALWAYS for offense",
             unitAbility.getSuicideOnOffense(),
-            is(CombatUnitAbility.Suicide.ALWAYS));
+            is(CombatUnitAbility.Suicide.AFTER_FIRE));
         assertThat(
             "isSuicideOnHit translates ALWAYS for defense",
             unitAbility.getSuicideOnDefense(),
-            is(CombatUnitAbility.Suicide.ALWAYS));
+            is(CombatUnitAbility.Suicide.AFTER_FIRE));
       }
 
       @Test

--- a/game-core/src/test/java/games/strategy/engine/data/unit/ability/UnitAbilityFactoryTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/unit/ability/UnitAbilityFactoryTest.java
@@ -1116,9 +1116,9 @@ class UnitAbilityFactoryTest {
           convertUnitAbility.getFrom(),
           is(unitAbility));
       assertThat(
-          "The convert ability is removing the AA ability so there is no To ability",
+          "The convert ability is removing the AA ability so the To is EMPTY",
           convertUnitAbility.getTo(),
-          nullValue());
+          is(CombatUnitAbility.EMPTY));
       assertThat(
           "The convert ability should be on the preventsFiringUnitType",
           convertUnitAbility.getAttachedUnitTypes(),

--- a/game-core/src/test/java/games/strategy/engine/data/unit/ability/UnitAbilityFactoryTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/unit/ability/UnitAbilityFactoryTest.java
@@ -164,6 +164,69 @@ class UnitAbilityFactoryTest {
       }
 
       @Test
+      void unitWithSuicideOnHit() {
+        unitAttachment.setAttack(1);
+        unitAttachment.setIsSuicideOnHit(true);
+
+        UnitAbilityFactory.generate(
+            playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+        assertThat(
+            "Unit has General abilities",
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
+            hasSize(1));
+
+        final CombatUnitAbility unitAbility =
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE).iterator().next();
+        assertThat(
+            "isSuicideOnHit translates into commitSuicideAfterSuccesfulHit on both sides",
+            unitAbility.getCommitSuicideAfterSuccessfulHit(),
+            is(List.of(BattleState.Side.OFFENSE, BattleState.Side.DEFENSE)));
+      }
+
+      @Test
+      void unitWithIsSuicideOnAttack() {
+        unitAttachment.setAttack(1);
+        unitAttachment.setIsSuicideOnAttack(true);
+
+        UnitAbilityFactory.generate(
+            playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+        assertThat(
+            "Unit has General abilities",
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
+            hasSize(1));
+
+        final CombatUnitAbility unitAbility =
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE).iterator().next();
+        assertThat(
+            "isSuicideOnAttack translates into commitSuicide on only offense",
+            unitAbility.getCommitSuicide(),
+            is(List.of(BattleState.Side.OFFENSE)));
+      }
+
+      @Test
+      void unitWithIsSuicideOnDefense() {
+        unitAttachment.setDefense(1);
+        unitAttachment.setIsSuicideOnDefense(true);
+
+        UnitAbilityFactory.generate(
+            playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+        assertThat(
+            "Unit has General abilities",
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
+            hasSize(1));
+
+        final CombatUnitAbility unitAbility =
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE).iterator().next();
+        assertThat(
+            "isSuicideOnDefense translates into commitSuicide on only defense",
+            unitAbility.getCommitSuicide(),
+            is(List.of(BattleState.Side.DEFENSE)));
+      }
+
+      @Test
       void twoUnitTypesWithSamePropertiesHaveCommonAbility() {
         unitAttachment.setAttack(1);
 
@@ -283,54 +346,6 @@ class UnitAbilityFactoryTest {
             "The ability should be attached to both unit types",
             unitAbility.getAttachedUnitTypes(),
             is(List.of(unitType, otherUnitType)));
-      }
-
-      @Test
-      void suicideOnHitUnitsDoNotCombineAbilities() {
-        unitAttachment.setAttack(1);
-        unitAttachment.setIsSuicideOnHit(true);
-
-        final UnitType otherSuicideUnitType = new UnitType("otherSuicide", gameData);
-        final UnitAttachment otherSuicideUnitAttachment =
-            new UnitAttachment("otherSuicide", otherSuicideUnitType, gameData);
-        otherSuicideUnitType.addAttachment(UNIT_ATTACHMENT_NAME, otherSuicideUnitAttachment);
-        otherSuicideUnitAttachment.setAttack(1);
-        otherSuicideUnitAttachment.setIsSuicideOnHit(true);
-        unitTypeList.addUnitType(otherSuicideUnitType);
-
-        UnitAbilityFactory.generate(
-            playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
-
-        assertThat(
-            "Even though both unitTypes have the same properties, they have their own ability "
-                + "because they are suicideOnHit",
-            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE),
-            hasSize(2));
-
-        assertThat(
-            "Both unit abilities should have only 1 attached unit type",
-            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE).stream()
-                .filter(combatUnitAbility -> combatUnitAbility.getAttachedUnitTypes().size() == 1)
-                .collect(Collectors.toList()),
-            hasSize(2));
-
-        assertThat(
-            "One unit ability should be attached to unitType",
-            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE).stream()
-                .filter(
-                    combatUnitAbility ->
-                        combatUnitAbility.getAttachedUnitTypes().contains(unitType))
-                .collect(Collectors.toList()),
-            hasSize(1));
-
-        assertThat(
-            "One unit ability should be attached to otherSuicideUnitType",
-            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE).stream()
-                .filter(
-                    combatUnitAbility ->
-                        combatUnitAbility.getAttachedUnitTypes().contains(otherSuicideUnitType))
-                .collect(Collectors.toList()),
-            hasSize(1));
       }
 
       @Test
@@ -500,6 +515,41 @@ class UnitAbilityFactoryTest {
 
     @Nested
     class FirstStrike {
+
+      @Test
+      void unitWithIsFirstStrike() {
+        unitAttachment.setAttack(1);
+        unitAttachment.setIsFirstStrike(true);
+
+        UnitAbilityFactory.generate(
+            playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+        assertThat(
+            "Unit has First Strike abilities",
+            getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE),
+            hasSize(1));
+      }
+
+      @Test
+      void unitWithIsSuicide() {
+        unitAttachment.setAttack(1);
+        unitAttachment.setIsSuicide(true);
+
+        UnitAbilityFactory.generate(
+            playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+        assertThat(
+            "isSuicide Unit has First Strike abilities",
+            getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE),
+            hasSize(1));
+
+        final CombatUnitAbility unitAbility =
+            getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE).iterator().next();
+        assertThat(
+            "isSuicide translates into commitSuicide on both sides",
+            unitAbility.getCommitSuicide(),
+            is(List.of(BattleState.Side.OFFENSE, BattleState.Side.DEFENSE)));
+      }
 
       @Test
       void unitWithIsSub() {
@@ -1039,59 +1089,6 @@ class UnitAbilityFactoryTest {
               + "to be the first set.",
           ability.getTargets(),
           is(targets1));
-    }
-
-    @Test
-    void suicideOnHitUnitsDoNotCombineAbilities() {
-      final Set<UnitType> targets = Set.of(mock(UnitType.class), mock(UnitType.class));
-      unitAttachment.setAttackAa(1);
-      unitAttachment.setIsAaForCombatOnly(true);
-      unitAttachment.setTargetsAa(targets);
-      unitAttachment.setTypeAa("test");
-      unitAttachment.setIsSuicideOnHit(true);
-
-      final UnitType otherSuicideUnitType = new UnitType("otherSuicide", gameData);
-      final UnitAttachment otherSuicideUnitAttachment =
-          new UnitAttachment("otherSuicide", otherSuicideUnitType, gameData);
-      otherSuicideUnitType.addAttachment(UNIT_ATTACHMENT_NAME, otherSuicideUnitAttachment);
-      otherSuicideUnitAttachment.setAttackAa(1);
-      otherSuicideUnitAttachment.setIsAaForCombatOnly(true);
-      otherSuicideUnitAttachment.setTargetsAa(targets);
-      otherSuicideUnitAttachment.setTypeAa("test");
-      otherSuicideUnitAttachment.setIsSuicideOnHit(true);
-      unitTypeList.addUnitType(otherSuicideUnitType);
-
-      UnitAbilityFactory.generate(
-          playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
-
-      assertThat(
-          "Each unit type should have its own ability since they are suicideOnHit",
-          getAbilities(BattlePhaseList.DEFAULT_AA_PHASE),
-          hasSize(2));
-
-      assertThat(
-          "Both unit abilities should have only 1 attached unit type",
-          getAbilities(BattlePhaseList.DEFAULT_AA_PHASE).stream()
-              .filter(combatUnitAbility -> combatUnitAbility.getAttachedUnitTypes().size() == 1)
-              .collect(Collectors.toList()),
-          hasSize(2));
-
-      assertThat(
-          "One unit ability should be attached to unitType",
-          getAbilities(BattlePhaseList.DEFAULT_AA_PHASE).stream()
-              .filter(
-                  combatUnitAbility -> combatUnitAbility.getAttachedUnitTypes().contains(unitType))
-              .collect(Collectors.toList()),
-          hasSize(1));
-
-      assertThat(
-          "One unit ability should be attached to otherSuicideUnitType",
-          getAbilities(BattlePhaseList.DEFAULT_AA_PHASE).stream()
-              .filter(
-                  combatUnitAbility ->
-                      combatUnitAbility.getAttachedUnitTypes().contains(otherSuicideUnitType))
-              .collect(Collectors.toList()),
-          hasSize(1));
     }
 
     @Test

--- a/game-core/src/test/java/games/strategy/engine/data/unit/ability/UnitAbilityFactoryTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/unit/ability/UnitAbilityFactoryTest.java
@@ -799,7 +799,7 @@ class UnitAbilityFactoryTest {
             battlePhaseList.getConvertAbilities().get(player).stream()
                 .filter(
                     unitAbility ->
-                        unitAbility.getFactions().contains(ConvertUnitAbility.Faction.ALLIED))
+                        unitAbility.getTeams().contains(ConvertUnitAbility.Team.FRIENDLY))
                 .findFirst()
                 .orElseThrow();
 
@@ -811,9 +811,7 @@ class UnitAbilityFactoryTest {
 
         final List<ConvertUnitAbility> enemyUnitAbilities =
             battlePhaseList.getConvertAbilities().get(player).stream()
-                .filter(
-                    unitAbility ->
-                        unitAbility.getFactions().contains(ConvertUnitAbility.Faction.ENEMY))
+                .filter(unitAbility -> unitAbility.getTeams().contains(ConvertUnitAbility.Team.FOE))
                 .collect(Collectors.toList());
 
         final ConvertUnitAbility enemyConvertUnitAbilityWhenFriendlyDestroyerPresent =
@@ -1125,8 +1123,8 @@ class UnitAbilityFactoryTest {
           is(List.of(preventsFiringUnitType)));
       assertThat(
           "The preventsFiringUnitType is preventing an enemy AA unit",
-          convertUnitAbility.getFactions(),
-          is(List.of(ConvertUnitAbility.Faction.ENEMY)));
+          convertUnitAbility.getTeams(),
+          is(List.of(ConvertUnitAbility.Team.FOE)));
     }
 
     @Test

--- a/game-core/src/test/java/games/strategy/engine/data/unit/ability/UnitAbilityFactoryTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/unit/ability/UnitAbilityFactoryTest.java
@@ -179,9 +179,13 @@ class UnitAbilityFactoryTest {
         final CombatUnitAbility unitAbility =
             getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE).iterator().next();
         assertThat(
-            "isSuicideOnHit translates into commitSuicideAfterSuccesfulHit on both sides",
-            unitAbility.getCommitSuicideAfterSuccessfulHit(),
-            is(List.of(BattleState.Side.OFFENSE, BattleState.Side.DEFENSE)));
+            "isSuicideOnHit translates ONLY_ON_HIT for offense",
+            unitAbility.getSuicideOnOffense(),
+            is(CombatUnitAbility.Suicide.ONLY_ON_HIT));
+        assertThat(
+            "isSuicideOnHit translates ONLY_ON_HIT for defense",
+            unitAbility.getSuicideOnDefense(),
+            is(CombatUnitAbility.Suicide.ONLY_ON_HIT));
       }
 
       @Test
@@ -200,9 +204,13 @@ class UnitAbilityFactoryTest {
         final CombatUnitAbility unitAbility =
             getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE).iterator().next();
         assertThat(
-            "isSuicideOnAttack translates into commitSuicide on only offense",
-            unitAbility.getCommitSuicide(),
-            is(List.of(BattleState.Side.OFFENSE)));
+            "isSuicideOnAttack translates into suicide on offense ALWAYS",
+            unitAbility.getSuicideOnOffense(),
+            is(CombatUnitAbility.Suicide.ALWAYS));
+        assertThat(
+            "isSuicideOnAttack should not cause suicide on defense to have anything",
+            unitAbility.getSuicideOnDefense(),
+            is(CombatUnitAbility.Suicide.NONE));
       }
 
       @Test
@@ -221,9 +229,34 @@ class UnitAbilityFactoryTest {
         final CombatUnitAbility unitAbility =
             getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE).iterator().next();
         assertThat(
-            "isSuicideOnDefense translates into commitSuicide on only defense",
-            unitAbility.getCommitSuicide(),
-            is(List.of(BattleState.Side.DEFENSE)));
+            "isSuicideOnDefense translates into suicide on defense ALWAYS",
+            unitAbility.getSuicideOnDefense(),
+            is(CombatUnitAbility.Suicide.ALWAYS));
+        assertThat(
+            "isSuicideOnDefense should not cause suicide on offense to have anything",
+            unitAbility.getSuicideOnOffense(),
+            is(CombatUnitAbility.Suicide.NONE));
+      }
+
+      @Test
+      void unitWithSuicideOnHitAndSuicideOnAttackAndDefense() {
+        unitAttachment.setAttack(1);
+        unitAttachment.setIsSuicideOnHit(true);
+        unitAttachment.setIsSuicideOnAttack(true);
+
+        UnitAbilityFactory.generate(
+            playerList, unitTypeList, battlePhaseList, new GameProperties(gameData));
+
+        final CombatUnitAbility unitAbility =
+            getAbilities(BattlePhaseList.DEFAULT_GENERAL_PHASE).iterator().next();
+        assertThat(
+            "isSuicideOnAttack supersedes isSuicideOnHit so offense is ALWAYS",
+            unitAbility.getSuicideOnOffense(),
+            is(CombatUnitAbility.Suicide.ALWAYS));
+        assertThat(
+            "isSuicideOnHit is by itself on defense so it is ONLY_ON_HIT",
+            unitAbility.getSuicideOnDefense(),
+            is(CombatUnitAbility.Suicide.ONLY_ON_HIT));
       }
 
       @Test
@@ -546,9 +579,13 @@ class UnitAbilityFactoryTest {
         final CombatUnitAbility unitAbility =
             getAbilities(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE).iterator().next();
         assertThat(
-            "isSuicide translates into commitSuicide on both sides",
-            unitAbility.getCommitSuicide(),
-            is(List.of(BattleState.Side.OFFENSE, BattleState.Side.DEFENSE)));
+            "isSuicideOnHit translates ALWAYS for offense",
+            unitAbility.getSuicideOnOffense(),
+            is(CombatUnitAbility.Suicide.ALWAYS));
+        assertThat(
+            "isSuicideOnHit translates ALWAYS for defense",
+            unitAbility.getSuicideOnDefense(),
+            is(CombatUnitAbility.Suicide.ALWAYS));
       }
 
       @Test


### PR DESCRIPTION
This adds the objects/classes for handling unit abilities and battle phases.  This doesn't yet add them to the XML nor does it add them to the actual battle logic.

I'll be working on adding them to the battle logic in a later PR.  I'm making them separate PRs because this already has a lot of lines (~1000 if you ignore the tests) and is needed to make the existing maps work.  I plan to do three more PRs: One that adds battle logic but doesn't actually use it, one that finally hooks it in, and one that adds them to the XML parsing.

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
