### PR TITLE
Send system-id headers to maps listing endpoint

### DIFF
--- a/http-clients/maps-client/src/main/java/org/triplea/http/client/maps/listing/MapsListingClient.java
+++ b/http-clients/maps-client/src/main/java/org/triplea/http/client/maps/listing/MapsListingClient.java
@@ -2,6 +2,7 @@ package org.triplea.http.client.maps.listing;
 
 import java.net.URI;
 import java.util.List;
+import org.triplea.http.client.AuthenticationHeaders;
 import org.triplea.http.client.HttpClient;
 
 /**
@@ -16,6 +17,6 @@ public class MapsListingClient {
   }
 
   public List<MapDownloadListing> fetchMapDownloads() {
-    return mapsListingFeignClient.fetchMapListing();
+    return mapsListingFeignClient.fetchMapListing(AuthenticationHeaders.systemIdHeaders());
   }
 }

--- a/http-clients/maps-client/src/main/java/org/triplea/http/client/maps/listing/MapsListingFeignClient.java
+++ b/http-clients/maps-client/src/main/java/org/triplea/http/client/maps/listing/MapsListingFeignClient.java
@@ -1,9 +1,11 @@
 package org.triplea.http.client.maps.listing;
 
 import feign.FeignException;
+import feign.HeaderMap;
 import feign.Headers;
 import feign.RequestLine;
 import java.util.List;
+import java.util.Map;
 import org.triplea.http.client.HttpConstants;
 
 @Headers({HttpConstants.CONTENT_TYPE_JSON, HttpConstants.ACCEPT_JSON})
@@ -15,5 +17,5 @@ public interface MapsListingFeignClient {
    * @throws FeignException Thrown on non-2xx responses.
    */
   @RequestLine("GET " + MapsListingClient.MAPS_LISTING_PATH)
-  List<MapDownloadListing> fetchMapListing();
+  List<MapDownloadListing> fetchMapListing(@HeaderMap Map<String, Object> headers);
 }


### PR DESCRIPTION
Without system-id headers the server will respond with a 401.

