### PR TITLE
Remove unnecessary inventory arg in 'deploy-prerelease'

### DIFF
--- a/.build/deploy-prerelease
+++ b/.build/deploy-prerelease
@@ -8,5 +8,4 @@ eval "$(ssh-agent -s)"
 cd infrastructure
 echo "$ANSIBLE_VAULT_PASSWORD" > vault_password
 trap "rm vault_password" EXIT
-./run_ansible_prerelease "$version" -i ansible/inventory/prerelease
-
+./run_ansible_prerelease "$version"


### PR DESCRIPTION
The inventory file is already baked into the script ./run_ansible_prerelease

