### PR TITLE
Add download size and download URI to map indexing

### DIFF
--- a/lib/java-extras/src/main/java/org/triplea/io/FileUtils.java
+++ b/lib/java-extras/src/main/java/org/triplea/io/FileUtils.java
@@ -204,4 +204,29 @@ public final class FileUtils {
       log.error("Failed to write file: {}, {}", fileToWrite.toAbsolutePath(), e.getMessage(), e);
     }
   }
+
+  /**
+   * Utility to delete file specified by the given path. This method handles any needed logging if
+   * the delete fails.
+   */
+  public static void delete(final Path pathToDelete) {
+    try {
+      Files.delete(pathToDelete);
+    } catch (final IOException e) {
+      log.error("Failed to delete file: {}, {}", pathToDelete.toAbsolutePath(), e.getMessage(), e);
+    }
+  }
+
+  /**
+   * Creates a temp file, logs and returns an empty optional if there is a problem creating the temp
+   * file.
+   */
+  public static Optional<Path> createTempFile() {
+    try {
+      return Optional.of(Files.createTempFile("triplea-temp-file", ".temp"));
+    } catch (final IOException e) {
+      log.error("Failed to create temp file: {}", e.getMessage(), e);
+      return Optional.empty();
+    }
+  }
 }

--- a/spitfire-server/database/src/main/resources/db/migration/lobby_db/V2.01.01__maps_index_tables.sql
+++ b/spitfire-server/database/src/main/resources/db/migration/lobby_db/V2.01.01__maps_index_tables.sql
@@ -17,6 +17,9 @@ create table map_index
     last_commit_date timestamptz  not null check (last_commit_date < now()),
     repo_url         varchar(256) not null unique check (repo_url like 'http%'),
     category_id      integer      not null references map_category (id),
+    description         varchar(3000) not null,
+    download_size_bytes integer       not null,
+    download_url        varchar(256)  not null unique check (download_url like 'http%'),
     date_created     timestamptz  not null default now(),
     date_updated     timestamptz  not null default now()
 );

--- a/spitfire-server/database/src/main/resources/db/migration/lobby_db/V2.01.02__maps_index_description_column.sql
+++ b/spitfire-server/database/src/main/resources/db/migration/lobby_db/V2.01.02__maps_index_description_column.sql
@@ -1,1 +1,0 @@
-alter table map_index add column description varchar(3000);

