### PR TITLE
Fix missing images - load them from assets

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatPlayerPanel.java
@@ -1,19 +1,16 @@
 package games.strategy.engine.chat;
 
+import games.strategy.triplea.EngineImageLoader;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.FontMetrics;
-import java.awt.Image;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
-import java.io.IOException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import java.util.function.BiConsumer;
-import javax.imageio.ImageIO;
 import javax.swing.Action;
 import javax.swing.DefaultListCellRenderer;
 import javax.swing.DefaultListModel;
@@ -38,17 +35,7 @@ public class ChatPlayerPanel extends JPanel implements ChatPlayerListener {
   private static final Icon ignoreIcon;
 
   static {
-    final URL ignore = ChatPlayerPanel.class.getResource("ignore.png");
-    if (ignore == null) {
-      throw new IllegalStateException("Could not find ignore icon");
-    }
-    final Image img;
-    try {
-      img = ImageIO.read(ignore);
-    } catch (final IOException e) {
-      throw new IllegalStateException(e);
-    }
-    ignoreIcon = new ImageIcon(img);
+    ignoreIcon = new ImageIcon(EngineImageLoader.loadImage("images", "ignore.png"));
   }
 
   private JList<ChatParticipant> players;

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -7,6 +7,7 @@ import games.strategy.engine.framework.lookandfeel.LookAndFeelSwingFrameListener
 import games.strategy.engine.framework.map.download.DownloadFile.DownloadState;
 import games.strategy.engine.framework.map.listing.MapListingFetcher;
 import games.strategy.engine.framework.ui.background.BackgroundTaskRunner;
+import games.strategy.triplea.EngineImageLoader;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
@@ -34,7 +35,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.triplea.java.Interruptibles;
 import org.triplea.java.ThreadRunner;
 import org.triplea.swing.JButtonBuilder;
-import org.triplea.swing.JFrameBuilder;
 import org.triplea.swing.SwingComponents;
 import org.triplea.swing.jpanel.JPanelBuilder;
 
@@ -67,7 +67,7 @@ public class DownloadMapsWindow extends JFrame {
     setLocationRelativeTo(null);
     setMinimumSize(new Dimension(200, 200));
 
-    setIconImage(JFrameBuilder.getGameIcon());
+    setIconImage(EngineImageLoader.loadFrameIcon());
     progressPanel = new MapDownloadProgressPanel();
 
     final Set<DownloadFileDescription> pendingDownloads = new HashSet<>();

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/MainFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/MainFrame.java
@@ -7,6 +7,7 @@ import games.strategy.engine.framework.startup.ui.panels.main.MainPanelBuilder;
 import games.strategy.engine.framework.startup.ui.panels.main.SetupPanelModel;
 import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorModel;
 import games.strategy.engine.framework.ui.background.BackgroundTaskRunner;
+import games.strategy.triplea.EngineImageLoader;
 import java.awt.event.WindowEvent;
 import java.util.ArrayList;
 import java.util.List;
@@ -27,6 +28,7 @@ public class MainFrame {
     mainFrame =
         JFrameBuilder.builder()
             .title("TripleA")
+            .iconImage(EngineImageLoader.loadFrameIcon())
             .windowClosedAction(GameRunner::exitGameIfNoWindowsVisible)
             .build();
     BackgroundTaskRunner.setMainFrame(mainFrame);

--- a/game-app/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/lobby/client/ui/LobbyFrame.java
@@ -12,6 +12,7 @@ import games.strategy.engine.lobby.client.ui.action.BanPlayerModeratorAction;
 import games.strategy.engine.lobby.client.ui.action.DisconnectPlayerModeratorAction;
 import games.strategy.engine.lobby.client.ui.action.MutePlayerAction;
 import games.strategy.engine.lobby.client.ui.action.player.info.ShowPlayerInformationAction;
+import games.strategy.triplea.EngineImageLoader;
 import games.strategy.triplea.ui.QuitHandler;
 import games.strategy.triplea.ui.menubar.LobbyMenu;
 import java.awt.BorderLayout;
@@ -26,7 +27,6 @@ import lombok.Getter;
 import org.triplea.domain.data.ChatParticipant;
 import org.triplea.live.servers.ServerProperties;
 import org.triplea.swing.DialogBuilder;
-import org.triplea.swing.JFrameBuilder;
 import org.triplea.swing.SwingComponents;
 
 /** The top-level frame window for the lobby client UI. */
@@ -41,7 +41,7 @@ public class LobbyFrame extends JFrame implements QuitHandler {
     super("TripleA Lobby");
     setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
     SwingComponents.addWindowClosedListener(this, GameRunner::exitGameIfNoWindowsVisible);
-    setIconImage(JFrameBuilder.getGameIcon());
+    setIconImage(EngineImageLoader.loadFrameIcon());
     this.lobbyClient = lobbyClient;
     setJMenuBar(new LobbyMenu(this));
     chatTransmitter =

--- a/game-app/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/ToolBoxWindow.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/ToolBoxWindow.java
@@ -1,6 +1,7 @@
 package games.strategy.engine.lobby.moderator.toolbox;
 
 import games.strategy.engine.lobby.moderator.toolbox.tabs.TabFactory;
+import games.strategy.triplea.EngineImageLoader;
 import java.awt.Component;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -24,6 +25,7 @@ public final class ToolBoxWindow {
             JFrameBuilder.builder()
                 .title("Moderator Toolbox")
                 .locateRelativeTo(parent)
+                .iconImage(EngineImageLoader.loadFrameIcon())
                 .size(800, 700)
                 .minSize(400, 400)
                 .add(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/EngineImageLoader.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/EngineImageLoader.java
@@ -1,0 +1,53 @@
+package games.strategy.triplea;
+
+import java.awt.Image;
+import java.io.IOException;
+import java.nio.file.Path;
+import javax.imageio.ImageIO;
+import lombok.experimental.UtilityClass;
+
+/**
+ * Use this to load images from the game engine 'assets' folder. Do *not* use this to read images
+ * from maps.
+ */
+@UtilityClass
+public class EngineImageLoader {
+
+  public Image loadFrameIcon() {
+    return loadImage("icons", "ta_icon.png");
+  }
+
+  /**
+   * Reads an image from the assets folder.
+   *
+   * @param path Path from assets folder to image, eg: loadImage("folder-in-assets", "image.png");
+   */
+  public Image loadImage(final String... path) {
+    final Path imageFilePath = createPathToImage(path);
+
+    if (!imageFilePath.toFile().exists()) {
+      throw new IllegalStateException(
+          "Error loading image, image does not exist at: "
+              + imageFilePath.toFile().getAbsolutePath());
+    }
+
+    try {
+      return ImageIO.read(imageFilePath.toFile());
+    } catch (final IOException e) {
+      throw new IllegalStateException(
+          "Error loading image at: "
+              + imageFilePath.toFile().getAbsolutePath()
+              + ", "
+              + e.getMessage(),
+          e);
+    }
+  }
+
+  private Path createPathToImage(final String... path) {
+    Path imageFilePath = Path.of("assets");
+    for (final String pathPart : path) {
+      imageFilePath = imageFilePath.resolve(pathPart);
+    }
+    return imageFilePath;
+  }
+}

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -41,6 +41,7 @@ import games.strategy.engine.history.Step;
 import games.strategy.engine.player.IPlayerBridge;
 import games.strategy.engine.random.PbemDiceRoller;
 import games.strategy.triplea.Constants;
+import games.strategy.triplea.EngineImageLoader;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.AbstractConditionsAttachment;
 import games.strategy.triplea.attachments.AbstractTriggerAttachment;
@@ -157,7 +158,6 @@ import org.triplea.sound.ClipPlayer;
 import org.triplea.sound.SoundPath;
 import org.triplea.swing.EventThreadJOptionPane;
 import org.triplea.swing.EventThreadJOptionPane.ConfirmDialogType;
-import org.triplea.swing.JFrameBuilder;
 import org.triplea.swing.SwingAction;
 import org.triplea.swing.SwingComponents;
 import org.triplea.swing.jpanel.JPanelBuilder;
@@ -407,7 +407,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
     super("TripleA - " + game.getData().getGameName());
 
     localPlayers = players;
-    setIconImage(JFrameBuilder.getGameIcon());
+    setIconImage(EngineImageLoader.loadFrameIcon());
     // 200 size is pretty arbitrary, goal is to not allow users to shrink window down to nothing.
     setMinimumSize(new Dimension(200, 200));
 

--- a/game-app/game-core/src/main/java/games/strategy/ui/ScrollableTextField.java
+++ b/game-app/game-core/src/main/java/games/strategy/ui/ScrollableTextField.java
@@ -1,6 +1,7 @@
 package games.strategy.ui;
 
 import games.strategy.engine.framework.system.SystemProperties;
+import games.strategy.triplea.EngineImageLoader;
 import java.awt.FlowLayout;
 import java.awt.Insets;
 import java.awt.event.ActionEvent;
@@ -125,10 +126,10 @@ public class ScrollableTextField extends JPanel {
     if (imagesLoaded) {
       return;
     }
-    up = new ImageIcon(ScrollableTextField.class.getResource("images/up.gif"));
-    down = new ImageIcon(ScrollableTextField.class.getResource("images/down.gif"));
-    max = new ImageIcon(ScrollableTextField.class.getResource("images/max.gif"));
-    min = new ImageIcon(ScrollableTextField.class.getResource("images/min.gif"));
+    up = new ImageIcon(EngineImageLoader.loadImage("images", "up.gif"));
+    down = new ImageIcon(EngineImageLoader.loadImage("images", "down.gif"));
+    max = new ImageIcon(EngineImageLoader.loadImage("images", "max.gif"));
+    min = new ImageIcon(EngineImageLoader.loadImage("images", "min.gif"));
     imagesLoaded = true;
   }
 

--- a/game-app/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceReportSwingView.java
+++ b/game-app/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceReportSwingView.java
@@ -1,5 +1,6 @@
 package org.triplea.debug.error.reporting;
 
+import games.strategy.triplea.EngineImageLoader;
 import java.awt.Component;
 import javax.annotation.Nullable;
 import javax.swing.Box;
@@ -26,6 +27,7 @@ class StackTraceReportSwingView implements StackTraceReportView {
   private final JFrame window =
       JFrameBuilder.builder()
           .title("Upload Error Report to TripleA Support")
+          .iconImage(EngineImageLoader.loadFrameIcon())
           .size(600, 450)
           .minSize(300, 350)
           .alwaysOnTop()

--- a/game-app/game-headed/build.gradle
+++ b/game-app/game-headed/build.gradle
@@ -43,7 +43,7 @@ clean.doFirst {
 task downloadAssets {
     doLast {
         download {
-            src "https://github.com/triplea-game/assets/releases/download/40/game_headed_assets.zip"
+            src "https://github.com/triplea-game/assets/releases/download/42/game_headed_assets.zip"
             dest "$projectDir/.assets/assets.zip"
             overwrite false
         }

--- a/lib/swing-lib/src/main/java/org/triplea/swing/JFrameBuilder.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/JFrameBuilder.java
@@ -6,17 +6,12 @@ import java.awt.Image;
 import java.awt.LayoutManager;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
-import java.io.File;
-import java.io.IOException;
-import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
 import java.util.function.Function;
 import javax.annotation.Nullable;
-import javax.imageio.ImageIO;
 import javax.swing.JFrame;
-import lombok.extern.slf4j.Slf4j;
 import org.triplea.swing.key.binding.KeyCode;
 import org.triplea.swing.key.binding.SwingKeyBinding;
 
@@ -30,7 +25,6 @@ import org.triplea.swing.key.binding.SwingKeyBinding;
  *   <li>JFrame dispose on close
  * </ul>
  */
-@Slf4j
 public class JFrameBuilder {
   private final Collection<Function<JFrame, Component>> children = new ArrayList<>();
   private boolean escapeClosesWindow;
@@ -45,6 +39,7 @@ public class JFrameBuilder {
   private int minHeight = 50;
   private int width;
   private int height;
+  private Image iconImage;
   @Nullable private LayoutManager layoutManager;
   @Nullable private Runnable windowClosedAction;
   @Nullable private Runnable windowActivatedAction;
@@ -75,7 +70,7 @@ public class JFrameBuilder {
         });
 
     frame.setMinimumSize(new Dimension(minWidth, minHeight));
-    frame.setIconImage(getGameIcon());
+    Optional.ofNullable(iconImage).ifPresent(frame::setIconImage);
     frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
 
     if ((width > 0) || (height > 0)) {
@@ -101,15 +96,9 @@ public class JFrameBuilder {
     return frame;
   }
 
-  /** Returns the standard application icon typically displayed in a window's title bar. */
-  public static Image getGameIcon() {
-    try {
-      final File iconFile = Path.of("assets").resolve("icons").resolve("ta_icon.png").toFile();
-      return ImageIO.read(iconFile);
-    } catch (final IOException e) {
-      log.error("ta_icon.png not loaded", e);
-    }
-    return null;
+  public JFrameBuilder iconImage(final Image iconImage) {
+    this.iconImage = iconImage;
+    return this;
   }
 
   public JFrameBuilder escapeKeyClosesFrame() {


### PR DESCRIPTION
Various images were missing after re-organizing subprojects.
The images were in source and were not saved because they matched
git ignore entries.

Those images have now been added to the 'assets' download, this update
changes the loading of those images to be from the assets folder.

