### PR TITLE
Add a (for-test) logback file to websocket-server to reduce test output

### DIFF
--- a/websocket-server/src/test/resources/logback-test.xml
+++ b/websocket-server/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%thread] %logger{36} %-5level: %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.triplea.web.socket.WebSocketMessagingBus" level="OFF"/>
+    <logger name="org.triplea.web.socket.GenericWebSocket" level="ERROR"/>
+</configuration>


### PR DESCRIPTION
Suppresses expected stack traces and warning messages.

