### PR TITLE
Improve unit separator parameters

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
@@ -328,7 +328,8 @@ public class CasualtySelector {
   private static boolean allTargetsOneTypeOneHitPoint(
       final Collection<Unit> targets, final Map<Unit, Collection<Unit>> dependents) {
     final Set<UnitCategory> categorized =
-        UnitSeparator.categorize(targets, dependents, false, false);
+        UnitSeparator.categorize(
+            targets, UnitSeparator.SeparatorCategories.builder().dependents(dependents).build());
     if (categorized.size() == 1) {
       final UnitCategory unitCategory = categorized.iterator().next();
       return unitCategory.getHitPoints() - unitCategory.getDamaged() <= 1;

--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/LowLuckTargetGroups.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/LowLuckTargetGroups.java
@@ -43,7 +43,8 @@ class LowLuckTargetGroups {
     }
 
     final Collection<UnitCategory> groupedTargets =
-        UnitSeparator.categorize(targets, null, false, true);
+        UnitSeparator.categorize(
+            targets, UnitSeparator.SeparatorCategories.builder().transportCost(true).build());
     for (final UnitCategory uc : groupedTargets) {
       final Deque<List<Unit>> guaranteedGroups =
           new ArrayDeque<>(Lists.partition(uc.getUnits(), guaranteeHitGroupSize));

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -903,9 +903,7 @@ public class BattleDisplay extends JPanel {
       } finally {
         gameData.releaseReadLock();
       }
-      final Collection<UnitCategory> unitCategories =
-          UnitSeparator.categorize(
-              units, UnitSeparator.SeparatorCategories.builder().sort(false).build());
+      final Collection<UnitCategory> unitCategories = UnitSeparator.categorize(units);
       for (final UnitCategory category : unitCategories) {
         final int[] shift = new int[gameData.getDiceSides() + 1];
         for (final Unit current : category.getUnits()) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -233,7 +233,9 @@ public class BattleDisplay extends JPanel {
       dependentUnitsReturned.addAll(dependentCollection);
     }
     for (final UnitCategory category :
-        UnitSeparator.categorize(killedUnits, dependentsMap, false, false)) {
+        UnitSeparator.categorize(
+            killedUnits,
+            UnitSeparator.SeparatorCategories.builder().dependents(dependentsMap).build())) {
       final JPanel panel = new JPanel();
       JLabel unit = uiContext.newUnitImageLabel(category.getType(), category.getOwner());
       panel.add(unit);
@@ -902,7 +904,8 @@ public class BattleDisplay extends JPanel {
         gameData.releaseReadLock();
       }
       final Collection<UnitCategory> unitCategories =
-          UnitSeparator.categorize(units, null, false, false, false);
+          UnitSeparator.categorize(
+              units, UnitSeparator.SeparatorCategories.builder().sort(false).build());
       for (final UnitCategory category : unitCategories) {
         final int[] shift = new int[gameData.getDiceSides() + 1];
         for (final Unit current : category.getUnits()) {
@@ -1009,14 +1012,16 @@ public class BattleDisplay extends JPanel {
         this.killed.add(new JLabel("Killed"));
       }
       final Iterable<UnitCategory> killedIter =
-          UnitSeparator.categorize(killed, dependents, false, false);
+          UnitSeparator.categorize(
+              killed, UnitSeparator.SeparatorCategories.builder().dependents(dependents).build());
       categorizeUnits(killedIter, false, false);
       damaged.removeAll(killed);
       if (!damaged.isEmpty()) {
         this.damaged.add(new JLabel("Damaged"));
       }
       final Iterable<UnitCategory> damagedIter =
-          UnitSeparator.categorize(damaged, dependents, false, false);
+          UnitSeparator.categorize(
+              damaged, UnitSeparator.SeparatorCategories.builder().dependents(dependents).build());
       categorizeUnits(damagedIter, true, true);
       invalidate();
       validate();
@@ -1029,7 +1034,8 @@ public class BattleDisplay extends JPanel {
         this.killed.add(new JLabel("Killed"));
       }
       final Iterable<UnitCategory> killedIter =
-          UnitSeparator.categorize(killed, dependents, false, false);
+          UnitSeparator.categorize(
+              killed, UnitSeparator.SeparatorCategories.builder().dependents(dependents).build());
       categorizeUnits(killedIter, false, false);
       invalidate();
       validate();

--- a/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -171,7 +171,12 @@ class EditPanel extends ActionPanel {
             final String text = "Remove from " + t.getName();
             final UnitChooser chooser =
                 new UnitChooser(
-                    unitsToMove, selectedUnits, null, false, false, false, getMap().getUiContext());
+                    unitsToMove,
+                    selectedUnits,
+                    null,
+                    UnitSeparator.SeparatorCategories.builder().build(),
+                    false,
+                    getMap().getUiContext());
             final int option =
                 JOptionPane.showOptionDialog(
                     getTopLevelAncestor(),
@@ -404,11 +409,21 @@ class EditPanel extends ActionPanel {
                       allUnits, o -> selectedUnitTypes.contains(o.getType()));
               final int allCategories =
                   UnitSeparator.categorize(
-                          allOfCorrectType, mustMoveWithDetails.getMustMoveWith(), true, true)
+                          allOfCorrectType,
+                          UnitSeparator.SeparatorCategories.builder()
+                              .dependents(mustMoveWithDetails.getMustMoveWith())
+                              .movement(true)
+                              .transportCost(true)
+                              .build())
                       .size();
               final int selectedCategories =
                   UnitSeparator.categorize(
-                          selectedUnits, mustMoveWithDetails.getMustMoveWith(), true, true)
+                          selectedUnits,
+                          UnitSeparator.SeparatorCategories.builder()
+                              .dependents(mustMoveWithDetails.getMustMoveWith())
+                              .movement(true)
+                              .transportCost(true)
+                              .build())
                       .size();
               mustChoose = (allCategories != selectedCategories);
             }
@@ -420,9 +435,8 @@ class EditPanel extends ActionPanel {
                       allUnits,
                       selectedUnits,
                       mustMoveWithDetails.getMustMoveWith(),
-                      true,
+                      UnitSeparator.SeparatorCategories.builder().movement(true).build(),
                       false,
-                      /* allowMultipleHits= */ false,
                       getMap().getUiContext());
               final int option =
                   JOptionPane.showOptionDialog(

--- a/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -65,7 +65,13 @@ public final class UnitChooser extends JPanel {
       final Map<Unit, Collection<Unit>> dependent,
       final boolean allowTwoHit,
       final UiContext uiContext) {
-    this(units, defaultSelections, dependent, false, false, allowTwoHit, uiContext);
+    this(
+        units,
+        defaultSelections,
+        dependent,
+        UnitSeparator.SeparatorCategories.builder().build(),
+        allowTwoHit,
+        uiContext);
   }
 
   private UnitChooser(
@@ -89,7 +95,10 @@ public final class UnitChooser extends JPanel {
     final List<Unit> combinedList = defaultSelections.getDamaged();
     // TODO: this adds it to the default selections list, is this intended?
     combinedList.addAll(defaultSelections.getKilled());
-    createEntries(units, dependent, false, false, combinedList);
+    createEntries(
+        units,
+        UnitSeparator.SeparatorCategories.builder().dependents(dependent).build(),
+        combinedList);
     layoutEntries();
   }
 
@@ -97,12 +106,12 @@ public final class UnitChooser extends JPanel {
       final Collection<Unit> units,
       final Collection<Unit> defaultSelections,
       final Map<Unit, Collection<Unit>> dependent,
-      final boolean categorizeMovement,
-      final boolean categorizeTransportCost,
+      final UnitSeparator.SeparatorCategories separatorCategories,
       final boolean allowMultipleHits,
       final UiContext uiContext) {
     this(dependent, allowMultipleHits, uiContext, null);
-    createEntries(units, dependent, categorizeMovement, categorizeTransportCost, defaultSelections);
+    createEntries(
+        units, separatorCategories.toBuilder().dependents(dependents).build(), defaultSelections);
     layoutEntries();
   }
 
@@ -110,13 +119,13 @@ public final class UnitChooser extends JPanel {
       final Collection<Unit> units,
       final Collection<Unit> defaultSelections,
       final Map<Unit, Collection<Unit>> dependent,
-      final boolean categorizeMovement,
-      final boolean categorizeTransportCost,
+      final UnitSeparator.SeparatorCategories separatorCategories,
       final boolean allowMultipleHits,
       final UiContext uiContext,
       final Predicate<Collection<Unit>> match) {
     this(dependent, allowMultipleHits, uiContext, match);
-    createEntries(units, dependent, categorizeMovement, categorizeTransportCost, defaultSelections);
+    createEntries(
+        units, separatorCategories.toBuilder().dependents(dependents).build(), defaultSelections);
     layoutEntries();
   }
 
@@ -190,15 +199,12 @@ public final class UnitChooser extends JPanel {
 
   private void createEntries(
       final Collection<Unit> units,
-      final Map<Unit, Collection<Unit>> dependent,
-      final boolean categorizeMovement,
-      final boolean categorizeTransportCost,
+      final UnitSeparator.SeparatorCategories separatorCategories,
       final Collection<Unit> defaultSelections) {
     final Collection<UnitCategory> categories =
-        UnitSeparator.categorize(units, dependent, categorizeMovement, categorizeTransportCost);
+        UnitSeparator.categorize(units, separatorCategories);
     final Collection<UnitCategory> defaultSelectionsCategorized =
-        UnitSeparator.categorize(
-            defaultSelections, dependent, categorizeMovement, categorizeTransportCost);
+        UnitSeparator.categorize(defaultSelections, separatorCategories);
     final IntegerMap<UnitCategory> defaultValues =
         newDefaultSelectionsMap(defaultSelectionsCategorized);
     for (final UnitCategory category : categories) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
@@ -193,10 +193,9 @@ public class MovePanel extends AbstractMovePanel {
               chooser =
                   new UnitChooser(
                       unitsToMove,
-                      selectedUnits, /* mustMoveWith */
+                      selectedUnits,
                       null,
-                      /* categorizeMovement */ false, /* categorizeTransportCost */
-                      false, /* allowTwoHit */
+                      UnitSeparator.SeparatorCategories.builder().build(),
                       false,
                       getMap().getUiContext(),
                       ownerMatch);
@@ -204,10 +203,9 @@ public class MovePanel extends AbstractMovePanel {
               chooser =
                   new UnitChooser(
                       unitsToMove,
-                      selectedUnits, /* mustMoveWith */
-                      null, /* categorizeMovement */
-                      false,
-                      /* categorizeTransportCost */ false, /* allowTwoHit */
+                      selectedUnits,
+                      null,
+                      UnitSeparator.SeparatorCategories.builder().build(),
                       false,
                       getMap().getUiContext());
             }
@@ -344,8 +342,7 @@ public class MovePanel extends AbstractMovePanel {
                   candidateAirTransports,
                   defaultSelections,
                   dependentUnits,
-                  /* categorizeMovement */ true, /* categorizeTransportCost */
-                  false, /* allowTwoHit */
+                  UnitSeparator.SeparatorCategories.builder().movement(true).build(),
                   false,
                   getMap().getUiContext(),
                   transportsToLoadMatch);
@@ -840,7 +837,11 @@ public class MovePanel extends AbstractMovePanel {
     // Are the transports all of the same type and if they are, then don't ask
     final Collection<UnitCategory> categories =
         UnitSeparator.categorize(
-            candidateTransports, mustMoveWithDetails.getMustMoveWith(), true, false);
+            candidateTransports,
+            UnitSeparator.SeparatorCategories.builder()
+                .dependents(mustMoveWithDetails.getMustMoveWith())
+                .movement(true)
+                .build());
     if (categories.size() == 1) {
       return ImmutableList.copyOf(unitsToUnload);
     }
@@ -915,10 +916,9 @@ public class MovePanel extends AbstractMovePanel {
         new UnitChooser(
             candidateTransports,
             defaultSelections,
-            mustMoveWithDetails.getMustMoveWith(), /* categorizeMovement */
-            true, /* categorizeTransportCost */
+            mustMoveWithDetails.getMustMoveWith(),
+            UnitSeparator.SeparatorCategories.builder().movement(true).build(),
             false,
-            /* allowTwoHit */ false,
             getMap().getUiContext(),
             transportsToUnloadMatch);
     chooser.setTitle("What transports do you want to unload");
@@ -1290,7 +1290,11 @@ public class MovePanel extends AbstractMovePanel {
       }
       // all the same type, dont ask unless we have more than 1 unit type
       if (UnitSeparator.categorize(
-                      candidateTransports, endMustMoveWith.getMustMoveWith(), true, false)
+                      candidateTransports,
+                      UnitSeparator.SeparatorCategories.builder()
+                          .dependents(endMustMoveWith.getMustMoveWith())
+                          .movement(true)
+                          .build())
                   .size()
               == 1
           && unitsToLoad.size() == 1) {
@@ -1317,10 +1321,9 @@ public class MovePanel extends AbstractMovePanel {
         new UnitChooser(
             candidateTransports,
             defaultSelections,
-            endMustMoveWith.getMustMoveWith(), /* categorizeMovement */
-            true, /* categorizeTransportCost */
+            endMustMoveWith.getMustMoveWith(),
+            UnitSeparator.SeparatorCategories.builder().movement(true).build(),
             false,
-            /* allowTwoHit */ false,
             getMap().getUiContext(),
             transportsToLoadMatch);
     chooser.setTitle("What transports do you want to load");
@@ -1355,7 +1358,11 @@ public class MovePanel extends AbstractMovePanel {
     if (!mustQueryUser) {
       final Set<UnitCategory> categories =
           UnitSeparator.categorize(
-              candidateUnits, mustMoveWithDetails.getMustMoveWith(), true, false);
+              candidateUnits,
+              UnitSeparator.SeparatorCategories.builder()
+                  .dependents(mustMoveWithDetails.getMustMoveWith())
+                  .movement(true)
+                  .build());
       for (final UnitCategory category1 : categories) {
         // we cant move these, dont bother to check
         if (category1.getMovement().compareTo(BigDecimal.ZERO) == 0) {
@@ -1402,8 +1409,7 @@ public class MovePanel extends AbstractMovePanel {
               candidateUnits,
               defaultSelections,
               mustMoveWithDetails.getMustMoveWith(),
-              true,
-              false,
+              UnitSeparator.SeparatorCategories.builder().movement(true).build(),
               false,
               getMap().getUiContext(),
               matchCriteria);
@@ -1477,8 +1483,7 @@ public class MovePanel extends AbstractMovePanel {
             unitsToLoad,
             defaultSelections,
             dependentUnits,
-            /* categorizeMovement */ false, /* categorizeTransportCost */
-            true, /* allowTwoHit */
+            UnitSeparator.SeparatorCategories.builder().transportCost(true).build(),
             false,
             getMap().getUiContext(),
             unitsToLoadMatch);

--- a/game-core/src/main/java/games/strategy/triplea/util/TransportUtils.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/TransportUtils.java
@@ -179,9 +179,10 @@ public final class TransportUtils {
 
     // Get a list of the unit categories
     final Collection<UnitCategory> unitTypes =
-        UnitSeparator.categorize(canBeTransported, null, false, true);
-    final Collection<UnitCategory> transportTypes =
-        UnitSeparator.categorize(airTransports, null, false, false);
+        UnitSeparator.categorize(
+            canBeTransported,
+            UnitSeparator.SeparatorCategories.builder().transportCost(true).build());
+    final Collection<UnitCategory> transportTypes = UnitSeparator.categorize(airTransports);
     for (final UnitCategory unitType : unitTypes) {
       final int transportCost = unitType.getTransportCost();
       for (final UnitCategory transportType : transportTypes) {

--- a/game-core/src/main/java/games/strategy/triplea/util/UnitCategory.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/UnitCategory.java
@@ -37,7 +37,7 @@ public class UnitCategory implements Comparable<UnitCategory> {
   private final BigDecimal movement;
   // movement of the units
   private final int transportCost;
-  private final boolean wasAmphibious;
+  private final boolean amphibious;
   private final GamePlayer owner;
   // the units in the category, may be duplicates.
   private final List<Unit> units = new ArrayList<>();
@@ -51,7 +51,7 @@ public class UnitCategory implements Comparable<UnitCategory> {
     movement = new BigDecimal(-1);
     transportCost = -1;
     this.owner = owner;
-    wasAmphibious = false;
+    amphibious = false;
   }
 
   UnitCategory(
@@ -62,7 +62,7 @@ public class UnitCategory implements Comparable<UnitCategory> {
       final int bombingDamage,
       final boolean disabled,
       final int transportCost,
-      final boolean wasAmphibious) {
+      final boolean amphibious) {
     type = unit.getType();
     this.movement = movement;
     this.transportCost = transportCost;
@@ -70,7 +70,7 @@ public class UnitCategory implements Comparable<UnitCategory> {
     this.damaged = damaged;
     this.bombingDamage = bombingDamage;
     this.disabled = disabled;
-    this.wasAmphibious = wasAmphibious;
+    this.amphibious = amphibious;
     units.add(unit);
     createDependents(dependents);
   }
@@ -95,8 +95,8 @@ public class UnitCategory implements Comparable<UnitCategory> {
     return UnitAttachment.get(type).getHitPoints();
   }
 
-  private boolean getWasAmphibious() {
-    return wasAmphibious;
+  private boolean getAmphibious() {
+    return amphibious;
   }
 
   private void createDependents(final Collection<Unit> dependents) {
@@ -122,7 +122,7 @@ public class UnitCategory implements Comparable<UnitCategory> {
         && other.damaged == this.damaged
         && other.bombingDamage == this.bombingDamage
         && other.disabled == this.disabled
-        && other.wasAmphibious == this.wasAmphibious;
+        && other.amphibious == this.amphibious;
   }
 
   private boolean equalsIgnoreDamagedAndBombingDamageAndDisabled(final UnitCategory other) {
@@ -152,7 +152,9 @@ public class UnitCategory implements Comparable<UnitCategory> {
         + " dependents:"
         + dependents
         + " movement:"
-        + movement;
+        + movement
+        + " amphibious:"
+        + amphibious;
   }
 
   /** Collection of UnitOwners, the type of our dependents, not the dependents. */
@@ -201,7 +203,7 @@ public class UnitCategory implements Comparable<UnitCategory> {
                 .thenComparingInt(UnitCategory::getDamaged)
                 .thenComparingInt(UnitCategory::getBombingDamage)
                 .thenComparing(UnitCategory::getDisabled)
-                .thenComparing(UnitCategory::getWasAmphibious))
+                .thenComparing(UnitCategory::getAmphibious))
         .compare(this, other);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/util/UnitCategory.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/UnitCategory.java
@@ -26,6 +26,7 @@ import org.triplea.java.collections.CollectionUtils;
  *   <li>Bombing damage
  *   <li>Disabled state
  *   <li>Dependents
+ *   <li>Amphibious
  * </ul>
  */
 public class UnitCategory implements Comparable<UnitCategory> {
@@ -36,6 +37,7 @@ public class UnitCategory implements Comparable<UnitCategory> {
   private final BigDecimal movement;
   // movement of the units
   private final int transportCost;
+  private final boolean wasAmphibious;
   private final GamePlayer owner;
   // the units in the category, may be duplicates.
   private final List<Unit> units = new ArrayList<>();
@@ -49,6 +51,7 @@ public class UnitCategory implements Comparable<UnitCategory> {
     movement = new BigDecimal(-1);
     transportCost = -1;
     this.owner = owner;
+    wasAmphibious = false;
   }
 
   UnitCategory(
@@ -58,7 +61,8 @@ public class UnitCategory implements Comparable<UnitCategory> {
       final int damaged,
       final int bombingDamage,
       final boolean disabled,
-      final int transportCost) {
+      final int transportCost,
+      final boolean wasAmphibious) {
     type = unit.getType();
     this.movement = movement;
     this.transportCost = transportCost;
@@ -66,6 +70,7 @@ public class UnitCategory implements Comparable<UnitCategory> {
     this.damaged = damaged;
     this.bombingDamage = bombingDamage;
     this.disabled = disabled;
+    this.wasAmphibious = wasAmphibious;
     units.add(unit);
     createDependents(dependents);
   }
@@ -90,6 +95,10 @@ public class UnitCategory implements Comparable<UnitCategory> {
     return UnitAttachment.get(type).getHitPoints();
   }
 
+  private boolean getWasAmphibious() {
+    return wasAmphibious;
+  }
+
   private void createDependents(final Collection<Unit> dependents) {
     this.dependents = new ArrayList<>();
     if (dependents == null) {
@@ -112,7 +121,8 @@ public class UnitCategory implements Comparable<UnitCategory> {
     return equalsIgnoreDamaged
         && other.damaged == this.damaged
         && other.bombingDamage == this.bombingDamage
-        && other.disabled == this.disabled;
+        && other.disabled == this.disabled
+        && other.wasAmphibious == this.wasAmphibious;
   }
 
   private boolean equalsIgnoreDamagedAndBombingDamageAndDisabled(final UnitCategory other) {
@@ -190,7 +200,8 @@ public class UnitCategory implements Comparable<UnitCategory> {
                     })
                 .thenComparingInt(UnitCategory::getDamaged)
                 .thenComparingInt(UnitCategory::getBombingDamage)
-                .thenComparing(UnitCategory::getDisabled))
+                .thenComparing(UnitCategory::getDisabled)
+                .thenComparing(UnitCategory::getWasAmphibious))
         .compare(this, other);
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/util/UnitSeparator.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/UnitSeparator.java
@@ -12,8 +12,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -40,11 +38,6 @@ public class UnitSeparator {
     @Builder.Default final boolean transportMovement = false;
     /** whether to categorize by amphibious */
     @Builder.Default final boolean amphibious = false;
-    /**
-     * If true then sort the categories in UnitCategory order; if false, then leave categories in
-     * original order (based on units).
-     */
-    @Builder.Default final boolean sort = true;
   }
 
   /**
@@ -93,12 +86,7 @@ public class UnitSeparator {
       final Collection<Unit> units, final SeparatorCategories separatorCategories) {
     // somewhat odd, but we map UnitCategory->UnitCategory, key and value are the same
     // we do this to take advantage of .equals() on objects that are equal in a special way
-    final Map<UnitCategory, UnitCategory> categories;
-    if (separatorCategories.sort) {
-      categories = new HashMap<>();
-    } else {
-      categories = new LinkedHashMap<>();
-    }
+    final Map<UnitCategory, UnitCategory> categories = new HashMap<>();
     for (final Unit current : units) {
       BigDecimal unitMovement = new BigDecimal(-1);
       if (separatorCategories.movement
@@ -137,8 +125,6 @@ public class UnitSeparator {
         categories.put(entry, entry);
       }
     }
-    return separatorCategories.sort
-        ? new TreeSet<>(categories.keySet())
-        : new LinkedHashSet<>(categories.keySet());
+    return new TreeSet<>(categories.keySet());
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/util/UnitSeparator.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/UnitSeparator.java
@@ -19,10 +19,32 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
+import javax.annotation.Nullable;
+import lombok.Builder;
 
 /** Separates a group of units into distinct categories. */
 public class UnitSeparator {
   private UnitSeparator() {}
+
+  @Builder(toBuilder = true)
+  public static class SeparatorCategories {
+    /**
+     * if not null, then will group units with the same dependents (compares type, owner, and
+     * amount)
+     */
+    @Builder.Default @Nullable final Map<Unit, Collection<Unit>> dependents = null;
+    /** whether to categorize by movement */
+    @Builder.Default final boolean movement = false;
+    /** whether to categorize by transport cost */
+    @Builder.Default final boolean transportCost = false;
+    /** whether to categorize transports by movement */
+    @Builder.Default final boolean transportMovement = false;
+    /**
+     * If true then sort the categories in UnitCategory order; if false, then leave categories in
+     * original order (based on units).
+     */
+    @Builder.Default final boolean sort = true;
+  }
 
   /**
    * Finds unit categories, removes not displayed, and then sorts them into logical order to display
@@ -57,63 +79,38 @@ public class UnitSeparator {
   }
 
   public static Set<UnitCategory> categorize(final Collection<Unit> units) {
-    return categorize(units, null, false, false);
-  }
-
-  public static Set<UnitCategory> categorize(
-      final Collection<Unit> units,
-      final Map<Unit, Collection<Unit>> dependent,
-      final boolean categorizeMovement,
-      final boolean categorizeTransportCost,
-      final boolean sort) {
-    return categorize(
-        units,
-        dependent,
-        categorizeMovement,
-        categorizeTransportCost, /* ctgzTrnMovement */
-        false,
-        sort);
+    return categorize(units, SeparatorCategories.builder().build());
   }
 
   /**
-   * Break the units into discrete categories. Do this based on unit owner, and optionally dependent
-   * units and movement
+   * Break the units into discrete categories. Do this based on unit owner and optionally other
+   * categories
    *
-   * @param dependent - can be null
-   * @param categorizeMovement - whether to categorize by movement
-   * @param categorizeTrnMovement - whether to categorize transports by movement
-   * @param sort If true then sort the categories in UnitCategory order; if false, then leave
-   *     categories in original order (based on units).
    * @return a Collection of UnitCategories
    */
   public static Set<UnitCategory> categorize(
-      final Collection<Unit> units,
-      final Map<Unit, Collection<Unit>> dependent,
-      final boolean categorizeMovement,
-      final boolean categorizeTransportCost,
-      final boolean categorizeTrnMovement,
-      final boolean sort) {
+      final Collection<Unit> units, final SeparatorCategories separatorCategories) {
     // somewhat odd, but we map UnitCategory->UnitCategory, key and value are the same
     // we do this to take advantage of .equals() on objects that are equal in a special way
     final Map<UnitCategory, UnitCategory> categories;
-    if (sort) {
+    if (separatorCategories.sort) {
       categories = new HashMap<>();
     } else {
       categories = new LinkedHashMap<>();
     }
     for (final Unit current : units) {
       BigDecimal unitMovement = new BigDecimal(-1);
-      if (categorizeMovement
-          || (categorizeTrnMovement && Matches.unitIsTransport().test(current))) {
+      if (separatorCategories.movement
+          || (separatorCategories.transportMovement && Matches.unitIsTransport().test(current))) {
         unitMovement = current.getMovementLeft();
       }
       int unitTransportCost = -1;
-      if (categorizeTransportCost) {
+      if (separatorCategories.transportCost) {
         unitTransportCost = UnitAttachment.get(current.getType()).getTransportCost();
       }
       Collection<Unit> currentDependents = null;
-      if (dependent != null) {
-        currentDependents = dependent.get(current);
+      if (separatorCategories.dependents != null) {
+        currentDependents = separatorCategories.dependents.get(current);
       }
       final boolean disabled = Matches.unitIsDisabled().test(current);
       final UnitCategory entry =
@@ -134,23 +131,8 @@ public class UnitSeparator {
         categories.put(entry, entry);
       }
     }
-    return sort ? new TreeSet<>(categories.keySet()) : new LinkedHashSet<>(categories.keySet());
-  }
-
-  /**
-   * Legacy interface. Break the units into discrete categories. Do this based on unit owner, and
-   * optionally dependent units and movement
-   *
-   * @param dependent - can be null
-   * @param categorizeMovement - whether to categorize by movement
-   * @return a Collection of UnitCategories
-   */
-  public static Set<UnitCategory> categorize(
-      final Collection<Unit> units,
-      final Map<Unit, Collection<Unit>> dependent,
-      final boolean categorizeMovement,
-      final boolean categorizeTransportCost) {
-    // sort by default
-    return categorize(units, dependent, categorizeMovement, categorizeTransportCost, true);
+    return separatorCategories.sort
+        ? new TreeSet<>(categories.keySet())
+        : new LinkedHashSet<>(categories.keySet());
   }
 }

--- a/game-core/src/main/java/games/strategy/triplea/util/UnitSeparator.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/UnitSeparator.java
@@ -5,7 +5,6 @@ import games.strategy.engine.data.GameState;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
-import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.ui.mapdata.MapData;
 import java.math.BigDecimal;
@@ -39,6 +38,8 @@ public class UnitSeparator {
     @Builder.Default final boolean transportCost = false;
     /** whether to categorize transports by movement */
     @Builder.Default final boolean transportMovement = false;
+    /** whether to categorize by amphibious */
+    @Builder.Default final boolean amphibious = false;
     /**
      * If true then sort the categories in UnitCategory order; if false, then leave categories in
      * original order (based on units).
@@ -106,11 +107,15 @@ public class UnitSeparator {
       }
       int unitTransportCost = -1;
       if (separatorCategories.transportCost) {
-        unitTransportCost = UnitAttachment.get(current.getType()).getTransportCost();
+        unitTransportCost = current.getUnitAttachment().getTransportCost();
       }
       Collection<Unit> currentDependents = null;
       if (separatorCategories.dependents != null) {
         currentDependents = separatorCategories.dependents.get(current);
+      }
+      boolean unitAmphibious = false;
+      if (separatorCategories.amphibious) {
+        unitAmphibious = current.getWasAmphibious();
       }
       final boolean disabled = Matches.unitIsDisabled().test(current);
       final UnitCategory entry =
@@ -121,7 +126,8 @@ public class UnitSeparator {
               current.getHits(),
               current.getUnitDamage(),
               disabled,
-              unitTransportCost);
+              unitTransportCost,
+              unitAmphibious);
       // we test to see if we have the key using equals, then since
       // key maps to key, we retrieve it to add the unit to the correct category
       if (categories.containsKey(entry)) {


### PR DESCRIPTION
<!-- If multiple commits please summarize the change above. -->

## Testing
<!-- Describe any manual testing performed below. -->
Played WW2 Global 1940 and tested that unit choosing still worked.  I tested selecting transports with dependents as well as just regular units.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->
This is initial work to separate amphibious/offloaded units in the unit chooser dialog.

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
