### PR TITLE
Delete bot10 server

### DIFF
--- a/infrastructure/ansible/inventory/prod2
+++ b/infrastructure/ansible/inventory/prod2
@@ -22,7 +22,6 @@ prod2-bot06.triplea-game.org  bot_prefix=6 bot_name=California
 prod2-bot07.triplea-game.org  bot_prefix=7 bot_name=Jersey
 prod2-bot08.triplea-game.org  bot_prefix=8 bot_name=London
 prod2-bot09.triplea-game.org  bot_prefix=9 bot_name=Frankfurt
-prod2-bot10.triplea-game.org  bot_prefix=10 bot_name=Jersey
 
 [botHosts:vars]
 bot_version="2.5.22294"


### PR DESCRIPTION
- One of running instances had a problem
- Two other instances were crashed

Server is now deleted from linode and is turned off.

Looks like the capacity will not be missed with only
one running host.


<!-- If multiple commits please summarize the change above. -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
