### PR TITLE
battleWindow title

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -263,7 +263,8 @@ public final class BattlePanel extends ActionPanel {
                   defendingWaitingToDieCopy,
                   BattlePanel.this.getMap(),
                   battleType);
-          final String battleStr = battleType == BattleType.NORMAL ? "" : String.format("  (%s)", battleType.toDisplayText());
+          final String battleStr = (battleType == BattleType.NORMAL) ? 
+            "" : String.format("  (%s)", battleType.toDisplayText());
           battleWindow.setTitle(attacker.getName() + " attacks " + defender.getName()
                                 + " in " + location.getName() + battleStr);
           battleWindow.getContentPane().removeAll();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -263,8 +263,10 @@ public final class BattlePanel extends ActionPanel {
                   defendingWaitingToDieCopy,
                   BattlePanel.this.getMap(),
                   battleType);
-          battleWindow.setTitle(
-              attacker.getName() + " attacks " + defender.getName() + " in " + location.getName());
+          String battleStr = battleType.toDisplayText();
+          battleStr = battleStr.equals("Battle") ? "" : String.format("  (%s)", battleStr);
+          battleWindow.setTitle(attacker.getName() + " attacks " + defender.getName() 
+                                + " in " + location.getName() + battleStr);
           battleWindow.getContentPane().removeAll();
           battleWindow.getContentPane().add(battleDisplay);
           final Frame parent = JOptionPane.getFrameForComponent(BattlePanel.this);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -263,8 +263,7 @@ public final class BattlePanel extends ActionPanel {
                   defendingWaitingToDieCopy,
                   BattlePanel.this.getMap(),
                   battleType);
-          String battleStr = battleType.toDisplayText();
-          battleStr = battleStr.equals("Battle") ? "" : String.format("  (%s)", battleStr);
+          final String battleStr = battleType == BattleType.NORMAL ? "" : String.format("  (%s)", battleType.toDisplayText());
           battleWindow.setTitle(attacker.getName() + " attacks " + defender.getName()
                                 + " in " + location.getName() + battleStr);
           battleWindow.getContentPane().removeAll();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -265,7 +265,7 @@ public final class BattlePanel extends ActionPanel {
                   battleType);
           String battleStr = battleType.toDisplayText();
           battleStr = battleStr.equals("Battle") ? "" : String.format("  (%s)", battleStr);
-          battleWindow.setTitle(attacker.getName() + " attacks " + defender.getName() 
+          battleWindow.setTitle(attacker.getName() + " attacks " + defender.getName()
                                 + " in " + location.getName() + battleStr);
           battleWindow.getContentPane().removeAll();
           battleWindow.getContentPane().add(battleDisplay);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -263,8 +263,8 @@ public final class BattlePanel extends ActionPanel {
                   defendingWaitingToDieCopy,
                   BattlePanel.this.getMap(),
                   battleType);
-          final String battleStr = (battleType == BattleType.NORMAL) ? 
-            "" : String.format("  (%s)", battleType.toDisplayText());
+          final String battleStr = (battleType == BattleType.NORMAL)
+            ? "" : String.format("  (%s)", battleType.toDisplayText());
           battleWindow.setTitle(attacker.getName() + " attacks " + defender.getName()
                                 + " in " + location.getName() + battleStr);
           battleWindow.getContentPane().removeAll();


### PR DESCRIPTION
Objective: Providing more detailed info in the battleWindow Dialog title.
The end-goal is to achieve the following output 
- "Germans attacks British in 110 Sea Zone (Battle Round 1 of 2)" 
the max number of battle rounds will be displayed if >1:   

Which would address the feature request:
https://forums.triplea-game.org/topic/209/gui-battle-interface-window-should-provide-battle-round-info-in-title-germans-attacks-british-in-110-sea-zone-round-1

This initial commit only partially addresses the issue. Expected output:
- Germans attacks Russians in Russia  (Air Raid)
- Germans attacks Russians in Russia  (Bombing Raid)
- Germans attacks British in 110 Sea Zone  (Air Battle)
- Germans attacks British in 110 Sea Zone
- Germans attacks Russians in Russia  

I'm hoping someone can suggest a way to get the current battleround info (it is available in IBattle, how to get it ?) to update the battleWindow title, in which case I'll update my commit. 

## Testing
I've not installed IDEA yet, and am compiling v2.5 code. So I'm relying on the automated tests for now.
