### PR TITLE
Update logging location and rotation policy

### DIFF
--- a/game-headed/src/main/resources/logback.xml
+++ b/game-headed/src/main/resources/logback.xml
@@ -1,11 +1,19 @@
 <configuration>
     <appender name="swingMessage" class="org.triplea.debug.Slf4jLogMessageUploader"/>
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
-        <file>triplea.log</file>
-        <append>false</append>
+        <file>${user.home}/triplea/triplea.log</file>
+        <append>true</append>
         <encoder>
             <pattern>%-4relative %d{HH:mm:ss.SSS} [%thread] %-5level %logger{35} - %msg%n</pattern>
         </encoder>
+        <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
+            <!-- rollover daily -->
+            <fileNamePattern>triplea-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
+            <!-- each file should be at most 10MB, keep 3 days worth of history, but at most 50MB -->
+            <maxFileSize>10MB</maxFileSize>
+            <maxHistory>3</maxHistory>
+            <totalSizeCap>50MB</totalSizeCap>
+        </rollingPolicy>
     </appender>
     <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
         <layout class="ch.qos.logback.classic.PatternLayout">


### PR DESCRIPTION
- Sets log location to the triplea folder in the users home
folder. On windows systems if TripleA is installed to
program files, the application is unable to write files
to that location.

- Set append to true, this is useful for supporting parallel
game instances so that each one will append rather than
clearing the log file when one starts.

- Set log rotation to rotate log file daily and cap to a max
size. With 'append' set to true, log files can get large.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing

Launched the app, verified the log file was written to home folder / triplea.