--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapIndexDao.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapIndexDao.java
@@ -13,12 +13,18 @@ public interface MapIndexDao {
 
   /** Upserts a map indexing result into the map_index table. */
   @SqlUpdate(
-      "insert into map_index(map_name, repo_url, category_id, description, last_commit_date)\n"
-          + "values(:mapName, :mapRepoUri, 1, :description, :lastCommitDate)\n"
+      "insert into map_index("
+          + "    map_name, repo_url, category_id, description, "
+          + "    download_url, download_size_bytes, last_commit_date)\n"
+          + "values("
+          + "     :mapName, :mapRepoUri, 1, :description, "
+          + "     :downloadUri, :mapDownloadSizeInBytes, :lastCommitDate)\n"
           + "on conflict(repo_url)\n"
           + "do update set\n"
           + "   map_name = :mapName,"
           + "   description = :description,"
+          + "   download_url = :downloadUri,"
+          + "   download_size_bytes = :mapDownloadSizeInBytes,"
           + "   last_commit_date = :lastCommitDate")
   void upsert(@BindBean MapIndexingResult mapIndexingResult);
 

--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapIndexingResult.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapIndexingResult.java
@@ -18,13 +18,21 @@ public class MapIndexingResult {
   /** URI to the repo, typically something like: "https://github.com/triplea-maps/test-map/" */
   @Nonnull String mapRepoUri;
 
+  /**
+   * URI to download the map:
+   * "https://github.com/triplea-maps/test-map/archive/refs/heads/master.zip"
+   */
+  @Nonnull String downloadUri;
+
+  /** The size of the map download in bytes. */
+  @Nonnull Long mapDownloadSizeInBytes;
+
   /** Date of the most recent commit to master. */
   @Nonnull Instant lastCommitDate;
 
   /**
-   * Data that is parsed from description.html. If the file is missing or if contents are two long
-   * then a message should be inserted stated that the map author needs to fix the description.html
-   * file.
+   * Description data parsed from description.html. If description file is missing or too long, then
+   * this field will continue an error message with details on how to fix the missing description.
    */
-  String description;
+  @Nonnull String description;
 }

--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapsIndexingObjectFactory.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/MapsIndexingObjectFactory.java
@@ -9,6 +9,7 @@ import org.triplea.http.client.github.GithubApiClient;
 import org.triplea.http.client.github.MapRepoListing;
 import org.triplea.maps.MapsModuleConfig;
 import org.triplea.maps.indexing.tasks.CommitDateFetcher;
+import org.triplea.maps.indexing.tasks.DownloadSizeFetcher;
 import org.triplea.maps.indexing.tasks.MapDescriptionReader;
 import org.triplea.maps.indexing.tasks.MapNameReader;
 import org.triplea.maps.indexing.tasks.SkipMapIndexingCheck;
@@ -60,6 +61,7 @@ public class MapsIndexingObjectFactory {
         .skipMapIndexingCheck(skipMapIndexingCheck)
         .mapNameReader(MapNameReader.builder().build())
         .mapDescriptionReader(new MapDescriptionReader())
+        .downloadSizeFetcher(new DownloadSizeFetcher())
         .build();
   }
 

--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/tasks/DownloadSizeFetcher.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/tasks/DownloadSizeFetcher.java
@@ -1,0 +1,55 @@
+package org.triplea.maps.indexing.tasks;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.util.Optional;
+import java.util.function.Function;
+import lombok.AccessLevel;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import org.triplea.http.client.github.MapRepoListing;
+import org.triplea.io.ContentDownloader;
+import org.triplea.io.FileUtils;
+import org.triplea.java.function.ThrowingFunction;
+
+/**
+ * Given a map repo, determines the map download size.
+ *
+ * <p>Implementation note: download size is determined by downloading the entire file at the given
+ * URI to a temp file and then returning the size of that temp file. The temp file is then deleted.
+ */
+@Slf4j
+public class DownloadSizeFetcher implements Function<MapRepoListing, Optional<Long>> {
+
+  @Setter(value = AccessLevel.PACKAGE, onMethod_ = @VisibleForTesting)
+  private ThrowingFunction<URI, InputStream, IOException> downloadFunction =
+      (uri -> new ContentDownloader(uri).getStream());
+
+  @Override
+  public Optional<Long> apply(final MapRepoListing mapRepoListing) {
+    final URI uri = URI.create(new DownloadUriCalculator().apply(mapRepoListing));
+
+    log.info("Checking file size, downloading: " + uri);
+    final Path tempFile = FileUtils.createTempFile().orElse(null);
+    if (tempFile == null) {
+      return Optional.empty();
+    }
+
+    // download the file at the given URI, the copy method will return the file sizes in bytes.
+    try {
+      final long fileSize =
+          Files.copy(downloadFunction.apply(uri), tempFile, StandardCopyOption.REPLACE_EXISTING);
+      FileUtils.delete(tempFile);
+      return Optional.of(fileSize);
+    } catch (final IOException e) {
+      log.error("Error downloading: {}, {}", uri, e.getMessage(), e);
+      FileUtils.delete(tempFile);
+      return Optional.empty();
+    }
+  }
+}

--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/tasks/DownloadUriCalculator.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/indexing/tasks/DownloadUriCalculator.java
@@ -1,0 +1,13 @@
+package org.triplea.maps.indexing.tasks;
+
+import java.util.function.Function;
+import org.triplea.http.client.github.MapRepoListing;
+
+/** Given a map repo URI, determines the download URI for that map. */
+public class DownloadUriCalculator implements Function<MapRepoListing, String> {
+
+  @Override
+  public String apply(final MapRepoListing mapRepoListing) {
+    return mapRepoListing.getUri().toString() + "/archive/refs/heads/master.zip";
+  }
+}

--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexDaoTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexDaoTest.java
@@ -31,6 +31,9 @@ class MapIndexDaoTest {
             .mapName("map-name-3")
             .mapRepoUri("http-map-repo-url-3")
             .lastCommitDate(LocalDateTime.of(2000, 1, 12, 23, 59).toInstant(ZoneOffset.UTC))
+            .mapDownloadSizeInBytes(3080L)
+            .downloadUri("http-map-repo-3-download")
+            .description("description")
             .build());
   }
 
