### PR TITLE
Fix noisy DB rider log warning

### DIFF
--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexDaoTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexDaoTest.java
@@ -25,7 +25,7 @@ class MapIndexDaoTest {
     mapIndexDao.upsert(
         MapIndexingResult.builder()
             .mapName("map-name-3")
-            .mapRepoUri("http://map-repo-url-3")
+            .mapRepoUri("http-map-repo-url-3")
             .lastCommitDate(LocalDateTime.of(2000, 1, 12, 23, 59).toInstant(ZoneOffset.UTC))
             .build());
   }
@@ -36,7 +36,7 @@ class MapIndexDaoTest {
     mapIndexDao.upsert(
         MapIndexingResult.builder()
             .mapName("map-name-updated")
-            .mapRepoUri("http://map-repo-url-2")
+            .mapRepoUri("http-map-repo-url-2")
             .lastCommitDate(LocalDateTime.of(2000, 1, 12, 23, 59).toInstant(ZoneOffset.UTC))
             .build());
   }
@@ -47,7 +47,7 @@ class MapIndexDaoTest {
     mapIndexDao.upsert(
         MapIndexingResult.builder()
             .mapName("map-name-2")
-            .mapRepoUri("http://map-repo-url-2")
+            .mapRepoUri("http-map-repo-url-2")
             .lastCommitDate(LocalDateTime.of(2016, 1, 1, 23, 59, 20).toInstant(ZoneOffset.UTC))
             .build());
   }
@@ -55,6 +55,6 @@ class MapIndexDaoTest {
   @Test
   @ExpectedDataSet("expected/map_index_post_remove.yml")
   void removeMaps() {
-    mapIndexDao.removeMapsNotIn(List.of("http://map-repo-url"));
+    mapIndexDao.removeMapsNotIn(List.of("http-map-repo-url"));
   }
 }

--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/listing/MapListingDaoTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/listing/MapListingDaoTest.java
@@ -31,7 +31,7 @@ class MapListingDaoTest {
     final var mapDownloadListing = results.get(0).toMapDownloadListing();
     assertThat(mapDownloadListing.getMapCategory(), is("category_name"));
     assertThat(mapDownloadListing.getMapName(), is("map-name"));
-    assertThat(mapDownloadListing.getUrl(), is("http://map-repo-url"));
+    assertThat(mapDownloadListing.getUrl(), is("http-map-repo-url"));
     assertThat(
         mapDownloadListing.getLastCommitDateEpochMilli(),
         is(LocalDateTime.of(2000, 12, 1, 23, 59, 20).toInstant(ZoneOffset.UTC).toEpochMilli()));

--- a/spitfire-server/maps-module/src/test/resources/datasets/expected/map_index_post_remove.yml
+++ b/spitfire-server/maps-module/src/test/resources/datasets/expected/map_index_post_remove.yml
@@ -1,6 +1,6 @@
 map_index:
   - id: 10
     map_name: map-name
-    repo_url: http://map-repo-url
+    repo_url: "http-map-repo-url"
     category_id: 1
     last_commit_date: 2000-12-01 23:59:20.0

--- a/spitfire-server/maps-module/src/test/resources/datasets/expected/map_index_upsert_new.yml
+++ b/spitfire-server/maps-module/src/test/resources/datasets/expected/map_index_upsert_new.yml
@@ -1,10 +1,10 @@
 map_index:
   - map_name: map-name
-    repo_url: http://map-repo-url
+    repo_url: "http-map-repo-url"
     last_commit_date: 2000-12-01 23:59:20.0
   - map_name: map-name-2
-    repo_url: http://map-repo-url-2
+    repo_url: "http-map-repo-url-2"
     last_commit_date: 2016-01-01 23:59:20.0
   - map_name: map-name-3
-    repo_url: http://map-repo-url-3
+    repo_url: "http-map-repo-url-3"
     last_commit_date: 2000-01-12 23:59:00.0

--- a/spitfire-server/maps-module/src/test/resources/datasets/expected/map_index_upsert_updated.yml
+++ b/spitfire-server/maps-module/src/test/resources/datasets/expected/map_index_upsert_updated.yml
@@ -1,11 +1,11 @@
 map_index:
   - id: 10
     map_name: map-name
-    repo_url: http://map-repo-url
+    repo_url: "http-map-repo-url"
     category_id: 1
     last_commit_date: 2000-12-01 23:59:20.0
   - id: 20
     map_name: map-name-updated
-    repo_url: http://map-repo-url-2
+    repo_url: "http-map-repo-url-2"
     category_id: 1
     last_commit_date: 2000-01-12 23:59:00.0

--- a/spitfire-server/maps-module/src/test/resources/datasets/map_index.yml
+++ b/spitfire-server/maps-module/src/test/resources/datasets/map_index.yml
@@ -1,11 +1,13 @@
 map_index:
   - id: 10
     map_name: map-name
-    repo_url: http://map-repo-url
+    # Do not use "http:" in test data, DB rider logs a noisy warning about this.
+    # repo_url must otherwise begin with 'http' per column constraint
+    repo_url: 'http-map-repo-url'
     category_id: 1
     last_commit_date: 2000-12-01 23:59:20.0
   - id: 20
     map_name: map-name-2
-    repo_url: http://map-repo-url-2
+    repo_url: 'http-map-repo-url-2'
     category_id: 1
     last_commit_date: 2016-01-01 23:59:20.0


### PR DESCRIPTION
Log message observed when running tests:

WARNING: Could not find script engine by name 'http'

This is caused seemingly by there being yaml string values
beginning with "http:"

As a hack around this we can change the test data to be "http-"
and satisfy the column constraints of begins with 'http' and
aso avoid an 'http:' prefix that triggers a noisy logging
message.
