### PR TITLE
Suppress new errorprone warnings and compiler warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -135,8 +135,7 @@ subprojects {
 
     tasks.withType(JavaCompile).configureEach {
         options.compilerArgs += [
-            '-Xlint:all,-processing',
-            '-Xmaxwarns', '15'
+            '-Xlint:none,-processing'
         ]
         options.encoding = 'UTF-8'
         options.errorprone {
@@ -172,6 +171,9 @@ subprojects {
             disable 'UnnecessaryLambda'
             // MissingSummary throws false positives on lombok @Builder annotations.
             disable 'MissingSummary'
+
+            disable 'UnescapedEntity'
+            disable 'InvalidBlockTag'
         }
         options.incremental = true
     }


### PR DESCRIPTION
Reduces build output so we can focus on important error messages.

-Xlint:none will print a single warning message regarding each
class of compiler warnings then each individual one.

New error prone warnings regarding unescaped entity in Javadoc
will be difficult to fix. Considering we do not render javadoc
into HTML, these are not important to us.

