### PR TITLE
Do not set invalid 'test' auth token for github API

### DIFF
--- a/http-clients/github-client/src/main/java/org/triplea/http/client/github/GithubApiClient.java
+++ b/http-clients/github-client/src/main/java/org/triplea/http/client/github/GithubApiClient.java
@@ -58,7 +58,7 @@ public class GithubApiClient {
     // authToken is not required, can happen in dev environments.
     // Without an auth token the only consequence is the github API rate
     // limit is more strict.
-    if (authToken != null && !authToken.isBlank()) {
+    if (authToken != null && !authToken.isBlank() && !authToken.equalsIgnoreCase("test")) {
       tokens.put("Authorization", "token " + authToken);
     }
     return tokens;


### PR DESCRIPTION
By default the auth token set to use with github is 'test'.
Sending this to github results in an 'access-denied'. This is
good if smoke tests are running, otherwise is not desirable.
Sending no token is fine, it incurs a rate limit.

This update does not set the github auth token when set to
the default value. This allows map indexing and other github
API interactions to work out of the box.

