### PR TITLE
Fix inventory 'database' host group name

### DIFF
--- a/infrastructure/ansible/inventory/prerelease
+++ b/infrastructure/ansible/inventory/prerelease
@@ -1,7 +1,7 @@
 [prerelease]
 prerelease.triplea-game.org
 
-[postgresHosts:children]
+[database:children]
 prerelease
 
 [lobbyServer:children]

--- a/infrastructure/ansible/inventory/prod2
+++ b/infrastructure/ansible/inventory/prod2
@@ -16,7 +16,7 @@ lobbyServer
 [letsEncrypt:children]
 lobbyServer
 
-[postgresHosts:children]
+[database:children]
 lobbyServer
 
 [botHosts]

--- a/infrastructure/ansible/inventory/vagrant
+++ b/infrastructure/ansible/inventory/vagrant
@@ -1,7 +1,7 @@
 [vagrant]
 vagrant ansible_host=127.0.0.1 ansible_port=2010 ansible_ssh_private_key_file=./.vagrant/machines/vagrantHost/virtualbox/private_key
 
-[postgresHosts:children]
+[database:children]
 vagrant
 
 [lobbyServer:children]

--- a/infrastructure/ansible/site.yml
+++ b/infrastructure/ansible/site.yml
@@ -14,14 +14,20 @@
     - system/apt_common_tools
     - nginx_forums_conf
 
+- hosts: database
+  tags: [database, postgres]
+  roles:
+    - system/admin_user
+    - system/apt_common_tools
+    - database/postgres
+    - {name: database/flyway, tags: flyway}
+
 - hosts: lobbyServer
   tags: [lobby, lobby_server]
   roles:
     - system/admin_user
     - system/apt_common_tools
     - java
-    - database/postgres
-    - {name: database/flyway, tags: flyway}
     - lobby_server
     - nginx
     - postfix
@@ -32,8 +38,6 @@
     - system/admin_user
     - system/apt_common_tools
     - java
-    - database/postgres
-    - {name: database/flyway, tags: flyway}
     - maps_server
     - nginx
 


### PR DESCRIPTION
1. Inventory files had an old name for the DB host that was not used.
   This group name was updated to 'database'

2. Update playbook 'site.yml' to have a single deploment step to the
   database hosts. Conceptually this fits better rather than forcing
   the lobby and maps server roles to install a DB on their same host.
   Second, if we run a full execution of the playbook then we'll get
   duplicate database installation commands running if maps and lobby
   server are on the same host.
