### PR TITLE
Fix of issue v2.6.118 - Negated the Confirm Dialog Response

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -334,7 +334,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
         // classes. maybe there is
         // a better way?
         stopGame =
-            EventThreadJOptionPane.showConfirmDialog(
+            !EventThreadJOptionPane.showConfirmDialog(
                 null,
                 "<html>" + displayMessage + "</html>",
                 "Continue Game?  (" + title + ")",


### PR DESCRIPTION
Added a negation to a confirm dialog call.

## Testing
Verified that both the end game dialog and bombardment dialog work as expected.

## Screens Shots
N/A

## Additional Notes to Reviewer

This is a fix of issue v2.6.118 by inverting the response from showConfirmDialog().

EndRoundDelegate.signalGameOver() asks "Continue Game?", but then uses the result to set "stopGame", inverting the meaning. From line 336:

```
        stopGame =
            EventThreadJOptionPane.showConfirmDialog(
                null,
                "<html>" + displayMessage + "</html>",
                "Continue Game?  (" + title + ")",
                ConfirmDialogType.YES_NO);
```

So pressing "Yes" to the "Continue Game?" dialog sets stopGame to TRUE. Hence, the game stops which is the opposite of expected behavior. I checked with bombardment, another non-Swing thread that opens a ConfirmationDialog, and confirmed that it expects "Yes" to return TRUE, showing I did not undo an inversion with recent work on ConfirmationDialog.

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->Fixed the end game dialog so "No" to "Continue Game?" now ends the game.<!--END_RELEASE_NOTE-->
