### PR TITLE
Remove Travis build-status badge from README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![TripleA license](https://img.shields.io/github/license/triplea-game/triplea.svg?style=flat-square)](https://github.com/triplea-game/triplea/blob/master/LICENSE)
-[![Build Status](https://travis-ci.com/triplea-game/triplea.svg?branch=master)](https://travis-ci.com/triplea-game/triplea)
 [![Total Alerts](https://img.shields.io/lgtm/alerts/g/triplea-game/triplea.svg?logo=lgtm&logoWidth=18&style=flat-square)](https://lgtm.com/projects/g/triplea-game/triplea/alerts)
 [![Maintainability](https://api.codeclimate.com/v1/badges/fa814ed45202485a92bf/maintainability)](https://codeclimate.com/github/triplea-game/triplea/maintainability)
 


### PR DESCRIPTION
We no longer use travis to build, the badge is no longer
up to date.
