### PR TITLE
Make CTRL-A, CTRL-D, CTRL-B work with focused battle calculator dialog

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorDialog.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorDialog.java
@@ -83,6 +83,7 @@ public class BattleCalculatorDialog extends JDialog {
           }
         });
 
+    taFrame.getTerritoryDetails().addBattleCalculatorKeyBindings(dialog);
     // close when hitting the escape key
     SwingKeyBinding.addKeyBinding(
         dialog,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -75,11 +75,6 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
 
     showOdds.addActionListener(
         e -> BattleCalculatorDialog.show(frame, currentTerritory, gameData.getHistory()));
-    SwingKeyBinding.addKeyBindingWithMetaAndCtrlMasks(
-        frame,
-        KeyCode.B,
-        () -> BattleCalculatorDialog.show(frame, currentTerritory, gameData.getHistory()));
-
     addAttackers.addActionListener(e -> BattleCalculatorDialog.addAttackers(currentTerritory));
     addDefenders.addActionListener(e -> BattleCalculatorDialog.addDefenders(currentTerritory));
     addBattleCalculatorKeyBindings(frame);
@@ -96,17 +91,22 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
   }
 
   /**
-   * Adds the battle calculator key bindings (CTRL-A, CTRL-D) to the frame {@code frame}. When
-   * triggered the {@code addAttackers(Territory)} and {@code addDefenders(Territory)} methods of
-   * the battle calculator are triggered with the current territory of this TerritoryDetailPanel.
+   * Adds the battle calculator key bindings (CTRL-A, CTRL-D, CTRL-B) to the frame {@code jframe}.
+   * When triggered the {@code addAttackers(Territory)}, {@code addDefenders(Territory)} and {@code
+   * show(TripleAFrame, Territory, History)} methods of the battle calculator are triggered with the
+   * TripleAFrame, current territory and history of this TerritoryDetailPanel.
    *
-   * @param frame the frame to add the key bindings to
+   * @param jframe the frame to add the key bindings to
    */
