### PR TITLE
Remove map override reset

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ArgParser.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ArgParser.java
@@ -13,8 +13,6 @@ public final class ArgParser {
 
   /** Move command line arguments to system properties or client settings. */
   public static void handleCommandLineArgs(final String... args) {
-    ClientSetting.mapFolderOverride.resetValue();
-
     if ((args.length == 1) && args[0].startsWith(TRIPLEA_PROTOCOL)) {
       handleMapDownloadArg(args[0]);
     } else if ((args.length == 1) && !args[0].contains("=")) {

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/ArgParserTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/ArgParserTest.java
@@ -90,17 +90,6 @@ class ArgParserTest extends AbstractClientSettingTestCase {
     assertThat(ClientSetting.mapFolderOverride.getValueOrThrow(), is(mapFolder));
   }
 
-  @Test
-  void mapFolderOverrideClientSettingIsResetWhenNotSpecified() {
-    ClientSetting.mapFolderOverride.setValue(Paths.get("some", "path"));
-
-    ArgParser.handleCommandLineArgs();
-
-    assertThat(
-        ClientSetting.mapFolderOverride.getValue(),
-        is(ClientSetting.mapFolderOverride.getDefaultValue()));
-  }
-
   private interface TestData {
     String propKey = "key";
     String propValue = "value";


### PR DESCRIPTION
Unclear why the map override setting is being reset
effectively on startup. The reset prevents a value
from being set and sticking after game restarts.

Fixes: https://github.com/triplea-game/triplea/issues/7004


<!-- If multiple commits please summarize the change above. -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Maps folder user preference no longer cleared on startup, value now remains after game restart.<!--END_RELEASE_NOTE-->
