### PR TITLE
Have gradle print a summary of failed test cases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -177,6 +177,31 @@ subprojects {
         }
     }
 
+    // Add a summary of failed test case to the end of execution
+    //   https://stackoverflow.com/questions/43917709/how-do-i-show-a-list-of-all-the-test-failures-after-completion-of-a-gradle-task
+    // add a collection to track failedTests
+    ext.failedTests = []
+
+    // add a testlistener to all tasks of type Test
+    tasks.withType(Test) {
+        afterTest { TestDescriptor descriptor, TestResult result ->
+            if(result.resultType == org.gradle.api.tasks.testing.TestResult.ResultType.FAILURE){
+                failedTests << ["${descriptor.className}::${descriptor.name}"]
+            }
+        }
+    }
+
+    // print out tracked failed tests when the build has finished
+    gradle.buildFinished {
+        if(!failedTests.empty){
+            println "Failed tests for ${project.name}:"
+            failedTests.each { failedTest ->
+                println failedTest
+            }
+            println ""
+        }
+    }
+
     check {
         dependsOn 'integTest'
     }


### PR DESCRIPTION
Adds some logic to track failed tests and print a listing
at the end of sub-project test execution.

Looks like this;

> Task :java-extras:test FAILED
Failed tests for java-extras:
[org.triplea.io.FileUtilsTest$NewFile::createNewFile()]
