### PR TITLE
Build Installers with Github Actions

### DIFF
--- a/.build/build-installer
+++ b/.build/build-installer
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+## Builds TripleA game-installers and build artifacts suitable
+## for distribution.  Build artifacts will be created for each
+## sub-project and copied into: './build/artifacts'
+
+## install install4j
+set -x
+
+function main() {
+  install_install4j
+  build_installers
+  collect_artifacts
+}
+
+# Installs install4j, the license key is injected into install4j during this step.
+function install_install4j() {
+  INSTALL4J_HOME=/tmp/install4j
+  mkdir $INSTALL4J_HOME
+
+  echo "Downloading and installing install4j to '$INSTALL4J_HOME'"
+  wget --no-verbose -O install4j_unix.sh \
+  https://raw.githubusercontent.com/triplea-game/assets/master/install4j/install4j_unix_8_0_7.sh
+  chmod +x install4j_unix.sh
+  ./install4j_unix.sh -q -dir "$INSTALL4J_HOME"
+  "$INSTALL4J_HOME/bin/install4jc" -L "$INSTALL4J_LICENSE"
+}
+
+
+## Runs gradle command that creates the installer executables, uses intall4j
+function build_installers() {
+  JAVA_OPTS=-Xmx4G ./gradlew \
+      --no-daemon \
+      --parallel \
+      -Pinstall4jHomeDir="$INSTALL4J_HOME" \
+      release
+}
+
+## Gathers built artifacts from all sub-projects to a single top-level to
+## include with the release
+function collect_artifacts() {
+  readonly ARTIFACTS_DIR=./build/artifacts
+  mkdir -p $ARTIFACTS_DIR
+  cp ./*/build/artifacts/* ${ARTIFACTS_DIR}
+  find $ARTIFACTS_DIR
+}
+
+main
+

--- a/.build/set-build-number
+++ b/.build/set-build-number
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+runNumber="$1"
+
+PROP_FILE="game-core/src/main/resources/META-INF/triplea/product.properties"
+
+## Update property file, set build number
+## Expect contents like: "version = 2.0.0"
+## Overwrite to contain something like: "version = 2.0.1234"
+
+sed -i "s/\(version *=.*\)$/\1.$runNumber/" $PROP_FILE
+
+## Read the new version number and print it.
+## EG: "version = 2.0.1234", print "2.0.1234"
+## Do this by:
+## 1. remove all spaces, EG: "version=2.0.1234"
+## 2. remove everything up to and including the equals sign, eg: "2.0.1234"
+
+sed 's/.*= *//' $PROP_FILE
+

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,61 @@
+name: Build and upload Prerelease
+on:
+  push:
+    branches:
+      - master
+      - release/*
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+jobs:
+  build:
+    name: Create Prerelease
+    runs-on: Ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: set build version variables
+        run: |
+          echo "base ref = ${{ github.ref }}"
+          if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
+              BUILD_NUMBER=$(.build/set-build-number ${{ github.run_number }}.pre)
+              echo "product_version=$BUILD_NUMBER" >> $GITHUB_ENV
+              echo "build_tag=prerelease" >> $GITHUB_ENV
+              echo "is_prerelease=true" >> $GITHUB_ENV
+              echo "release_name=$(date +%Y-%B-%d--%H.%m) - Prerelease - $BUILD_NUMBER" >> $GITHUB_ENV
+          else
+              BUILD_NUMBER=$(.build/set-build-number ${{ github.run_number }})
+              echo "product_version=$BUILD_NUMBER" >> $GITHUB_ENV
+              echo "build_tag=$BUILD_NUMBER" >> $GITHUB_ENV
+              echo "is_prerelease=false" >> $GITHUB_ENV
+              echo "release_name=$(date +%Y-%B) - Release - $BUILD_NUMBER" >> $GITHUB_ENV
+          fi
+      - name: echo build version values
+        run: |
+            echo "product_version = ${{ env.product_version }}" 
+            echo "build_tag = ${{ env.build_tag }}" 
+            echo "is_prerelease = ${{ env.is_prerelease }}" 
+            echo "release_name = ${{ env.release_name }}" 
+      - name: Build installers
+        run: .build/build-installer
+        env:
+          BUILD_NUMBER: ${{ github.run_number }}
+          INSTALL4J_LICENSE: ${{ secrets.INSTALL4J_LICENSE }}
+      - uses: dev-drprasad/delete-tag-and-release@v0.1.2
+        with:
+          delete_release: true
+          tag_name: ${{ env.build_tag }}
+      - name: Create Github Release
+        uses: actions/create-release@v1
+        with:        
+          tag_name: ${{ env.build_tag }}
+          release_name: ${{ env.release_name }}
+          prerelease: ${{ env.is_prerelease }}
+          draft: false
+      - name: Upload Release Asset
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ env.build_tag }}
+          file: build/artifacts/*
+          file_glob: true
+

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -17,7 +17,7 @@ jobs:
         run: |
           echo "base ref = ${{ github.ref }}"
           if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
-              BUILD_NUMBER=$(.build/set-build-number ${{ github.run_number }}.pre)
+              BUILD_NUMBER=$(.build/set-build-number ${{ github.run_number }}.$(echo ${{ github.sha }} | cut -c 1-10))
               echo "product_version=$BUILD_NUMBER" >> $GITHUB_ENV
               echo "build_tag=prerelease" >> $GITHUB_ENV
               echo "is_prerelease=true" >> $GITHUB_ENV

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,20 +25,6 @@ jobs:
       script: [ $DEPLOY_PRERELEASE_STAGE/deploy-to-prerelease-servers/run || $REPORT_FAIL "prerelease deployment" ]
 
 
-    - stage: DeployPrerelease
-      name: "Build Installer Downloads & Upload to Github Releases"
-      if: ((branch = master) or (branch =~ /^release\//)) and (repo = 'triplea-game/triplea') and (type != 'pull_request')
-      script: [ $DEPLOY_PRERELEASE_STAGE/push-to-github-releases/run || $REPORT_FAIL "build installers" ]
-      deploy:
-        on: { tags: false, repo: triplea-game/triplea, all_branches: true }
-        provider: releases
-        file_glob: true
-        file: build/artifacts/*
-        skip_cleanup: true
-        prerelease: true
-        api_key:
-          secure: nxaqYrkXLGL3W20/eCnf63DLjMrQAhEuW44jggh1/nI383goa+u6w0bBtWCxRdVzos7t4dpVfS6+kv6oIHacm9zVA+RYrqy5opzCJhq8lmXVVRijbALzUeiFif2HURMaKWj0ynRNVlAyBHzazPTLZVWywifpdSubSkuMWkl20cmuKu/Hg3c1EC9se3OYhhTHx3Hya7xSrctrDEYLsEBAUZzkKfscqRVqwwltS88CgIMtRISDpSBGrtH0t1uAH6NitTSguGgb+QEpqnELcRLymX2G1yzMA4Xr5c/L34MfbBKf8vIuG9t411xYuLoyKoUbroTWxSnPwlSy6PHz+QJ7UCXbDkATOGO3chxlKxglppvI/G3n2YP5Zf2dAaDlHblpvarh55i/4i4sKB2AbvvzkIHrQJwUgmLCbpN8/Vp9GWcGkd6i5U7F8tNInCs6ttX3oGvGOfYEXs02Ctyiea4LAqk4S7GZTuV2QXqxXglL4eRIwZ4UETiwgoAAtHma63Eq7+9t2ykMlk7zAK96FGwJrB97wa08aPuSxL94IYEBmn9Ht/vKXRiNQMvpnfp4rWQtL3cqbVyYAg5EjKb4PsBmnb91+RXtnWFOY1RpZGt8sPXYd+KZYzN1BXTFJEpaLLsIDN6r7nMcAvJDUmucaM+m7giPXz1ZBGAic3UBM1qMCgI=
-
     ########################################################################
 
     - stage: DeployProd

--- a/docs/admin/release-steps.md
+++ b/docs/admin/release-steps.md
@@ -19,7 +19,27 @@ to prep for the next release and commit this to master.
 
 ## Finalize Release Notes
 
-{ TODO: link to the release note creation script and instructions here }
+## Release Note Script
+
+Run this script to parse release notes from merged PRs (this script could use some work! YMMV)
+
+```
+#!/bin/bash
+
+for page in $(seq 1 4); do
+curl "https://api.github.com/repos/triplea-game/triplea/pulls?state=closed&page=$page" \
+  | grep -Eo "merged_at\":|number\":.*|RELEASE_NOTE.*END_RELEASE_NOTE" \
+  | grep -B3 "merged_at\":" \
+  | grep -B1 RELEASE_NOTE  \
+  | sed 's@^number": \([0-9]*\),$@|[#\1](https://github.com/triplea-game/triplea/pull/\1)|@' \
+  | sed 's/RELEASE_NOTE-->//' \
+  | sed 's/<!--END_RELEASE_NOTE$/|/' \
+  | paste -d '' - -
+done >> release-notes
+```
+
+Clean up the above output and update the release-notes.md page on website.
+
 
 ## Update servers.yml
 

--- a/docs/admin/release-steps.md
+++ b/docs/admin/release-steps.md
@@ -1,49 +1,58 @@
 # Release Steps
 
-## How to Release
+## Create release branch
 
-- Update release notes
-- Update github releases, uncheck "this is a prerelease" on the release:
-  <https://github.com/triplea-game/triplea/releases>
-- Update servers.yml, increase latest version to the release. This will
-trigger in-game notifications to upgrade
-
-- create release branch (assuming the release is the latest version on master)
 ```
-git checkout master
-git checkout -b release/<release_number>  # eg: release/2.2
+git checkout master   # or checkout a specific SHA instead of master
+git checkout -b release/<release_number> # eg: release/10.2
 git push origin release/<release_number>
 ```
 
-The release branch will be there in case we need to do any patches post-release.
-Post-releases patches are not at all good things, but are there in case we
-really need to fix something.
+This will build installers and create a release in github releases.
 
-- Change the version number in 'product.properties', increase the version number
-to prep for the next release.
 
-- Update partner sites:
+## Increment version
+
+
+Change the version number in 'product.properties', increase the version number
+to prep for the next release and commit this to master.
+
+## Finalize Release Notes
+
+{ TODO: link to the release note creation script and instructions here }
+
+## Update servers.yml
+
+Increase latest version to the release. This will trigger in-game
+notifications to upgrade
+
+
+## Update partner sites:
+
   - http://www.freewarefiles.com/TripleA_program_56699.html
   - http://download.cnet.com/TripleA/3000-18516_4-75184098.html
 
-- Post to forums:
+
+## Post to forums:
+
   - https://forums.triplea-game.org/category/1/announcements
   - http://www.axisandallies.org/forums/index.php?board=53.0
 
-## Releasing a Patch
+
+# Hotfix - Releasing a Patch
 
 The process is very similar to a standard release.
 
 ```
 git checkout release/<release_number>
-git checkout -b <patch-branch-name>
+git checkout -b <patch-feature-branch-name>
 # do work
 git commit
 git push <patch-branch-name>
 # create a PR to merge <patch-branch-name> into release/<release_number>
 ```
 
-Once the above is done, Travis will build and push artifacts to github releases.
-Double check the version number and follow the steps in the above sections to update
-version numbers and issue notifications.
+Once the above is done, artifacts will be built and pushed to github releases.
+Double check the version number and follow the steps in the above sections
+to update version numbers and issue notifications.
 

--- a/docs/pr-release-notes.md
+++ b/docs/pr-release-notes.md
@@ -32,22 +32,3 @@ Example format for a very long note:
 <!--RELEASE_NOTE-->FEATURE|This is a very long feature request comment.  This is a very long feature request comment.  This is a very long feature request comment. This is a very long feature request comment. This is a very long feature request comment.<!--END_RELEASE_NOTE-->
 ```
 
-## Release Note Script
-
-Run this script to parse release notes from merged PRs (this script could use some work! YMMV)
-
-```
-#!/bin/bash
-
-for page in $(seq 1 4); do
-curl "https://api.github.com/repos/triplea-game/triplea/pulls?state=closed&page=$page" \
-  | grep -Eo "merged_at\":|number\":.*|RELEASE_NOTE.*END_RELEASE_NOTE" \
-  | grep -B3 "merged_at\":" \
-  | grep -B1 RELEASE_NOTE  \
-  | sed 's@^number": \([0-9]*\),$@|[#\1](https://github.com/triplea-game/triplea/pull/\1)|@' \
-  | sed 's/RELEASE_NOTE-->//' \
-  | sed 's/<!--END_RELEASE_NOTE$/|/' \
-  | paste -d '' - -
-done >> release-notes
-```
-

--- a/game-core/src/main/resources/META-INF/triplea/product.properties
+++ b/game-core/src/main/resources/META-INF/triplea/product.properties
@@ -1,1 +1,1 @@
-version = 2.6.0
+version = 2.6


### PR DESCRIPTION
- Use github actions to build installers
- Stop using Travis CI for installer builds
- Updates documentation to describe updated release process

Changes:
 - Notable: To release, instead of marking an existing prerelease
   as a release, instead we create a 'release/<version>' branch.
   Builds from 'release/*' branches will be built as releases.
   Builds from 'master' will be built as a prerelease.

 - Major: There will now be a single prerelease build, this reduces
   the number of tags being pushed and we will no longer
   have a unique tag for every build.

 - Minor: Run number is now appended to the version value in
   product.properties instead of replacing the trailing '.0'.
   This is to make the version value replacement less brittle,
   a person incrementing the version value no longer needs to
   know that it must end with '.0' to work with the build.

 - Minor: '.pre' will now be suffixed to prerelease build versions


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing

Verified builds against my fork: https://github.com/DanVanAtta/triplea/releases

- Checked that if a prerelease tag DNE, then deleting it is a no-op
- [x] TODO:  check that a release branch is built as a release 
- [x] TODO:  double check non-release and non-master branches are not built
- [x] TODO: double check PRs do not create releases
 
## Additional

- [x] TODO: add github action secrets so they are available to triplea-game
<!-- Describe any manual testing performed below. -->
