### PR TITLE
Add doc with database conventional usages

### DIFF
--- a/docs/development/reference/code-conventions/database.md
+++ b/docs/development/reference/code-conventions/database.md
@@ -1,0 +1,9 @@
+
+## Database TimeZone Handling
+
+In short, always use zoned values and use UTC.
+
+<https://justatheory.com/2012/04/postgres-use-timestamptz/>
+
+- Use timestamp with time zone (aka timestamptz)
+- Always specify a time zone when inserting into a timestamptz or timetz column. 


### PR DESCRIPTION
- Document that we should prefer to use timestamptz instead of timestamp as
  a datatype. This fits into a general timezone handling strategy to generally
  favor using UTC with everything database related.
