### PR TITLE
Fix refresh lag in purchase panel.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/ui/ScrollableTextField.java
+++ b/game-app/game-core/src/main/java/games/strategy/ui/ScrollableTextField.java
@@ -169,6 +169,7 @@ public class ScrollableTextField extends JPanel {
       maxButton.setEnabled(false);
       minButton.setEnabled(false);
     }
+    invalidate();
   }
 
   public int getValue() {


### PR DESCRIPTION
Fix refresh lag in purchase panel. When clicking the up/down and min/max buttons in the purchase panel, the UI may lag behind, with different buttons updating their enabled/disabled state very slowly, sometimes taking seconds for everything to be ready. Calling invalidate() fixes the issue.

## Testing
On the map "Over The Top" (which has lots of units on purchase screen), click Max button on trenches and observe how fast everything updates. Before this change, it can be regularly laggy when trying a few times, whereas after this change it's consistently fast.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->Fixed UI lag when interacting with the purchase panel.<!--END_RELEASE_NOTE-->
