### PR TITLE
Fixed issue 2.6.89 by calling JOptionPane in a Swing event thread

### DIFF
--- a/lib/swing-lib/src/main/java/org/triplea/swing/EventThreadJOptionPane.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/EventThreadJOptionPane.java
@@ -211,42 +211,64 @@ public final class EventThreadJOptionPane {
    * @return True if user confirms, false if user closes the confirmation dialog or selects no.
    */
   public static boolean showConfirmDialog(
-      final @Nullable Component parentComponent,
-      final @Nullable Object message,
-      final @Nullable String title,
-      final ConfirmDialogType confirmDialogType) {
+          final @Nullable Component parentComponent,
+          final @Nullable Object message,
+          final @Nullable String title,
+          final ConfirmDialogType confirmDialogType) {
 
-    // Construct a 'JDialog' the "hard" way through a JOptionPane so that we can
-    // set modal to be false.
-    final JOptionPane optionPane =
-        new JOptionPane(
-            message, JOptionPane.QUESTION_MESSAGE, confirmDialogType.optionTypeMagicNumber);
-    final JDialog dialog = optionPane.createDialog(parentComponent, title);
-    dialog.setAlwaysOnTop(true);
-    if (!SwingUtilities.isEventDispatchThread()) {
-      dialog.setModal(false);
-    }
-
+    // We want to construct a 'JDialog' the "hard" way through a JOptionPane so
+    // that we can set modal to be false.
     // Only modal dialogs are blocking. To mimic this, we use a latch to block once
     // the dialog is set to visible. We use a property listener to capture the users
     // confirmation choice and to unblock.
     final CountDownLatch latch = new CountDownLatch(1);
     final AtomicReference<Boolean> confirmation = new AtomicReference<>();
-    optionPane.addPropertyChangeListener(
-        JOptionPane.VALUE_PROPERTY,
-        ignored -> {
-          final Object selectedValue = optionPane.getValue();
-          confirmation.set(selectedValue != null && JOptionPane.OK_OPTION == (int) selectedValue);
-          latch.countDown();
-          dialog.dispose();
-        });
 
+    // Swing components must be created in Swing event threads. If we are already
+    // in one, dialog creation is fairly easy.
     if (SwingUtilities.isEventDispatchThread()) {
+      final JOptionPane optionPane =
+              new JOptionPane(
+                      message, JOptionPane.QUESTION_MESSAGE, confirmDialogType.optionTypeMagicNumber);
+      final JDialog dialog = optionPane.createDialog(parentComponent, title);
+      dialog.setAlwaysOnTop(true);
+
+      optionPane.addPropertyChangeListener(
+              JOptionPane.VALUE_PROPERTY,
+              ignored -> {
+                final Object selectedValue = optionPane.getValue();
+                confirmation.set(selectedValue != null && JOptionPane.OK_OPTION == (int) selectedValue);
+                latch.countDown();
+                dialog.dispose();
+              });
+
       // modal dialog being set to visible is blocking
       dialog.setVisible(true);
-    } else {
-      // non modal dialog set to visible is not blocking and must be done on EDT
-      SwingUtilities.invokeLater(() -> dialog.setVisible(true));
+    }
+
+    // For non-Swing event threads, we must request our code be invoked and block manually
+    else {
+      SwingUtilities.invokeLater(() -> {
+        final JOptionPane optionPane =
+                new JOptionPane(
+                        message, JOptionPane.QUESTION_MESSAGE, confirmDialogType.optionTypeMagicNumber);
+        final JDialog dialog = optionPane.createDialog(parentComponent, title);
+        dialog.setAlwaysOnTop(true);
+        dialog.setModal(false);
+
+        optionPane.addPropertyChangeListener(
+                JOptionPane.VALUE_PROPERTY,
+                ignored -> {
+                  final Object selectedValue = optionPane.getValue();
+                  confirmation.set(selectedValue != null && JOptionPane.OK_OPTION == (int) selectedValue);
+                  latch.countDown();
+                  dialog.dispose();
+                });
+
+        // non modal dialog set to visible is not blocking and must be done on EDT
+        dialog.setVisible(true);
+      });
+
       try {
         // start blocking, wait for the dialog property event to fire to clear this latch
         latch.await();

--- a/lib/swing-lib/src/main/java/org/triplea/swing/EventThreadJOptionPane.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/EventThreadJOptionPane.java
@@ -229,7 +229,8 @@ public final class EventThreadJOptionPane {
     if (SwingUtilities.isEventDispatchThread()) {
       final JOptionPane optionPane =
               new JOptionPane(
-                      message, JOptionPane.QUESTION_MESSAGE, confirmDialogType.optionTypeMagicNumber);
+                      message, JOptionPane.QUESTION_MESSAGE,
+                      confirmDialogType.optionTypeMagicNumber);
       final JDialog dialog = optionPane.createDialog(parentComponent, title);
       dialog.setAlwaysOnTop(true);
 
@@ -237,21 +238,21 @@ public final class EventThreadJOptionPane {
               JOptionPane.VALUE_PROPERTY,
               ignored -> {
                 final Object selectedValue = optionPane.getValue();
-                confirmation.set(selectedValue != null && JOptionPane.OK_OPTION == (int) selectedValue);
+                confirmation.set(selectedValue != null
+                        && JOptionPane.OK_OPTION == (int) selectedValue);
                 latch.countDown();
                 dialog.dispose();
               });
 
       // modal dialog being set to visible is blocking
       dialog.setVisible(true);
-    }
 
     // For non-Swing event threads, we must request our code be invoked and block manually
-    else {
+    } else {
       SwingUtilities.invokeLater(() -> {
         final JOptionPane optionPane =
-                new JOptionPane(
-                        message, JOptionPane.QUESTION_MESSAGE, confirmDialogType.optionTypeMagicNumber);
+                new JOptionPane(message, JOptionPane.QUESTION_MESSAGE,
+                        confirmDialogType.optionTypeMagicNumber);
         final JDialog dialog = optionPane.createDialog(parentComponent, title);
         dialog.setAlwaysOnTop(true);
         dialog.setModal(false);
@@ -260,7 +261,8 @@ public final class EventThreadJOptionPane {
                 JOptionPane.VALUE_PROPERTY,
                 ignored -> {
                   final Object selectedValue = optionPane.getValue();
-                  confirmation.set(selectedValue != null && JOptionPane.OK_OPTION == (int) selectedValue);
+                  confirmation.set(selectedValue != null
+                          && JOptionPane.OK_OPTION == (int) selectedValue);
                   latch.countDown();
                   dialog.dispose();
                 });


### PR DESCRIPTION
Only one commit and one method modified.

## Testing
I was able to verify the problem in my own save game on a World War II Classic map with Java 15.0.2 running on Windows 10.

To reproduce, load [this save game](https://github.com/triplea-game/triplea/files/6262327/2021-4-5-World-War-II-Classic.zip). Then...

Move infantry from Panama to West Panama Sea Zone
Move transport and battleships from West Panama Sea Zone to Mexico Sea Zone
Move infantry from Mexico Sea Zone to Mexico
Press "Done" to end the combat phase

This does not work with the current master branch. It does work in my modification. I also verified that confirmation dialogs from Swing event threads still work, such as requesting to exit the program.

## Screens Shots
![Failure](https://user-images.githubusercontent.com/24846405/113664767-962a0200-9669-11eb-88de-8b65ee534d54.png)
![Success](https://user-images.githubusercontent.com/24846405/113664790-9e823d00-9669-11eb-877a-df519fb33da5.png)

## Additional Notes to Reviewer
First pull request. Please let me know if anything is incorrect.

## Release Note
<!--RELEASE_NOTE-->FIX|Fixed a bug that caused confirmation dialogs to show no content.<!--END_RELEASE_NOTE-->
