### PR TITLE
Update stalebot config: only issues and older

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,29 +1,27 @@
 # Number of days of inactivity before an issue becomes stale
-daysUntilStale: 30
+# Chosen to be relatively large so that a stale issue is
+# very likely actually stale and really not moving forward.
+daysUntilStale: 180
+
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 30
+# Close date is chosen to be large so that we rarely
+# close issues due to staleness.
+daysUntilClose: 1800
+
 # Issues with these labels will never be considered stale
 exemptLabels:
-  - "Problem"
-  - "Error Report"
   
 # Label to use when marking an issue as stale
 staleLabel: 'Stale'
 
 markComment: >
-  This issue has been automatically marked as stale because it has not
-  had recent activity. If there is something that can be done to resolve
-  this issue, please add a comment indicating what that would be and this issue will
-  be re-opened. If there are multiple items that can be completed independently,
-  we encourage you to use the "reference in new issue" option next to any
-  outstanding comment so that we may divide and conquer.
+  I noticed there has not been much activity on this issue.
+  Please check this issue and close it if it no longer applies.
+
+  Otherwise to help move this issue move forward, please add a
+  comment summarizing any further actions that need to be taken
+  in order to resolve this issue.
 
 closeComment: false
-
-pulls:
-   daysUntilStale: 14
-   markComment: >
-     This pull request has been automatically marked as stale because it has not had
-     recent activity. We are eager to see this work completed, please update and
-     re-open as soon as possible.
+only: issues
 


### PR DESCRIPTION
- Updates stalebot config to consider issues as stale if they
180 days old and only close if they are open for multiple years (5)

- Improve stale bot 'stale' commentary to ask for a summarizing comment.

- Only mark issues as stale, no longer PRs.

Motivation: PRs marked as stale is not very helpful. The previous
stale comment was not that helpful for getting issues resolved,
it's better to ask for an issue to be summarized rather than
re-partitioned and re-tasked as was previously commented. Second,
the 90 day window to close was actually pretty short, particularly
for a project that is not worked on consistently all the time, hence
issues were being closed a bit too promptly.

