### PR TITLE
Add ansible tags: [deploy, prerelease, release]

### DIFF
--- a/infrastructure/ansible/inventory/prod2
+++ b/infrastructure/ansible/inventory/prod2
@@ -33,7 +33,6 @@ botHosts
 
 [prod2:vars]
 lobby_uri="https://prod2-lobby.triplea-game.org"
-using_latest=false
 
 [vault:children]
 prod2

--- a/infrastructure/ansible/roles/bot/defaults/main.yml
+++ b/infrastructure/ansible/roles/bot/defaults/main.yml
@@ -25,11 +25,8 @@ bot_numbers: ["01", "02", "03", "04" ]
 # EG: with bot_prefix = 1, and bot_number=01, the bot number in the bot name will be '101'.
 bot_prefix: ""
 
-# Using latest flag indicates we should use assets that are built locally. False indicates we
-# will download assets for a target bot_version.
-using_latest: true
-
-# Download URL for grabbing bot artifacts, not used if using_latest is false.
+# Download URL for grabbing bot artifacts, used only in production release builds, prerelease
+# builds use a locally built artifact.
 zip_download: "https://github.com/triplea-game/triplea/releases/download/{{ bot_version }}/triplea-game-headless-{{ bot_version }}.zip"
 
 # Name of the bot server, this will typically be overriden in inventory. The final name of the bot host is

--- a/infrastructure/ansible/roles/bot/tasks/main.yml
+++ b/infrastructure/ansible/roles/bot/tasks/main.yml
@@ -38,8 +38,8 @@
   tags: update_maps
   command: "{{ admin_home }}/download-all-maps {{ update_maps }}"
 
-- name: deploy zip file if using latest
-  when: using_latest|bool
+- name: deploy zip file (prerelease build only)
+  tags: [prerelease, deploy]
   copy:
     src: "triplea-game-headless-{{ bot_version }}.zip"
     dest: "{{ bot_install_home }}/triplea-game-headless-{{ bot_version }}.zip"
@@ -47,8 +47,8 @@
     group: "{{ bot_user }}"
 
 
-- name: download zip file if not using latest
-  when: not using_latest|bool
+- name: download zip file (release build only)
+  tags: [releases, deploy]
   get_url:
     url: "{{ zip_download }}"
     dest: "{{ bot_install_home }}/triplea-game-headless-{{ bot_version }}.zip"
@@ -56,6 +56,7 @@
     group: "{{ bot_user }}"
 
 - name: extract zip file
+  tags: [deploy]
   unarchive:
     remote_src: yes
     src: "{{ bot_install_home }}/triplea-game-headless-{{ bot_version }}.zip"
@@ -72,6 +73,7 @@
     group: "{{ bot_user }}"
 
 - name: deploy run_server script
+  tags: [deploy]
   template:
     src: run_server.j2
     dest: "{{ bot_folder }}/run_server"
@@ -80,17 +82,19 @@
     group: "{{ bot_user }}"
 
 - name: install systemd service script
+  tags: [deploy]
   template:
     src: bot.service.j2
     dest: /lib/systemd/system/bot@.service
     mode: "644"
 
 - name: reload systemd
+  tags: [deploy]
   systemd:
     daemon_reload: yes
 
-- name: restart bots if deploying latest
-  when: using_latest|bool
+- name: restart bots (prerelease build only)
+  tags: [prerelease]
   service:
     name: "bot@{{ item }}"
     state: restarted
@@ -98,7 +102,6 @@
   with_items: "{{ bot_numbers }}"
 
 - name: enable and ensure bots are started
-  when: not using_latest|bool
   service:
     name: "bot@{{ item }}"
     state: started

--- a/infrastructure/ansible/roles/database/flyway/tasks/main.yml
+++ b/infrastructure/ansible/roles/database/flyway/tasks/main.yml
@@ -22,8 +22,8 @@
     owner: flyway
     group: flyway
 
-- name: copy flyway migrations zip if deploying latest
-  when: using_latest|bool
+- name: copy flyway migrations zip (prerelease build only)
+  tags: [deploy, prerelease]
   copy:
     src: "migrations.zip"
     dest: "/home/flyway/migrations.zip"
@@ -31,8 +31,8 @@
     owner: flyway
     group: flyway
 
-- name: download flyway migrations if deploying a specific version
-  when: not using_latest|bool
+- name: download flyway migrations (release build only)
+  tags: [deploy, release]
   get_url:
     url: "{{ migrations_url }}"
     dest: "/home/flyway/migrations.zip"
@@ -48,6 +48,7 @@
     path : "{{ flyway_extracted_location }}/migrations"
 
 - name: extract migrations
