### PR TITLE
Fix Map Indexing 'map.yml' URL

### DIFF
--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapIndexer.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapIndexer.java
@@ -80,7 +80,8 @@ class MapIndexer implements Function<MapRepoListing, Optional<MapIndexResult>> {
   @VisibleForTesting
   @Nullable
   String readMapNameFromYaml(final MapRepoListing mapRepoListing) {
-    final URI mapYmlUri = URI.create(mapRepoListing.getUri().toString() + "/map.yml?raw=true");
+    final URI mapYmlUri =
+        URI.create(mapRepoListing.getUri().toString() + "/blob/master/map.yml?raw=true");
 
     final String mapYamlContents = downloadFunction.apply(mapYmlUri);
     if (mapYamlContents == null) {


### PR DESCRIPTION
Simply corrects the location where we expect to find a map.yml file
in a map repository.

