### PR TITLE
Suppress error prone 'missing-summary' error

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -170,6 +170,8 @@ subprojects {
             // UnnecessaryLambda: frequent false positive - we use lambda's assigned to variables
             // frequently to facilitate testing.
             disable 'UnnecessaryLambda'
+            // MissingSummary throws false positives on lombok @Builder annotations.
+            disable 'MissingSummary'
         }
         options.incremental = true
     }


### PR DESCRIPTION
Triggers false positives with lombok annotations.

