### PR TITLE
For localize-links performance, get map folder location from resource loader

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -40,11 +40,12 @@ public class ResourceLoader implements Closeable {
   private final URLClassLoader loader;
 
   @Getter private final List<URL> searchUrls;
+  @Getter private final File mapLocation;
 
   public ResourceLoader(final String mapName) {
     Preconditions.checkNotNull(mapName);
 
-    final File mapLocation =
+    mapLocation =
         DownloadedMapsListing.findContentRootForMapName(mapName)
             .orElseThrow(
                 () -> {

--- a/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -6,7 +6,6 @@ import games.strategy.engine.data.GameState;
 import games.strategy.engine.data.PlayerList;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.delegate.IDelegateBridge;
-import games.strategy.engine.framework.map.file.system.loader.DownloadedMapsListing;
 import games.strategy.engine.message.IRemote;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.Properties;
@@ -323,9 +322,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
         // now tell the HOST, and see if they want to continue the game.
         String displayMessage =
             LocalizeHtml.localizeImgLinksInHtml(
-                status,
-                DownloadedMapsListing.parseMapFiles()
-                    .findContentRootForMapNameOrElseThrow(UiContext.getMapDir()));
+                status, UiContext.getResourceLoader().getMapLocation());
         if (displayMessage.endsWith("</body>")) {
           displayMessage =
               displayMessage.substring(0, displayMessage.length() - "</body>".length())

--- a/game-core/src/main/java/games/strategy/triplea/ui/NotesPanel.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/NotesPanel.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.ui;
 
-import games.strategy.engine.framework.map.file.system.loader.DownloadedMapsListing;
 import java.awt.Color;
 import javax.swing.JEditorPane;
 import javax.swing.JScrollPane;
@@ -14,9 +13,7 @@ public class NotesPanel extends JScrollPane {
     super(
         createNotesPane(
             LocalizeHtml.localizeImgLinksInHtml(
-                trimmedNotes,
-                DownloadedMapsListing.parseMapFiles()
-                    .findContentRootForMapNameOrElseThrow(UiContext.getMapDir()))));
+                trimmedNotes, UiContext.getResourceLoader().getMapLocation())));
   }
 
   private static JEditorPane createNotesPane(final String html) {

--- a/game-core/src/main/java/games/strategy/triplea/ui/TooltipProperties.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TooltipProperties.java
@@ -2,7 +2,6 @@ package games.strategy.triplea.ui;
 
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.UnitType;
-import games.strategy.engine.framework.map.file.system.loader.DownloadedMapsListing;
 import games.strategy.triplea.ResourceLoader;
 import games.strategy.triplea.attachments.UnitAttachment;
 import java.io.IOException;
@@ -53,12 +52,11 @@ public final class TooltipProperties {
 
   /** Get unit type tooltip checking for custom tooltip content. */
   public String getTooltip(final UnitType unitType, final GamePlayer gamePlayer) {
+
     final String customTip = getToolTip(unitType, gamePlayer, false);
     if (!customTip.isEmpty()) {
       return LocalizeHtml.localizeImgLinksInHtml(
-          customTip,
-          DownloadedMapsListing.parseMapFiles()
-              .findContentRootForMapNameOrElseThrow(UiContext.getMapDir()));
+          customTip, UiContext.getResourceLoader().getMapLocation());
     }
     final String generated =
         UnitAttachment.get(unitType)
@@ -68,9 +66,7 @@ public final class TooltipProperties {
     if (!appendedTip.isEmpty()) {
       return generated
           + LocalizeHtml.localizeImgLinksInHtml(
-              appendedTip,
-              DownloadedMapsListing.parseMapFiles()
-                  .findContentRootForMapNameOrElseThrow(UiContext.getMapDir()));
+              appendedTip, UiContext.getResourceLoader().getMapLocation());
     }
     return generated;
   }

--- a/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -33,7 +33,6 @@ import games.strategy.engine.framework.HistorySynchronizer;
 import games.strategy.engine.framework.IGame;
 import games.strategy.engine.framework.LocalPlayers;
 import games.strategy.engine.framework.ServerGame;
-import games.strategy.engine.framework.map.file.system.loader.DownloadedMapsListing;
 import games.strategy.engine.framework.startup.ui.InGameLobbyWatcherWrapper;
 import games.strategy.engine.framework.ui.SaveGameFileChooser;
 import games.strategy.engine.history.HistoryNode;
@@ -922,9 +921,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
   public void notifyError(final String message) {
     final String displayMessage =
         LocalizeHtml.localizeImgLinksInHtml(
-            message,
-            DownloadedMapsListing.parseMapFiles()
-                .findContentRootForMapNameOrElseThrow(UiContext.getMapDir()));
+            message, UiContext.getResourceLoader().getMapLocation());
     messageAndDialogThreadPool.submit(
         () ->
             EventThreadJOptionPane.showMessageDialogWithScrollPane(
@@ -961,9 +958,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
     }
     final String displayMessage =
         LocalizeHtml.localizeImgLinksInHtml(
-            message,
-            DownloadedMapsListing.parseMapFiles()
-                .findContentRootForMapNameOrElseThrow(UiContext.getMapDir()));
+            message, UiContext.getResourceLoader().getMapLocation());
     messageAndDialogThreadPool.submit(
         () ->
             EventThreadJOptionPane.showMessageDialogWithScrollPane(


### PR DESCRIPTION
Rather than from downloaded maps, which scans all downloaded maps
to find a given map name, get the current map folder from
resource loader (already contains the location of the map folder,
constant time lookup).

This should improve performance.


<!-- If multiple commits please summarize the change above. -->

## Testing
Verified on 'age of tribes (classical)', which is a map that has a tooltip.properties file & displays images in tooltips, that images were still rendered in unit tooltips.
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