@@ -42,9 +45,13 @@ class MapIndexDaoTest {
             .mapName("map-name-updated")
             .mapRepoUri("http-map-repo-url-2")
             .lastCommitDate(LocalDateTime.of(2000, 1, 12, 23, 59).toInstant(ZoneOffset.UTC))
+            .mapDownloadSizeInBytes(6789L)
+            .downloadUri("http-map-repo-3-download-updated-url")
+            .description("description-updated")
             .build());
   }
 
+  /** The data we are inserting matches what is present in map_index.yml */
   @Test
   @ExpectedDataSet("map_index.yml")
   void upsertSameData() {
@@ -52,8 +59,10 @@ class MapIndexDaoTest {
         MapIndexingResult.builder()
             .mapName("map-name-2")
             .mapRepoUri("http-map-repo-url-2")
-            .description("description-repo-2")
             .lastCommitDate(LocalDateTime.of(2016, 1, 1, 23, 59, 20).toInstant(ZoneOffset.UTC))
+            .mapDownloadSizeInBytes(1000L)
+            .downloadUri("http-map-repo-url-2/archives/master.zip")
+            .description("description-repo-2")
             .build());
   }
 

--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexingIntegrationTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexingIntegrationTest.java
@@ -43,5 +43,11 @@ public class MapIndexingIntegrationTest {
         "Description is downloaded from description.html",
         result.getDescription(),
         containsString("<br><b><em>by test</em></b>"));
+
+    assertThat(
+        result.getDownloadUri(),
+        is("https://github.com/triplea-maps/test-map/archive/refs/heads/master.zip"));
+
+    assertThat(result.getMapDownloadSizeInBytes() > 0, is(true));
   }
 }

