### PR TITLE
Fix vagrant port conflict with maps server

### DIFF
--- a/infrastructure/Vagrantfile
+++ b/infrastructure/Vagrantfile
@@ -6,7 +6,7 @@ Vagrant.configure("2") do |config|
     vagrantHost.vm.network "forwarded_port", guest: 4001, host: 4100, host_ip: "127.0.0.1"
     vagrantHost.vm.network "forwarded_port", guest: 443, host: 8000, host_ip: "127.0.0.1"
     vagrantHost.vm.network "forwarded_port", guest: 8080, host: 8008, host_ip: "127.0.0.1"
-    vagrantHost.vm.network "forwarded_port", guest: 9090, host: 9090, host_ip: "127.0.0.1"
+    vagrantHost.vm.network "forwarded_port", guest: 9090, host: 9000, host_ip: "127.0.0.1"
   end
 end
 

--- a/infrastructure/run_ansible_vagrant
+++ b/infrastructure/run_ansible_vagrant
@@ -27,5 +27,5 @@ function main() {
 main "$@"
 
 echo "lobby port -> 8008"
-echo "maps server port -> 9090"
+echo "maps server port -> 9000"
 


### PR DESCRIPTION
If vagrant is using port 9090 to forward to maps server (running within
vagrant), this collides with a locally (running on the host OS) maps
server. To resolve, we will have host port 9000 forward to the maps
server running within vagrant.

