### PR TITLE
Add Map server indexing scheduled job

### DIFF
--- a/github-client/src/main/java/org/triplea/http/client/github/GithubApiFeignClient.java
+++ b/github-client/src/main/java/org/triplea/http/client/github/GithubApiFeignClient.java
@@ -5,7 +5,9 @@ import feign.FeignException;
 import feign.HeaderMap;
 import feign.Headers;
 import feign.Param;
+import feign.QueryMap;
 import feign.RequestLine;
+import java.util.List;
 import java.util.Map;
 import org.triplea.http.client.HttpConstants;
 
@@ -14,6 +16,7 @@ import org.triplea.http.client.HttpConstants;
 interface GithubApiFeignClient {
 
   @VisibleForTesting String CREATE_ISSUE_PATH = "/repos/{org}/{repo}/issues";
+  @VisibleForTesting String LIST_REPOS_PATH = "/orgs/{org}/repos";
 
   /**
    * Creates a new issue on github.com.
@@ -26,4 +29,10 @@ interface GithubApiFeignClient {
       @Param("org") String org,
       @Param("repo") String repo,
       CreateIssueRequest createIssueRequest);
+
+  @RequestLine("GET " + LIST_REPOS_PATH)
+  List<RepoListingResponse> listRepos(
+      @HeaderMap Map<String, Object> headerMap,
+      @QueryMap Map<String, String> queryParams,
+      @Param("org") String org);
 }

--- a/github-client/src/main/java/org/triplea/http/client/github/RepoListingResponse.java
+++ b/github-client/src/main/java/org/triplea/http/client/github/RepoListingResponse.java
@@ -1,0 +1,15 @@
+package org.triplea.http.client.github;
+
+import com.google.gson.annotations.SerializedName;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+/** Response object from Github listing the details of an organization's repositories. */
+@ToString
+@AllArgsConstructor
+@Getter
+class RepoListingResponse {
+  @SerializedName("html_url")
+  String htmlUrl;
+}

--- a/java-extras/src/main/java/org/triplea/io/ContentDownloader.java
+++ b/java-extras/src/main/java/org/triplea/io/ContentDownloader.java
@@ -6,7 +6,9 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.Optional;
 import java.util.function.Consumer;
+import java.util.function.Function;
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -32,6 +34,7 @@ import org.triplea.java.Interruptibles;
  * <p>Warning: The input stream provided by this class can only be consumed once (property of input
  * streams, the input stream is not reset in any way after reading it).
  */
+@Slf4j
 public final class ContentDownloader implements CloseableDownloader {
   private final CloseableHttpClient httpClient;
 
@@ -93,5 +96,26 @@ public final class ContentDownloader implements CloseableDownloader {
     stream.close();
     response.close();
     httpClient.close();
+  }
+
+  /**
+   * Downloads content from a given URI and runs a function on the downloaded content and returns
+   * that functions output.
+   *
+   * @param uri The URI to download
+   * @param streamProcessor Function to process the downloaded input.
+   * @return Result of the stream processing function, otherwise an empty result if there were
+   *     errors or if the processing function returns null.
+   */
+  public static <T> Optional<T> downloadAndExecute(
+      final URI uri, final Function<InputStream, T> streamProcessor) {
+    try (CloseableDownloader downloader = new ContentDownloader(uri)) {
+      final InputStream stream = downloader.getStream();
+      return Optional.ofNullable(streamProcessor.apply(stream));
+    } catch (final IOException e) {
+      log.error(
+          "Failed to download and process content from URI: " + uri + ", " + e.getMessage(), e);
+      return Optional.empty();
+    }
   }
 }

--- a/lobby-server/src/main/java/org/triplea/modules/error/reporting/CreateIssueStrategy.java
+++ b/lobby-server/src/main/java/org/triplea/modules/error/reporting/CreateIssueStrategy.java
@@ -20,9 +20,17 @@ public class CreateIssueStrategy implements Function<CreateIssueParams, ErrorRep
   @Nonnull private final Function<CreateIssueResponse, ErrorReportResponse> responseAdapter;
   @Nonnull private final GithubApiClient githubApiClient;
   @Nonnull private final ErrorReportingDao errorReportingDao;
+  @Nonnull private final String githubOrg;
+  @Nonnull private final String githubRepo;
 
-  public static CreateIssueStrategy build(final GithubApiClient githubApiClient, final Jdbi jdbi) {
+  public static CreateIssueStrategy build(
+      final String githubOrg,
+      final String githubRepo,
+      final GithubApiClient githubApiClient,
+      final Jdbi jdbi) {
     return CreateIssueStrategy.builder()
+        .githubOrg(githubOrg)
+        .githubRepo(githubRepo)
         .githubApiClient(githubApiClient)
         .responseAdapter(new ErrorReportResponseConverter())
         .errorReportingDao(jdbi.onDemand(ErrorReportingDao.class))
@@ -50,6 +58,8 @@ public class CreateIssueStrategy implements Function<CreateIssueParams, ErrorRep
   private ErrorReportResponse sendRequest(final ErrorReportRequest errorReportRequest) {
     return responseAdapter.apply(
         githubApiClient.newIssue(
+            githubOrg,
+            githubRepo,
             CreateIssueRequest.builder()
                 .title(errorReportRequest.getGameVersion() + ": " + errorReportRequest.getTitle())
                 .body(errorReportRequest.getBody())

--- a/lobby-server/src/main/java/org/triplea/modules/error/reporting/ErrorReportController.java
+++ b/lobby-server/src/main/java/org/triplea/modules/error/reporting/ErrorReportController.java
@@ -34,8 +34,6 @@ public class ErrorReportController extends HttpController {
         GithubApiClient.builder()
             .uri(LobbyServerConfig.GITHUB_WEB_SERVICE_API_URL)
             .authToken(configuration.getGithubApiToken())
-            .githubOrg(LobbyServerConfig.GITHUB_ORG)
-            .githubRepo(configuration.getGithubRepo())
             .isTest(isTest)
             .build();
 
@@ -44,7 +42,9 @@ public class ErrorReportController extends HttpController {
     }
 
     return ErrorReportController.builder()
-        .errorReportIngestion(CreateIssueStrategy.build(githubApiClient, jdbi))
+        .errorReportIngestion(
+            CreateIssueStrategy.build(
+                LobbyServerConfig.GITHUB_ORG, configuration.getGithubRepo(), githubApiClient, jdbi))
         .canReportModule(CanUploadErrorReportStrategy.build(jdbi))
         .build();
   }

--- a/lobby-server/src/test/java/org/triplea/modules/error/reporting/CreateIssueStrategyTest.java
+++ b/lobby-server/src/test/java/org/triplea/modules/error/reporting/CreateIssueStrategyTest.java
@@ -3,6 +3,7 @@ package org.triplea.modules.error.reporting;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsSame.sameInstance;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -36,12 +37,14 @@ class CreateIssueStrategyTest {
   void verifyFlow() {
     final CreateIssueStrategy createIssueStrategy =
         CreateIssueStrategy.builder()
+            .githubOrg("org")
+            .githubRepo("repo")
             .githubApiClient(githubApiClient)
             .responseAdapter(responseAdapter)
             .errorReportingDao(errorReportingDao)
             .build();
 
-    when(githubApiClient.newIssue(any())).thenReturn(createIssueResponse);
+    when(githubApiClient.newIssue(eq("org"), eq("repo"), any())).thenReturn(createIssueResponse);
     when(responseAdapter.apply(createIssueResponse)).thenReturn(errorReportResponse);
 
     final ErrorReportResponse response =

--- a/maps-server/build.gradle
+++ b/maps-server/build.gradle
@@ -25,7 +25,8 @@ dependencies {
     implementation "org.jdbi:jdbi3-core:$jdbiVersion"
     implementation "org.jdbi:jdbi3-sqlobject:$jdbiVersion"
     implementation project(':dropwizard-common')
-    implementation project(':http-clients')
+    implementation project(':java-extras')
+    implementation project(':github-client')
     implementation project(':maps-server-client')
     runtimeOnly "org.postgresql:postgresql:$postgresqlVersion"
     testImplementation "com.github.database-rider:rider-junit5:$databaseRiderVersion"

--- a/maps-server/configuration.yml
+++ b/maps-server/configuration.yml
@@ -8,8 +8,12 @@ server:
 database:
   driverClass: org.postgresql.Driver
   user: maps_user
-  password: postgres
+  password: ${DB_PASSWORD:-postgres}
   url: jdbc:postgresql://localhost:5432/maps_db
   properties:
     charSet: UTF-8
   validationQuery: select 1
+
+githubMapsOrgName: ${GITHUB_MAPS_ORG_NAME:-triplea-maps}
+githubApiKey: ${GITHUB_API_KEY:-}
+githubApiUri: ${GITHUB_API_URI:-https://api.github.com}

--- a/maps-server/src/main/java/org/triplea/maps/indexing/MapIndexDao.java
+++ b/maps-server/src/main/java/org/triplea/maps/indexing/MapIndexDao.java
@@ -1,0 +1,21 @@
+package org.triplea.maps.indexing;
+
+import java.util.List;
+import org.jdbi.v3.sqlobject.customizer.BindBean;
+import org.jdbi.v3.sqlobject.customizer.BindList;
+import org.jdbi.v3.sqlobject.statement.SqlUpdate;
+
+interface MapIndexDao {
+
+  /** Upserts a map indexing result into the map_index table. */
+  @SqlUpdate(
+      "insert into map_index(map_name, repo_url, category_id, version)\n"
+          + "values(:mapName, :mapRepoUri, 1, :mapVersion)\n"
+          + "on conflict(repo_url)\n"
+          + "do update set map_name = :mapName, version = :mapVersion")
+  void upsert(@BindBean MapIndexResult mapIndexResult);
+
+  /** Deletes maps that are not in the parameter list from the map_index table. */
+  @SqlUpdate("delete from map_index where repo_url not in(<mapUriList>)")
+  int removeMapsNotIn(@BindList("mapUriList") List<String> mapUriList);
+}

--- a/maps-server/src/main/java/org/triplea/maps/indexing/MapIndexResult.java
+++ b/maps-server/src/main/java/org/triplea/maps/indexing/MapIndexResult.java
@@ -1,0 +1,17 @@
+package org.triplea.maps.indexing;
+
+import javax.annotation.Nonnull;
+import lombok.Builder;
+import lombok.Value;
+
+/**
+ * Data object representing a map index entry. URI is the location of the map repo, name and version
+ * are read from the 'map.yml' file located in the map repo.
+ */
+@Builder
+@Value
+public class MapIndexResult {
+  @Nonnull String mapName;
+  @Nonnull String mapRepoUri;
+  @Nonnull Integer mapVersion;
+}

--- a/maps-server/src/main/java/org/triplea/maps/indexing/MapIndexer.java
+++ b/maps-server/src/main/java/org/triplea/maps/indexing/MapIndexer.java
@@ -1,0 +1,48 @@
+package org.triplea.maps.indexing;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+import org.triplea.io.ContentDownloader;
+import org.triplea.yaml.YamlReader;
+
+/**
+ * Given a map URI, attempts to fetch the 'map.yml' file from the URI and if available generates a
+ * {@code MapIndexResult}.
+ */
+@Slf4j
+class MapIndexer implements Function<URI, Optional<MapIndexResult>> {
+  @Override
+  public Optional<MapIndexResult> apply(final URI uri) {
+    final URI mapYmlUri = URI.create(uri.toString() + "/map.yml?raw=true");
+    return ContentDownloader.downloadAndExecute(
+        mapYmlUri, mapYmlContentStream -> indexMapYmlContent(mapYmlUri, mapYmlContentStream));
+  }
+
+  /**
+   * Reads the input stream for map index YAML information, returns null if any data is missing or
+   * formatting is bad.
+   */
+  @VisibleForTesting
+  @Nullable
+  static MapIndexResult indexMapYmlContent(final URI mapYmlUri, final InputStream inputStream) {
+    try {
+      final Map<String, Object> mapYamlData = YamlReader.readMap(inputStream);
+      return MapIndexResult.builder()
+          .mapRepoUri(mapYmlUri.toString())
+          .mapName((String) mapYamlData.get("map_name"))
+          .mapVersion((Integer) mapYamlData.get("version"))
+          .build();
+    } catch (final ClassCastException
+        | YamlReader.InvalidYamlFormatException
+        | NullPointerException e) {
+      log.error("Invalid map.yml data found at URI: {}, error: {}", mapYmlUri, e.getMessage());
+      return null;
+    }
+  }
+}

--- a/maps-server/src/main/java/org/triplea/maps/indexing/MapIndexingTask.java
+++ b/maps-server/src/main/java/org/triplea/maps/indexing/MapIndexingTask.java
@@ -1,0 +1,70 @@
+package org.triplea.maps.indexing;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.Optional;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import javax.annotation.Nonnull;
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+import org.triplea.http.client.github.GithubApiClient;
+
+/**
+ * Task that runs a map indexing pass on all maps. The indexing will update database to reflect the
+ * latest checked in across all map repositories.
+ *
+ * <ul>
+ *   <li>Queries Github for list of map repos
+ *   <li>Checks each map repo for a 'map.yml' and reads the map name and version
+ *   <li>Deletes from database maps that have been removed
+ *   <li>Upserts latest map info into database
+ * </ul>
+ */
+@Builder
+@Slf4j
+class MapIndexingTask implements Runnable {
+
+  @Nonnull private final String githubOrgName;
+  @Nonnull private final MapIndexDao mapIndexDao;
+  @Nonnull private final GithubApiClient githubApiClient;
+  @Nonnull private final Function<URI, Optional<MapIndexResult>> mapIndexer;
+
+  @Override
+  public void run() {
+    log.info("Map indexing started, github org: {}", githubOrgName);
+
+    final long start = System.currentTimeMillis();
+
+    // get list of maps
+    final Collection<URI> mapUris =
+        githubApiClient.listRepositories(githubOrgName).stream()
+            .sorted()
+            .collect(Collectors.toList());
+
+    // remove deleted maps
+    final int mapsRemovedCount =
+        mapIndexDao.removeMapsNotIn(
+            mapUris.stream() //
+                .map(URI::toString)
+                .collect(Collectors.toList()));
+
+    // index all maps
+    final Collection<MapIndexResult> indexedMapData =
+        mapUris.stream()
+            .map(mapIndexer)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(Collectors.toList());
+
+    // upsert indexed map data into DB
+    indexedMapData.forEach(mapIndexDao::upsert);
+
+    log.info(
+        "Map indexing finished in {} ms, repos found: {}, repos with map.yml: {}, maps deleted: {}",
+        (System.currentTimeMillis() - start),
+        mapUris.size(),
+        indexedMapData.size(),
+        mapsRemovedCount);
+  }
+}

--- a/maps-server/src/main/java/org/triplea/maps/indexing/MapsIndexingSchedule.java
+++ b/maps-server/src/main/java/org/triplea/maps/indexing/MapsIndexingSchedule.java
@@ -1,0 +1,60 @@
+package org.triplea.maps.indexing;
+
+import io.dropwizard.lifecycle.Managed;
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.jdbi.v3.core.Jdbi;
+import org.triplea.http.client.github.GithubApiClient;
+import org.triplea.java.timer.ScheduledTimer;
+import org.triplea.java.timer.Timers;
+import org.triplea.maps.server.http.MapsConfig;
+
+/**
+ * Given a map indexing task, creates a schedule to run the indexing and once started will run at a
+ * fixed rate until stopped.
+ */
+@Slf4j
+public class MapsIndexingSchedule implements Managed {
+
+  private final ScheduledTimer taskTimer;
+
+  MapsIndexingSchedule(final MapIndexingTask mapIndexingTask) {
+    taskTimer =
+        Timers.fixedRateTimer("thread-name")
+            .period(10, TimeUnit.MINUTES)
+            .delay(10, TimeUnit.SECONDS)
+            .task(mapIndexingTask);
+  }
+
+  /**
+   * Factory method to create indexing task on a schedule. This does not start indexing, the
+   * 'start()' method must be called for map indexing to begin.
+   */
+  public static MapsIndexingSchedule build(final MapsConfig configuration, final Jdbi jdbi) {
+    return new MapsIndexingSchedule(
+        MapIndexingTask.builder()
+            .githubOrgName(configuration.getGithubMapsOrgName())
+            .githubApiClient(
+                GithubApiClient.builder()
+                    .uri(URI.create(configuration.getGithubApiUri()))
+                    .authToken(configuration.getGithubApiKey())
+                    .isTest(false)
+                    .build())
+            .mapIndexer(new MapIndexer())
+            .mapIndexDao(jdbi.onDemand(MapIndexDao.class))
+            .build());
+  }
+
+  @Override
+  public void start() {
+    log.info("Map indexing started");
+    taskTimer.start();
+  }
+
+  @Override
+  public void stop() {
+    log.info("Map indexing stopped");
+    taskTimer.cancel();
+  }
+}

--- a/maps-server/src/main/java/org/triplea/maps/indexing/README.md
+++ b/maps-server/src/main/java/org/triplea/maps/indexing/README.md
@@ -1,0 +1,13 @@
+Map indexing refers to the process where the map server fetches
+metadata from all maps available to download. As part of this
+fetch we are gathering enough information to list the map as
+available to download.
+
+To index we gather data from two key locations:
+
+- **Github API**: This tells us which repositories exist,
+each repository represents a map
+
+- **map.yml file**: Each repository is expected to contain
+a map.yml file that in turn tells us the name and the
+version of the map.

--- a/maps-server/src/main/java/org/triplea/maps/listing/MapListingRecord.java
+++ b/maps-server/src/main/java/org/triplea/maps/listing/MapListingRecord.java
@@ -5,15 +5,15 @@ import org.jdbi.v3.core.mapper.reflect.ColumnName;
 import org.triplea.http.client.maps.listing.MapDownloadListing;
 
 public class MapListingRecord {
-  private final String url;
   private final String name;
+  private final String url;
   private final String version;
   private final String categoryName;
 
   @Builder
   public MapListingRecord(
-      @ColumnName("repo_url") final String url,
       @ColumnName("map_name") final String name,
+      @ColumnName("repo_url") final String url,
       @ColumnName("version") final String version,
       @ColumnName("category_name") final String categoryName) {
     this.url = url;

--- a/maps-server/src/main/java/org/triplea/maps/server/http/MapsConfig.java
+++ b/maps-server/src/main/java/org/triplea/maps/server/http/MapsConfig.java
@@ -6,9 +6,22 @@ import io.dropwizard.db.DataSourceFactory;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
+import lombok.Setter;
 
-class MapsConfig extends Configuration {
+public class MapsConfig extends Configuration {
 
   @Valid @NotNull @JsonProperty @Getter
   private final DataSourceFactory database = new DataSourceFactory();
+
+  @Getter(onMethod_ = {@JsonProperty})
+  @Setter(onMethod_ = {@JsonProperty})
+  private String githubMapsOrgName;
+
+  @Getter(onMethod_ = {@JsonProperty})
+  @Setter(onMethod_ = {@JsonProperty})
+  private String githubApiKey;
+
+  @Getter(onMethod_ = {@JsonProperty})
+  @Setter(onMethod_ = {@JsonProperty})
+  private String githubApiUri;
 }

--- a/maps-server/src/main/java/org/triplea/maps/server/http/MapsServer.java
+++ b/maps-server/src/main/java/org/triplea/maps/server/http/MapsServer.java
@@ -8,6 +8,7 @@ import io.dropwizard.setup.Environment;
 import java.util.List;
 import org.jdbi.v3.core.Jdbi;
 import org.triplea.dropwizard.common.ServerConfiguration;
+import org.triplea.maps.indexing.MapsIndexingSchedule;
 import org.triplea.maps.listing.MapsListingController;
 import org.triplea.maps.server.db.RowMappers;
 
@@ -40,5 +41,7 @@ public class MapsServer extends Application<MapsConfig> {
 
     final JerseyEnvironment jerseyEnvironment = environment.jersey();
     List.of(MapsListingController.build(jdbi)).forEach(jerseyEnvironment::register);
+
+    environment.lifecycle().manage(MapsIndexingSchedule.build(configuration, jdbi));
   }
 }

--- a/maps-server/src/test/java/org/triplea/maps/indexing/MapIndexDaoTest.java
+++ b/maps-server/src/test/java/org/triplea/maps/indexing/MapIndexDaoTest.java
@@ -1,0 +1,54 @@
+package org.triplea.maps.indexing;
+
+import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.junit.jupiter.api.Test;
+import org.triplea.maps.server.http.MapServerTest;
+
+@AllArgsConstructor
+@DataSet(value = "map_category.yml,map_index.yml", useSequenceFiltering = false)
+class MapIndexDaoTest extends MapServerTest {
+
+  private final MapIndexDao mapIndexDao;
+
+  @Test
+  @ExpectedDataSet(value = "expected/map_index_upsert_new.yml", orderBy = "map_name")
+  void upsertCreatesNewRecords() {
+    mapIndexDao.upsert(
+        MapIndexResult.builder()
+            .mapName("map-name-3")
+            .mapRepoUri("http://map-repo-url-3")
+            .mapVersion(2)
+            .build());
+  }
+
+  @Test
+  @ExpectedDataSet(value = "expected/map_index_upsert_updated.yml", orderBy = "id")
+  void upsertUpdatesRecords() {
+    mapIndexDao.upsert(
+        MapIndexResult.builder()
+            .mapName("map-name-updated")
+            .mapRepoUri("http://map-repo-url-2")
+            .mapVersion(1000)
+            .build());
+  }
+
+  @Test
+  @ExpectedDataSet("map_index.yml")
+  void upsertSameData() {
+    mapIndexDao.upsert(
+        MapIndexResult.builder()
+            .mapName("map-name-2")
+            .mapRepoUri("http://map-repo-url-2")
+            .mapVersion(100)
+            .build());
+  }
+
+  @Test
+  @ExpectedDataSet("expected/map_index_post_remove.yml")
+  void removeMaps() {
+    mapIndexDao.removeMapsNotIn(List.of("http://map-repo-url"));
+  }
+}

--- a/maps-server/src/test/java/org/triplea/maps/indexing/MapIndexerTest.java
+++ b/maps-server/src/test/java/org/triplea/maps/indexing/MapIndexerTest.java
@@ -1,0 +1,56 @@
+package org.triplea.maps.indexing;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+
+import java.io.InputStream;
+import java.net.URI;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.triplea.test.common.StringToInputStream;
+
+class MapIndexerTest {
+
+  @Test
+  void ymlIndexing() {
+    final InputStream inputStream =
+        StringToInputStream.asInputStream("map_name: map_name\nversion: 2");
+
+    final MapIndexResult mapIndexResult =
+        MapIndexer.indexMapYmlContent(URI.create("http://uri"), inputStream);
+
+    assertThat(
+        mapIndexResult,
+        is(
+            MapIndexResult.builder()
+                .mapRepoUri("http://uri")
+                .mapName("map_name")
+                .mapVersion(2)
+                .build()));
+  }
+
+  @DisplayName("Verify that if the indexer finds missing data it returns null")
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "",
+        "map_name: missing_version",
+        "version: 2",
+        "map_name: bad_version_number\nversion: NaN",
+        "map_name: bad_indentation\n  version: 2",
+        "map_name:  \nversion: 2",
+        "map_name: map_name\nversion: ",
+      })
+  void ymlIndexingInvalidCases(final String inputString) {
+
+    final InputStream inputStream = StringToInputStream.asInputStream(inputString);
+
+    final MapIndexResult mapIndexResult =
+        MapIndexer.indexMapYmlContent(URI.create("http://uri"), inputStream);
+
+    assertThat(mapIndexResult, is(nullValue()));
+  }
+}

--- a/maps-server/src/test/java/org/triplea/maps/indexing/MapIndexingTaskTest.java
+++ b/maps-server/src/test/java/org/triplea/maps/indexing/MapIndexingTaskTest.java
@@ -1,0 +1,55 @@
+package org.triplea.maps.indexing;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.Function;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.triplea.http.client.github.GithubApiClient;
+
+@ExtendWith(MockitoExtension.class)
+class MapIndexingTaskTest {
+
+  static final MapIndexResult MAP_INDEX_RESULT =
+      MapIndexResult.builder().mapVersion(7).mapName("map-name").mapRepoUri("http://repo").build();
+
+  @Mock MapIndexDao mapIndexDao;
+  @Mock GithubApiClient githubApiClient;
+  @Mock Function<URI, Optional<MapIndexResult>> mapIndexer;
+
+  MapIndexingTask mapIndexingTask;
+
+  @BeforeEach
+  void setup() {
+    mapIndexingTask =
+        MapIndexingTask.builder()
+            .githubOrgName("ORG_NAME")
+            .mapIndexDao(mapIndexDao)
+            .githubApiClient(githubApiClient)
+            .mapIndexer(mapIndexer)
+            .build();
+  }
+
+  @Test
+  @DisplayName(
+      "Verify we fetch repos, run indexer, and then process results on non-empty indexed repos")
+  void runMapIndexing() {
+    when(githubApiClient.listRepositories("ORG_NAME"))
+        .thenReturn(List.of(URI.create("https://uri-1"), URI.create("https://uri-2")));
+    when(mapIndexer.apply(URI.create("https://uri-1"))).thenReturn(Optional.of(MAP_INDEX_RESULT));
+    when(mapIndexer.apply(URI.create("https://uri-2"))).thenReturn(Optional.empty());
+
+    mapIndexingTask.run();
+
+    verify(mapIndexDao).removeMapsNotIn(List.of("https://uri-1", "https://uri-2"));
+    verify(mapIndexDao).upsert(MAP_INDEX_RESULT);
+  }
+}

--- a/maps-server/src/test/java/org/triplea/maps/listing/MapListingDaoTest.java
+++ b/maps-server/src/test/java/org/triplea/maps/listing/MapListingDaoTest.java
@@ -19,6 +19,7 @@ class MapListingDaoTest extends MapServerTest {
 
   @Test
   void verifySelect() {
+
     final var results = mapListingDao.fetchMapListings();
 
     assertThat(results, hasSize(2));

--- a/maps-server/src/test/resources/datasets/expected/map_index_post_remove.yml
+++ b/maps-server/src/test/resources/datasets/expected/map_index_post_remove.yml
@@ -1,0 +1,6 @@
+map_index:
+  - id: 10
+    map_name: map-name
+    repo_url: http://map-repo-url
+    category_id: 1
+    version: 100

--- a/maps-server/src/test/resources/datasets/expected/map_index_upsert_new.yml
+++ b/maps-server/src/test/resources/datasets/expected/map_index_upsert_new.yml
@@ -1,0 +1,10 @@
+map_index:
+  - map_name: map-name
+    repo_url: http://map-repo-url
+    version: 100
+  - map_name: map-name-2
+    repo_url: http://map-repo-url-2
+    version: 100
+  - map_name: map-name-3
+    repo_url: http://map-repo-url-3
+    version: 2

--- a/maps-server/src/test/resources/datasets/expected/map_index_upsert_updated.yml
+++ b/maps-server/src/test/resources/datasets/expected/map_index_upsert_updated.yml
@@ -1,0 +1,11 @@
+map_index:
+  - id: 10
+    map_name: map-name
+    repo_url: http://map-repo-url
+    category_id: 1
+    version: 100
+  - id: 20
+    map_name: map-name-updated
+    repo_url: http://map-repo-url-2
+    category_id: 1
+    version: 1000

--- a/maps-server/src/test/resources/logback-test.xml
+++ b/maps-server/src/test/resources/logback-test.xml
@@ -1,0 +1,13 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d [%thread] %logger{36} %-5level: %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="ERROR">
+        <appender-ref ref="STDOUT"/>
+    </root>
+
+    <logger name="org.triplea.maps.indexing.MapIndexer" level="OFF"/>
+</configuration>


### PR DESCRIPTION
Adds a scheduled job to the maps-server to run periodically and scan
all map repositories for a 'map.yml' file, index it, and add the
indexed information to database. That DB information is then used
later to server map-download requests to get the list of maps
available for download.

Overview:
- add scheduled indexing job
- add API client to query github orgs for repo listing
- add maps-server config to inject github credentials
- updates maps-server DB, recreates tables to fit necessary information.
  Description and preview image will be at a standard location, we will
  not need to store in DB, game clients can determine those locations
  dynamically based on the map repo URL


<!-- If multiple commits please summarize the change above. -->

