### PR TITLE
Add config to run 'apt autoremove' to reclaim kernel update disk space

### DIFF
--- a/infrastructure/run_ansible_prerelease
+++ b/infrastructure/run_ansible_prerelease
@@ -48,6 +48,10 @@ function runCleanup() {
   # With grep -v we filter out folders that begin with a '.', and the 'maps' folder and run_server script 
   ansible -i ansible/inventory/prerelease botHosts -m shell -a \
     "find /home/bot -type d -mindepth 1 -maxdepth 1 | grep -Ev \"/\.|maps|run_server|$VERSION\" | xargs --no-run-if-empty rm -rf"
+
+  # auto-remove to clean up /usr/lib/modules, each kernel update leaves data in that folder  
+  ansible -i ansible/inventory/prerelease all -m shell -a \
+    "sudo apt autoremove"
 }
 
 main "$@"


### PR DESCRIPTION
/usr/lib/modules was consuming close to 7G of disk space, mostly due
to a dozen kernal specific folders. This was mostly reclaimed
by running autoremove.

https://askubuntu.com/questions/115791/why-lib-modules-taking-so-much-space-on-xubuntu


<!-- If multiple commits please summarize the change above. -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
