### PR TITLE
Rename 'DownloadedMaps' -> 'InstalledMaps'

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/auto/update/UpdatedMapsCheck.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/auto/update/UpdatedMapsCheck.java
@@ -51,12 +51,10 @@ class UpdatedMapsCheck {
       return;
     }
 
-    final DownloadedMapsListing downloadedMapsListing = DownloadedMapsListing.parseMapFiles();
+    final InstalledMapsListing installedMapsListing = InstalledMapsListing.parseMapFiles();
 
     final Collection<String> outOfDateMapNames =
-        computeOutOfDateMaps(
-            availableToDownloadMaps,
-            name -> InstalledMapsListing.parseMapFiles().getMapVersionByName(name));
+        computeOutOfDateMaps(availableToDownloadMaps, installedMapsListing::getMapVersionByName);
 
     if (!outOfDateMapNames.isEmpty()) {
       promptUserToUpdateMaps(outOfDateMapNames);

--- a/game-app/game-core/src/main/java/games/strategy/engine/auto/update/UpdatedMapsCheck.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/auto/update/UpdatedMapsCheck.java
@@ -3,7 +3,7 @@ package games.strategy.engine.auto.update;
 import com.google.common.annotations.VisibleForTesting;
 import games.strategy.engine.framework.map.download.DownloadFileDescription;
 import games.strategy.engine.framework.map.download.DownloadMapsWindow;
-import games.strategy.engine.framework.map.file.system.loader.DownloadedMapsListing;
+import games.strategy.engine.framework.map.file.system.loader.InstalledMapsListing;
 import games.strategy.engine.framework.map.listing.MapListingFetcher;
 import games.strategy.triplea.settings.ClientSetting;
 import java.time.Instant;
@@ -54,7 +54,7 @@ class UpdatedMapsCheck {
     final Collection<String> outOfDateMapNames =
         computeOutOfDateMaps(
             availableToDownloadMaps,
-            name -> DownloadedMapsListing.parseMapFiles().getMapVersionByName(name));
+            name -> InstalledMapsListing.parseMapFiles().getMapVersionByName(name));
 
     if (!outOfDateMapNames.isEmpty()) {
       promptUserToUpdateMaps(outOfDateMapNames);

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/AvailableMapsListing.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/AvailableMapsListing.java
@@ -3,7 +3,7 @@ package games.strategy.engine.framework.map.download;
 import static java.util.function.Predicate.not;
 
 import com.google.common.annotations.VisibleForTesting;
-import games.strategy.engine.framework.map.file.system.loader.DownloadedMapsListing;
+import games.strategy.engine.framework.map.file.system.loader.InstalledMapsListing;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -18,22 +18,22 @@ class AvailableMapsListing {
   private final List<DownloadFileDescription> outOfDate = new ArrayList<>();
 
   AvailableMapsListing(final Collection<DownloadFileDescription> downloads) {
-    this(downloads, DownloadedMapsListing.parseMapFiles());
+    this(downloads, InstalledMapsListing.parseMapFiles());
   }
 
   @VisibleForTesting
   AvailableMapsListing(
       final Collection<DownloadFileDescription> downloads,
-      final DownloadedMapsListing downloadedMapsListing) {
+      final InstalledMapsListing installedMapsListing) {
     for (final DownloadFileDescription download : downloads) {
       if (download == null) {
         return;
       }
 
-      if (!downloadedMapsListing.isMapInstalled(download.getMapName())) {
+      if (!installedMapsListing.isMapInstalled(download.getMapName())) {
         available.add(download);
       } else {
-        final int mapVersion = downloadedMapsListing.getMapVersionByName(download.getMapName());
+        final int mapVersion = installedMapsListing.getMapVersionByName(download.getMapName());
         if (download.getVersion() != null && download.getVersion() > mapVersion) {
           outOfDate.add(download);
         } else {

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
@@ -1,7 +1,7 @@
 package games.strategy.engine.framework.map.download;
 
 import com.google.common.base.MoreObjects;
-import games.strategy.engine.framework.map.file.system.loader.DownloadedMapsListing;
+import games.strategy.engine.framework.map.file.system.loader.InstalledMapsListing;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -92,7 +92,7 @@ public final class DownloadFileDescription {
 
   public static DownloadFileDescription ofMapDownloadListing(
       final MapDownloadListing mapDownloadListing,
-      final DownloadedMapsListing downloadedMapsListing) {
+      final InstalledMapsListing installedMapsListing) {
     return DownloadFileDescription.builder()
         .url(mapDownloadListing.getUrl())
         .mapName(mapDownloadListing.getMapName())
@@ -100,7 +100,7 @@ public final class DownloadFileDescription {
         .version(1)
         .mapCategory(MapCategory.fromString(mapDownloadListing.getMapCategory()))
         .installLocation(
-            downloadedMapsListing.findMapFolderByName(mapDownloadListing.getMapName()).orElse(null))
+            installedMapsListing.findMapFolderByName(mapDownloadListing.getMapName()).orElse(null))
         .build();
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
@@ -3,7 +3,7 @@ package games.strategy.engine.framework.map.download;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.base.Strings;
-import games.strategy.engine.framework.map.file.system.loader.DownloadedMapsListing;
+import games.strategy.engine.framework.map.file.system.loader.InstalledMapsListing;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -41,7 +41,7 @@ final class DownloadFileParser {
     final List<Map<String, Object>> yamlData = YamlReader.readList(is);
 
     final List<DownloadFileDescription> downloads = new ArrayList<>();
-    final DownloadedMapsListing downloadedMapsListing = DownloadedMapsListing.parseMapFiles();
+    final InstalledMapsListing installedMapsListing = InstalledMapsListing.parseMapFiles();
     yamlData.stream()
         .map(Map.class::cast)
         .forEach(
@@ -70,7 +70,7 @@ final class DownloadFileParser {
                       .mapCategory(mapCategory)
                       .img(img)
                       .installLocation(
-                          downloadedMapsListing.findMapFolderByName(mapName).orElse(null))
+                          installedMapsListing.findMapFolderByName(mapName).orElse(null))
                       .build());
             });
     return downloads;

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMap.java
@@ -13,7 +13,7 @@ import org.triplea.util.LocalizeHtml;
 
 /** Object representing a map that is downloaded and installed. */
 @AllArgsConstructor
-public class DownloadedMap {
+public class InstalledMap {
   private final MapDescriptionYaml mapDescriptionYaml;
 
   public String getMapName() {

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/listing/MapListingFetcher.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/listing/MapListingFetcher.java
@@ -2,7 +2,7 @@ package games.strategy.engine.framework.map.listing;
 
 import games.strategy.engine.framework.map.download.DownloadFileDescription;
 import games.strategy.engine.framework.map.download.DownloadRunnable;
-import games.strategy.engine.framework.map.file.system.loader.DownloadedMapsListing;
+import games.strategy.engine.framework.map.file.system.loader.InstalledMapsListing;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.triplea.settings.ClientSetting;
 import java.net.URI;
@@ -18,10 +18,10 @@ import org.triplea.live.servers.LiveServersFetcher.LobbyAddressFetchException;
 @Slf4j
 public class MapListingFetcher {
 
-  private final DownloadedMapsListing downloadedMapsListing;
+  private final InstalledMapsListing installedMapsListing;
 
   private MapListingFetcher() {
-    downloadedMapsListing = DownloadedMapsListing.parseMapFiles();
+    installedMapsListing = InstalledMapsListing.parseMapFiles();
   }
 
   /**
@@ -59,7 +59,7 @@ public class MapListingFetcher {
       final List<MapDownloadListing> downloadListings) {
 
     return downloadListings.stream()
-        .map(map -> DownloadFileDescription.ofMapDownloadListing(map, downloadedMapsListing))
+        .map(map -> DownloadFileDescription.ofMapDownloadListing(map, installedMapsListing))
         .collect(Collectors.toList());
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -8,7 +8,7 @@ import games.strategy.engine.data.properties.IEditableProperty;
 import games.strategy.engine.data.properties.PropertiesUi;
 import games.strategy.engine.framework.HeadlessAutoSaveType;
 import games.strategy.engine.framework.map.download.DownloadMapsWindow;
-import games.strategy.engine.framework.map.file.system.loader.DownloadedMapsListing;
+import games.strategy.engine.framework.map.file.system.loader.InstalledMapsListing;
 import games.strategy.engine.framework.startup.mc.ClientModel;
 import games.strategy.engine.framework.startup.ui.FileBackedGamePropertiesCache;
 import games.strategy.engine.framework.startup.ui.IGamePropertiesCache;
@@ -377,13 +377,13 @@ public final class GameSelectorPanel extends JPanel implements Observer {
 
   private void selectGameFile() {
     try {
-      final DownloadedMapsListing downloadedMapsListing =
+      final InstalledMapsListing installedMapsListing =
           BackgroundTaskRunner.runInBackgroundAndReturn(
-              "Loading all available games...", DownloadedMapsListing::parseMapFiles);
+              "Loading all available games...", InstalledMapsListing::parseMapFiles);
 
       GameChooser.chooseGame(
           JOptionPane.getFrameForComponent(this),
-          downloadedMapsListing,
+          installedMapsListing,
           model.getGameName(),
           this::gameSelected);
     } catch (final InterruptedException e) {

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/DefaultGameChooserEntry.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/DefaultGameChooserEntry.java
@@ -1,6 +1,6 @@
 package games.strategy.engine.framework.ui;
 
-import games.strategy.engine.framework.map.file.system.loader.DownloadedMap;
+import games.strategy.engine.framework.map.file.system.loader.InstalledMap;
 import java.nio.file.Path;
 import java.util.Optional;
 import lombok.Builder;
@@ -9,7 +9,7 @@ import lombok.Getter;
 @Builder
 @Getter
 public class DefaultGameChooserEntry implements Comparable<DefaultGameChooserEntry> {
-  private final DownloadedMap downloadedMap;
+  private final InstalledMap installedMap;
   private final String gameName;
 
   @Override
@@ -27,7 +27,7 @@ public class DefaultGameChooserEntry implements Comparable<DefaultGameChooserEnt
     if (rhs instanceof DefaultGameChooserEntry) {
       final var chooserEntry = (DefaultGameChooserEntry) rhs;
       return chooserEntry.gameName.equals(gameName)
-          && downloadedMap.getMapName().equals(chooserEntry.downloadedMap.getMapName());
+          && installedMap.getMapName().equals(chooserEntry.installedMap.getMapName());
     } else {
       return false;
     }
@@ -35,14 +35,14 @@ public class DefaultGameChooserEntry implements Comparable<DefaultGameChooserEnt
 
   @Override
   public int hashCode() {
-    return gameName.hashCode() * downloadedMap.getMapName().hashCode();
+    return gameName.hashCode() * installedMap.getMapName().hashCode();
   }
 
   String readGameNotes() {
-    return downloadedMap.readGameNotes(gameName).orElse("");
+    return installedMap.readGameNotes(gameName).orElse("");
   }
 
   Optional<Path> getGameXmlFilePath() {
-    return downloadedMap.getGameXmlFilePath(gameName);
+    return installedMap.getGameXmlFilePath(gameName);
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
@@ -1,6 +1,6 @@
 package games.strategy.engine.framework.ui;
 
-import games.strategy.engine.framework.map.file.system.loader.DownloadedMapsListing;
+import games.strategy.engine.framework.map.file.system.loader.InstalledMapsListing;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -48,7 +48,7 @@ public class GameChooser {
    */
   public static void chooseGame(
       final Frame owner,
-      final DownloadedMapsListing downloadedMapsListing,
+      final InstalledMapsListing installedMapsListing,
       final String gameName,
       final Consumer<Path> gameChosenCallback) {
 
@@ -56,7 +56,7 @@ public class GameChooser {
     dialog.setLayout(new BorderLayout());
 
     final DefaultListModel<DefaultGameChooserEntry> gameChooserModel = new DefaultListModel<>();
-    downloadedMapsListing //
+    installedMapsListing //
         .createGameChooserEntries()
         .forEach(gameChooserModel::addElement);
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -3,7 +3,7 @@ package games.strategy.triplea;
 import com.google.common.annotations.VisibleForTesting;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.map.download.DownloadMapsWindow;
-import games.strategy.engine.framework.map.file.system.loader.DownloadedMapsListing;
+import games.strategy.engine.framework.map.file.system.loader.InstalledMapsListing;
 import games.strategy.engine.framework.startup.launcher.MapNotFoundException;
 import games.strategy.triplea.ui.OrderedProperties;
 import java.awt.Image;
@@ -47,7 +47,7 @@ public class ResourceLoader implements Closeable {
     mapLocation =
         mapName == null || mapName.isBlank()
             ? null
-            : DownloadedMapsListing.parseMapFiles()
+            : InstalledMapsListing.parseMapFiles()
                 .findContentRootForMapName(mapName)
                 .orElseThrow(
                     () -> {

--- a/game-app/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
+++ b/game-app/game-core/src/main/java/org/triplea/game/server/HeadlessGameServer.java
@@ -18,7 +18,7 @@ import games.strategy.engine.framework.ArgParser;
 import games.strategy.engine.framework.GameDataManager;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.ServerGame;
-import games.strategy.engine.framework.map.file.system.loader.DownloadedMapsListing;
+import games.strategy.engine.framework.map.file.system.loader.InstalledMapsListing;
 import games.strategy.engine.framework.map.file.system.loader.ZippedMapsExtractor;
 import games.strategy.engine.framework.startup.mc.ServerModel;
 import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorModel;
@@ -41,7 +41,7 @@ public class HeadlessGameServer {
   public static final String BOT_GAME_HOST_NAME_PREFIX = "Bot";
   private static HeadlessGameServer instance = null;
 
-  private final DownloadedMapsListing availableGames = DownloadedMapsListing.parseMapFiles();
+  private final InstalledMapsListing availableGames = InstalledMapsListing.parseMapFiles();
   private final GameSelectorModel gameSelectorModel = new GameSelectorModel();
   private final HeadlessServerSetupPanelModel setupPanelModel =
       new HeadlessServerSetupPanelModel(gameSelectorModel);

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/AvailableMapsListingTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/AvailableMapsListingTest.java
@@ -5,8 +5,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 
-import games.strategy.engine.framework.map.file.system.loader.DownloadedMap;
-import games.strategy.engine.framework.map.file.system.loader.DownloadedMapsListing;
+import games.strategy.engine.framework.map.file.system.loader.InstalledMap;
+import games.strategy.engine.framework.map.file.system.loader.InstalledMapsListing;
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import java.nio.file.Path;
 import java.util.List;
@@ -29,10 +29,10 @@ class AvailableMapsListingTest extends AbstractClientSettingTestCase {
 
   @Test
   void testAvailable() {
-    final DownloadedMapsListing downloadedMapsListing = new DownloadedMapsListing(List.of());
+    final InstalledMapsListing installedMapsListing = new InstalledMapsListing(List.of());
 
     final AvailableMapsListing availableMapsListing =
-        new AvailableMapsListing(List.of(TEST_MAP), downloadedMapsListing);
+        new AvailableMapsListing(List.of(TEST_MAP), installedMapsListing);
 
     assertThat(availableMapsListing.getAvailable(), hasSize(1));
     assertThat(availableMapsListing.getInstalled(), is(empty()));
@@ -41,13 +41,13 @@ class AvailableMapsListingTest extends AbstractClientSettingTestCase {
 
   @Test
   void testAvailableExcluding() {
-    final DownloadedMapsListing downloadedMapsListing = new DownloadedMapsListing(List.of());
+    final InstalledMapsListing installedMapsListing = new InstalledMapsListing(List.of());
 
     final DownloadFileDescription download1 = newDownloadWithUrl("url1");
     final DownloadFileDescription download2 = newDownloadWithUrl("url2");
     final DownloadFileDescription download3 = newDownloadWithUrl("url3");
     final AvailableMapsListing availableMapsListing =
-        new AvailableMapsListing(List.of(download1, download2, download3), downloadedMapsListing);
+        new AvailableMapsListing(List.of(download1, download2, download3), installedMapsListing);
 
     final List<DownloadFileDescription> available =
         availableMapsListing.getAvailableExcluding(List.of(download1, download3));
@@ -78,26 +78,25 @@ class AvailableMapsListingTest extends AbstractClientSettingTestCase {
 
   @Test
   void testInstalled() {
-    final DownloadedMapsListing downloadedMapsListing =
+    final InstalledMapsListing installedMapsListing =
         buildIndexWithMapVersions(Map.of("mapName url", MAP_VERSION));
 
     final AvailableMapsListing availableMapsListing =
-        new AvailableMapsListing(
-            List.of(newInstalledDownloadWithUrl("url")), downloadedMapsListing);
+        new AvailableMapsListing(List.of(newInstalledDownloadWithUrl("url")), installedMapsListing);
 
     assertThat(availableMapsListing.getAvailable(), is(empty()));
     assertThat(availableMapsListing.getInstalled(), hasSize(1));
     assertThat(availableMapsListing.getOutOfDate(), is(empty()));
   }
 
-  private static DownloadedMapsListing buildIndexWithMapVersions(
+  private static InstalledMapsListing buildIndexWithMapVersions(
       final Map<String, Integer> mapNameToVersion) {
 
-    return new DownloadedMapsListing(
+    return new InstalledMapsListing(
         mapNameToVersion.entrySet().stream()
             .map(
                 entry ->
-                    new DownloadedMap(
+                    new InstalledMap(
                         MapDescriptionYaml.builder()
                             .yamlFileLocation(Path.of("/local/file").toUri())
                             .mapName(entry.getKey())
@@ -114,11 +113,10 @@ class AvailableMapsListingTest extends AbstractClientSettingTestCase {
 
   @Test
   void testOutOfDate() {
-    final DownloadedMapsListing downloadedMapsListing =
+    final InstalledMapsListing installedMapsListing =
         buildIndexWithMapVersions(Map.of("mapName url", MAP_VERSION - 1));
     final AvailableMapsListing availableMapsListing =
-        new AvailableMapsListing(
-            List.of(newInstalledDownloadWithUrl("url")), downloadedMapsListing);
+        new AvailableMapsListing(List.of(newInstalledDownloadWithUrl("url")), installedMapsListing);
 
     assertThat(availableMapsListing.getAvailable(), is(empty()));
     assertThat(availableMapsListing.getInstalled(), is(empty()));
@@ -131,7 +129,7 @@ class AvailableMapsListingTest extends AbstractClientSettingTestCase {
     final DownloadFileDescription download2 = newInstalledDownloadWithUrl("url2");
     final DownloadFileDescription download3 = newInstalledDownloadWithUrl("url3");
 
-    final DownloadedMapsListing downloadedMapsListing =
+    final InstalledMapsListing installedMapsListing =
         buildIndexWithMapVersions(
             Map.of(
                 download1.getMapName(), download1.getVersion() - 1,
@@ -139,7 +137,7 @@ class AvailableMapsListingTest extends AbstractClientSettingTestCase {
                 download3.getMapName(), download3.getVersion() - 1));
 
     final AvailableMapsListing availableMapsListing =
-        new AvailableMapsListing(List.of(download1, download2, download3), downloadedMapsListing);
+        new AvailableMapsListing(List.of(download1, download2, download3), installedMapsListing);
 
     final List<DownloadFileDescription> outOfDate =
         availableMapsListing.getOutOfDateExcluding(List.of(download1, download3));

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadMapsWindowMapsListingTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadMapsWindowMapsListingTest.java
@@ -5,8 +5,8 @@ import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 
-import games.strategy.engine.framework.map.file.system.loader.DownloadedMap;
-import games.strategy.engine.framework.map.file.system.loader.DownloadedMapsListing;
+import games.strategy.engine.framework.map.file.system.loader.InstalledMap;
+import games.strategy.engine.framework.map.file.system.loader.InstalledMapsListing;
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import java.nio.file.Path;
 import java.util.List;
@@ -29,10 +29,10 @@ class DownloadMapsWindowMapsListingTest extends AbstractClientSettingTestCase {
 
   @Test
   void testAvailable() {
-    final DownloadedMapsListing downloadedMapsListing = new DownloadedMapsListing(List.of());
+    final InstalledMapsListing installedMapsListing = new InstalledMapsListing(List.of());
 
     final DownloadMapsWindowMapsListing downloadMapsWindowMapsListing =
-        new DownloadMapsWindowMapsListing(List.of(TEST_MAP), downloadedMapsListing);
+        new DownloadMapsWindowMapsListing(List.of(TEST_MAP), installedMapsListing);
 
     assertThat(downloadMapsWindowMapsListing.getAvailable(), hasSize(1));
     assertThat(downloadMapsWindowMapsListing.getInstalled(), is(empty()));
@@ -41,14 +41,14 @@ class DownloadMapsWindowMapsListingTest extends AbstractClientSettingTestCase {
 
   @Test
   void testAvailableExcluding() {
-    final DownloadedMapsListing downloadedMapsListing = new DownloadedMapsListing(List.of());
+    final InstalledMapsListing installedMapsListing = new InstalledMapsListing(List.of());
 
     final DownloadFileDescription download1 = newDownloadWithUrl("url1");
     final DownloadFileDescription download2 = newDownloadWithUrl("url2");
     final DownloadFileDescription download3 = newDownloadWithUrl("url3");
     final DownloadMapsWindowMapsListing downloadMapsWindowMapsListing =
         new DownloadMapsWindowMapsListing(
-            List.of(download1, download2, download3), downloadedMapsListing);
+            List.of(download1, download2, download3), installedMapsListing);
 
     final List<DownloadFileDescription> available =
         downloadMapsWindowMapsListing.getAvailableExcluding(List.of(download1, download3));
@@ -84,7 +84,7 @@ class DownloadMapsWindowMapsListingTest extends AbstractClientSettingTestCase {
 
     final DownloadMapsWindowMapsListing downloadMapsWindowMapsListing =
         new DownloadMapsWindowMapsListing(
-            List.of(newInstalledDownloadWithUrl("url")), downloadedMapsListing);
+            List.of(newInstalledDownloadWithUrl("url")), installedMapsListing);
 
     assertThat(downloadMapsWindowMapsListing.getAvailable(), is(empty()));
     assertThat(downloadMapsWindowMapsListing.getInstalled(), hasSize(1));
@@ -119,7 +119,7 @@ class DownloadMapsWindowMapsListingTest extends AbstractClientSettingTestCase {
         buildIndexWithMapVersions(Map.of("mapName url", MAP_VERSION - 1));
     final DownloadMapsWindowMapsListing downloadMapsWindowMapsListing =
         new DownloadMapsWindowMapsListing(
-            List.of(newInstalledDownloadWithUrl("url")), downloadedMapsListing);
+            List.of(newInstalledDownloadWithUrl("url")), installedMapsListing);
 
     assertThat(downloadMapsWindowMapsListing.getAvailable(), is(empty()));
     assertThat(downloadMapsWindowMapsListing.getInstalled(), is(empty()));
@@ -141,10 +141,10 @@ class DownloadMapsWindowMapsListingTest extends AbstractClientSettingTestCase {
 
     final DownloadMapsWindowMapsListing downloadMapsWindowMapsListing =
         new DownloadMapsWindowMapsListing(
-            List.of(download1, download2, download3), downloadedMapsListing);
+            List.of(download1, download2, download3), installedMapsListing);
 
     final List<DownloadFileDescription> outOfDate =
-        availableMapsListing.getOutOfDateExcluding(List.of(download1, download3));
+        downloadMapsWindowMapsListing.getOutOfDateExcluding(List.of(download1, download3));
 
     assertThat(outOfDate, is(List.of(download2)));
   }

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/map/file/system/loader/InstalledMapsListingTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/map/file/system/loader/InstalledMapsListingTest.java
@@ -12,12 +12,12 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.triplea.map.description.file.MapDescriptionYaml;
 
-class DownloadedMapsListingTest {
+class InstalledMapsListingTest {
 
-  final DownloadedMapsListing downloadedMapsListing =
-      new DownloadedMapsListing(
+  final InstalledMapsListing installedMapsListing =
+      new InstalledMapsListing(
           List.of(
-              new DownloadedMap(
+              new InstalledMap(
                   MapDescriptionYaml.builder()
                       .yamlFileLocation(Path.of("/path/map0/map.yml").toUri())
                       .mapName("map-name0")
@@ -29,7 +29,7 @@ class DownloadedMapsListingTest {
                                   .xmlFileName("path.xml")
                                   .build()))
                       .build()),
-              new DownloadedMap(
+              new InstalledMap(
                   MapDescriptionYaml.builder()
                       .yamlFileLocation(Path.of("/path/map1/map.yml").toUri())
                       .mapName("map-name1")
@@ -48,7 +48,7 @@ class DownloadedMapsListingTest {
 
   @Test
   void getSortedGamesList() {
-    final List<String> sortedGameNames = downloadedMapsListing.getSortedGameList();
+    final List<String> sortedGameNames = installedMapsListing.getSortedGameList();
 
     assertThat(sortedGameNames, hasSize(3));
     assertThat(sortedGameNames, hasItems("aGame0", "gameName0", "gameName1"));
@@ -58,15 +58,15 @@ class DownloadedMapsListingTest {
   void getMapVersionByName() {
     assertThat(
         "If a map does not exist, we default version value to '0'",
-        downloadedMapsListing.getMapVersionByName("DNE"),
+        installedMapsListing.getMapVersionByName("DNE"),
         is(0));
     assertThat(
         "This map in the listing has a version value of '0'",
-        downloadedMapsListing.getMapVersionByName("map-name0"),
+        installedMapsListing.getMapVersionByName("map-name0"),
         is(0));
     assertThat(
         "This map in the listing has a version value of '2'",
-        downloadedMapsListing.getMapVersionByName("map-name1"),
+        installedMapsListing.getMapVersionByName("map-name1"),
         is(2));
   }
 
@@ -81,7 +81,7 @@ class DownloadedMapsListingTest {
         "name0"
       })
   void isMapInstalled_NegativeCases(final String mapName) {
-    assertThat(downloadedMapsListing.isMapInstalled(mapName), is(false));
+    assertThat(installedMapsListing.isMapInstalled(mapName), is(false));
   }
 
   /** Verify match is not case sensitive with insignificant characters ignored */
@@ -98,6 +98,6 @@ class DownloadedMapsListingTest {
         "MAPNAME0"
       })
   void isMapInstalled_PositiveCases(final String mapName) {
-    assertThat(downloadedMapsListing.isMapInstalled(mapName), is(true));
+    assertThat(installedMapsListing.isMapInstalled(mapName), is(true));
   }
 }


### PR DESCRIPTION
Also renames 'DownloadedMapsListing' -> 'InstalledMapsListing'

The reason for this rename is to make it more clear that these
are installed maps that have already been downloaded and are
not recent downloads or merely available to download. The difference
in terms makes it easier to distinguish from maps that are available
for download.
