### PR TITLE
Remove maps_server_uri parameter in servers.yml

### DIFF
--- a/game-app/game-core/src/main/java/org/triplea/live/servers/LiveServersFetcher.java
+++ b/game-app/game-core/src/main/java/org/triplea/live/servers/LiveServersFetcher.java
@@ -89,7 +89,7 @@ public class LiveServersFetcher {
   }
 
   @VisibleForTesting
-  static final class LobbyAddressFetchException extends RuntimeException {
+  public static final class LobbyAddressFetchException extends RuntimeException {
     private static final long serialVersionUID = -301010780022774627L;
 
     LobbyAddressFetchException(final IOException e) {
@@ -109,9 +109,5 @@ public class LiveServersFetcher {
       log.warn("(No network connection?) Failed to get server locations", e);
       return Optional.empty();
     }
-  }
-
-  public Optional<URI> getMapsServerUri() {
-    return fetchServerProperties().map(ServerProperties::getMapsServerUri);
   }
 }

--- a/game-app/game-core/src/main/java/org/triplea/live/servers/ServerProperties.java
+++ b/game-app/game-core/src/main/java/org/triplea/live/servers/ServerProperties.java
@@ -11,8 +11,6 @@ import org.triplea.util.Version;
 public class ServerProperties {
   /** URI of the remote server */
   private final URI uri;
-
-  private final URI mapsServerUri;
   /** Lobby welcome text shown to the user */
   private final String message;
   /** Minimum engine version compatible with this server */

--- a/game-app/game-core/src/main/java/org/triplea/live/servers/ServerYamlParser.java
+++ b/game-app/game-core/src/main/java/org/triplea/live/servers/ServerYamlParser.java
@@ -40,8 +40,6 @@ public class ServerYamlParser implements Function<InputStream, LiveServers> {
             new Version(Preconditions.checkNotNull(String.valueOf(props.get("version")))))
         .message(Strings.nullToEmpty((String) props.get("message")))
         .uri(Optional.ofNullable((String) props.get("lobby_uri")).map(URI::create).orElse(null))
-        .mapsServerUri(
-            Optional.ofNullable((String) props.get("maps_uri")).map(URI::create).orElse(null))
         .inactive(Optional.ofNullable((Boolean) props.get("inactive")).orElse(false))
         .build();
   }

--- a/servers.yml
+++ b/servers.yml
@@ -2,7 +2,6 @@ latest: 2.5.22294
 servers:
   - version: "2.0.20057"
     lobby_uri: https://prod2-lobby.triplea-game.org
-    maps_uri: https://prerelease-maps.triplea-game.org
     message: |
       Welcome to the TripleA lobby!
       Please no politics, stay respectful, be welcoming, have fun.
@@ -10,7 +9,6 @@ servers:
     inactive: true
   - version: "2.0.0"
     lobby_uri: https://prerelease.triplea-game.org
-    maps_uri: https://prerelease-maps.triplea-game.org
     message: |
       Welcome to the TripleA PRE-RELEASE lobby!
   - version: "0.0"


### PR DESCRIPTION
The URI of the maps server will no longer be needed because
the lobby and maps server are being merged into one.

