### PR TITLE
Mark getMapVersionByName as non-static

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/auto/update/UpdatedMapsCheck.java
+++ b/game-core/src/main/java/games/strategy/engine/auto/update/UpdatedMapsCheck.java
@@ -53,7 +53,9 @@ class UpdatedMapsCheck {
     }
 
     final Collection<String> outOfDateMapNames =
-        computeOutOfDateMaps(availableToDownloadMaps, DownloadedMaps::getMapVersionByName);
+        computeOutOfDateMaps(
+            availableToDownloadMaps,
+            name -> DownloadedMaps.parseMapFiles().getMapVersionByName(name));
 
     if (!outOfDateMapNames.isEmpty()) {
       promptUserToUpdateMaps(outOfDateMapNames);

--- a/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/DownloadedMaps.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/DownloadedMaps.java
@@ -79,7 +79,7 @@ public class DownloadedMaps {
    * installed othewrise returns an empty. Fuzzy matching means we will do name normalization and
    * replace spaces with underscores, convert to lower case, etc.
    */
-  public static Optional<Integer> getMapVersionByName(final String mapName) {
+  public Optional<Integer> getMapVersionByName(final String mapName) {
     final String normalizedMapName = normalizeName(mapName);
 
     // see if we have a map folder that matches the target name


### PR DESCRIPTION
Preps for future changes where access to downloaded maps
will be stateful. This update marks getMapVersionByName
as non-static and updates callers in preparation for this.

