### PR TITLE
Read game name from map.yml when parsing game files.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/EngineVersionException.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/EngineVersionException.java
@@ -1,10 +1,23 @@
 package games.strategy.engine.data;
 
+import java.io.File;
+import org.triplea.injection.Injections;
+
 /** A checked exception that indicates a game engine is not compatible with a map. */
 public final class EngineVersionException extends Exception {
   private static final long serialVersionUID = 8800415601463715772L;
 
   public EngineVersionException(final String error) {
     super(error);
+  }
+
+  public EngineVersionException(final String minimumVersionFound, final File xmlFileBeingParsed) {
+    super(
+        String.format(
+            "Current engine version: %s, is not compatible with version: %s, "
+                + "required by game-XML: %s",
+            Injections.getInstance().getEngineVersion(),
+            minimumVersionFound,
+            xmlFileBeingParsed.getAbsolutePath()));
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -395,7 +395,7 @@ public final class GameSelectorPanel extends JPanel implements Observer {
     BackgroundTaskRunner.runInBackground(
         "Loading map...",
         () -> {
-          model.load(gameFile.toFile().toURI());
+          model.load(gameFile.toFile());
           // warning: NPE check is not to protect against concurrency, another thread could still
           // null
           // out game data.

--- a/game-app/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-app/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -94,7 +94,7 @@ public class HeadlessGameServer {
       gameSelectorModel.load(
           availableGames
               .findGameXmlPathByGameName(gameName) //
-              .map(Path::toUri)
+              .map(Path::toFile)
               .orElseThrow());
       log.info("Changed to game map: " + gameName);
     } else {

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/gameparser/GameParserTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/gameparser/GameParserTest.java
@@ -10,7 +10,8 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.RulesAttachment;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
-import java.net.URI;
+import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
@@ -24,11 +25,12 @@ final class GameParserTest {
   @Test
   @DisplayName("Verify backward compatibility can parse 1.8 maps")
   void backwardCompatibilityCheck() throws Exception {
-    final URI mapUri =
-        GameParserTest.class.getClassLoader().getResource("v1_8_map__270BC.xml").toURI();
+    final File mapFile =
+        Path.of(GameParserTest.class.getClassLoader().getResource("v1_8_map__270BC.xml").toURI())
+            .toFile();
 
     final GameData gameData =
-        GameParser.parse(mapUri, new XmlGameElementMapper(), new Version("2.0.0")).orElseThrow();
+        GameParser.parse(mapFile, new XmlGameElementMapper(), new Version("2.0.0")).orElseThrow();
     assertNotNullGameData(gameData);
 
     verifyLegacyPropertiesAreUpdated(gameData);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/xml/TestMapGameData.java
@@ -5,8 +5,9 @@ import games.strategy.engine.data.TestAttachment;
 import games.strategy.engine.data.gameparser.GameParser;
 import games.strategy.engine.data.gameparser.XmlGameElementMapper;
 import games.strategy.triplea.delegate.TestDelegate;
-import java.net.URI;
+import java.io.File;
 import java.net.URISyntaxException;
+import java.nio.file.Path;
 import java.util.Map;
 import org.triplea.util.Version;
 
@@ -65,9 +66,9 @@ public enum TestMapGameData {
    * @throws RuntimeException If an error occurs while loading the map.
    */
   public GameData getGameData() {
-    final URI mapUri;
+    final File mapUri;
     try {
-      mapUri = getClass().getClassLoader().getResource(fileName).toURI();
+      mapUri = Path.of(getClass().getClassLoader().getResource(fileName).toURI()).toFile();
     } catch (final URISyntaxException e) {
       throw new IllegalStateException("Can't find " + fileName, e);
     }

--- a/game-app/map-data/src/main/java/org/triplea/map/data/elements/Game.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/data/elements/Game.java
@@ -21,7 +21,9 @@ import org.triplea.generic.xml.reader.annotations.Tag;
 @AllArgsConstructor
 @ToString
 public class Game {
-  @XmlElement @Tag private Info info;
+  /** @deprecated Do not use, game name should be read from map.yml file instead. */
+  @Deprecated @XmlElement @Tag private Info info;
+
   @XmlElement @Tag private Triplea triplea;
 
   @XmlElement(name = "attachmentList")

--- a/game-app/map-data/src/main/java/org/triplea/map/data/elements/Info.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/data/elements/Info.java
@@ -14,5 +14,6 @@ import org.triplea.generic.xml.reader.annotations.Attribute;
 @AllArgsConstructor
 @ToString
 public class Info {
-  @XmlAttribute @Attribute private String name;
+  /** @deprecated Do not use, game name should be read from map.yml file instead. */
+  @Deprecated @XmlAttribute @Attribute private String name;
 }

--- a/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYaml.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYaml.java
@@ -164,6 +164,30 @@ public class MapDescriptionYaml {
     }
   }
 
+  /**
+   * Given an XML file, does something of a reverse lookup in the map.yml file to find the
+   * corresponding game name. The match is based on the file name.
+   *
+   * @throws IllegalStateException thrown if no entry exists in this map.yml file with a game whose
+   *     file name matches the input file name.
+   */
+  public String findGameNameFromXmlFileName(final File xmlFile) {
+    // Find map game entry whose xml file name matches input file name.
+    // Once found, return the corresponding game name.
+    return mapGameList.stream()
+        .filter(game -> game.getXmlFileName().equals(xmlFile.getName()))
+        .findAny()
+        .map(MapGame::getGameName)
+        .orElseThrow(
+            () ->
+                new IllegalStateException(
+                    "map.yml file at: "
+                        + yamlFileLocation
+                        + ", did not contain an entry"
+                        + "for "
+                        + xmlFile.getAbsolutePath()));
+  }
+
   /** Lookup game XML file name in map.yml by game name. */
   private Optional<String> findFileNameForGame(final String gameName) {
     final Optional<String> fileName =

--- a/game-app/map-data/src/test/java/org/triplea/map/description/file/MapDescriptionYamlTest.java
+++ b/game-app/map-data/src/test/java/org/triplea/map/description/file/MapDescriptionYamlTest.java
@@ -3,6 +3,7 @@ package org.triplea.map.description.file;
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.File;
 import java.nio.file.Path;
@@ -52,5 +53,46 @@ class MapDescriptionYamlTest {
     assertThat(
         gameFilePath,
         isPresentAndIs(mapFolder.resolve("games").resolve("game1").resolve("game-file.xml")));
+  }
+
+  @Test
+  void findGameNameFromXmlFileName_PositiveCase() {
+    final MapDescriptionYaml mapDescriptionYaml =
+        MapDescriptionYaml.builder()
+            .yamlFileLocation(new File("/path/on/disk/map.yml").toURI())
+            .mapName("map name")
+            .mapVersion(1)
+            .mapGameList(
+                List.of(
+                    MapDescriptionYaml.MapGame.builder() //
+                        .gameName("game name")
+                        .xmlFileName("path.xml")
+                        .build()))
+            .build();
+
+    final String gameName =
+        mapDescriptionYaml.findGameNameFromXmlFileName(new File("/root/path.xml"));
+
+    assertThat(gameName, is("game name"));
+  }
+
+  @Test
+  void findGameNameFromXmlFileName_NegativeCase() {
+    final MapDescriptionYaml mapDescriptionYaml =
+        MapDescriptionYaml.builder()
+            .yamlFileLocation(new File("/path/on/disk/map.yml").toURI())
+            .mapName("map name")
+            .mapVersion(1)
+            .mapGameList(
+                List.of(
+                    MapDescriptionYaml.MapGame.builder() //
+                        .gameName("game name")
+                        .xmlFileName("path.xml")
+                        .build()))
+            .build();
+
+    assertThrows(
+        IllegalStateException.class,
+        () -> mapDescriptionYaml.findGameNameFromXmlFileName(new File("DNE.xml")));
   }
 }

--- a/smoke-testing/src/test/java/games/strategy/engine/data/ParseGameXmlsTest.java
+++ b/smoke-testing/src/test/java/games/strategy/engine/data/ParseGameXmlsTest.java
@@ -21,7 +21,7 @@ class ParseGameXmlsTest {
   void parseGameFiles(final File xmlFile) {
     final Optional<GameData> result =
         GameParser.parse(
-            xmlFile.toURI(), new XmlGameElementMapper(), new ProductVersionReader().getVersion());
+            xmlFile, new XmlGameElementMapper(), new ProductVersionReader().getVersion());
     assertThat(result, OptionalMatchers.isPresent());
   }
 


### PR DESCRIPTION
- Additionally, change parameter to Parser#load method
  to be a file instead of a URI.


<!-- If multiple commits please summarize the change above. -->

## Testing

- verified default game selected when launching engine, loading save games and various downloaded maps and could start game and save and then load those saves
<!-- Describe any manual testing performed below. -->
