### PR TITLE
Configure 2.6 clients to use prerelease server

### DIFF
--- a/servers.yml
+++ b/servers.yml
@@ -1,5 +1,9 @@
 latest: 2.5.22294
 servers:
+  - version: "2.6.0"
+    lobby_uri: https://prerelease.triplea-game.org
+    message: |
+      Welcome to the TripleA PRE-RELEASE lobby!
   - version: "2.0.20057"
     lobby_uri: https://prod2-lobby.triplea-game.org
     message: |


### PR DESCRIPTION
Update changes 2.6 and above clients to connect to the prerelease
server rather than production. This will be important for bringing
the maps server online, without this 2.6 clients will connect
to production which does not have a maps server (and hence map downloads
would then be broken for 2.6 clients).
