### PR TITLE
Add 'run: bot update maps' github action

### DIFF
--- a/.github/workflows/run-bot-update-maps
+++ b/.github/workflows/run-bot-update-maps
@@ -1,0 +1,18 @@
+name: Run - Update Bot Maps
+on:
+  workflow_dispatch:
+jobs:
+  deploy:
+    name: Run Bot Update Maps
+    runs-on: Ubuntu-20.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Run Ansible to Deploy
+        run: |
+          cd infrastructure
+          echo "$ANSIBLE_VAULT_PASSWORD" > vault_password
+          ./run_ansible_update_bots
+        with:
+          ANSIBLE_VAULT_PASSWORD: ${{ secrets.ANSIBLE_VAULT_PASSWORD }}
+

--- a/docs/infrastructure/bot-ops.md
+++ b/docs/infrastructure/bot-ops.md
@@ -24,18 +24,6 @@ systemctl start bot@01.service
 
 ## Updating maps
 
-Done by hand from your local system.
-Requires access to vault secret
-
-```bash
-# setup vault_password file
-cd triplea/infrastructure
-echo "<vault secret>" > vault_password
-```
-
-Run update script:
-```bash
-cd triplea/infrastructure
-./run_ansible_update_bots
-```
+Done via github actions:
+  github.com > actions > 'run bot update maps' > run-action
 


### PR DESCRIPTION
Enables a github action to update maps on bots.
To access the action:
  github.com > actions > select this action > 'run'

