### PR TITLE
Use Path instead of passing streams

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -202,7 +202,7 @@ public class MapData {
       final String path,
       final ThrowingFunction<Path, Map<K, V>, IOException> mapper)
       throws IOException {
-    @Nullable Path resourcePath = loader.optionalResource(path).orElse(null);
+    @Nullable final Path resourcePath = loader.optionalResource(path).orElse(null);
     if (resourcePath != null) {
       return mapper.apply(resourcePath);
     }

--- a/game-app/game-core/src/main/java/org/triplea/util/PointFileReaderWriter.java
+++ b/game-app/game-core/src/main/java/org/triplea/util/PointFileReaderWriter.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -266,7 +267,7 @@ public final class PointFileReaderWriter {
   static void readPath(final Path input, final Consumer<String> lineParser) throws IOException {
 
     try {
-      Files.lines(input).filter(current -> current.trim().length() != 0).forEachOrdered(lineParser);
+      Files.lines(input).filter(Predicate.not(String::isBlank)).forEachOrdered(lineParser);
     } catch (final IllegalArgumentException e) {
       throw new IOException(e);
     }

--- a/game-app/game-core/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/game-app/game-core/src/main/java/tools/image/AutoPlacementFinder.java
@@ -11,7 +11,6 @@ import java.awt.Rectangle;
 import java.awt.Shape;
 import java.awt.geom.Rectangle2D;
 import java.io.IOException;
-import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -275,8 +274,8 @@ public final class AutoPlacementFinder {
       textOptionPane.dispose();
       return;
     }
-    try (OutputStream os = Files.newOutputStream(fileName)) {
-      PointFileReaderWriter.writeOneToMany(os, placements);
+    try {
+      PointFileReaderWriter.writeOneToMany(fileName, placements);
       textOptionPane.appendNewLine("Data written to :" + fileName.normalize().toAbsolutePath());
     } catch (final IOException e) {
       log.error("Failed to write points file: " + fileName, e);

--- a/game-app/game-core/src/main/java/tools/image/CenterPicker.java
+++ b/game-app/game-core/src/main/java/tools/image/CenterPicker.java
@@ -16,8 +16,6 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionAdapter;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -135,8 +133,8 @@ public final class CenterPicker {
                   "File Suggestion",
                   JOptionPane.YES_NO_CANCEL_OPTION)
               == 0) {
-        try (InputStream is = Files.newInputStream(file)) {
-          polygons = PointFileReaderWriter.readOneToManyPolygons(is);
+        try {
+          polygons = PointFileReaderWriter.readOneToManyPolygons(file);
         } catch (final IOException e) {
           log.error("Something wrong with your Polygons file: " + file.toAbsolutePath());
           throw e;
@@ -145,8 +143,8 @@ public final class CenterPicker {
         final Path polyPath =
             new FileOpen("Select A Polygon File", mapFolderLocation, ".txt").getFile();
         if (polyPath != null) {
-          try (InputStream is = Files.newInputStream(polyPath)) {
-            polygons = PointFileReaderWriter.readOneToManyPolygons(is);
+          try {
+            polygons = PointFileReaderWriter.readOneToManyPolygons(polyPath);
           } catch (final IOException e) {
             log.error("Something wrong with your Polygons file: " + polyPath);
             throw e;
@@ -237,8 +235,8 @@ public final class CenterPicker {
       if (fileName == null) {
         return;
       }
-      try (OutputStream out = Files.newOutputStream(fileName)) {
-        PointFileReaderWriter.writeOneToOne(out, centers);
+      try {
+        PointFileReaderWriter.writeOneToOne(fileName, centers);
         log.info("Data written to :" + fileName.normalize().toAbsolutePath());
       } catch (final IOException e) {
         log.error("Failed to save centers: " + fileName, e);
@@ -253,8 +251,8 @@ public final class CenterPicker {
       if (centerName == null) {
         return;
       }
-      try (InputStream in = Files.newInputStream(centerName)) {
-        centers = PointFileReaderWriter.readOneToOne(in);
+      try {
+        centers = PointFileReaderWriter.readOneToOne(centerName);
       } catch (final IOException e) {
         log.error("Failed to load centers: " + centerName, e);
       }

--- a/game-app/game-core/src/main/java/tools/image/DecorationPlacer.java
+++ b/game-app/game-core/src/main/java/tools/image/DecorationPlacer.java
@@ -19,8 +19,6 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionAdapter;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -223,9 +221,9 @@ public final class DecorationPlacer {
                   "File Suggestion",
                   JOptionPane.YES_NO_CANCEL_OPTION)
               == 0) {
-        try (InputStream is = Files.newInputStream(fileCenters)) {
+        try {
           log.info("Centers : " + fileCenters);
-          centers = PointFileReaderWriter.readOneToOne(is);
+          centers = PointFileReaderWriter.readOneToOne(fileCenters);
         } catch (final IOException e) {
           log.error("Something wrong with Centers file");
           throw e;
@@ -237,9 +235,7 @@ public final class DecorationPlacer {
               new FileOpen("Select A Center File", mapFolderLocation, ".txt").getFile();
           if (centerPath != null) {
             log.info("Centers : " + centerPath);
-            try (InputStream is = Files.newInputStream(centerPath)) {
-              centers = PointFileReaderWriter.readOneToOne(is);
-            }
+            centers = PointFileReaderWriter.readOneToOne(centerPath);
           } else {
             log.info("You must specify a centers file.");
             log.info("Shutting down.");
@@ -260,9 +256,9 @@ public final class DecorationPlacer {
                   "File Suggestion",
                   JOptionPane.YES_NO_CANCEL_OPTION)
               == 0) {
-        try (InputStream is = Files.newInputStream(filePoly)) {
+        try {
           log.info("Polygons : " + filePoly);
-          polygons = PointFileReaderWriter.readOneToManyPolygons(is);
+          polygons = PointFileReaderWriter.readOneToManyPolygons(filePoly);
         } catch (final IOException e) {
           log.error("Something wrong with your Polygons file: " + filePoly.toAbsolutePath());
           throw e;
@@ -273,8 +269,8 @@ public final class DecorationPlacer {
             new FileOpen("Select A Polygon File", mapFolderLocation, ".txt").getFile();
         if (polyPath != null) {
           log.info("Polygons : " + polyPath);
-          try (InputStream is = Files.newInputStream(polyPath)) {
-            polygons = PointFileReaderWriter.readOneToManyPolygons(is);
+          try {
+            polygons = PointFileReaderWriter.readOneToManyPolygons(polyPath);
           } catch (final IOException e) {
             log.error("Something wrong with your Polygons file: " + polyPath);
             throw e;
@@ -499,8 +495,8 @@ public final class DecorationPlacer {
       if (fileName == null) {
         return;
       }
-      try (OutputStream out = Files.newOutputStream(fileName)) {
-        PointFileReaderWriter.writeOneToMany(out, currentPoints);
+      try {
+        PointFileReaderWriter.writeOneToMany(fileName, currentPoints);
         log.info("Data written to :" + fileName.normalize().toAbsolutePath());
       } catch (final IOException e) {
         log.error("Failed to save points: " + fileName, e);
@@ -666,8 +662,8 @@ public final class DecorationPlacer {
               ".txt");
       currentImagePointsTextFile = centerName.getFile();
       if (centerName.getFile() != null && Files.exists(centerName.getFile())) {
-        try (InputStream in = Files.newInputStream(centerName.getFile())) {
-          currentPoints = PointFileReaderWriter.readOneToMany(in);
+        try {
+          currentPoints = PointFileReaderWriter.readOneToMany(centerName.getFile());
         } catch (final IOException e) {
           log.error("Failed to load image points: " + centerName.getFile(), e);
           currentPoints = new HashMap<>();

--- a/game-app/game-core/src/main/java/tools/image/PolygonGrabber.java
+++ b/game-app/game-core/src/main/java/tools/image/PolygonGrabber.java
@@ -17,8 +17,6 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionAdapter;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -146,9 +144,9 @@ public final class PolygonGrabber {
                   "File Suggestion",
                   JOptionPane.YES_NO_CANCEL_OPTION)
               == 0) {
-        try (InputStream is = Files.newInputStream(file)) {
+        try {
           log.info("Centers : " + file);
-          centers = PointFileReaderWriter.readOneToOne(is);
+          centers = PointFileReaderWriter.readOneToOne(file);
         } catch (final IOException e) {
           log.error("Something wrong with Centers file", e);
         }
@@ -159,9 +157,7 @@ public final class PolygonGrabber {
               new FileOpen("Select A Center File", mapFolderLocation, ".txt").getFile();
           if (centerPath != null) {
             log.info("Centers : " + centerPath);
-            try (InputStream is = Files.newInputStream(centerPath)) {
-              centers = PointFileReaderWriter.readOneToOne(is);
-            }
+            centers = PointFileReaderWriter.readOneToOne(centerPath);
           } else {
             log.info("You must specify a centers file.");
             log.info("Shutting down.");
@@ -379,8 +375,8 @@ public final class PolygonGrabber {
       if (polyName == null) {
         return;
       }
-      try (OutputStream out = Files.newOutputStream(polyName)) {
-        PointFileReaderWriter.writeOneToManyPolygons(out, polygons);
+      try {
+        PointFileReaderWriter.writeOneToManyPolygons(polyName, polygons);
         log.info("Data written to :" + polyName.normalize().toAbsolutePath());
       } catch (final IOException e) {
         log.error("Failed to save polygons: " + polyName, e);
@@ -395,8 +391,8 @@ public final class PolygonGrabber {
       if (polyName == null) {
         return;
       }
-      try (InputStream in = Files.newInputStream(polyName)) {
-        polygons = PointFileReaderWriter.readOneToManyPolygons(in);
+      try {
+        polygons = PointFileReaderWriter.readOneToManyPolygons(polyName);
       } catch (final IOException e) {
         log.error("Failed to load polygons: " + polyName, e);
       }

--- a/game-app/game-core/src/main/java/tools/image/TileImageReconstructor.java
+++ b/game-app/game-core/src/main/java/tools/image/TileImageReconstructor.java
@@ -16,7 +16,6 @@ import java.awt.Transparency;
 import java.awt.image.BufferedImage;
 import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
@@ -145,8 +144,8 @@ public final class TileImageReconstructor {
         final Path polyName =
             new FileOpen("Load A Polygon File", mapFolderLocation, ".txt").getFile();
         if (polyName != null) {
-          try (InputStream in = Files.newInputStream(polyName)) {
-            polygons = PointFileReaderWriter.readOneToManyPolygons(in);
+          try {
+            polygons = PointFileReaderWriter.readOneToManyPolygons(polyName);
           } catch (final IOException e) {
             log.error("Failed to load polygons: " + polyName, e);
             return;

--- a/game-app/game-core/src/main/java/tools/map/making/ConnectionFinder.java
+++ b/game-app/game-core/src/main/java/tools/map/making/ConnectionFinder.java
@@ -11,7 +11,6 @@ import java.awt.geom.Area;
 import java.awt.geom.PathIterator;
 import java.awt.geom.Point2D;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -108,8 +107,8 @@ public final class ConnectionFinder {
     }
     final Map<String, List<Area>> territoryAreas = new HashMap<>();
     final Map<String, List<Polygon>> mapOfPolygons;
-    try (InputStream in = Files.newInputStream(polyFile)) {
-      mapOfPolygons = PointFileReaderWriter.readOneToManyPolygons(in);
+    try {
+      mapOfPolygons = PointFileReaderWriter.readOneToManyPolygons(polyFile);
       for (final Entry<String, List<Polygon>> entry : mapOfPolygons.entrySet()) {
         territoryAreas.put(
             entry.getKey(), entry.getValue().stream().map(Area::new).collect(Collectors.toList()));

--- a/game-app/game-core/src/main/java/tools/map/making/PlacementPicker.java
+++ b/game-app/game-core/src/main/java/tools/map/making/PlacementPicker.java
@@ -18,8 +18,6 @@ import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.awt.event.MouseMotionAdapter;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -310,9 +308,9 @@ public final class PlacementPicker {
                   "File Suggestion",
                   JOptionPane.YES_NO_CANCEL_OPTION)
               == 0) {
-        try (InputStream is = Files.newInputStream(file)) {
+        try {
           log.info("Polygons : " + file);
-          polygons = PointFileReaderWriter.readOneToManyPolygons(is);
+          polygons = PointFileReaderWriter.readOneToManyPolygons(file);
         } catch (final IOException e) {
           log.error("Failed to load polygons: " + file.toAbsolutePath());
           throw e;
@@ -323,8 +321,8 @@ public final class PlacementPicker {
             new FileOpen("Select A Polygon File", mapFolderLocation, ".txt").getFile();
         if (polyPath != null) {
           log.info("Polygons : " + polyPath);
-          try (InputStream is = Files.newInputStream(polyPath)) {
-            polygons = PointFileReaderWriter.readOneToManyPolygons(is);
+          try {
+            polygons = PointFileReaderWriter.readOneToManyPolygons(polyPath);
           } catch (final IOException e) {
             log.error("Failed to load polygons: " + polyPath);
             throw e;
@@ -533,8 +531,8 @@ public final class PlacementPicker {
       if (fileName == null) {
         return;
       }
-      try (OutputStream out = Files.newOutputStream(fileName)) {
-        PointFileReaderWriter.writeOneToManyPlacements(out, placements);
+      try {
+        PointFileReaderWriter.writeOneToManyPlacements(fileName, placements);
         log.info("Data written to :" + fileName.normalize().toAbsolutePath());
       } catch (final IOException e) {
         log.error("Failed to write placements: " + fileName, e);
@@ -549,8 +547,8 @@ public final class PlacementPicker {
       if (placeName == null) {
         return;
       }
-      try (InputStream in = Files.newInputStream(placeName)) {
-        placements = PointFileReaderWriter.readOneToManyPlacements(in);
+      try {
+        placements = PointFileReaderWriter.readOneToManyPlacements(placeName);
       } catch (final IOException e) {
         log.error("Failed to load placements: " + placeName, e);
       }


### PR DESCRIPTION
Using a Path which can also point to a file inside a zip (even though I think that's no longer needed) simplifies the code by a lot and avoids us having to pass streams around everywhere

## Testing
I verified a game could be launched as usual