### PR TITLE
Fix bad-zip folder could not be created false-positive error message

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/ZippedMapsExtractor.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/ZippedMapsExtractor.java
@@ -159,7 +159,7 @@ public class ZippedMapsExtractor {
    */
   private Optional<Path> moveBadZip(final File mapZip) {
     final Path badZipFolder = downloadedMapsFolder.resolve("bad-zips");
-    if (!badZipFolder.toFile().mkdirs()) {
+    if (!badZipFolder.toFile().exists() && !badZipFolder.toFile().mkdirs()) {
       log.error(
           "Unable to create folder: "
               + badZipFolder.toFile().getAbsolutePath()


### PR DESCRIPTION
If the 'bad-zip' folder already exists, the game engine when trying
to move bad-zips into that folder would give a false-positive
error message stating the folder could not be created.

The cause behind this is 'mkdirs' returns false if a folder already
exists. This update fixes that problem by checking if the bad-zip
folder exists, and if so skips trying to create it.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
