### PR TITLE
Simplify create-release github action & use unique tags

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -15,40 +15,27 @@ jobs:
         uses: actions/checkout@v2
       - name: set build version variables
         run: |
-          echo "base ref = ${{ github.ref }}"
           if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
               BUILD_NUMBER=$(.build/set-build-number ${{ github.run_number }}@$(echo ${{ github.sha }} | cut -c 1-10))
-              echo "product_version=$BUILD_NUMBER" >> $GITHUB_ENV
-              echo "build_tag=prerelease" >> $GITHUB_ENV
-              echo "is_prerelease=true" >> $GITHUB_ENV
-              echo "release_name=$(date +%Y-%B-%d--%H.%m) - Prerelease - $BUILD_NUMBER" >> $GITHUB_ENV
+              echo "product_version=$BUILD_NUMBER" | tee -a $GITHUB_ENV
+              echo "is_prerelease=true" | tee -a $GITHUB_ENV
+              echo "release_name=$(date +%Y-%B-%d--%H.%m) - Prerelease - $BUILD_NUMBER" | tee -a $GITHUB_ENV
           else
               BUILD_NUMBER=$(.build/set-build-number ${{ github.run_number }})
-              echo "product_version=$BUILD_NUMBER" >> $GITHUB_ENV
-              echo "build_tag=$BUILD_NUMBER" >> $GITHUB_ENV
-              echo "is_prerelease=false" >> $GITHUB_ENV
-              echo "release_name=$(date +%Y-%B) - Release - $BUILD_NUMBER" >> $GITHUB_ENV
+              echo "product_version=$BUILD_NUMBER" | tee -a $GITHUB_ENV
+              echo "is_prerelease=false" | tee -a $GITHUB_ENV
+              echo "release_name=$(date +%Y-%B) - Release - $BUILD_NUMBER" | tee -a $GITHUB_ENV
           fi
-      - name: echo build version values
-        run: |
-            echo "product_version = ${{ env.product_version }}" 
-            echo "build_tag = ${{ env.build_tag }}" 
-            echo "is_prerelease = ${{ env.is_prerelease }}" 
-            echo "release_name = ${{ env.release_name }}" 
       - name: Build installers
         run: .build/build-installer
         env:
           BUILD_NUMBER: ${{ github.run_number }}
           INSTALL4J_LICENSE: ${{ secrets.INSTALL4J_LICENSE }}
-      - uses: dev-drprasad/delete-tag-and-release@v0.1.2
-        with:
-          delete_release: true
-          tag_name: ${{ env.build_tag }}
       - name: Create Github Release
         uses: ncipollo/release-action@v1
         with:        
           artifact: build/artifacts/*
-          tag: ${{ env.build_tag }} 
+          tag: ${{ env.product_version }} 
           name: ${{ env.release_name }}
           prerelease: ${{ env.is_prerelease }}
           commit: master


### PR DESCRIPTION
Deleting and recreating tags does not consistently replace a release.
We are observing the replacement of the tag but the release can then
be created as a draft. This is not what we want.

This update simplifies the steps in the create-release action
and instead of deleting and re-using the 'prerelease' tag,
instead the tag will just match the product version
and will be unique each time.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
