### PR TITLE
Read IP address from X-Forwarded-For

### DIFF
--- a/infrastructure/ansible/roles/lobby_server/templates/lobby_server.service.j2
+++ b/infrastructure/ansible/roles/lobby_server/templates/lobby_server.service.j2
@@ -6,6 +6,7 @@ Documentation=
 Environment=ERROR_REPORT_TO_GITHUB_ENABLED=true
 Environment=MAP_INDEXING_ENABLED=true
 Environment=GAME_HOST_CONNECTIVITY_CHECK_ENABLED=true
+Environment=USE_FORWARDED_HEADERS=true
 Environment=DATABASE_USER={{ lobby_server_db_user }}
 Environment=DATABASE_PASSWORD={{ lobby_db_password }}
 Environment=DB_URL={{ lobby_server_db_host }}:{{ lobby_server_db_port }}/{{ lobby_server_db_name }}

--- a/infrastructure/ansible/roles/nginx/templates/etc_nginx_sites_enabled_default.j2
+++ b/infrastructure/ansible/roles/nginx/templates/etc_nginx_sites_enabled_default.j2
@@ -50,6 +50,12 @@ server {
     location /game-connection/ws {
       proxy_pass http://localhost:8080;
       proxy_http_version 1.1;
+
+      proxy_set_header        Host $host;
+      proxy_set_header        X-Real-IP $remote_addr;
+      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header        X-Forwarded-Proto $scheme;
+
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
     }
@@ -57,6 +63,12 @@ server {
     location /player-connection/ws {
       proxy_pass http://localhost:8080;
       proxy_http_version 1.1;
+
+      proxy_set_header        Host $host;
+      proxy_set_header        X-Real-IP $remote_addr;
+      proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+      proxy_set_header        X-Forwarded-Proto $scheme;
+
       proxy_set_header Upgrade $http_upgrade;
       proxy_set_header Connection "upgrade";
     }

--- a/spitfire-server/dropwizard-server/build.gradle
+++ b/spitfire-server/dropwizard-server/build.gradle
@@ -31,6 +31,10 @@ task release(group: 'release', dependsOn: portableInstaller) {
 
 shadowJar {
     archiveClassifier.set ''
+    // mergeServiceFiles is needed by dropwizard
+    // Without this configuration parsing breaks and is unable to find connector type 'http' for
+    // the following YAML snippet:  server: {applicationConnectors: [{type: http, port: 8080}]
+    mergeServiceFiles()
 }
 
 configurations {

--- a/spitfire-server/dropwizard-server/configuration.yml
+++ b/spitfire-server/dropwizard-server/configuration.yml
@@ -71,3 +71,14 @@ logging:
   loggers:
     # Set this to DEBUG to troubleshoot HTTP 400 "Unable to process JSON" errors.
     io.dropwizard.jersey.jackson.JsonProcessingExceptionMapper: INFO
+
+server:
+  applicationConnectors:
+    - type: http
+      port: 8080
+      # useForwardedHeaders is important for when behind a reverse proxy (NGINX)
+      # Without this 'getRemoteAddr' will return the IP of the reverse proxy server.
+      # By default when building locally useForwardedPorts should be 'false', but
+      # for all other environments that do have a NGINX server, the value should be
+      # set to true.
+      useForwardedHeaders: ${USE_FORWARDED_HEADERS:-false}


### PR DESCRIPTION
When dropwizard is behind a NGINX (reverse proxy) server, The IP address
return by 'request.getRemoteAddr()' is the IP of the NGINX server and
not the client IP.

To get the correct IP we must read the 'X-Forwarded-For'. This update
makes that change and adds a configuration flag to read 'getRemoteAddr()'
in the development case (where there is no NGINX server).

Note, websocket code that depends on IP address has this same problem
but worse as it has no access to the 'X-Forwarded-For' header. A
future update will need to fix this.


<!-- If multiple commits please summarize the change above. -->

## Testing
Deployed to prerelease manually and added some extra debugging to logs to verify the correct IP address was being used.
Then built a local client and connected to lobby (currently that automatically connects to the 2.6 prerelease server).

