### PR TITLE
Fix download file unzip folder move

### DIFF
--- a/game-core/src/test/java/games/strategy/engine/ClientFileSystemHelperTest.java
+++ b/game-core/src/test/java/games/strategy/engine/ClientFileSystemHelperTest.java
@@ -2,69 +2,16 @@ package games.strategy.engine;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.when;
 
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import games.strategy.triplea.settings.ClientSetting;
 import java.io.File;
-import java.io.IOException;
 import java.nio.file.Paths;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
 @SuppressWarnings("InnerClassMayBeStatic")
 final class ClientFileSystemHelperTest {
-  @ExtendWith(MockitoExtension.class)
-  @Nested
-  final class GetFolderContainingFileWithNameTest {
-    @Mock private File file;
-
-    @Mock private File parentFolder;
-
-    @Mock private File startFolder;
-
-    private File getFolderContainingFileWithName() throws Exception {
-      return ClientFileSystemHelper.getFolderContainingFileWithName(file.getName(), startFolder);
-    }
-
-    @BeforeEach
-    void setUp() {
-      when(file.getName()).thenReturn("filename.ext");
-    }
-
-    @Test
-    void shouldReturnStartFolderWhenStartFolderContainsFile() throws Exception {
-      when(file.isFile()).thenReturn(true);
-      when(startFolder.listFiles()).thenReturn(new File[] {file});
-
-      assertThat(getFolderContainingFileWithName(), is(startFolder));
-    }
-
-    @Test
-    void shouldReturnAncestorFolderWhenAncestorFolderContainsFile() throws Exception {
-      when(file.isFile()).thenReturn(true);
-      when(startFolder.getParentFile()).thenReturn(parentFolder);
-      when(startFolder.listFiles()).thenReturn(new File[0]);
-      when(parentFolder.listFiles()).thenReturn(new File[] {file});
-
-      assertThat(getFolderContainingFileWithName(), is(parentFolder));
-    }
-
-    @Test
-    void shouldThrowExceptionWhenNoFolderContainsFile() {
-      when(startFolder.getParentFile()).thenReturn(parentFolder);
-      when(startFolder.listFiles()).thenReturn(new File[0]);
-      when(parentFolder.listFiles()).thenReturn(new File[0]);
-
-      assertThrows(IOException.class, this::getFolderContainingFileWithName);
-    }
-  }
-
   @Nested
   final class GetUserMapsFolderTest extends AbstractClientSettingTestCase {
     @Test

--- a/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadFileTest.java
+++ b/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadFileTest.java
@@ -6,6 +6,8 @@ import static org.mockito.Mockito.mock;
 
 import games.strategy.engine.framework.map.download.DownloadFile.DownloadState;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 class DownloadFileTest {
   @Test
@@ -27,5 +29,21 @@ class DownloadFileTest {
 
     testObj.cancelDownload();
     assertThat(testObj.getDownloadState(), is(DownloadState.CANCELLED));
+  }
+
+  @Test
+  void normalizeMapName() {
+    assertThat(DownloadFile.normalizeMapName("valid-name"), is("valid-name"));
+    assertThat(DownloadFile.normalizeMapName("also_valid"), is("also_valid"));
+    assertThat(
+        "Ampersand is a valid map name but scary in a file system, should be stripped",
+        DownloadFile.normalizeMapName("a&b"),
+        is("ab"));
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"*", ".", "\"", "/", "\\", "[", "]", ":", ";", "|", ","})
+  void invalidCharactersAreStripped(final String invalidCharacter) {
+    assertThat(DownloadFile.normalizeMapName(invalidCharacter), is(""));
   }
 }

--- a/java-extras/src/main/java/org/triplea/io/FileUtils.java
+++ b/java-extras/src/main/java/org/triplea/io/FileUtils.java
@@ -25,12 +25,20 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public final class FileUtils {
 
-  /**
-   * Creates a new file with a parent folder and any number of child folders. This is a convenience
-   * method to concatenate the path together with an OS specific file separator.
-   */
-  public static File newFile(final String parentDir, final String... childDirs) {
-    return Path.of(parentDir, childDirs).toFile();
+  public static Path newTempFolder() {
+    try {
+      return Files.createTempDirectory("triplea");
+    } catch (final IOException e) {
+      throw new FileSystemException(e);
+    }
+  }
+
+  private static class FileSystemException extends RuntimeException {
+    private static final long serialVersionUID = -2046259158805830577L;
+
+    FileSystemException(final IOException e) {
+      super("File system exception (check available disk space), " + e.getMessage(), e);
+    }
   }
 
   /**

--- a/java-extras/src/main/java/org/triplea/java/UrlUtils.java
+++ b/java-extras/src/main/java/org/triplea/java/UrlUtils.java
@@ -1,0 +1,15 @@
+package org.triplea.java;
+
+import com.google.common.base.Charsets;
+import java.net.URLDecoder;
+import lombok.experimental.UtilityClass;
+
+/** Utility methods for working with URLs and URL-formatted String objects. */
+@UtilityClass
+public class UrlUtils {
+
+  /** URL decodes a given string, eg: replaces '%20' with a space. */
+  public String urlDecode(final String urlEncoded) {
+    return URLDecoder.decode(urlEncoded, Charsets.UTF_8);
+  }
+}

--- a/java-extras/src/test/java/org/triplea/io/FileUtilsTest.java
+++ b/java-extras/src/test/java/org/triplea/io/FileUtilsTest.java
@@ -16,20 +16,6 @@ import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("InnerClassMayBeStatic")
 final class FileUtilsTest {
-
-  @Nested
-  final class NewFile {
-    @Test
-    void createNewFile() {
-      assertThat(FileUtils.newFile("file", "path"), is(new File("file" + File.separator + "path")));
-    }
-
-    @Test
-    void createNewFileFromSingleton() {
-      assertThat(FileUtils.newFile("file"), is(new File("file")));
-    }
-  }
-
   @Nested
   final class ListFilesTest {
     @Test

--- a/java-extras/src/test/java/org/triplea/java/UrlUtilsTest.java
+++ b/java-extras/src/test/java/org/triplea/java/UrlUtilsTest.java
@@ -1,0 +1,16 @@
+package org.triplea.java;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import org.junit.jupiter.api.Test;
+
+class UrlUtilsTest {
+  @Test
+  void urlDecode() {
+    assertThat(UrlUtils.urlDecode(""), is(""));
+    assertThat(UrlUtils.urlDecode("abc"), is("abc"));
+    assertThat(UrlUtils.urlDecode(" "), is(" "));
+    assertThat(UrlUtils.urlDecode("%20"), is(" "));
+  }
+}


### PR DESCRIPTION
Overview:
- fixes downloaded map extraction folder name
- cleans up FileUtils

Problem: we download to a temp file and it is the temp file that is moved
(without rename) to the downloaded-maps folder.

Fix: Instead of downloading to an arbitrary temp file, we instead create
a temp folder and download to a file that has the target file name.
We then extract that into downloadedMaps with the correct folder name.

This problem was introduced when handling the case of variants being extracted
from downloadedMaps folder and expanded in place.


<!-- If multiple commits please summarize the change above. -->

## Testing
- manually tested, downloaded a map, in a debugger stepped through the code and verified the newly created folder had the right name
- 
