### PR TITLE
Allow null client settings value

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponent.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponent.java
@@ -69,10 +69,10 @@ public interface SelectionComponent<T> {
      * @param value The new setting value or {@code null} to clear the setting value.
      */
     default <T> void setValue(final GameSetting<T> gameSetting, final @Nullable T value) {
-      final Optional<String> validationErrorMessage = gameSetting.validateValue(value);
-      if (validationErrorMessage.isPresent()) {
+      // null values are always valid
+      if (value != null && gameSetting.validateValue(value).isPresent()) {
         LoggerFactory.getLogger(SelectionComponentFactory.class)
-            .warn("Setting not saved, invalid: {}", validationErrorMessage.get());
+            .warn("Setting not saved, invalid: {}", gameSetting.validateValue(value).get());
       } else {
         setValue(gameSetting, value, ValueSensitivity.INSENSITIVE);
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponent.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponent.java
@@ -1,6 +1,5 @@
 package games.strategy.triplea.settings;
 
-import java.util.Optional;
 import javax.annotation.Nullable;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
Fixes incorrect error message and bug when setting values with
an existing blank (null) setting from the preferences window.

Null values should be allowed to unset values


<!-- If multiple commits please summarize the change above. -->

## Testing
- various manual testing around the settings window, particularly with file path choices where a NPE can be observed through normal usage.
