### PR TITLE
Remove explicit --parallel flag when running unit tests

### DIFF
--- a/.travis/stages/verify/unit-testing/run
+++ b/.travis/stages/verify/unit-testing/run
@@ -27,7 +27,7 @@ function downloadCodeClimateReporter() {
 }
 
 function runTests() {
-  ./gradlew -x :smoke-testing:test -parallel test jacocoTestReport
+  ./gradlew -x :smoke-testing:test test jacocoTestReport
 }
 
 function compileCodeClimateReports() {


### PR DESCRIPTION
To favor easier to debug test failures, removing --parallel for
running unit tests as part of build verification.
