### PR TITLE
Fix banned username matching

### DIFF
--- a/database/src/main/resources/db/migration/lobby_db/V2.01.00__fix_username_ban_casing.sql
+++ b/database/src/main/resources/db/migration/lobby_db/V2.01.00__fix_username_ban_casing.sql
@@ -1,0 +1,11 @@
+-- delete any extra name bans that are duplicates
+delete from banned_username bu
+where exists (
+  select 1
+  from banned_username t2
+  where bu.date_created < t2.date_created
+    and bu.username ilike t2.username
+);
+
+-- upper case existing entries
+update banned_username set username = upper(username);

--- a/lobby-server/src/main/java/org/triplea/db/dao/username/ban/UsernameBanDao.java
+++ b/lobby-server/src/main/java/org/triplea/db/dao/username/ban/UsernameBanDao.java
@@ -29,6 +29,6 @@ public interface UsernameBanDao {
       "select exists ( "
           + "select * "
           + "from banned_username "
-          + "where username = lower(:playerName))")
+          + "where username = upper(:playerName))")
   boolean nameIsBanned(@Bind("playerName") String playerName);
 }

--- a/lobby-server/src/main/java/org/triplea/modules/moderation/ban/name/UsernameBanController.java
+++ b/lobby-server/src/main/java/org/triplea/modules/moderation/ban/name/UsernameBanController.java
@@ -45,7 +45,8 @@ public class UsernameBanController extends HttpController {
       @Auth final AuthenticatedUser authenticatedUser, final String username) {
     Preconditions.checkArgument(username != null && !username.isEmpty());
     return Response.status(
-            bannedNamesService.addBannedUserName(authenticatedUser.getUserIdOrThrow(), username)
+            bannedNamesService.addBannedUserName(
+                    authenticatedUser.getUserIdOrThrow(), username.toUpperCase())
                 ? 200
                 : 400)
         .build();

--- a/lobby-server/src/test/java/org/triplea/db/dao/username/ban/UsernameBanDaoTest.java
+++ b/lobby-server/src/test/java/org/triplea/db/dao/username/ban/UsernameBanDaoTest.java
@@ -25,10 +25,10 @@ class UsernameBanDaoTest extends LobbyServerTest {
     final List<UsernameBanRecord> result = usernameBanDao.getBannedUserNames();
     assertThat(result, hasSize(2));
 
-    assertThat(result.get(0).getUsername(), is("username1"));
+    assertThat(result.get(0).getUsername(), is("USERNAME1"));
     assertThat(result.get(0).getDateCreated(), isInstant(2001, 1, 1, 23, 59, 59));
 
-    assertThat(result.get(1).getUsername(), is("username2"));
+    assertThat(result.get(1).getUsername(), is("USERNAME2"));
     assertThat(result.get(1).getDateCreated(), isInstant(2000, 1, 1, 23, 59, 59));
   }
 

--- a/lobby-server/src/test/java/org/triplea/modules/moderation/ban/name/UsernameBanControllerTest.java
+++ b/lobby-server/src/test/java/org/triplea/modules/moderation/ban/name/UsernameBanControllerTest.java
@@ -83,7 +83,8 @@ class UsernameBanControllerTest {
     }
 
     private void givenAddBanResult(final boolean result) {
-      when(bannedNamesService.addBannedUserName(AUTHENTICATED_USER.getUserId(), USERNAME))
+      when(bannedNamesService.addBannedUserName(
+              AUTHENTICATED_USER.getUserId(), USERNAME.toUpperCase()))
           .thenReturn(result);
     }
   }

--- a/lobby-server/src/test/resources/datasets/username_ban/get_banned_usernames.yml
+++ b/lobby-server/src/test/resources/datasets/username_ban/get_banned_usernames.yml
@@ -1,5 +1,5 @@
 banned_username:
-  - username: username1
+  - username: USERNAME1
     date_created: 2001-01-01 23:59:59
-  - username: username2
+  - username: USERNAME2
     date_created: 2000-01-01 23:59:59


### PR DESCRIPTION
The check for username bans attempted to do a case insensitive match
by lower casing the name to check. But, the names stored where in whatever
casing was originally entered. This implies the username ban only worked
when the original casing was all lower casing.

This update fixes the matching so it is case insensitive, banned usernames
are upper-cased when entered into database and then the name to match is also upper-cased.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->
This will go out with the next lobby release.
<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
