### PR TITLE
Fix getNeighborsByMovementCost() result not always being mutable.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -259,8 +259,8 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
   }
 
   /**
-   * Returns a mutable set of all neighbors within a certain distance of the starting territory that match the
-   * condition. Does NOT include the original/starting territory in the returned Set.
+   * Returns a mutable set of all neighbors within a certain distance of the starting territory
+   * that match the condition. Returned Set does NOT include the original/starting territory.
    *
    * <p>TODO: update to properly consider movement cost not just distance
    */

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -259,7 +259,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
   }
 
   /**
-   * Returns all neighbors within a certain distance of the starting territory that match the
+   * Returns a mutable set of all neighbors within a certain distance of the starting territory that match the
    * condition. Does NOT include the original/starting territory in the returned Set.
    *
    * <p>TODO: update to properly consider movement cost not just distance
@@ -274,7 +274,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
         movementLeft.compareTo(BigDecimal.ZERO) >= 0,
         "MovementLeft must be non-negative: " + movementLeft);
     if (movementLeft.compareTo(BigDecimal.ZERO) == 0) {
-      return Set.of();
+      return new HashSet<>();
     }
     final Set<Territory> neighbors = getNeighbors(territory, territoryCondition);
     if (movementLeft.compareTo(BigDecimal.ONE) <= 0) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -1516,7 +1516,6 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
             data.getMap().getTerritories(),
             Matches.territoryHasEnemyUnits(alliedPlayer, data.getRelationshipTracker())));
     final Collection<Territory> possibleTerrs =
-        new ArrayList<>(
             data.getMap()
                 .getNeighborsByMovementCost(
                     currentTerr,
@@ -1526,7 +1525,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
                         alliedPlayer,
                         data.getProperties(),
                         data.getRelationshipTracker(),
-                        areNeutralsPassableByAir)));
+                        areNeutralsPassableByAir));
     final Iterator<Territory> possibleIter = possibleTerrs.iterator();
     while (possibleIter.hasNext()) {
       final Route route =


### PR DESCRIPTION
Fix getNeighborsByMovementCost() result not always being mutable.,

Callers expect it to be mutable, by adding territories to it. But the previous code sometimes returned Set.of() which would break those expectations.

Also changes one caller that wrapped the result in an ArrayList<>() which was unnecessary.


<!-- If multiple commits please summarize the change above. -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
