### PR TITLE
Remove vagrant port mapping for 'maps server'

### DIFF
--- a/infrastructure/Vagrantfile
+++ b/infrastructure/Vagrantfile
@@ -6,7 +6,6 @@ Vagrant.configure("2") do |config|
     vagrantHost.vm.network "forwarded_port", guest: 4001, host: 4100, host_ip: "127.0.0.1"
     vagrantHost.vm.network "forwarded_port", guest: 443, host: 8000, host_ip: "127.0.0.1"
     vagrantHost.vm.network "forwarded_port", guest: 8080, host: 8008, host_ip: "127.0.0.1"
-    vagrantHost.vm.network "forwarded_port", guest: 9090, host: 9000, host_ip: "127.0.0.1"
   end
 end
 


### PR DESCRIPTION
Map server was merged with the lobby server, it no longer needs
a port mapping.

