### PR TITLE
Conditional Map Indexing - Disable map indexing for smoke tests

### DIFF
--- a/.build/smoke-testing/run
+++ b/.build/smoke-testing/run
@@ -65,6 +65,7 @@ function buildJars() {
 }
 
 function startLobby() {
+  export MAP_INDEXING_ENABLED="false"
   java -jar "$LOBBY_SERVER_JAR_PATH" \
        server ./spitfire-server/dropwizard-server/configuration.yml \
        > "$LOBBY_SERVER_OUTPUT" 2>&1 &

--- a/spitfire-server/dropwizard-server/configuration.yml
+++ b/spitfire-server/dropwizard-server/configuration.yml
@@ -4,6 +4,8 @@ githubOrgForErrorReports: triplea-game
 githubRepoForErrorReports: ${ERROR_REPORT_GITHUB_REPO:-test}
 githubMapsOrgName: triplea-maps
 
+mapIndexingEnabled: ${MAP_INDEXING_ENABLED:-true}
+
 # if we are using any stubbing, we'll assert that this value is false.
 # this is to help guarantee that we do not accidentally use test configuration in prod.
 prod: ${PROD_FLAG:-false}

--- a/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/SpitfireServerApplication.java
+++ b/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/SpitfireServerApplication.java
@@ -7,6 +7,7 @@ import io.dropwizard.jdbi3.JdbiFactory;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.jdbi.v3.core.Jdbi;
 import org.triplea.db.LobbyModuleRowMappers;
 import org.triplea.dropwizard.common.AuthenticationConfiguration;
@@ -55,6 +56,7 @@ import org.triplea.web.socket.WebSocketMessagingBus;
  * any Jersey plugins, registering resources (controllers) and injecting those resources with
  * configuration properties from 'AppConfig'.
  */
+@Slf4j
 public class SpitfireServerApplication extends Application<SpitfireServerConfig> {
 
   private static final String[] DEFAULT_ARGS = new String[] {"server", "configuration.yml"};
@@ -95,7 +97,13 @@ public class SpitfireServerApplication extends Application<SpitfireServerConfig>
     if (configuration.isLogSqlStatements()) {
       JdbiLogging.registerSqlLogger(jdbi);
     }
-    environment.lifecycle().manage(MapsIndexingSchedule.build(configuration, jdbi));
+
+    if (configuration.isMapIndexingEnabled()) {
+      environment.lifecycle().manage(MapsIndexingSchedule.build(configuration, jdbi));
+      log.info("Map indexing is enabled and has been scheduled");
+    } else {
+      log.info("Map indexing is disabled");
+    }
 
     serverConfiguration.registerRequestFilter(
         environment, BannedPlayerFilter.newBannedPlayerFilter(jdbi));

--- a/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/SpitfireServerConfig.java
+++ b/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/SpitfireServerConfig.java
@@ -56,4 +56,8 @@ public class SpitfireServerConfig extends Configuration
   @Getter(onMethod_ = {@JsonProperty, @Override})
   @Setter(onMethod_ = {@JsonProperty})
   private String githubMapsOrgName;
+
+  @Getter(onMethod_ = {@JsonProperty})
+  @Setter(onMethod_ = {@JsonProperty})
+  private boolean mapIndexingEnabled;
 }


### PR DESCRIPTION
Add a param to configuration.yml to disable map indexing. By default
map indexing will be enabled. Smoke-testing is updated here to
disable map indexing. Smoke tests do not exercise map download and
have no need to hit the github API.

