### PR TITLE
Use different create release github action

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -45,17 +45,11 @@ jobs:
           delete_release: true
           tag_name: ${{ env.build_tag }}
       - name: Create Github Release
-        uses: actions/create-release@v1
+        uses: ncipollo/release-action@v1
         with:        
-          tag_name: ${{ env.build_tag }}
-          release_name: ${{ env.release_name }}
+          artifact: build/artifacts/*
+          tag: ${{ env.build_tag }} 
+          name: ${{ env.release_name }}
           prerelease: ${{ env.is_prerelease }}
-          draft: false
-      - name: Upload Release Asset
-        uses: svenstaro/upload-release-action@v2
-        with:
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
-          tag: ${{ env.build_tag }}
-          file: build/artifacts/*
-          file_glob: true
+          commit: master
 


### PR DESCRIPTION
The previous, when not on a fork, create both a release *and*
a tag rather than a single release with tag. Hopefully this
new action will create one release with a given name and tag and
not two.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
