### PR TITLE
Non-Modal Combat Prompts (Allow user to scroll map during bombard prompt)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -25,11 +25,11 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Predicate;
 import java.util.stream.StreamSupport;
-import javax.swing.JOptionPane;
 import org.triplea.game.server.HeadlessGameServer;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.sound.SoundPath;
 import org.triplea.swing.EventThreadJOptionPane;
+import org.triplea.swing.EventThreadJOptionPane.ConfirmDialogType;
 import org.triplea.util.LocalizeHtml;
 
 /** A delegate used to check for end of game conditions. */
@@ -334,12 +334,11 @@ public class EndRoundDelegate extends BaseTripleADelegate {
         // classes. maybe there is
         // a better way?
         stopGame =
-            JOptionPane.OK_OPTION
-                != EventThreadJOptionPane.showConfirmDialog(
-                    null,
-                    "<html>" + displayMessage + "</html>",
-                    "Continue Game?  (" + title + ")",
-                    JOptionPane.YES_NO_OPTION);
+            EventThreadJOptionPane.showConfirmDialog(
+                null,
+                "<html>" + displayMessage + "</html>",
+                "Continue Game?  (" + title + ")",
+                ConfirmDialogType.YES_NO);
       }
       if (stopGame) {
         bridge.stopGameSequence();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -43,6 +43,7 @@ import javax.swing.WindowConstants;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.java.Interruptibles;
 import org.triplea.swing.EventThreadJOptionPane;
+import org.triplea.swing.EventThreadJOptionPane.ConfirmDialogType;
 import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.SwingAction;
 import org.triplea.swing.SwingComponents;
@@ -317,15 +318,11 @@ public final class BattlePanel extends ActionPanel {
         .result
         .map(
             comp -> {
-              int option = JOptionPane.NO_OPTION;
-              while (option != JOptionPane.OK_OPTION) {
-                option =
+              boolean confirmed = false;
+              while (!confirmed) {
+                confirmed =
                     EventThreadJOptionPane.showConfirmDialog(
-                        this,
-                        comp,
-                        "Bombardment Territory Selection",
-                        JOptionPane.OK_OPTION,
-                        getMap().getUiContext().getCountDownLatchHandler());
+                        this, comp, "Bombardment Territory Selection", ConfirmDialogType.YES_NO);
               }
               return comp.getSelection();
             })
@@ -335,45 +332,28 @@ public final class BattlePanel extends ActionPanel {
   public boolean getAttackSubs(final Territory terr) {
     getMap().centerOn(terr);
     return EventThreadJOptionPane.showConfirmDialog(
-            null,
-            "Attack submarines in " + terr.toString() + "?",
-            "Attack",
-            JOptionPane.YES_NO_OPTION,
-            getMap().getUiContext().getCountDownLatchHandler())
-        == 0;
+        null, "Attack submarines in " + terr.toString() + "?", "Attack", ConfirmDialogType.YES_NO);
   }
 
   public boolean getAttackTransports(final Territory terr) {
     getMap().centerOn(terr);
     return EventThreadJOptionPane.showConfirmDialog(
-            null,
-            "Attack transports in " + terr.toString() + "?",
-            "Attack",
-            JOptionPane.YES_NO_OPTION,
-            getMap().getUiContext().getCountDownLatchHandler())
-        == 0;
+        null, "Attack transports in " + terr.toString() + "?", "Attack", ConfirmDialogType.YES_NO);
   }
 
   public boolean getAttackUnits(final Territory terr) {
     getMap().centerOn(terr);
     return EventThreadJOptionPane.showConfirmDialog(
-            null,
-            "Attack units in " + terr.toString() + "?",
-            "Attack",
-            JOptionPane.YES_NO_OPTION,
-            getMap().getUiContext().getCountDownLatchHandler())
-        == 0;
+        null, "Attack units in " + terr.toString() + "?", "Attack", ConfirmDialogType.YES_NO);
   }
 
   public boolean getShoreBombard(final Territory terr) {
     getMap().centerOn(terr);
     return EventThreadJOptionPane.showConfirmDialog(
-            null,
-            "Conduct naval bombard in " + terr.toString() + "?",
-            "Bombard",
-            JOptionPane.YES_NO_OPTION,
-            getMap().getUiContext().getCountDownLatchHandler())
-        == 0;
+        null,
+        "Conduct naval bombard in " + terr.toString() + "?",
+        "Bombard",
+        ConfirmDialogType.YES_NO);
   }
 
   public void casualtyNotification(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
@@ -24,6 +24,7 @@ import javax.swing.SwingUtilities;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.swing.EventThreadJOptionPane;
+import org.triplea.swing.EventThreadJOptionPane.ConfirmDialogType;
 import org.triplea.swing.SwingAction;
 import org.triplea.util.Tuple;
 
@@ -57,9 +58,8 @@ public class PickTerritoryAndUnitsPanel extends ActionPanel {
           final UnitChooser unitChooser =
               new UnitChooser(unitChoices, Map.of(), false, getMap().getUiContext());
           unitChooser.setMaxAndShowMaxButton(unitsPerPick);
-          if (JOptionPane.OK_OPTION
-              == EventThreadJOptionPane.showConfirmDialog(
-                  parent, unitChooser, "Select Units", JOptionPane.OK_CANCEL_OPTION)) {
+          if (EventThreadJOptionPane.showConfirmDialog(
+              parent, unitChooser, "Select Units", ConfirmDialogType.OK_CANCEL)) {
             pickedUnits.clear();
             pickedUnits.addAll(unitChooser.getSelected());
           }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -155,6 +155,7 @@ import org.triplea.java.concurrency.CompletableFutureUtils;
 import org.triplea.sound.ClipPlayer;
 import org.triplea.sound.SoundPath;
 import org.triplea.swing.EventThreadJOptionPane;
+import org.triplea.swing.EventThreadJOptionPane.ConfirmDialogType;
 import org.triplea.swing.JFrameBuilder;
 import org.triplea.swing.SwingAction;
 import org.triplea.swing.SwingComponents;
@@ -780,14 +781,14 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
   @Override
   public boolean shutdown() {
     if (isVisible()) {
-      final int selectedOption =
+
+      final boolean confirmed =
           EventThreadJOptionPane.showConfirmDialog(
               this,
               "Are you sure you want to exit TripleA?\nUnsaved game data will be lost.",
               "Exit Program",
-              JOptionPane.YES_NO_OPTION,
-              getUiContext().getCountDownLatchHandler());
-      if (selectedOption != JOptionPane.OK_OPTION) {
+              ConfirmDialogType.YES_NO);
+      if (!confirmed) {
         return false;
       }
     }
@@ -802,14 +803,13 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
    * and the application will return to the main menu.
    */
   public void leaveGame() {
-    final int selectedOption =
+    final boolean confirmed =
         EventThreadJOptionPane.showConfirmDialog(
             this,
             "Are you sure you want to leave the current game?\nUnsaved game data will be lost.",
             "Leave Game",
-            JOptionPane.YES_NO_OPTION,
-            getUiContext().getCountDownLatchHandler());
-    if (selectedOption != JOptionPane.OK_OPTION) {
+            ConfirmDialogType.YES_NO);
+    if (!confirmed) {
       return;
     }
     if (game instanceof ServerGame) {
@@ -1074,30 +1074,22 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
       final String acceptanceQuestion,
       final boolean politics) {
     messageAndDialogThreadPool.waitForAll();
-    final int choice =
-        EventThreadJOptionPane.showConfirmDialog(
-            this,
-            acceptanceQuestion,
-            "Accept "
-                + (politics ? "Political " : "")
-                + "Proposal from "
-                + playerSendingProposal.getName()
-                + "?",
-            JOptionPane.YES_NO_OPTION,
-            getUiContext().getCountDownLatchHandler());
-    return choice == JOptionPane.YES_OPTION;
+
+    return EventThreadJOptionPane.showConfirmDialog(
+        this,
+        acceptanceQuestion,
+        "Accept "
+            + (politics ? "Political " : "")
+            + "Proposal from "
+            + playerSendingProposal.getName()
+            + "?",
+        ConfirmDialogType.YES_NO);
   }
 
   public boolean getOk(final String message) {
     messageAndDialogThreadPool.waitForAll();
-    final int choice =
-        EventThreadJOptionPane.showConfirmDialog(
-            this,
-            message,
-            message,
-            JOptionPane.OK_CANCEL_OPTION,
-            getUiContext().getCountDownLatchHandler());
-    return choice == JOptionPane.OK_OPTION;
+    return EventThreadJOptionPane.showConfirmDialog(
+        this, message, message, ConfirmDialogType.OK_CANCEL);
   }
 
   /** Displays a message to the user informing them of the results of rolling for technologies. */


### PR DESCRIPTION
In short, this allows users to scroll the map during combat prompts such
as bombardment (attack subs, etc)

This update converts mainly combat confirmation dialog prompts to be non-modal
and uses a latch to simulate the blocking nature of a modal prompt. The benefit
of a non-modal prompt is that a user can scroll around on the map. This is very
handy for example when there is a territory bombard prompt for multiple territories
that are offscreen.

In addition, this update improve the API for these confirmation prompts:
  - return a simple true/false to indicate if user confirms or not rather
    than a magic number.
  - use an enum input parameter instead of magic number for confirmation type.


<!-- If multiple commits please summarize the change above. -->

## Testing

Set up a bombard scenario and verified game was blocked pending choice selection and was able to scroll around on the map.
<!-- Describe any manual testing performed below. -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->UPDATE|Map can now be scrolled when combat prompts are visible, for example the map can now be scrolled while selecting territories to bombard.<!--END_RELEASE_NOTE-->
