### PR TITLE
Update Oil and Snow with Name Change

### DIFF
--- a/triplea_maps.yaml
+++ b/triplea_maps.yaml
@@ -39,11 +39,11 @@
   version: 2
   description: |
     <br>This is a tutorial for players new to TripleA and its game engine.
-- mapName: WW2 Oil and Snow 
+- mapName: WW2 Oil and Snow 1st Edition
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/ww2_oil_and_snow_1st_edition/archive/master.zip
   img: https://github.com/triplea-maps/ww2_oil_and_snow_1st_edition/raw/master/preview.png
-  version: 1
+  version: 2
   description: |
     <br>* Combined terrain effects + true seasonal winter & fuel production / usage
     <br>* Historical focus on weapon development + production & more unit variation.  


### PR DESCRIPTION
![Screenshot from 2021-03-05 21-15-27](https://user-images.githubusercontent.com/24382682/110193273-b65f6a80-7df8-11eb-9c88-893101644473.png)
So i tried removing 1st edition everywhere in the existing map folders an xml and it would show up with the description picture but just go blank when I selected it. I noticed where it was originally forked from it's named Oil and Snow without the 1st Edition. 

At any rate, if the yaml mapName here is the same as the triplea-maps repo one  and it automatically adds underscore to spaces and makes it all lower case, then I think we should be fine. I don't really know how to test until it's added though. I did rename the zip in downloaded maps with 1st_edition and it worked then, so I think it should work.

Just found it here. Was looking at the bottom of the list for it lol :)


<!-- If multiple commits please summarize the change above. -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
