### PR TITLE
Use fallback encodings when reading files

### DIFF
--- a/lib/java-extras/src/main/java/org/triplea/io/FileUtils.java
+++ b/lib/java-extras/src/main/java/org/triplea/io/FileUtils.java
@@ -196,19 +196,13 @@ public final class FileUtils {
       }
 
       try {
-        return Optional.of(Files.readString(fileToRead, Charsets.UTF_8));
-      } catch (final MalformedInputException e) {
-        log.info(
-            "Warning: "
-                + "unable to read file (character encoding problem), will next try ISO-8859_1: {}, {}",
-            fileToRead.toFile().getAbsolutePath(),
-            e.getMessage());
-      }
-
-      try {
         return Optional.of(Files.readString(fileToRead, Charsets.ISO_8859_1));
       } catch (final MalformedInputException e) {
-        throw e;
+        log.warn(
+            "Bad file encoding on file: "
+                + fileToRead.toAbsolutePath().toString()
+                + ", contact the map maker and ask them to save this file as UTF-8");
+        return Optional.empty();
       }
     } catch (final IOException e) {
       log.error(

--- a/lib/java-extras/src/main/java/org/triplea/io/FileUtils.java
+++ b/lib/java-extras/src/main/java/org/triplea/io/FileUtils.java
@@ -175,7 +175,10 @@ public final class FileUtils {
 
   /**
    * Reads and returns the contents of a given file. Returns empty if the file does not exist or if
-   * there were any errors reading the file.
+   * there were any errors reading the file. Character encodings allowed: UTf-8, ISO_8859_1
+   *
+   * @throws MalformedInputException thrown if unrecongized character encodings found
+   * @throws IOException thrown if there are any problems reading the target file
    */
   public static Optional<String> readContents(final Path fileToRead) {
     if (!fileToRead.toFile().exists()) {
@@ -189,8 +192,7 @@ public final class FileUtils {
         return Optional.of(Files.readString(fileToRead));
       } catch (final MalformedInputException e) {
         log.info(
-            "Warning: "
-                + "unable to read file (character encoding problem), will next try UTF-8: {}, {}",
+            "Warning: file was not saved as UTF-8, some characters may not render:  {}, {}",
             fileToRead.toFile().getAbsolutePath(),
             e.getMessage());
       }
@@ -199,7 +201,7 @@ public final class FileUtils {
         return Optional.of(Files.readString(fileToRead, Charsets.ISO_8859_1));
       } catch (final MalformedInputException e) {
         log.warn(
-            "Bad file encoding on file: "
+            "Bad file encoding: "
                 + fileToRead.toAbsolutePath().toString()
                 + ", contact the map maker and ask them to save this file as UTF-8");
         return Optional.empty();

--- a/lib/java-extras/src/test/java/org/triplea/io/FileUtilsTest.java
+++ b/lib/java-extras/src/test/java/org/triplea/io/FileUtilsTest.java
@@ -1,6 +1,7 @@
 package org.triplea.io;
 
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresent;
 import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -11,6 +12,7 @@ import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -97,5 +99,20 @@ final class FileUtilsTest {
           FileUtils.findFileInParentFolders(testFolderPath.toPath(), "touch-parent"),
           isPresentAndIs(testFolderPath.toPath().resolve("touch-parent")));
     }
+  }
+
+  @Test
+  @DisplayName("Verify we can read file contents with ISO-8859-1 encoded characters")
+  void readContents() {
+    final File testFile =
+        new File(
+            ZipExtractorTest.class
+                .getClassLoader()
+                .getResource("ISO-8859-1-test-file.txt")
+                .getFile());
+
+    final Optional<String> contentRead = FileUtils.readContents(testFile.toPath());
+
+    assertThat(contentRead, isPresent());
   }
 }

--- a/lib/java-extras/src/test/resources/ISO-8859-1-test-file.txt
+++ b/lib/java-extras/src/test/resources/ISO-8859-1-test-file.txt
@@ -1,0 +1,1 @@
+Test data with ISO-8859 characters: 


### PR DESCRIPTION
Allows for ISO-8859 files to be read if files
are not encoded as ASCII (UTF-8). ISO-8859 characters
may not render correctly but the file will at least
be read (avoiding relatively obscure error scenarios).

Resolves: https://github.com/triplea-game/triplea/issues/9028
