### PR TITLE
Fix delete of maps, use and add a FileUtiles#deleteDirectory method

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindowUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindowUtils.java
@@ -7,6 +7,7 @@ import java.nio.file.Path;
 import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.http.client.maps.listing.MapDownloadItem;
+import org.triplea.io.FileUtils;
 import org.triplea.java.Interruptibles;
 
 /** Various logic methods used by DownloadMapsWindows. */
@@ -34,7 +35,7 @@ class DownloadMapsWindowUtils {
     }
 
     try {
-      Files.delete(installLocation);
+      FileUtils.deleteDirectory(installLocation);
     } catch (final IOException e) {
       log.warn(
           "Unable to delete maps files.<br>Manual removal may be necessary: {}<br>{}",

--- a/lib/java-extras/build.gradle
+++ b/lib/java-extras/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     implementation "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
     implementation "org.apache.httpcomponents:httpclient:$apacheHttpComponentsVersion"
     implementation "org.snakeyaml:snakeyaml-engine:$snakeYamlVersion"
+    implementation 'commons-io:commons-io:2.8.0'
     testImplementation "commons-io:commons-io:$commonsIoVersion"
     testImplementation project(':lib:test-common')
 }

--- a/lib/java-extras/src/main/java/org/triplea/io/FileUtils.java
+++ b/lib/java-extras/src/main/java/org/triplea/io/FileUtils.java
@@ -229,4 +229,8 @@ public final class FileUtils {
       return Optional.empty();
     }
   }
+
+  public static void deleteDirectory(final Path path) throws IOException {
+    org.apache.commons.io.FileUtils.deleteDirectory(path.toFile());
+  }
 }

--- a/lib/java-extras/src/test/java/org/triplea/io/FileUtilsTest.java
+++ b/lib/java-extras/src/test/java/org/triplea/io/FileUtilsTest.java
@@ -8,6 +8,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
 
+import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Optional;
@@ -111,5 +112,23 @@ final class FileUtilsTest {
     final Optional<String> contentRead = FileUtils.readContents(testFile);
 
     assertThat(contentRead, isPresent());
+  }
+
+  /**
+   * Creates a non-empty directory, run delete, verify directory is deleted. Linux systems
+   * will fail the delete operation if the directory is not empty, this test verifies
+   * that we do a recursive delete before removing the directory.
+   */
+  @Test
+  void deleteDirectory() throws IOException {
+    final Path directory = Path.of("directory");
+    Files.createDirectory(directory);
+    // create a file in the directory so that it is non-empty
+    Files.createFile(directory.resolve("touch-file"));
+    assertThat("Precondition, make sure the directory exists", Files.exists(directory), is(true));
+
+    FileUtils.deleteDirectory(directory);
+
+    assertThat(Files.exists(directory), is(false));
   }
 }


### PR DESCRIPTION
Deleting non-empty directories fails, now that maps are directories and
no longer zip files, the delete command that was used to delete the zip
fail can fail when used to delete the map directory.

This update solves the problem by using a library to delete the directory
which does a recursive delete first of all files and directories first.

