### PR TITLE
Re-enable DOA tests in lobby-module and maps-module

### DIFF
--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/access/log/AccessLogDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/access/log/AccessLogDaoTest.java
@@ -8,16 +8,16 @@ import static org.triplea.test.common.IsInstant.isInstant;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.database.rider.junit5.DBUnitExtension;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
 
-@Disabled
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
+@ExtendWith(DBUnitExtension.class)
 class AccessLogDaoTest {
   private static final String EMPTY_ACCESS_LOG =
       "access_log/user_role.yml,access_log/lobby_user.yml";

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/api/key/GameHostingApiKeyDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/api/key/GameHostingApiKeyDaoTest.java
@@ -5,15 +5,15 @@ import static org.hamcrest.Matchers.is;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.database.rider.junit5.DBUnitExtension;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
 
-@Disabled
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
+@ExtendWith(DBUnitExtension.class)
 class GameHostingApiKeyDaoTest {
 
   private final GameHostingApiKeyDao gameHostApiKeyDao;

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/api/key/PlayerApiKeyDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/api/key/PlayerApiKeyDaoTest.java
@@ -7,15 +7,14 @@ import static org.hamcrest.core.Is.is;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.database.rider.junit5.DBUnitExtension;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
 import org.triplea.db.dao.user.role.UserRole;
 
-@Disabled
 @DataSet(
     value =
         "lobby_api_key/user_role.yml,"
@@ -24,6 +23,7 @@ import org.triplea.db.dao.user.role.UserRole;
     useSequenceFiltering = false)
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
+@ExtendWith(DBUnitExtension.class)
 class PlayerApiKeyDaoTest {
 
   private static final int USER_ID = 50;

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/chat/history/LobbyChatHistoryDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/chat/history/LobbyChatHistoryDaoTest.java
@@ -2,15 +2,15 @@ package org.triplea.db.dao.chat.history;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.database.rider.junit5.DBUnitExtension;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
 
-@Disabled
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
+@ExtendWith(DBUnitExtension.class)
 class LobbyChatHistoryDaoTest {
 
   private final LobbyChatHistoryDao lobbyChatHistoryDao;

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/error/reporting/ErrorReportingDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/error/reporting/ErrorReportingDaoTest.java
@@ -5,12 +5,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.database.rider.junit5.DBUnitExtension;
 import com.github.npathai.hamcrestopt.OptionalMatchers;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -18,9 +18,9 @@ import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
 
-@Disabled
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
+@ExtendWith(DBUnitExtension.class)
 final class ErrorReportingDaoTest {
   private final ErrorReportingDao errorReportingDao;
 

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/lobby/games/LobbyGameDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/lobby/games/LobbyGameDaoTest.java
@@ -2,8 +2,8 @@ package org.triplea.db.dao.lobby.games;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.database.rider.junit5.DBUnitExtension;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.TestData;
@@ -12,9 +12,9 @@ import org.triplea.domain.data.ApiKey;
 import org.triplea.http.client.lobby.game.lobby.watcher.ChatMessageUpload;
 import org.triplea.http.client.lobby.game.lobby.watcher.LobbyGameListing;
 
-@Disabled
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
+@ExtendWith(DBUnitExtension.class)
 class LobbyGameDaoTest {
   private final LobbyGameDao lobbyGameDao;
 

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/moderator/BadWordsDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/moderator/BadWordsDaoTest.java
@@ -5,10 +5,10 @@ import static org.hamcrest.core.Is.is;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.database.rider.junit5.DBUnitExtension;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -16,10 +16,10 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
 
-@Disabled
 @DataSet(value = "bad_words/bad_word.yml", useSequenceFiltering = false)
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
+@ExtendWith(DBUnitExtension.class)
 class BadWordsDaoTest {
   private static final List<String> expectedBadWords = List.of("aaa", "one", "two", "zzz");
 

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/moderator/ModeratorAuditHistoryDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/moderator/ModeratorAuditHistoryDaoTest.java
@@ -9,15 +9,14 @@ import static org.triplea.test.common.IsInstant.isInstant;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.database.rider.junit5.DBUnitExtension;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.jdbi.v3.core.statement.UnableToExecuteStatementException;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
 
-@Disabled
 @RequiredArgsConstructor
 @DataSet(
     value =
@@ -26,6 +25,7 @@ import org.triplea.db.LobbyModuleDatabaseTestSupport;
             + "moderator_audit/moderator_action_history.yml",
     useSequenceFiltering = false)
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
+@ExtendWith(DBUnitExtension.class)
 class ModeratorAuditHistoryDaoTest {
 
   private static final int MODERATOR_ID = 900000;

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/moderator/ModeratorsDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/moderator/ModeratorsDaoTest.java
@@ -8,20 +8,20 @@ import static org.triplea.test.common.IsInstant.isInstant;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.database.rider.junit5.DBUnitExtension;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
 import org.triplea.db.dao.user.role.UserRole;
 
-@Disabled
 @DataSet(
     value = "moderators/user_role.yml, moderators/lobby_user.yml, moderators/access_log.yml",
     useSequenceFiltering = false)
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
+@ExtendWith(DBUnitExtension.class)
 class ModeratorsDaoTest {
 
   private static final int NOT_MODERATOR_ID = 100000;

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/moderator/chat/history/GameChatHistoryDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/moderator/chat/history/GameChatHistoryDaoTest.java
@@ -6,16 +6,15 @@ import static org.hamcrest.core.Is.is;
 import static org.triplea.test.common.IsInstant.isInstant;
 
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.junit5.DBUnitExtension;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.hamcrest.collection.IsCollectionWithSize;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
 
-@Disabled
 @DataSet(
     value =
         "game_chat_history/game_hosting_api_key.yml,"
@@ -24,6 +23,7 @@ import org.triplea.db.LobbyModuleDatabaseTestSupport;
     useSequenceFiltering = false)
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
+@ExtendWith(DBUnitExtension.class)
 class GameChatHistoryDaoTest {
   private static final String SIR_HOSTS_A_LOT = "sir_hosts_a_lot";
   private static final String SIR_HOSTS_A_LITTLE = "sir_hosts_a_little";

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/moderator/player/info/PlayerInfoForModeratorDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/moderator/player/info/PlayerInfoForModeratorDaoTest.java
@@ -7,17 +7,17 @@ import static org.hamcrest.core.Is.is;
 import static org.triplea.test.common.IsInstant.isInstant;
 
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.junit5.DBUnitExtension;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
 
-@Disabled
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
+@ExtendWith(DBUnitExtension.class)
 class PlayerInfoForModeratorDaoTest {
 
   private final PlayerInfoForModeratorDao playerInfoForModeratorDao;

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/temp/password/TempPasswordDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/temp/password/TempPasswordDaoTest.java
@@ -6,13 +6,12 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.junit5.DBUnitExtension;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
 
-@Disabled
 @DataSet(
     value =
         "temp_password/user_role.yml,"
@@ -21,6 +20,7 @@ import org.triplea.db.LobbyModuleDatabaseTestSupport;
     useSequenceFiltering = false)
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
+@ExtendWith(DBUnitExtension.class)
 class TempPasswordDaoTest {
 
   private static final String USERNAME = "username";

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/user/UserJdbiDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/user/UserJdbiDaoTest.java
@@ -7,18 +7,18 @@ import static org.hamcrest.core.Is.is;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.database.rider.junit5.DBUnitExtension;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
 import org.triplea.db.dao.user.role.UserRole;
 import org.triplea.db.dao.user.role.UserRoleLookup;
 
-@Disabled
 @DataSet(value = "user/user_role.yml,user/lobby_user.yml", useSequenceFiltering = false)
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
+@ExtendWith(DBUnitExtension.class)
 class UserJdbiDaoTest {
 
   private static final int USER_ID = 900000;

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/user/ban/UserBanDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/user/ban/UserBanDaoTest.java
@@ -9,20 +9,20 @@ import static org.triplea.test.common.IsInstant.isInstant;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.database.rider.junit5.DBUnitExtension;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
 
-@Disabled
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
+@ExtendWith(DBUnitExtension.class)
 class UserBanDaoTest {
   private final UserBanDao userBanDao;
 

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/user/role/UserRoleDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/user/role/UserRoleDaoTest.java
@@ -4,16 +4,16 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.junit5.DBUnitExtension;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
 
-@Disabled
 @DataSet(value = "user_role/initial.yml", useSequenceFiltering = false)
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
+@ExtendWith(DBUnitExtension.class)
 class UserRoleDaoTest {
 
   private final UserRoleDao userRoleDao;

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/username/ban/UsernameBanDaoTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/db/dao/username/ban/UsernameBanDaoTest.java
@@ -7,17 +7,17 @@ import static org.triplea.test.common.IsInstant.isInstant;
 
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
+import com.github.database.rider.junit5.DBUnitExtension;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.db.LobbyModuleDatabaseTestSupport;
 
-@Disabled
 @RequiredArgsConstructor
 @ExtendWith(LobbyModuleDatabaseTestSupport.class)
+@ExtendWith(DBUnitExtension.class)
 class UsernameBanDaoTest {
 
   private final UsernameBanDao usernameBanDao;

--- a/spitfire-server/lobby-module/src/test/java/org/triplea/modules/player/info/FetchPlayerInfoModuleTest.java
+++ b/spitfire-server/lobby-module/src/test/java/org/triplea/modules/player/info/FetchPlayerInfoModuleTest.java
@@ -19,7 +19,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -43,7 +42,6 @@ import org.triplea.modules.chat.Chatters;
 import org.triplea.modules.game.listing.GameListing;
 import org.triplea.web.socket.WebSocketSession;
 
-@Disabled
 @ExtendWith(MockitoExtension.class)
 class FetchPlayerInfoModuleTest {
 
@@ -115,7 +113,9 @@ class FetchPlayerInfoModuleTest {
         .thenReturn(Optional.empty());
     assertThrows(
         IllegalArgumentException.class,
-        () -> fetchPlayerInfoModule.fetchPlayerInfo(PlayerChatId.of("id")));
+        () -> fetchPlayerInfoModule.fetchPlayerInfoAsModerator(PlayerChatId.of("id")),
+        "Using the lookup play info function requires a player to be in the lobby, "
+            + "we therefore expect to find their play id, or else throws.");
   }
 
   @Test

--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexDaoTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexDaoTest.java
@@ -7,13 +7,13 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
 import lombok.AllArgsConstructor;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.triplea.maps.MapsModuleDatabaseTestSupport;
 
-@Disabled
 @AllArgsConstructor
 @DataSet(value = "map_category.yml,map_index.yml", useSequenceFiltering = false)
+@ExtendWith(MapsModuleDatabaseTestSupport.class)
 @ExtendWith(DBUnitExtension.class)
 class MapIndexDaoTest {
 

--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/listing/MapListingDaoTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/listing/MapListingDaoTest.java
@@ -5,15 +5,17 @@ import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
 
 import com.github.database.rider.core.api.dataset.DataSet;
+import com.github.database.rider.junit5.DBUnitExtension;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.triplea.maps.MapsModuleDatabaseTestSupport;
 
-@Disabled
 @DataSet(value = "map_category.yml,map_index.yml", useSequenceFiltering = false)
-class MapListingDaoTest extends MapsModuleDatabaseTestSupport {
+@ExtendWith(MapsModuleDatabaseTestSupport.class)
+@ExtendWith(DBUnitExtension.class)
+class MapListingDaoTest {
 
   private final MapListingDao mapListingDao;
 


### PR DESCRIPTION
Fixes tests in newly combined server modules. Most
tests were missing '@ExtendWith(DbUnitExtension.class)'

