### PR TITLE
Add Map-Indexing Integration Test

### DIFF
--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexingIntegrationTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexingIntegrationTest.java
@@ -1,0 +1,46 @@
+package org.triplea.maps.indexing;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.notNullValue;
+
+import java.net.URI;
+import org.junit.jupiter.api.Test;
+import org.triplea.http.client.github.GithubApiClient;
+import org.triplea.http.client.github.MapRepoListing;
+
+/**
+ * Test that does a live indexing (goes over network to github) of 'triplea-maps/test-map'. We'll
+ * build an indexer and then run indexing on the test map. The test map will be in a known state and
+ * we'll then verify the returned indexing results are as expected.
+ */
+public class MapIndexingIntegrationTest {
+
+  @Test
+  void runIndexingOnTestMap() {
+    final MapIndexingTask mapIndexingTaskRunner =
+        MapIndexingTask.builder()
+            .lastCommitDateFetcher(
+                MapsIndexingObjectFactory.lastCommitDateFetcher(
+                    GithubApiClient.builder().uri(URI.create("https://api.github.com")).build(),
+                    "triplea-maps"))
+            .build();
+
+    final MapIndexingResult result =
+        mapIndexingTaskRunner
+            .apply(
+                MapRepoListing.builder()
+                    .name("test-map")
+                    .htmlUrl("https://github.com/triplea-maps/test-map")
+                    .build())
+            .orElseThrow(
+                () -> new AssertionError("Expected a result to be returned, check logs for cause"));
+
+    assertThat(result.getMapRepoUri(), is("https://github.com/triplea-maps/test-map"));
+    assertThat("Map name is read from map.yml", result.getMapName(), is("Test Map"));
+    assertThat(
+        "Last commit date is parsed from an API call",
+        result.getLastCommitDate(),
+        is(notNullValue()));
+  }
+}

--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexingTaskRunnerTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexingTaskRunnerTest.java
@@ -57,7 +57,6 @@ class MapIndexingTaskRunnerTest {
     when(githubApiClient.listRepositories("ORG_NAME"))
         .thenReturn(List.of(repoListing1, repoListing2));
     when(mapIndexer.apply(repoListing1)).thenReturn(Optional.of(MAP_INDEX_RESULT));
-    when(mapIndexer.apply(repoListing2)).thenReturn(Optional.empty());
 
     mapIndexingTaskRunner.run();
 


### PR DESCRIPTION
A repo has been set up in triplea-maps with a minimal
number of files read by indexing. This test verifies
that those can be read and is a live example
of the map indexing working to gather information
about a single map repo.

