### PR TITLE
Increase test timeout threshold

### DIFF
--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexingTaskTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexingTaskTest.java
@@ -62,6 +62,6 @@ class MapIndexingTaskTest {
     mapIndexingTask.run();
 
     verify(mapIndexDao).removeMapsNotIn(List.of("https://uri-1", "https://uri-2"));
-    verify(mapIndexDao, timeout(300)).upsert(MAP_INDEX_RESULT);
+    verify(mapIndexDao, timeout(2000)).upsert(MAP_INDEX_RESULT);
   }
 }


### PR DESCRIPTION
Help avoid a flaky test, increase wait time in MapIndexingTaskTest.java

