### PR TITLE
Added killed units to the property "killed" in MustFightBattle.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -625,6 +625,9 @@ public class MustFightBattle extends DependentBattle
       removeFromDependentBattles(killedUnits, bridge, dependentBattles);
     }
 
+    // Remember all these killed units to build after-battle statistics
+    this.killed.addAll(killedUnits);
+
     if (side == DEFENSE) {
       defendingUnits.addAll(transformedUnits);
       defendingUnits.removeAll(killedUnits);


### PR DESCRIPTION
Fix of issue #9049. Units killed in the MustFightBattle class are now added to the "killed" property. At a minimum, this corrects statistics in the battle calculator.

## Testing
Verified that the battle calculator now shows better statistics for the "units left" calculations.

## Screens Shots
Examples of problem and fix are in issue #9049.

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Squashed a bug that caused the battle calculator to show incorrect "units left" calculations.<!--END_RELEASE_NOTE-->
