### PR TITLE
Prefer mavenCentral over jcenter

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,7 +115,7 @@ subprojects {
     }
 
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {

--- a/gradle/scripts/yaml.gradle
+++ b/gradle/scripts/yaml.gradle
@@ -20,7 +20,7 @@ import org.yaml.snakeyaml.Yaml
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
     }
 
     dependencies {


### PR DESCRIPTION
JCenter no longer accepts any new packages and will shutdown in a year completely.
See https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/ and https://github.com/gradle/gradle/pull/16176 for more information