### PR TITLE
Migrate from java.io.File to java.nio.file.Path (Part 8)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -395,15 +395,14 @@ public class DownloadMapsWindow extends JFrame {
                         .append(")"));
       }
     } else {
+      sb.append(doubleSpace).append(" (");
       try {
-        sb.append(doubleSpace)
-            .append(" (")
-            .append(newSizeLabel(Files.size(map.getInstallLocation().get())))
-            .append(")");
+        sb.append(newSizeLabel(Files.size(map.getInstallLocation().get())));
       } catch (final IOException e) {
         log.warn("Failed to read file size", e);
+        sb.append("N/A");
       }
-      sb.append("<br>").append(map.getInstallLocation().get().toAbsolutePath());
+      sb.append(")").append("<br>").append(map.getInstallLocation().get().toAbsolutePath());
     }
     sb.append("<br>");
     sb.append("</html>");

--- a/game-app/game-core/src/main/java/games/strategy/triplea/EngineImageLoader.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/EngineImageLoader.java
@@ -2,6 +2,7 @@ package games.strategy.triplea;
 
 import java.awt.Image;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import javax.imageio.ImageIO;
 import lombok.experimental.UtilityClass;
@@ -25,21 +26,16 @@ public class EngineImageLoader {
   public Image loadImage(final String... path) {
     final Path imageFilePath = createPathToImage(path);
 
-    if (!imageFilePath.toFile().exists()) {
+    if (!Files.exists(imageFilePath)) {
       throw new IllegalStateException(
-          "Error loading image, image does not exist at: "
-              + imageFilePath.toFile().getAbsolutePath());
+          "Error loading image, image does not exist at: " + imageFilePath.toAbsolutePath());
     }
 
     try {
       return ImageIO.read(imageFilePath.toFile());
     } catch (final IOException e) {
       throw new IllegalStateException(
-          "Error loading image at: "
-              + imageFilePath.toFile().getAbsolutePath()
-              + ", "
-              + e.getMessage(),
-          e);
+          "Error loading image at: " + imageFilePath.toAbsolutePath() + ", " + e.getMessage(), e);
     }
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/PathClientSetting.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/PathClientSetting.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea.settings;
 
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Optional;
@@ -25,10 +26,10 @@ final class PathClientSetting extends ClientSetting<Path> {
 
   @Override
   public Optional<String> validateValue(final Path value) {
-    if (!value.toFile().exists() || !value.toFile().canWrite()) {
+    if (!Files.exists(value) || !Files.isWritable(value)) {
       return Optional.of(
           "Invalid path, does not exist or cannot be written (permissions): "
-              + value.toFile().getAbsolutePath());
+              + value.toAbsolutePath());
     } else {
       return Optional.empty();
     }

--- a/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYaml.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYaml.java
@@ -211,7 +211,7 @@ public class MapDescriptionYaml {
     final Optional<Path> gamesFolder = FileUtils.find(mapFolder, 5, "games");
 
     if (gamesFolder.isEmpty()) {
-      log.warn("No 'games' folder found under location: {}", mapFolder.toFile().getAbsolutePath());
+      log.warn("No 'games' folder found under location: {}", mapFolder.toAbsolutePath());
     }
     return gamesFolder;
   }

--- a/game-app/map-data/src/main/java/org/triplea/map/game/notes/GameNotes.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/game/notes/GameNotes.java
@@ -1,6 +1,7 @@
 package org.triplea.map.game.notes;
 
 import com.google.common.base.Preconditions;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import lombok.experimental.UtilityClass;
 import org.triplea.io.FileUtils;
@@ -18,19 +19,19 @@ public class GameNotes {
    */
   public static String loadGameNotes(final Path xmlGameFile, final String gameName) {
     Preconditions.checkArgument(
-        xmlGameFile.toFile().exists(),
-        "Error, expected file did not exist: " + xmlGameFile.toFile().getAbsolutePath());
+        Files.exists(xmlGameFile),
+        "Error, expected file did not exist: " + xmlGameFile.toAbsolutePath());
     Preconditions.checkArgument(
-        xmlGameFile.toFile().isFile(),
-        "Error, expected file was not a file: " + xmlGameFile.toFile().getAbsolutePath());
+        !Files.isDirectory(xmlGameFile),
+        "Error, expected file was not a file: " + xmlGameFile.toAbsolutePath());
 
     final String notesFileName = createExpectedNotesFileName(xmlGameFile);
     final Path notesFile = xmlGameFile.resolveSibling(notesFileName);
 
     final String gameNotes =
-        notesFile.toFile().exists() ? FileUtils.readContents(notesFile).orElse("") : "";
+        Files.exists(notesFile) ? FileUtils.readContents(notesFile).orElse("") : "";
     return String.format(
-        "<h1>%s</h1>Path: %s<br>%s", gameName, xmlGameFile.toFile().getAbsolutePath(), gameNotes);
+        "<h1>%s</h1>Path: %s<br>%s", gameName, xmlGameFile.toAbsolutePath(), gameNotes);
   }
 
   /**
@@ -39,18 +40,18 @@ public class GameNotes {
    */
   static String createExpectedNotesFileName(final Path gameXmlFile) {
     Preconditions.checkArgument(
-        gameXmlFile.toFile().getName().endsWith(".xml"),
-        "Required a '.xml' file, got instead: " + gameXmlFile.toFile().getAbsolutePath());
-    return StringUtils.truncateEnding(gameXmlFile.toFile().getName(), ".xml") + ".notes.html";
+        gameXmlFile.getFileName().toString().endsWith(".xml"),
+        "Required a '.xml' file, got instead: " + gameXmlFile.toAbsolutePath());
+    return StringUtils.truncateEnding(gameXmlFile.getFileName().toString(), ".xml") + ".notes.html";
   }
 
   /** For a given game-xml-file, checks if there is a companion notes html file that exists. */
   static boolean gameNotesFileExistsForGameXmlFile(final Path gameXmlFile) {
     Preconditions.checkArgument(
-        gameXmlFile.toFile().getName().endsWith(".xml"),
-        "Required a '.xml' file, got instead: " + gameXmlFile.toFile().getAbsolutePath());
+        gameXmlFile.getFileName().toString().endsWith(".xml"),
+        "Required a '.xml' file, got instead: " + gameXmlFile.toAbsolutePath());
 
     final String expectedNotesFile = createExpectedNotesFileName(gameXmlFile);
