### PR TITLE
Fix and re-enable smoke tests

### DIFF
--- a/.build/smoke-testing/run
+++ b/.build/smoke-testing/run
@@ -13,14 +13,11 @@
 
 set -eux
 
-echo "TODO; aborting smoke test (WIP)"
-exit 0 
-
 .build/setup-database
 
 readonly VERSION=$(sed 's/version\s*=\s*//' game-app/game-core/src/main/resources/META-INF/triplea/product.properties)
 
-readonly LOBBY_SERVER_JAR_PATH="spitfire-server/dropwizard-common/build/libs/triplea-dropwizard-common-${VERSION}.jar"
+readonly LOBBY_SERVER_JAR_PATH="spitfire-server/dropwizard-server/build/libs/triplea-dropwizard-server-${VERSION}.jar"
 readonly BOT_JAR_PATH="game-app/game-headless/build/libs/triplea-game-headless-${VERSION}.jar"
 readonly SMOKE_TEST_JAR_PATH="smoke-testing/build/libs/triplea-smoke-testing-${VERSION}.jar"
 
@@ -62,14 +59,14 @@ function printLogs() {
 
 function buildJars() {
   ./gradlew --parallel \
-     :spitfire-server:dropwizard-common:shadowJar \
+     :spitfire-server:dropwizard-server:shadowJar \
      :game-app:game-headless:shadowJar \
      :smoke-testing:shadowJar 
 }
 
 function startLobby() {
   java -jar "$LOBBY_SERVER_JAR_PATH" \
-       server ./spitfire-server/dropwizard-common/configuration.yml \
+       server ./spitfire-server/dropwizard-server/configuration.yml \
        > "$LOBBY_SERVER_OUTPUT" 2>&1 &
   echo $!
 }


### PR DESCRIPTION
Smoke tests needed module names to be updated
after dropwizard-common was renamed to dropwizard-server

