### PR TITLE
Remove 'SHA' from build number suffix

### DIFF
--- a/.build/set-build-number
+++ b/.build/set-build-number
@@ -3,28 +3,18 @@
 # Updates version file to have an updated build number.
 # Params:
 #  runNumber: [required] run number, or build number
-#  githubSha: [optional] used as a an additional version number, only
-#     the first 10 characters are used
+#
 
 set -x
 runNumber="$1"
-githubSha="$2"
 
 PROP_FILE="game-app/game-core/src/main/resources/META-INF/triplea/product.properties"
-
-
-versionSuffix="$runNumber"
-if [ -n "$githubSha" ]; then
-  # if githubSha is specified, append the version value with the first 10
-  # characters of the SHA
-  versionSuffix="$versionSuffix@$(echo "$githubSha" | cut -c 1-10)"
-fi
 
 ## Update property file, set build number
 ## Expect contents like: "version = 2.0.0"
 ## Overwrite to contain something like: "version = 2.0.1234"
 
-sed -i "s/\(version *=.*\)$/\1.$versionSuffix/" $PROP_FILE
+sed -i "s/\(version *=.*\)$/\1.$runNumber/" $PROP_FILE
 
 ## Read the new version number and print it.
 ## EG: "version = 2.0.1234", print "2.0.1234"

--- a/.github/workflows/deploy-artifacts.yml
+++ b/.github/workflows/deploy-artifacts.yml
@@ -15,18 +15,17 @@ jobs:
         uses: actions/checkout@v2
       - name: set build version variables
         run: |
+          BUILD_NUMBER=$(.build/set-build-number ${{ github.run_number }})
+          echo "product_version=$BUILD_NUMBER" | tee -a $GITHUB_ENV
+
           if [[ "${{ github.ref }}" == "refs/heads/master" ]]; then
-              BUILD_NUMBER=$(.build/set-build-number ${{ github.run_number }} ${{ github.sha }})
-              echo "product_version=$BUILD_NUMBER" | tee -a $GITHUB_ENV
               echo "is_prerelease=true" | tee -a $GITHUB_ENV
               echo "release_name=$(date +%Y-%B-%d) - Prerelease - $BUILD_NUMBER" | tee -a $GITHUB_ENV
           else
-              BUILD_NUMBER=$(.build/set-build-number ${{ github.run_number }})
-              echo "product_version=$BUILD_NUMBER" | tee -a $GITHUB_ENV
               echo "is_prerelease=false" | tee -a $GITHUB_ENV
               echo "release_name=$(date +%Y-%B) - Release - $BUILD_NUMBER" | tee -a $GITHUB_ENV
           fi
-      - name: Build installers
+      - name: Build Installers
         run: .build/build-installer
         env:
           BUILD_NUMBER: ${{ github.run_number }}

--- a/.github/workflows/deploy-prerelease.yml
+++ b/.github/workflows/deploy-prerelease.yml
@@ -14,7 +14,7 @@ jobs:
         uses: actions/checkout@v2
       - name: set build version variables
         run: |
-          BUILD_NUMBER=$(.build/set-build-number ${{ github.run_number }} ${{ github.sha }})
+          BUILD_NUMBER=$(.build/set-build-number ${{ github.run_number }})
           echo "product_version=$BUILD_NUMBER" | tee -a $GITHUB_ENV
       - name: Deploy to Prerelease
         run: |


### PR DESCRIPTION
Instead of 2.6.50@abc123, just have 2.6.50
The version value '2.6.50' is consistently used as a tag, we will always
be able to then correlate to a SHA by using the tag.

