### PR TITLE
Improve robustness of ScheduledTimer - catch task exceptions

### DIFF
--- a/java-extras/src/main/java/org/triplea/java/timer/ScheduledTimer.java
+++ b/java-extras/src/main/java/org/triplea/java/timer/ScheduledTimer.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import java.util.Timer;
 import java.util.TimerTask;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Class for creating a class to be executed periodically. Sample usage:
@@ -20,13 +21,14 @@ import lombok.Getter;
  * The scheduled timer can also be started at time of creation:
  *
  * <pre><code>
- *   ScheduledTimer timer = Timers.newFixedRateTimer("thread-name")
+ *   ScheduledTimer timer = Timers.fixedRateTimer("thread-name")
  *      .period(20, TimeUnit.SECONDS)
  *      .task(() -> executeTask())
  *      .start();
  *   timer.cancel();
  * </code></pre>
  */
+@Slf4j
 public class ScheduledTimer {
   private final Runnable task;
   private final long delayMillis;
@@ -56,7 +58,11 @@ public class ScheduledTimer {
         new TimerTask() {
           @Override
           public void run() {
-            task.run();
+            try {
+              task.run();
+            } catch (final Exception e) {
+              log.error("Scheduled task encountered an exception", e);
+            }
           }
         },
         delayMillis,


### PR DESCRIPTION
Long term we may want to use Executors, in the meantime this is
a simple fix to catch any exceptions from scheduled tasks to ensure
a scheduled task does not stop running. Any exceptions from a
scheduled task kills the timer, by catching them we'll prevent this.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
