### PR TITLE
Fix game chooser to select game only on 'okay' and not window close

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
@@ -126,7 +126,13 @@ public class GameChooser {
     mainSplit.setRightComponent(infoPanel);
     mainSplit.setBorder(null);
 
-    final Runnable selectAndReturn = () -> dialog.setVisible(false);
+    final Runnable selectAndReturn =
+        () -> {
+          dialog.setVisible(false);
+          Optional.ofNullable(gameList.getSelectedValue())
+              .flatMap(DefaultGameChooserEntry::getGameXmlFilePath)
+              .ifPresent(gameChosenCallback);
+        };
 
     final JButton cancelButton =
         new JButtonBuilder("Cancel").actionListener(dialog::dispose).build();
@@ -170,9 +176,5 @@ public class GameChooser {
     dialog.setLocationRelativeTo(owner);
     dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
     dialog.setVisible(true); // Blocking and waits for user action
-
-    Optional.ofNullable(gameList.getSelectedValue())
-        .flatMap(DefaultGameChooserEntry::getGameXmlFilePath)
-        .ifPresent(gameChosenCallback);
   }
 }


### PR DESCRIPTION
Fire the game selected callback only when the game-chooser dialog
is closed via the 'okay-button-clicked' action rather than firing it
no matter how the dialog is cancelled (eg: through 'cancel-button')

Fixes: https://github.com/triplea-game/triplea/issues/8928

