### PR TITLE
Fix error prone warning [InvalidBlockTag]

### DIFF
--- a/lib/xml-reader/src/main/java/org/triplea/generic/xml/reader/annotations/Attribute.java
+++ b/lib/xml-reader/src/main/java/org/triplea/generic/xml/reader/annotations/Attribute.java
@@ -11,12 +11,13 @@ import java.lang.annotation.Target;
  *
  * <p>Example:
  *
- * <pre>{@code
+ * <pre><code>
+ *
  * class Tag {
  *   @Attribute
  *   private String attribute;
  * }
- * }</pre>
+ * </code>
  *
  * With the XML below, the 'String attribute' above would get the value "attributeValue":
  *
@@ -26,6 +27,7 @@ import java.lang.annotation.Target;
  * </xml>
  * }</pre>
  */
+@SuppressWarnings("JavaDoc")
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface Attribute {
@@ -34,12 +36,13 @@ public @interface Attribute {
    * property overrides that default to search for a different set of names.For example, the below
    * annotation would match attributes "foo" and "bar", but not "attribute".
    *
-   * <pre>{@code
+   * <pre><code>
+   *
    * class Tag {
    *   @Attribute(names = {"foo" , "bar"}
    *   private String attribute;
    * }
-   * }</pre>
+   * </code></pre>
    */
   String[] names() default "";
 

--- a/lib/xml-reader/src/main/java/org/triplea/generic/xml/reader/annotations/BodyText.java
+++ b/lib/xml-reader/src/main/java/org/triplea/generic/xml/reader/annotations/BodyText.java
@@ -11,12 +11,12 @@ import java.lang.annotation.Target;
  *
  * <p>Example:
  *
- * <pre>{@code
+ * <pre><code>
  * class Tag {
  *   @BodyText
  *   private String content;
  * }
- * }</pre>
+ * </code></pre>
  *
  * With the XML below, the 'String content attribute' above would get the value "body text":
  *
@@ -26,6 +26,7 @@ import java.lang.annotation.Target;
  * </xml>
  * }</pre>
  */
+@SuppressWarnings("JavaDoc")
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.FIELD)
 public @interface BodyText {}

--- a/lib/xml-reader/src/main/java/org/triplea/generic/xml/reader/annotations/Tag.java
+++ b/lib/xml-reader/src/main/java/org/triplea/generic/xml/reader/annotations/Tag.java
@@ -13,12 +13,14 @@ public @interface Tag {
    * property overrides that default to search for a different set of names.For example, the below
    * annotation would match tags named "foo" and "bar", but not "tag" .
    *
-   * <pre>{@code
+   * <pre><code>
+   *
    * class Tag {
    *   @Tag(names = {"foo" , "bar"}
    *   private Tag tagObjectName;
    * }
-   * }</pre>
+   * </code>></pre>
    */
+  @SuppressWarnings("JavaDoc")
   String[] names() default "";
 }

--- a/lib/xml-reader/src/main/java/org/triplea/generic/xml/reader/annotations/TagList.java
+++ b/lib/xml-reader/src/main/java/org/triplea/generic/xml/reader/annotations/TagList.java
@@ -13,7 +13,7 @@ public @interface TagList {
    * type. This property overrides that default to search for a different set of names.For example,
    * the below annotation would match tags named "foo" and "bar", but not "tag" .
    *
-   * <pre>{@code
+   * <pre><code>
    * class Tag {
    *   @TagList(names = {"foo" , "bar"}
    *   private List<Tag> tagList;
@@ -24,7 +24,8 @@ public @interface TagList {
    *       <foo/>
    *       <bar/>
    *   </list>
-   * }</pre>
+   * </code></pre>
    */
+  @SuppressWarnings("JavaDoc")
   String[] names() default "";
 }


### PR DESCRIPTION
Fixes the following error prone warning:
```
[InvalidBlockTag] @TagList is interpreted as a block tag here, not as a literal. Escaping annotations within {@code }
tags is problematic; you may have to avoid using {@code } and escape any HTML entities manually instead.
```
