### PR TITLE
Update peview.png for Global 40 House Rules

### DIFF
--- a/triplea_maps.yaml
+++ b/triplea_maps.yaml
@@ -2019,7 +2019,7 @@
 - mapName: Global 40 House Rules
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/global_40_house_rules/archive/master.zip
-  version: 13
+  version: 14
   img: https://raw.githubusercontent.com/triplea-maps/global_40_house_rules/master/description/TripleA_ww2_global_1940_mini.png
   description:
     <br>

--- a/triplea_maps.yaml
+++ b/triplea_maps.yaml
@@ -2019,8 +2019,8 @@
 - mapName: Global 40 House Rules
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/global_40_house_rules/archive/master.zip
-  version: 14
-  img: https://raw.githubusercontent.com/triplea-maps/global_40_house_rules/master/description/TripleA_ww2_global_1940_mini.png
+  version: 13
+  img: https://raw.githubusercontent.com/triplea-maps/global_40_house_rules/master/preview.png
   description:
     <br>
     <br>Global 40 House Rules. Adds House Rules using Technologies and Map Options. Also adds Canada that was created by simon 33.<br>


### PR DESCRIPTION
Not real confident but will give it a shot anyway


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->
Reinstalled map and it started.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->
This is what it looks like now
![Screenshot from 2021-01-27 23-34-13](https://user-images.githubusercontent.com/24382682/106095033-addc8b80-60f8-11eb-9033-bf61d32575dd.png)

## Additional Notes to Reviewer
Trying to update according to this

https://forums.triplea-game.org/topic/2603/standard-preview-png-image

The Neutral_Navy.png was in the game notes. I left it in the doc/images folder too. Not too sure about that but ...

<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
