### PR TITLE
Fix maps packaging, add 'mergeServiceFiles' to shadow jar

### DIFF
--- a/maps-server/build.gradle
+++ b/maps-server/build.gradle
@@ -56,5 +56,6 @@ task release(group: 'release', dependsOn: portableInstaller) {
 }
 
 shadowJar {
+    mergeServiceFiles()
     archiveClassifier.set ''
 }


### PR DESCRIPTION
Avoids problem "'http' connector type is not recognized."
Fix is as described here:
<https://github.com/dropwizard/dropwizard/issues/455>
