### PR TITLE
Fix ambiguous method call error.

### DIFF
--- a/lib/java-extras/src/main/java/org/triplea/io/ZipExtractor.java
+++ b/lib/java-extras/src/main/java/org/triplea/io/ZipExtractor.java
@@ -79,7 +79,7 @@ public class ZipExtractor {
     }
 
     // iterate over each zip entry and write to a corresponding file
-    try (FileSystem zipFileSystem = FileSystems.newFileSystem(fileZip, null)) {
+    try (FileSystem zipFileSystem = FileSystems.newFileSystem(fileZip, (ClassLoader) null)) {
       final Path zipRoot = zipFileSystem.getRootDirectories().iterator().next();
       try (Stream<Path> files = Files.walk(zipRoot, MAX_DEPTH)) {
         for (final Path zipEntry : files.collect(Collectors.toList())) {


### PR DESCRIPTION
There's two signatures that match the call with second param null. Fix compile error by specifying it's a ClassLoader param.


<!-- If multiple commits please summarize the change above. -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
