### PR TITLE
Improve SpitFire server test configurations

### DIFF
--- a/.build/smoke-testing/run
+++ b/.build/smoke-testing/run
@@ -65,7 +65,6 @@ function buildJars() {
 }
 
 function startLobby() {
-  export MAP_INDEXING_ENABLED="false"
   java -jar "$LOBBY_SERVER_JAR_PATH" \
        server ./spitfire-server/dropwizard-server/configuration.yml \
        > "$LOBBY_SERVER_OUTPUT" 2>&1 &

--- a/http-clients/github-client/src/main/java/org/triplea/http/client/github/GithubApiClient.java
+++ b/http-clients/github-client/src/main/java/org/triplea/http/client/github/GithubApiClient.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import lombok.Builder;
 import org.triplea.http.client.HttpClient;
 
@@ -18,20 +19,25 @@ public class GithubApiClient {
   static final String STUBBED_RETURN_VALUE =
       "API-token==test--returned-a-stubbed-github-issue-link";
 
-  private final String authToken;
+  /**
+   * 'authToken' is optionally needed. If null, the client will still work but will have more
+   * restrictive API rate limits.
+   */
+  @Nullable private final String authToken;
+
   private final GithubApiFeignClient githubApiFeignClient;
   /**
-   * For local or integration testing, we may want to have a fake that does not actually call
-   * github. This method returns true if we are doing a fake call to github.
+   * Flag useful for testing, when set to true no API calls will be made and a hardcoded stubbed
+   * value of {@code STUBBED_RETURN_VALUE} will always be returned.
    */
-  private final boolean test;
+  private final boolean stubbingModeEnabled;
 
   @Builder
   public GithubApiClient(
-      @Nonnull final URI uri, @Nonnull final String authToken, final boolean isTest) {
+      @Nonnull final URI uri, @Nonnull final String authToken, final boolean stubbingModeEnabled) {
     githubApiFeignClient = new HttpClient<>(GithubApiFeignClient.class, uri).get();
     this.authToken = authToken;
-    this.test = isTest;
+    this.stubbingModeEnabled = stubbingModeEnabled;
   }
 
   /**
@@ -45,7 +51,7 @@ public class GithubApiClient {
       final String githubOrg,
       final String githubRepo,
       final CreateIssueRequest createIssueRequest) {
-    if (test) {
+    if (stubbingModeEnabled) {
       return new CreateIssueResponse(STUBBED_RETURN_VALUE);
     }
 

--- a/http-clients/github-client/src/test/java/org/triplea/http/client/github/GithubApiClientTest.java
+++ b/http-clients/github-client/src/test/java/org/triplea/http/client/github/GithubApiClientTest.java
@@ -39,7 +39,6 @@ class GithubApiClientTest {
 
     final Collection<MapRepoListing> repos =
         GithubApiClient.builder()
-            .authToken("test-token")
             .uri(URI.create(server.baseUrl()))
             .build()
             .listRepositories("example-org");
@@ -72,7 +71,6 @@ class GithubApiClientTest {
       final int expectedPageNumber, final WireMockServer server, final String response) {
     server.stubFor(
         get("/orgs/example-org/repos?per_page=100&page=" + expectedPageNumber)
-            .withHeader(AuthenticationHeaders.API_KEY_HEADER, equalTo("token test-token"))
             .willReturn(aResponse().withStatus(200).withBody(response)));
   }
 

--- a/infrastructure/ansible/roles/lobby_server/defaults/main.yml
+++ b/infrastructure/ansible/roles/lobby_server/defaults/main.yml
@@ -8,7 +8,7 @@ lobby_server_db_host: "127.0.0.1"
 lobby_server_db_port: "5432"
 lobby_server_db_name: lobby_db
 lobby_server_db_user: lobby_user
-github_api_token: test
+github_api_token: ""
 lobby_artifact: triplea-dropwizard-server-{{ lobby_version }}.zip
 lobby_jar_file: triplea-dropwizard-server-{{ lobby_version }}.jar
 lobby_artifact_download: |

--- a/infrastructure/ansible/roles/lobby_server/templates/lobby_server.service.j2
+++ b/infrastructure/ansible/roles/lobby_server/templates/lobby_server.service.j2
@@ -3,6 +3,9 @@ Description=TripleA Lobby Server
 Documentation=
 
 [Service]
+Environment=ERROR_REPORT_TO_GITHUB_ENABLED=true
+Environment=MAP_INDEXING_ENABLED=true
+Environment=GAME_HOST_CONNECTIVITY_CHECK_ENABLED=true
 Environment=DATABASE_USER={{ lobby_server_db_user }}
 Environment=DATABASE_PASSWORD={{ lobby_db_password }}
 Environment=DB_URL={{ lobby_server_db_host }}:{{ lobby_server_db_port }}/{{ lobby_server_db_name }}

--- a/spitfire-server/dropwizard-server/configuration.yml
+++ b/spitfire-server/dropwizard-server/configuration.yml
@@ -1,4 +1,4 @@
-githubApiToken: ${GITHUB_API_TOKEN:-test}
+githubApiToken: ${GITHUB_API_TOKEN:-}
 githubWebServiceUrl: https://api.github.com
 githubOrgForErrorReports: triplea-game
 githubRepoForErrorReports: ${ERROR_REPORT_GITHUB_REPO:-test}
@@ -6,7 +6,7 @@ githubMapsOrgName: triplea-maps
 
 # If map indexing is enabled, it will begin shortly after server startup.
 # If disabled no map indexing will occur.
-mapIndexingEnabled: ${MAP_INDEXING_ENABLED:-true}
+mapIndexingEnabled: ${MAP_INDEXING_ENABLED:-false}
 
 # How often between map indexing runs. On each map indexing run we will
 # index all maps. If the previous map indexing run is still going
@@ -26,9 +26,12 @@ mapIndexingPeriodMinutes: ${MAP_INDEXING_PERIOD_MINUTES:-300}
 # Authenticated Github API requests are limited to 1000 requests per hour.
 indexingTaskDelaySeconds: ${MAP_INDEXING_DELAY_SECONDS:-120}
 
-# if we are using any stubbing, we'll assert that this value is false.
 # this is to help guarantee that we do not accidentally use test configuration in prod.
-prod: ${PROD_FLAG:-false}
+gameHostConnectivityCheckEnabled: ${GAME_HOST_CONNECTIVITY_CHECK_ENABLED:-false}
+
+# When disabled, API calls to github to create error reports will not
+# be made and instead a hardcoded value returned.
+errorReportToGithubEnabled: ${ERROR_REPORT_TO_GITHUB_ENABLED:-false}
 
 # Whether to print out SQL statements as executed, useful for debugging.
 logSqlStatements: false

--- a/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/SpitfireServerConfig.java
+++ b/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/SpitfireServerConfig.java
@@ -27,7 +27,7 @@ public class SpitfireServerConfig extends Configuration
    */
   @Getter(onMethod_ = {@JsonProperty, @Override})
   @Setter(onMethod_ = {@JsonProperty})
-  private boolean prod;
+  private boolean gameHostConnectivityCheckEnabled;
 
   @Getter(onMethod_ = {@JsonProperty})
   @Setter(onMethod_ = {@JsonProperty})
@@ -68,4 +68,8 @@ public class SpitfireServerConfig extends Configuration
   @Getter(onMethod_ = {@JsonProperty, @Override})
   @Setter(onMethod_ = {@JsonProperty})
   private int indexingTaskDelaySeconds;
+
+  @Getter(onMethod_ = {@JsonProperty, @Override})
+  @Setter(onMethod_ = {@JsonProperty})
+  private boolean errorReportToGithubEnabled;
 }

--- a/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/controllers/ErrorReportController.java
+++ b/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/controllers/ErrorReportController.java
@@ -1,6 +1,5 @@
 package org.triplea.spitfire.server.controllers;
 
-import com.google.common.base.Preconditions;
 import java.net.URI;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
@@ -32,18 +31,15 @@ public class ErrorReportController extends HttpController {
   /** Factory method. */
   public static ErrorReportController build(
       final LobbyModuleConfig configuration, final Jdbi jdbi) {
-    final boolean isTest = configuration.getGithubApiToken().equals("test");
+
+    final boolean errorReportStubbingMode = !configuration.isErrorReportToGithubEnabled();
 
     final GithubApiClient githubApiClient =
         GithubApiClient.builder()
             .uri(URI.create(configuration.getGithubWebServiceUrl()))
             .authToken(configuration.getGithubApiToken())
-            .isTest(isTest)
+            .stubbingModeEnabled(errorReportStubbingMode)
             .build();
-
-    if (isTest) {
-      Preconditions.checkState(!configuration.isProd());
-    }
 
     return ErrorReportController.builder()
         .errorReportIngestion(

--- a/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/controllers/lobby/LobbyWatcherController.java
+++ b/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/controllers/lobby/LobbyWatcherController.java
@@ -44,7 +44,7 @@ public class LobbyWatcherController extends HttpController {
   @VisibleForTesting
   public static final String TEST_ONLY_GAME_POSTING_PATH = "/test-only/lobby/post-game";
 
-  @Nonnull private final Boolean isProd;
+  @Nonnull private final Boolean gameHostConnectivityCheckEnabled;
   @Nonnull private final GameListing gameListing;
   @Nonnull private final ChatUploadModule chatUploadModule;
   @Nonnull private final GamePostingModule gamePostingModule;
@@ -52,7 +52,7 @@ public class LobbyWatcherController extends HttpController {
   public static LobbyWatcherController build(
       final LobbyModuleConfig lobbyModuleConfig, final Jdbi jdbi, final GameListing gameListing) {
     return LobbyWatcherController.builder()
-        .isProd(lobbyModuleConfig.isProd())
+        .gameHostConnectivityCheckEnabled(lobbyModuleConfig.isGameHostConnectivityCheckEnabled())
         .gameListing(gameListing)
         .chatUploadModule(ChatUploadModule.build(jdbi, gameListing))
         .gamePostingModule(GamePostingModule.build(gameListing))
@@ -75,7 +75,7 @@ public class LobbyWatcherController extends HttpController {
   }
 
   /**
-   * A endpont available for non-prod-only that allows for integration tests to post games without
+   * A endpoint available for non-prod-only that allows for integration tests to post games without
    * actually hosting a game themselves (bypasses the reverse connectivity check).
    */
   @POST
@@ -86,7 +86,7 @@ public class LobbyWatcherController extends HttpController {
     Preconditions.checkArgument(gamePostingRequest != null);
     Preconditions.checkArgument(gamePostingRequest.getLobbyGame() != null);
 
-    return isProd
+    return gameHostConnectivityCheckEnabled
         ? Response.status(HttpStatus.NOT_FOUND_404).build()
         : Response.ok()
             .entity(

--- a/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/controllers/user/account/ForgotPasswordController.java
+++ b/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/controllers/user/account/ForgotPasswordController.java
@@ -29,7 +29,9 @@ public class ForgotPasswordController extends HttpController {
   public static ForgotPasswordController build(
       final LobbyModuleConfig lobbyModuleConfig, final Jdbi jdbi) {
     return ForgotPasswordController.builder()
-        .forgotPasswordModule(ForgotPasswordModule.build(lobbyModuleConfig.isProd(), jdbi))
+        .forgotPasswordModule(
+            ForgotPasswordModule.build(
+                lobbyModuleConfig.isGameHostConnectivityCheckEnabled(), jdbi))
         .build();
   }
 

--- a/spitfire-server/lobby-module/src/main/java/org/triplea/modules/LobbyModuleConfig.java
+++ b/spitfire-server/lobby-module/src/main/java/org/triplea/modules/LobbyModuleConfig.java
@@ -1,18 +1,30 @@
 package org.triplea.modules;
 
+import javax.annotation.Nullable;
+
 /**
  * Interface for configuration parameters, typically these values will come from the servers
  * 'configuration.yml' file.
  */
 public interface LobbyModuleConfig {
   /**
-   * Should return true if we are in a production environment. Useful if we need to stub out
-   * behavior in non-prod environments.
+   * When true we will do a reverse connectivity check to game hosts. Otherwise false will enable a
+   * special test only endpoint that still does authentication but will not do the reverse
+   * connectivity check.
    */
-  boolean isProd();
+  boolean isGameHostConnectivityCheckEnabled();
 
+  /** If enabled, we will send real API requests to github to create error reports. */
+  boolean isErrorReportToGithubEnabled();
+
+  /**
+   * Auth token that will be sent to Github for webservice calls. Can be empty, but if specified
+   * must be valid (no auth token still works, but rate limits will be more restrictive).
+   */
+  @Nullable
   String getGithubApiToken();
 
+  /** Github API webserivce URL. */
   String getGithubWebServiceUrl();
 
   String getGithubOrgForErrorReports();

--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapsIndexingSchedule.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapsIndexingSchedule.java
@@ -37,7 +37,6 @@ public class MapsIndexingSchedule implements Managed {
         GithubApiClient.builder()
             .uri(URI.create(configuration.getGithubWebServiceUrl()))
             .authToken(configuration.getGithubApiToken())
-            .isTest(false)
             .build();
 
     return new MapsIndexingSchedule(


### PR DESCRIPTION
Renaming updates and documentation enhancments to improve clarity
on spitfire server test configuration modes.

Notable, we no longer use a magic github API token of 'test',
it is now either left blank or specified. Instead a new feature
flag is used in the place of checking for an API token of 'test'.

A new consistency is put in place here where out of the box
features are turned off, but all turned on by default in
prerelease and production.

