### PR TITLE
Fix 'cannot find annotation method name' warning

### DIFF
--- a/game-app/game-core/build.gradle
+++ b/game-app/game-core/build.gradle
@@ -1,6 +1,7 @@
 dependencies {
     implementation "com.googlecode.soundlibs:jlayer:$jlayerVersion"
     implementation "com.sun.mail:jakarta.mail:$jakartaMailVersion"
+    implementation "com.sun.xml.bind:jaxb-impl:$jaxbImplVersion"
     implementation "commons-cli:commons-cli:$commonsCliVersion"
     implementation "commons-codec:commons-codec:$commonsCodecVersion"
     implementation "commons-io:commons-io:$commonsIoVersion"


### PR DESCRIPTION
Adds jaxb dependency to game-core. Fixes this warning that was appearing
during 'game-core' compiliation:
> warning: Cannot find annotation method 'name()' in type 'XmlElement'
