### PR TITLE
Auto-select battle calc sides when using 'ctrl+A' and 'ctrl+D'

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/AbstractBuiltInAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/AbstractBuiltInAi.java
@@ -372,7 +372,7 @@ public abstract class AbstractBuiltInAi extends AbstractBasePlayer {
             } else {
               final IntegerMap<Territory> distanceMap =
                   data.getMap().getDistance(capitals.get(0), doesNotHaveFactoryYet, it -> true);
-              picked = distanceMap.lowestKey();
+              picked = distanceMap.minKey();
             }
           }
         } else {
@@ -387,7 +387,7 @@ public abstract class AbstractBuiltInAi extends AbstractBasePlayer {
               final IntegerMap<Territory> distanceMap =
                   data.getMap().getDistance(test.get(0), territoryChoices, it -> true);
               for (int i = 0; i < maxTerritoriesToPopulate; i++) {
-                final Territory choice = distanceMap.lowestKey();
+                final Territory choice = distanceMap.minKey();
                 distanceMap.removeKey(choice);
                 test.add(choice);
               }
@@ -413,7 +413,7 @@ public abstract class AbstractBuiltInAi extends AbstractBasePlayer {
               }
               final List<Territory> choices = new ArrayList<>();
               for (int i = 0; i < maxTerritoriesToPopulate; i++) {
-                final Territory choice = distanceMap.lowestKey();
+                final Territory choice = distanceMap.minKey();
                 distanceMap.removeKey(choice);
                 choices.add(choice);
               }
@@ -443,7 +443,7 @@ public abstract class AbstractBuiltInAi extends AbstractBasePlayer {
           } else {
             final IntegerMap<Territory> distanceMap =
                 data.getMap().getDistance(capitals.get(0), notOwned, it -> true);
-            picked = distanceMap.lowestKey();
+            picked = distanceMap.minKey();
           }
         }
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -1074,7 +1074,7 @@ class BattleCalculatorPanel extends JPanel {
 
         // Default attacker to current player
         final Optional<GamePlayer> currentPlayer = getCurrentPlayer(history);
-        currentPlayer.ifPresent(attackerCombo::setSelectedItem);
+        currentPlayer.ifPresent(this::setAttacker);
 
         // Get players with units sorted
         final List<GamePlayer> players = location.getUnitCollection().getPlayersByUnitCount();
@@ -1140,7 +1140,7 @@ class BattleCalculatorPanel extends JPanel {
     revalidate();
   }
 
-  private Optional<GamePlayer> getCurrentPlayer(final History history) {
+  public Optional<GamePlayer> getCurrentPlayer(final History history) {
     final Optional<GamePlayer> player = history.getActivePlayer();
     if (player.isPresent()) {
       return player;
@@ -1152,8 +1152,16 @@ class BattleCalculatorPanel extends JPanel {
     return (GamePlayer) attackerCombo.getSelectedItem();
   }
 
+  void setAttacker(final GamePlayer gamePlayer) {
+    attackerCombo.setSelectedItem(gamePlayer);
+  }
+
   GamePlayer getDefender() {
     return (GamePlayer) defenderCombo.getSelectedItem();
+  }
+
+  void setDefender(final GamePlayer gamePlayer) {
+    defenderCombo.setSelectedItem(gamePlayer);
   }
 
   private GamePlayer getSwapSides() {
@@ -1354,6 +1362,14 @@ class BattleCalculatorPanel extends JPanel {
         getDefender(),
         CollectionUtils.getMatches(units, Matches.unitCanBeInBattle(false, isLand(), 1, false)),
         isLand());
+  }
+
+  public boolean hasAttackingUnitsAdded() {
+    return !attackingUnitsPanel.isEmpty();
+  }
+
+  public boolean hasDefendingUnitsAdded() {
+    return !defendingUnitsPanel.isEmpty();
   }
 
   private boolean isLand() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/PlayerUnitsPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/PlayerUnitsPanel.java
@@ -232,6 +232,14 @@ public class PlayerUnitsPanel extends JPanel {
     return unitTypes;
   }
 
+  /**
+   * Returns true if all of the unit panel numbers are zero, false if there are any units 'added' to
+   * the panel.
+   */
+  boolean isEmpty() {
+    return unitPanels.stream().allMatch(unitPanel -> unitPanel.getCount() == 0);
+  }
+
   public void addChangeListener(final Runnable listener) {
     listeners.add(listener);
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/UnitPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/UnitPanel.java
@@ -111,6 +111,10 @@ public class UnitPanel extends JPanel {
     textField.setValue(value);
   }
 
+  int getCount() {
+    return textField.getValue();
+  }
+
   void addChangeListener(final Runnable listener) {
     listeners.add(listener);
   }

--- a/lib/java-extras/src/main/java/org/triplea/java/collections/IntegerMap.java
+++ b/lib/java-extras/src/main/java/org/triplea/java/collections/IntegerMap.java
@@ -1,10 +1,13 @@
 package org.triplea.java.collections;
 
 import java.io.Serializable;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
+import javax.annotation.Nullable;
 
 /**
  * A utility class for mapping Objects to ints. <br>
@@ -22,6 +25,23 @@ public final class IntegerMap<T> implements Serializable {
 
   public IntegerMap(final Map<T, Integer> map) {
     mapValues = new LinkedHashMap<>(map);
+  }
+
+  /**
+   * Creates an IntegerMap using a counting function. The counting function maps each given element
+   * to a value that is then counted. The end result is a map with each counted elemented and how
+   * many occurrences of each counted element was found.
+   *
+   * @param collection A collection to iterate over and map each element with a counting function.
+   * @param countingFunction How to map each element of the input collection to a value that is then
+   *     to be counted.
+   */
+  public <X> IntegerMap(final Collection<X> collection, final Function<X, T> countingFunction) {
+    mapValues = new LinkedHashMap<>();
+    collection.stream()
+        .map(countingFunction)
+        .filter(Objects::nonNull)
+        .forEach(value -> mapValues.put(value, mapValues.getOrDefault(value, 0)));
   }
 
   /** Creates a shallow clone of the provided IntegerMap. */
@@ -81,9 +101,18 @@ public final class IntegerMap<T> implements Serializable {
   }
 
   /** Will return null if empty. */
-  public T lowestKey() {
+  @Nullable
+  public T minKey() {
     return mapValues.entrySet().stream()
         .min(Map.Entry.comparingByValue())
+        .map(Map.Entry::getKey)
+        .orElse(null);
+  }
+
+  @Nullable
+  public T maxKey() {
+    return mapValues.entrySet().stream()
+        .max(Map.Entry.comparingByValue())
         .map(Map.Entry::getKey)
         .orElse(null);
   }

--- a/lib/java-extras/src/test/java/org/triplea/java/collections/IntegerMapTest.java
+++ b/lib/java-extras/src/test/java/org/triplea/java/collections/IntegerMapTest.java
@@ -189,15 +189,27 @@ class IntegerMapTest {
   }
 
   @Test
-  void testLowestKey() {
+  void testMin() {
     final IntegerMap<Object> map = new IntegerMap<>();
-    assertNull(map.lowestKey());
+    assertNull(map.minKey());
     map.put(k1, 0);
-    assertEquals(k1, map.lowestKey());
+    assertEquals(k1, map.minKey());
     map.put(k2, 10);
-    assertEquals(k1, map.lowestKey());
+    assertEquals(k1, map.minKey());
     map.put(k3, -10);
-    assertEquals(k3, map.lowestKey());
+    assertEquals(k3, map.minKey());
+  }
+
+  @Test
+  void testMax() {
+    final IntegerMap<Object> map = new IntegerMap<>();
+    assertNull(map.maxKey());
+    map.put(k1, 0);
+    assertEquals(k1, map.maxKey());
+    map.put(k2, 10);
+    assertEquals(k2, map.maxKey());
+    map.put(k3, -10);
+    assertEquals(k2, map.maxKey());
   }
 
   @Test


### PR DESCRIPTION
This update adds two behaviors for the battle calculator when using
the hotkeys 'ctrl+A' and 'ctrl+D' to add attackers or defenders
to reduce having to switch the current attacker or defender
in the battle calc.

When adding attackers, if there are no matching attackers with
the current side, and there is a defender present in the battle
calc, then the attacking side is automatically set to the player
whith the most units in that territory. For example, if a player
has set up 1 defending UK infantry, and there is a territory
with 1 german tank, and the battle calc has italy set as the
attacker, then using control-a will automatically add the tank
and set the attacker to germany.

For defenders, if there are no units added to the battle calcuator
at all, then if a player uses 'ctrl+d', the defending side will
be set to match any unit that is in the current territory. For
example if a default calculator has germany as the defender, and
a player uses 'ctrl+d' in a russian territory with russian units,
then those units will be added to defenders and the defending
side will be automatically set to russia.


<!-- If multiple commits please summarize the change above. -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->UPDATE|Battle calculator 'ctrl+A' and 'ctrl+D' will automatically set defending and attacking sides if there are no units currently set as the attacker or defender. For example, if there are UK attacking troops in a territory and the calculator has Russia selected as the attacker but no units were added to the calculator, then using 'ctrl+A' on the UK territory will change the attacker from Russia to UK and will add the UK units.<!--END_RELEASE_NOTE-->
