### PR TITLE
Update single player alliance button tooltip "click to play <alliance>"

### DIFF
--- a/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
+++ b/game-core/src/main/java/games/strategy/engine/framework/startup/ui/PlayerSelectorRow.java
@@ -92,8 +92,7 @@ public class PlayerSelectorRow implements PlayerCountrySelection {
     if (!playerAlliances.contains(playerName)) {
       final String alliancesLabelText = playerAlliances.toString();
       alliances = new JButton(alliancesLabelText);
-      alliances.setToolTipText(
-          "Set all " + alliancesLabelText + " to " + PlayerTypes.HUMAN_PLAYER.getLabel());
+      alliances.setToolTipText("Click to play " + alliancesLabelText);
       alliances.addActionListener(
           e ->
               playerRows.stream()


### PR DESCRIPTION
Resolves: https://github.com/triplea-game/triplea/issues/8162

Unifies the tooltip text of the alliance button between single
and multiplayer games.

