### PR TITLE
Convert MapCategory 'enum' to a simple String type

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
@@ -1,6 +1,5 @@
 package games.strategy.engine.framework.map.download;
 
-import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
@@ -20,36 +19,8 @@ public final class DownloadFileDescription {
   private final String description;
   private final String mapName;
   private final Integer version;
-  private final MapCategory mapCategory;
+  private final String mapCategory;
   private final String img;
-
-  enum MapCategory {
-    BEST("High Quality"),
-
-    GOOD("Good Quality"),
-
-    DEVELOPMENT("In Development"),
-
-    EXPERIMENTAL("Experimental");
-
-    final String outputLabel;
-
-    MapCategory(final String label) {
-      outputLabel = label;
-    }
-
-    @Override
-    public String toString() {
-      return outputLabel;
-    }
-
-    private static MapCategory fromString(final String category) {
-      return Arrays.stream(values())
-          .filter(mapCategory -> mapCategory.outputLabel.equalsIgnoreCase(category))
-          .findAny()
-          .orElse(EXPERIMENTAL);
-    }
-  }
 
   public static DownloadFileDescription ofMapDownloadListing(
       final MapDownloadListing mapDownloadListing) {
@@ -59,7 +30,7 @@ public final class DownloadFileDescription {
         .description(mapDownloadListing.getDescription())
         // TODO: PROJECT#17 replace with latest commit date
         .version(1)
-        .mapCategory(MapCategory.fromString(mapDownloadListing.getMapCategory()))
+        .mapCategory(mapDownloadListing.getMapCategory())
         .build();
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
@@ -51,12 +51,8 @@ final class DownloadFileParser {
 
               final Integer version = (Integer) yaml.get(Tags.version.toString());
 
-              final DownloadFileDescription.MapCategory mapCategory =
-                  optEnum(
-                      yaml,
-                      DownloadFileDescription.MapCategory.class,
-                      Tags.mapCategory.toString(),
-                      DownloadFileDescription.MapCategory.EXPERIMENTAL);
+              final String mapCategory =
+                  (String) yaml.getOrDefault(Tags.mapCategory.toString(), "EXPERIMENTAL");
 
               final String img = Strings.nullToEmpty((String) yaml.get(Tags.img.toString()));
               downloads.add(
@@ -70,16 +66,5 @@ final class DownloadFileParser {
                       .build());
             });
     return downloads;
-  }
-
-  private static <T extends Enum<T>> T optEnum(
-      final Map<?, ?> jsonObject, final Class<T> type, final String name, final T defaultValue) {
-    checkNotNull(jsonObject);
-    checkNotNull(type);
-    checkNotNull(name);
-    checkNotNull(defaultValue);
-
-    final String valueName = Strings.nullToEmpty((String) jsonObject.get(name));
-    return valueName.isEmpty() ? defaultValue : Enum.valueOf(type, valueName);
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadSwingTable.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadSwingTable.java
@@ -25,7 +25,7 @@ public class MapDownloadSwingTable {
                 maps.stream()
                     .sorted(Comparator.comparing(DownloadFileDescription::getMapName))
                     .collect(Collectors.toList()))
-            .rowMapper(map -> List.of(map.getMapName(), map.getMapCategory().outputLabel))
+            .rowMapper(map -> List.of(map.getMapName(), map.getMapCategory()))
             .build();
   }
 

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadFileTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadFileTest.java
@@ -18,7 +18,7 @@ class DownloadFileTest {
             .description("description")
             .mapName("mapName")
             .version(0)
-            .mapCategory(DownloadFileDescription.MapCategory.BEST)
+            .mapCategory("BEST")
             .build();
     final DownloadFile testObj =
         new DownloadFile(downloadFileDescription, mock(DownloadListener.class));

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadMapsWindowMapsListingTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadMapsWindowMapsListingTest.java
@@ -24,7 +24,7 @@ class DownloadMapsWindowMapsListingTest extends AbstractClientSettingTestCase {
           .url("")
           .mapName(MAP_NAME)
           .version(MAP_VERSION)
-          .mapCategory(DownloadFileDescription.MapCategory.EXPERIMENTAL)
+          .mapCategory("EXPERIMENTAL")
           .build();
 
   @Test
@@ -62,7 +62,7 @@ class DownloadMapsWindowMapsListingTest extends AbstractClientSettingTestCase {
         .description("description")
         .mapName("mapName " + url)
         .version(MAP_VERSION)
-        .mapCategory(DownloadFileDescription.MapCategory.BEST)
+        .mapCategory("BEST")
         .build();
   }
 
@@ -72,7 +72,7 @@ class DownloadMapsWindowMapsListingTest extends AbstractClientSettingTestCase {
         .description("description")
         .mapName("mapName " + url)
         .version(MAP_VERSION)
-        .mapCategory(DownloadFileDescription.MapCategory.BEST)
+        .mapCategory("BEST")
         .build();
   }
 


### PR DESCRIPTION
Game client really no longer needs to know about the set of map categories.
To facilitate this, this update changes teh MapCategory enum to a simple String
type.