-  public void addBattleCalculatorKeyBindings(final JFrame frame) {
+  public void addBattleCalculatorKeyBindings(final JFrame jframe) {
     SwingKeyBinding.addKeyBindingWithMetaAndCtrlMasks(
-        frame, KeyCode.A, () -> BattleCalculatorDialog.addAttackers(currentTerritory));
+        jframe,
+        KeyCode.B,
+        () -> BattleCalculatorDialog.show(frame, currentTerritory, gameData.getHistory()));
     SwingKeyBinding.addKeyBindingWithMetaAndCtrlMasks(
-        frame, KeyCode.D, () -> BattleCalculatorDialog.addDefenders(currentTerritory));
+        jframe, KeyCode.A, () -> BattleCalculatorDialog.addAttackers(currentTerritory));
+    SwingKeyBinding.addKeyBindingWithMetaAndCtrlMasks(
+        jframe, KeyCode.D, () -> BattleCalculatorDialog.addDefenders(currentTerritory));
   }
 
   /**
@@ -115,6 +115,10 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
    * @param dialog the dialog to add the key bindings to
    */
   public void addBattleCalculatorKeyBindings(final JDialog dialog) {
+    SwingKeyBinding.addKeyBindingWithMetaAndCtrlMasks(
+        dialog,
+        KeyCode.B,
+        () -> BattleCalculatorDialog.show(frame, currentTerritory, gameData.getHistory()));
     SwingKeyBinding.addKeyBindingWithMetaAndCtrlMasks(
         dialog, KeyCode.A, () -> BattleCalculatorDialog.addAttackers(currentTerritory));
     SwingKeyBinding.addKeyBindingWithMetaAndCtrlMasks(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -23,6 +23,8 @@ import javax.swing.BoxLayout;
 import javax.swing.Icon;
 import javax.swing.ImageIcon;
 import javax.swing.JButton;
+import javax.swing.JDialog;
+import javax.swing.JFrame;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
@@ -79,12 +81,8 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
         () -> BattleCalculatorDialog.show(frame, currentTerritory, gameData.getHistory()));
 
     addAttackers.addActionListener(e -> BattleCalculatorDialog.addAttackers(currentTerritory));
-    SwingKeyBinding.addKeyBindingWithMetaAndCtrlMasks(
-        frame, KeyCode.A, () -> BattleCalculatorDialog.addAttackers(currentTerritory));
-
     addDefenders.addActionListener(e -> BattleCalculatorDialog.addDefenders(currentTerritory));
-    SwingKeyBinding.addKeyBindingWithMetaAndCtrlMasks(
-        frame, KeyCode.D, () -> BattleCalculatorDialog.addDefenders(currentTerritory));
+    addBattleCalculatorKeyBindings(frame);
     units.setBorder(BorderFactory.createEmptyBorder());
     units.getVerticalScrollBar().setUnitIncrement(20);
     add(showOdds);
@@ -95,6 +93,32 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
     add(unitInfo);
     add(units);
     setElementsVisible(false);
+  }
+
+  /**
+   * Adds the battle calculator key bindings (CTRL-A, CTRL-D) to the frame {@code frame}. When
+   * triggered the {@code addAttackers(Territory)} and {@code addDefenders(Territory)} methods of
+   * the battle calculator are triggered with the current territory of this TerritoryDetailPanel.
+   *
+   * @param frame the frame to add the key bindings to
+   */
+  public void addBattleCalculatorKeyBindings(final JFrame frame) {
+    SwingKeyBinding.addKeyBindingWithMetaAndCtrlMasks(
+        frame, KeyCode.A, () -> BattleCalculatorDialog.addAttackers(currentTerritory));
+    SwingKeyBinding.addKeyBindingWithMetaAndCtrlMasks(
+        frame, KeyCode.D, () -> BattleCalculatorDialog.addDefenders(currentTerritory));
+  }
+
+  /**
+   * Same as {@code addBattleCalculatorKeyBindings(JFrame)} but for {@code JDialog}.
+   *
+   * @param dialog the dialog to add the key bindings to
+   */
+  public void addBattleCalculatorKeyBindings(final JDialog dialog) {
+    SwingKeyBinding.addKeyBindingWithMetaAndCtrlMasks(
+        dialog, KeyCode.A, () -> BattleCalculatorDialog.addAttackers(currentTerritory));
+    SwingKeyBinding.addKeyBindingWithMetaAndCtrlMasks(
+        dialog, KeyCode.D, () -> BattleCalculatorDialog.addDefenders(currentTerritory));
   }
 
   private void setElementsVisible(final boolean visible) {

--- a/lib/swing-lib/src/main/java/org/triplea/swing/key/binding/SwingKeyBinding.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/key/binding/SwingKeyBinding.java
@@ -66,6 +66,23 @@ public class SwingKeyBinding {
         action);
   }
 
+  /**
+   * Same as {@code addKeyBindingWithMetaAndCtrlMasks(JFrame, KeyCode, Runnable)} but for {@code
+   * JDialog}.
+   */
+  public static void addKeyBindingWithMetaAndCtrlMasks(
+      final JDialog component, final KeyCode key, final Runnable action) {
+
+    addKeyMapping(
+        (JComponent) component.getContentPane(),
+        KeyCombination.of(key, ButtonDownMask.CTRL),
+        action);
+    addKeyMapping(
+        (JComponent) component.getContentPane(),
+        KeyCombination.of(key, ButtonDownMask.META),
+        action);
+  }
+
   private static void addKeyMapping(
       final JComponent component, final KeyCode keyCode, final Runnable action) {
     addKeyMapping(component, KeyCombination.of(keyCode, ButtonDownMask.NONE), action);


### PR DESCRIPTION
Until now CTRL-A, CTRL-D, CTRL-B do only work when the main window has the focus.  This patchset enhances the battle calculator to also recognize these bindings and act the same way.  Thus, it now does not matter any more whether the main window or the battle calculator has the focus.

## Testing
Not sure its sensible to test whether a key binding is active or not.

## Additional Notes to Reviewer

Note quite happy about duplicating the functions for JFrame and JDialog but SwingKeyBinding already does it in other functions, so yeah.

## Release Note

<!--RELEASE_NOTE-->NEW|Shortcuts (CTRL-A, CTRL-D, CTRL-B) for adding attackers, defenders or opening a new battle calculator dialog now also work when the battle calculator dialog is focused<!--END_RELEASE_NOTE-->
