### PR TITLE
Allow build number in 'version' to be a string

### DIFF
--- a/game-core/src/main/java/org/triplea/util/Version.java
+++ b/game-core/src/main/java/org/triplea/util/Version.java
@@ -5,13 +5,11 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.io.Serializable;
 import java.util.Comparator;
 import javax.annotation.Nonnull;
-import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 /** Represents a version string. versions are of the form major.minor.point */
 @Getter
-@AllArgsConstructor
 @EqualsAndHashCode
 public final class Version implements Serializable, Comparable<Version> {
   private static final long serialVersionUID = -4770210855326775333L;
@@ -20,8 +18,14 @@ public final class Version implements Serializable, Comparable<Version> {
   private final int major;
   /** Indicates engine compatible releases. */
   private final int minor;
-  /** Build identifiers, incremented on each build. */
-  private final int point;
+  /**
+   * Point (build number), unused, kept for serialization compatibility.
+   *
+   * @deprecated Do not use, use 'buildNumber' instead.
+   */
+  @Deprecated private int point;
+
+  private final String buildNumber;
 
   /** version must be of the from xx.xx.xx or xx.xx or xx where xx is a positive integer */
   public Version(final String version) {
@@ -32,7 +36,7 @@ public final class Version implements Serializable, Comparable<Version> {
 
     major = Integer.parseInt(parts[0]);
     minor = parts.length <= 1 ? 0 : Integer.parseInt(parts[1]);
-    point = parts.length <= 2 ? 0 : Integer.parseInt(parts[2]);
+    buildNumber = parts.length <= 2 ? "" : parts[2];
   }
 
   @Override
@@ -41,7 +45,6 @@ public final class Version implements Serializable, Comparable<Version> {
 
     return Comparator.comparingInt(Version::getMajor)
         .thenComparingInt(Version::getMinor)
-        .thenComparingInt(Version::getPoint)
         .compare(this, other);
   }
 
@@ -61,7 +64,8 @@ public final class Version implements Serializable, Comparable<Version> {
   /** Creates a complete version string with '.' as separator. */
   @Override
   public String toString() {
-    return String.join(".", String.valueOf(major), String.valueOf(minor), String.valueOf(point));
+    return String.join(".", String.valueOf(major), String.valueOf(minor))
+        + (buildNumber.isEmpty() ? "" : "." + buildNumber);
   }
 
   /**

--- a/game-core/src/test/java/games/strategy/engine/data/gameparser/GameParserTest.java
+++ b/game-core/src/test/java/games/strategy/engine/data/gameparser/GameParserTest.java
@@ -28,7 +28,7 @@ final class GameParserTest {
         GameParserTest.class.getClassLoader().getResource("v1_8_map__270BC.xml").toURI();
 
     final GameData gameData =
-        GameParser.parse(mapUri, new XmlGameElementMapper(), new Version(2, 0, 0)).orElseThrow();
+        GameParser.parse(mapUri, new XmlGameElementMapper(), new Version("2.0.0")).orElseThrow();
     assertNotNullGameData(gameData);
 
     verifyLegacyPropertiesAreUpdated(gameData);

--- a/game-core/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/GameDataManagerTest.java
@@ -18,10 +18,10 @@ final class GameDataManagerTest {
     void shouldPreserveGameName() throws Exception {
       final GameData data = new GameData();
       final byte[] bytes =
-          IoUtils.writeToMemory(os -> GameDataManager.saveGame(os, data, new Version(2, 0, 0)));
+          IoUtils.writeToMemory(os -> GameDataManager.saveGame(os, data, new Version("2.0.0")));
       final GameData loaded =
           IoUtils.readFromMemory(
-                  bytes, input -> GameDataManager.loadGame(new Version(2, 0, 0), input))
+                  bytes, input -> GameDataManager.loadGame(new Version("2.0.0"), input))
               .orElseThrow();
       assertEquals(loaded.getGameName(), data.getGameName());
     }
@@ -33,7 +33,7 @@ final class GameDataManagerTest {
     void shouldCloseOutputStream() throws Exception {
       final OutputStream os = mock(OutputStream.class);
 
-      GameDataManager.saveGame(os, new GameData(), new Version(2, 0, 0));
+      GameDataManager.saveGame(os, new GameData(), new Version("2.0.0"));
 
       verify(os).close();
     }

--- a/game-core/src/test/java/games/strategy/engine/framework/startup/login/ClientLoginIntegrationTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/startup/login/ClientLoginIntegrationTest.java
@@ -42,7 +42,7 @@ final class ClientLoginIntegrationTest {
 
   private static ILoginValidator newLoginValidator(final IServerMessenger serverMessenger) {
     final ClientLoginValidator clientLoginValidator =
-        new ClientLoginValidator(new Version(2, 0, 0));
+        new ClientLoginValidator(new Version("2.0.00"));
     clientLoginValidator.setServerMessenger(serverMessenger);
     clientLoginValidator.setGamePassword(PASSWORD);
     return clientLoginValidator;
@@ -61,7 +61,7 @@ final class ClientLoginIntegrationTest {
     }
 
     TestConnectionLogin(final String password) {
-      super(null, new Version(2, 0, 0));
+      super(null, new Version("2.0.0"));
 
       this.password = password;
     }

--- a/game-core/src/test/java/games/strategy/engine/framework/startup/login/ClientLoginValidatorTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/startup/login/ClientLoginValidatorTest.java
@@ -20,7 +20,7 @@ final class ClientLoginValidatorTest {
   @Nested
   final class AuthenticateTest {
     private final ClientLoginValidator clientLoginValidator =
-        new ClientLoginValidator(new Version(2, 0, 0));
+        new ClientLoginValidator(new Version("2.0.0"));
 
     @BeforeEach
     void givenPasswordSet() {

--- a/game-core/src/test/java/games/strategy/triplea/odds/calculator/BattleCalculatorTest.java
+++ b/game-core/src/test/java/games/strategy/triplea/odds/calculator/BattleCalculatorTest.java
@@ -36,7 +36,7 @@ class BattleCalculatorTest {
     final GamePlayer germans = germans(gameData);
     final List<Unit> attackingUnits = infantry(gameData).create(100, russians);
     final List<Unit> bombardingUnits = List.of();
-    final BattleCalculator calculator = new BattleCalculator(gameData, false, new Version(2, 0, 0));
+    final BattleCalculator calculator = new BattleCalculator(gameData, false, new Version("2.0.0"));
     final AggregateResults results =
         calculator.calculate(
             russians,
@@ -65,7 +65,7 @@ class BattleCalculatorTest {
     final List<Unit> attackingUnits = infantry(gameData).create(1, germans);
     attackingUnits.addAll(bomber(gameData).create(1, germans));
     final List<Unit> bombardingUnits = List.of();
-    final BattleCalculator calculator = new BattleCalculator(gameData, false, new Version(2, 0, 0));
+    final BattleCalculator calculator = new BattleCalculator(gameData, false, new Version("2.0.0"));
     calculator.setKeepOneAttackingLandUnit(true);
     final AggregateResults results =
         calculator.calculate(
@@ -87,7 +87,7 @@ class BattleCalculatorTest {
     final Territory sz1 = territory("1 Sea Zone", gameData);
     final List<Unit> attacking = transport(gameData).create(2, americans(gameData));
     final List<Unit> defending = submarine(gameData).create(2, germans(gameData));
-    final BattleCalculator calculator = new BattleCalculator(gameData, false, new Version(2, 0, 0));
+    final BattleCalculator calculator = new BattleCalculator(gameData, false, new Version("2.0.0"));
     calculator.setKeepOneAttackingLandUnit(false);
     final AggregateResults results =
         calculator.calculate(
@@ -111,7 +111,7 @@ class BattleCalculatorTest {
     final Territory sz1 = territory("1 Sea Zone", gameData);
     final List<Unit> attacking = submarine(gameData).create(2, americans(gameData));
     final List<Unit> defending = transport(gameData).create(2, germans(gameData));
-    final BattleCalculator calculator = new BattleCalculator(gameData, false, new Version(2, 0, 0));
+    final BattleCalculator calculator = new BattleCalculator(gameData, false, new Version("2.0.0"));
     calculator.setKeepOneAttackingLandUnit(false);
     final AggregateResults results =
         calculator.calculate(

--- a/game-core/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
+++ b/game-core/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
@@ -77,7 +77,7 @@ public enum TestMapGameData {
             new XmlGameElementMapper(
                 Map.of("TestDelegate", TestDelegate::new),
                 Map.of("TestAttachment", TestAttachment::new)),
-            new Version(2, 0, 0))
+            new Version("2.0.0"))
         .orElseThrow(() -> new IllegalStateException("Error parsing: " + mapUri));
   }
 }

--- a/game-core/src/test/java/org/triplea/config/product/ProductVersionReaderIntegrationTest.java
+++ b/game-core/src/test/java/org/triplea/config/product/ProductVersionReaderIntegrationTest.java
@@ -12,6 +12,6 @@ final class ProductVersionReaderIntegrationTest {
 
   @Test
   void shouldReadPropertiesFromResource() {
-    assertThat(productVersionReader.getVersion().toString(), matchesPattern("\\d+\\.\\d+\\.\\d+"));
+    assertThat(productVersionReader.getVersion().toString(), matchesPattern("\\d+\\.\\d+"));
   }
 }

--- a/game-core/src/test/java/org/triplea/config/product/ProductVersionReaderTest.java
+++ b/game-core/src/test/java/org/triplea/config/product/ProductVersionReaderTest.java
@@ -17,6 +17,6 @@ final class ProductVersionReaderTest {
   void getVersion() {
     memoryPropertyReader.setProperty(PropertyKeys.VERSION, "1.6.0");
 
-    assertThat(productVersionReader.getVersion(), is(new Version(1, 6, 0)));
+    assertThat(productVersionReader.getVersion(), is(new Version("1.6.0")));
   }
 }

--- a/game-core/src/test/java/org/triplea/debug/error/reporting/formatting/ErrorReportBodyFormatterTest.java
+++ b/game-core/src/test/java/org/triplea/debug/error/reporting/formatting/ErrorReportBodyFormatterTest.java
@@ -32,7 +32,7 @@ class ErrorReportBodyFormatterTest {
   void containsUseSuppliedData() {
     final String body =
         ErrorReportBodyFormatter.buildBody(
-            SAMPLE_USER_DESCRIPTION, "mapName", "memoryStats", logRecord, new Version(2, 0, 0));
+            SAMPLE_USER_DESCRIPTION, "mapName", "memoryStats", logRecord, new Version("2.0.0"));
 
     assertThat(body, containsString(SAMPLE_USER_DESCRIPTION));
   }
@@ -41,7 +41,7 @@ class ErrorReportBodyFormatterTest {
   void containsMapName() {
     final String body =
         ErrorReportBodyFormatter.buildBody(
-            SAMPLE_USER_DESCRIPTION, "mapName", "memoryStats", logRecord, new Version(2, 0, 0));
+            SAMPLE_USER_DESCRIPTION, "mapName", "memoryStats", logRecord, new Version("2.0.0"));
 
     assertThat(body, containsString("mapName"));
   }
@@ -50,12 +50,12 @@ class ErrorReportBodyFormatterTest {
   void containsSystemData() {
     final String body =
         ErrorReportBodyFormatter.buildBody(
-            SAMPLE_USER_DESCRIPTION, "mapName", "memoryStats", logRecord, new Version(2, 0, 0));
+            SAMPLE_USER_DESCRIPTION, "mapName", "memoryStats", logRecord, new Version("2.0.0"));
 
     assertThat(body, containsString(SAMPLE_USER_DESCRIPTION));
     assertThat(body, containsString(SystemProperties.getOperatingSystem()));
     assertThat(body, containsString(SystemProperties.getJavaVersion()));
-    assertThat(body, containsString(new Version(2, 0, 0).toString()));
+    assertThat(body, containsString(new Version("2.0.0").toString()));
   }
 
   @Test
@@ -77,7 +77,7 @@ class ErrorReportBodyFormatterTest {
 
     final String body =
         ErrorReportBodyFormatter.buildBody(
-            SAMPLE_USER_DESCRIPTION, "mapName", "memoryStats", logRecord, new Version(2, 0, 0));
+            SAMPLE_USER_DESCRIPTION, "mapName", "memoryStats", logRecord, new Version("2.0.0"));
 
     Stream.of(EXCEPTION_WITH_CAUSE, EXCEPTION_WITH_MESSAGE)
         .map(Throwable::getStackTrace)
@@ -108,7 +108,7 @@ class ErrorReportBodyFormatterTest {
 
     final String body =
         ErrorReportBodyFormatter.buildBody(
-            SAMPLE_USER_DESCRIPTION, "mapName", "memoryStats", logRecord, new Version(2, 0, 0));
+            SAMPLE_USER_DESCRIPTION, "mapName", "memoryStats", logRecord, new Version("2.0.0"));
 
     assertThat(body, containsString(EXCEPTION_WITH_MESSAGE.getClass().getName()));
     assertThat(body, containsString(LOG_MESSAGE));
@@ -123,7 +123,7 @@ class ErrorReportBodyFormatterTest {
 
     final String body =
         ErrorReportBodyFormatter.buildBody(
-            SAMPLE_USER_DESCRIPTION, "mapName", "memoryStats", logRecord, new Version(2, 0, 0));
+            SAMPLE_USER_DESCRIPTION, "mapName", "memoryStats", logRecord, new Version("2.0.0"));
 
     assertThat(body, containsString("NullPointerException"));
   }

--- a/game-core/src/test/java/org/triplea/live/servers/CurrentVersionSelectorTest.java
+++ b/game-core/src/test/java/org/triplea/live/servers/CurrentVersionSelectorTest.java
@@ -95,7 +95,13 @@ class CurrentVersionSelectorTest {
 
     final Version versionResult = currentVersionSelector.apply(liveServers).getMinEngineVersion();
 
-    assertThat(versionResult, is(expectedVersion));
+    assertThat(
+        "Current version: "
+            + currentVersion
+            + ", latest version: 10.0, expected => "
+            + expectedVersion,
+        versionResult,
+        is(expectedVersion));
   }
 
   /** Each argument is a triplet: {current_version} {test values} {expected_version} */
@@ -121,15 +127,15 @@ class CurrentVersionSelectorTest {
             List.of(
                 serverPropertiesWithVersion("0.0.0"),
                 serverPropertiesWithVersion("9.8.0"),
-                serverPropertiesWithVersion("10.0.1")),
+                serverPropertiesWithVersion("10.1.1")),
             "9.8.0"),
         Arguments.of(
-            "10.0.10",
+            "10.10",
             List.of(
-                serverPropertiesWithVersion("10.0.0"),
-                serverPropertiesWithVersion("10.0.5"),
-                serverPropertiesWithVersion("10.0.20")),
-            "10.0.5"),
+                serverPropertiesWithVersion("10.0"),
+                serverPropertiesWithVersion("10.5"),
+                serverPropertiesWithVersion("10.20")),
+            "10.5"),
         // verify if major version is not matching that we can get a right value
         Arguments.of(
             "10.0.10",
@@ -184,11 +190,11 @@ class CurrentVersionSelectorTest {
             List.of(
                 serverPropertiesWithVersion("0.0"),
                 serverPropertiesWithVersion("99.9.9"),
-                serverPropertiesWithVersion("100.0.1")),
+                serverPropertiesWithVersion("100.1.1")),
             "99.9.9"),
         Arguments.of(
-            "0.0.10",
-            List.of(serverPropertiesWithVersion("0.0"), serverPropertiesWithVersion("0.0.5")),
-            "0.0.5"));
+            "0.10",
+            List.of(serverPropertiesWithVersion("0.0"), serverPropertiesWithVersion("0.5")),
+            "0.5"));
   }
 }

