### PR TITLE
Update map zip extraction to extract to a folder

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/ZippedMapsExtractor.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/ZippedMapsExtractor.java
@@ -111,8 +111,15 @@ public class ZippedMapsExtractor {
     final Path tempFolder = Files.createTempDirectory("triplea-unzip");
     ZipExtractor.unzipFile(mapZip, tempFolder.toFile());
 
+    // Check if the zip extracts to a single folder, if so, then to preserve pre-2.6 functionality
+    // we will use that as the map folder.
+    final Path folderToMove =
+        FileUtils.listFiles(tempFolder.toFile()).size() == 1
+            ? FileUtils.listFiles(tempFolder.toFile()).iterator().next().toPath()
+            : tempFolder;
+
     // extraction done, now move the extracted folder to target location
-    Files.move(tempFolder, extractionTarget);
+    Files.move(folderToMove, extractionTarget);
 
     // move properties file if it exists
     final Path propertiesFile = mapZip.toPath().resolveSibling(mapZip.getName() + ".properties");

--- a/game-core/src/test/java/games/strategy/engine/framework/map/file/system/loader/ZippedMapsExtractorTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/map/file/system/loader/ZippedMapsExtractorTest.java
@@ -1,0 +1,17 @@
+package games.strategy.engine.framework.map.file.system.loader;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import org.junit.jupiter.api.Test;
+
+class ZippedMapsExtractorTest {
+
+  @Test
+  void testExtractionFolderNaming() {
+    assertThat(ZippedMapsExtractor.createExtractionFolderName("zip"), is("zip"));
+    assertThat(ZippedMapsExtractor.createExtractionFolderName("zip-master"), is("zip"));
+    assertThat(ZippedMapsExtractor.createExtractionFolderName("zip-master.zip"), is("zip"));
+    assertThat(ZippedMapsExtractor.createExtractionFolderName("zip.zip"), is("zip"));
+  }
+}


### PR DESCRIPTION
Rather than unzipping map zips directly into the download folder,
this update changes that behavior to create a folder first that
is named after the map zip.

Most map zips have a folder inside of map wherein is all content.
Other zips, notably manually packaged and older zip files instead
have all contents zipped. When extracting these zips their contents
would otherwise be exploded into the downloaded maps folder.

By creating a folder first and extracting there, these latter
type of zips will be more cleanly extracted.

Addresses: https://github.com/triplea-game/triplea/issues/8679


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing

- Verified manually extraction of zip files and a .properties file was renamed accordingly.
<!-- Describe any manual testing performed below. -->

## Additional Notes

Extracting into a folder lead to the logic being a bit simpler. Rather than having multiple files land in a temp folder and moving files one-by-one from the temp folder into the target location, we instead just move the temp folder to the target location and rename the temp folder.