### PR TITLE
Fix victory bonds technology

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -376,8 +376,13 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   public static int getWarBondDiceSides(final Collection<TechAdvance> techAdvances) {
-    return sumNumbers(
-        TechAbilityAttachment::getWarBondDiceSides, TechAdvance.TECH_NAME_WAR_BONDS, techAdvances);
+    return techAdvances.stream()
+        .map(TechAbilityAttachment::get)
+        .filter(Objects::nonNull)
+        .mapToInt(t -> t.getWarBondDiceSides())
+        .filter(t -> t > 0)
+        .findAny()
+        .orElse(0);
   }
 
   private void resetWarBondDiceSides() {
@@ -397,8 +402,12 @@ public class TechAbilityAttachment extends DefaultAttachment {
   }
 
   public static int getWarBondDiceNumber(final Collection<TechAdvance> techAdvances) {
-    return sumNumbers(
-        TechAbilityAttachment::getWarBondDiceNumber, TechAdvance.TECH_NAME_WAR_BONDS, techAdvances);
+    return techAdvances.stream()
+        .map(TechAbilityAttachment::get)
+        .filter(Objects::nonNull)
+        .mapToInt(t -> t.getWarBondDiceNumber())
+        .filter(t -> t > 0)
+        .sum();
   }
 
   private void resetWarBondDiceNumber() {


### PR DESCRIPTION
The correct name for the technology is actually 'warBonds' though
two maps used the name 'victoryBonds'. Previously it was working
arguably happenstance where the code scanned all techs for the
war bonds bonus values and then used those (without looking at
the name).

In cc6de441 a filter was introduced that first filtered technologies
by name (looking for 'warBonds') and only used the war bond attribute
properties from that specific tech. This meant maps with an incorrect
naming for 'warBonds' no longer worked.

This update restores the previous behavior and removes the filter,
any technology with the warbonds bonuses will be picked up and
are additive. This means a person can design multiple technologies
that give a stacking war bonds bonus. Of note, any of the 'dice sides'
attributes may be used, if there are multiple war bonds technologies
then they should all use the same 'dice sides' bonus.

Fixes:
- https://github.com/triplea-game/triplea/issues/6792
- https://github.com/triplea-game/triplea/issues/8609

Problem introduced in: cc6de441db25348ebe74e6a590f23b6b7295f55d


<!-- If multiple commits please summarize the change above. -->

## Testing

- verified the save game attached to #8609 started to roll war bonds after this fix.
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
