### PR TITLE
Fix ansible deloyment & add provisioning github actions

### DIFF
--- a/.github/workflows/deploy-prerelease-provisioning.yml
+++ b/.github/workflows/deploy-prerelease-provisioning.yml
@@ -1,0 +1,18 @@
+name: Deploy Prerelease Server Provisioning
+on:
+  workflow_dispatch:
+jobs:
+  deploy:
+    name: Deploy Prerelease Server Provisioning
+    runs-on: Ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Run Ansible to Provision Prerelease Servers
+        run: |
+          cd infrastructure
+          echo "$ANSIBLE_VAULT_PASSWORD" > vault_password
+          ./run_ansible_provision "ansible/inventory/prerelease"
+        with:
+          ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
+

--- a/.github/workflows/deploy-production-provisioning.yml
+++ b/.github/workflows/deploy-production-provisioning.yml
@@ -1,0 +1,18 @@
+name: Deploy Production Server Provisioning
+on:
+  workflow_dispatch:
+jobs:
+  deploy:
+    name: Deploy Production Server Provisioning
+    runs-on: Ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Run Ansible to Provision Production Servers
+        run: |
+          cd infrastructure
+          echo "$ANSIBLE_VAULT_PASSWORD" > vault_password
+          ./run_ansible_provision "ansible/inventory/production"
+        with:
+          ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
+

--- a/docs/infrastructure/deployment-design.md
+++ b/docs/infrastructure/deployment-design.md
@@ -1,36 +1,15 @@
 # Deployment Design
 
