### PR TITLE
Fix NPE when using 'ctrl-a' to add attackers with no territory selected

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorDialog.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorDialog.java
@@ -98,7 +98,7 @@ public class BattleCalculatorDialog extends JDialog {
   }
 
   public static void addAttackers(final Territory t) {
-    if (instances.isEmpty()) {
+    if (instances.isEmpty() || t == null) {
       return;
     }
     final BattleCalculatorPanel currentPanel = instances.get(instances.size() - 1).panel;


### PR DESCRIPTION
This updates prevent a NPE from occuring when no territory is
currently selected (hover over a territory border) and then pressing
'ctrl+a' to add attackers.

To repro NPE, open battle calculator, hover over a territory border
such that no territory is current, then use 'ctrl+a' to add attackers
and observe a NPE.

The 'add defenders' feature already this NPE fix, the add attackers
is missing it.


## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Fix null pointer exception error when pressing 'ctrl-a' to add units to the battle calculator and currently hovering over a territory border.<!--END_RELEASE_NOTE-->
