### PR TITLE
Update bot deployment - always deploy zip file

### DIFF
--- a/infrastructure/.include/build_latest_artifacts
+++ b/infrastructure/.include/build_latest_artifacts
@@ -19,11 +19,11 @@ function main() {
 function buildArtifacts() {
   (
     cd ..
-    ./gradlew :lobby-server:release :game-headless:shadowJar :database:release
+    ./gradlew :lobby-server:release :game-headless:release :database:release
   )
   copyBuildArtifact "../database/build/artifacts/migrations.zip" "ansible/roles/database/flyway/files/"
   copyBuildArtifact "../lobby-server/build/artifacts/triplea-lobby-server-$VERSION.zip" "ansible/roles/lobby_server/files/"
-  copyBuildArtifact "../game-headless/build/libs/triplea-game-headless-$VERSION.jar" "ansible/roles/bot/files/"
+  copyBuildArtifact "../game-headless/build/libs/triplea-game-headless-$VERSION.zip" "ansible/roles/bot/files/"
 }
 
 function copyBuildArtifact() {
@@ -40,5 +40,4 @@ function copyBuildArtifact() {
 }
 
 main
-
 

--- a/infrastructure/ansible/roles/bot/tasks/main.yml
+++ b/infrastructure/ansible/roles/bot/tasks/main.yml
@@ -37,21 +37,14 @@
 - name: download maps on bot server
   command: "{{ admin_home }}/download-all-maps {{ update_maps }}"
 
-- name: deploy jar file if using latest
+- name: deploy zip file if using latest
   when: using_latest
   copy:
-    src: "triplea-game-headless-{{ bot_version }}.jar"
+    src: "triplea-game-headless-{{ bot_version }}.zip"
     dest: "{{ bot_jar }}"
     owner: "{{ bot_user }}"
     group: "{{ bot_user }}"
 
-- name: create triplea-root touch file
-  file:
-    state: touch
-    path: "{{ bot_install_home }}/.triplea-root"
-    mode: "0644"
-    owner: "{{ bot_user }}"
-    group: "{{ bot_user }}"
 
 - name: download zip file if not using latest
   when: not using_latest
@@ -61,8 +54,7 @@
     owner: "{{ bot_user }}"
     group: "{{ bot_user }}"
 
-- name: extract zip file if not using latest
-  when: not using_latest
+- name: extract zip file
   unarchive:
     remote_src: yes
     src: "{{ bot_install_home }}/triplea-game-headless-{{ bot_version }}.zip"
@@ -70,12 +62,11 @@
     owner: "{{ bot_user }}"
     group: "{{ bot_user }}"
 
-- name: move jar file to expected location if not using latest
-  when: not using_latest
-  copy:
-    remote_src: true
-    src: "{{ bot_install_home }}/bin/triplea-game-headless-{{ bot_version }}.jar"
-    dest: "{{ bot_jar }}"
+- name: create triplea-root touch file
+  file:
+    state: touch
+    path: "{{ bot_install_home }}/.triplea-root"
+    mode: "0644"
     owner: "{{ bot_user }}"
     group: "{{ bot_user }}"
 


### PR DESCRIPTION
Instead of deploying a jar file for 'latest', instead
run 'releases' task to generate a zip file and copy that.
When not using latest, we download the zip file, by also
using a zip file in the latest case, we get similar steps
where the zip file after being copied or downloaded is
then always extracted.

