### PR TITLE
Downloaded map window fixes

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/AvailableMapsListing.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/AvailableMapsListing.java
@@ -30,7 +30,7 @@ class AvailableMapsListing {
         return;
       }
 
-      if (download.getInstallLocation().isEmpty()) {
+      if (!downloadedMapsListing.isMapInstalled(download.getMapName())) {
         available.add(download);
       } else {
         final int mapVersion = downloadedMapsListing.getMapVersionByName(download.getMapName());

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -286,16 +286,15 @@ public class DownloadMapsWindow extends JFrame {
 
     final List<DownloadFileDescription> outOfDateDownloads =
         mapList.getOutOfDateExcluding(pendingDownloads);
-    final JPanel outOfDate =
-        outOfDateDownloads.isEmpty()
-            ? null
-            : newMapSelectionPanel(outOfDateDownloads, MapAction.UPDATE);
     // For the UX, always show an available maps tab, even if it is empty
     final JPanel available =
         newMapSelectionPanel(mapList.getAvailableExcluding(pendingDownloads), MapAction.INSTALL);
-
     tabbedPane.addTab("Available", available);
-    tabbedPane.addTab("Update", outOfDate);
+
+    if (!outOfDateDownloads.isEmpty()) {
+      final JPanel outOfDate = newMapSelectionPanel(outOfDateDownloads, MapAction.UPDATE);
+      tabbedPane.addTab("Update", outOfDate);
+    }
 
     if (!mapList.getInstalled().isEmpty()) {
       final JPanel installed = newMapSelectionPanel(mapList.getInstalled(), MapAction.REMOVE);
@@ -319,6 +318,9 @@ public class DownloadMapsWindow extends JFrame {
           mapSelections ->
               newDescriptionPanelUpdatingSelectionListener(
                   mapSelections.get(0), descriptionPane, unsortedMaps, mapSizeLabel));
+
+      descriptionPane.setText(unsortedMaps.get(0).toHtmlString());
+      descriptionPane.scrollRectToVisible(new Rectangle(0, 0, 0, 0));
 
       main.add(SwingComponents.newJScrollPane(gamesList), BorderLayout.WEST);
       final JPanel southPanel =

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/DownloadedMapsListing.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/DownloadedMapsListing.java
@@ -57,6 +57,18 @@ public class DownloadedMapsListing {
   }
 
   /**
+   * Checks if a given map by name is installed, returns true if so. Map name matching is done
+   * case-insensitive with spaces, dashes and underscores ignored.
+   */
+  public boolean isMapInstalled(final String mapName) {
+    final String nameToMatch = normalizeName(mapName);
+    return downloadedMaps.stream()
+        .map(DownloadedMap::getMapName)
+        .map(DownloadedMapsListing::normalizeName)
+        .anyMatch(nameToMatch::equalsIgnoreCase);
+  }
+
+  /**
    * Returns the path to the file associated with the specified game. Returns empty if there is no
    * game matching the given name.
    *

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/map/file/system/loader/DownloadedMapsListingTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/map/file/system/loader/DownloadedMapsListingTest.java
@@ -8,6 +8,8 @@ import static org.hamcrest.core.IsCollectionContaining.hasItems;
 import java.io.File;
 import java.util.List;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.triplea.map.description.file.MapDescriptionYaml;
 
 class DownloadedMapsListingTest {
@@ -54,8 +56,48 @@ class DownloadedMapsListingTest {
 
   @Test
   void getMapVersionByName() {
-    assertThat(downloadedMapsListing.getMapVersionByName("DNE"), is(0));
-    assertThat(downloadedMapsListing.getMapVersionByName("map-name0"), is(0));
-    assertThat(downloadedMapsListing.getMapVersionByName("map-name1"), is(2));
+    assertThat(
+        "If a map does not exist, we default version value to '0'",
+        downloadedMapsListing.getMapVersionByName("DNE"),
+        is(0));
+    assertThat(
+        "This map in the listing has a version value of '0'",
+        downloadedMapsListing.getMapVersionByName("map-name0"),
+        is(0));
+    assertThat(
+        "This map in the listing has a version value of '2'",
+        downloadedMapsListing.getMapVersionByName("map-name1"),
+        is(2));
+  }
+
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "",
+        "DNE",
+        "map_name", // does not quite match, missing trailing 0
+        "map-name", // does not quite match, missing trailing 0
+        "map",
+        "name0"
+      })
+  void isMapInstalled_NegativeCases(final String mapName) {
+    assertThat(downloadedMapsListing.isMapInstalled(mapName), is(false));
+  }
+
+  /** Verify match is not case sensitive with insignificant characters ignored */
+  @ParameterizedTest
+  @ValueSource(
+      strings = {
+        "MAP NAME0",
+        "MAP_NAME0",
+        "MAP-NAME0",
+        "map name0",
+        "map_name0",
+        "map-name0",
+        "mapname0",
+        "MAPNAME0"
+      })
+  void isMapInstalled_PositiveCases(final String mapName) {
+    assertThat(downloadedMapsListing.isMapInstalled(mapName), is(true));
   }
 }


### PR DESCRIPTION
- Fix game not recognizing folders as installed maps. Use 'map.yml'
  index to find maps that are installed rather than using the
  "expected install location".
- Fix game download window not showing first map download selection
  details.

