### PR TITLE
Convert the BattlePhaseList into BattlePhaseStep

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/battle/phase/BattlePhaseList.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/battle/phase/BattlePhaseList.java
@@ -1,13 +1,24 @@
 package games.strategy.engine.data.battle.phase;
 
 import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.UnitType;
+import games.strategy.engine.data.unit.ability.CombatUnitAbility;
 import games.strategy.engine.data.unit.ability.ConvertUnitAbility;
+import games.strategy.triplea.delegate.battle.BattleState;
+import games.strategy.triplea.delegate.battle.steps.BattlePhaseStep;
+import games.strategy.triplea.delegate.battle.steps.BattleStep;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.Getter;
+import lombok.Value;
 
 /**
  * Stores all of the {@link BattlePhase}s that will be used during a battle
@@ -53,11 +64,121 @@ public class BattlePhaseList {
     }
   }
 
-  public void addAbility(final GamePlayer player, final ConvertUnitAbility convertUnitAbility) {
-    convertAbilities.computeIfAbsent(player, p -> new ArrayList<>()).add(convertUnitAbility);
-  }
-
   public void clearConvertAbilities() {
     convertAbilities.clear();
+  }
+
+  /** Gathers the battle steps that the units will perform in all the phases */
+  public Collection<BattleStep> getBattleSteps(final BattleState battleState) {
+    final List<BattleStep> battleSteps = new ArrayList<>();
+    battleSteps.addAll(getBattleStepsForSide(battleState, BattleState.Side.OFFENSE));
+    battleSteps.addAll(getBattleStepsForSide(battleState, BattleState.Side.DEFENSE));
+    return battleSteps;
+  }
+
+  private List<BattleStep> getBattleStepsForSide(
+      final BattleState battleState, final BattleState.Side side) {
+    final Collection<UnitTypeAndOwner> units =
+        battleState.filterUnits(BattleState.UnitBattleFilter.ACTIVE, side).stream()
+            .map(unit -> new UnitTypeAndOwner(unit.getType(), unit.getOwner()))
+            .collect(Collectors.toSet());
+    final Collection<UnitTypeAndOwner> oppositeUnits =
+        battleState.filterUnits(BattleState.UnitBattleFilter.ACTIVE, side.getOpposite()).stream()
+            .map(unit -> new UnitTypeAndOwner(unit.getType(), unit.getOwner()))
+            .collect(Collectors.toSet());
+
+    final Collection<ConvertUnitAbility> convertAbilities =
+        units.stream()
+            .map(unit -> getConvertUnitAbilities(unit, ConvertUnitAbility.Team.FRIENDLY))
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList());
+
+    convertAbilities.addAll(
+        oppositeUnits.stream()
+            .map(unit -> getConvertUnitAbilities(unit, ConvertUnitAbility.Team.FOE))
+            .flatMap(Collection::stream)
+            .collect(Collectors.toList()));
+
+    final Map<CombatUnitAbility, CombatUnitAbility> fromToAbilities = new HashMap<>();
+    final Map<CombatUnitAbility, CombatUnitAbility> toFromAbilities = new HashMap<>();
+    for (final ConvertUnitAbility convertAbility : convertAbilities) {
+      fromToAbilities.put(convertAbility.getFrom(), convertAbility.getTo());
+      toFromAbilities.put(convertAbility.getTo(), convertAbility.getFrom());
+    }
+
+    return phases.stream()
+        .sorted(Comparator.comparingInt(BattlePhase::getOrder))
+        .map(
+            phase -> {
+              final Collection<CombatUnitAbility> abilities = getPhaseAbilities(units, phase);
+              final Collection<UnitAbilityAndUnits> unitAbilityAndUnits =
+                  getActiveAbilitiesAndUnits(fromToAbilities, toFromAbilities, abilities);
+              if (unitAbilityAndUnits.isEmpty()) {
+                return null;
+              } else {
+                return new BattlePhaseStep(
+                    phase.getName(), phase.getOrder(), unitAbilityAndUnits, side);
+              }
+            })
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
+  }
+
+  @Value
+  private static class UnitTypeAndOwner {
+    UnitType type;
+    GamePlayer owner;
+  }
+
+  @Value
+  public static class UnitAbilityAndUnits {
+    CombatUnitAbility unitAbility;
+    Collection<UnitType> unitTypes;
+  }
+
+  private Collection<ConvertUnitAbility> getConvertUnitAbilities(
+      final UnitTypeAndOwner unitTypeAndOwner, final ConvertUnitAbility.Team team) {
+
+    return filterConvertAbilitiesForUnits(unitTypeAndOwner.getOwner(), unitTypeAndOwner.getType())
+        .filter(convertUnitAbility -> convertUnitAbility.getTeams().contains(team))
+        .collect(Collectors.toList());
+  }
+
+  private Stream<ConvertUnitAbility> filterConvertAbilitiesForUnits(
+      final GamePlayer player, final UnitType unitType) {
+    return convertAbilities.getOrDefault(player, List.of()).stream()
+        .filter(ability -> ability.getAttachedUnitTypes().contains(unitType));
+  }
+
+  private Collection<CombatUnitAbility> getPhaseAbilities(
+      final Collection<UnitTypeAndOwner> units, final BattlePhase phase) {
+    return units.stream()
+        .map(unitTypeAndOwner -> phase.getAbilities(unitTypeAndOwner.getOwner()))
+        .flatMap(Collection::stream)
+        .collect(Collectors.toSet());
+  }
+
+  private Collection<UnitAbilityAndUnits> getActiveAbilitiesAndUnits(
+      final Map<CombatUnitAbility, CombatUnitAbility> fromToAbilities,
+      final Map<CombatUnitAbility, CombatUnitAbility> toFromAbilities,
+      final Collection<CombatUnitAbility> abilities) {
+    return abilities.stream()
+        .map(
+            ability -> {
+              // this ability will be converted to another ability so don't add it
+              if (fromToAbilities.containsKey(ability)) {
+                return null;
+              }
+              final Collection<UnitType> unitTypes =
+                  toFromAbilities.getOrDefault(ability, ability).getAttachedUnitTypes();
+              // this ability has no active units in the battle so don't add it
+              if (unitTypes.isEmpty()) {
+                return null;
+              }
+              return new UnitAbilityAndUnits(
+                  ability, toFromAbilities.getOrDefault(ability, ability).getAttachedUnitTypes());
+            })
+        .filter(Objects::nonNull)
+        .collect(Collectors.toList());
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/unit/ability/ConvertUnitAbility.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/unit/ability/ConvertUnitAbility.java
@@ -18,7 +18,7 @@ import lombok.experimental.NonFinal;
 @Builder(toBuilder = true)
 public class ConvertUnitAbility {
 
-  enum Team {
+  public enum Team {
     FRIENDLY,
     FOE
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattlePhaseStep.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattlePhaseStep.java
@@ -1,0 +1,35 @@
+package games.strategy.triplea.delegate.battle.steps;
+
+import com.google.common.annotations.VisibleForTesting;
+import games.strategy.engine.data.battle.phase.BattlePhaseList;
+import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.delegate.ExecutionStack;
+import games.strategy.triplea.delegate.battle.BattleState;
+import java.util.Collection;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+public class BattlePhaseStep implements BattleStep {
+
+  private static final long serialVersionUID = -6567033620405540508L;
+
+  @VisibleForTesting @Getter private String battlePhaseName;
+  private int battlePhaseOrder;
+  @VisibleForTesting @Getter private Collection<BattlePhaseList.UnitAbilityAndUnits> unitAbilities;
+  private BattleState.Side side;
+
+  @Override
+  public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {}
+
+  @Override
+  public List<String> getNames() {
+    return null;
+  }
+
+  @Override
+  public Order getOrder() {
+    return null;
+  }
+}

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattlePhaseStep.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattlePhaseStep.java
@@ -21,7 +21,10 @@ public class BattlePhaseStep implements BattleStep {
 
   @VisibleForTesting @Getter private String battlePhaseName;
   private int battlePhaseOrder;
-  @VisibleForTesting @Getter private Collection<BattlePhaseList.UnitAbilityAndUnits> unitAbilities;
+
+  @VisibleForTesting @Getter
+  private Collection<BattlePhaseList.UnitAbilityAndUnitTypes> unitAbilities;
+
   private BattleState.Side side;
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattlePhaseStep.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattlePhaseStep.java
@@ -11,8 +11,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 /**
- * TODO: BattlePhase - This needs to be expanded so that it actually implements the unit abilities
- * for a fight.
+ * BattlePhase - This needs to be expanded so that it actually implements the unit abilities for a
+ * fight.
  */
 @AllArgsConstructor
 public class BattlePhaseStep implements BattleStep {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattlePhaseStep.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/BattlePhaseStep.java
@@ -10,6 +10,10 @@ import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+/**
+ * TODO: BattlePhase - This needs to be expanded so that it actually implements the unit abilities
+ * for a fight.
+ */
 @AllArgsConstructor
 public class BattlePhaseStep implements BattleStep {
 
@@ -21,7 +25,9 @@ public class BattlePhaseStep implements BattleStep {
   private BattleState.Side side;
 
   @Override
-  public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {}
+  public void execute(final ExecutionStack stack, final IDelegateBridge bridge) {
+    // this is just a placeholder for now but it will be expanded in a later PR
+  }
 
   @Override
   public List<String> getNames() {

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/battle/phase/BattlePhaseListTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/battle/phase/BattlePhaseListTest.java
@@ -1,0 +1,552 @@
+package games.strategy.engine.data.battle.phase;
+
+import static games.strategy.triplea.delegate.battle.FakeBattleState.givenBattleStateBuilder;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.UnitType;
+import games.strategy.engine.data.unit.ability.CombatUnitAbility;
+import games.strategy.engine.data.unit.ability.ConvertUnitAbility;
+import games.strategy.triplea.delegate.battle.BattleState;
+import games.strategy.triplea.delegate.battle.steps.BattlePhaseStep;
+import games.strategy.triplea.delegate.battle.steps.BattleStep;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BattlePhaseListTest {
+
+  BattlePhaseList battlePhaseList;
+  @Mock GamePlayer attacker;
+  @Mock GamePlayer defender;
+  @Mock GameData gameData;
+
+  @BeforeEach
+  void initializeBattlePhaseList() {
+    battlePhaseList = new BattlePhaseList();
+  }
+
+  @Nested
+  class BattleStepCalculation {
+
+    @Test
+    void noUnitAbilitiesHasNoSteps() {
+      final BattleState battleState = givenBattleStateBuilder().build();
+
+      final Collection<BattleStep> steps = battlePhaseList.getBattleSteps(battleState);
+      assertThat("The phases have no abilities so no steps should be created.", steps, is(empty()));
+    }
+
+    @Test
+    void unitAbilityButNoUnitTypesAttachedCreatesNoSteps() {
+      final BattleState battleState = givenBattleStateBuilder().attacker(attacker).build();
+
+      battlePhaseList
+          .getPhase(BattlePhaseList.DEFAULT_GENERAL_PHASE)
+          .ifPresent(
+              battlePhase -> {
+                battlePhase.addAbility(attacker, CombatUnitAbility.builder().name("1").build());
+              });
+      final Collection<BattleStep> steps = battlePhaseList.getBattleSteps(battleState);
+      assertThat("Ability has no unit types attached, so no steps", steps, is(empty()));
+    }
+
+    @Test
+    void unitAbilityWithAttachedUnitTypesButNoActualUnitsCreatesNoSteps() {
+      final BattleState battleState = givenBattleStateBuilder().attacker(attacker).build();
+
+      final UnitType unitType = new UnitType("infantry", gameData);
+
+      battlePhaseList
+          .getPhase(BattlePhaseList.DEFAULT_GENERAL_PHASE)
+          .ifPresent(
+              battlePhase -> {
+                battlePhase.addAbility(
+                    attacker,
+                    CombatUnitAbility.builder()
+                        .name("1")
+                        .attachedUnitTypes(List.of(unitType))
+                        .build());
+              });
+      final Collection<BattleStep> steps = battlePhaseList.getBattleSteps(battleState);
+      assertThat(
+          "Ability unit types attached but they aren't in the battle state, so no steps",
+          steps,
+          is(empty()));
+    }
+
+    @Test
+    void phaseWithOneAbilityMakesOneStep() {
+      final UnitType unitType = new UnitType("infantry", gameData);
+
+      final BattleState battleState =
+          givenBattleStateBuilder()
+              .attacker(attacker)
+              .attackingUnits(unitType.createTemp(1, attacker))
+              .build();
+
+      battlePhaseList
+          .getPhase(BattlePhaseList.DEFAULT_GENERAL_PHASE)
+          .ifPresent(
+              battlePhase -> {
+                battlePhase.addAbility(
+                    attacker,
+                    CombatUnitAbility.builder()
+                        .name("1")
+                        .attachedUnitTypes(List.of(unitType))
+                        .build());
+              });
+      final Collection<BattleStep> steps = battlePhaseList.getBattleSteps(battleState);
+      assertThat(
+          "Phase has one ability with attached unit types and that unit type is in the battle,"
+              + " so create a step",
+          steps,
+          hasSize(1));
+    }
+
+    @Test
+    void phaseWithTwoAbilitiesMakesOneStep() {
+      final UnitType unitType = new UnitType("infantry", gameData);
+
+      final BattleState battleState =
+          givenBattleStateBuilder()
+              .attacker(attacker)
+              .attackingUnits(unitType.createTemp(1, attacker))
+              .build();
+
+      battlePhaseList
+          .getPhase(BattlePhaseList.DEFAULT_GENERAL_PHASE)
+          .ifPresent(
+              battlePhase -> {
+                battlePhase.addAbility(
+                    attacker,
+                    CombatUnitAbility.builder()
+                        .name("1")
+                        .attachedUnitTypes(List.of(unitType))
+                        .build());
+                battlePhase.addAbility(
+                    attacker,
+                    CombatUnitAbility.builder()
+                        .name("2")
+                        .attachedUnitTypes(List.of(unitType))
+                        .build());
+              });
+      final Collection<BattleStep> steps = battlePhaseList.getBattleSteps(battleState);
+      assertThat(
+          "Phase has two abilities with attached unit types and that unit type is in the battle,"
+              + " so create a step for the phase. Only one step is needed for the phase.",
+          steps,
+          hasSize(1));
+    }
+
+    @Test
+    void twoPhasesWithAnAbilityMakeTwoSteps() {
+      final UnitType unitType = new UnitType("infantry", gameData);
+
+      final BattleState battleState =
+          givenBattleStateBuilder()
+              .attacker(attacker)
+              .attackingUnits(unitType.createTemp(1, attacker))
+              .build();
+
+      battlePhaseList
+          .getPhase(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE)
+          .ifPresent(
+              battlePhase -> {
+                battlePhase.addAbility(
+                    attacker,
+                    CombatUnitAbility.builder()
+                        .name("1")
+                        .attachedUnitTypes(List.of(unitType))
+                        .build());
+              });
+      battlePhaseList
+          .getPhase(BattlePhaseList.DEFAULT_GENERAL_PHASE)
+          .ifPresent(
+              battlePhase -> {
+                battlePhase.addAbility(
+                    attacker,
+                    CombatUnitAbility.builder()
+                        .name("2")
+                        .attachedUnitTypes(List.of(unitType))
+                        .build());
+              });
+      final Collection<BattleStep> steps = battlePhaseList.getBattleSteps(battleState);
+      assertThat("Two phases each with their own ability get their own steps", steps, hasSize(2));
+    }
+
+    @Test
+    void phaseWithBothSidesMakeTwoSteps() {
+      final UnitType unitType = new UnitType("infantry", gameData);
+
+      final BattleState battleState =
+          givenBattleStateBuilder()
+              .attacker(attacker)
+              .defender(defender)
+              .attackingUnits(unitType.createTemp(1, attacker))
+              .defendingUnits(unitType.createTemp(1, defender))
+              .build();
+
+      battlePhaseList
+          .getPhase(BattlePhaseList.DEFAULT_GENERAL_PHASE)
+          .ifPresent(
+              battlePhase -> {
+                battlePhase.addAbility(
+                    attacker,
+                    CombatUnitAbility.builder()
+                        .name("1")
+                        .attachedUnitTypes(List.of(unitType))
+                        .build());
+                battlePhase.addAbility(
+                    defender,
+                    CombatUnitAbility.builder()
+                        .name("2")
+                        .attachedUnitTypes(List.of(unitType))
+                        .build());
+              });
+      final Collection<BattleStep> steps = battlePhaseList.getBattleSteps(battleState);
+      assertThat(
+          "One phase has an attacker ability and a defender ability and both sides have units,"
+              + " so create 1 step for each side for a total of 2 steps.",
+          steps,
+          hasSize(2));
+    }
+
+    @Test
+    void convertUnitsAbilityInSamePhase() {
+      final UnitType infantryUnitType = new UnitType("infantry", gameData);
+      final UnitType artilleryUnitType = new UnitType("artillery", gameData);
+
+      final BattleState battleState =
+          givenBattleStateBuilder()
+              .attacker(attacker)
+              .attackingUnits(
+                  List.of(
+                      infantryUnitType.createTemp(1, attacker).get(0),
+                      artilleryUnitType.createTemp(1, attacker).get(0)))
+              .build();
+
+      final CombatUnitAbility initialAbility =
+          CombatUnitAbility.builder()
+              .name("1")
+              .attachedUnitTypes(List.of(infantryUnitType))
+              .build();
+      // the converted ability should not have any attached unit types initially
+      final CombatUnitAbility convertedAbility = CombatUnitAbility.builder().name("2").build();
+
+      battlePhaseList.addAbilityOrMergeAttached(
+          attacker,
+          ConvertUnitAbility.builder()
+              .name("convert")
+              .attachedUnitTypes(List.of(artilleryUnitType))
+              .teams(List.of(ConvertUnitAbility.Team.FRIENDLY))
+              .from(initialAbility)
+              .to(convertedAbility)
+              .build());
+
+      battlePhaseList
+          .getPhase(BattlePhaseList.DEFAULT_GENERAL_PHASE)
+          .ifPresent(
+              battlePhase -> {
+                battlePhase.addAbility(attacker, initialAbility);
+                battlePhase.addAbility(attacker, convertedAbility);
+              });
+      final Collection<BattleStep> steps = battlePhaseList.getBattleSteps(battleState);
+      assertThat(
+          "Only one step should exist since the infantry was converted from the general phase"
+              + " to the first strike phase",
+          steps,
+          hasSize(1));
+      final BattlePhaseStep step = (BattlePhaseStep) steps.iterator().next();
+      assertThat(
+          "There should only be one unit ability in this step.",
+          step.getUnitAbilities(),
+          hasSize(1));
+      final BattlePhaseList.UnitAbilityAndUnits unitAbilityAndUnits =
+          step.getUnitAbilities().iterator().next();
+      assertThat(
+          "And the only one unit ability should be the ability that was the result"
+              + " of the conversion",
+          unitAbilityAndUnits.getUnitAbility(),
+          is(convertedAbility));
+    }
+
+    @Test
+    void convertUnitsAbilityInDifferentPhase() {
+      final UnitType infantryUnitType = new UnitType("infantry", gameData);
+      final UnitType artilleryUnitType = new UnitType("artillery", gameData);
+
+      final BattleState battleState =
+          givenBattleStateBuilder()
+              .attacker(attacker)
+              .attackingUnits(
+                  List.of(
+                      infantryUnitType.createTemp(1, attacker).get(0),
+                      artilleryUnitType.createTemp(1, attacker).get(0)))
+              .build();
+
+      final CombatUnitAbility initialAbility =
+          CombatUnitAbility.builder()
+              .name("1")
+              .attachedUnitTypes(List.of(infantryUnitType))
+              .build();
+      // the converted ability should not have any attached unit types initially
+      final CombatUnitAbility convertedAbility = CombatUnitAbility.builder().name("2").build();
+
+      battlePhaseList.addAbilityOrMergeAttached(
+          attacker,
+          ConvertUnitAbility.builder()
+              .name("convert")
+              .attachedUnitTypes(List.of(artilleryUnitType))
+              .teams(List.of(ConvertUnitAbility.Team.FRIENDLY))
+              .from(initialAbility)
+              .to(convertedAbility)
+              .build());
+
+      battlePhaseList
+          .getPhase(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE)
+          .ifPresent(
+              battlePhase -> {
+                battlePhase.addAbility(attacker, convertedAbility);
+              });
+
+      battlePhaseList
+          .getPhase(BattlePhaseList.DEFAULT_GENERAL_PHASE)
+          .ifPresent(
+              battlePhase -> {
+                battlePhase.addAbility(attacker, initialAbility);
+              });
+      final Collection<BattleStep> steps = battlePhaseList.getBattleSteps(battleState);
+      assertThat(
+          "Only one step should exist since the infantry was converted from the general phase"
+              + " to the first strike phase",
+          steps,
+          hasSize(1));
+      final BattlePhaseStep step = (BattlePhaseStep) steps.iterator().next();
+      assertThat(
+          "The step should be first strike since it was converted",
+          step.getBattlePhaseName(),
+          is(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE));
+    }
+
+    @Test
+    void removeUnitsAbilityThroughConversion() {
+      final UnitType infantryUnitType = new UnitType("infantry", gameData);
+      final UnitType artilleryUnitType = new UnitType("artillery", gameData);
+
+      final BattleState battleState =
+          givenBattleStateBuilder()
+              .attacker(attacker)
+              .attackingUnits(
+                  List.of(
+                      infantryUnitType.createTemp(1, attacker).get(0),
+                      artilleryUnitType.createTemp(1, attacker).get(0)))
+              .build();
+
+      final CombatUnitAbility initialAbility =
+          CombatUnitAbility.builder()
+              .name("1")
+              .attachedUnitTypes(List.of(infantryUnitType))
+              .build();
+
+      battlePhaseList.addAbilityOrMergeAttached(
+          attacker,
+          ConvertUnitAbility.builder()
+              .name("convert")
+              .attachedUnitTypes(List.of(artilleryUnitType))
+              .teams(List.of(ConvertUnitAbility.Team.FRIENDLY))
+              .from(initialAbility)
+              .build());
+
+      battlePhaseList
+          .getPhase(BattlePhaseList.DEFAULT_GENERAL_PHASE)
+          .ifPresent(
+              battlePhase -> {
+                battlePhase.addAbility(attacker, initialAbility);
+              });
+      final Collection<BattleStep> steps = battlePhaseList.getBattleSteps(battleState);
+      assertThat(
+          "No steps should exist as the infantry's ability was converted to empty",
+          steps,
+          is(empty()));
+    }
+
+    @Test
+    void convertAbilityHasNoAvailableUnitsToActivateIt() {
+      final UnitType infantryUnitType = new UnitType("infantry", gameData);
+      final UnitType artilleryUnitType = new UnitType("artillery", gameData);
+
+      final BattleState battleState =
+          givenBattleStateBuilder()
+              .attacker(attacker)
+              .attackingUnits(infantryUnitType.createTemp(1, attacker))
+              .build();
+
+      final CombatUnitAbility initialAbility =
+          CombatUnitAbility.builder()
+              .name("1")
+              .attachedUnitTypes(List.of(infantryUnitType))
+              .build();
+      // the converted ability should not have any attached unit types initially
+      final CombatUnitAbility convertedAbility = CombatUnitAbility.builder().name("2").build();
+
+      battlePhaseList.addAbilityOrMergeAttached(
+          attacker,
+          ConvertUnitAbility.builder()
+              .name("convert")
+              .attachedUnitTypes(List.of(artilleryUnitType))
+              .teams(List.of(ConvertUnitAbility.Team.FRIENDLY))
+              .from(initialAbility)
+              .to(convertedAbility)
+              .build());
+
+      battlePhaseList
+          .getPhase(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE)
+          .ifPresent(
+              battlePhase -> {
+                battlePhase.addAbility(attacker, convertedAbility);
+              });
+
+      battlePhaseList
+          .getPhase(BattlePhaseList.DEFAULT_GENERAL_PHASE)
+          .ifPresent(
+              battlePhase -> {
+                battlePhase.addAbility(attacker, initialAbility);
+              });
+      final Collection<BattleStep> steps = battlePhaseList.getBattleSteps(battleState);
+      assertThat(
+          "There are no artillery present, so the infantry should still be in general phase",
+          steps,
+          hasSize(1));
+      final BattlePhaseStep step = (BattlePhaseStep) steps.iterator().next();
+      assertThat(
+          "There are no artillery present, so the infantry should still be in general phase",
+          step.getBattlePhaseName(),
+          is(BattlePhaseList.DEFAULT_GENERAL_PHASE));
+    }
+
+    @Test
+    void convertEnemyUnitsAbilityInDifferentPhase() {
+      final UnitType infantryUnitType = new UnitType("infantry", gameData);
+      final UnitType artilleryUnitType = new UnitType("artillery", gameData);
+
+      final BattleState battleState =
+          givenBattleStateBuilder()
+              .attacker(attacker)
+              .attacker(defender)
+              .attackingUnits(infantryUnitType.createTemp(1, attacker))
+              .defendingUnits(artilleryUnitType.createTemp(1, defender))
+              .build();
+
+      final CombatUnitAbility initialAbility =
+          CombatUnitAbility.builder()
+              .name("1")
+              .attachedUnitTypes(List.of(infantryUnitType))
+              .build();
+      // the converted ability should not have any attached unit types initially
+      final CombatUnitAbility convertedAbility = CombatUnitAbility.builder().name("2").build();
+
+      battlePhaseList.addAbilityOrMergeAttached(
+          defender,
+          ConvertUnitAbility.builder()
+              .name("convert")
+              .attachedUnitTypes(List.of(artilleryUnitType))
+              .teams(List.of(ConvertUnitAbility.Team.FOE))
+              .from(initialAbility)
+              .to(convertedAbility)
+              .build());
+
+      battlePhaseList
+          .getPhase(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE)
+          .ifPresent(
+              battlePhase -> {
+                battlePhase.addAbility(attacker, initialAbility);
+              });
+
+      battlePhaseList
+          .getPhase(BattlePhaseList.DEFAULT_GENERAL_PHASE)
+          .ifPresent(
+              battlePhase -> {
+                battlePhase.addAbility(attacker, convertedAbility);
+              });
+      final Collection<BattleStep> steps = battlePhaseList.getBattleSteps(battleState);
+      assertThat(
+          "Only one step should exist since the infantry was converted from"
+              + " the first strike phase to the general phase",
+          steps,
+          hasSize(1));
+      final BattlePhaseStep step = (BattlePhaseStep) steps.iterator().next();
+      assertThat(
+          "The step should be general since it was converted",
+          step.getBattlePhaseName(),
+          is(BattlePhaseList.DEFAULT_GENERAL_PHASE));
+    }
+
+    @Test
+    void convertUnitsAbilityDoesNotHappenIfTheConverterIsOnTheWrongSide() {
+      final UnitType infantryUnitType = new UnitType("infantry", gameData);
+      final UnitType artilleryUnitType = new UnitType("artillery", gameData);
+
+      final BattleState battleState =
+          givenBattleStateBuilder()
+              .attacker(attacker)
+              .attacker(defender)
+              .attackingUnits(
+                  List.of(
+                      infantryUnitType.createTemp(1, attacker).get(0),
+                      artilleryUnitType.createTemp(1, defender).get(0)))
+              .build();
+
+      final CombatUnitAbility initialAbility =
+          CombatUnitAbility.builder()
+              .name("1")
+              .attachedUnitTypes(List.of(infantryUnitType))
+              .build();
+      // the converted ability should not have any attached unit types initially
+      final CombatUnitAbility convertedAbility = CombatUnitAbility.builder().name("2").build();
+
+      battlePhaseList.addAbilityOrMergeAttached(
+          defender,
+          ConvertUnitAbility.builder()
+              .name("convert")
+              .attachedUnitTypes(List.of(artilleryUnitType))
+              .teams(List.of(ConvertUnitAbility.Team.FOE))
+              .from(initialAbility)
+              .to(convertedAbility)
+              .build());
+
+      battlePhaseList
+          .getPhase(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE)
+          .ifPresent(
+              battlePhase -> {
+                battlePhase.addAbility(attacker, initialAbility);
+              });
+
+      battlePhaseList
+          .getPhase(BattlePhaseList.DEFAULT_GENERAL_PHASE)
+          .ifPresent(
+              battlePhase -> {
+                battlePhase.addAbility(attacker, convertedAbility);
+              });
+      final Collection<BattleStep> steps = battlePhaseList.getBattleSteps(battleState);
+      assertThat(
+          "Only one step should exist since the infantry was NOT converted", steps, hasSize(1));
+      final BattlePhaseStep step = (BattlePhaseStep) steps.iterator().next();
+      assertThat(
+          "The step should be first strike since the artillery is a FRIENDLY but the"
+              + " convert ability is only for FOE",
+          step.getBattlePhaseName(),
+          is(BattlePhaseList.DEFAULT_FIRST_STRIKE_PHASE));
+    }
+  }
+}


### PR DESCRIPTION
<!-- If multiple commits please summarize the change above. -->
Sorry for taking a long time but here's the next part of the BattlePhase change.  This takes the phases that are created by UnitAbilityFactory (and maybe the XML at a later point) and creates BattlePhaseSteps.

The next part after this will be to flesh out the BattlePhaseSteps so that they actually do stuff.  Then, I'll change the code to use the BattlePhases instead of the existing logic.

## Testing
<!-- Describe any manual testing performed below. -->
This code is currently not used in the game yet.  So manual testing isn't possible.

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
