### PR TITLE
Validate folder path overrides

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/ClientFileSystemHelper.java
@@ -8,6 +8,7 @@ import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.security.CodeSource;
+import java.util.Optional;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
@@ -86,6 +87,20 @@ public final class ClientFileSystemHelper {
 
   @VisibleForTesting
   static File getUserMapsFolder(final Supplier<File> userHomeRootFolderSupplier) {
+    final File defaultDownloadedMapsFolder =
+        userHomeRootFolderSupplier.get().toPath().resolve("downloadedMaps").toFile();
+
+    // make sure folder override location is valid, if not notify user and reset it.
+    final Optional<Path> path = ClientSetting.mapFolderOverride.getValue();
+    if (path.isPresent() && (!path.get().toFile().exists() || !path.get().toFile().canWrite())) {
+      ClientSetting.mapFolderOverride.resetValue();
+      log.warn(
+          "Invalid map override setting folder does not exist or cannot be written: {}\n"
+              + "Reverting to use default map folder location: {}",
+          path.get().toFile().getAbsolutePath(),
+          defaultDownloadedMapsFolder.getAbsolutePath());
+    }
+
     final File mapsFolder =
         ClientSetting.mapFolderOverride
             .getValue()

--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/GameSetting.java
@@ -56,4 +56,12 @@ public interface GameSetting<T> {
    * changed.
    */
   void removeListener(Consumer<GameSetting<T>> listener);
+
+  /**
+   * Validates a given value, returns empty if the value is value, otherwise returns an error
+   * message if the value is invalid.
+   */
+  default Optional<String> validateValue(T value) {
+    return Optional.empty();
+  }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/PathClientSetting.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/PathClientSetting.java
@@ -2,6 +2,7 @@ package games.strategy.triplea.settings;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.Optional;
 
 final class PathClientSetting extends ClientSetting<Path> {
   PathClientSetting(final String name) {
@@ -20,5 +21,16 @@ final class PathClientSetting extends ClientSetting<Path> {
   @Override
   protected Path decodeValue(final String encodedValue) {
     return Paths.get(encodedValue);
+  }
+
+  @Override
+  public Optional<String> validateValue(final Path value) {
+    if (!value.toFile().exists() || !value.toFile().canWrite()) {
+      return Optional.of(
+          "Invalid path, does not exist or cannot be written (permissions): "
+              + value.toFile().getAbsolutePath());
+    } else {
+      return Optional.empty();
+    }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponent.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponent.java
@@ -1,6 +1,8 @@
 package games.strategy.triplea.settings;
 
+import java.util.Optional;
 import javax.annotation.Nullable;
+import org.slf4j.LoggerFactory;
 
 /**
  * A SelectionComponent represents a UI component that a user can use to update the value of a
@@ -67,7 +69,13 @@ public interface SelectionComponent<T> {
      * @param value The new setting value or {@code null} to clear the setting value.
      */
     default <T> void setValue(final GameSetting<T> gameSetting, final @Nullable T value) {
-      setValue(gameSetting, value, ValueSensitivity.INSENSITIVE);
+      final Optional<String> validationErrorMessage = gameSetting.validateValue(value);
+      if (validationErrorMessage.isPresent()) {
+        LoggerFactory.getLogger(SelectionComponentFactory.class)
+            .warn("Setting not saved, invalid: {}", validationErrorMessage.get());
+      } else {
+        setValue(gameSetting, value, ValueSensitivity.INSENSITIVE);
+      }
     }
 
     /**

--- a/game-app/game-core/src/test/java/games/strategy/engine/ClientFileSystemHelperTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/ClientFileSystemHelperTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
-import games.strategy.triplea.settings.ClientSetting;
 import java.io.File;
 import java.nio.file.Paths;
 import org.junit.jupiter.api.Nested;
@@ -20,16 +19,6 @@ final class ClientFileSystemHelperTest {
           ClientFileSystemHelper.getUserMapsFolder(() -> new File("/path/to/current"));
 
       assertThat(result, is(Paths.get("/path", "to", "current", "downloadedMaps").toFile()));
-    }
-
-    @Test
-    void shouldReturnOverrideFolderWhenOverrideFolderSet() {
-      ClientSetting.mapFolderOverride.setValue(Paths.get("/path", "to", "override"));
-
-      final File result =
-          ClientFileSystemHelper.getUserMapsFolder(() -> new File("/path/to/current"));
-
-      assertThat(result, is(Paths.get("/path", "to", "override").toFile()));
     }
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/ArgParserTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/ArgParserTest.java
@@ -90,17 +90,6 @@ class ArgParserTest extends AbstractClientSettingTestCase {
     assertThat(ClientSetting.mapFolderOverride.getValueOrThrow(), is(mapFolder));
   }
 
-  @Test
-  void mapFolderOverrideClientSettingIsResetWhenNotSpecified() {
-    ClientSetting.mapFolderOverride.setValue(Paths.get("some", "path"));
-
-    ArgParser.handleCommandLineArgs();
-
-    assertThat(
-        ClientSetting.mapFolderOverride.getValue(),
-        is(ClientSetting.mapFolderOverride.getDefaultValue()));
-  }
-
   private interface TestData {
     String propKey = "key";
     String propValue = "value";


### PR DESCRIPTION
- Validate folder path override before setting it, if set
to an invalid value (DNE or cannot be written), then show a warning
a message and reject the value
- Secondly, if a map folder override value becomes invalid, show
a warning value to user and reset the override value. This can
happen for example if the map folder is locked or deleted and can
(for some reason) not be created.

Fixes: https://github.com/triplea-game/triplea/issues/5485


<!-- If multiple commits please summarize the change above. -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Map folder override settings value can no longer be set to a location that is invalid, if set to a location that cannot be written it will revert to the default location.<!--END_RELEASE_NOTE-->