-    return gameXmlFile.resolveSibling(expectedNotesFile).toFile().exists();
+    return Files.exists(gameXmlFile.resolveSibling(expectedNotesFile));
   }
 }

--- a/game-app/map-data/src/main/java/org/triplea/map/game/notes/GameNotesMigrator.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/game/notes/GameNotesMigrator.java
@@ -47,7 +47,7 @@ public class GameNotesMigrator {
                   final String gameNotes = readGameNotesFromXml(xmlGameFile);
                   final String fileNameToWrite = GameNotes.createExpectedNotesFileName(xmlGameFile);
                   final Path fileToWrite = xmlGameFile.resolveSibling(fileNameToWrite);
-                  log.info("Writing game notes file: " + fileToWrite.toFile().getAbsolutePath());
+                  log.info("Writing game notes file: " + fileToWrite.toAbsolutePath());
                   FileUtils.writeToFile(fileToWrite, gameNotes);
                 });
 

--- a/game-app/map-data/src/test/java/org/triplea/map/game/notes/GameNotesTest.java
+++ b/game-app/map-data/src/test/java/org/triplea/map/game/notes/GameNotesTest.java
@@ -29,7 +29,7 @@ class GameNotesTest {
         is(
             "<h1>Game Name</h1>"
                 + "Path: "
-                + gameXmlPath.toFile().getAbsolutePath()
+                + gameXmlPath.toAbsolutePath()
                 + "<br>"
                 + "<blink>Game notes!</blink>"));
   }

--- a/lib/java-extras/src/main/java/org/triplea/io/FileUtils.java
+++ b/lib/java-extras/src/main/java/org/triplea/io/FileUtils.java
@@ -89,11 +89,7 @@ public final class FileUtils {
       return files.filter(f -> f.getFileName().toString().equals(fileName)).findAny();
     } catch (final IOException e) {
       log.error(
-          "Unable to access files in: "
-              + searchRoot.toFile().getAbsolutePath()
-              + ", "
-              + e.getMessage(),
-          e);
+          "Unable to access files in: " + searchRoot.toAbsolutePath() + ", " + e.getMessage(), e);
       return Optional.empty();
     }
   }
@@ -108,7 +104,7 @@ public final class FileUtils {
       return Optional.empty();
     }
 
-    if (searchRoot.resolve(fileName).toFile().exists()) {
+    if (Files.exists(searchRoot.resolve(fileName))) {
       return Optional.of(searchRoot.resolve(fileName));
     } else {
       return findFileInParentFolders(searchRoot.getParent(), fileName);
@@ -168,12 +164,9 @@ public final class FileUtils {
   /**
    * Reads and returns the contents of a given file. Returns empty if the file does not exist or if
    * there were any errors reading the file. Character encodings allowed: UTf-8, ISO_8859_1
-   *
-   * @throws MalformedInputException thrown if unrecongized character encodings found
-   * @throws IOException thrown if there are any problems reading the target file
    */
   public static Optional<String> readContents(final Path fileToRead) {
-    if (!fileToRead.toFile().exists()) {
+    if (!Files.exists(fileToRead)) {
       return Optional.empty();
     }
 
@@ -185,7 +178,7 @@ public final class FileUtils {
       } catch (final MalformedInputException e) {
         log.info(
             "Warning: file was not saved as UTF-8, some characters may not render:  {}, {}",
-            fileToRead.toFile().getAbsolutePath(),
+            fileToRead.toAbsolutePath(),
             e.getMessage());
       }
 
@@ -194,13 +187,12 @@ public final class FileUtils {
       } catch (final MalformedInputException e) {
         log.warn(
             "Bad file encoding: "
-                + fileToRead.toAbsolutePath().toString()
+                + fileToRead.toAbsolutePath()
                 + ", contact the map maker and ask them to save this file as UTF-8");
         return Optional.empty();
       }
     } catch (final IOException e) {
-      log.error(
-          "Error reading file: {}, {}", fileToRead.toFile().getAbsolutePath(), e.getMessage(), e);
+      log.error("Error reading file: {}, {}", fileToRead.toAbsolutePath(), e.getMessage(), e);
     }
     return Optional.empty();
   }
@@ -209,11 +201,7 @@ public final class FileUtils {
     try {
       Files.writeString(fileToWrite, contents);
     } catch (final IOException e) {
-      log.error(
-          "Failed to write file: {}, {}",
-          fileToWrite.toFile().getAbsolutePath(),
-          e.getMessage(),
-          e);
+      log.error("Failed to write file: {}, {}", fileToWrite.toAbsolutePath(), e.getMessage(), e);
     }
   }
 }


### PR DESCRIPTION
This is the final part of a series where java.io.File APIs get migrated to java.nio.file.Path

Part 1: #9039
Part 2: #9074
Part 3: #9112
Part 4: #9113
Part 5:  #9133
Part 6: #9216
Part 7: #9256

## Testing
None
