### PR TITLE
Show the sub retreat step even if a destroyer is present

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreat.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreat.java
@@ -38,8 +38,9 @@ public class DefensiveSubsRetreat implements BattleStep {
 
   @Override
   public List<String> getNames() {
-    // do not check for destroyer because it could die before the retreat step
-    // and thus allow the retreat step
+    // even though the #execute method checks for destroyers, we don't do it here
+    // because this is called at the beginning of the round and any destroyer that exists
+    // might die before the #execute is called
     if (isEvaderNotPresent() || isRetreatNotPossible()) {
       return List.of();
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreat.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreat.java
@@ -38,14 +38,9 @@ public class DefensiveSubsRetreat implements BattleStep {
 
   @Override
   public List<String> getNames() {
+    // do not check for destroyer because it could die before the retreat step
+    // and thus allow the retreat step
     if (isEvaderNotPresent() || isRetreatNotPossible()) {
-      return List.of();
-    }
-
-    if (getOrder() == SUB_DEFENSIVE_RETREAT_BEFORE_BATTLE && isDestroyerPresent()) {
-      // only check for destroyers if subs can retreat before battle
-      // because the destroyer could be killed during the battle which would
-      // allow the sub to withdraw at the end of the battle
       return List.of();
     }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveSubsRetreat.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveSubsRetreat.java
@@ -34,8 +34,9 @@ public class OffensiveSubsRetreat implements BattleStep {
 
   @Override
   public List<String> getNames() {
-    // do not check for destroyer because it could die before the retreat step
-    // and thus allow the retreat step
+    // even though the #execute method checks for destroyers, we don't do it here
+    // because this is called at the beginning of the round and any destroyer that exists
+    // might die before the #execute is called
     if (isEvaderNotPresent() || isRetreatNotPossible()) {
       return List.of();
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveSubsRetreat.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveSubsRetreat.java
@@ -34,14 +34,9 @@ public class OffensiveSubsRetreat implements BattleStep {
 
   @Override
   public List<String> getNames() {
+    // do not check for destroyer because it could die before the retreat step
+    // and thus allow the retreat step
     if (isEvaderNotPresent() || isRetreatNotPossible()) {
-      return List.of();
-    }
-
-    if (getOrder() == SUB_OFFENSIVE_RETREAT_BEFORE_BATTLE && isDestroyerPresent()) {
-      // only check for destroyers if subs can retreat before battle
-      // because the destroyer could be killed during the battle which would
-      // allow the sub to withdraw at the end of the battle
       return List.of();
     }
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -1107,6 +1107,7 @@ class WW2V3Year41Test {
     final List<String> steps = battle.determineStepStrings();
     assertEquals(
         BattleStepsTest.mergeSteps(
+                List.of(attacker + SUBS_SUBMERGE),
                 List.of(defender + SUBS_SUBMERGE),
                 BattleStepsTest.firstStrikeFightStepStrings(defenderPlayer, attackerPlayer),
                 List.of(REMOVE_SNEAK_ATTACK_CASUALTIES),
@@ -1132,6 +1133,7 @@ class WW2V3Year41Test {
   void testAttackDestroyerAndSubsAgainstSub() {
     final GamePlayer defenderPlayer = germans(gameData);
     final String attacker = "British";
+    final String defender = "Germans";
     final GamePlayer attackerPlayer = british(gameData);
     final Territory attacked = territory("31 Sea Zone", gameData);
     final Territory from = territory("32 Sea Zone", gameData);
@@ -1153,6 +1155,7 @@ class WW2V3Year41Test {
     assertEquals(
         BattleStepsTest.mergeSteps(
                 List.of(attacker + SUBS_SUBMERGE),
+                List.of(defender + SUBS_SUBMERGE),
                 BattleStepsTest.firstStrikeFightStepStrings(attackerPlayer, defenderPlayer),
                 List.of(REMOVE_SNEAK_ATTACK_CASUALTIES),
                 BattleStepsTest.generalFightStepStrings(attackerPlayer, defenderPlayer),
@@ -1177,6 +1180,7 @@ class WW2V3Year41Test {
   void testAttackDestroyerAndSubsAgainstSubAndDestroyer() {
     final GamePlayer defenderPlayer = germans(gameData);
     final String attacker = "British";
+    final String defender = "Germans";
     final GamePlayer attackerPlayer = british(gameData);
     final Territory attacked = territory("31 Sea Zone", gameData);
     final Territory from = territory("32 Sea Zone", gameData);
@@ -1198,6 +1202,8 @@ class WW2V3Year41Test {
     final List<String> steps = battle.determineStepStrings();
     assertEquals(
         BattleStepsTest.mergeSteps(
+                List.of(attacker + SUBS_SUBMERGE),
+                List.of(defender + SUBS_SUBMERGE),
                 BattleStepsTest.firstStrikeFightStepStrings(attackerPlayer, defenderPlayer),
                 BattleStepsTest.generalFightStepStrings(attackerPlayer, defenderPlayer),
                 BattleStepsTest.firstStrikeFightStepStrings(defenderPlayer, attackerPlayer),

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
@@ -684,7 +684,7 @@ public class BattleStepsTest {
 
   @Test
   @DisplayName(
-      "Verify defending canEvade units can not retreat if SUB_RETREAT_BEFORE_BATTLE and destroyers")
+      "Verify defending canEvade units can retreat if SUB_RETREAT_BEFORE_BATTLE and destroyers")
   void defendingSubsNotRetreatIfDestroyersAndCanRetreatBeforeBattle() {
     final Unit unit1 = givenUnitDestroyer();
     final Unit unit2 = givenUnitCanEvade();
@@ -706,7 +706,9 @@ public class BattleStepsTest {
                 .battleSite(battleSite)
                 .build());
 
-    assertThat(steps, is(basicFightStepStrings()));
+    assertThat(
+        steps,
+        is(mergeSteps(List.of(defender.getName() + SUBS_SUBMERGE), basicFightStepStrings())));
   }
 
   @Test

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreatTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/DefensiveSubsRetreatTest.java
@@ -78,8 +78,7 @@ class DefensiveSubsRetreatTest {
     final BattleState battleState =
         givenBattleStateBuilder()
             .defendingUnits(List.of(givenUnitCanEvade()))
-            .gameData(
-                givenGameData().withSubRetreatBeforeBattle(false).withSubmersibleSubs(true).build())
+            .gameData(givenGameData().withSubmersibleSubs(true).build())
             .build();
     final DefensiveSubsRetreat defensiveSubsRetreat =
         new DefensiveSubsRetreat(battleState, battleActions);
@@ -94,8 +93,7 @@ class DefensiveSubsRetreatTest {
             // it shouldn't even care if the attacking unit is a destroyer
             .attackingUnits(List.of(mock(Unit.class)))
             .defendingUnits(List.of(givenUnitCanEvade()))
-            .gameData(
-                givenGameData().withSubRetreatBeforeBattle(false).withSubmersibleSubs(true).build())
+            .gameData(givenGameData().withSubmersibleSubs(true).build())
             .build();
     final DefensiveSubsRetreat defensiveSubsRetreat =
         new DefensiveSubsRetreat(battleState, battleActions);
@@ -104,18 +102,17 @@ class DefensiveSubsRetreatTest {
   }
 
   @Test
-  void hasNoNamesWhenDestroyerIsOnOffenseAndWithdrawIsBeforeBattle() {
+  void hasNameWhenDestroyerIsOnOffenseAndWithdrawIsBeforeBattle() {
     final BattleState battleState =
         givenBattleStateBuilder()
             .attackingUnits(List.of(givenUnitDestroyer()))
             .defendingUnits(List.of(givenUnitCanEvade()))
-            .gameData(
-                givenGameData().withSubmersibleSubs(true).withSubRetreatBeforeBattle(true).build())
+            .gameData(givenGameData().withSubmersibleSubs(true).build())
             .build();
     final DefensiveSubsRetreat defensiveSubsRetreat =
         new DefensiveSubsRetreat(battleState, battleActions);
 
-    assertThat(defensiveSubsRetreat.getNames(), is(empty()));
+    assertThat(defensiveSubsRetreat.getNames(), hasSize(1));
   }
 
   @Test

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveSubsRetreatTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveSubsRetreatTest.java
@@ -78,11 +78,7 @@ public class OffensiveSubsRetreatTest {
     final BattleState battleState =
         givenBattleStateBuilder()
             .attackingUnits(List.of(givenUnitCanEvade()))
-            .gameData(
-                MockGameData.givenGameData()
-                    .withSubRetreatBeforeBattle(false)
-                    .withSubmersibleSubs(true)
-                    .build())
+            .gameData(MockGameData.givenGameData().withSubmersibleSubs(true).build())
             .attackerRetreatTerritories(List.of())
             .build();
     final OffensiveSubsRetreat offensiveSubsRetreat =
@@ -107,21 +103,17 @@ public class OffensiveSubsRetreatTest {
   }
 
   @Test
-  void hasNoNamesWhenDestroyerIsOnDefenseAndWithdrawIsBeforeBattle() {
+  void hasNameWhenDestroyerIsOnDefenseAndWithdrawIsBeforeBattle() {
     final BattleState battleState =
         givenBattleStateBuilder()
             .attackingUnits(List.of(givenUnitCanEvade()))
             .defendingUnits(List.of(givenUnitDestroyer()))
-            .gameData(
-                MockGameData.givenGameData()
-                    .withSubmersibleSubs(true)
-                    .withSubRetreatBeforeBattle(true)
-                    .build())
+            .gameData(MockGameData.givenGameData().withSubmersibleSubs(true).build())
             .build();
     final OffensiveSubsRetreat offensiveSubsRetreat =
         new OffensiveSubsRetreat(battleState, battleActions);
 
-    assertThat(offensiveSubsRetreat.getNames(), is(empty()));
+    assertThat(offensiveSubsRetreat.getNames(), hasSize(1));
   }
 
   @Test

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveSubsRetreatTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/retreat/OffensiveSubsRetreatTest.java
@@ -113,7 +113,10 @@ public class OffensiveSubsRetreatTest {
     final OffensiveSubsRetreat offensiveSubsRetreat =
         new OffensiveSubsRetreat(battleState, battleActions);
 
-    assertThat(offensiveSubsRetreat.getNames(), hasSize(1));
+    assertThat(
+        "The destroyer could be killed during the AA phase which would allow the sub to retreat.",
+        offensiveSubsRetreat.getNames(),
+        hasSize(1));
   }
 
   @Test


### PR DESCRIPTION
If the destroyer is killed during the AA phase, then the subs are
allowed to retreat BEFORE_BATTLE.  And if the destroyer is killed at
anytime during the round, the subs are allwed to retreat AFTER_BATTLE.

Fixes #9069 

<!-- If multiple commits please summarize the change above. -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Fix the "Could not find step name" error from showing up in TotalWorldWar.  This happens when  all the destroyers are killed during the Substrike phase.<!--END_RELEASE_NOTE-->
