### PR TITLE
Parameterize map indexing rate

### DIFF
--- a/infrastructure/ansible/roles/lobby_server/defaults/main.yml
+++ b/infrastructure/ansible/roles/lobby_server/defaults/main.yml
@@ -15,3 +15,14 @@ lobby_artifact_download: |
   "{{ github_releases_url }}/{{ lobby_version }}/{{ lobby_artifact }}"
 lobby_restart_on_new_deployment: true
 
+# How often to run map indexing. We need to be able to index all maps
+# before the next run starts to avoid overlapping runs. The smaller this
+# value the more responsive indexing will be to map updates.
+# 120 -> 2 hours in between runs -> (if indexing 360 / hour) -> 720 maps to be indexed per run
+map_indexing_period_minutes: 120
+
+# Indexing delay is how much of a backoff there is between indexing
+# each map. We need to keep this number to be under 1000 tasks per
+# hour to avoid rate limiting
+# 10 => 6 per minute => 360 per hour.
+map_indexing_task_delay_seconds: 10

--- a/infrastructure/ansible/roles/lobby_server/templates/lobby_server.service.j2
+++ b/infrastructure/ansible/roles/lobby_server/templates/lobby_server.service.j2
@@ -8,6 +8,8 @@ Environment=DATABASE_PASSWORD={{ lobby_db_password }}
 Environment=DB_URL={{ lobby_server_db_host }}:{{ lobby_server_db_port }}/{{ lobby_server_db_name }}
 Environment=ERROR_REPORT_GITHUB_REPO=triplea
 Environment=GITHUB_API_TOKEN={{ github_api_token }}
+Environment=MAP_INDEXING_PERIOD_MINUTES={{ map_indexing_period_minutes }}
+Environment=MAP_INDEXING_DELAY_SECONDS={{ map_indexing_task_delay_seconds }}
 WorkingDirectory={{ lobby_server_home_folder }}
 User={{ lobby_server_user }}
 Group={{ lobby_server_user }}

--- a/lib/java-extras/src/main/java/org/triplea/java/timer/Timers.java
+++ b/lib/java-extras/src/main/java/org/triplea/java/timer/Timers.java
@@ -2,6 +2,7 @@ package org.triplea.java.timer;
 
 import com.google.common.base.Preconditions;
 import java.util.Optional;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import lombok.AccessLevel;
@@ -9,9 +10,24 @@ import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
 import org.triplea.java.ArgChecker;
 
