### PR TITLE
Migrate from java.io.File to java.nio.Path (Part 7)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataManager.java
@@ -9,7 +9,6 @@ import games.strategy.triplea.UrlConstants;
 import games.strategy.triplea.settings.ClientSetting;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
@@ -184,8 +183,8 @@ public final class GameDataManager {
       final Version engineVersion)
       throws IOException {
     final Path tempFile =
-        File.createTempFile(GameDataManager.class.getSimpleName(), GameDataFileUtils.getExtension())
-            .toPath();
+        Files.createTempFile(
+            GameDataManager.class.getSimpleName(), GameDataFileUtils.getExtension());
     try {
       // write to temporary file first in case of error
       try (OutputStream os = Files.newOutputStream(tempFile);

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
@@ -2,7 +2,6 @@ package games.strategy.engine.framework;
 
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.system.SystemProperties;
-import java.io.File;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
 import java.nio.file.Files;
@@ -17,8 +16,7 @@ final class ProcessRunnerUtil {
   private ProcessRunnerUtil() {}
 
   static void populateBasicJavaArgs(final List<String> commands) {
-    final String javaCommand =
-        SystemProperties.getJavaHome() + File.separator + "bin" + File.separator + "java";
+    final String javaCommand = Path.of(SystemProperties.getJavaHome(), "bin", "java").toString();
     commands.add(javaCommand);
     commands.add("-classpath");
     commands.add(SystemProperties.getJavaClassPath());

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/ContentReader.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/ContentReader.java
@@ -3,11 +3,11 @@ package games.strategy.engine.framework.map.download;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.Optional;
 import lombok.AllArgsConstructor;
@@ -59,11 +59,10 @@ public final class ContentReader {
    * @param file The file that will receive the resource; must not be {@code null}.
    * @throws IOException If an error occurs during the download.
    */
-  void downloadToFile(final String uri, final File file) throws IOException {
+  void downloadToFile(final String uri, final Path file) throws IOException {
     checkNotNull(uri);
     checkNotNull(file);
 
-    downloadAndApplyAction(
-        uri, is -> Files.copy(is, file.toPath(), StandardCopyOption.REPLACE_EXISTING));
+    downloadAndApplyAction(uri, is -> Files.copy(is, file, StandardCopyOption.REPLACE_EXISTING));
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
@@ -59,12 +59,12 @@ final class DownloadFile {
 
           final FileSizeWatcher watcher =
               new FileSizeWatcher(
-                  targetTempFileToDownloadTo.toFile(),
+                  targetTempFileToDownloadTo,
                   bytesReceived -> downloadListener.downloadUpdated(download, bytesReceived));
 
           try {
             DownloadConfiguration.contentReader()
-                .downloadToFile(download.getUrl(), targetTempFileToDownloadTo.toFile());
+                .downloadToFile(download.getUrl(), targetTempFileToDownloadTo);
           } catch (final IOException e) {
             log.error("Failed to download: " + download.getUrl(), e);
             return;

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
@@ -2,9 +2,9 @@ package games.strategy.engine.framework.map.download;
 
 import com.google.common.base.MoreObjects;
 import games.strategy.engine.framework.map.file.system.loader.DownloadedMapsListing;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Optional;
 import javax.annotation.Nullable;
@@ -32,7 +32,7 @@ public final class DownloadFileDescription {
   private final Integer version;
   private final MapCategory mapCategory;
   private final String img;
-  @Nullable private final File installLocation;
+  @Nullable private final Path installLocation;
 
   boolean delete() {
     if (installLocation == null) {
@@ -40,11 +40,11 @@ public final class DownloadFileDescription {
     }
 
     try {
-      Files.delete(installLocation.toPath());
+      Files.delete(installLocation);
     } catch (final IOException e) {
       log.warn(
           "Unable to delete maps files.<br>Manual removal may be necessary: {}<br>{}",
-          installLocation.getAbsolutePath(),
+          installLocation.toAbsolutePath(),
           e.getMessage(),
           e);
       return false;
@@ -52,10 +52,10 @@ public final class DownloadFileDescription {
 
     // now sleep a short while before we check our work
     Interruptibles.sleep(10);
-    if (installLocation.exists()) {
+    if (Files.exists(installLocation)) {
       log.warn(
           "Unable to delete maps files.<br>Manual removal may be necessary: {}",
-          installLocation.getAbsolutePath());
+          installLocation.toAbsolutePath());
       return false;
     } else {
       return true;
@@ -104,13 +104,8 @@ public final class DownloadFileDescription {
         .build();
   }
 
-  /** Returns the name of the zip file. */
-  String getMapZipFileName() {
-    return (url != null && url.contains("/")) ? url.substring(url.lastIndexOf('/') + 1) : "";
-  }
-
   /** File reference for where to install the file, empty if not installed. */
-  Optional<File> getInstallLocation() {
+  Optional<Path> getInstallLocation() {
     return Optional.ofNullable(installLocation);
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -12,6 +12,8 @@ import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Rectangle;
+import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -393,11 +395,15 @@ public class DownloadMapsWindow extends JFrame {
                         .append(")"));
       }
     } else {
-      sb.append(doubleSpace)
-          .append(" (")
-          .append(newSizeLabel(map.getInstallLocation().get().length()))
-          .append(")");
-      sb.append("<br>").append(map.getInstallLocation().get().getAbsolutePath());
+      try {
+        sb.append(doubleSpace)
+            .append(" (")
+            .append(newSizeLabel(Files.size(map.getInstallLocation().get())))
+            .append(")");
+      } catch (final IOException e) {
+        log.warn("Failed to read file size", e);
+      }
+      sb.append("<br>").append(map.getInstallLocation().get().toAbsolutePath());
     }
     sb.append("<br>");
     sb.append("</html>");

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/DownloadedMapsListing.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/DownloadedMapsListing.java
@@ -2,7 +2,6 @@ package games.strategy.engine.framework.map.file.system.loader;
 
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.ui.DefaultGameChooserEntry;
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collection;
@@ -120,8 +119,8 @@ public class DownloadedMapsListing {
    * Finds the map folder storing a given map by name. The map folder is assumed to be the parent
    * directory of the 'map.yml' file describing that map.
    */
-  public Optional<File> findMapFolderByName(final String mapName) {
-    return findContentRootForMapName(mapName).map(Path::getParent).map(Path::toFile);
+  public Optional<Path> findMapFolderByName(final String mapName) {
+    return findContentRootForMapName(mapName).map(Path::getParent);
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbf/test/post/TestPostAction.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbf/test/post/TestPostAction.java
@@ -5,8 +5,9 @@ import games.strategy.engine.posted.game.pbf.NodeBbForumPoster;
 import games.strategy.engine.posted.game.pbf.NodeBbForumPoster.SaveGameParameter;
 import java.awt.Graphics;
 import java.awt.image.BufferedImage;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.function.BiConsumer;
@@ -33,14 +34,14 @@ public class TestPostAction implements BiConsumer<String, Integer> {
 
     ThreadRunner.runInNewThread(
         () -> {
-          File f = null;
+          Path f = null;
           try {
-            f = File.createTempFile("123", ".jpg");
-            f.deleteOnExit();
+            f = Files.createTempFile("123", ".jpg");
+            f.toFile().deleteOnExit();
             final BufferedImage image = new BufferedImage(130, 40, BufferedImage.TYPE_INT_RGB);
             final Graphics g = image.getGraphics();
             g.drawString("Testing file upload", 10, 20);
-            ImageIO.write(image, "jpg", f);
+            ImageIO.write(image, "jpg", f.toFile());
           } catch (final IOException e) {
             // ignore
           }
@@ -54,7 +55,7 @@ public class TestPostAction implements BiConsumer<String, Integer> {
                       + DateTimeUtil.getLocalizedTime(),
                   "Testing Forum poster",
                   f != null
-                      ? SaveGameParameter.builder().path(f.toPath()).displayName("Test.jpg").build()
+                      ? SaveGameParameter.builder().path(f).displayName("Test.jpg").build()
                       : null);
           testPostProgressDisplay.close();
           try {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/CountryChart.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/CountryChart.java
@@ -5,11 +5,11 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.UnitCollection;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.delegate.Matches;
-import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -45,10 +45,10 @@ class CountryChart {
       infoMap.put(currentTerritory, unitPairs);
       availableUnits = printData.getData().getUnitTypeList().iterator();
     }
-    final File outFile = new File(printData.getOutDir(), player.getName() + ".csv");
+    final Path outFile = printData.getOutDir().resolve(player.getName() + ".csv");
     try (Writer countryFileWriter =
         Files.newBufferedWriter(
-            outFile.toPath(),
+            outFile,
             StandardCharsets.UTF_8,
             StandardOpenOption.CREATE,
             StandardOpenOption.APPEND)) {
@@ -86,7 +86,7 @@ class CountryChart {
         countryFileWriter.write("\r\n");
       }
     } catch (final IOException e) {
-      log.error("Failed Saving to File " + outFile.toString(), e);
+      log.error("Failed Saving to File " + outFile, e);
     }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/PlayerOrder.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/PlayerOrder.java
@@ -6,11 +6,11 @@ import games.strategy.triplea.delegate.BidPlaceDelegate;
 import games.strategy.triplea.delegate.BidPurchaseDelegate;
 import games.strategy.triplea.delegate.EndRoundDelegate;
 import games.strategy.triplea.delegate.InitializationDelegate;
-import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -45,11 +45,11 @@ class PlayerOrder {
         playerSet.add(currentGamePlayer);
       }
     }
-    printData.getOutDir().mkdir();
-    final File outFile = new File(printData.getOutDir(), "General Information.csv");
+    Files.createDirectory(printData.getOutDir());
+    final Path outFile = printData.getOutDir().resolve("General Information.csv");
     try (Writer turnWriter =
         Files.newBufferedWriter(
-            outFile.toPath(),
+            outFile,
             StandardCharsets.UTF_8,
             StandardOpenOption.CREATE,
             StandardOpenOption.APPEND)) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/PrintGenerationData.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/PrintGenerationData.java
@@ -1,13 +1,13 @@
 package games.strategy.triplea.printgenerator;
 
 import games.strategy.engine.data.GameData;
-import java.io.File;
+import java.nio.file.Path;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
 class PrintGenerationData {
-  private final File outDir;
+  private final Path outDir;
   private final GameData data;
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/PuChart.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/PuChart.java
@@ -11,8 +11,8 @@ import java.awt.Graphics2D;
 import java.awt.geom.Ellipse2D;
 import java.awt.geom.Rectangle2D;
 import java.awt.image.BufferedImage;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import javax.imageio.ImageIO;
@@ -28,7 +28,7 @@ class PuChart {
   private final Font chartFont = new Font("Serif", Font.PLAIN, 12);
   private final BufferedImage puImage;
   private final Graphics2D g2d;
-  private final File outDir;
+  private final Path outDir;
 
   PuChart(final PrintGenerationData printData) {
     final GameState gameData = printData.getData();
@@ -115,8 +115,8 @@ class PuChart {
       // Write to file
       final int firstNum = cols * rows * i;
       final int secondNum = cols * rows * (i + 1) - 1;
-      final File outputFile = new File(outDir, "PUchart" + firstNum + "-" + secondNum + ".png");
-      ImageIO.write(puImage, "png", outputFile);
+      final Path outputFile = outDir.resolve("PUchart" + firstNum + "-" + secondNum + ".png");
+      ImageIO.write(puImage, "png", outputFile.toFile());
       final Color transparent = new Color(0, 0, 0, 0);
       g2d.setColor(transparent);
       g2d.setComposite(AlphaComposite.Src);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/PuInfo.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/PuInfo.java
@@ -2,11 +2,11 @@ package games.strategy.triplea.printgenerator;
 
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Resource;
-import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.Map;
@@ -28,10 +28,10 @@ class PuInfo {
                       Function.identity(), currentPlayer.getResources()::getQuantity)));
     }
     try {
-      final File outFile = new File(printData.getOutDir(), "General Information.csv");
+      final Path outFile = printData.getOutDir().resolve("General Information.csv");
       try (Writer resourceWriter =
           Files.newBufferedWriter(
-              outFile.toPath(),
+              outFile,
               StandardCharsets.UTF_8,
               StandardOpenOption.CREATE,
               StandardOpenOption.APPEND)) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/SetupFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/SetupFrame.java
@@ -2,7 +2,7 @@ package games.strategy.triplea.printgenerator;
 
 import games.strategy.engine.data.GameData;
 import java.awt.BorderLayout;
-import java.io.File;
+import java.nio.file.Path;
 import javax.swing.ButtonGroup;
 import javax.swing.JButton;
 import javax.swing.JFileChooser;
@@ -20,7 +20,7 @@ public class SetupFrame extends JPanel {
   private final JFileChooser outChooser;
   private final JRadioButton originalState;
   private final GameData data;
-  private File outDir;
+  private Path outDir;
 
   public SetupFrame(final GameData data) {
     super(new BorderLayout());
@@ -44,15 +44,15 @@ public class SetupFrame extends JPanel {
         e -> {
           final int returnVal = outChooser.showOpenDialog(null);
           if (returnVal == JFileChooser.APPROVE_OPTION) {
-            final File outDir = outChooser.getSelectedFile();
-            outField.setText(outDir.getAbsolutePath());
+            final Path outDir = outChooser.getSelectedFile().toPath();
+            outField.setText(outDir.toAbsolutePath().toString());
           }
         });
     runButton.setText("Generate the Files");
     runButton.addActionListener(
         e -> {
           if (!outField.getText().isEmpty()) {
-            outDir = new File(outField.getText());
+            outDir = Path.of(outField.getText());
             final PrintGenerationData printData =
                 PrintGenerationData.builder().outDir(outDir).data(this.data).build();
             new InitialSetup().run(printData, originalState.isSelected());

--- a/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/UnitInformation.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/printgenerator/UnitInformation.java
@@ -9,11 +9,11 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.util.TuvUtils;
-import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -22,90 +22,89 @@ import org.triplea.java.StringUtils;
 
 @Slf4j
 class UnitInformation {
-  //  private GameData data;
-
   void saveToFile(
       final PrintGenerationData printData, final Map<UnitType, UnitAttachment> unitInfoMap) {
-    printData.getOutDir().mkdir();
-    final File outFile = new File(printData.getOutDir(), "General Information.csv");
-    try (Writer unitInformation =
-        Files.newBufferedWriter(outFile.toPath(), StandardCharsets.UTF_8)) {
-      for (int i = 0; i < 8; i++) {
-        unitInformation.write(",");
-      }
-      unitInformation.write("Unit Information");
-      for (int i = 10; i < 20; i++) {
-        unitInformation.write(",");
-      }
-      unitInformation.write("\r\n");
-      unitInformation.write(
-          "Unit,Cost,Movement,Attack,Defense,CanBlitz,Artillery?,ArtillerySupportable?,"
-              + "Can Produce Units?,Marine?,Transport Cost,AA Gun?,Air Unit?,Strategic Bomber?,"
-              + "Carrier Cost,Sea Unit?,Hit Points?,Transport Capacity,Carrier Capacity,"
-              + "Submarine?,Destroyer?");
-      unitInformation.write("\r\n");
-      for (final Entry<UnitType, UnitAttachment> entry : unitInfoMap.entrySet()) {
-        final UnitType currentType = entry.getKey();
-        final UnitAttachment currentAttachment = entry.getValue();
-        if (currentType.getName().equals(Constants.UNIT_TYPE_AAGUN)) {
-          unitInformation.write(currentType.getName() + ",");
-        } else {
-          unitInformation.write(StringUtils.capitalize(currentType.getName()) + ",");
+    final Path outFile = printData.getOutDir().resolve("General Information.csv");
+    try {
+      Files.createDirectory(printData.getOutDir());
+      try (Writer unitInformation = Files.newBufferedWriter(outFile, StandardCharsets.UTF_8)) {
+        for (int i = 0; i < 8; i++) {
+          unitInformation.write(",");
         }
-        unitInformation.write(getCostInformation(currentType, printData.getData()) + ",");
+        unitInformation.write("Unit Information");
+        for (int i = 10; i < 20; i++) {
+          unitInformation.write(",");
+        }
+        unitInformation.write("\r\n");
         unitInformation.write(
-            currentAttachment.getMovement(GamePlayer.NULL_PLAYERID)
-                + ","
-                + currentAttachment.getAttack(GamePlayer.NULL_PLAYERID)
-                + ","
-                + currentAttachment.getDefense(GamePlayer.NULL_PLAYERID)
-                + ","
-                + (!currentAttachment.getCanBlitz(GamePlayer.NULL_PLAYERID) ? "-" : "true")
-                + ","
-                + (!currentAttachment.getArtillery() ? "-" : "true")
-                + ","
-                + (!currentAttachment.getArtillerySupportable() ? "-" : "true")
-                + ","
-                + (!currentAttachment.getCanProduceUnits() ? "-" : "true")
-                + ","
-                + (currentAttachment.getIsMarine() == 0 ? "-" : currentAttachment.getIsMarine())
-                + ","
-                + (currentAttachment.getTransportCost() == -1
-                    ? "-"
-                    : currentAttachment.getTransportCost())
-                + ","
-                + (!Matches.unitTypeIsAaForAnything().test(currentType) ? "-" : "true")
-                + ","
-                + (!currentAttachment.getIsAir() ? "-" : "true")
-                + ","
-                + (!currentAttachment.getIsStrategicBomber() ? "-" : "true")
-                + ","
-                + (currentAttachment.getCarrierCost() == -1
-                    ? "-"
-                    : currentAttachment.getCarrierCost())
-                + ","
-                + (!currentAttachment.getIsSea() ? "-" : "true")
-                + ","
-                + currentAttachment.getHitPoints()
-                + ","
-                + (currentAttachment.getTransportCapacity() == -1
-                    ? "-"
-                    : currentAttachment.getTransportCapacity())
-                + ","
-                + (currentAttachment.getCarrierCapacity() == -1
-                    ? "-"
-                    : currentAttachment.getCarrierCapacity())
-                + ","
-                + (!(currentAttachment.getCanEvade() && currentAttachment.getIsFirstStrike())
-                    ? "-"
-                    : "true")
-                + ","
-                + (!currentAttachment.getIsDestroyer() ? "-" : "true"));
+            "Unit,Cost,Movement,Attack,Defense,CanBlitz,Artillery?,ArtillerySupportable?,"
+                + "Can Produce Units?,Marine?,Transport Cost,AA Gun?,Air Unit?,Strategic Bomber?,"
+                + "Carrier Cost,Sea Unit?,Hit Points?,Transport Capacity,Carrier Capacity,"
+                + "Submarine?,Destroyer?");
+        unitInformation.write("\r\n");
+        for (final Entry<UnitType, UnitAttachment> entry : unitInfoMap.entrySet()) {
+          final UnitType currentType = entry.getKey();
+          final UnitAttachment currentAttachment = entry.getValue();
+          if (currentType.getName().equals(Constants.UNIT_TYPE_AAGUN)) {
+            unitInformation.write(currentType.getName() + ",");
+          } else {
+            unitInformation.write(StringUtils.capitalize(currentType.getName()) + ",");
+          }
+          unitInformation.write(getCostInformation(currentType, printData.getData()) + ",");
+          unitInformation.write(
+              currentAttachment.getMovement(GamePlayer.NULL_PLAYERID)
+                  + ","
+                  + currentAttachment.getAttack(GamePlayer.NULL_PLAYERID)
+                  + ","
+                  + currentAttachment.getDefense(GamePlayer.NULL_PLAYERID)
+                  + ","
+                  + (!currentAttachment.getCanBlitz(GamePlayer.NULL_PLAYERID) ? "-" : "true")
+                  + ","
+                  + (!currentAttachment.getArtillery() ? "-" : "true")
+                  + ","
+                  + (!currentAttachment.getArtillerySupportable() ? "-" : "true")
+                  + ","
+                  + (!currentAttachment.getCanProduceUnits() ? "-" : "true")
+                  + ","
+                  + (currentAttachment.getIsMarine() == 0 ? "-" : currentAttachment.getIsMarine())
+                  + ","
+                  + (currentAttachment.getTransportCost() == -1
+                      ? "-"
+                      : currentAttachment.getTransportCost())
+                  + ","
+                  + (!Matches.unitTypeIsAaForAnything().test(currentType) ? "-" : "true")
+                  + ","
+                  + (!currentAttachment.getIsAir() ? "-" : "true")
+                  + ","
+                  + (!currentAttachment.getIsStrategicBomber() ? "-" : "true")
+                  + ","
+                  + (currentAttachment.getCarrierCost() == -1
+                      ? "-"
+                      : currentAttachment.getCarrierCost())
+                  + ","
+                  + (!currentAttachment.getIsSea() ? "-" : "true")
+                  + ","
+                  + currentAttachment.getHitPoints()
+                  + ","
+                  + (currentAttachment.getTransportCapacity() == -1
+                      ? "-"
+                      : currentAttachment.getTransportCapacity())
+                  + ","
+                  + (currentAttachment.getCarrierCapacity() == -1
+                      ? "-"
+                      : currentAttachment.getCarrierCapacity())
+                  + ","
+                  + (!(currentAttachment.getCanEvade() && currentAttachment.getIsFirstStrike())
+                      ? "-"
+                      : "true")
+                  + ","
+                  + (!currentAttachment.getIsDestroyer() ? "-" : "true"));
+          unitInformation.write("\r\n");
+        }
         unitInformation.write("\r\n");
       }
-      unitInformation.write("\r\n");
     } catch (final IOException e) {
-      log.error("There was an error while trying to save File " + outFile.toString(), e);
+      log.error("There was an error while trying to save File " + outFile, e);
     }
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
@@ -313,7 +313,7 @@ final class SelectionComponentFactory {
               .actionListener(
                   () ->
                       SwingComponents.showJFileChooser(folderSelectionMode)
-                          .ifPresent(file -> field.setText(file.getAbsolutePath())))
+                          .ifPresent(file -> field.setText(file.toAbsolutePath().toString())))
               .build();
 
       @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/MacOsIntegration.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/MacOsIntegration.java
@@ -5,6 +5,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.awt.Desktop;
 import java.io.File;
 import java.net.URI;
+import java.nio.file.Path;
 import java.util.function.Consumer;
 
 /** Utility class to add macOS integration. */
@@ -33,10 +34,11 @@ public final class MacOsIntegration {
    * allows for multiple files to be opened at once this doesn't make sense for currently existing
    * use-cases. Therefore this feature can't be accessed via this wrapper.
    */
-  public static void setOpenFileHandler(final Consumer<File> handler) {
+  public static void setOpenFileHandler(final Consumer<Path> handler) {
     checkNotNull(handler);
     Desktop.getDesktop()
-        .setOpenFileHandler(event -> event.getFiles().stream().findAny().ifPresent(handler));
+        .setOpenFileHandler(
+            event -> event.getFiles().stream().findAny().map(File::toPath).ifPresent(handler));
   }
 
   /** Sets the specified quit handler to the application. */

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/export/ScreenshotExporter.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/export/ScreenshotExporter.java
@@ -15,8 +15,8 @@ import java.awt.Font;
 import java.awt.Graphics2D;
 import java.awt.RenderingHints;
 import java.awt.image.BufferedImage;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Path;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import javax.imageio.ImageIO;
@@ -54,11 +54,11 @@ public final class ScreenshotExporter {
     exporter.promptSaveFile().ifPresent(file -> exporter.runSave(gameData, node, file));
   }
 
-  private Optional<File> promptSaveFile() {
+  private Optional<Path> promptSaveFile() {
     return SwingComponents.promptSaveFile(frame, "png", "Saved Map Snapshots");
   }
 
-  private void runSave(final GameData gameData, final HistoryNode node, final File file) {
+  private void runSave(final GameData gameData, final HistoryNode node, final Path file) {
     final CompletableFuture<?> future =
         SwingComponents.runWithProgressBar(
                 frame,
@@ -74,7 +74,7 @@ public final class ScreenshotExporter {
                           if (e == null) {
                             JOptionPane.showMessageDialog(
                                 frame,
-                                "Saved to: " + file.getAbsolutePath(),
+                                "Saved to: " + file.toAbsolutePath(),
                                 "Gameboard Picture Saved",
                                 JOptionPane.INFORMATION_MESSAGE);
                           } else {
@@ -89,7 +89,7 @@ public final class ScreenshotExporter {
         future, throwable -> log.error("Failed to save map snapshot", throwable));
   }
 
-  private void save(final GameData gameData, final HistoryNode node, final File file)
+  private void save(final GameData gameData, final HistoryNode node, final Path file)
       throws IOException {
     // get round/step/player from history tree
     int round = 0;
@@ -143,7 +143,7 @@ public final class ScreenshotExporter {
       }
 
       // save Image as .png
-      ImageIO.write(mapImage, "png", file);
+      ImageIO.write(mapImage, "png", file.toFile());
     } finally {
       // Clean up objects. There might be some overkill here,
       // but there were memory leaks that are fixed by some/all of these.

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -24,12 +24,12 @@ import games.strategy.triplea.ui.history.HistoryPanel;
 import games.strategy.triplea.ui.menubar.help.UnitStatsTable;
 import games.strategy.triplea.util.PlayerOrderComparator;
 import java.awt.event.KeyEvent;
-import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
@@ -94,7 +94,7 @@ final class ExportMenu extends JMenu {
   private void exportXmlFile() {
     final JFileChooser chooser = new JFileChooser();
     chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
-    final File rootDir = new File(SystemProperties.getUserDir());
+    final Path rootDir = Path.of(SystemProperties.getUserDir());
 
     final int round = gameData.getCurrentRound();
     final String defaultFileName =
@@ -105,7 +105,7 @@ final class ExportMenu extends JMenu {
                     gameData.getGameName(),
                     round))
             + ".xml";
-    chooser.setSelectedFile(new File(rootDir, defaultFileName));
+    chooser.setSelectedFile(rootDir.resolve(defaultFileName).toFile());
     if (chooser.showSaveDialog(frame) != JOptionPane.OK_OPTION) {
       return;
     }
@@ -152,7 +152,7 @@ final class ExportMenu extends JMenu {
     final ExtendedStats statPanel = new ExtendedStats(gameData, uiContext);
     final JFileChooser chooser = new JFileChooser();
     chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
-    final File rootDir = new File(SystemProperties.getUserDir());
+    final Path rootDir = Path.of(SystemProperties.getUserDir());
     final int currentRound = gameData.getCurrentRound();
     final String defaultFileName =
         FileNameUtils.removeIllegalCharacters(
@@ -163,7 +163,7 @@ final class ExportMenu extends JMenu {
                     currentRound,
                     showPhaseStats ? "full" : "short"))
             + ".csv";
-    chooser.setSelectedFile(new File(rootDir, defaultFileName));
+    chooser.setSelectedFile(rootDir.resolve(defaultFileName).toFile());
     if (chooser.showSaveDialog(frame) != JOptionPane.OK_OPTION) {
       return;
     }
@@ -281,7 +281,6 @@ final class ExportMenu extends JMenu {
       }
       writer.println();
       clone.getHistory().gotoNode(clone.getHistory().getLastNode());
-      @SuppressWarnings("unchecked")
       final Enumeration<TreeNode> nodes =
           ((DefaultMutableTreeNode) clone.getHistory().getRoot()).preorderEnumeration();
       @Nullable GamePlayer currentPlayer = null;
@@ -371,10 +370,10 @@ final class ExportMenu extends JMenu {
   private void exportUnitCharts() {
     final JFileChooser chooser = new JFileChooser();
     chooser.setFileSelectionMode(JFileChooser.FILES_ONLY);
-    final File rootDir = new File(SystemProperties.getUserDir());
+    final Path rootDir = Path.of(SystemProperties.getUserDir());
     final String defaultFileName =
         FileNameUtils.removeIllegalCharacters(gameData.getGameName()) + "_unit_stats.html";
-    chooser.setSelectedFile(new File(rootDir, defaultFileName));
+    chooser.setSelectedFile(rootDir.resolve(defaultFileName).toFile());
     if (chooser.showSaveDialog(frame) != JOptionPane.OK_OPTION) {
       return;
     }

--- a/game-app/game-core/src/main/java/tools/image/TileImageBreaker.java
+++ b/game-app/game-core/src/main/java/tools/image/TileImageBreaker.java
@@ -12,7 +12,6 @@ import java.awt.Rectangle;
 import java.awt.Toolkit;
 import java.awt.Transparency;
 import java.awt.image.BufferedImage;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Path;
 import javax.imageio.ImageIO;
@@ -129,10 +128,10 @@ public final class TileImageBreaker {
                 bounds.y + TILE_SIZE,
                 observer);
 
-        final String outFileName = location + File.separator + x + "_" + y + ".png";
+        final Path outFile = location.resolve(x + "_" + y + ".png");
 
-        ImageIO.write(relief, "png", new File(outFileName));
-        textOptionPane.appendNewLine("wrote " + outFileName);
+        ImageIO.write(relief, "png", outFile.toFile());
+        textOptionPane.appendNewLine("wrote " + outFile);
       }
     }
     textOptionPane.appendNewLine("\r\nAll Finished!");

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/gameparser/GameDataVariableParserTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/gameparser/GameDataVariableParserTest.java
@@ -7,9 +7,9 @@ import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 
 import java.io.DataInputStream;
-import java.io.File;
-import java.io.FileInputStream;
 import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
@@ -37,10 +37,10 @@ class GameDataVariableParserTest {
   }
 
   private static VariableList readFile(final String fileName) throws Exception {
-    final File file = new File(fileName);
-    checkState(file.isFile());
+    final Path file = Path.of(fileName);
+    checkState(!Files.isDirectory(file));
 
-    try (InputStream inputStream = new DataInputStream(new FileInputStream(file))) {
+    try (InputStream inputStream = new DataInputStream(Files.newInputStream(file))) {
 
       return new XmlMapper(inputStream).mapXmlToObject(Game.class).getVariableList();
     }

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/AvailableMapsListingTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/AvailableMapsListingTest.java
@@ -8,7 +8,7 @@ import static org.hamcrest.collection.IsEmptyCollection.empty;
 import games.strategy.engine.framework.map.file.system.loader.DownloadedMap;
 import games.strategy.engine.framework.map.file.system.loader.DownloadedMapsListing;
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
-import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -72,7 +72,7 @@ class AvailableMapsListingTest extends AbstractClientSettingTestCase {
         .mapName("mapName " + url)
         .version(MAP_VERSION)
         .mapCategory(DownloadFileDescription.MapCategory.BEST)
-        .installLocation(new File("/"))
+        .installLocation(Path.of("/"))
         .build();
   }
 
@@ -99,7 +99,7 @@ class AvailableMapsListingTest extends AbstractClientSettingTestCase {
                 entry ->
                     new DownloadedMap(
                         MapDescriptionYaml.builder()
-                            .yamlFileLocation(new File("/local/file").toURI())
+                            .yamlFileLocation(Path.of("/local/file").toUri())
                             .mapName(entry.getKey())
                             .mapVersion(entry.getValue())
                             .mapGameList(

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/ContentReaderTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/ContentReaderTest.java
@@ -6,7 +6,6 @@ import static org.mockito.Mockito.when;
 
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import java.io.ByteArrayInputStream;
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,11 +26,11 @@ final class ContentReaderTest extends AbstractClientSettingTestCase {
   final class DownloadToFileTest {
     @Mock private CloseableDownloader closeableDownloader;
 
-    private File file;
+    private Path file;
 
     @BeforeEach
     void setUp(@TempDir final Path tempDirPath) throws Exception {
-      file = Files.createTempFile(tempDirPath, null, null).toFile();
+      file = Files.createTempFile(tempDirPath, null, null);
     }
 
     @Test
@@ -53,7 +52,7 @@ final class ContentReaderTest extends AbstractClientSettingTestCase {
     }
 
     private byte[] fileContent() throws Exception {
-      return Files.readAllBytes(file.toPath());
+      return Files.readAllBytes(file);
     }
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/map/file/system/loader/DownloadedMapsListingTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/map/file/system/loader/DownloadedMapsListingTest.java
@@ -5,7 +5,7 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsCollectionContaining.hasItems;
 
-import java.io.File;
+import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -19,7 +19,7 @@ class DownloadedMapsListingTest {
           List.of(
               new DownloadedMap(
                   MapDescriptionYaml.builder()
-                      .yamlFileLocation(new File("/path/map0/map.yml").toURI())
+                      .yamlFileLocation(Path.of("/path/map0/map.yml").toUri())
                       .mapName("map-name0")
                       .mapVersion(0)
                       .mapGameList(
@@ -31,7 +31,7 @@ class DownloadedMapsListingTest {
                       .build()),
               new DownloadedMap(
                   MapDescriptionYaml.builder()
-                      .yamlFileLocation(new File("/path/map1/map.yml").toURI())
+                      .yamlFileLocation(Path.of("/path/map1/map.yml").toUri())
                       .mapName("map-name1")
                       .mapVersion(2)
                       .mapGameList(

--- a/game-app/game-core/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/ResourceLoaderTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.io.File;
 import java.net.URLClassLoader;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -25,17 +24,17 @@ final class ResourceLoaderTest {
   final class FindDirectoryTest {
     private static final String TARGET_DIR_NAME = "182c91fa8e";
 
-    private File startDir;
+    private Path startDir;
 
     @BeforeEach
     void createStartDir(@TempDir final Path tempDirPath) throws Exception {
-      startDir = Files.createTempDirectory(tempDirPath, null).toFile();
+      startDir = Files.createTempDirectory(tempDirPath, null);
     }
 
     @Test
-    void shouldReturnDirWhenTargetDirExistsInStartDir() {
-      final File targetDir = new File(startDir, TARGET_DIR_NAME);
-      targetDir.mkdirs();
+    void shouldReturnDirWhenTargetDirExistsInStartDir() throws Exception {
+      final Path targetDir = startDir.resolve(TARGET_DIR_NAME);
+      Files.createDirectories(targetDir);
 
       assertThat(
           ResourceLoader.findDirectory(startDir, TARGET_DIR_NAME), is(Optional.of(targetDir)));
@@ -43,16 +42,16 @@ final class ResourceLoaderTest {
 
     @Test
     void shouldReturnEmptyWhenTargetFileExistsInStartDir() throws Exception {
-      final File targetDir = new File(startDir, TARGET_DIR_NAME);
-      targetDir.createNewFile();
+      final Path targetDir = startDir.resolve(TARGET_DIR_NAME);
+      Files.createFile(targetDir);
 
       assertThat(ResourceLoader.findDirectory(startDir, TARGET_DIR_NAME), is(Optional.empty()));
     }
 
     @Test
-    void shouldReturnDirWhenTargetDirExistsInParentDir() {
-      final File targetDir = new File(startDir.getParentFile(), TARGET_DIR_NAME);
-      targetDir.mkdirs();
+    void shouldReturnDirWhenTargetDirExistsInParentDir() throws Exception {
+      final Path targetDir = startDir.resolveSibling(TARGET_DIR_NAME);
+      Files.createDirectories(targetDir);
 
       assertThat(
           ResourceLoader.findDirectory(startDir, TARGET_DIR_NAME), is(Optional.of(targetDir)));
@@ -60,8 +59,8 @@ final class ResourceLoaderTest {
 
     @Test
     void shouldReturnEmptyWhenTargetFileExistsInParentDir() throws Exception {
-      final File targetDir = new File(startDir.getParentFile(), TARGET_DIR_NAME);
-      targetDir.createNewFile();
+      final Path targetDir = startDir.resolveSibling(TARGET_DIR_NAME);
+      Files.createFile(targetDir);
 
       assertThat(ResourceLoader.findDirectory(startDir, TARGET_DIR_NAME), is(Optional.empty()));
     }

--- a/game-app/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
+++ b/game-app/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
@@ -77,7 +77,7 @@ public final class HeadedGameRunner {
                             + " is currently not supported on macOS.",
                         "Unsupported feature",
                         JOptionPane.INFORMATION_MESSAGE));
-            System.setProperty(CliProperties.TRIPLEA_GAME, file.getAbsolutePath());
+            System.setProperty(CliProperties.TRIPLEA_GAME, file.toAbsolutePath().toString());
             GameRunner.showMainFrame();
           });
     }

--- a/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYamlGenerator.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYamlGenerator.java
@@ -2,7 +2,6 @@ package org.triplea.map.description.file;
 
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Ints;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
@@ -46,7 +45,7 @@ class MapDescriptionYamlGenerator {
    *     be generated a map.yml descriptor file. The map.yml file will be created at the map's
    *     content root, where the map data files are located.
    */
-  static Optional<File> generateYamlDataForMap(final Path mapFolder) {
+  static Optional<Path> generateYamlDataForMap(final Path mapFolder) {
     Preconditions.checkArgument(Files.exists(mapFolder));
     Preconditions.checkArgument(Files.isDirectory(mapFolder));
 
@@ -74,7 +73,7 @@ class MapDescriptionYamlGenerator {
       return Optional.empty();
     }
 
-    final Optional<File> writtenYmlFile =
+    final Optional<Path> writtenYmlFile =
         MapDescriptionYamlWriter.writeYmlPojoToFile(mapDescriptionYaml);
 
     if (writtenYmlFile.isPresent() && Files.exists(propsFile)) {

--- a/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYamlWriter.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYamlWriter.java
@@ -1,7 +1,6 @@
 package org.triplea.map.description.file;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -20,19 +19,19 @@ import org.triplea.yaml.YamlWriter;
 @UtilityClass
 @Slf4j
 class MapDescriptionYamlWriter {
-  static Optional<File> writeYmlPojoToFile(final MapDescriptionYaml mapDescriptionYaml) {
+  static Optional<Path> writeYmlPojoToFile(final MapDescriptionYaml mapDescriptionYaml) {
 
     final String yamlString = toYamlString(mapDescriptionYaml);
-    final Path mapYmlTargetPath = new File(mapDescriptionYaml.getYamlFileLocation()).toPath();
+    final Path mapYmlTargetPath = Path.of(mapDescriptionYaml.getYamlFileLocation());
 
     try {
       Files.writeString(mapYmlTargetPath, yamlString);
-      log.info("Wrote map yaml to file: {}", mapYmlTargetPath.toFile().getAbsolutePath());
-      return Optional.of(mapYmlTargetPath.toFile());
+      log.info("Wrote map yaml to file: {}", mapYmlTargetPath.toAbsolutePath());
+      return Optional.of(mapYmlTargetPath);
     } catch (final IOException e) {
       log.error(
           "Failed to write map.yml file to: {}, {}",
-          mapYmlTargetPath.toFile().getAbsolutePath(),
+          mapYmlTargetPath.toAbsolutePath(),
           e.getMessage(),
           e);
       return Optional.empty();

--- a/game-app/map-data/src/test/java/org/triplea/map/description/file/MapDescriptionYamlGeneratorTest.java
+++ b/game-app/map-data/src/test/java/org/triplea/map/description/file/MapDescriptionYamlGeneratorTest.java
@@ -4,7 +4,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
 
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,9 +31,9 @@ class MapDescriptionYamlGeneratorTest {
 
   // functionality under test
   private MapDescriptionYaml generateAndReadDescriptionYamlFile() {
-    final File generatedFile =
+    final Path generatedFile =
         MapDescriptionYamlGenerator.generateYamlDataForMap(exampleMapFolder).orElseThrow();
-    generatedFile.deleteOnExit();
+    generatedFile.toFile().deleteOnExit();
 
     // after generation of the YAML file, read it back so we can compare written data to expected
     return MapDescriptionYamlReader.readFromMap(exampleMapFolder).orElseThrow();

--- a/game-app/map-data/src/test/java/org/triplea/map/description/file/MapDescriptionYamlTest.java
+++ b/game-app/map-data/src/test/java/org/triplea/map/description/file/MapDescriptionYamlTest.java
@@ -5,7 +5,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-import java.io.File;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
@@ -25,7 +24,7 @@ class MapDescriptionYamlTest {
   static List<MapDescriptionYaml> isValid() {
     return List.of(
         MapDescriptionYaml.builder()
-            .yamlFileLocation(new File("/path/on/disk/map.yml").toURI())
+            .yamlFileLocation(Path.of("/path/on/disk/map.yml").toUri())
             .mapName("map name")
             .mapVersion(1)
             .mapGameList(
@@ -59,7 +58,7 @@ class MapDescriptionYamlTest {
   void findGameNameFromXmlFileName_PositiveCase() {
     final MapDescriptionYaml mapDescriptionYaml =
         MapDescriptionYaml.builder()
-            .yamlFileLocation(new File("/path/on/disk/map.yml").toURI())
+            .yamlFileLocation(Path.of("/path/on/disk/map.yml").toUri())
             .mapName("map name")
             .mapVersion(1)
             .mapGameList(
@@ -80,7 +79,7 @@ class MapDescriptionYamlTest {
   void findGameNameFromXmlFileName_NegativeCase() {
     final MapDescriptionYaml mapDescriptionYaml =
         MapDescriptionYaml.builder()
-            .yamlFileLocation(new File("/path/on/disk/map.yml").toURI())
+            .yamlFileLocation(Path.of("/path/on/disk/map.yml").toUri())
             .mapName("map name")
             .mapVersion(1)
             .mapGameList(

--- a/lib/java-extras/src/main/java/org/triplea/io/ImageLoader.java
+++ b/lib/java-extras/src/main/java/org/triplea/io/ImageLoader.java
@@ -3,8 +3,9 @@ package org.triplea.io;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import java.awt.Image;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import javax.imageio.ImageIO;
 import lombok.experimental.UtilityClass;
 
@@ -16,13 +17,13 @@ public class ImageLoader {
    *
    * @param path Location of the file to be read as an image.
    */
-  public static Image getImage(final File path) {
-    checkArgument(path.exists(), "File must exist at path: " + path.getAbsolutePath());
-    checkArgument(path.isFile(), "Must be a file: " + path.getAbsolutePath());
+  public static Image getImage(final Path path) {
+    checkArgument(Files.exists(path), "File must exist at path: " + path.toAbsolutePath());
+    checkArgument(!Files.isDirectory(path), "Must be a file: " + path.toAbsolutePath());
     try {
-      return ImageIO.read(path);
+      return ImageIO.read(path.toFile());
     } catch (final IOException e) {
-      throw new RuntimeException("Unable to load image at path: " + path.getAbsolutePath(), e);
+      throw new RuntimeException("Unable to load image at path: " + path.toAbsolutePath(), e);
     }
   }
 }

--- a/lib/java-extras/src/test/java/org/triplea/io/FileUtilsTest.java
+++ b/lib/java-extras/src/test/java/org/triplea/io/FileUtilsTest.java
@@ -8,7 +8,6 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
-import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -55,7 +54,7 @@ final class FileUtilsTest {
     @Test
     void fileDoesNotExist() {
       final Optional<Path> result =
-          FileUtils.findFileInParentFolders(new File("").toPath(), "does not exist");
+          FileUtils.findFileInParentFolders(Path.of(""), "does not exist");
       assertThat(result, isEmpty());
     }
 
@@ -68,10 +67,10 @@ final class FileUtilsTest {
       //      |- child2/
       //         |- touch-file
 
-      final File testFolderPath =
-          new File(
+      final Path testFolderPath =
+          Path.of(
               ZipExtractorTest.class.getClassLoader().getResource("test-folder-path").getFile());
-      final Path child1 = testFolderPath.toPath().resolve("child1");
+      final Path child1 = testFolderPath.resolve("child1");
       final Path child2 = child1.resolve("child2");
 
       assertThat(
@@ -87,29 +86,29 @@ final class FileUtilsTest {
       assertThat(
           "all three test folder contain 'touch-parent' at a top level",
           FileUtils.findFileInParentFolders(child1, "touch-parent"),
-          isPresentAndIs(testFolderPath.toPath().resolve("touch-parent")));
+          isPresentAndIs(testFolderPath.resolve("touch-parent")));
 
       assertThat(
           FileUtils.findFileInParentFolders(child2, "touch-parent"),
-          isPresentAndIs(testFolderPath.toPath().resolve("touch-parent")));
+          isPresentAndIs(testFolderPath.resolve("touch-parent")));
 
       assertThat(
-          FileUtils.findFileInParentFolders(testFolderPath.toPath(), "touch-parent"),
-          isPresentAndIs(testFolderPath.toPath().resolve("touch-parent")));
+          FileUtils.findFileInParentFolders(testFolderPath, "touch-parent"),
+          isPresentAndIs(testFolderPath.resolve("touch-parent")));
     }
   }
 
   @Test
   @DisplayName("Verify we can read file contents with ISO-8859-1 encoded characters")
   void readContents() {
-    final File testFile =
-        new File(
+    final Path testFile =
+        Path.of(
             ZipExtractorTest.class
                 .getClassLoader()
                 .getResource("ISO-8859-1-test-file.txt")
                 .getFile());
 
-    final Optional<String> contentRead = FileUtils.readContents(testFile.toPath());
+    final Optional<String> contentRead = FileUtils.readContents(testFile);
 
     assertThat(contentRead, isPresent());
   }

--- a/lib/swing-lib/src/main/java/org/triplea/awt/OpenFileUtility.java
+++ b/lib/swing-lib/src/main/java/org/triplea/awt/OpenFileUtility.java
@@ -1,7 +1,6 @@
 package org.triplea.awt;
 
 import java.awt.Desktop;
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import lombok.extern.slf4j.Slf4j;
@@ -11,24 +10,6 @@ import org.triplea.swing.SwingComponents;
 @Slf4j
 public final class OpenFileUtility {
   private OpenFileUtility() {}
-
-  /**
-   * Opens a specific file on the user's computer using the local computer's file associations.
-   *
-   * @param file The file to be opened.
-   * @param action What to do if the Desktop API is not supported.
-   */
-  public static void openFile(final File file, final Runnable action) {
-    if (Desktop.isDesktopSupported()) {
-      try {
-        Desktop.getDesktop().open(file);
-      } catch (final IOException e) {
-        log.error("Could not open File " + file.getAbsolutePath(), e);
-      }
-    } else {
-      action.run();
-    }
-  }
 
   /**
    * Opens the specified web page in the user's default browser.

--- a/lib/swing-lib/src/test/java/org/triplea/swing/SwingComponentsTest.java
+++ b/lib/swing-lib/src/test/java/org/triplea/swing/SwingComponentsTest.java
@@ -6,7 +6,7 @@ import static org.triplea.swing.SwingComponents.appendExtensionIfAbsent;
 import static org.triplea.swing.SwingComponents.extensionWithLeadingPeriod;
 import static org.triplea.swing.SwingComponents.extensionWithoutLeadingPeriod;
 
-import java.io.File;
+import java.nio.file.Path;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
@@ -16,30 +16,29 @@ final class SwingComponentsTest {
     @Test
     void shouldAppendExtensionWhenExtensionAbsent() {
       assertThat(
-          appendExtensionIfAbsent(new File("path/file.aaa"), "bbb"),
-          is(new File("path/file.aaa.bbb")));
+          appendExtensionIfAbsent(Path.of("path/file.aaa"), "bbb"),
+          is(Path.of("path/file.aaa.bbb")));
       assertThat(
-          appendExtensionIfAbsent(new File("path/filebbb"), "bbb"),
-          is(new File("path/filebbb.bbb")));
+          appendExtensionIfAbsent(Path.of("path/filebbb"), "bbb"), is(Path.of("path/filebbb.bbb")));
     }
 
     @Test
     void shouldNotAppendExtensionWhenExtensionPresent() {
       assertThat(
-          appendExtensionIfAbsent(new File("path/file.bbb"), "bbb"), is(new File("path/file.bbb")));
+          appendExtensionIfAbsent(Path.of("path/file.bbb"), "bbb"), is(Path.of("path/file.bbb")));
     }
 
     @Test
     void shouldHandleExtensionThatStartsWithPeriod() {
       assertThat(
-          appendExtensionIfAbsent(new File("path/file.aaa"), ".bbb"),
-          is(new File("path/file.aaa.bbb")));
+          appendExtensionIfAbsent(Path.of("path/file.aaa"), ".bbb"),
+          is(Path.of("path/file.aaa.bbb")));
     }
 
     @Test
     void shouldUseCaseInsensitiveComparisonForExtension() {
       assertThat(
-          appendExtensionIfAbsent(new File("path/file.bBb"), "BbB"), is(new File("path/file.bBb")));
+          appendExtensionIfAbsent(Path.of("path/file.bBb"), "BbB"), is(Path.of("path/file.bBb")));
     }
   }
 


### PR DESCRIPTION
This is part 7 of a series where java.io.File APIs get migrated to java.nio.Path

There might be a final part 8 with some cleanups to remaining toFile() usages for legacy code

Part 1: #9039
Part 2: #9074
Part 3: #9112
Part 4: #9113
Part 5:  #9133
Part 6: #9216

## Testing
None
