### PR TITLE
Fix various 'UnescapedEntity' error prone warnings.

### DIFF
--- a/lib/java-extras/src/main/java/org/triplea/java/Postconditions.java
+++ b/lib/java-extras/src/main/java/org/triplea/java/Postconditions.java
@@ -10,13 +10,13 @@ import lombok.NoArgsConstructor;
  * and provides room for nicer APIs and additional functionality when asserted states fail. <br>
  * Example Usage:
  *
- * <pre><code>
+ * <pre>{@code
  * int methodCall() {
  *    int returnValue = doCalculation();
  *    Postconditions.assertState(returnValue > 0);
  *    return returnValue;
  * }
- * </code></pre>
+ * }</pre>
  */
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public final class Postconditions {

--- a/lib/java-extras/src/main/java/org/triplea/java/StringUtils.java
+++ b/lib/java-extras/src/main/java/org/triplea/java/StringUtils.java
@@ -55,15 +55,15 @@ public final class StringUtils {
   /**
    * Removes an ending suffix from a String. Example:
    *
-   * <pre>
+   * <pre>{@code
    * truncateEnding(input.xml, xml) -> input
-   * </pre>
+   * }</pre>
    *
    * <p>The original input will be returned if the ending is not found, eg:
    *
-   * <pre>
+   * <pre>{@code
    * truncateEnding(input, xml) -> input
-   * </pre>
+   * }</pre>
    *
    * @throws IllegalArgumentException Thrown if endingToTruncate parameter is empty.
    */

--- a/lib/java-extras/src/main/java/org/triplea/java/ViewModelListener.java
+++ b/lib/java-extras/src/main/java/org/triplea/java/ViewModelListener.java
@@ -38,10 +38,11 @@ package org.triplea.java;
  * @param <ViewModelT> The type of view model, view model listeners should generally be 1:1 to a
  *     view model.
  */
+@SuppressWarnings("UnescapedEntity")
 public interface ViewModelListener<ViewModelT> {
   /**
    * Called when view model state is updated and the view needs to also be updated. An
-   * implementation is expected to query the {@param viewModel} via 'getter' methods and update
+   * implementation is expected to query the {@code viewModel} via 'getter' methods and update
    * any/all UI components.
    *
    * @param viewModel A reference to the updated view model with latest state. Note, this parameter

--- a/lib/java-extras/src/main/java/org/triplea/java/concurrency/AsyncRunner.java
+++ b/lib/java-extras/src/main/java/org/triplea/java/concurrency/AsyncRunner.java
@@ -13,10 +13,12 @@ import lombok.experimental.UtilityClass;
  * Utility class to make the API of {@code CompletableFuture.runAsync} a bit nicer and avoids the
  * return null in the exception handler.
  *
- * <p>Example usage: <code>
- *   AsyncRunner.runAsync(() -> taskToRun())
- *      .exceptionally(throwable -> log.log(Level.Severe, "Error message", throwable));
- * </code>
+ * <p>Example usage:
+ *
+ * <pre>{@code
+ * AsyncRunner.runAsync(() -> taskToRun())
+ *    .exceptionally(throwable -> log.log(Level.Severe, "Error message", throwable));
+ * }</pre>
  */
 @UtilityClass
 public class AsyncRunner {

--- a/lib/java-extras/src/main/java/org/triplea/java/concurrency/CompletableFutureUtils.java
+++ b/lib/java-extras/src/main/java/org/triplea/java/concurrency/CompletableFutureUtils.java
@@ -9,7 +9,7 @@ import lombok.experimental.UtilityClass;
 public final class CompletableFutureUtils {
 
   /**
-   * Invokes {@param exceptionHandler} with any exception thrown by {@code future} when it is
+   * Invokes {@code exceptionHandler} with any exception thrown by {@code future} when it is
    * complete. If {@code future} completes normally, no action is taken.
    */
   @SuppressWarnings("FutureReturnValueIgnored")

--- a/lib/java-extras/src/main/java/org/triplea/java/timer/ScheduledTimer.java
+++ b/lib/java-extras/src/main/java/org/triplea/java/timer/ScheduledTimer.java
@@ -9,24 +9,24 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * Class for creating a class to be executed periodically. Sample usage:
  *
- * <pre><code>
- *   ScheduledTimer timer = Timers.newFixedRateTimer("thread-name")
- *      .period(20, TimeUnit.SECONDS)
- *      .delay(10, TimeUnit.SECONDS)
- *      .task(() -> executeTask());
- *   timer.start();
- *   timer.cancel();
- * </code></pre>
+ * <pre>{@code
+ * ScheduledTimer timer = Timers.newFixedRateTimer("thread-name")
+ *    .period(20, TimeUnit.SECONDS)
+ *    .delay(10, TimeUnit.SECONDS)
+ *    .task(() -> executeTask());
+ * timer.start();
+ * timer.cancel();
+ * }</pre>
  *
  * The scheduled timer can also be started at time of creation:
  *
- * <pre><code>
- *   ScheduledTimer timer = Timers.fixedRateTimer("thread-name")
- *      .period(20, TimeUnit.SECONDS)
- *      .task(() -> executeTask())
- *      .start();
- *   timer.cancel();
- * </code></pre>
+ * <pre>{@code
+ * ScheduledTimer timer = Timers.fixedRateTimer("thread-name")
+ *    .period(20, TimeUnit.SECONDS)
+ *    .task(() -> executeTask())
+ *    .start();
+ * timer.cancel();
+ * }</pre>
  */
 @Slf4j
 public class ScheduledTimer {

--- a/lib/java-extras/src/main/java/org/triplea/performance/PerfTimer.java
+++ b/lib/java-extras/src/main/java/org/triplea/performance/PerfTimer.java
@@ -10,15 +10,22 @@ import org.triplea.java.function.ThrowingSupplier;
 
 /**
  * Provides a high level API to the game engine for performance measurements. This class handles the
- * library details and sends output to 'PerformanceConsole.java' <br>
- * Example usage with auto-close try block: <code>
+ * library details and sends output to 'PerformanceConsole.java.
+ *
+ * <p>Example usage with auto-close try block:
+ *
+ * <pre>{@code
  * try(PerfTimer timer = PerfTimer.startTimer("timer_name_0")) {
  *   // code to be timed
  * }
- * </code> Example usage with inline runnable: <code>
- *   long someValue = PerfTimer.time("timer name", () -> exampleValueComputation());
- *   PerfTimer.time("timer name", () -> exampleCodeToBeTimed());
- * </code>
+ * }</pre>
+ *
+ * Example usage with inline runnable:
+ *
+ * <pre>{@code
+ * long someValue = PerfTimer.time("timer name", () -> exampleValueComputation());
+ * PerfTimer.time("timer name", () -> exampleCodeToBeTimed());
+ * }</pre>
  */
 @SuppressWarnings("unused") // used on-demand by dev where needed and removed afterwards.
 @Slf4j


### PR DESCRIPTION
Fixes a numer of these error prone warnings:
>  This HTML entity is invalid. Enclosing the code in this
<pre>/<code> tag with a {@code } block will force Javadoc to
interpret HTML literally.

