### PR TITLE
Update YAML dump output style for maps to be block style

### DIFF
--- a/java-extras/src/main/java/org/triplea/yaml/YamlWriter.java
+++ b/java-extras/src/main/java/org/triplea/yaml/YamlWriter.java
@@ -4,11 +4,14 @@ import java.util.Map;
 import lombok.experimental.UtilityClass;
 import org.snakeyaml.engine.v2.api.Dump;
 import org.snakeyaml.engine.v2.api.DumpSettings;
+import org.snakeyaml.engine.v2.common.FlowStyle;
 
 /** Methods useful for writing YAML POJO data to a YAML formatted String. */
 @UtilityClass
 public class YamlWriter {
   public static String writeToString(final Map<String, Object> input) {
-    return new Dump(DumpSettings.builder().build()).dumpToString(input);
+    return new Dump(
+            DumpSettings.builder().setIndent(2).setDefaultFlowStyle(FlowStyle.BLOCK).build())
+        .dumpToString(input);
   }
 }


### PR DESCRIPTION
Instead of generating YAML maps that look like this:
{key1: value1, key2, value2}

Will be generated like this:
  key1: value1
  key2: value2

When additional keys in the future, the latter format will
be easier to modify.


<!-- If multiple commits please summarize the change above. -->
