### PR TITLE
BattleSimulator - Calculate and show standard deviation

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/AggregateResults.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/AggregateResults.java
@@ -13,6 +13,7 @@ import java.util.List;
 import java.util.Optional;
 import lombok.Getter;
 import lombok.Setter;
+import org.apache.commons.math3.stat.descriptive.moment.Mean;
 import org.apache.commons.math3.stat.descriptive.moment.StandardDeviation;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.util.Tuple;
@@ -82,16 +83,19 @@ public class AggregateResults {
   public Tuple<Double, Double> getAverageTuvOfUnitsLeftOver(
       final IntegerMap<UnitType> attackerCostsForTuv,
       final IntegerMap<UnitType> defenderCostsForTuv) {
-    if (results.isEmpty()) {
-      return Tuple.of(0.0, 0.0);
-    }
-    double attackerTuv = 0;
-    double defenderTuv = 0;
+    final Mean attackerTuvMean = new Mean();
+    final Mean defenderTuvMean = new Mean();
     for (final BattleResults result : results) {
-      attackerTuv += TuvUtils.getTuv(result.getRemainingAttackingUnits(), attackerCostsForTuv);
-      defenderTuv += TuvUtils.getTuv(result.getRemainingDefendingUnits(), defenderCostsForTuv);
+      attackerTuvMean.increment(
+          TuvUtils.getTuv(result.getRemainingAttackingUnits(), attackerCostsForTuv));
+      defenderTuvMean.increment(
+          TuvUtils.getTuv(result.getRemainingDefendingUnits(), defenderCostsForTuv));
     }
-    return Tuple.of(attackerTuv / results.size(), defenderTuv / results.size());
+    final double attackerM = attackerTuvMean.getResult();
+    final double defenderM = defenderTuvMean.getResult();
+    // If there are no battles, mean.getResult() returns Double.NaN.
+    return Tuple.of(
+        Double.isNaN(attackerM) ? 0 : attackerM, Double.isNaN(defenderM) ? 0 : defenderM);
   }
 
   /**
@@ -131,20 +135,29 @@ public class AggregateResults {
       final GamePlayer defender,
       final Collection<Unit> defenders,
       final GameData data) {
-    if (results.isEmpty()) {
-      return 0.0;
-    }
+    // The TUV swing is defenderTuvLost - attackerTuvLost and tuvLost = startingTuv - remainingTuv.
+    // Thus, the TUV swing of a singe battle is:
+    // TUV swing = defenderStartingTuv - attackerStartingTuv - defenderRemainingTuv +
+    // attackerRemainingTuv
+    //
+    // Because mean(x_i+c) = mean(x_i)+c for a constant c - the startingTuv in this case - we save
+    // some computations and add the startingTuv after we have calculated the mean.
     final IntegerMap<UnitType> attackerCostsForTuv = TuvUtils.getCostsForTuv(attacker, data);
     final IntegerMap<UnitType> defenderCostsForTuv = TuvUtils.getCostsForTuv(defender, data);
-    final int attackerTuv = TuvUtils.getTuv(attackers, attackerCostsForTuv);
-    final int defenderTuv = TuvUtils.getTuv(defenders, defenderCostsForTuv);
-    // could we possibly cause a bug by comparing UnitType's from one game data, to a different game
-    // data's UnitTypes?
-    final Tuple<Double, Double> average =
-        getAverageTuvOfUnitsLeftOver(attackerCostsForTuv, defenderCostsForTuv);
-    final double attackerLost = attackerTuv - average.getFirst();
-    final double defenderLost = defenderTuv - average.getSecond();
-    return defenderLost - attackerLost;
+    final int attackerStartingTuv = TuvUtils.getTuv(attackers, attackerCostsForTuv);
+    final int defenderStartingTuv = TuvUtils.getTuv(defenders, defenderCostsForTuv);
+    final Mean mean = new Mean();
+    final double m =
+        mean.evaluate(
+            results.stream()
+                .mapToDouble(
+                    result ->
+                        TuvUtils.getTuv(result.getRemainingAttackingUnits(), attackerCostsForTuv)
+                            - TuvUtils.getTuv(
+                                result.getRemainingDefendingUnits(), defenderCostsForTuv))
+                .toArray());
+    // If there are no battles, stdDev.getResult() returns Double.NaN.
+    return Double.isNaN(m) ? 0 : defenderStartingTuv - attackerStartingTuv + m;
   }
 
   /** Returns the standard deviation of the TUV swing. */
@@ -171,14 +184,15 @@ public class AggregateResults {
   }
 
   public double getAverageAttackingUnitsLeft() {
-    if (results.isEmpty()) {
-      return 0.0;
-    }
-    return results.stream()
-            .map(BattleResults::getRemainingAttackingUnits)
-            .mapToDouble(Collection::size)
-            .sum()
-        / results.size();
+    final Mean mean = new Mean();
+    final double m =
+        mean.evaluate(
+            results.stream()
+                .map(BattleResults::getRemainingAttackingUnits)
+                .mapToDouble(Collection::size)
+                .toArray());
+    // If there are no battles, mean.evaluate() returns Double.NaN.
+    return Double.isNaN(m) ? 0 : m;
   }
 
   /** Returns the standard deviation of the attacking units left. */
@@ -196,21 +210,16 @@ public class AggregateResults {
   }
 
   public double getAverageAttackingUnitsLeftWhenAttackerWon() {
-    if (results.isEmpty()) {
-      return 0.0;
-    }
-    double count = 0;
-    double total = 0;
-    for (final BattleResults result : results) {
-      if (result.attackerWon()) {
-        count += result.getRemainingAttackingUnits().size();
-        total += 1;
-      }
-    }
-    if (total <= 0) {
-      return 0;
-    }
-    return count / total;
+    final Mean mean = new Mean();
+    final double m =
+        mean.evaluate(
+            results.stream()
+                .filter(BattleResults::attackerWon)
+                .map(BattleResults::getRemainingAttackingUnits)
+                .mapToDouble(Collection::size)
+                .toArray());
+    // If there are no battles, mean.evaluate() returns Double.NaN.
+    return Double.isNaN(m) ? 0 : m;
   }
 
   /** Returns the standard deviation of the attacking units left if the attacker won. */
@@ -229,14 +238,15 @@ public class AggregateResults {
   }
 
   public double getAverageDefendingUnitsLeft() {
-    if (results.isEmpty()) {
-      return 0.0;
-    }
-    return results.stream()
-            .map(BattleResults::getRemainingDefendingUnits)
-            .mapToDouble(Collection::size)
-            .sum()
-        / results.size();
+    final Mean mean = new Mean();
+    final double m =
+        mean.evaluate(
+            results.stream()
+                .map(BattleResults::getRemainingDefendingUnits)
+                .mapToDouble(Collection::size)
+                .toArray());
+    // If there are no battles, mean.evaluate() returns Double.NaN.
+    return Double.isNaN(m) ? 0 : m;
   }
 
   /** Returns the standard deviation of the defending units left. */
@@ -254,21 +264,16 @@ public class AggregateResults {
   }
 
   public double getAverageDefendingUnitsLeftWhenDefenderWon() {
-    if (results.isEmpty()) {
-      return 0.0;
-    }
-    double count = 0;
-    double total = 0;
-    for (final BattleResults result : results) {
-      if (result.defenderWon()) {
-        count += result.getRemainingDefendingUnits().size();
-        total += 1;
-      }
-    }
-    if (total <= 0) {
-      return 0;
-    }
-    return count / total;
+    final Mean mean = new Mean();
+    final double m =
+        mean.evaluate(
+            results.stream()
+                .filter(BattleResults::defenderWon)
+                .map(BattleResults::getRemainingDefendingUnits)
+                .mapToDouble(Collection::size)
+                .toArray());
+    // If there are no battles, mean.evaluate() returns Double.NaN.
+    return Double.isNaN(m) ? 0 : m;
   }
 
   /** Returns the standard deviation of the defending units left if the defender won. */
@@ -287,10 +292,12 @@ public class AggregateResults {
   }
 
   public double getAttackerWinPercent() {
-    if (results.isEmpty()) {
-      return 0.0;
-    }
-    return results.stream().filter(BattleResults::attackerWon).count() / (double) results.size();
+    final Mean mean = new Mean();
+    final double m =
+        mean.evaluate(
+            results.stream().mapToDouble(result -> result.attackerWon() ? 1 : 0).toArray());
+    // If there are no battles, mean.evaluate() returns Double.NaN.
+    return Double.isNaN(m) ? 0 : m;
   }
 
   /** Returns the standard deviation of the attacker wins percentage. */
@@ -307,10 +314,12 @@ public class AggregateResults {
   }
 
   public double getDefenderWinPercent() {
-    if (results.isEmpty()) {
-      return 0.0;
-    }
-    return results.stream().filter(BattleResults::defenderWon).count() / (double) results.size();
+    final Mean mean = new Mean();
+    final double m =
+        mean.evaluate(
+            results.stream().mapToDouble(result -> result.defenderWon() ? 1 : 0).toArray());
+    // If there are no battles, mean.evaluate() returns Double.NaN.
+    return Double.isNaN(m) ? 0 : m;
   }
 
   /** Returns the standard deviation of the defender wins percentage. */
@@ -327,10 +336,11 @@ public class AggregateResults {
   }
 
   public double getDrawPercent() {
-    if (results.isEmpty()) {
-      return 0.0;
-    }
-    return results.stream().filter(BattleResults::draw).count() / (double) results.size();
+    final Mean mean = new Mean();
+    final double m =
+        mean.evaluate(results.stream().mapToDouble(result -> result.draw() ? 1 : 0).toArray());
+    // If there are no battles, mean.evaluate() returns Double.NaN.
+    return Double.isNaN(m) ? 0 : m;
   }
 
   /** Returns the standard deviation of the draw percentage. */
@@ -362,15 +372,11 @@ public class AggregateResults {
 
   /** Returns the average number of rounds fought across all simulations of the battle. */
   public double getAverageBattleRoundsFought() {
-    if (results.isEmpty()) {
-      return 0.0;
-    }
-    final long count = results.stream().mapToInt(BattleResults::getBattleRoundsFought).sum();
-    if (count == 0) {
-      // If this is a 'fake' aggregate result, return 1.0
-      return 1.0;
-    }
-    return count / (double) results.size();
+    final Mean mean = new Mean();
+    final double m =
+        mean.evaluate(results.stream().mapToDouble(BattleResults::getBattleRoundsFought).toArray());
+    // If there are no battles, mean.evaluate() returns Double.NaN.
+    return Double.isNaN(m) ? 0 : m;
   }
 
   /** Returns the standard deviation of the number of battle rounds. */

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/AggregateResults.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/AggregateResults.java
@@ -25,7 +25,7 @@ public class AggregateResults {
     results = new ArrayList<>(expectedCount);
   }
 
-  AggregateResults(final List<BattleResults> results) {
+  public AggregateResults(final List<BattleResults> results) {
     this.results = new ArrayList<>(results);
   }
 
@@ -112,7 +112,7 @@ public class AggregateResults {
     return defenderLost - attackerLost;
   }
 
-  double getAverageAttackingUnitsLeft() {
+  public double getAverageAttackingUnitsLeft() {
     if (results.isEmpty()) {
       return 0.0;
     }
@@ -123,7 +123,7 @@ public class AggregateResults {
         / results.size();
   }
 
-  double getAverageAttackingUnitsLeftWhenAttackerWon() {
+  public double getAverageAttackingUnitsLeftWhenAttackerWon() {
     if (results.isEmpty()) {
       return 0.0;
     }
@@ -141,7 +141,7 @@ public class AggregateResults {
     return count / total;
   }
 
-  double getAverageDefendingUnitsLeft() {
+  public double getAverageDefendingUnitsLeft() {
     if (results.isEmpty()) {
       return 0.0;
     }
@@ -152,7 +152,7 @@ public class AggregateResults {
         / results.size();
   }
 
-  double getAverageDefendingUnitsLeftWhenDefenderWon() {
+  public double getAverageDefendingUnitsLeftWhenDefenderWon() {
     if (results.isEmpty()) {
       return 0.0;
     }
@@ -177,14 +177,14 @@ public class AggregateResults {
     return results.stream().filter(BattleResults::attackerWon).count() / (double) results.size();
   }
 
-  double getDefenderWinPercent() {
+  public double getDefenderWinPercent() {
     if (results.isEmpty()) {
       return 0.0;
     }
     return results.stream().filter(BattleResults::defenderWon).count() / (double) results.size();
   }
 
-  double getDrawPercent() {
+  public double getDrawPercent() {
     if (results.isEmpty()) {
       return 0.0;
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/AggregateResults.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/AggregateResults.java
@@ -66,17 +66,6 @@ public class AggregateResults {
         .orElseGet(ArrayList::new);
   }
 
-  double getAverageAttackingUnitsLeft() {
-    if (results.isEmpty()) {
-      return 0.0;
-    }
-    return results.stream()
-            .map(BattleResults::getRemainingAttackingUnits)
-            .mapToDouble(Collection::size)
-            .sum()
-        / results.size();
-  }
-
   /** First is Attacker, Second is Defender. */
   public Tuple<Double, Double> getAverageTuvOfUnitsLeftOver(
       final IntegerMap<UnitType> attackerCostsForTuv,
@@ -121,6 +110,17 @@ public class AggregateResults {
     final double attackerLost = attackerTuv - average.getFirst();
     final double defenderLost = defenderTuv - average.getSecond();
     return defenderLost - attackerLost;
+  }
+
+  double getAverageAttackingUnitsLeft() {
+    if (results.isEmpty()) {
+      return 0.0;
+    }
+    return results.stream()
+            .map(BattleResults::getRemainingAttackingUnits)
+            .mapToDouble(Collection::size)
+            .sum()
+        / results.size();
   }
 
   double getAverageAttackingUnitsLeftWhenAttackerWon() {
@@ -184,6 +184,13 @@ public class AggregateResults {
     return results.stream().filter(BattleResults::defenderWon).count() / (double) results.size();
   }
 
+  double getDrawPercent() {
+    if (results.isEmpty()) {
+      return 0.0;
+    }
+    return results.stream().filter(BattleResults::draw).count() / (double) results.size();
+  }
+
   /** Returns the average number of rounds fought across all simulations of the battle. */
   public double getAverageBattleRoundsFought() {
     if (results.isEmpty()) {
@@ -195,13 +202,6 @@ public class AggregateResults {
       return 1.0;
     }
     return count / (double) results.size();
-  }
-
-  double getDrawPercent() {
-    if (results.isEmpty()) {
-      return 0.0;
-    }
-    return results.stream().filter(BattleResults::draw).count() / (double) results.size();
   }
 
   public int getRollCount() {


### PR DESCRIPTION
Calculate and show standard deviation in battle simulator.

I used String.format() which is a printf like function instead of the DecmialFormat class since this makes it easier to see the whole string "a ± b / c" in the code. (According to the docs String.format() is also local sensitive.)

## Testing

No tests where written as I have no clue how to write those. (Might also not be necessary.)

## Additional Notes to Reviewer

I named the functions calculating the standard deviation "getXXXStandardDeviation()" not very happy with that name but fits. Feel free to change that as you like.

## Release Note

<!--RELEASE_NOTE-->NEW|Battle Calculator now shows the standard deviation along with the expected value.<!--END_RELEASE_NOTE-->

## Fixes

Fixes #9489 