### PR TITLE
Put map download listing behind an interface 'MapsListingClienting'

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadFileParser.java
@@ -9,6 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import lombok.experimental.UtilityClass;
+import org.triplea.http.client.maps.listing.MapDownloadListing;
 import org.triplea.yaml.YamlReader;
 import org.triplea.yaml.YamlReader.InvalidYamlFormatException;
 
@@ -28,7 +29,7 @@ final class DownloadFileParser {
     img
   }
 
-  public static List<DownloadFileDescription> parse(final InputStream is) throws IOException {
+  public static List<MapDownloadListing> parse(final InputStream is) throws IOException {
     try {
       return parseImpl(is);
     } catch (final InvalidYamlFormatException e) {
@@ -36,10 +37,10 @@ final class DownloadFileParser {
     }
   }
 
-  private static List<DownloadFileDescription> parseImpl(final InputStream is) {
+  private static List<MapDownloadListing> parseImpl(final InputStream is) {
     final List<Map<String, Object>> yamlData = YamlReader.readList(is);
 
-    final List<DownloadFileDescription> downloads = new ArrayList<>();
+    final List<MapDownloadListing> downloads = new ArrayList<>();
     yamlData.stream()
         .map(Map.class::cast)
         .forEach(
@@ -56,7 +57,7 @@ final class DownloadFileParser {
 
               final String img = Strings.nullToEmpty((String) yaml.get(Tags.img.toString()));
               downloads.add(
-                  DownloadFileDescription.builder()
+                  MapDownloadListing.builder()
                       .downloadUrl(url)
                       .description(description)
                       .mapName(mapName)

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadRunnable.java
@@ -1,41 +1,25 @@
 package games.strategy.engine.framework.map.download;
 
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.List;
-import lombok.extern.slf4j.Slf4j;
+import lombok.AllArgsConstructor;
+import org.triplea.http.client.maps.listing.MapDownloadListing;
+import org.triplea.http.client.maps.listing.MapsListingClient;
 
 /**
  * Downloads a map index file, parses it and returns a <code>List</code> of <code>
  * DownloadFileDescription</code>.
  */
-@Slf4j
-public class DownloadRunnable {
+@AllArgsConstructor
+public class DownloadRunnable implements MapsListingClient {
 
-  private DownloadRunnable() {}
+  /** URL of the maps YAML file */
+  private final String url;
 
-  /**
-   * Parses a file at the given URL into a List of {@link DownloadFileDescription}s. If an error
-   * occurs this will return an empty list.
-   */
-  public static List<DownloadFileDescription> download(final String url) {
+  /** Parses a file at the given URL. If an error occurs this will return an empty list. */
+  @Override
+  public List<MapDownloadListing> fetchMapDownloads() {
     return DownloadConfiguration.contentReader()
         .download(url, DownloadFileParser::parse)
         .orElseGet(List::of);
-  }
-
-  /**
-   * Parses a file at the given {@link Path} into a List of {@link DownloadFileDescription}s. If an
-   * error occurs this will return an empty list.
-   */
-  public static List<DownloadFileDescription> readLocalFile(final Path path) {
-    try (InputStream inputStream = Files.newInputStream(path)) {
-      return DownloadFileParser.parse(inputStream);
-    } catch (final IOException e) {
-      log.error("Failed to read file at: " + path.toAbsolutePath(), e);
-      return List.of();
-    }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/listing/MapListingFetcher.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/listing/MapListingFetcher.java
@@ -4,56 +4,25 @@ import games.strategy.engine.framework.map.download.DownloadFileDescription;
 import games.strategy.engine.framework.map.download.DownloadRunnable;
 import games.strategy.triplea.UrlConstants;
 import games.strategy.triplea.settings.ClientSetting;
-import java.net.URI;
 import java.util.List;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
-import org.triplea.http.client.maps.listing.MapDownloadListing;
+import lombok.experimental.UtilityClass;
 import org.triplea.http.client.maps.listing.MapsListingClient;
+import org.triplea.http.client.maps.listing.MapsListingHttpClient;
 import org.triplea.live.servers.LiveServersFetcher;
-import org.triplea.live.servers.LiveServersFetcher.LobbyAddressFetchException;
 
-/** Fetches the full listing of maps that are available for download. */
-@Slf4j
+@UtilityClass
 public class MapListingFetcher {
 
-  private MapListingFetcher() {}
-
-  /**
-   * Parses a map list source for a list of maps available for download. Multiple sources for the
-   * download list are checked, first any override locations followed by the live file that is on
-   * remote server.
-   */
+  /** Fetches the full listing of maps that are available for download. */
   public static List<DownloadFileDescription> getMapDownloadList() {
-    final MapListingFetcher mapListingFetcher = new MapListingFetcher();
+    final MapsListingClient mapsListingClient =
+        ClientSetting.useMapsServerBetaFeature.getValue().orElse(false)
+            ? new MapsListingHttpClient(new LiveServersFetcher().serverForCurrentVersion().getUri())
+            : new DownloadRunnable(UrlConstants.MAP_DOWNLOAD_LIST);
 
-    if (ClientSetting.useMapsServerBetaFeature.getValue().orElse(false)) {
-      // Get the URI of the maps server (either from override or read it from the servers file) and
-      // then send an API call to it requesting the list of maps available for download.
-      try {
-        final URI serverUri = new LiveServersFetcher().serverForCurrentVersion().getUri();
-        final var downloads = new MapsListingClient(serverUri).fetchMapDownloads();
-        return mapListingFetcher.convertDownloadListings(downloads);
-      } catch (final LobbyAddressFetchException e) {
-        log.warn(
-            "Failed to download server properties. Check network connection. "
-                + "Map listing will be empty. Error: "
-                + e.getMessage(),
-            e);
-        return List.of();
-      }
-    } else {
-      return ClientSetting.mapListOverride
-          .getValue()
-          .map(DownloadRunnable::readLocalFile)
-          .orElseGet(() -> DownloadRunnable.download(UrlConstants.MAP_DOWNLOAD_LIST));
-    }
-  }
-
-  private List<DownloadFileDescription> convertDownloadListings(
-      final List<MapDownloadListing> downloadListings) {
-
-    return downloadListings.stream()
+    // fetch downloads and convert to each to a DownloadFileDescription
+    return mapsListingClient.fetchMapDownloads().stream()
         .map(DownloadFileDescription::ofMapDownloadListing)
         .collect(Collectors.toList());
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -100,8 +100,6 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
       new IntegerClientSetting("MAP_ZOOM_FACTOR", 10);
   public static final ClientSetting<Path> mapFolderOverride =
       new PathClientSetting("MAP_FOLDER_OVERRIDE");
-  public static final ClientSetting<Path> mapListOverride =
-      new PathClientSetting("MAP_LIST_OVERRIDE");
   public static final ClientSetting<Boolean> notifyAllUnitsMoved =
       new BooleanClientSetting("NOTIFY_ALL_UNITS_MOVED", true);
   public static final ClientSetting<HttpProxy.ProxyChoice> proxyChoice =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSettingSwingUiBinding.java
@@ -2,7 +2,6 @@ package games.strategy.triplea.settings;
 
 import static games.strategy.triplea.settings.SelectionComponentFactory.booleanRadioButtons;
 import static games.strategy.triplea.settings.SelectionComponentFactory.diceRollerOverrideSelection;
-import static games.strategy.triplea.settings.SelectionComponentFactory.filePath;
 import static games.strategy.triplea.settings.SelectionComponentFactory.folderPath;
 import static games.strategy.triplea.settings.SelectionComponentFactory.intValueRange;
 import static games.strategy.triplea.settings.SelectionComponentFactory.lobbyOverrideSelection;
@@ -275,17 +274,6 @@ enum ClientSettingSwingUiBinding implements GameSettingUiBinding<JComponent> {
     @Override
     public SelectionComponent<JComponent> newSelectionComponent() {
       return booleanRadioButtons(ClientSetting.useMapsServerBetaFeature);
-    }
-  },
-
-  MAP_LIST_OVERRIDE_BINDING(
-      "Map List Override",
-      SettingType.TESTING,
-      "Overrides the location of the map listing file. You can, for example, download "
-          + "a copy of the listing file, update it, and put the path to that file here.") {
-    @Override
-    public SelectionComponent<JComponent> newSelectionComponent() {
-      return filePath(ClientSetting.mapListOverride);
     }
   },
 

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/maps/listing/MapDownloadListing.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/maps/listing/MapDownloadListing.java
@@ -15,8 +15,10 @@ public class MapDownloadListing {
   private final String previewImageUrl;
 
   @Nonnull private final String mapName;
-  @Nonnull private final Long lastCommitDateEpochMilli;
+  private final Long lastCommitDateEpochMilli;
   @Nonnull private final String mapCategory;
   /** HTML description of the map. */
   @Nonnull private final String description;
+  /** @deprecated use lastCommitDateEpochMilli and file time stamps instead. */
+  @Deprecated private final Integer version;
 }

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/maps/listing/MapsListingClient.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/maps/listing/MapsListingClient.java
@@ -1,22 +1,12 @@
 package org.triplea.http.client.maps.listing;
 
-import java.net.URI;
 import java.util.List;
-import org.triplea.http.client.AuthenticationHeaders;
-import org.triplea.http.client.HttpClient;
 
 /**
  * Http client to communicate with the maps server and get a listing of maps available for download.
  */
-public class MapsListingClient {
-  public static final String MAPS_LISTING_PATH = "/maps/listing";
-  private final MapsListingFeignClient mapsListingFeignClient;
+public interface MapsListingClient {
+  String MAPS_LISTING_PATH = "/maps/listing";
 
-  public MapsListingClient(final URI mapsServerUri) {
-    mapsListingFeignClient = new HttpClient<>(MapsListingFeignClient.class, mapsServerUri).get();
-  }
-
-  public List<MapDownloadListing> fetchMapDownloads() {
-    return mapsListingFeignClient.fetchMapListing(AuthenticationHeaders.systemIdHeaders());
-  }
+  List<MapDownloadListing> fetchMapDownloads();
 }

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/maps/listing/MapsListingHttpClient.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/maps/listing/MapsListingHttpClient.java
@@ -1,0 +1,22 @@
+package org.triplea.http.client.maps.listing;
+
+import java.net.URI;
+import java.util.List;
+import org.triplea.http.client.AuthenticationHeaders;
+import org.triplea.http.client.HttpClient;
+
+/**
+ * Http client to communicate with the maps server and get a listing of maps available for download.
+ */
+public class MapsListingHttpClient implements MapsListingClient {
+  private final MapsListingFeignClient mapsListingFeignClient;
+
+  public MapsListingHttpClient(final URI mapsServerUri) {
+    mapsListingFeignClient = new HttpClient<>(MapsListingFeignClient.class, mapsServerUri).get();
+  }
+
+  @Override
+  public List<MapDownloadListing> fetchMapDownloads() {
+    return mapsListingFeignClient.fetchMapListing(AuthenticationHeaders.systemIdHeaders());
+  }
+}

--- a/spitfire-server/dropwizard-server/src/test/java/org/triplea/maps/listing/MapsListingControllerTest.java
+++ b/spitfire-server/dropwizard-server/src/test/java/org/triplea/maps/listing/MapsListingControllerTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.triplea.http.client.maps.listing.MapDownloadListing;
 import org.triplea.http.client.maps.listing.MapsListingClient;
+import org.triplea.http.client.maps.listing.MapsListingHttpClient;
 import org.triplea.spitfire.server.SpitfireServerTest;
 
 @SuppressWarnings("UnmatchedTest")
@@ -28,7 +29,7 @@ class MapsListingControllerTest extends SpitfireServerTest {
   private final MapsListingClient mapsListingClient;
 
   MapsListingControllerTest(final URI serverUri) {
-    mapsListingClient = new MapsListingClient(serverUri);
+    mapsListingClient = new MapsListingHttpClient(serverUri);
   }
 
   @Test


### PR DESCRIPTION
Puts the fetch of map download listing from YAML file and the
fetch for download listing from maps server behind the same interface.
This simplifies how we fetch map download listings and now we only
need to select the right implementation based on feature flag
that tells us whether to go to maps (lobby) server or whether
to download and parse YAML file.

