### PR TITLE
Simplify 'which transports to load' dialog

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
@@ -921,12 +921,11 @@ public class MovePanel extends AbstractMovePanel {
             false,
             getMap().getUiContext(),
             transportsToUnloadMatch);
-    chooser.setTitle("What transports do you want to unload");
     final int option =
         JOptionPane.showOptionDialog(
             getTopLevelAncestor(),
             chooser,
-            "What transports do you want to unload",
+            "Select transports to unload",
             JOptionPane.OK_CANCEL_OPTION,
             JOptionPane.PLAIN_MESSAGE,
             null,
@@ -1326,12 +1325,11 @@ public class MovePanel extends AbstractMovePanel {
             false,
             getMap().getUiContext(),
             transportsToLoadMatch);
-    chooser.setTitle("What transports do you want to load");
     final int option =
         JOptionPane.showOptionDialog(
             getTopLevelAncestor(),
             chooser,
-            "What transports do you want to load",
+            "Select transports to load",
             JOptionPane.OK_CANCEL_OPTION,
             JOptionPane.PLAIN_MESSAGE,
             null,


### PR DESCRIPTION
Change text on 'what transports do you want to load dialog'
to: 'Select transports to load'

Also, remove redundant dialog sub-title, no need to print
the same title twice.



## Screens Shots

![Screenshot from 2021-02-28 11-39-19](https://user-images.githubusercontent.com/12397753/109431144-ca026f80-79b9-11eb-8108-1c694118bb7a.png)

![Screenshot from 2021-02-28 11-37-53](https://user-images.githubusercontent.com/12397753/109431143-c969d900-79b9-11eb-8a94-01b2922b8520.png)

<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
