### PR TITLE
Improve failed to load 'polygons.txt' error message

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -18,9 +18,11 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.nio.file.Path;
+import java.util.List;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.imageio.ImageIO;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.io.ImageLoader;
 import org.triplea.java.UrlStreams;
@@ -36,6 +38,8 @@ public class ResourceLoader implements Closeable {
   public static final String ASSETS_FOLDER = "assets";
 
   private final URLClassLoader loader;
+
+  @Getter private final List<URL> searchUrls;
 
   public ResourceLoader(final String mapName) {
     Preconditions.checkNotNull(mapName);
@@ -65,9 +69,8 @@ public class ResourceLoader implements Closeable {
     // To solve this we will get all matching paths and then filter by what matched
     // the assets folder.
     try {
-      loader =
-          new URLClassLoader(
-              new URL[] {mapLocation.toURI().toURL(), gameAssetsDirectory.toURI().toURL()});
+      searchUrls = List.of(mapLocation.toURI().toURL(), gameAssetsDirectory.toURI().toURL());
+      loader = new URLClassLoader(searchUrls.toArray(URL[]::new));
     } catch (final MalformedURLException e) {
       throw new IllegalArgumentException(
           "Error creating file system paths with map: "

--- a/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -134,13 +134,12 @@ public class MapData {
       try {
         if (loader.getResource(POLYGON_FILE) == null) {
           throw new IllegalStateException(
-              "Error in resource loading. Unable to load expected resource: "
+              "Error in resource loading for map: "
+                  + mapNameDir
+                  + ". Unable to load file: "
                   + POLYGON_FILE
-                  + ", the error"
-                  + " is that either we did not find the correct path to load. Check the resource "
-                  + "loader to make sure the map zip or dir was added. Failing that, the path in "
-                  + "this error message should be available relative to the map folder, or "
-                  + "relative to the root of the map zip");
+                  + ", searched these locations: "
+                  + loader.getSearchUrls());
         }
 
         place.putAll(readPlacementsOneToMany(loader.optionalResource(PLACEMENT_FILE)));


### PR DESCRIPTION
If the resource loader path is bad and cannot locate the 'polygons.txt'
file witin a map, an error message is displayed that is both very
wordy and does not give much information about the problem.

This update changes the error message to list the ResourceLoader
search paths and reduces the wordiness of the error message.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