-/** Factory class for creating timers to execute recurring tasks. */
+/** Factory class for creating timers to execute recurring tasks or one-off delayed tasks */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class Timers {
+
+  /**
+   * Waits a fixed delay and then executes a given runnable.
+   *
+   * @param delay The number of units to delay (eg: 1, 2, 3)
+   * @param delayTimeUnit The unit of the delay (eg: minutes, seconds).
+   * @param runnable The task to be run.
+   */
+  @SuppressWarnings("FutureReturnValueIgnored")
+  public static void executeAfterDelay(
+      final int delay, final TimeUnit delayTimeUnit, final Runnable runnable) {
+    Preconditions.checkArgument(delay >= 0, "Delay must be non-negative, was %s", delay);
+    new ScheduledThreadPoolExecutor(1).schedule(runnable, delay, delayTimeUnit);
+  }
+
   /**
    * Returns a type-safe builder to create a timer that executes a given task at a regular periodic
    * frequency.

--- a/spitfire-server/dropwizard-server/configuration.yml
+++ b/spitfire-server/dropwizard-server/configuration.yml
@@ -4,11 +4,33 @@ githubOrgForErrorReports: triplea-game
 githubRepoForErrorReports: ${ERROR_REPORT_GITHUB_REPO:-test}
 githubMapsOrgName: triplea-maps
 
+# If map indexing is enabled, it will begin shortly after server startup.
+# If disabled no map indexing will occur.
 mapIndexingEnabled: ${MAP_INDEXING_ENABLED:-true}
+
+# How often between map indexing runs. On each map indexing run we will
+# index all maps. If the previous map indexing run is still going
+# we will then have multiple indexing jobs running at the same time.
+# To avoid overlapping indexing jobs, this value needs to be greater than:
+#  (number of maps) * (processing time) * (indexingTaskDelaySeconds / 60)
+mapIndexingPeriodMinutes: ${MAP_INDEXING_PERIOD_MINUTES:-300}
+
+# Time period in seconds between indexing each individual map. This must
+# be configured to avoid github API rate limiting.
+# Eg:
+#      1 -> one indexing task per second -> 3600 requests per hour.
+#      5 -> one indexing task every 5 seconds -> 720 requests per hour.
+#     60 -> one indexing task per minute -> 60 requests per hour.
+#    120 -> one indexing task every other minute -> 30 requests per hour.
+# Unauthenticated Github API requests are limited to 60 request per hour.
+# Authenticated Github API requests are limited to 1000 requests per hour.
+indexingTaskDelaySeconds: ${MAP_INDEXING_DELAY_SECONDS:-120}
 
 # if we are using any stubbing, we'll assert that this value is false.
 # this is to help guarantee that we do not accidentally use test configuration in prod.
 prod: ${PROD_FLAG:-false}
+
+# Whether to print out SQL statements as executed, useful for debugging.
 logSqlStatements: false
 
 database:

--- a/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/SpitfireServerApplication.java
+++ b/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/SpitfireServerApplication.java
@@ -100,7 +100,11 @@ public class SpitfireServerApplication extends Application<SpitfireServerConfig>
 
     if (configuration.isMapIndexingEnabled()) {
       environment.lifecycle().manage(MapsIndexingSchedule.build(configuration, jdbi));
-      log.info("Map indexing is enabled and has been scheduled");
+      log.info(
+          "Map indexing is enabled to run every:"
+              + " {} minutes with one map indexing request every {} seconds",
+          configuration.getMapIndexingPeriodMinutes(),
+          configuration.getIndexingTaskDelaySeconds());
     } else {
       log.info("Map indexing is disabled");
     }

--- a/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/SpitfireServerConfig.java
+++ b/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/SpitfireServerConfig.java
@@ -60,4 +60,12 @@ public class SpitfireServerConfig extends Configuration
   @Getter(onMethod_ = {@JsonProperty})
   @Setter(onMethod_ = {@JsonProperty})
   private boolean mapIndexingEnabled;
+
+  @Getter(onMethod_ = {@JsonProperty, @Override})
+  @Setter(onMethod_ = {@JsonProperty})
+  private int mapIndexingPeriodMinutes;
+
+  @Getter(onMethod_ = {@JsonProperty, @Override})
+  @Setter(onMethod_ = {@JsonProperty})
+  private int indexingTaskDelaySeconds;
 }

--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/MapsModuleConfig.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/MapsModuleConfig.java
@@ -6,4 +6,8 @@ public interface MapsModuleConfig {
   String getGithubApiToken();
 
   String getGithubWebServiceUrl();
+
+  int getMapIndexingPeriodMinutes();
+
+  int getIndexingTaskDelaySeconds();
 }

--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapIndexingTask.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapIndexingTask.java
@@ -1,9 +1,12 @@
 package org.triplea.maps.indexing;
 
 import java.net.URI;
+import java.util.ArrayDeque;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.Deque;
 import java.util.Optional;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
@@ -11,6 +14,7 @@ import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.http.client.github.GithubApiClient;
 import org.triplea.http.client.github.MapRepoListing;
+import org.triplea.java.timer.Timers;
 
 /**
  * Task that runs a map indexing pass on all maps. The indexing will update database to reflect the
@@ -31,12 +35,18 @@ class MapIndexingTask implements Runnable {
   @Nonnull private final MapIndexDao mapIndexDao;
   @Nonnull private final GithubApiClient githubApiClient;
   @Nonnull private final Function<MapRepoListing, Optional<MapIndexResult>> mapIndexer;
+  @Nonnull private final Integer indexingTaskDelaySeconds;
+
+  private int totalNumberMaps;
+  private long startTimeEpochMillis;
+  private int mapsDeleted;
+  private int mapsIndexed;
 
   @Override
   public void run() {
     log.info("Map indexing started, github org: {}", githubOrgName);
 
-    final long start = System.currentTimeMillis();
+    startTimeEpochMillis = System.currentTimeMillis();
 
     // get list of maps
     final Collection<MapRepoListing> mapUris =
@@ -44,30 +54,57 @@ class MapIndexingTask implements Runnable {
             .sorted(Comparator.comparing(MapRepoListing::getName))
             .collect(Collectors.toList());
 
+    totalNumberMaps = mapUris.size();
+
     // remove deleted maps
-    final int mapsRemovedCount =
+    mapsDeleted =
         mapIndexDao.removeMapsNotIn(
             mapUris.stream()
                 .map(MapRepoListing::getUri)
                 .map(URI::toString)
                 .collect(Collectors.toList()));
 
-    // index all maps
-    final Collection<MapIndexResult> indexedMapData =
-        mapUris.stream()
-            .map(mapIndexer)
-            .filter(Optional::isPresent)
-            .map(Optional::get)
-            .collect(Collectors.toList());
+    // start indexing - convert maps to index to a stack and then process that
+    // stack at a fixed rate to avoid rate limits.
+    final Deque<MapRepoListing> reposToIndex = new ArrayDeque<>(mapUris);
+    indexNextMapRepo(reposToIndex);
+  }
 
-    // upsert indexed map data into DB
-    indexedMapData.forEach(mapIndexDao::upsert);
+  /**
+   * Recursive method to process a stack of map repo listings. On each iteration we wait a fixed
+   * delay, we then pop an element, process it, and then repeat until the stack is empty.
+   */
+  private void indexNextMapRepo(final Deque<MapRepoListing> reposToIndex) {
+    performIndexing(reposToIndex.pop());
+    if (reposToIndex.isEmpty()) {
+      notifyCompletion();
+    } else {
+      Timers.executeAfterDelay(
+          indexingTaskDelaySeconds, TimeUnit.SECONDS, () -> indexNextMapRepo(reposToIndex));
+    }
+  }
 
+  /**
+   * Performs the actual indexing of a single map repo listing. Indexing is two parts, first we
+   * reach out to the repo to gather indexing informaton, second we upsert that info into database.
+   */
+  private void performIndexing(final MapRepoListing mapRepoListing) {
+    log.info("Indexing map: " + mapRepoListing.getName());
+    mapIndexer
+        .apply(mapRepoListing)
+        .ifPresent(
+            mapIndexResult -> {
+              mapIndexDao.upsert(mapIndexResult);
+              mapsIndexed++;
+            });
+  }
+
+  private void notifyCompletion() {
     log.info(
         "Map indexing finished in {} ms, repos found: {}, repos with map.yml: {}, maps deleted: {}",
-        (System.currentTimeMillis() - start),
-        mapUris.size(),
-        indexedMapData.size(),
-        mapsRemovedCount);
+        (System.currentTimeMillis() - startTimeEpochMillis),
+        totalNumberMaps,
+        mapsIndexed,
+        mapsDeleted);
   }
 }

