### PR TITLE
Fix error prone warning TypeParameterUnusedInFormals

### DIFF
--- a/java-extras/src/main/java/org/triplea/yaml/YamlReader.java
+++ b/java-extras/src/main/java/org/triplea/yaml/YamlReader.java
@@ -20,9 +20,10 @@ public class YamlReader {
    *
    * @throws InvalidYamlFormatException Thrown if the YAML is badly formatted.
    */
+  @SuppressWarnings("unchecked")
   public static List<Map<String, Object>> readList(final String input) {
     try {
-      return readYaml(asStream(input));
+      return (List<Map<String, Object>>) readYaml(asStream(input));
     } catch (final YamlEngineException | ClassCastException e) {
       throw new InvalidYamlFormatException(e);
     }
@@ -33,9 +34,10 @@ public class YamlReader {
    *
    * @throws InvalidYamlFormatException Thrown if the YAML is badly formatted.
    */
+  @SuppressWarnings("unchecked")
   public static List<Map<String, Object>> readList(final InputStream input) {
     try {
-      return readYaml(input);
+      return (List<Map<String, Object>>) readYaml(input);
     } catch (final YamlEngineException | ClassCastException e) {
       throw new InvalidYamlFormatException(e);
     }
@@ -46,9 +48,10 @@ public class YamlReader {
    *
    * @throws InvalidYamlFormatException Thrown if the YAML is badly formatted.
    */
+  @SuppressWarnings("unchecked")
   public static Map<String, Object> readMap(final String input) {
     try {
-      return readYaml(asStream(input));
+      return (Map<String, Object>) readYaml(asStream(input));
     } catch (final YamlEngineException | ClassCastException e) {
       throw new InvalidYamlFormatException(e);
     }
@@ -59,9 +62,10 @@ public class YamlReader {
    *
    * @throws InvalidYamlFormatException Thrown if the YAML is badly formatted.
    */
+  @SuppressWarnings("unchecked")
   public static Map<String, Object> readMap(final InputStream input) {
     try {
-      return readYaml(input);
+      return (Map<String, Object>) readYaml(input);
     } catch (final YamlEngineException | ClassCastException e) {
       throw new InvalidYamlFormatException(e);
     }
@@ -72,10 +76,9 @@ public class YamlReader {
         Strings.nullToEmpty(inputString).getBytes(StandardCharsets.UTF_8));
   }
 
-  @SuppressWarnings("unchecked")
-  private static <T> T readYaml(final InputStream inputStream) {
+  private static Object readYaml(final InputStream inputStream) {
     final Load load = new Load(LoadSettings.builder().build());
-    final var result = (T) load.loadFromInputStream(inputStream);
+    final var result = load.loadFromInputStream(inputStream);
     return Optional.ofNullable(result)
         .orElseThrow(() -> new InvalidYamlFormatException("Unable to read yaml data"));
   }


### PR DESCRIPTION
> YamlReader.java:76: warning: [TypeParameterUnusedInFormals] Declaring a type parameter that is only used in the return type is a misuse of generics: operations on the type parameter are unchecked, it hides unsafe casts at invocations of the method, and it interacts badly with method overload resolution.
  private static <T> T readYaml(final InputStream inputStream) {
                       ^

The warning is accurate as class cast exception was thrown at
the caller level and for this reason this method was made private
and the value cast by caller methods.

To resolve this warning, the return type is now an explicit 'Object'
and the caller methods do an explicit type cast.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
