### PR TITLE
Ensure that air units with less movement left is killed first

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -862,7 +862,8 @@ public class UnitAttachment extends DefaultAttachment {
     isAir = getBool(s);
   }
 
-  private void setIsAir(final Boolean s) {
+  @VisibleForTesting
+  public void setIsAir(final Boolean s) {
     isAir = s;
   }
 
@@ -1539,7 +1540,8 @@ public class UnitAttachment extends DefaultAttachment {
     movement = getInt(s);
   }
 
-  private void setMovement(final Integer s) {
+  @VisibleForTesting
+  public void setMovement(final Integer s) {
     movement = s;
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
@@ -150,13 +150,16 @@ public class CasualtySelector {
       killAmphibiousFirst(killed, sortedTargetsToPickFrom);
     }
 
-    // if partial retreat isn't possible, then ensure units with marine bonus are removed first or
-    // last depending on whether the bonus is negative or positive
+    // if partial retreat isn't possible and it was an amphibious assault, then ensure units with
+    // marine bonus are removed first or last depending on whether the bonus is negative or positive
     if (!Properties.getPartialAmphibiousRetreat(data.getProperties())
         && (casualtySelection.getKilled().stream()
-                .anyMatch(unit -> unit.getUnitAttachment().getIsMarine() != 0)
+                .anyMatch(
+                    unit -> unit.getUnitAttachment().getIsMarine() != 0 && unit.getWasAmphibious())
             || casualtySelection.getDamaged().stream()
-                .anyMatch(unit -> unit.getUnitAttachment().getIsMarine() != 0))) {
+                .anyMatch(
+                    unit ->
+                        unit.getUnitAttachment().getIsMarine() != 0 && unit.getWasAmphibious()))) {
       casualtySelection =
           casualtySelection.ensureUnitsWithPositiveMarineBonusAreTakenLast(sortedTargetsToPickFrom);
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
@@ -150,18 +150,21 @@ public class CasualtySelector {
       killAmphibiousFirst(killed, sortedTargetsToPickFrom);
     }
 
-    // if partial retreat isn't possible and it was an amphibious assault, then ensure units with
-    // marine bonus are removed first or last depending on whether the bonus is negative or positive
-    if (!Properties.getPartialAmphibiousRetreat(data.getProperties())
-        && (casualtySelection.getKilled().stream()
-                .anyMatch(
-                    unit -> unit.getUnitAttachment().getIsMarine() != 0 && unit.getWasAmphibious())
-            || casualtySelection.getDamaged().stream()
-                .anyMatch(
-                    unit ->
-                        unit.getUnitAttachment().getIsMarine() != 0 && unit.getWasAmphibious()))) {
-      casualtySelection =
-          casualtySelection.ensureUnitsWithPositiveMarineBonusAreTakenLast(sortedTargetsToPickFrom);
+    if (!Properties.getPartialAmphibiousRetreat(data.getProperties())) {
+      final boolean isUnitWithMarineBonusAndWasAmphibiousKilled =
+          casualtySelection.getKilled().stream()
+              .anyMatch(
+                  unit -> unit.getUnitAttachment().getIsMarine() != 0 && unit.getWasAmphibious());
+      final boolean isUnitWithMarineBonusAndWasAmphibiousDamaged =
+          casualtySelection.getDamaged().stream()
+              .anyMatch(
+                  unit -> unit.getUnitAttachment().getIsMarine() != 0 && unit.getWasAmphibious());
+      if (isUnitWithMarineBonusAndWasAmphibiousKilled
+          || isUnitWithMarineBonusAndWasAmphibiousDamaged) {
+        casualtySelection =
+            casualtySelection.ensureUnitsWithPositiveMarineBonusAreTakenLast(
+                sortedTargetsToPickFrom);
+      }
     }
 
     if (casualtySelection.getKilled().stream().anyMatch(Matches.unitIsAir())

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/data/CasualtyDetails.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/data/CasualtyDetails.java
@@ -1,7 +1,14 @@
 package games.strategy.triplea.delegate.data;
 
 import games.strategy.engine.data.Unit;
+import games.strategy.triplea.delegate.Matches;
+import games.strategy.triplea.util.UnitOwner;
+import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * A casualty list that also tracks whether or not casualties should be automatically calculated.
@@ -42,5 +49,89 @@ public class CasualtyDetails extends CasualtyList {
 
   public boolean getAutoCalculated() {
     return autoCalculated;
+  }
+
+  /**
+   * Ensure that any killed or damaged air units have less movement than others of the same type
+   *
+   * @param units should be a superset of the union of killed and damaged.
+   */
+  public CasualtyDetails ensureAirUnitsWithLessMovementAreTakenFirst(final Collection<Unit> units) {
+    return this.ensureUnitsAreTakenFirst(
+        units, Matches.unitIsAir(), Comparator.comparing(Unit::getMovementLeft));
+  }
+
+  private CasualtyDetails ensureUnitsAreTakenFirst(
+      final Collection<Unit> targets,
+      final Predicate<Unit> matcher,
+      final Comparator<Unit> comparator) {
+
+    final Map<UnitOwner, List<Unit>> targetsGroupedByOwnerAndType =
+        targets.stream().collect(Collectors.groupingBy(UnitOwner::new, Collectors.toList()));
+
+    final List<Unit> killed =
+        ensureUnitsAreTakenFirst(
+            comparator,
+            targetsGroupedByOwnerAndType,
+            getKilled().stream()
+                .filter(matcher)
+                .collect(Collectors.groupingBy(UnitOwner::new, Collectors.toList())));
+    final List<Unit> damaged =
+        ensureUnitsAreTakenFirst(
+            comparator,
+            targetsGroupedByOwnerAndType,
+            getDamaged().stream()
+                .filter(matcher)
+                .collect(Collectors.groupingBy(UnitOwner::new, Collectors.toList())));
+
+    // copy over the killed and damaged that don't match the matcher
+    killed.addAll(getKilled().stream().filter(Predicate.not(matcher)).collect(Collectors.toList()));
+    damaged.addAll(
+        getDamaged().stream().filter(Predicate.not(matcher)).collect(Collectors.toList()));
+
+    return new CasualtyDetails(killed, damaged, this.getAutoCalculated());
+  }
+
+  /**
+   * sort all of the units of the same owner/type by the comparator and then take the top N units
+   * (where N is the number of oldUnits)
+   *
+   * <p>Every key in oldUnitsGroupedByOwnerAndType should be in allUnitsGroupedByOwnerAndType and
+   * the values of oldUnitsGroupedByOwnerAndType should be a subset of the values in
+   * allUnitsGroupedByOwnerAndType
+   */
+  private List<Unit> ensureUnitsAreTakenFirst(
+      final Comparator<Unit> comparator,
+      final Map<UnitOwner, List<Unit>> allUnitsGroupedByOwnerAndType,
+      final Map<UnitOwner, List<Unit>> oldUnitsGroupedByOwnerAndType) {
+
+    return oldUnitsGroupedByOwnerAndType.entrySet().stream()
+        .flatMap(
+            entry ->
+                allUnitsGroupedByOwnerAndType.get(entry.getKey()).stream()
+                    .sorted(comparator)
+                    .limit(entry.getValue().size()))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Ensure that any killed or damaged air units have less movement than others of the same type
+   *
+   * @param units should be a superset of the union of killed and damaged.
+   */
+  public CasualtyDetails ensureUnitsWithPositiveMarineBonusAreTakenLast(
+      final Collection<Unit> units) {
+    return this.ensureUnitsAreTakenFirst(
+        units,
+        unit -> unit.getUnitAttachment().getIsMarine() != 0,
+        (unit1, unit2) -> {
+          // wasAmphibious marines should be removed last if marine bonus is positive, otherwise
+          // should be removed first
+          if (unit1.getUnitAttachment().getIsMarine() > 0) {
+            return Boolean.compare(unit1.getWasAmphibious(), unit2.getWasAmphibious());
+          } else {
+            return Boolean.compare(unit2.getWasAmphibious(), unit1.getWasAmphibious());
+          }
+        });
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/data/CasualtyDetailsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/data/CasualtyDetailsTest.java
@@ -1,0 +1,234 @@
+package games.strategy.triplea.delegate.data;
+
+import static games.strategy.triplea.Constants.UNIT_ATTACHMENT_NAME;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.Unit;
+import games.strategy.engine.data.UnitType;
+import games.strategy.triplea.attachments.UnitAttachment;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CasualtyDetailsTest {
+
+  @Mock private GameData gameData;
+  @Mock private GamePlayer player;
+
+  private UnitType givenUnitType(final String name) {
+    final UnitType unitType = new UnitType(name, gameData);
+    final UnitAttachment unitAttachment = new UnitAttachment(name, unitType, gameData);
+    unitType.addAttachment(UNIT_ATTACHMENT_NAME, unitAttachment);
+    return unitType;
+  }
+
+  @Test
+  void ignoreNonAirUnitsAlreadyKilled() {
+    final UnitType infantry = givenUnitType("infantry");
+
+    final List<Unit> units = new ArrayList<>();
+    units.addAll(infantry.createTemp(2, player));
+
+    final List<Unit> killed = new ArrayList<>();
+    killed.add(units.get(0));
+
+    final CasualtyDetails originalDetails = new CasualtyDetails(killed, List.of(), true);
+    final CasualtyDetails updatedDetails =
+        originalDetails.ensureAirUnitsWithLessMovementAreTakenFirst(units);
+    assertThat(
+        "The infantry should still be killed",
+        updatedDetails.getKilled(),
+        is(containsInAnyOrder(units.get(0))));
+  }
+
+  @Test
+  void ignoreNonAirUnitsAlreadyDamaged() {
+    final UnitType infantry = givenUnitType("infantry");
+
+    final List<Unit> units = new ArrayList<>();
+    units.addAll(infantry.createTemp(2, player));
+
+    final List<Unit> damaged = new ArrayList<>();
+    damaged.add(units.get(0));
+
+    final CasualtyDetails originalDetails = new CasualtyDetails(List.of(), damaged, true);
+    final CasualtyDetails updatedDetails =
+        originalDetails.ensureAirUnitsWithLessMovementAreTakenFirst(units);
+    assertThat(
+        "The infantry should still be damaged",
+        updatedDetails.getDamaged(),
+        is(containsInAnyOrder(units.get(0))));
+  }
+
+  @Test
+  void killLowestMovementAirUnitsWhenOnlyOneTypeIsAvailable() {
+    final UnitType fighter = givenUnitType("fighter");
+    UnitAttachment.get(fighter).setMovement(4);
+    UnitAttachment.get(fighter).setIsAir(true);
+
+    final List<Unit> units = new ArrayList<>();
+    units.addAll(fighter.createTemp(2, player));
+
+    units.get(0).setAlreadyMoved(BigDecimal.ONE);
+    units.get(1).setAlreadyMoved(BigDecimal.valueOf(2));
+
+    final List<Unit> killed = new ArrayList<>();
+    killed.add(units.get(0));
+
+    final CasualtyDetails originalDetails = new CasualtyDetails(killed, List.of(), true);
+    final CasualtyDetails updatedDetails =
+        originalDetails.ensureAirUnitsWithLessMovementAreTakenFirst(units);
+    assertThat(
+        "The second air unit has no movement left so it should be killed",
+        updatedDetails.getKilled(),
+        is(containsInAnyOrder(units.get(1))));
+  }
+
+  @Test
+  void damageLowestMovementAirUnitsWhenOnlyOneTypeIsAvailable() {
+    final UnitType fighter = givenUnitType("fighter");
+    UnitAttachment.get(fighter).setMovement(4);
+    UnitAttachment.get(fighter).setIsAir(true);
+
+    final List<Unit> units = new ArrayList<>();
+    units.addAll(fighter.createTemp(2, player));
+
+    units.get(0).setAlreadyMoved(BigDecimal.ONE);
+    units.get(1).setAlreadyMoved(BigDecimal.valueOf(2));
+
+    final List<Unit> damaged = new ArrayList<>();
+    damaged.add(units.get(0));
+
+    final CasualtyDetails originalDetails = new CasualtyDetails(List.of(), damaged, true);
+    final CasualtyDetails updatedDetails =
+        originalDetails.ensureAirUnitsWithLessMovementAreTakenFirst(units);
+
+    assertThat(
+        "The second air unit has no movement left so it should be damaged",
+        updatedDetails.getDamaged(),
+        is(containsInAnyOrder(units.get(1))));
+  }
+
+  @Test
+  void killLowestMovementAirUnitsInTwoTypes() {
+    final UnitType fighter = givenUnitType("fighter");
+    UnitAttachment.get(fighter).setMovement(4);
+    UnitAttachment.get(fighter).setIsAir(true);
+    final UnitType bomber = givenUnitType("bomber");
+    UnitAttachment.get(bomber).setMovement(6);
+    UnitAttachment.get(bomber).setIsAir(true);
+
+    final List<Unit> units = new ArrayList<>();
+    units.addAll(fighter.createTemp(2, player));
+    units.addAll(bomber.createTemp(2, player));
+
+    units.get(0).setAlreadyMoved(BigDecimal.ONE);
+    units.get(1).setAlreadyMoved(BigDecimal.valueOf(2));
+
+    units.get(2).setAlreadyMoved(BigDecimal.ONE);
+    units.get(3).setAlreadyMoved(BigDecimal.valueOf(2));
+
+    final List<Unit> killed = new ArrayList<>();
+    killed.add(units.get(0));
+    killed.add(units.get(2));
+
+    final CasualtyDetails originalDetails = new CasualtyDetails(killed, List.of(), true);
+    final CasualtyDetails updatedDetails =
+        originalDetails.ensureAirUnitsWithLessMovementAreTakenFirst(units);
+
+    assertThat(
+        "The second and fourth air unit have no movement left so it should be killed",
+        updatedDetails.getKilled(),
+        is(containsInAnyOrder(units.get(1), units.get(3))));
+  }
+
+  @Test
+  void damageLowestMovementAirUnitsInTwoTypes() {
+    final UnitType fighter = givenUnitType("fighter");
+    UnitAttachment.get(fighter).setMovement(4);
+    UnitAttachment.get(fighter).setIsAir(true);
+    final UnitType bomber = givenUnitType("bomber");
+    UnitAttachment.get(bomber).setMovement(6);
+    UnitAttachment.get(bomber).setIsAir(true);
+
+    final List<Unit> units = new ArrayList<>();
+    units.addAll(fighter.createTemp(2, player));
+    units.addAll(bomber.createTemp(2, player));
+
+    units.get(0).setAlreadyMoved(BigDecimal.ONE);
+    units.get(1).setAlreadyMoved(BigDecimal.valueOf(2));
+
+    units.get(2).setAlreadyMoved(BigDecimal.ONE);
+    units.get(3).setAlreadyMoved(BigDecimal.valueOf(2));
+
+    final List<Unit> damaged = new ArrayList<>();
+    damaged.add(units.get(0));
+    damaged.add(units.get(2));
+
+    final CasualtyDetails originalDetails = new CasualtyDetails(List.of(), damaged, true);
+    final CasualtyDetails updatedDetails =
+        originalDetails.ensureAirUnitsWithLessMovementAreTakenFirst(units);
+
+    assertThat(
+        "The second and fourth air unit have no movement left so it should be damaged",
+        updatedDetails.getDamaged(),
+        is(containsInAnyOrder(units.get(1), units.get(3))));
+  }
+
+  @Test
+  void killPositiveMarineBonusLastIfAmphibious() {
+    final UnitType infantry = givenUnitType("infantry");
+    UnitAttachment.get(infantry).setIsMarine(1);
+
+    final List<Unit> units = new ArrayList<>();
+    units.addAll(infantry.createTemp(2, player));
+
+    units.get(0).setWasAmphibious(true);
+    units.get(1).setWasAmphibious(false);
+
+    final List<Unit> killed = new ArrayList<>();
+    killed.add(units.get(0));
+
+    final CasualtyDetails originalDetails = new CasualtyDetails(killed, List.of(), true);
+    final CasualtyDetails updatedDetails =
+        originalDetails.ensureUnitsWithPositiveMarineBonusAreTakenLast(units);
+    assertThat(
+        "The second unit was not amphibious, so it doesn't have the positive marine bonus "
+            + "and should be taken first.",
+        updatedDetails.getKilled(),
+        is(containsInAnyOrder(units.get(1))));
+  }
+
+  @Test
+  void killNegativeMarineBonusFirstIfAmphibious() {
+    final UnitType infantry = givenUnitType("infantry");
+    UnitAttachment.get(infantry).setIsMarine(-1);
+
+    final List<Unit> units = new ArrayList<>();
+    units.addAll(infantry.createTemp(2, player));
+
+    units.get(0).setWasAmphibious(false);
+    units.get(1).setWasAmphibious(true);
+
+    final List<Unit> killed = new ArrayList<>();
+    killed.add(units.get(0));
+
+    final CasualtyDetails originalDetails = new CasualtyDetails(killed, List.of(), true);
+    final CasualtyDetails updatedDetails =
+        originalDetails.ensureUnitsWithPositiveMarineBonusAreTakenLast(units);
+    assertThat(
+        "The second unit was amphibious, so it has the negative marine bonus "
+            + "and should be taken first.",
+        updatedDetails.getKilled(),
+        is(containsInAnyOrder(units.get(1))));
+  }
+}


### PR DESCRIPTION
<!-- If multiple commits please summarize the change above. -->

## Testing
<!-- Describe any manual testing performed below. -->
Stepped through a few battles with different air units with different movements left.  Ensured that the units with less movement left was selected.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->CHANGE|Air units with less movement is killed before units with more movement.<!--END_RELEASE_NOTE-->
