### PR TITLE
Fix out-of-date maps check recomputing available maps

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/auto/update/UpdatedMapsCheck.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/auto/update/UpdatedMapsCheck.java
@@ -51,10 +51,10 @@ class UpdatedMapsCheck {
       return;
     }
 
+    final DownloadedMapsListing downloadedMapsListing = DownloadedMapsListing.parseMapFiles();
+
     final Collection<String> outOfDateMapNames =
-        computeOutOfDateMaps(
-            availableToDownloadMaps,
-            name -> DownloadedMapsListing.parseMapFiles().getMapVersionByName(name));
+        computeOutOfDateMaps(availableToDownloadMaps, downloadedMapsListing::getMapVersionByName);
 
     if (!outOfDateMapNames.isEmpty()) {
       promptUserToUpdateMaps(outOfDateMapNames);


### PR DESCRIPTION
This update moves the call to 'DownloadedMapsListing.parseMapFiles()'
to outside of our out-of-date computation function. This avoids
repetitious calls to parsing the available files.

This likely fixes the performance problem reported in:
https://github.com/triplea-game/triplea/issues/9301