--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexingTaskRunnerTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/MapIndexingTaskRunnerTest.java
@@ -26,6 +26,9 @@ class MapIndexingTaskRunnerTest {
           .lastCommitDate(LocalDateTime.of(2000, 1, 12, 23, 59).toInstant(ZoneOffset.UTC))
           .mapName("map-name")
           .mapRepoUri("http://repo")
+          .downloadUri("http://repo-download")
+          .mapDownloadSizeInBytes(555L)
+          .description("description")
           .build();
 
   @Mock MapIndexDao mapIndexDao;

--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/tasks/DownloadSizeFetcherTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/tasks/DownloadSizeFetcherTest.java
@@ -1,0 +1,54 @@
+package org.triplea.maps.indexing.tasks;
+
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isEmpty;
+import static com.github.npathai.hamcrestopt.OptionalMatchers.isPresentAndIs;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.triplea.http.client.github.MapRepoListing;
+import org.triplea.test.common.StringToInputStream;
+
+class DownloadSizeFetcherTest {
+
+  private static final MapRepoListing mapRepoListing =
+      MapRepoListing.builder().name("repo name").htmlUrl("htttps://fake-uri").build();
+
+  /**
+   * In this test we stub the downloaded content to be a fixed size string. We then verify the
+   * reported download size matches teh byte length of the string.
+   */
+  @Test
+  @DisplayName("Happy case, return content size downloaded")
+  void returnContentSizeDownloaded() {
+    final DownloadSizeFetcher downloadSizeFetcher = new DownloadSizeFetcher();
+    final String contentsString = "this is a test";
+    downloadSizeFetcher.setDownloadFunction(
+        uri -> StringToInputStream.asInputStream(contentsString));
+
+    final Optional<Long> result = downloadSizeFetcher.apply(mapRepoListing);
+
+    assertThat(
+        "The 'contentString' was 'fake' downloaded, reported download size should match the "
+            + "byte length of that string.",
+        result,
+        isPresentAndIs((long) contentsString.getBytes(StandardCharsets.UTF_8).length));
+  }
+
+  @Test
+  @DisplayName("Error case, error during download returns empty optional")
+  void returnEmptyOnErrorDownloading() {
+    final DownloadSizeFetcher downloadSizeFetcher = new DownloadSizeFetcher();
+    downloadSizeFetcher.setDownloadFunction(
+        uri -> {
+          throw new IOException("test");
+        });
+
+    final Optional<Long> result = downloadSizeFetcher.apply(mapRepoListing);
+
+    assertThat(result, isEmpty());
+  }
+}

--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/tasks/DownloadUriCalculatorTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/indexing/tasks/DownloadUriCalculatorTest.java
@@ -1,0 +1,24 @@
+package org.triplea.maps.indexing.tasks;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+
+import org.junit.jupiter.api.Test;
+import org.triplea.http.client.github.MapRepoListing;
+
+class DownloadUriCalculatorTest {
+
+  @Test
+  void verifyDownloadUriCalculation() {
+    final var mapRepoListing =
+        MapRepoListing.builder()
+            .htmlUrl("https://github.com/triplea-maps/test-map")
+            .name("repo name")
+            .build();
+
+    final String result = new DownloadUriCalculator().apply(mapRepoListing);
+
+    assertThat(
+        result, is("https://github.com/triplea-maps/test-map/archive/refs/heads/master.zip"));
+  }
+}

--- a/spitfire-server/maps-module/src/test/resources/datasets/expected/map_index_upsert_new.yml
+++ b/spitfire-server/maps-module/src/test/resources/datasets/expected/map_index_upsert_new.yml
@@ -1,10 +1,19 @@
 map_index:
   - map_name: map-name
     repo_url: "http-map-repo-url"
+    description: description-repo-1
+    download_url: 'http-map-repo-url/archives/master.zip'
+    download_size_bytes: 4000
     last_commit_date: 2000-12-01 23:59:20.0
   - map_name: map-name-2
     repo_url: "http-map-repo-url-2"
+    description: description-repo-2
+    download_url: 'http-map-repo-url-2/archives/master.zip'
+    download_size_bytes: 1000
     last_commit_date: 2016-01-01 23:59:20.0
   - map_name: map-name-3
     repo_url: "http-map-repo-url-3"
+    description: description
+    download_url: 'http-map-repo-3-download'
+    download_size_bytes: 3080
     last_commit_date: 2000-01-12 23:59:00.0

--- a/spitfire-server/maps-module/src/test/resources/datasets/expected/map_index_upsert_updated.yml
+++ b/spitfire-server/maps-module/src/test/resources/datasets/expected/map_index_upsert_updated.yml
@@ -1,11 +1,17 @@
 map_index:
   - id: 10
     map_name: map-name
-    repo_url: "http-map-repo-url"
+    repo_url: 'http-map-repo-url'
     category_id: 1
+    description: description-repo-1
+    download_url: 'http-map-repo-url/archives/master.zip'
+    download_size_bytes: 4000
     last_commit_date: 2000-12-01 23:59:20.0
   - id: 20
     map_name: map-name-updated
     repo_url: "http-map-repo-url-2"
     category_id: 1
+    description: description-updated
+    download_url: 'http-map-repo-3-download-updated-url'
+    download_size_bytes: 6789
     last_commit_date: 2000-01-12 23:59:00.0

--- a/spitfire-server/maps-module/src/test/resources/datasets/map_index.yml
+++ b/spitfire-server/maps-module/src/test/resources/datasets/map_index.yml
@@ -6,10 +6,14 @@ map_index:
     repo_url: 'http-map-repo-url'
     category_id: 1
     description: description-repo-1
+    download_url: 'http-map-repo-url/archives/master.zip'
+    download_size_bytes: 4000
     last_commit_date: 2000-12-01 23:59:20.0
   - id: 20
     map_name: map-name-2
     repo_url: 'http-map-repo-url-2'
     category_id: 1
     description: description-repo-2
+    download_url: 'http-map-repo-url-2/archives/master.zip'
+    download_size_bytes: 1000
     last_commit_date: 2016-01-01 23:59:20.0

--- a/spitfire-server/maps-module/src/test/resources/logback-test.xml
+++ b/spitfire-server/maps-module/src/test/resources/logback-test.xml
@@ -10,4 +10,5 @@
     </root>
 
     <logger name="org.triplea.maps.indexing.MapIndexingTask" level="OFF"/>
+    <logger name="org.triplea.maps.indexing.tasks.DownloadSizeFetcher" level="OFF"/>
 </configuration>


### PR DESCRIPTION
Adds two new columns to map_index database table and updates indexing
to populate those columns.

1. Download size, this is determined by downloading the map zip file and
   check its file size after download. This is more reliable then doing
   a head request (which the game client already does and it is not reliable).

2. Download URI is best computed once rather than having the client determine
   this URI based on the repo URI. This is being parameterized in case the URI
   location somehow changes, in that case we can update the server and deliver
   a corrected download URI. This is *not* being added for the benefit of arbitrary
   download locations (EG: perhaps someone wants to use a different branch from
   master. Again, this column is to avoid the client from having to compute
   download location and we have the server do it instead).

