### PR TITLE
Separate out air units by movement left in the casualty selector

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
+++ b/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
@@ -329,7 +329,11 @@ public class CasualtySelector {
       final Collection<Unit> targets, final Map<Unit, Collection<Unit>> dependents) {
     final Set<UnitCategory> categorized =
         UnitSeparator.categorize(
-            targets, UnitSeparator.SeparatorCategories.builder().dependents(dependents).build());
+            targets,
+            UnitSeparator.SeparatorCategories.builder()
+                .airMovement(true)
+                .dependents(dependents)
+                .build());
     if (categorized.size() == 1) {
       final UnitCategory unitCategory = categorized.iterator().next();
       return unitCategory.getHitPoints() - unitCategory.getDamaged() <= 1;

--- a/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -97,7 +97,7 @@ public final class UnitChooser extends JPanel {
     combinedList.addAll(defaultSelections.getKilled());
     createEntries(
         units,
-        UnitSeparator.SeparatorCategories.builder().dependents(dependent).build(),
+        UnitSeparator.SeparatorCategories.builder().dependents(dependent).airMovement(true).build(),
         combinedList);
     layoutEntries();
   }

--- a/game-core/src/main/java/games/strategy/triplea/util/UnitSeparator.java
+++ b/game-core/src/main/java/games/strategy/triplea/util/UnitSeparator.java
@@ -32,6 +32,8 @@ public class UnitSeparator {
     @Builder.Default @Nullable final Map<Unit, Collection<Unit>> dependents = null;
     /** whether to categorize by movement */
     @Builder.Default final boolean movement = false;
+    /** whether to categorize air units by movement */
+    @Builder.Default final boolean airMovement = false;
     /** whether to categorize by transport cost */
     @Builder.Default final boolean transportCost = false;
     /** whether to categorize transports by movement */
@@ -91,6 +93,9 @@ public class UnitSeparator {
       BigDecimal unitMovement = new BigDecimal(-1);
       if (separatorCategories.movement
           || (separatorCategories.transportMovement && Matches.unitIsTransport().test(current))) {
+        unitMovement = current.getMovementLeft();
+      }
+      if (separatorCategories.airMovement && current.getUnitAttachment().getIsAir()) {
         unitMovement = current.getMovementLeft();
       }
       int unitTransportCost = -1;


### PR DESCRIPTION
<!-- If multiple commits please summarize the change above. -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->
<img width="346" alt="Screen Shot 2021-02-27 at 4 41 04 PM" src="https://user-images.githubusercontent.com/2044248/109403407-9fada500-791a-11eb-9c93-ae07fdd39f86.png">


## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->NEW|Air units are now separated by their movement left in the battle casualty selection. This allows selecting the air unit with less movement than the other air units.<!--END_RELEASE_NOTE-->
