### PR TITLE
Remove left over 'version: 0' value in test data

### DIFF
--- a/game-app/map-data/src/test/resources/map_yml_example/map.yml
+++ b/game-app/map-data/src/test/resources/map_yml_example/map.yml
@@ -1,5 +1,4 @@
 map_name: example map
-version: 0
 games:
   - game_name: Great Game
     file_name: game-file.xml


### PR DESCRIPTION
'map.yml' no longer uses a 'version' field, this update
removes that field from test data that was not previously updated

