### PR TITLE
Remove test case with illegal reflective access

### DIFF
--- a/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingTest.java
@@ -20,17 +20,6 @@ import org.triplea.java.function.ThrowingFunction;
 
 final class ClientSettingTest {
   @Nested
-  final class EqualsAndHashCodeTest {
-    @Test
-    void shouldBeEquatableAndHashable() {
-      EqualsVerifier.forClass(ClientSetting.class)
-          .withNonnullFields("name")
-          .withOnlyTheseFields("name")
-          .verify();
-    }
-  }
-
-  @Nested
   final class GetValueTest extends AbstractClientSettingTestCase {
     @Test
     void shouldReturnDefaultValueWhenDecodeValueThrowsException() {

--- a/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/settings/ClientSettingTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.verify;
 
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
-import nl.jqno.equalsverifier.EqualsVerifier;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;


### PR DESCRIPTION
Test case generates the following warning:

> WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by nl.jqno.equalsverifier.internal.reflection.FieldModifier (file:/home/dan/.gradle/caches/modules-2/files-2.1/nl.jqno.equalsverifier/equalsverifier/3.5.2/db280faa2d45c1201abcab70fe795584fcc9751b/equalsverifier-3.5.2.jar) to field java.security.Permission.name
WARNING: Please consider reporting this to the maintainers of nl.jqno.equalsverifier.internal.reflection.FieldModifier
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release

Removing as the value of reducing test output is greater than that provided by this
specific test case.

