### PR TITLE
Scrollable confirmation dialogs

### DIFF
--- a/lib/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
@@ -125,19 +125,32 @@ public final class SwingComponents {
     }
 
     if (showMessage) {
-      SwingUtilities.invokeLater(
-          () -> {
-            // blocks until the user responds to the modal dialog
-            final int response =
-                JOptionPane.showConfirmDialog(
-                    null, message, title, JOptionPane.YES_NO_OPTION, JOptionPane.QUESTION_MESSAGE);
+      // If message is long, place it in a scroll pane with a max size set.
+      // The max size is required to prevent the confirmation window from expanding
+      // to fit the full message (which might extend beyond the height of the screen).
+      final Component messageComponent =
+          message.length() < 1000
+              ? new JLabel(message)
+              : new JScrollPaneBuilder(new JLabel(message))
+                  .preferredSize(600, 600)
+                  .maxSize(600, 600)
+                  .border(BorderBuilder.EMPTY_BORDER)
+                  .build();
 
-            // dialog is now closed
-            visiblePrompts.remove(message);
-            if (response == JOptionPane.YES_OPTION) {
-              confirmedAction.run();
-            }
-          });
+      // blocks until the user responds to the modal dialog
+      final int response =
+          JOptionPane.showConfirmDialog(
+              null,
+              messageComponent,
+              title,
+              JOptionPane.YES_NO_OPTION,
+              JOptionPane.QUESTION_MESSAGE);
+
+      // dialog is now closed
+      visiblePrompts.remove(message);
+      if (response == JOptionPane.YES_OPTION) {
+        confirmedAction.run();
+      }
     }
   }
 


### PR DESCRIPTION
Add a conditional scrollbar to confirmation dialogs when
the dialog is large. This prevents a dialog from having an
extreme vertical height that can stretch off screen.

The condition for scrollbars is not extremely precies, uses
the total message length in characters as a measure for
how large the contents are, anything over 1000 characters
will get scrollbars.

## Screenshots

Example after this update, before this update the example stretched off-screen and was extremely 'tall':

![Screenshot from 2021-05-08 20-31-48](https://user-images.githubusercontent.com/12397753/118067726-fc373280-b355-11eb-9741-db07ddf1e7d3.png)

