### PR TITLE
Fix error prone warning ProtectedMembersInFinalClass in UrlStreams.java

### DIFF
--- a/lib/java-extras/src/main/java/org/triplea/java/UrlStreams.java
+++ b/lib/java-extras/src/main/java/org/triplea/java/UrlStreams.java
@@ -17,7 +17,7 @@ public final class UrlStreams {
   /** Used to obtain a connection from a given URL. */
   private final Function<URL, URLConnection> urlConnectionFactory;
 
-  protected UrlStreams() {
+  UrlStreams() {
     // By default just try open a connection, raise any exceptions encountered
     this.urlConnectionFactory =
         (url) -> {
@@ -30,7 +30,7 @@ public final class UrlStreams {
   }
 
   /** For test, a constructor that allows mock object injection. */
-  protected UrlStreams(final Function<URL, URLConnection> connectionFactory) {
+  UrlStreams(final Function<URL, URLConnection> connectionFactory) {
     this.urlConnectionFactory = connectionFactory;
   }
 


### PR DESCRIPTION
Fixes this error prone:

```
Make members of final classes package-private:
  protected UrlStreams(final Function<URL, URLConnection> connectionFactory) {
            ^
    (see https://errorprone.info/bugpattern/ProtectedMembersInFinalClass)
  Did you mean 'UrlStreams(final Function<URL, URLConnection> connectionFactory) {'?
```


<!-- If multiple commits please summarize the change above. -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