--- a/game-core/src/test/java/org/triplea/live/servers/FetchingCacheTest.java
+++ b/game-core/src/test/java/org/triplea/live/servers/FetchingCacheTest.java
@@ -46,7 +46,7 @@ class FetchingCacheTest extends AbstractClientSettingTestCase {
         FetchingCache.builder()
             .contentDownloader(closeableDownloaderFactory)
             .yamlParser(yamlParser)
-            .engineVersion(new Version(1, 0, 0))
+            .engineVersion(new Version("1.0.0"))
             .build();
   }
 

--- a/smoke-testing/src/main/java/org/triplea/test/smoke/ClientConnect.java
+++ b/smoke-testing/src/main/java/org/triplea/test/smoke/ClientConnect.java
@@ -50,7 +50,7 @@ public final class ClientConnect {
                 .port(4000)
                 .build(),
             new GameObjectStreamFactory(null),
-            new ClientLogin(null, new Version(2, 0, 0)));
+            new ClientLogin(null, new Version("2.0.0")));
     Thread.sleep(500L);
     log.info("Connection to bot server SUCCESSFUL, closing connection");
     messenger.shutDown();


### PR DESCRIPTION
Allows for a build number like '1.2.1@abc'
Notable, this update removes the used-by-test-only Verson
constructor that accepted ints and updates all tests to use
the single string arg constructor.

Also of note, build number is updated to be non-comparable
and insignificant when comparing version numbers.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
- updated product.properties to have a version string like '1.2.3@123xyz' to verify there was an error parsing it and then later no longer repro'd after the fix.
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
