### PR TITLE
Update infrastructure to only deploy a single DB and show flyway migration results

### DIFF
--- a/infrastructure/ansible/roles/database/postgres/defaults/main.yml
+++ b/infrastructure/ansible/roles/database/postgres/defaults/main.yml
@@ -12,8 +12,7 @@ postgres_user_db_password: postgres
 #  user: the name of the application user that can access
 #     the database
 #  password: the database password for the application user
-databases:
-  - name: "lobby_db"
-    user: "{{ lobby_db_user }}"
-    password: "{{ lobby_db_password }}"
+database_name: "lobby_db"
+database_user: "{{ lobby_db_user }}"
+database_password: "{{ lobby_db_password }}"
 

--- a/infrastructure/ansible/roles/database/postgres/tasks/main.yml
+++ b/infrastructure/ansible/roles/database/postgres/tasks/main.yml
@@ -34,40 +34,29 @@
 - name: Create application database users
   become_user: postgres
   postgresql_user:
-    name: "{{ item.user }}"
-    password: "{{ item.password }}"
-    login_password: "{{ item.password }}"
+    name: "{{ database_user }}"
+    password: "{{ database_password }}"
+    login_password: "{{ database_password }}"
     encrypted: yes
     state: "present"
-  loop: "{{ databases }}"
-  loop_control:
-    label: "{{ item.user }}"
-  no_log: true
 
 - name: Create application databases
   become_user: postgres
   postgresql_db:
-    name: "{{ item.name }}"
-    owner: "{{ item.user }}"
-  loop: "{{ databases }}"
-  loop_control:
-    label: "{{ item.name }}"
+    name: "{{ database_name }}"
+    owner: "{{ database_user }}"
 
 - name: Ensure user has access to the database
   become_user: postgres
   postgresql_user:
-    db: "{{ item.name }}"
-    name: "{{ item.user }}"
-    password: "{{ item.password }}"
-    login_password: "{{ item.password }}"
+    db: "{{ database_name }}"
+    name: "{{ database_user }}"
+    password: "{{ database_password }}"
+    login_password: "{{ database_password }}"
     encrypted: yes
     priv: "ALL"
     role_attr_flags: NOSUPERUSER,NOCREATEDB
     state: "present"
-  loop: "{{ databases }}"
-  loop_control:
-    label: "{{ item.name }} {{ item.user }}"
-  no_log: true
 
 # This is a hack because the previous tasks were supposed to set
 # the DB level password for our DB user, but it typically does not.
@@ -75,11 +64,8 @@
 # user DB password.
 - name: set DB user passwords via CLI
   shell: >
-    echo "alter role {{ item.user }} with password '{{ item.password }}';"  | sudo -u postgres psql
+    echo "alter role {{ database_user }} with password '{{ database_password }}';"  | sudo -u postgres psql
   environment:
     PGPASSWORD: "{{ postgres_user_db_password }}"
   changed_when: false
-  loop: "{{ databases }}"
-  loop_control:
-    label: "{{ item.user }}"
   no_log: true


### PR DESCRIPTION
We had to 'no-log' the flyway migration results to avoid leaking the database
password. A downside to this is if there were any migration errors, they would
not show up and further troubleshooting would have to be done.

The database password was leaked because we were looping over a list of databases
and ansible will print out the contents of loop variables.

This update changes database configurations from being multiple to just allowing
only one database. This then allows us to show the flyway logging without
leaking a password. Meanwhile, we are likely to stay on the one database for
some time.

