### PR TITLE
Fix NonMonotonicSequenceException again (#9035)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapRouteDrawer.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapRouteDrawer.java
@@ -177,13 +177,10 @@ public class MapRouteDrawer {
    */
   protected double[] newParameterizedIndex(final Point2D[] points) {
     final double[] index = new double[points.length];
-    if (index.length > 0) {
-      index[0] = 0;
-    }
     for (int i = 1; i < points.length; i++) {
       final double sqrtDistance = Math.sqrt(points[i - 1].distance(points[i]));
       // Ensure that values are increasing even if the distance is 0
-      index[i] = index[i - 1] + Math.max(Double.MIN_NORMAL, sqrtDistance);
+      index[i] = Math.max(Math.nextUp(index[i - 1]), index[i - 1] + sqrtDistance);
     }
     return index;
   }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ui/panels/map/MapRouteDrawerTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ui/panels/map/MapRouteDrawerTest.java
@@ -37,13 +37,6 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.triplea.java.collections.IntegerMap;
 
 final class MapRouteDrawerTest {
-  /**
-   * This is a very special value because {@code 13.44 + Double.MIN_NORMAL == 13.44} evaluates to
-   * true. So we use the square of this value (because the code computes the square root) in order
-   * to test a very specific edge case.
-   */
-  private static final double MAGIC_VALUE = 13.44 * 13.44;
-
   private final Point[] dummyPoints =
       new Point[] {new Point(0, 0), new Point(100, 0), new Point(0, 100)};
   private final MapData dummyMapData = mock(MapData.class);
@@ -145,7 +138,14 @@ final class MapRouteDrawerTest {
             Arguments.of(new Double(-1, -1)),
             Arguments.of(new Double(1, -1), new Double(1, -1), new Double(1, -1)),
             Arguments.of(new Double(-1, -1), new Double(1, 1), new Double(0, 0)),
-            Arguments.of(new Double(0, 0), new Double(0, MAGIC_VALUE), new Double(0, MAGIC_VALUE)))
+            // 13.44 is chosen specifically to test a rare edge case that used to cause an exception
+            // in the past. We used to add a minimal positive double to indices to make them
+            // strictly increasing as required by commons-math. However in case of 13.44 the
+            // expression 13.44 + Double.MIN_NORMAL == 13.44 evaluates to true, so the sequence is
+            // no longer strictly increasing. So we use the square of this value (because the code
+            // computes the square root) in order to verify we don't get this issue again.
+            Arguments.of(
+                new Double(0, 0), new Double(0, 13.44 * 13.44), new Double(0, 13.44 * 13.44)))
         // Turn varargs into single array instance
         .map(Arguments::get)
         .map(Arrays::stream)

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ui/panels/map/MapRouteDrawerTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ui/panels/map/MapRouteDrawerTest.java
@@ -37,6 +37,13 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.triplea.java.collections.IntegerMap;
 
 final class MapRouteDrawerTest {
+  /**
+   * This is a very special value because {@code 13.44 + Double.MIN_NORMAL == 13.44} evaluates to
+   * true. So we use the square of this value (because the code computes the square root) in order
+   * to test a very specific edge case.
+   */
+  private static final double MAGIC_VALUE = 13.44 * 13.44;
+
   private final Point[] dummyPoints =
       new Point[] {new Point(0, 0), new Point(100, 0), new Point(0, 100)};
   private final MapData dummyMapData = mock(MapData.class);
@@ -137,7 +144,8 @@ final class MapRouteDrawerTest {
             Arguments.of(new Double(1, 1)),
             Arguments.of(new Double(-1, -1)),
             Arguments.of(new Double(1, -1), new Double(1, -1), new Double(1, -1)),
-            Arguments.of(new Double(-1, -1), new Double(1, 1), new Double(0, 0)))
+            Arguments.of(new Double(-1, -1), new Double(1, 1), new Double(0, 0)),
+            Arguments.of(new Double(0, 0), new Double(0, MAGIC_VALUE), new Double(0, MAGIC_VALUE)))
         // Turn varargs into single array instance
         .map(Arguments::get)
         .map(Arrays::stream)

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ui/panels/map/MapRouteDrawerTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ui/panels/map/MapRouteDrawerTest.java
@@ -138,14 +138,10 @@ final class MapRouteDrawerTest {
             Arguments.of(new Double(-1, -1)),
             Arguments.of(new Double(1, -1), new Double(1, -1), new Double(1, -1)),
             Arguments.of(new Double(-1, -1), new Double(1, 1), new Double(0, 0)),
-            // 13.44 is chosen specifically to test a rare edge case that used to cause an exception
-            // in the past. We used to add a minimal positive double to indices to make them
-            // strictly increasing as required by commons-math. However in case of 13.44 the
-            // expression 13.44 + Double.MIN_NORMAL == 13.44 evaluates to true, so the sequence is
-            // no longer strictly increasing. So we use the square of this value (because the code
-            // computes the square root) in order to verify we don't get this issue again.
-            Arguments.of(
-                new Double(0, 0), new Double(0, 13.44 * 13.44), new Double(0, 13.44 * 13.44)))
+            // We used to add a minimal positive double to indices to make them strictly increasing
+            // as required by commons-math. However in some cases x + Double.MIN_NORMAL == x
+            // evaluates to true, so the sequence is no longer strictly increasing.
+            Arguments.of(new Double(0, 0), new Double(0, 1), new Double(0, 1)))
         // Turn varargs into single array instance
         .map(Arguments::get)
         .map(Arrays::stream)

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ui/panels/map/MapRouteDrawerTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ui/panels/map/MapRouteDrawerTest.java
@@ -138,9 +138,6 @@ final class MapRouteDrawerTest {
             Arguments.of(new Double(-1, -1)),
             Arguments.of(new Double(1, -1), new Double(1, -1), new Double(1, -1)),
             Arguments.of(new Double(-1, -1), new Double(1, 1), new Double(0, 0)),
-            // We used to add a minimal positive double to indices to make them strictly increasing
-            // as required by commons-math. However in some cases x + Double.MIN_NORMAL == x
-            // evaluates to true, so the sequence is no longer strictly increasing.
             Arguments.of(new Double(0, 0), new Double(0, 1), new Double(0, 1)))
         // Turn varargs into single array instance
         .map(Arguments::get)


### PR DESCRIPTION
This fixes #9035 for real this time.
Quite an interesting bug.

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|In rare edge cases a NonMonotonicSequenceException could occur when planning moves<!--END_RELEASE_NOTE-->
