### PR TITLE
Unzip maps into a lower cased folder name

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/ZippedMapsExtractor.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/ZippedMapsExtractor.java
@@ -161,7 +161,7 @@ public class ZippedMapsExtractor {
     if (newName.endsWith("-master")) {
       newName = newName.substring(0, newName.length() - "-master".length());
     }
-    return newName;
+    return newName.toLowerCase();
   }
 
   /**


### PR DESCRIPTION
Needed for 2.5 backward compatibility, 2.5 looks for map folders
with lower cased names.


<!-- If multiple commits please summarize the change above. -->

## Testing
- Downloaded a map with 2.6, verified it extracted to a folder
- Started 2.5, loaded that map, then restarted and clicked 'select games'
<!-- Describe any manual testing performed below. -->
