### PR TITLE
Restore explicit CLI update of DB password and align passwords

### DIFF
--- a/database/sql/init/01-create-users.sql
+++ b/database/sql/init/01-create-users.sql
@@ -1,3 +1,3 @@
-create user lobby_user password 'postgres';
-create user maps_user password 'postgres';
+create user lobby_user password 'lobby';
+create user maps_user password 'maps';
 

--- a/infrastructure/ansible/group_vars/vagrant.yml
+++ b/infrastructure/ansible/group_vars/vagrant.yml
@@ -3,8 +3,8 @@ ansible_ssh_extra_args: '-o StrictHostKeyChecking=no'
 ansible_host: 127.0.0.1
 ansible_python_interpreter: /usr/bin/python3
 lobby_uri: "http://localhost:8080"
-lobby_db_password: "lobby-db-password"
-maps_db_password: "maps-db-password"
+lobby_db_password: "lobby"
+maps_db_password: "maps"
 nginx_ssl_certificate: "/vagrant/.vagrant/{{ lookup('env','CRT_FILE') }}"
 bot_numbers: ["01", "02"]
 log_sending_private_key_file_source: log_aggregation_sample

--- a/infrastructure/ansible/roles/database/postgres/defaults/main.yml
+++ b/infrastructure/ansible/roles/database/postgres/defaults/main.yml
@@ -3,7 +3,7 @@
 # database and has full privileges. Typically the
 # postgres account should not be used, instead
 # use an application database user.
-postgres_user_db_password: postgres_vagrant
+postgres_user_db_password: postgres
 
 # Definition of application databases. Each list element will
 # be one database created on the postgres database.

--- a/infrastructure/ansible/roles/database/postgres/tasks/main.yml
+++ b/infrastructure/ansible/roles/database/postgres/tasks/main.yml
@@ -69,3 +69,17 @@
     label: "{{ item.name }} {{ item.user }}"
   no_log: true
 
+# This is a hack because the previous tasks were supposed to set
+# the DB level password for our DB user, but it typically does not.
+# To achieve this, we'll run the native SQL commands to set the
+# user DB password.
+- name: set DB user passwords via CLI
+  shell: >
+    echo "alter role {{ item.user }} with password '{{ item.password }}';"  | sudo -u postgres psql
+  environment:
+    PGPASSWORD: "{{ postgres_user_db_password }}"
+  changed_when: false
+  loop: "{{ databases }}"
+  loop_control:
+    label: "{{ item.user }}"
+  no_log: true

--- a/lobby-server/configuration.yml
+++ b/lobby-server/configuration.yml
@@ -8,7 +8,7 @@ logSqlStatements: false
 database:
   driverClass: org.postgresql.Driver
   user: ${DATABASE_USER:-lobby_user}
-  password: ${DATABASE_PASSWORD:-postgres}
+  password: ${DATABASE_PASSWORD:-lobby}
   url: jdbc:postgresql://${DB_URL:-localhost:5432/lobby_db}
   properties:
     charSet: UTF-8


### PR DESCRIPTION
The ansible postgres_user role seems to _not_ be updating passwords.
On deployment am seeing invalid password. This update restores
the CLI 'hack' of setting the database user passwords explicitly.

Second, passwords are updated and aligned for default cases to
be 'lobby' and 'maps' for respecively the 'lobby_db' and 'maps_db'.
That update is so we are not sharing the same password with the
postgres user, which gives us more confidence we are using the right
DB account when accessing database.