--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapsIndexingSchedule.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapsIndexingSchedule.java
@@ -19,10 +19,10 @@ public class MapsIndexingSchedule implements Managed {
 
   private final ScheduledTimer taskTimer;
 
-  MapsIndexingSchedule(final MapIndexingTask mapIndexingTask) {
+  MapsIndexingSchedule(final int indexingPeriodMinutes, final MapIndexingTask mapIndexingTask) {
     taskTimer =
         Timers.fixedRateTimer("thread-name")
-            .period(10, TimeUnit.MINUTES)
+            .period(indexingPeriodMinutes, TimeUnit.MINUTES)
             .delay(10, TimeUnit.SECONDS)
             .task(mapIndexingTask);
   }
@@ -40,6 +40,7 @@ public class MapsIndexingSchedule implements Managed {
             .build();
 
     return new MapsIndexingSchedule(
+        configuration.getMapIndexingPeriodMinutes(),
         MapIndexingTask.builder()
             .githubOrgName(configuration.getGithubMapsOrgName())
             .githubApiClient(githubApiClient)
@@ -51,6 +52,7 @@ public class MapsIndexingSchedule implements Managed {
                                 configuration.getGithubMapsOrgName(), repoName, "master")
                             .getLastCommitDate()))
             .mapIndexDao(jdbi.onDemand(MapIndexDao.class))
+            .indexingTaskDelaySeconds(configuration.getIndexingTaskDelaySeconds())
             .build());
   }
 

--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexingTaskTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexingTaskTest.java
@@ -1,5 +1,6 @@
 package org.triplea.maps.indexing;
 
+import static org.mockito.Mockito.timeout;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -40,6 +41,7 @@ class MapIndexingTaskTest {
             .mapIndexDao(mapIndexDao)
             .githubApiClient(githubApiClient)
             .mapIndexer(mapIndexer)
+            .indexingTaskDelaySeconds(0)
             .build();
   }
 
@@ -60,6 +62,6 @@ class MapIndexingTaskTest {
     mapIndexingTask.run();
 
     verify(mapIndexDao).removeMapsNotIn(List.of("https://uri-1", "https://uri-2"));
-    verify(mapIndexDao).upsert(MAP_INDEX_RESULT);
+    verify(mapIndexDao, timeout(300)).upsert(MAP_INDEX_RESULT);
   }
 }


### PR DESCRIPTION
Allows for us to control how quickly map indexing occurs. This is important
to avoid hitting rate limits. In this change we update the core indexing task
to have a back-off between each map indexing execution. This allows us to
stay under github API request rate limits.

Secondly, we parameterize how often to schedule map indexing runs, previously
it was 10 minutes.

Unauthorized API requests (those without a github API token) need to occur at
a relatively slow rate with a max of one API request per minute. Authorized
requests can get 1000 requests per hour before being rate limited.

We could in theory make request rate more dynamic by computing the remaining
rate limit and how many maps are needed. This can be problematic
if we are doing a constant rate and do not need that many requests. For example,
if we only need 50 requests and can do up to 1000 per hour, then firing
one every minute is excessively slow. Worse yet, if an individual indexing
task is slow then we start to have potential for overlapping between the indexing
runs. For these reasons the request rate is currently just pre-computed and
fixed at startup time.