+  tags: [deploy]
   unarchive:
      src: "/home/flyway/migrations.zip"
      remote_src: true
@@ -57,6 +58,7 @@
      group: flyway
 
 - name: run flyway
+  tags: [deploy]
   command: |
      {{ flyway_extracted_location }}/flyway
           -X
@@ -75,3 +77,4 @@
   loop_control:
     label: "{{ item.migration_dir }}"
   no_log: true
+

--- a/infrastructure/ansible/roles/lobby_server/tasks/main.yml
+++ b/infrastructure/ansible/roles/lobby_server/tasks/main.yml
@@ -17,8 +17,8 @@
     owner: "{{ lobby_server_user }}"
     group: "{{ lobby_server_user }}"
 
-- name: deploy zip artifact file if using latest
-  when: using_latest|bool
+- name: upload zip artifact file (prerelease build)
+  tags: [prerelease, deploy]
   register: deploy_artifact
   copy:
     src: "{{ lobby_artifact }}"
@@ -26,8 +26,8 @@
     owner: "{{ lobby_server_user }}"
     group: "{{ lobby_server_user }}"
 
-- name: download zip artifact file if not using latest
-  when: not using_latest|bool
+- name: download zip artifact file (release build)
+  tags: [release, deploy]
   register: deploy_artifact
   get_url:
     url: "{{ lobby_artifact_download }}"
@@ -36,6 +36,7 @@
     group: "{{ lobby_server_user }}"
 
 - name: extract zip file
+  tags: [deploy]
   unarchive:
     remote_src: yes
     src: "{{ lobby_server_home_folder }}/{{ lobby_artifact }}"
@@ -44,6 +45,7 @@
     group: "{{ lobby_server_user }}"
 
 - name: install systemd service script
+  tags: [deploy]
   register: service_script
   template:
     src: lobby_server.service.j2
@@ -51,11 +53,13 @@
     mode: "644"
 
 - name: reload systemd
+  tags: [deploy]
   when: service_script.changed
   systemd:
     daemon_reload: yes
 
 - name: restart service if new artifact was deployed
+  tags: [deploy]
   when: (lobby_restart_on_new_deployment) and ((deploy_artifact.changed) or (service_script.changed))
   service:
     name: lobby_server

--- a/infrastructure/run_ansible_prerelease
+++ b/infrastructure/run_ansible_prerelease
@@ -34,11 +34,10 @@ function addPrivateSshKeyToAgent() {
 function runDeployment() {
   ansible-playbook \
     --extra-vars "version=$VERSION" \
-    --extra-vars "using_latest=true" \
+    --skip-tags release \
     --vault-password-file "$VAULT_PASSWORD_FILE" \
     --inventory ansible/inventory/prerelease \
-   "$@" \
-   ansible/site.yml
+   "$@" ansible/site.yml
 }
 
 function runCleanup() {

--- a/infrastructure/run_ansible_production
+++ b/infrastructure/run_ansible_production
@@ -31,7 +31,7 @@ ansible-vault view \
 # Run Deployment
 ansible-playbook \
     --extra-vars "version=$VERSION" \
-    --extra-vars "using_latest=false" \
+    --skip-tags prerelease \
     --vault-password-file vault_password \
     "$@" \
     -i ansible/inventory/prod2 \

--- a/infrastructure/run_ansible_vagrant
+++ b/infrastructure/run_ansible_vagrant
@@ -19,10 +19,10 @@ version=$(sed 's/.*=\s*//' $(find .. -path "*/src/main/*" -name "product.propert
 .include/build_latest_artifacts "$version"
 
 unbuffer ansible-playbook --diff --verbose \
-    "$@" --extra-vars "using_latest=true" \
     --extra-vars "version=$version" \
+    --skip-tags release \
     --inventory-file ansible/inventory/vagrant \
-    ansible/site.yml \
+    $@ ansible/site.yml \
   | tee output \
   | sed 's|\\n|\n|g'
 rm output


### PR DESCRIPTION
[prerelease|release] tags replace the 'using_latest' flag.
Rather than setting the 'using_latest' flag via CLI 'extra-vars'
ansible flag, instead we will 'skip-tags' to skip either
prerelease or release and thereby run the other instructions.

Note, we use skip tags to allow more tags to be passed in from
CLI. Hence, you could do something like `./run_ansible_vagrant -t TAG`
If the script were to use tags instead of skip tags, then the above
would result in a double '-t' argument. In such a case ansible
only runs one of the flags and does not run the union (error prone:
https://github.com/ansible/ansible/issues/22396)

[deploy] tag is added to only run the deploy steps and is useful
for a faster deployment where the one-time setup steps are aleady
done and all we need is to build and deploy a binary. Example
usage: `./run_ansible_vagrant -t deploy`

