### PR TITLE
Fix file watcher race condition NPE

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/FileSizeWatcher.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/FileSizeWatcher.java
@@ -32,7 +32,9 @@ final class FileSizeWatcher {
     return () -> {
       while (!stop) {
         try {
-          progressListener.accept(Files.size(fileToWatch));
+          if (Files.exists(fileToWatch)) {
+            progressListener.accept(Files.size(fileToWatch));
+          }
         } catch (final IOException e) {
           log.error("Failed to read filesize", e);
         }


### PR DESCRIPTION
If FileWatcher is too quick to start, it can check the size
of a file that we simply have not yet created. This results
in a NPE. This update fixes the problem by no-op'ing if
the file does not yet exist.

