### PR TITLE
Fix loading map names with a numeric name

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -259,7 +259,7 @@ public class UiContext {
   }
 
   private static String getDefaultMapDir(final GameState data) {
-    final String mapName = (String) data.getProperties().get(Constants.MAP_NAME);
+    final String mapName = String.valueOf(data.getProperties().get(Constants.MAP_NAME));
     if (mapName == null || mapName.isBlank()) {
       throw new IllegalStateException("Map name property not set on game");
     }


### PR DESCRIPTION
Fixes loading maps with names like '1941'.

When stored in game data properties, the value at some point
turns into an Integer. When extracting we attempt to cast this
to a 'String' and this then causes a ClassCastException. To fix
this, we can instead do a 'String.valueOf' rather than do an
explicit cast.


<!--
  Commit comment above summarizing the update.  If multiple commits please
  summarize the change above.
  Code standards and PR guidelines can be found at:
  <https://github.com/triplea-game/triplea/wiki/Contribution-Guidelines>
-->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Games with numeric names, like '1941', would not load.<!--END_RELEASE_NOTE-->
