### PR TITLE
Set game notes & unit help windows to always be on top

### DIFF
--- a/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/InformationDialog.java
+++ b/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/InformationDialog.java
@@ -15,6 +15,7 @@ import org.triplea.swing.SwingAction;
 class InformationDialog {
   static JDialog createDialog(final JComponent component, final String title) {
     final JDialog dialog = new JDialog((JFrame) null, title);
+    dialog.setAlwaysOnTop(true);
     dialog.add(component, BorderLayout.CENTER);
     final JPanel buttons = new JPanel();
     final JButton button =


### PR DESCRIPTION
<!-- If multiple commits please summarize the change above. -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->UPDATE|Game notes and unit help windows are now always displayed on top of other windows<!--END_RELEASE_NOTE-->
