### PR TITLE
Fix 'using-latest' boolean var evaluation

### DIFF
--- a/infrastructure/ansible/roles/bot/tasks/main.yml
+++ b/infrastructure/ansible/roles/bot/tasks/main.yml
@@ -38,7 +38,7 @@
   command: "{{ admin_home }}/download-all-maps {{ update_maps }}"
 
 - name: deploy zip file if using latest
-  when: using_latest
+  when: using_latest|bool
   copy:
     src: "triplea-game-headless-{{ bot_version }}.zip"
     dest: "{{ bot_install_home }}/triplea-game-headless-{{ bot_version }}.zip"
@@ -47,7 +47,8 @@
 
 
 - name: download zip file if not using latest
-  when: not using_latest
+  tags: testing
+  when: not using_latest|bool
   get_url:
     url: "{{ zip_download }}"
     dest: "{{ bot_install_home }}/triplea-game-headless-{{ bot_version }}.zip"
@@ -89,7 +90,7 @@
     daemon_reload: yes
 
 - name: restart bots if deploying latest
-  when: using_latest
+  when: using_latest|bool
   service:
     name: "bot@{{ item }}"
     state: restarted
@@ -97,7 +98,7 @@
   with_items: "{{ bot_numbers }}"
 
 - name: enable and ensure bots are started
-  when: not using_latest
+  when: not using_latest|bool
   service:
     name: "bot@{{ item }}"
     state: started

--- a/infrastructure/ansible/roles/bot/tasks/main.yml
+++ b/infrastructure/ansible/roles/bot/tasks/main.yml
@@ -47,7 +47,6 @@
 
 
 - name: download zip file if not using latest
-  tags: testing
   when: not using_latest|bool
   get_url:
     url: "{{ zip_download }}"

--- a/infrastructure/ansible/roles/database/flyway/tasks/main.yml
+++ b/infrastructure/ansible/roles/database/flyway/tasks/main.yml
@@ -32,7 +32,7 @@
     group: flyway
 
 - name: download flyway migrations if deploying a specific version
-  when: using_latest|bool
+  when: not using_latest|bool
   get_url:
     url: "{{ migrations_url }}"
     dest: "/home/flyway/migrations.zip"

--- a/infrastructure/ansible/roles/database/flyway/tasks/main.yml
+++ b/infrastructure/ansible/roles/database/flyway/tasks/main.yml
@@ -23,7 +23,7 @@
     group: flyway
 
 - name: copy flyway migrations zip if deploying latest
-  when: using_latest == "true"
+  when: using_latest|bool
   copy:
     src: "migrations.zip"
     dest: "/home/flyway/migrations.zip"
@@ -32,7 +32,7 @@
     group: flyway
 
 - name: download flyway migrations if deploying a specific version
-  when: using_latest == "false"
+  when: using_latest|bool
   get_url:
     url: "{{ migrations_url }}"
     dest: "/home/flyway/migrations.zip"

--- a/infrastructure/ansible/roles/lobby_server/tasks/main.yml
+++ b/infrastructure/ansible/roles/lobby_server/tasks/main.yml
@@ -18,7 +18,7 @@
     group: "{{ lobby_server_user }}"
 
 - name: deploy zip artifact file if using latest
-  when: using_latest
+  when: using_latest|bool
   register: deploy_artifact
   copy:
     src: "{{ lobby_artifact }}"
@@ -27,7 +27,7 @@
     group: "{{ lobby_server_user }}"
 
 - name: download zip artifact file if not using latest
-  when: not using_latest
+  when: not using_latest|bool
   register: deploy_artifact
   get_url:
     url: "{{ lobby_artifact_download }}"

--- a/infrastructure/ansible/roles/maps_server/tasks/main.yml
+++ b/infrastructure/ansible/roles/maps_server/tasks/main.yml
@@ -17,7 +17,7 @@
     group: "{{ maps_server_user }}"
 
 - name: deploy zip artifact file if using latest
-  when: using_latest
+  when: using_latest|bool
   register: deploy_artifact
   copy:
     src: "{{ maps_server_artifact }}"
@@ -26,7 +26,7 @@
     group: "{{ maps_server_user }}"
 
 - name: download zip artifact file if not using latest
-  when: not using_latest
+  when: not using_latest|bool
   register: deploy_artifact
   get_url:
     url: "{{ maps_server_artifact_download }}"


### PR DESCRIPTION
This update adds an explicit boolean variable cast in ansible
that allows for a 'when' cause to evaluate properly. Without
the cast to 'bool' a when condition with 'using_latest' is
always false. IE, both of these both evaluated to false:
 "when: using_latest" and "when: not using_latest"

