### PR TITLE
Change version number of 41_oztea_variants

### DIFF
--- a/triplea_maps.yaml
+++ b/triplea_maps.yaml
@@ -2308,7 +2308,7 @@
 - mapName: 41 Oztea Variants
   mapCategory: EXPERIMENTAL
   url: https://github.com/triplea-maps/41_oztea_variants/archive/master.zip
-  version: 1
+  version: 2
   img: https://raw.githubusercontent.com/triplea-maps/41_oztea_variants/master/preview.png
   description: |
     <br>Oztea's 1941 setup for the World War II Global, with various rules modifications


### PR DESCRIPTION
I corrected an error in 41_oztea_variants where movement restrictions were not being lifted on the Americans when they went to war.


<!-- If multiple commits please summarize the change above. -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
