### PR TITLE
Rename DownloadFileDescription and MapDownloadListing fields

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFile.java
@@ -64,9 +64,9 @@ final class DownloadFile {
 
           try {
             DownloadConfiguration.contentReader()
-                .downloadToFile(download.getUrl(), targetTempFileToDownloadTo);
+                .downloadToFile(download.getDownloadUrl(), targetTempFileToDownloadTo);
           } catch (final IOException e) {
-            log.error("Failed to download: " + download.getUrl(), e);
+            log.error("Failed to download: " + download.getDownloadUrl(), e);
             return;
           } finally {
             watcher.stop();

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileDescription.java
@@ -15,22 +15,23 @@ import org.triplea.http.client.maps.listing.MapDownloadListing;
 @Builder
 @AllArgsConstructor
 public final class DownloadFileDescription {
-  @EqualsAndHashCode.Include private final String url;
+  @EqualsAndHashCode.Include private final String downloadUrl;
   private final String description;
   private final String mapName;
   private final Integer version;
   private final String mapCategory;
-  private final String img;
+  private final String previewImageUrl;
 
   public static DownloadFileDescription ofMapDownloadListing(
       final MapDownloadListing mapDownloadListing) {
     return DownloadFileDescription.builder()
-        .url(mapDownloadListing.getUrl())
+        .downloadUrl(mapDownloadListing.getDownloadUrl())
         .mapName(mapDownloadListing.getMapName())
         .description(mapDownloadListing.getDescription())
         // TODO: PROJECT#17 replace with latest commit date
         .version(1)
         .mapCategory(mapDownloadListing.getMapCategory())
+        .previewImageUrl(mapDownloadListing.getPreviewImageUrl())
         .build();
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
@@ -57,12 +57,12 @@ final class DownloadFileParser {
               final String img = Strings.nullToEmpty((String) yaml.get(Tags.img.toString()));
               downloads.add(
                   DownloadFileDescription.builder()
-                      .url(url)
+                      .downloadUrl(url)
                       .description(description)
                       .mapName(mapName)
                       .version(version)
                       .mapCategory(mapCategory)
-                      .img(img)
+                      .previewImageUrl(img)
                       .build());
             });
     return downloads;

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -386,7 +386,7 @@ public class DownloadMapsWindow extends JFrame {
         .append(map.getVersion());
 
     if (!downloadMapsWindowUtils.isInstalled(map)) {
-      final String mapUrl = map.getUrl();
+      final String mapUrl = map.getDownloadUrl();
       if (mapUrl != null) {
         DownloadConfiguration.downloadLengthReader()
             .getDownloadLength(mapUrl)

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindowUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindowUtils.java
@@ -57,8 +57,8 @@ class DownloadMapsWindowUtils {
 
   String toHtmlString(final DownloadFileDescription downloadFileDescription) {
     String text = "<h1>" + downloadFileDescription.getMapName() + "</h1>\n";
-    if (!downloadFileDescription.getImg().isEmpty()) {
-      text += "<img src='" + downloadFileDescription.getImg() + "' />\n";
+    if (!downloadFileDescription.getPreviewImageUrl().isEmpty()) {
+      text += "<img src='" + downloadFileDescription.getPreviewImageUrl() + "' />\n";
     }
     text += downloadFileDescription.getDescription();
     return text;

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressListener.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/MapDownloadProgressListener.java
@@ -43,7 +43,7 @@ final class MapDownloadProgressListener {
         () ->
             downloadLength =
                 DownloadConfiguration.downloadLengthReader()
-                    .getDownloadLength(download.getUrl())
+                    .getDownloadLength(download.getDownloadUrl())
                     .orElse(null));
   }
 

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadFileTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadFileTest.java
@@ -14,7 +14,7 @@ class DownloadFileTest {
   void testBasicStartCancel() {
     final DownloadFileDescription downloadFileDescription =
         DownloadFileDescription.builder()
-            .url("url")
+            .downloadUrl("url")
             .description("description")
             .mapName("mapName")
             .version(0)

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadMapsWindowMapsListingTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadMapsWindowMapsListingTest.java
@@ -21,7 +21,7 @@ class DownloadMapsWindowMapsListingTest extends AbstractClientSettingTestCase {
 
   private static final DownloadFileDescription TEST_MAP =
       DownloadFileDescription.builder()
-          .url("")
+          .downloadUrl("")
           .mapName(MAP_NAME)
           .version(MAP_VERSION)
           .mapCategory("EXPERIMENTAL")
@@ -58,7 +58,7 @@ class DownloadMapsWindowMapsListingTest extends AbstractClientSettingTestCase {
 
   private static DownloadFileDescription newDownloadWithUrl(final String url) {
     return DownloadFileDescription.builder()
-        .url(url)
+        .downloadUrl(url)
         .description("description")
         .mapName("mapName " + url)
         .version(MAP_VERSION)
@@ -68,7 +68,7 @@ class DownloadMapsWindowMapsListingTest extends AbstractClientSettingTestCase {
 
   private static DownloadFileDescription newInstalledDownloadWithUrl(final String url) {
     return DownloadFileDescription.builder()
-        .url(url)
+        .downloadUrl(url)
         .description("description")
         .mapName("mapName " + url)
         .version(MAP_VERSION)

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/maps/listing/MapDownloadListing.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/maps/listing/MapDownloadListing.java
@@ -9,9 +9,14 @@ import lombok.Getter;
 @AllArgsConstructor
 @Getter
 public class MapDownloadListing {
-  @Nonnull private final String url;
+  /** URL where the map can be downloaded. */
+  @Nonnull private final String downloadUrl;
+  /** URL of the preview image of the map. */
+  private final String previewImageUrl;
+
   @Nonnull private final String mapName;
   @Nonnull private final Long lastCommitDateEpochMilli;
   @Nonnull private final String mapCategory;
+  /** HTML description of the map. */
   @Nonnull private final String description;
 }

--- a/spitfire-server/dropwizard-server/src/test/java/org/triplea/maps/listing/MapsListingControllerTest.java
+++ b/spitfire-server/dropwizard-server/src/test/java/org/triplea/maps/listing/MapsListingControllerTest.java
@@ -39,13 +39,13 @@ class MapsListingControllerTest extends SpitfireServerTest {
     assertThat(downloadListings.get(0).getMapName(), is("map-name"));
     assertThat(
         downloadListings.get(0).getLastCommitDateEpochMilli(), is(commitDate1.toEpochMilli()));
-    assertThat(downloadListings.get(0).getUrl(), is("http://map-repo-url"));
+    assertThat(downloadListings.get(0).getDownloadUrl(), is("http://map-repo-url"));
     assertThat(downloadListings.get(0).getMapCategory(), is("category_name"));
 
     assertThat(downloadListings.get(1).getMapName(), is("map-name-2"));
     assertThat(
         downloadListings.get(1).getLastCommitDateEpochMilli(), is(commitDate2.toEpochMilli()));
-    assertThat(downloadListings.get(1).getUrl(), is("http://map-repo-url-2"));
+    assertThat(downloadListings.get(1).getDownloadUrl(), is("http://map-repo-url-2"));
     assertThat(downloadListings.get(1).getMapCategory(), is("category_name"));
   }
 }

--- a/spitfire-server/maps-module/src/main/java/org/triplea/maps/listing/MapListingRecord.java
+++ b/spitfire-server/maps-module/src/main/java/org/triplea/maps/listing/MapListingRecord.java
@@ -28,7 +28,7 @@ public class MapListingRecord {
 
   MapDownloadListing toMapDownloadListing() {
     return MapDownloadListing.builder()
-        .url(url)
+        .downloadUrl(url)
         .mapName(name)
         .lastCommitDateEpochMilli(lastCommitDate.toEpochMilli())
         .mapCategory(categoryName)

--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/listing/MapListingDaoTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/listing/MapListingDaoTest.java
@@ -31,7 +31,7 @@ class MapListingDaoTest {
     final var mapDownloadListing = results.get(0).toMapDownloadListing();
     assertThat(mapDownloadListing.getMapCategory(), is("category_name"));
     assertThat(mapDownloadListing.getMapName(), is("map-name"));
-    assertThat(mapDownloadListing.getUrl(), is("http-map-repo-url"));
+    assertThat(mapDownloadListing.getDownloadUrl(), is("http-map-repo-url"));
     assertThat(mapDownloadListing.getDescription(), is("description-repo-1"));
     assertThat(
         mapDownloadListing.getLastCommitDateEpochMilli(),

--- a/spitfire-server/maps-module/src/test/java/org/triplea/maps/listing/MapsListingModuleTest.java
+++ b/spitfire-server/maps-module/src/test/java/org/triplea/maps/listing/MapsListingModuleTest.java
@@ -55,12 +55,12 @@ class MapsListingModuleTest {
     // expected sort by map name, so first map should be id "1"
     assertThat(results.get(0).getMapName(), is("map-name-1"));
     assertThat(results.get(0).getLastCommitDateEpochMilli(), is(commitDate1.toEpochMilli()));
-    assertThat(results.get(0).getUrl(), is("http://map-url-1"));
+    assertThat(results.get(0).getDownloadUrl(), is("http://map-url-1"));
     assertThat(results.get(0).getMapCategory(), is("category-1"));
 
     assertThat(results.get(1).getMapName(), is("map-name-2"));
     assertThat(results.get(1).getLastCommitDateEpochMilli(), is(commitDate2.toEpochMilli()));
-    assertThat(results.get(1).getUrl(), is("http://map-url-2"));
+    assertThat(results.get(1).getDownloadUrl(), is("http://map-url-2"));
     assertThat(results.get(1).getMapCategory(), is("category-2"));
   }
 }


### PR DESCRIPTION
Rename 'url' -> downloadUrl: this is just more specific and clarifies
that we are not referring to the repo url

Rename 'img' -> 'previewImageUrl': Also more specific

Otherwise this update aligns DownloadFileDescription and MapDownloadListing
so that they can be merged in a future step.

