### PR TITLE
Use a simpler content downloader on maps server

### DIFF
--- a/lib/java-extras/src/main/java/org/triplea/io/ContentDownloader.java
+++ b/lib/java-extras/src/main/java/org/triplea/io/ContentDownloader.java
@@ -6,9 +6,7 @@ import java.io.InputStream;
 import java.net.URI;
 import java.util.Optional;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpStatus;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -34,7 +32,6 @@ import org.triplea.java.Interruptibles;
  * <p>Warning: The input stream provided by this class can only be consumed once (property of input
  * streams, the input stream is not reset in any way after reading it).
  */
-@Slf4j
 public final class ContentDownloader implements CloseableDownloader {
   private final CloseableHttpClient httpClient;
 
@@ -96,26 +93,5 @@ public final class ContentDownloader implements CloseableDownloader {
     stream.close();
     response.close();
     httpClient.close();
-  }
-
-  /**
-   * Downloads content from a given URI and runs a function on the downloaded content and returns
-   * that functions output.
-   *
-   * @param uri The URI to download
-   * @param streamProcessor Function to process the downloaded input.
-   * @return Result of the stream processing function, otherwise an empty result if there were
-   *     errors or if the processing function returns null.
-   */
-  public static <T> Optional<T> downloadAndExecute(
-      final URI uri, final Function<InputStream, T> streamProcessor) {
-    try (CloseableDownloader downloader = new ContentDownloader(uri)) {
-      final InputStream stream = downloader.getStream();
-      return Optional.ofNullable(streamProcessor.apply(stream));
-    } catch (final IOException e) {
-      log.error(
-          "Failed to download and process content from URI: " + uri + ", " + e.getMessage(), e);
-      return Optional.empty();
-    }
   }
 }

--- a/lib/java-extras/src/main/java/org/triplea/io/SimpleDownloader.java
+++ b/lib/java-extras/src/main/java/org/triplea/io/SimpleDownloader.java
@@ -1,0 +1,73 @@
+package org.triplea.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.util.Optional;
+import java.util.function.Function;
+import lombok.Getter;
+import lombok.experimental.UtilityClass;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+
+/**
+ * Bare-bones utility class to download content from a specific URI and process the downloaded
+ * content.
+ */
+@UtilityClass
+public final class SimpleDownloader {
+
+  /** Thrown if there are any problems downloading or reading downloaded content. */
+  @Getter
+  public static class DownloadException extends Exception {
+    private static final long serialVersionUID = -4049197878908223175L;
+    private final int statusCode;
+
+    DownloadException(final int statusCode, final String message) {
+      super(message);
+      this.statusCode = statusCode;
+    }
+
+    DownloadException(final int statusCode, final Exception cause) {
+      super(cause);
+      this.statusCode = statusCode;
+    }
+  }
+
+  /**
+   * Downloads content from a given URI and runs a function on the downloaded content and returns
+   * that functions output.
+   *
+   * @param uri The URI to download
+   * @param streamProcessor Function to process the downloaded input.
+   * @return Result of the stream processing function
+   * @throws DownloadException Thrown if there are any problems during download.
+   */
+  public static <T> T downloadAndExecute(
+      final URI uri, final Function<InputStream, T> streamProcessor) throws DownloadException {
+
+    final HttpGet request = new HttpGet(uri);
+    try (CloseableHttpClient httpClient = HttpClients.custom().disableCookieManagement().build();
+        CloseableHttpResponse response = httpClient.execute(request)) {
+      final int statusCode = response.getStatusLine().getStatusCode();
+      if (statusCode != HttpStatus.SC_OK) {
+        throw new DownloadException(
+            statusCode, String.format("Unexpected status code (%d)", statusCode));
+      }
+      final HttpEntity entity =
+          Optional.ofNullable(response.getEntity())
+              .orElseThrow(() -> new DownloadException(statusCode, "Entity is missing"));
+      try (InputStream stream = entity.getContent()) {
+        return streamProcessor.apply(stream);
+      } catch (final IOException e) {
+        throw new DownloadException(statusCode, e);
+      }
+    } catch (final IOException e) {
+      throw new DownloadException(0, e);
+    }
+  }
+}


### PR DESCRIPTION
Allows for status code to be received by caller and then processed.
Notable as before a 404 triggered an error logging from within the
library with stack trace. For cases where a 404 is expected, this
is not desirable behavior. This update adds a simpler version
of the downloader library that throws an exception that provides
access to returned status code. The net result is the logging
for 404 can be handled by client and print a more friendly and
expected message rather than a scary error message with stack trace.

