### PR TITLE
Index map description file

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
@@ -96,6 +96,7 @@ public final class DownloadFileDescription {
     return DownloadFileDescription.builder()
         .url(mapDownloadListing.getUrl())
         .mapName(mapDownloadListing.getMapName())
+        .description(mapDownloadListing.getDescription())
         // TODO: PROJECT#17 replace with latest commit date
         .version(1)
         .mapCategory(MapCategory.fromString(mapDownloadListing.getMapCategory()))

--- a/http-clients/maps-client/src/main/java/org/triplea/http/client/maps/listing/MapDownloadListing.java
+++ b/http-clients/maps-client/src/main/java/org/triplea/http/client/maps/listing/MapDownloadListing.java
@@ -13,4 +13,5 @@ public class MapDownloadListing {
   @Nonnull private final String mapName;
   @Nonnull private final long lastCommitDateEpochMilli;
   @Nonnull private final String mapCategory;
+  @Nonnull private final String description;
 }

--- a/spitfire-server/database/src/main/resources/db/migration/lobby_db/V2.01.02__maps_index_description_column.sql
+++ b/spitfire-server/database/src/main/resources/db/migration/lobby_db/V2.01.02__maps_index_description_column.sql
@@ -1,0 +1,1 @@
+alter table map_index add column description varchar(3000);

--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapIndexDao.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapIndexDao.java
@@ -9,10 +9,13 @@ interface MapIndexDao {
 
   /** Upserts a map indexing result into the map_index table. */
   @SqlUpdate(
-      "insert into map_index(map_name, repo_url, category_id, last_commit_date)\n"
-          + "values(:mapName, :mapRepoUri, 1, :lastCommitDate)\n"
+      "insert into map_index(map_name, repo_url, category_id, description, last_commit_date)\n"
+          + "values(:mapName, :mapRepoUri, 1, :description, :lastCommitDate)\n"
           + "on conflict(repo_url)\n"
-          + "do update set map_name = :mapName, last_commit_date = :lastCommitDate")
+          + "do update set\n"
+          + "   map_name = :mapName,"
+          + "   description = :description,"
+          + "   last_commit_date = :lastCommitDate")
   void upsert(@BindBean MapIndexingResult mapIndexingResult);
 
   /** Deletes maps that are not in the parameter list from the map_index table. */

--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapIndexingResult.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapIndexingResult.java
@@ -12,8 +12,19 @@ import lombok.Value;
 @Builder
 @Value
 public class MapIndexingResult {
+  /** Name of the map as found in the 'map.yml' file located in the map repo. */
   @Nonnull String mapName;
+
+  /** URI to the repo, typically something like: "https://github.com/triplea-maps/test-map/" */
   @Nonnull String mapRepoUri;
+
   /** Date of the most recent commit to master. */
   @Nonnull Instant lastCommitDate;
+
+  /**
+   * Data that is parsed from description.html. If the file is missing or if contents are two long
+   * then a message should be inserted stated that the map author needs to fix the description.html
+   * file.
+   */
+  String description;
 }

--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapIndexingTaskRunner.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapIndexingTaskRunner.java
@@ -86,7 +86,7 @@ class MapIndexingTaskRunner implements Runnable {
 
   /**
    * Performs the actual indexing of a single map repo listing. Indexing is two parts, first we
-   * reach out to the repo to gather indexing informaton, second we upsert that info into database.
+   * reach out to the repo to gather indexing information, second we upsert that info into database.
    */
   private void performIndexing(final MapRepoListing mapRepoListing) {
     log.info("Indexing map: " + mapRepoListing.getName());

--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/listing/MapListingDao.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/listing/MapListingDao.java
@@ -8,6 +8,7 @@ public interface MapListingDao {
       "select"
           + "    m.map_name,"
           + "    m.repo_url,"
+          + "    m.description,"
           + "    m.last_commit_date,"
           + "    c.name as category_name"
           + "  from map_index m"

--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/listing/MapListingRecord.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/listing/MapListingRecord.java
@@ -8,6 +8,7 @@ import org.triplea.http.client.maps.listing.MapDownloadListing;
 public class MapListingRecord {
   private final String name;
   private final String url;
+  private final String description;
   private final Instant lastCommitDate;
   private final String categoryName;
 
@@ -15,12 +16,14 @@ public class MapListingRecord {
   public MapListingRecord(
       @ColumnName("map_name") final String name,
       @ColumnName("repo_url") final String url,
+      @ColumnName("description") final String description,
       @ColumnName("last_commit_date") final Instant lastCommitDate,
       @ColumnName("category_name") final String categoryName) {
     this.url = url;
     this.name = name;
     this.lastCommitDate = lastCommitDate;
     this.categoryName = categoryName;
+    this.description = description;
   }
 
   MapDownloadListing toMapDownloadListing() {
@@ -29,6 +32,7 @@ public class MapListingRecord {
         .mapName(name)
         .lastCommitDateEpochMilli(lastCommitDate.toEpochMilli())
         .mapCategory(categoryName)
+        .description(description)
         .build();
   }
 }

--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexDaoTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexDaoTest.java
@@ -48,6 +48,7 @@ class MapIndexDaoTest {
         MapIndexingResult.builder()
             .mapName("map-name-2")
             .mapRepoUri("http-map-repo-url-2")
+            .description("description-repo-2")
             .lastCommitDate(LocalDateTime.of(2016, 1, 1, 23, 59, 20).toInstant(ZoneOffset.UTC))
             .build());
   }

--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexingIntegrationTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexingIntegrationTest.java
@@ -3,6 +3,7 @@ package org.triplea.maps.indexing;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.hamcrest.core.StringContains.containsString;
 
 import java.net.URI;
 import org.junit.jupiter.api.Test;
@@ -42,5 +43,9 @@ public class MapIndexingIntegrationTest {
         "Last commit date is parsed from an API call",
         result.getLastCommitDate(),
         is(notNullValue()));
+    assertThat(
+        "Description is downloaded from description.html",
+        result.getDescription(),
+        containsString("<br><b><em>by test</em></b>"));
   }
 }

--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/listing/MapListingDaoTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/listing/MapListingDaoTest.java
@@ -32,6 +32,7 @@ class MapListingDaoTest {
     assertThat(mapDownloadListing.getMapCategory(), is("category_name"));
     assertThat(mapDownloadListing.getMapName(), is("map-name"));
     assertThat(mapDownloadListing.getUrl(), is("http-map-repo-url"));
+    assertThat(mapDownloadListing.getDescription(), is("description-repo-1"));
     assertThat(
         mapDownloadListing.getLastCommitDateEpochMilli(),
         is(LocalDateTime.of(2000, 12, 1, 23, 59, 20).toInstant(ZoneOffset.UTC).toEpochMilli()));

--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/listing/MapsListingModuleTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/listing/MapsListingModuleTest.java
@@ -40,12 +40,14 @@ class MapsListingModuleTest {
                     .name("map-name-1")
                     .lastCommitDate(commitDate1)
                     .categoryName("category-1")
+                    .description("description-1")
                     .build(),
                 MapListingRecord.builder()
                     .url("http://map-url-2")
                     .name("map-name-2")
                     .lastCommitDate(commitDate2)
                     .categoryName("category-2")
+                    .description("description-1")
                     .build()));
 
     final List<MapDownloadListing> results = mapsListingModule.get();

--- a/spitfire-server/maps-module/src/test/resources/datasets/map_index.yml
+++ b/spitfire-server/maps-module/src/test/resources/datasets/map_index.yml
@@ -5,9 +5,11 @@ map_index:
     # repo_url must otherwise begin with 'http' per column constraint
     repo_url: 'http-map-repo-url'
     category_id: 1
+    description: description-repo-1
     last_commit_date: 2000-12-01 23:59:20.0
   - id: 20
     map_name: map-name-2
     repo_url: 'http-map-repo-url-2'
     category_id: 1
+    description: description-repo-2
     last_commit_date: 2016-01-01 23:59:20.0


### PR DESCRIPTION
Add scraping for map indexing to read 'description.html' file in map repos
and stores contents in database. When serving map listings the description
will be retrieved from database and sent to game client.

Game clients could very well download map description data when selecting
different maps. There is a pretty significant performance penalty to this
and having a larger one-time download to get all the data should have
better performance than downloading descriptions on-demand.


<!-- If multiple commits please summarize the change above. -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
