### PR TITLE
Switch back to 'flow' style for map.yml generation

### DIFF
--- a/lib/java-extras/src/main/java/org/triplea/yaml/YamlWriter.java
+++ b/lib/java-extras/src/main/java/org/triplea/yaml/YamlWriter.java
@@ -4,14 +4,11 @@ import java.util.Map;
 import lombok.experimental.UtilityClass;
 import org.snakeyaml.engine.v2.api.Dump;
 import org.snakeyaml.engine.v2.api.DumpSettings;
-import org.snakeyaml.engine.v2.common.FlowStyle;
 
 /** Methods useful for writing YAML POJO data to a YAML formatted String. */
 @UtilityClass
 public class YamlWriter {
   public static String writeToString(final Map<String, Object> input) {
-    return new Dump(
-            DumpSettings.builder().setIndent(2).setDefaultFlowStyle(FlowStyle.BLOCK).build())
-        .dumpToString(input);
+    return new Dump(DumpSettings.builder().setIndent(2).build()).dumpToString(input);
   }
 }


### PR DESCRIPTION
The flow structure would have all elements aligning on
the left hand edge of a map.yml file. While this could
be more difficult to diff and automatically update, it
does make the indentation concerns easier to deal with.
It has been observed that getting indentation right
has been a stumbling block for map makers and YML files.

For example, instead of a map being generated as:
- this_is_map_key: value
  key2: valu2

We will now generate it as:
- {this_is_map_key: value, key2, value2}

