### PR TITLE
Map Indexing - Breakup Tasks & Skip Indexing if Map Not Changed

### DIFF
--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapIndexDao.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapIndexDao.java
@@ -1,11 +1,15 @@
 package org.triplea.maps.indexing;
 
+import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
+import org.jdbi.v3.sqlobject.customizer.Bind;
 import org.jdbi.v3.sqlobject.customizer.BindBean;
 import org.jdbi.v3.sqlobject.customizer.BindList;
+import org.jdbi.v3.sqlobject.statement.SqlQuery;
 import org.jdbi.v3.sqlobject.statement.SqlUpdate;
 
-interface MapIndexDao {
+public interface MapIndexDao {
 
   /** Upserts a map indexing result into the map_index table. */
   @SqlUpdate(
@@ -21,4 +25,7 @@ interface MapIndexDao {
   /** Deletes maps that are not in the parameter list from the map_index table. */
   @SqlUpdate("delete from map_index where repo_url not in(<mapUriList>)")
   int removeMapsNotIn(@BindList("mapUriList") List<String> mapUriList);
+
+  @SqlQuery("select last_commit_date from map_index where repo_url = :repoUrl")
+  Optional<Instant> getLastCommitDate(@Bind("repoUrl") String repoUrl);
 }

--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapIndexingTask.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapIndexingTask.java
@@ -1,117 +1,54 @@
 package org.triplea.maps.indexing;
 
-import com.google.common.annotations.VisibleForTesting;
-import java.net.URI;
 import java.time.Instant;
-import java.util.Map;
 import java.util.Optional;
+import java.util.function.BiPredicate;
 import java.util.function.Function;
 import javax.annotation.Nonnull;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.extern.slf4j.Slf4j;
 import org.triplea.http.client.github.MapRepoListing;
-import org.triplea.io.ContentDownloader;
-import org.triplea.yaml.YamlReader;
 
 /**
- * Given a map repo name and URI, reads pertinent indexing information.
+ * Given a map repo name and URI, reads pertinent indexing information. Indexing will be skipped if
+ * database is up to date and the repo has not been updated since.
  *
  * <ul>
  *   <li>mapName: read from map.yml found in the repository
  *   <li>lastCommitDate: github API is queried for the repo's master branch last commit date.
+ *   <li>description: read from description.html file
  * </ul>
  */
-@Slf4j
-@RequiredArgsConstructor
-@AllArgsConstructor
 @Builder
 class MapIndexingTask implements Function<MapRepoListing, Optional<MapIndexingResult>> {
-  private static final int DESCRIPTION_COLUMN_DATABASE_MAX_LENGTH = 3000;
-
-  /* Function that uses github API to map a {repoName -> lastCommitDate} */
-  @Nonnull private final Function<String, Instant> lastCommitDateFetcher;
-
-  /* Function to download content as a string and log an info message if not found. */
-  @Setter(value = AccessLevel.PACKAGE, onMethod_ = @VisibleForTesting)
-  @Builder.Default
-  private Function<URI, String> downloadFunction =
-      uri -> ContentDownloader.downloadAsString(uri).orElse(null);
+  @Nonnull private final Function<MapRepoListing, Optional<Instant>> lastCommitDateFetcher;
+  @Nonnull private final BiPredicate<MapRepoListing, Instant> skipMapIndexingCheck;
+  @Nonnull private final Function<MapRepoListing, Optional<String>> mapNameReader;
+  @Nonnull private final Function<MapRepoListing, String> mapDescriptionReader;
 
   @Override
   public Optional<MapIndexingResult> apply(final MapRepoListing mapRepoListing) {
-    final String mapName = readMapNameFromYaml(mapRepoListing).orElse(null);
+    final Instant lastCommitDateOnRepo = lastCommitDateFetcher.apply(mapRepoListing).orElse(null);
+    if (lastCommitDateOnRepo == null) {
+      return Optional.empty();
+    }
+
+    if (skipMapIndexingCheck.test(mapRepoListing, lastCommitDateOnRepo)) {
+      return Optional.empty();
+    }
+
+    final String mapName = mapNameReader.apply(mapRepoListing).orElse(null);
     if (mapName == null) {
       return Optional.empty();
     }
 
-    final Instant lastCommitDate = lastCommitDateFetcher.apply(mapRepoListing.getName());
-    if (lastCommitDate == null) {
-      log.warn(
-          "Could not index map: {}, unable to fetch last commit date", mapRepoListing.getUri());
-      return Optional.empty();
-    }
-
-    String description = downloadDescription(mapRepoListing).orElse(null);
-    if (description == null) {
-      description =
-          String.format(
-              "No description available for: %s"
-                  + "Contact the map author and request they add a 'description.html' file",
-              mapRepoListing.getUri());
-    } else if (description.length() > DESCRIPTION_COLUMN_DATABASE_MAX_LENGTH) {
-      description =
-          String.format(
-              "The description for this map is too long at %s characters. Max length is %s."
-                  + "Contact the map author for: %s"
-                  + ", and request they reduce the length of the file 'description.html'",
-              description.length(),
-              DESCRIPTION_COLUMN_DATABASE_MAX_LENGTH,
-              mapRepoListing.getUri());
-    }
+    final String description = mapDescriptionReader.apply(mapRepoListing);
 
     return Optional.of(
         MapIndexingResult.builder()
             .mapName(mapName)
             .mapRepoUri(mapRepoListing.getUri().toString())
-            .lastCommitDate(lastCommitDate)
+            .lastCommitDate(lastCommitDateOnRepo)
             .description(description)
             .build());
-  }
-
-  private Optional<String> downloadDescription(final MapRepoListing mapRepoListing) {
-    final String descriptionUri =
-        mapRepoListing.getUri().toString() + "/blob/master/description.html?raw=true";
-    return ContentDownloader.downloadAsString(URI.create(descriptionUri));
-  }
-
-  /**
-   * Determines the expected location of a map.yml file, downloads it, reads and returns the
-   * 'map_name' attribute. Returns null if the file could not be found or otherwise could not be
-   * read.
-   */
-  private Optional<String> readMapNameFromYaml(final MapRepoListing mapRepoListing) {
-    final URI mapYmlUri =
-        URI.create(mapRepoListing.getUri().toString() + "/blob/master/map.yml?raw=true");
-
-    final String mapYamlContents = downloadFunction.apply(mapYmlUri);
-    if (mapYamlContents == null) {
-      log.warn("Could not index, missing map.yml. Expected URI: {}", mapYmlUri);
-      return Optional.empty();
-    }
-
-    // parse and return the 'map_name' attribute from the YML file we just downloaded
-    try {
-      final Map<String, Object> mapYamlData = YamlReader.readMap(mapYamlContents);
-      return Optional.of((String) mapYamlData.get("map_name"));
-    } catch (final ClassCastException
-        | YamlReader.InvalidYamlFormatException
-        | NullPointerException e) {
-      log.error("Invalid map.yml data found at URI: {}, error: {}", mapYmlUri, e.getMessage());
-      return Optional.empty();
-    }
   }
 }

--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapsIndexingSchedule.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapsIndexingSchedule.java
@@ -2,6 +2,7 @@ package org.triplea.maps.indexing;
 
 import io.dropwizard.lifecycle.Managed;
 import java.util.concurrent.TimeUnit;
+import lombok.Builder;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.java.timer.ScheduledTimer;
 import org.triplea.java.timer.Timers;
@@ -15,6 +16,7 @@ public class MapsIndexingSchedule implements Managed {
 
   private final ScheduledTimer taskTimer;
 
+  @Builder
   MapsIndexingSchedule(
       final int indexingPeriodMinutes, final MapIndexingTaskRunner mapIndexingTaskRunner) {
     taskTimer =

--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/tasks/CommitDateFetcher.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/tasks/CommitDateFetcher.java
@@ -1,0 +1,40 @@
+package org.triplea.maps.indexing.tasks;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+import org.triplea.http.client.github.GithubApiClient;
+import org.triplea.http.client.github.MapRepoListing;
+
+/**
+ * Given a map repo listing, does an API call to github to return the last commit date for that
+ * repo. Returns an empty if there are any errors fetching last commit date.
+ */
+@Builder
+@Slf4j
+public class CommitDateFetcher implements Function<MapRepoListing, Optional<Instant>> {
+
+  @Nonnull private final GithubApiClient githubApiClient;
+  @Nonnull private final String githubOrgName;
+
+  @Override
+  public Optional<Instant> apply(final MapRepoListing mapRepoListing) {
+    try {
+      return Optional.of(
+          githubApiClient
+              .fetchBranchInfo(githubOrgName, mapRepoListing.getName(), "master")
+              .getLastCommitDate());
+    } catch (final Exception e) {
+      log.error(
+          "Could not index map: {}, unable to fetch last commit date. Either the last commit"
+              + "date was missing from the webservice call payload from github, or most likely"
+              + "the webservice call to github failed.",
+          mapRepoListing.getUri(),
+          e);
+      return Optional.empty();
+    }
+  }
+}

--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/tasks/MapDescriptionReader.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/tasks/MapDescriptionReader.java
@@ -1,0 +1,41 @@
+package org.triplea.maps.indexing.tasks;
+
+import java.net.URI;
+import java.util.Optional;
+import java.util.function.Function;
+import org.triplea.http.client.github.MapRepoListing;
+import org.triplea.io.ContentDownloader;
+
+/**
+ * A function where if given a map repo listing will find the 'description.html' file in that repo
+ * and returns its contents. If the contents are too long or the file is missing then will return a
+ * 'description-missing' error message with details on how to fix it.
+ */
+public class MapDescriptionReader implements Function<MapRepoListing, String> {
+  private static final int DESCRIPTION_COLUMN_DATABASE_MAX_LENGTH = 3000;
+
+  @Override
+  public String apply(final MapRepoListing mapRepoListing) {
+    final String description = downloadDescription(mapRepoListing).orElse(null);
+    if (description == null) {
+      return String.format(
+          "No description available for: %s"
+              + "Contact the map author and request they add a 'description.html' file",
+          mapRepoListing.getUri());
+    } else if (description.length() > DESCRIPTION_COLUMN_DATABASE_MAX_LENGTH) {
+      return String.format(
+          "The description for this map is too long at %s characters. Max length is %s."
+              + "Contact the map author for: %s"
+              + ", and request they reduce the length of the file 'description.html'",
+          description.length(), DESCRIPTION_COLUMN_DATABASE_MAX_LENGTH, mapRepoListing.getUri());
+    } else {
+      return description;
+    }
+  }
+
+  private Optional<String> downloadDescription(final MapRepoListing mapRepoListing) {
+    final String descriptionUri =
+        mapRepoListing.getUri().toString() + "/blob/master/description.html?raw=true";
+    return ContentDownloader.downloadAsString(URI.create(descriptionUri));
+  }
+}

--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/tasks/MapNameReader.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/tasks/MapNameReader.java
@@ -1,0 +1,52 @@
+package org.triplea.maps.indexing.tasks;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.net.URI;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Function;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.triplea.http.client.github.MapRepoListing;
+import org.triplea.io.ContentDownloader;
+import org.triplea.yaml.YamlReader;
+
+@Slf4j
+@Builder
+public class MapNameReader implements Function<MapRepoListing, Optional<String>> {
+  /* Function to download content as a string and log an info message if not found. */
+  @Setter(value = AccessLevel.PACKAGE, onMethod_ = @VisibleForTesting)
+  @Builder.Default
+  private Function<URI, String> downloadFunction =
+      uri -> ContentDownloader.downloadAsString(uri).orElse(null);
+
+  /**
+   * Determines the expected location of a map.yml file, downloads it, reads and returns the
+   * 'map_name' attribute. Returns null if the file could not be found or otherwise could not be
+   * read.
+   */
+  @Override
+  public Optional<String> apply(final MapRepoListing mapRepoListing) {
+    final URI mapYmlUri =
+        URI.create(mapRepoListing.getUri().toString() + "/blob/master/map.yml?raw=true");
+
+    final String mapYamlContents = downloadFunction.apply(mapYmlUri);
+    if (mapYamlContents == null) {
+      log.warn("Could not index, missing map.yml. Expected URI: {}", mapYmlUri);
+      return Optional.empty();
+    }
+
+    // parse and return the 'map_name' attribute from the YML file we just downloaded
+    try {
+      final Map<String, Object> mapYamlData = YamlReader.readMap(mapYamlContents);
+      return Optional.of((String) mapYamlData.get("map_name"));
+    } catch (final ClassCastException
+        | YamlReader.InvalidYamlFormatException
+        | NullPointerException e) {
+      log.error("Invalid map.yml data found at URI: {}, error: {}", mapYmlUri, e.getMessage());
+      return Optional.empty();
+    }
+  }
+}

--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/tasks/SkipMapIndexingCheck.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/tasks/SkipMapIndexingCheck.java
@@ -1,0 +1,48 @@
+package org.triplea.maps.indexing.tasks;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.function.BiPredicate;
+import java.util.function.Function;
+import javax.annotation.Nonnull;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.triplea.http.client.github.MapRepoListing;
+import org.triplea.maps.indexing.MapIndexDao;
+
+/**
+ * Given a repo and the last commit date of that repo, this predicate checks if we should skip
+ * indexing of that repo. We should skip indexing if the last commit date of the repo is more recent
+ * then what we have stored in database.
+ */
+@Slf4j
+@AllArgsConstructor(onConstructor_ = @VisibleForTesting)
+public class SkipMapIndexingCheck implements BiPredicate<MapRepoListing, Instant> {
+  @Nonnull private final Function<MapRepoListing, Optional<Instant>> databaseLastCommitDateLookup;
+
+  public SkipMapIndexingCheck(final MapIndexDao mapIndexDao) {
+    databaseLastCommitDateLookup =
+        mapRepoListing -> mapIndexDao.getLastCommitDate(mapRepoListing.getUri().toString());
+  }
+
+  @Override
+  public boolean test(final MapRepoListing mapRepoListing, final Instant lastCommitDateOnRepo) {
+    final Instant lastCommitDateInDatabase =
+        databaseLastCommitDateLookup.apply(mapRepoListing).orElse(null);
+
+    if (lastCommitDateInDatabase != null
+        && !lastCommitDateInDatabase.isBefore(lastCommitDateOnRepo)) {
+      log.info(
+          "Skipping, map indexing is up to date for: {}, "
+              + "last commit date on repo: {}, "
+              + "last commit date in database: {}",
+          mapRepoListing.getUri(),
+          lastCommitDateInDatabase,
+          lastCommitDateInDatabase);
+      return true;
+    } else {
+      return false;
+    }
+  }
+}

--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexDaoTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexDaoTest.java
@@ -1,8 +1,12 @@
 package org.triplea.maps.indexing;
 
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
+import static org.hamcrest.MatcherAssert.assertThat;
+
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.core.api.dataset.ExpectedDataSet;
 import com.github.database.rider.junit5.DBUnitExtension;
+import com.github.npathai.hamcrestopt.OptionalMatchers;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
@@ -57,5 +61,20 @@ class MapIndexDaoTest {
   @ExpectedDataSet("expected/map_index_post_remove.yml")
   void removeMaps() {
     mapIndexDao.removeMapsNotIn(List.of("http-map-repo-url"));
+  }
+
+  @Test
+  void getLastCommitDate() {
+    assertThat(
+        mapIndexDao.getLastCommitDate("http-map-repo-url"),
+        isPresentAndIs(LocalDateTime.of(2000, 12, 1, 23, 59, 20).toInstant(ZoneOffset.UTC)));
+    assertThat(
+        mapIndexDao.getLastCommitDate("http-map-repo-url-2"),
+        isPresentAndIs(LocalDateTime.of(2016, 1, 1, 23, 59, 20).toInstant(ZoneOffset.UTC)));
+
+    assertThat(
+        "Map repo URL does not exist",
+        mapIndexDao.getLastCommitDate("http://map-repo-url-DNE"),
+        OptionalMatchers.isEmpty());
   }
 }

--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexingIntegrationTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexingIntegrationTest.java
@@ -5,9 +5,7 @@ import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.hamcrest.core.StringContains.containsString;
 
-import java.net.URI;
 import org.junit.jupiter.api.Test;
-import org.triplea.http.client.github.GithubApiClient;
 import org.triplea.http.client.github.MapRepoListing;
 
 /**
@@ -20,12 +18,10 @@ public class MapIndexingIntegrationTest {
   @Test
   void runIndexingOnTestMap() {
     final MapIndexingTask mapIndexingTaskRunner =
-        MapIndexingTask.builder()
-            .lastCommitDateFetcher(
-                MapsIndexingObjectFactory.lastCommitDateFetcher(
-                    GithubApiClient.builder().uri(URI.create("https://api.github.com")).build(),
-                    "triplea-maps"))
-            .build();
+        MapsIndexingObjectFactory.mapIndexingTask(
+            "triplea-maps",
+            MapsIndexingObjectFactory.githubApiClient("https://api.github.com", null),
+            (repo, repoLastCommitDate) -> false);
 
     final MapIndexingResult result =
         mapIndexingTaskRunner

--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexingTaskTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexingTaskTest.java
@@ -1,0 +1,84 @@
+package org.triplea.maps.indexing;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsNull.nullValue;
+
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.triplea.http.client.github.MapRepoListing;
+
+class MapIndexingTaskTest {
+
+  private static final Instant instant = Instant.now();
+
+  @Test
+  @DisplayName("On successful indexing, data is aggregated correctly")
+  void verifyMapIndexingHappyCase() {
+    final var mapIndexingTask =
+        MapIndexingTask.builder()
+            .lastCommitDateFetcher(repoListing -> Optional.of(instant))
+            .skipMapIndexingCheck((mapRepoListing, instant1) -> false)
+            .mapNameReader(mapRepoListing -> Optional.of("map name"))
+            .mapDescriptionReader(mapRepoListing -> "description")
+            .build();
+
+    final var mapIndexingResult =
+        mapIndexingTask
+            .apply(MapRepoListing.builder().htmlUrl("http://url").name("repo name").build())
+            .orElseThrow(() -> new IllegalStateException("Unexpected empty result, check logs.."));
+
+    assertThat(mapIndexingResult.getMapName(), is("map name"));
+    assertThat(mapIndexingResult.getLastCommitDate(), is(instant));
+    assertThat(mapIndexingResult.getDescription(), is("description"));
+    assertThat(mapIndexingResult.getMapRepoUri(), is("http://url"));
+  }
+
+  @Test
+  @DisplayName("No result if there is a failure getting last commit date from repo")
+  void verifyNoResultIfLastCommitDateCannotBeObtained() {
+    final var mapIndexingTask =
+        MapIndexingTask.builder()
+            .lastCommitDateFetcher(repoListing -> Optional.empty())
+            .skipMapIndexingCheck((mapRepoListing, instant1) -> false)
+            .mapNameReader(mapRepoListing -> Optional.of("map name"))
+            .mapDescriptionReader(mapRepoListing -> "description")
+            .build();
+
+    final var mapIndexingResult =
+        mapIndexingTask
+            .apply(MapRepoListing.builder().htmlUrl("http://url").name("repo name").build())
+            .orElse(null);
+
+    assertThat(
+        "No value indicates we skipped indexing, because last commit date fetcher"
+            + "return an empty we expect indexing to have been skipped.",
+        mapIndexingResult,
+        is(nullValue()));
+  }
+
+  @Test
+  @DisplayName("No result if there skip check returns true")
+  void verifyNoResultIfIndexingIsSkipped() {
+    final var mapIndexingTask =
+        MapIndexingTask.builder()
+            .lastCommitDateFetcher(repoListing -> Optional.of(instant))
+            .skipMapIndexingCheck((mapRepoListing, instant1) -> true)
+            .mapNameReader(mapRepoListing -> Optional.of("map name"))
+            .mapDescriptionReader(mapRepoListing -> "description")
+            .build();
+
+    final var mapIndexingResult =
+        mapIndexingTask
+            .apply(MapRepoListing.builder().htmlUrl("http://url").name("repo name").build())
+            .orElse(null);
+
+    assertThat(
+        "No value indicates we skipped indexing, because skip check returned true"
+            + " we expect indexing to have been skipped.",
+        mapIndexingResult,
+        is(nullValue()));
+  }
+}

--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/tasks/MapNameReaderTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/tasks/MapNameReaderTest.java
@@ -1,0 +1,35 @@
+package org.triplea.maps.indexing.tasks;
+
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.triplea.http.client.github.MapRepoListing;
+
+class MapNameReaderTest {
+
+  @Test
+  void readMapName() {
+    final var mapNameReader =
+        MapNameReader.builder().downloadFunction(uri -> "map_name: The Map Name").build();
+
+    final Optional<String> result =
+        mapNameReader.apply(
+            MapRepoListing.builder().name("repo name").htmlUrl("http://repo").build());
+
+    assertThat(result, isPresentAndIs("The Map Name"));
+  }
+
+  @Test
+  void readMapNameErrorCaseWithNoMapNameRead() {
+    final var mapNameReader = MapNameReader.builder().downloadFunction(uri -> null).build();
+
+    final Optional<String> result =
+        mapNameReader.apply(
+            MapRepoListing.builder().name("repo name").htmlUrl("http://repo").build());
+
+    assertThat(result, isEmpty());
+  }
+}


### PR DESCRIPTION
1. MapIndexingTask is started to get heavy, knows how to do everything and is difficult
to test. To resolve this, this update breaks up the functionality of the indexing
into 'jobs' and then adds individual class files to implement each job.

2. Add logic to fetch the last commit date from database for a given repo. We then
also add logic to check if that last commit date is recent, then we will skip
map repo indexing (as nothing will have changed). This will become more important
as the indexing task becomes more and more intensive and therefore if makes more
sense to skip unnecessary work.
