### PR TITLE
ScrollPaneBuilder Enhancements

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/SettingsWindow.java
@@ -112,8 +112,8 @@ public enum SettingsWindow {
     // provides a satisfactory display. Most non-Substance L&Fs use a {@code null} default text
     // field border, and so the
     // default scroll pane border in those cases is not changed.
-    final Optional<Border> descriptionScrollPaneBorder =
-        Optional.ofNullable(UIManager.getBorder("TextField.border"));
+    @Nullable final Border descriptionScrollPaneBorder =
+        UIManager.getBorder("TextField.border");
 
     int row = 0;
     for (final ClientSettingSwingUiBinding setting : settings) {
@@ -150,14 +150,13 @@ public enum SettingsWindow {
               0,
               0));
       panel.add(
-          JScrollPaneBuilder.builder()
-              .border(descriptionScrollPaneBorder)
-              .view(
+          new JScrollPaneBuilder(
                   JTextAreaBuilder.builder()
                       .text(setting.getDescription())
                       .rows(2)
                       .readOnly()
                       .build())
+              .border(descriptionScrollPaneBorder)
               .build(),
           new GridBagConstraints(
               2,

--- a/lib/swing-lib/src/main/java/org/triplea/swing/BorderBuilder.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/BorderBuilder.java
@@ -6,6 +6,14 @@ import javax.swing.border.EmptyBorder;
 /** Presents a builder API for creating a swing Border object. */
 public final class BorderBuilder {
 
+  public static final Border EMPTY_BORDER =
+      new BorderBuilder()
+          .bottom(0) //
+          .top(0)
+          .left(0)
+          .right(0)
+          .build();
+
   private int top;
   private int bottom;
   private int left;

--- a/lib/swing-lib/src/main/java/org/triplea/swing/JScrollPaneBuilder.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/JScrollPaneBuilder.java
@@ -1,9 +1,9 @@
 package org.triplea.swing;
 
-import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import java.awt.Component;
+import java.awt.Dimension;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.swing.JScrollPane;
@@ -24,12 +24,13 @@ import javax.swing.border.Border;
  */
 public final class JScrollPaneBuilder {
   private @Nullable Border border;
-  private Component view;
+  private Dimension preferredSize;
+  private Dimension maxSize;
 
-  private JScrollPaneBuilder() {}
+  private final Component view;
 
-  public static JScrollPaneBuilder builder() {
-    return new JScrollPaneBuilder();
+  public JScrollPaneBuilder(final Component view) {
+    this.view = view;
   }
 
   /**
@@ -38,33 +39,17 @@ public final class JScrollPaneBuilder {
    * @param border The border.
    */
   public JScrollPaneBuilder border(final Border border) {
-    checkNotNull(border);
-
     this.border = border;
     return this;
   }
 
-  /**
-   * Conditionally sets the scroll pane border.
-   *
-   * @param border The border; if empty, the current border will not be changed.
-   */
-  public JScrollPaneBuilder border(final Optional<Border> border) {
-    checkNotNull(border);
-
-    border.ifPresent(this::border);
+  public JScrollPaneBuilder maxSize(final int width, final int height) {
+    maxSize = new Dimension(width, height);
     return this;
   }
 
-  /**
-   * Sets the component to display in the scroll pane's viewport.
-   *
-   * @param view The component to display in the scroll pane's viewport.
-   */
-  public JScrollPaneBuilder view(final Component view) {
-    checkNotNull(view);
-
-    this.view = view;
+  public JScrollPaneBuilder preferredSize(final int width, final int height) {
+    preferredSize = new Dimension(width, height);
     return this;
   }
 
@@ -78,11 +63,9 @@ public final class JScrollPaneBuilder {
     checkState(view != null, "view must be specified");
 
     final JScrollPane scrollPane = new JScrollPane(view);
-
-    if (border != null) {
-      scrollPane.setBorder(border);
-    }
-
+    Optional.ofNullable(border).ifPresent(scrollPane::setBorder);
+    Optional.ofNullable(maxSize).ifPresent(scrollPane::setMaximumSize);
+    Optional.ofNullable(preferredSize).ifPresent(scrollPane::setPreferredSize);
     return scrollPane;
   }
 }

--- a/lib/swing-lib/src/test/java/org/triplea/swing/JScrollPaneBuilderTest.java
+++ b/lib/swing-lib/src/test/java/org/triplea/swing/JScrollPaneBuilderTest.java
@@ -1,12 +1,9 @@
 package org.triplea.swing;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.sameInstance;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.awt.Component;
 import javax.swing.BorderFactory;
 import javax.swing.JLabel;
 import javax.swing.JScrollPane;
@@ -14,29 +11,30 @@ import javax.swing.border.Border;
 import org.junit.jupiter.api.Test;
 
 final class JScrollPaneBuilderTest {
-  private final JScrollPaneBuilder builder = JScrollPaneBuilder.builder();
-
-  @Test
-  void buildShouldThrowExceptionWhenViewUnspecified() {
-    final Exception e = assertThrows(IllegalStateException.class, builder::build);
-    assertThat(e.getMessage(), containsString("view"));
-  }
+  private final JScrollPaneBuilder builder = new JScrollPaneBuilder(new JLabel());
 
   @Test
   void buildShouldSetBorderWhenProvided() {
     final Border border = BorderFactory.createEmptyBorder();
 
-    final JScrollPane scrollPane = builder.view(new JLabel()).border(border).build();
+    final JScrollPane scrollPane = builder.border(border).build();
 
     assertThat(scrollPane.getBorder(), is(sameInstance(border)));
   }
 
   @Test
-  void buildShouldSetView() {
-    final Component view = new JLabel();
+  void maxSize() {
+    final JScrollPane scrollPane = builder.maxSize(100, 200).build();
 
-    final JScrollPane scrollPane = builder.view(view).build();
+    assertThat(scrollPane.getMaximumSize().width, is(100));
+    assertThat(scrollPane.getMaximumSize().height, is(200));
+  }
 
-    assertThat(scrollPane.getViewport().getView(), is(sameInstance(view)));
+  @Test
+  void preferredSize() {
+    final JScrollPane scrollPane = builder.preferredSize(300, 500).build();
+
+    assertThat(scrollPane.getPreferredSize().width, is(300));
+    assertThat(scrollPane.getPreferredSize().height, is(500));
   }
 }


### PR DESCRIPTION
- Use constructor instead of factory method
- Move required 'view' parameter to constructor
- Add maxSize and preferredSize parameters (for future usage)
- Remove Optional<Border> parameter method and instead
  use 'Border' method with nullable parameter.

