### PR TITLE
Rename 'AvailableMapsListing' -> 'DownloadMapsWindowMapsListing'

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -283,7 +283,7 @@ public class DownloadMapsWindow extends JFrame {
   private JTabbedPane newAvailableInstalledTabbedPanel(
       final List<DownloadFileDescription> downloads,
       final Set<DownloadFileDescription> pendingDownloads) {
-    final AvailableMapsListing mapList = new AvailableMapsListing(downloads);
+    final DownloadMapsWindowMapsListing mapList = new DownloadMapsWindowMapsListing(downloads);
 
     final JTabbedPane tabbedPane = new JTabbedPane();
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindowMapsListing.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindowMapsListing.java
@@ -11,18 +11,18 @@ import java.util.stream.Collectors;
 import lombok.Getter;
 
 @Getter
-class AvailableMapsListing {
+class DownloadMapsWindowMapsListing {
 
   private final List<DownloadFileDescription> available = new ArrayList<>();
   private final List<DownloadFileDescription> installed = new ArrayList<>();
   private final List<DownloadFileDescription> outOfDate = new ArrayList<>();
 
-  AvailableMapsListing(final Collection<DownloadFileDescription> downloads) {
+  DownloadMapsWindowMapsListing(final Collection<DownloadFileDescription> downloads) {
     this(downloads, DownloadedMapsListing.parseMapFiles());
   }
 
   @VisibleForTesting
-  AvailableMapsListing(
+  DownloadMapsWindowMapsListing(
       final Collection<DownloadFileDescription> downloads,
       final DownloadedMapsListing downloadedMapsListing) {
     for (final DownloadFileDescription download : downloads) {

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadMapsWindowMapsListingTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadMapsWindowMapsListingTest.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 import org.triplea.map.description.file.MapDescriptionYaml;
 
-class AvailableMapsListingTest extends AbstractClientSettingTestCase {
+class DownloadMapsWindowMapsListingTest extends AbstractClientSettingTestCase {
   private static final String MAP_NAME = "new_test_order";
   private static final int MAP_VERSION = 10;
 
@@ -31,12 +31,12 @@ class AvailableMapsListingTest extends AbstractClientSettingTestCase {
   void testAvailable() {
     final DownloadedMapsListing downloadedMapsListing = new DownloadedMapsListing(List.of());
 
-    final AvailableMapsListing availableMapsListing =
-        new AvailableMapsListing(List.of(TEST_MAP), downloadedMapsListing);
+    final DownloadMapsWindowMapsListing downloadMapsWindowMapsListing =
+        new DownloadMapsWindowMapsListing(List.of(TEST_MAP), downloadedMapsListing);
 
-    assertThat(availableMapsListing.getAvailable(), hasSize(1));
-    assertThat(availableMapsListing.getInstalled(), is(empty()));
-    assertThat(availableMapsListing.getOutOfDate(), is(empty()));
+    assertThat(downloadMapsWindowMapsListing.getAvailable(), hasSize(1));
+    assertThat(downloadMapsWindowMapsListing.getInstalled(), is(empty()));
+    assertThat(downloadMapsWindowMapsListing.getOutOfDate(), is(empty()));
   }
 
   @Test
@@ -46,11 +46,12 @@ class AvailableMapsListingTest extends AbstractClientSettingTestCase {
     final DownloadFileDescription download1 = newDownloadWithUrl("url1");
     final DownloadFileDescription download2 = newDownloadWithUrl("url2");
     final DownloadFileDescription download3 = newDownloadWithUrl("url3");
-    final AvailableMapsListing availableMapsListing =
-        new AvailableMapsListing(List.of(download1, download2, download3), downloadedMapsListing);
+    final DownloadMapsWindowMapsListing downloadMapsWindowMapsListing =
+        new DownloadMapsWindowMapsListing(
+            List.of(download1, download2, download3), downloadedMapsListing);
 
     final List<DownloadFileDescription> available =
-        availableMapsListing.getAvailableExcluding(List.of(download1, download3));
+        downloadMapsWindowMapsListing.getAvailableExcluding(List.of(download1, download3));
 
     assertThat(available, is(List.of(download2)));
   }
@@ -81,13 +82,13 @@ class AvailableMapsListingTest extends AbstractClientSettingTestCase {
     final DownloadedMapsListing downloadedMapsListing =
         buildIndexWithMapVersions(Map.of("mapName url", MAP_VERSION));
 
-    final AvailableMapsListing availableMapsListing =
-        new AvailableMapsListing(
+    final DownloadMapsWindowMapsListing downloadMapsWindowMapsListing =
+        new DownloadMapsWindowMapsListing(
             List.of(newInstalledDownloadWithUrl("url")), downloadedMapsListing);
 
-    assertThat(availableMapsListing.getAvailable(), is(empty()));
-    assertThat(availableMapsListing.getInstalled(), hasSize(1));
-    assertThat(availableMapsListing.getOutOfDate(), is(empty()));
+    assertThat(downloadMapsWindowMapsListing.getAvailable(), is(empty()));
+    assertThat(downloadMapsWindowMapsListing.getInstalled(), hasSize(1));
+    assertThat(downloadMapsWindowMapsListing.getOutOfDate(), is(empty()));
   }
 
   private static DownloadedMapsListing buildIndexWithMapVersions(
@@ -116,13 +117,13 @@ class AvailableMapsListingTest extends AbstractClientSettingTestCase {
   void testOutOfDate() {
     final DownloadedMapsListing downloadedMapsListing =
         buildIndexWithMapVersions(Map.of("mapName url", MAP_VERSION - 1));
-    final AvailableMapsListing availableMapsListing =
-        new AvailableMapsListing(
+    final DownloadMapsWindowMapsListing downloadMapsWindowMapsListing =
+        new DownloadMapsWindowMapsListing(
             List.of(newInstalledDownloadWithUrl("url")), downloadedMapsListing);
 
-    assertThat(availableMapsListing.getAvailable(), is(empty()));
-    assertThat(availableMapsListing.getInstalled(), is(empty()));
-    assertThat(availableMapsListing.getOutOfDate(), hasSize(1));
+    assertThat(downloadMapsWindowMapsListing.getAvailable(), is(empty()));
+    assertThat(downloadMapsWindowMapsListing.getInstalled(), is(empty()));
+    assertThat(downloadMapsWindowMapsListing.getOutOfDate(), hasSize(1));
   }
 
   @Test
@@ -138,11 +139,12 @@ class AvailableMapsListingTest extends AbstractClientSettingTestCase {
                 download2.getMapName(), download2.getVersion() - 1,
                 download3.getMapName(), download3.getVersion() - 1));
 
-    final AvailableMapsListing availableMapsListing =
-        new AvailableMapsListing(List.of(download1, download2, download3), downloadedMapsListing);
+    final DownloadMapsWindowMapsListing downloadMapsWindowMapsListing =
+        new DownloadMapsWindowMapsListing(
+            List.of(download1, download2, download3), downloadedMapsListing);
 
     final List<DownloadFileDescription> outOfDate =
-        availableMapsListing.getOutOfDateExcluding(List.of(download1, download3));
+        downloadMapsWindowMapsListing.getOutOfDateExcluding(List.of(download1, download3));
 
     assertThat(outOfDate, is(List.of(download2)));
   }


### PR DESCRIPTION
Just a simple class rename. DownloadMapsWindowMapsListing is very
wordy but makes it more clear which map listing it refers to.
There are three map listings, availalbe, installed, and the listing
that is presented in the maps window. This rename makes it clear
which listing this represents.
