### PR TITLE
Move MapsIndexing object creation to a 'MapsIndexingObjectFactory'

### DIFF
--- a/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/SpitfireServerApplication.java
+++ b/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/SpitfireServerApplication.java
@@ -16,7 +16,7 @@ import org.triplea.dropwizard.common.ServerConfiguration;
 import org.triplea.dropwizard.common.ServerConfiguration.WebsocketConfig;
 import org.triplea.http.client.web.socket.WebsocketPaths;
 import org.triplea.maps.MapsModuleRowMappers;
-import org.triplea.maps.indexing.MapsIndexingSchedule;
+import org.triplea.maps.indexing.MapsIndexingObjectFactory;
 import org.triplea.modules.chat.ChatMessagingService;
 import org.triplea.modules.chat.Chatters;
 import org.triplea.modules.game.listing.GameListing;
@@ -99,7 +99,9 @@ public class SpitfireServerApplication extends Application<SpitfireServerConfig>
     }
 
     if (configuration.isMapIndexingEnabled()) {
-      environment.lifecycle().manage(MapsIndexingSchedule.build(configuration, jdbi));
+      environment
+          .lifecycle()
+          .manage(MapsIndexingObjectFactory.buildMapsIndexingSchedule(configuration, jdbi));
       log.info(
           "Map indexing is enabled to run every:"
               + " {} minutes with one map indexing request every {} seconds",

--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapsIndexingObjectFactory.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapsIndexingObjectFactory.java
@@ -1,0 +1,48 @@
+package org.triplea.maps.indexing;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.function.Function;
+import lombok.experimental.UtilityClass;
+import org.jdbi.v3.core.Jdbi;
+import org.triplea.http.client.github.GithubApiClient;
+import org.triplea.maps.MapsModuleConfig;
+
+@UtilityClass
+public class MapsIndexingObjectFactory {
+  /**
+   * Factory method to create indexing task on a schedule. This does not start indexing, the
+   * 'start()' method must be called for map indexing to begin.
+   */
+  public static MapsIndexingSchedule buildMapsIndexingSchedule(
+      final MapsModuleConfig configuration, final Jdbi jdbi) {
+    final var githubApiClient =
+        GithubApiClient.builder()
+            .uri(URI.create(configuration.getGithubWebServiceUrl()))
+            .authToken(configuration.getGithubApiToken())
+            .build();
+
+    return new MapsIndexingSchedule(
+        configuration.getMapIndexingPeriodMinutes(),
+        MapIndexingTaskRunner.builder()
+            .githubOrgName(configuration.getGithubMapsOrgName())
+            .githubApiClient(githubApiClient)
+            .mapIndexer(
+                new MapIndexingTask(
+                    lastCommitDateFetcher(githubApiClient, configuration.getGithubMapsOrgName())))
+            .mapIndexDao(jdbi.onDemand(MapIndexDao.class))
+            .indexingTaskDelaySeconds(configuration.getIndexingTaskDelaySeconds())
+            .build());
+  }
+
+  /**
+   * Returns function that can fetch the last commit date for a given repository specified by name.
+   */
+  static Function<String, Instant> lastCommitDateFetcher(
+      final GithubApiClient githubApiClient, final String githubOrgName) {
+    return githubRepoName ->
+        githubApiClient
+            .fetchBranchInfo(githubOrgName, githubRepoName, "master")
+            .getLastCommitDate();
+  }
+}

--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapsIndexingSchedule.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapsIndexingSchedule.java
@@ -1,14 +1,10 @@
 package org.triplea.maps.indexing;
 
 import io.dropwizard.lifecycle.Managed;
-import java.net.URI;
 import java.util.concurrent.TimeUnit;
 import lombok.extern.slf4j.Slf4j;
-import org.jdbi.v3.core.Jdbi;
-import org.triplea.http.client.github.GithubApiClient;
 import org.triplea.java.timer.ScheduledTimer;
 import org.triplea.java.timer.Timers;
-import org.triplea.maps.MapsModuleConfig;
 
 /**
  * Given a map indexing task, creates a schedule to run the indexing and once started will run at a
@@ -26,34 +22,6 @@ public class MapsIndexingSchedule implements Managed {
             .period(indexingPeriodMinutes, TimeUnit.MINUTES)
             .delay(10, TimeUnit.SECONDS)
             .task(mapIndexingTaskRunner);
-  }
-
-  /**
-   * Factory method to create indexing task on a schedule. This does not start indexing, the
-   * 'start()' method must be called for map indexing to begin.
-   */
-  public static MapsIndexingSchedule build(final MapsModuleConfig configuration, final Jdbi jdbi) {
-    final var githubApiClient =
-        GithubApiClient.builder()
-            .uri(URI.create(configuration.getGithubWebServiceUrl()))
-            .authToken(configuration.getGithubApiToken())
-            .build();
-
-    return new MapsIndexingSchedule(
-        configuration.getMapIndexingPeriodMinutes(),
-        MapIndexingTaskRunner.builder()
-            .githubOrgName(configuration.getGithubMapsOrgName())
-            .githubApiClient(githubApiClient)
-            .mapIndexer(
-                new MapIndexingTask(
-                    repoName ->
-                        githubApiClient
-                            .fetchBranchInfo(
-                                configuration.getGithubMapsOrgName(), repoName, "master")
-                            .getLastCommitDate()))
-            .mapIndexDao(jdbi.onDemand(MapIndexDao.class))
-            .indexingTaskDelaySeconds(configuration.getIndexingTaskDelaySeconds())
-            .build());
   }
 
   @Override


### PR DESCRIPTION
It was a bit non-obvious for all object init code to be in MapsIndexingSchedule.
This update puts that code on its own to make it easier to find.
