### PR TITLE
Partial Restore of Unit scroller Buttons

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
@@ -1550,9 +1550,7 @@ public class MovePanel extends AbstractMovePanel {
 
   private void registerKeyBindings(final JFrame frame) {
     SwingKeyBinding.addKeyBinding(
-        frame, KeyCode.SPACE, unitScrollerAction(unitScroller::skipCurrentUnits));
-    SwingKeyBinding.addKeyBinding(
-        frame, KeyCode.S, unitScrollerAction(unitScroller::sleepCurrentUnits));
+        frame, KeyCode.S, unitScrollerAction(unitScroller::skipCurrentUnits));
     SwingKeyBinding.addKeyBinding(
         frame, KeyCode.PERIOD, unitScrollerAction(unitScroller::centerOnNextMovableUnit));
     SwingKeyBinding.addKeyBinding(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
@@ -1550,9 +1550,13 @@ public class MovePanel extends AbstractMovePanel {
 
   private void registerKeyBindings(final JFrame frame) {
     SwingKeyBinding.addKeyBinding(
+        frame, KeyCode.SPACE, unitScrollerAction(unitScroller::skipCurrentUnits));
+    SwingKeyBinding.addKeyBinding(
         frame, KeyCode.S, unitScrollerAction(unitScroller::sleepCurrentUnits));
     SwingKeyBinding.addKeyBinding(
-        frame, KeyCode.PERIOD, unitScrollerAction(unitScroller::selectNextMovableUnit));
+        frame, KeyCode.PERIOD, unitScrollerAction(unitScroller::centerOnNextMovableUnit));
+    SwingKeyBinding.addKeyBinding(
+        frame, KeyCode.COMMA, unitScrollerAction(unitScroller::centerOnPreviousMovableUnit));
     SwingKeyBinding.addKeyBinding(frame, KeyCode.F, this::highlightMovableUnits);
     SwingKeyBinding.addKeyBinding(
         frame,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -5,6 +5,7 @@ import games.strategy.engine.data.GameDataEvent;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
+import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.MouseDetails;
@@ -12,7 +13,9 @@ import games.strategy.triplea.ui.panels.map.MapPanel;
 import games.strategy.triplea.ui.panels.map.MapSelectionListener;
 import java.awt.BorderLayout;
 import java.awt.Component;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -53,11 +56,16 @@ public class UnitScroller {
 
   private static final int HORIZONTAL_BUTTON_GAP = 2;
 
-  private static final String NEXT_UNITS_TOOLTIP = "Press '.' or click to see 'Next' unmoved unit.";
+  private static final String PREVIOUS_UNITS_TOOLTIP =
+      "Press ',' or click to see 'Previous' unmoved units.";
+  private static final String NEXT_UNITS_TOOLTIP =
+      "Press '.' or click to see 'Next' unmoved units.";
   private static final String SLEEP_UNITS_TOOLTIP =
       "Press 'S' or click to 'Sleep' these unmoved units until manually moved or alerted.";
+  private static final String SKIP_UNITS_TOOLTIP =
+      "Press 'Space' or click to 'Skip' these unmoved units until next move phase.";
   private static final String WAKE_ALL_TOOLTIP =
-      "Click to 'Activate' all skipped and sleeping units on the map.";
+      "Click to 'Alert' all skipped and sleeping units on the map.";
 
   private Collection<Unit> skippedUnits = new HashSet<>();
   private final Collection<Unit> sleepingUnits = new HashSet<>();
@@ -68,7 +76,7 @@ public class UnitScroller {
 
   private final Supplier<GamePlayer> currentPlayerSupplier;
   private final Supplier<MovePhase> movePhaseSupplier;
-  private final Supplier<Boolean> parentPanelIsVisible;
+  private Supplier<Boolean> parentPanelIsVisible;
 
   private final AvatarPanelFactory avatarPanelFactory;
   private final JLabel territoryNameLabel = new JLabelBuilder().biggerFont().centerAlign().build();
@@ -119,11 +127,11 @@ public class UnitScroller {
     }
 
     updateMovesLeft();
-    clearUnitAvatarArea();
-    // Units in lastFocusedTerritory become skipped when a player clicks 'next units'.
-    // If moving some units out of a territory, the remaining units should not be skipped
-    // if a player clicks 'next units'.
-    lastFocusedTerritory = null;
+    if (lastFocusedTerritory == null) {
+      focusCapital();
+    } else {
+      drawUnitAvatarPane(lastFocusedTerritory);
+    }
 
     // remove any moved units from the sleeping units
     sleepingUnits.removeAll(
@@ -179,6 +187,22 @@ public class UnitScroller {
     selectUnitImagePanel.removeAll();
     selectUnitImagePanel.repaint();
     updateMovesLeft();
+    focusCapital();
+  }
+
+  private void focusCapital() {
+    Optional.ofNullable(currentPlayerSupplier.get())
+        .ifPresent(
+            player -> {
+              lastFocusedTerritory =
+                  TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, gameData);
+              Optional.ofNullable(lastFocusedTerritory)
+                  .ifPresent(
+                      t -> {
+                        drawUnitAvatarPane(t);
+                        territoryNameLabel.setText(t.getName());
+                      });
+            });
   }
 
   private void drawUnitAvatarPane(final Territory t) {
@@ -190,7 +214,8 @@ public class UnitScroller {
     final List<Unit> moveableUnits =
         player == null
             ? List.of()
-            : UnitScrollerModel.getPlayerUnitsInTerritory(t, movePhaseSupplier.get(), player);
+            : UnitScrollerModel.getMoveableUnits(
+                t, movePhaseSupplier.get(), player, getAllSkippedUnits());
 
     SwingUtilities.invokeLater(
         () -> {
@@ -215,9 +240,18 @@ public class UnitScroller {
     panel.add(territoryNameLabel);
     panel.add(Box.createVerticalStrut(2));
 
+    final JButton prevUnit = new JButton(UnitScrollerIcon.LEFT_ARROW.get());
+    prevUnit.setToolTipText(PREVIOUS_UNITS_TOOLTIP);
+    prevUnit.setAlignmentX(JComponent.CENTER_ALIGNMENT);
+    prevUnit.addActionListener(e -> centerOnPreviousMovableUnit());
+
     final JButton sleepButton = new JButton(UnitScrollerIcon.SLEEP.get());
     sleepButton.setToolTipText(SLEEP_UNITS_TOOLTIP);
     sleepButton.addActionListener(e -> sleepCurrentUnits());
+
+    final JButton skipButton = new JButton(UnitScrollerIcon.SKIP.get());
+    skipButton.setToolTipText(SKIP_UNITS_TOOLTIP);
+    skipButton.addActionListener(e -> skipCurrentUnits());
 
     final JButton wakeAllButton = new JButton(UnitScrollerIcon.WAKE_ALL.get());
     wakeAllButton.setToolTipText(WAKE_ALL_TOOLTIP);
@@ -226,14 +260,18 @@ public class UnitScroller {
 
     final JButton nextUnit = new JButton(UnitScrollerIcon.RIGHT_ARROW.get());
     nextUnit.setToolTipText(NEXT_UNITS_TOOLTIP);
-    nextUnit.addActionListener(e -> selectNextMovableUnit());
+    nextUnit.addActionListener(e -> centerOnNextMovableUnit());
 
     final JPanel skipAndSleepPanel =
         new JPanelBuilder()
             .boxLayoutHorizontal()
+            .add(prevUnit)
+            .addHorizontalStrut(HORIZONTAL_BUTTON_GAP)
             .add(wakeAllButton)
             .addHorizontalStrut(HORIZONTAL_BUTTON_GAP)
             .add(sleepButton)
+            .addHorizontalStrut(HORIZONTAL_BUTTON_GAP)
+            .add(skipButton)
             .addHorizontalStrut(HORIZONTAL_BUTTON_GAP)
             .add(nextUnit)
             .build();
@@ -253,7 +291,7 @@ public class UnitScroller {
       skippedUnits.addAll(getMovableUnits(lastFocusedTerritory));
       updateMovesLeft();
     }
-    selectNextMovableUnit();
+    centerOnNextMovableUnit();
   }
 
   private List<Unit> getMovableUnits(final Territory territory) {
@@ -269,23 +307,19 @@ public class UnitScroller {
       sleepingUnits.addAll(getMovableUnits(lastFocusedTerritory));
       updateMovesLeft();
     }
-    selectNextMovableUnit();
+    centerOnNextMovableUnit();
   }
 
   private void wakeAllUnits() {
     sleepingUnits.clear();
     skippedUnits.clear();
     updateMovesLeft();
-    focusMapOnNextMovableUnit();
+    centerOnNextMovableUnit();
   }
 
-  public void selectNextMovableUnit() {
-    if (lastFocusedTerritory != null) {
-      skippedUnits.addAll(getMovableUnits(lastFocusedTerritory));
-    }
+  public void centerOnNextMovableUnit() {
+    centerOnMovableUnit(true);
 
-    focusMapOnNextMovableUnit();
-    updateMovesLeft();
     if (lastFocusedTerritory != null) {
       showAllUnitsMovedIfNeeded();
     }
@@ -319,9 +353,19 @@ public class UnitScroller {
     }
   }
 
-  private void focusMapOnNextMovableUnit() {
-    final List<Territory> allTerritories = gameData.getMap().getTerritories();
+  public void centerOnPreviousMovableUnit() {
+    centerOnMovableUnit(false);
+    showAllUnitsMovedIfNeeded();
+  }
 
+  private void centerOnMovableUnit(final boolean selectNext) {
+    List<Territory> allTerritories = gameData.getMap().getTerritories();
+
+    if (!selectNext) {
+      final List<Territory> territories = new ArrayList<>(allTerritories);
+      Collections.reverse(territories);
+      allTerritories = territories;
+    }
     // new focused index is 1 greater
     int newFocusedIndex =
         lastFocusedTerritory == null ? 0 : allTerritories.indexOf(lastFocusedTerritory) + 1;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -60,8 +60,6 @@ public class UnitScroller {
       "Press ',' or click to see 'Previous' unmoved units.";
   private static final String NEXT_UNITS_TOOLTIP =
       "Press '.' or click to see 'Next' unmoved units.";
-  private static final String SLEEP_UNITS_TOOLTIP =
-      "Press 'S' or click to 'Sleep' these unmoved units until manually moved or alerted.";
   private static final String SKIP_UNITS_TOOLTIP =
       "Press 'Space' or click to 'Skip' these unmoved units until next move phase.";
   private static final String WAKE_ALL_TOOLTIP =
@@ -195,7 +193,8 @@ public class UnitScroller {
         .ifPresent(
             player -> {
               lastFocusedTerritory =
-                  TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, gameData);
+                  TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(
+                      player, gameData.getMap());
               Optional.ofNullable(lastFocusedTerritory)
                   .ifPresent(
                       t -> {
@@ -245,10 +244,6 @@ public class UnitScroller {
     prevUnit.setAlignmentX(JComponent.CENTER_ALIGNMENT);
     prevUnit.addActionListener(e -> centerOnPreviousMovableUnit());
 
-    final JButton sleepButton = new JButton(UnitScrollerIcon.SLEEP.get());
-    sleepButton.setToolTipText(SLEEP_UNITS_TOOLTIP);
-    sleepButton.addActionListener(e -> sleepCurrentUnits());
-
     final JButton skipButton = new JButton(UnitScrollerIcon.SKIP.get());
     skipButton.setToolTipText(SKIP_UNITS_TOOLTIP);
     skipButton.addActionListener(e -> skipCurrentUnits());
@@ -268,8 +263,6 @@ public class UnitScroller {
             .add(prevUnit)
             .addHorizontalStrut(HORIZONTAL_BUTTON_GAP)
             .add(wakeAllButton)
-            .addHorizontalStrut(HORIZONTAL_BUTTON_GAP)
-            .add(sleepButton)
             .addHorizontalStrut(HORIZONTAL_BUTTON_GAP)
             .add(skipButton)
             .addHorizontalStrut(HORIZONTAL_BUTTON_GAP)

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScrollerIcon.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScrollerIcon.java
@@ -16,7 +16,6 @@ class UnitScrollerIcon implements Supplier<Icon> {
   static final UnitScrollerIcon LEFT_ARROW = new UnitScrollerIcon("left_arrow.png");
   static final UnitScrollerIcon RIGHT_ARROW = new UnitScrollerIcon("right_arrow.png");
   static final UnitScrollerIcon SKIP = new UnitScrollerIcon("skip.png");
-  static final UnitScrollerIcon SLEEP = new UnitScrollerIcon("unit_sleep.png");
   static final UnitScrollerIcon WAKE_ALL = new UnitScrollerIcon("wake_all.png");
 
   private static final String UNIT_SCROLLER_IMAGES_FOLDER = "unit_scroller";

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScrollerIcon.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScrollerIcon.java
@@ -13,7 +13,9 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 class UnitScrollerIcon implements Supplier<Icon> {
 
+  static final UnitScrollerIcon LEFT_ARROW = new UnitScrollerIcon("left_arrow.png");
   static final UnitScrollerIcon RIGHT_ARROW = new UnitScrollerIcon("right_arrow.png");
+  static final UnitScrollerIcon SKIP = new UnitScrollerIcon("skip.png");
   static final UnitScrollerIcon SLEEP = new UnitScrollerIcon("unit_sleep.png");
   static final UnitScrollerIcon WAKE_ALL = new UnitScrollerIcon("wake_all.png");
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScrollerModel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScrollerModel.java
@@ -24,22 +24,16 @@ class UnitScrollerModel {
       final Collection<Unit> skippedUnits) {
     Preconditions.checkNotNull(t);
 
-    return getPlayerUnitsInTerritory(t, movePhase, player).stream()
-        .filter(Matches.unitHasMovementLeft())
-        .filter(Predicate.not(skippedUnits::contains))
-        .collect(Collectors.toList());
-  }
-
-  static List<Unit> getPlayerUnitsInTerritory(
-      final Territory t, final UnitScroller.MovePhase movePhase, final GamePlayer player) {
-    Preconditions.checkNotNull(t);
-
-    final Predicate<Unit> movableInCurrentPhaseAndOwnedByMe =
+    final Predicate<Unit> moveableUnitOwnedByMe =
         PredicateBuilder.of(Matches.unitIsOwnedBy(player))
+            .and(Matches.unitHasMovementLeft())
+            // if not non combat, cannot move aa units
             .andIf(
                 movePhase == UnitScroller.MovePhase.COMBAT, Matches.unitCanMoveDuringCombatMove())
             .build();
-    return t.getUnitCollection().getMatches(movableInCurrentPhaseAndOwnedByMe);
+    final List<Unit> units = t.getUnitCollection().getMatches(moveableUnitOwnedByMe);
+    units.removeAll(skippedUnits);
+    return units;
   }
 
   static int computeUnitsToMoveCount(


### PR DESCRIPTION
commit 2314a81ab75208cda010d3f72fe337e04234caa3

    Revert "Simplify unit scroller behavior (#8278)"
    
    This reverts commit 42cfad3a16fcc51c01f9b5b655d99522cc933639.

commit c7c7a142a170e44ec881649cb4ae8c76c8eb3aa3

    Remove unit scroller 'sleep button', assign 's' key to 'skip'


<!-- If multiple commits please summarize the change above. -->

Before:
![Screenshot from 2021-03-08 20-12-37](https://user-images.githubusercontent.com/12397753/110417563-a9d25080-804a-11eb-83d9-f9df5b0141ea.png)


After:
![Screenshot from 2021-03-08 20-11-36](https://user-images.githubusercontent.com/12397753/110417464-87403780-804a-11eb-9719-b206472d0cad.png)

