### PR TITLE
Replace 'none' territory selected with an empty string

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -228,7 +228,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
         void refresh() {
           territoryInfo.removeAll();
 
-          message.setText((territoryLastEntered == null) ? "none" : territoryLastEntered.getName());
+          message.setText((territoryLastEntered == null) ? "" : territoryLastEntered.getName());
 
           // If territory is null or doesn't have an attachment then just display the name or "none"
           if (territoryLastEntered == null


### PR DESCRIPTION
In the status bar we print the name of the territory as
the mouse cursor changes. When hovering over a territory
boundary the territory text changes to 'none'. Instead
of this behavior, this update prints an empty string
instead of the text 'none'. So we display nothing
rather than the text 'none'.


<!-- If multiple commits please summarize the change above. -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots

Before:
![Screenshot from 2021-03-07 17-27-35](https://user-images.githubusercontent.com/12397753/110263358-5210e800-7f6b-11eb-8cd7-5bf705471874.png)

After:
![Screenshot from 2021-03-07 17-28-17](https://user-images.githubusercontent.com/12397753/110263360-52a97e80-7f6b-11eb-9c29-aa336e9ad913.png)

<!-- If there are UI updates, include screenshots below -->