-Deployments are triggered as part of
-[travis](https://travis-ci.org/github/triplea-game/triplea) builds.
+Infrastructure is managed as code. This means changes are checked in to
+configuration scripts and those scripts are then across the servers.
+Nobody should be logging in to a server to make changes (only to
+view logs or do other kinds of troubleshooting).
 
-- Avoid logging in to servers, favor checking in changes that
-are then automatically deployed in stages to prerelease and then
-production.
+Deployments are triggered as part of the build via github actions.
 
 ## Deployments
 
 - Prerelease will receive the latest code after every merge.
 
-- Production will also receive latest code but the version number
-  that is deployed is fixed and controlled by configuration.
-  The 'using_latest' variable is what controls whether a specific
-  version or if the latest code is used.
-
-## Setup Deployments
-
-There is a special hostgroup in inventory 'setup' where new servers should
-be added. We run a setup deployment first. Once a server has received
-the setup deployment it can be removed from the setup group. We do this
-to avoid overly repetitive installation of things like firewall. Generally
-we want to run the full installation each time to ensure that any configuration
-drift is fixed, some tasks are really better just run once though.
-
-## Production Deployment
-
-- Avoid deploying changes directly to prerelease or prod, but
-  if needed, it can be done. Use the '--limit' tag to deploy
-  to just a specific host. EG:
-
-```
-./run_ansible_production --limit prod2-bot02.triplea-game.org
-```
+- Production is deployed to on demand. The version to deploy to production
+  is defined in configuration.

--- a/docs/infrastructure/server-setup.md
+++ b/docs/infrastructure/server-setup.md
@@ -53,3 +53,9 @@ This is needed for lobby server or any server that will be serving https traffic
 - Add the server to [inventory configuration](/infrastructure/ansible/inventory)
 - Commit the changes and submit for a PR. After the PR is merged, travis will run a deployment
   automatically deploying all needed configurations to the server.
+
+## Run Github Action "Provision"
+
+In github actions, find the "deploy server provisioning" action and run it. This is
+a one-time step.
+

--- a/infrastructure/.include/build_latest_artifacts
+++ b/infrastructure/.include/build_latest_artifacts
@@ -20,13 +20,12 @@ function buildArtifacts() {
   (
     cd ..
     ./gradlew \
-        :spitfire-server:dropwizard-common:release \
-        :spitfire-server:maps-module:release \
+        :spitfire-server:dropwizard-server:release \
         :game-app:game-headless:release \
-        :servers:database:release
+        :spitfire-server:database:release
   )
-  copyBuildArtifact "../servers/database/build/artifacts/migrations.zip" "ansible/roles/database/flyway/files/"
-  copyBuildArtifact "../servers/dropwizard-server/build/artifacts/triplea-dropwizard-server-$VERSION.zip" "ansible/roles/lobby_server/files/"
+  copyBuildArtifact "../spitfire-server/database/build/artifacts/migrations.zip" "ansible/roles/database/flyway/files/"
+  copyBuildArtifact "../spitfire-server/dropwizard-server/build/artifacts/triplea-dropwizard-server-$VERSION.zip" "ansible/roles/lobby_server/files/"
   copyBuildArtifact "../game-app/game-headless/build/artifacts/triplea-game-headless-$VERSION.zip" "ansible/roles/bot/files/"
 }
 

--- a/infrastructure/ansible/inventory/vagrant
+++ b/infrastructure/ansible/inventory/vagrant
@@ -1,5 +1,5 @@
 [vagrant_local]
-vagrant ansible_host=127.0.0.1 ansible_port=2010 ansible_ssh_private_key_file=./.vagrant/machines/vagrantHost/virtualbox/private_key
+vagrant ansible_user=vagrant ansible_host=127.0.0.1 ansible_port=2010 ansible_ssh_private_key_file=.vagrant/machines/vagrantHost/virtualbox/private_key
 
 [database:children]
 vagrant_local

--- a/infrastructure/ansible/provision.yml
+++ b/infrastructure/ansible/provision.yml
@@ -1,0 +1,10 @@
+- hosts: all
+  roles:
+    - system/hostname
+    - system/apt_update
+    - system/firewall
+    - system/security
+    - system/journald
+    - system/apt_common_tools
+    - system/admin_user
+

--- a/infrastructure/ansible/site.yml
+++ b/infrastructure/ansible/site.yml
@@ -1,32 +1,17 @@
-- hosts: all
-  tags: system
-  roles:
-    - system/hostname
-    - system/apt_update
-    - system/firewall
-    - system/security
-    - system/journald
-
 - hosts: forums
   tags: forums
   roles:
-    - system/admin_user
-    - system/apt_common_tools
     - nginx_forums_conf
 
 - hosts: database
   tags: [database, postgres]
   roles:
-    - system/admin_user
-    - system/apt_common_tools
     - database/postgres
     - {name: database/flyway, tags: flyway}
 
 - hosts: lobbyServer
   tags: [lobby, lobby_server]
   roles:
-    - system/admin_user
-    - system/apt_common_tools
     - java
     - lobby_server
     - nginx
@@ -45,7 +30,6 @@
 - hosts: botHosts
   tags: [bot, bots]
   roles:
-    - system/apt_common_tools
     - java
     - bot
 

--- a/infrastructure/run_ansible_provision
+++ b/infrastructure/run_ansible_provision
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# This script is used to execute server provisioning.
+# This needs to be run one-time after new servers
+# are added to the fleet before application deployments.
+
+VAULT_PASSWORD_FILE="vault_password"
+if [ ! -f "$VAULT_PASSWORD_FILE" ]; then
+  echo "Error: $VAULT_PASSWORD_FILE must exist"
+  exit 1
+fi
+
+
+inventoryFile="$1"
+
+if [ -z "$inventoryFile" ]; then
+   echo "Error, missing arg [inventory file]"
+   echo "Usage: $0 [inventory file]"
+   exit 1
+fi
+
+if [ ! -f "$inventoryFile" ]; then
+  echo "Error, invalid inventory file specified: $inventoryFile"
+  echo "File does not exist."
+  exit 1
+fi
+
+set -eu
+
+function main() {
+  addPrivateSshKeyToAgent
+  runProvisioning
+}
+
+function addPrivateSshKeyToAgent() {
+  ansible-vault view \
+    --vault-password-file="$VAULT_PASSWORD_FILE" \
+    ansible_ssh_key.ed25519 \
+  | ssh-add -
+}
+
+function runProvisioning() {
+  ansible-playbook \
+    --vault-password-file "$VAULT_PASSWORD_FILE" \
+    --inventory "$inventoryFile" \
+   ansible/provision.yml
+}
+
+
+main

--- a/infrastructure/run_ansible_vagrant
+++ b/infrastructure/run_ansible_vagrant
@@ -8,24 +8,24 @@ if [ "$CUR_FOLDER" != infrastructure ]; then
   exit 1
 fi
 
+unbuffer ansible-playbook --diff --verbose \
+    "$@" ansible/provision.yml \
+  | tee output \
+  | sed 's|\\n|\n|g'
+rm output
 
-function main() {
-  local -r version=$(sed 's/.*=\s*//' ../game-core/src/main/resources/META-INF/triplea/product.properties)
-  .include/build_latest_artifacts "$version"
 
-  unbuffer ansible-playbook --diff --verbose \
-      "$@" \
-      --extra-vars "using_latest=true" \
-      --extra-vars "version=$version" \
-      --inventory-file ansible/inventory/vagrant \
-      ansible/site.yml \
-    | tee output \
-    | sed 's|\\n|\n|g'
-  rm output
-}
+version=$(sed 's/.*=\s*//' $(find .. -path "*/src/main/*" -name "product.properties"))
+.include/build_latest_artifacts "$version"
 
-main "$@"
+unbuffer ansible-playbook --diff --verbose \
+    "$@" --extra-vars "using_latest=true" \
+    --extra-vars "version=$version" \
+    --inventory-file ansible/inventory/vagrant \
+    ansible/site.yml \
+  | tee output \
+  | sed 's|\\n|\n|g'
+rm output
 
 echo "lobby port -> 8008"
-echo "maps server port -> 9000"
 


### PR DESCRIPTION
- Includes various fixes to deployment config
- Splits app deployment (site.yml) play from standard provisioning.
  This re-introduces a two step deployment process where new machines
  need to be provisioned first before we can deply to them.
  It was being observed that various tasks like updating apt packages
  was crashing, to avoid this we can simply not re-run it on every
  deployment.
  Instead there is now a github action that can be triggered whenever
  we add a new sever.


<!-- If multiple commits please summarize the change above. -->

## Testing

```
cd infrastructure
vagrant up
./run_ansible_vagrant
```
