### PR TITLE
Amphibious units without marine bonus should be sorted first

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
@@ -28,7 +28,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.java.collections.CollectionUtils;
@@ -102,13 +101,6 @@ public class CasualtySelector {
       return new CasualtyDetails(List.of(), List.of(), true);
     }
 
-    if (allTargetsOneTypeOneHitPoint(targetsToPickFrom, dependents)) {
-      final List<Unit> killed =
-          targetsToPickFrom.stream()
-              .limit(Math.min(hitsRemaining, targetsToPickFrom.size()))
-              .collect(Collectors.toList());
-      return new CasualtyDetails(killed, List.of(), true);
-    }
     // Create production cost map, Maybe should do this elsewhere, but in case prices change, we do
     // it here.
     final IntegerMap<UnitType> costs = TuvUtils.getCostsForTuv(player, data);
@@ -135,6 +127,7 @@ public class CasualtySelector {
 
     final CasualtyDetails casualtySelection =
         hitsRemaining >= totalHitpoints
+                || allTargetsOneTypeOneHitPoint(sortedTargetsToPickFrom, dependents)
             ? new CasualtyDetails(defaultCasualties, true)
             : tripleaPlayer.selectCasualties(
                 sortedTargetsToPickFrom,


### PR DESCRIPTION
<!-- If multiple commits please summarize the change above. -->

This partially solves #8855.  It ensures that the amphibious units are taken first when they don't have marine bonuses.

## Testing
I played Global 1940 and did an amphibious assault with 2 infantry as well as 2 non-amphibious infantry.  Verified that the 2 amphibious infantry were taken first

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Amphibious units that do not have a marine bonus will be auto selected as a casualty before the non-amphibious units are.  If the amphibious units have a marine bonus, then they will be auto selected after the non-amphibious units.<!--END_RELEASE_NOTE-->
