### PR TITLE
Fix resource loader not set error on hosted game chat

### DIFF
--- a/game-app/game-core/src/main/java/org/triplea/sound/ClipPlayer.java
+++ b/game-app/game-core/src/main/java/org/triplea/sound/ClipPlayer.java
@@ -222,13 +222,12 @@ public class ClipPlayer {
    * @param gamePlayer - the name of the player, or null
    */
   public static void play(final String clipPath, final GamePlayer gamePlayer) {
-    final ClipPlayer result;
     synchronized (ClipPlayer.class) {
-      result =
-          Optional.ofNullable(clipPlayer)
-              .orElseThrow(() -> new IllegalStateException("No resource loader has been set"));
+      if (clipPlayer == null) {
+        clipPlayer = new ClipPlayer(ResourceLoader.getGameEngineAssetLoader());
+      }
     }
-    result.playClip(clipPath, gamePlayer);
+    clipPlayer.playClip(clipPath, gamePlayer);
   }
 
   private void playClip(final String clipName, final GamePlayer gamePlayer) {


### PR DESCRIPTION
This update restores the defaulting of a game-engine only asset loader
when there is no resource loader otherwise set.

Problem introduced in: f3face998ca1ee91eae5ffce1c7580fb9d0ebf0e,

Fixes: https://github.com/triplea-game/triplea/issues/8927
