### PR TITLE
Swap ctrl+L accelerator, remove from Unit Help add to Lock Map

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -431,7 +431,11 @@ final class ViewMenu extends JMenu {
   }
 
   private void addLockMap() {
-    add(new JMenuItemCheckBoxBuilder("Lock Map", 'M').bindSetting(ClientSetting.lockMap).build());
+    add(
+        new JMenuItemCheckBoxBuilder("Lock Map", 'M')
+            .accelerator(KeyCode.L)
+            .bindSetting(ClientSetting.lockMap)
+            .build());
   }
 
   private void addFlagDisplayModeMenu() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/HelpMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/HelpMenu.java
@@ -3,11 +3,9 @@ package games.strategy.triplea.ui.menubar.help;
 import games.strategy.engine.data.GameData;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.triplea.ui.UiContext;
-import java.awt.Toolkit;
 import java.awt.event.KeyEvent;
 import javax.swing.Action;
 import javax.swing.JMenu;
-import javax.swing.KeyStroke;
 import lombok.experimental.UtilityClass;
 import org.triplea.swing.SwingAction;
 import org.triplea.swing.SwingComponents;
@@ -33,9 +31,6 @@ public final class HelpMenu {
 
     final var helpMenu = menu.add(UnitHelpMenu.buildMenu(gameData, uiContext));
     helpMenu.setMnemonic(KeyEvent.VK_U);
-    helpMenu.setAccelerator(
-        KeyStroke.getKeyStroke(
-            KeyEvent.VK_L, Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()));
 
     final String gameNotes = gameData.loadGameNotes();
     if (!gameNotes.isBlank()) {

--- a/lib/swing-lib/src/main/java/org/triplea/swing/JMenuItemCheckBoxBuilder.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/JMenuItemCheckBoxBuilder.java
@@ -1,10 +1,13 @@
 package org.triplea.swing;
 
 import com.google.common.base.Preconditions;
+import java.awt.Toolkit;
 import java.util.Optional;
 import java.util.function.Consumer;
 import javax.swing.JCheckBoxMenuItem;
+import javax.swing.KeyStroke;
 import org.triplea.java.ArgChecker;
+import org.triplea.swing.key.binding.KeyCode;
 
 /**
  * Builds a JMenuCheckBox. This is a menu item with a checkbox next to it. By default the checkbox
@@ -25,6 +28,7 @@ public class JMenuItemCheckBoxBuilder {
   private Consumer<Boolean> action;
   private boolean selected;
   private SettingPersistence settingPersistence;
+  private KeyCode accelerator;
 
   /** Sets the title that appears next to the checkbox. */
   public JMenuItemCheckBoxBuilder(final String title, final char mnemonic) {
@@ -58,6 +62,14 @@ public class JMenuItemCheckBoxBuilder {
               .ifPresent(s -> s.saveSetting(checkBox.isSelected()));
           Optional.ofNullable(action).ifPresent(a -> a.accept(checkBox.isSelected()));
         });
+
+    Optional.ofNullable(accelerator)
+        .map(
+            accelerator ->
+                KeyStroke.getKeyStroke(
+                    accelerator.getInputEventCode(),
+                    Toolkit.getDefaultToolkit().getMenuShortcutKeyMaskEx()))
+        .ifPresent(checkBox::setAccelerator);
     return checkBox;
   }
 
@@ -77,6 +89,14 @@ public class JMenuItemCheckBoxBuilder {
    */
   public JMenuItemCheckBoxBuilder bindSetting(final SettingPersistence settingPersistence) {
     this.settingPersistence = settingPersistence;
+    return this;
+  }
+
+  /**
+   * Sets up an accelerator, or a hotkey for the menu. Typically activated via "control + keyCode".
+   */
+  public JMenuItemCheckBoxBuilder accelerator(final KeyCode keyCode) {
+    this.accelerator = keyCode;
     return this;
   }
 }


### PR DESCRIPTION
After this update, ctrl+L will toggle 'lock map' instead of opening
the 'unit help' screen.

