### PR TITLE
Battle Simulator: Focus "Calculate Odds" button by default

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorDialog.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorDialog.java
@@ -159,10 +159,4 @@ public class BattleCalculatorDialog extends JDialog {
     lastPosition = new Point(getLocation());
     super.dispose();
   }
-
-  @Override
-  public void setVisible(final boolean vis) {
-    super.setVisible(vis);
-    panel.selectCalculateButton();
-  }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorDialog.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorDialog.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Optional;
 import javax.swing.JDialog;
 import javax.swing.JFrame;
+import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.swing.key.binding.KeyCode;
@@ -98,6 +99,14 @@ public class BattleCalculatorDialog extends JDialog {
       dialog.setLocation(lastPosition);
     }
     dialog.setVisible(true);
+    // On some desktop environments, there is an odd behaviour: The new battle calculator dialog is
+    // not put at the front if the last user-interaction was to move the window of an already
+    // existing battle calculator dialog.  Oddly enough, calling toFront() directly here (before or
+    // after setVisible(true)) has no effect either, but delaying the call to the end of the queue
+    // of the Event Dispatch Thread solves the issue (though you can see the new dialog in the
+    // background for an blink of an eye).
+    // Tested with Cinnamon Desktop 4.8.5.
+    SwingUtilities.invokeLater(dialog::toFront);
     taFrame.getUiContext().addShutdownWindow(dialog);
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -1133,6 +1133,7 @@ class BattleCalculatorPanel extends JPanel {
                     () -> {
                       calculateButton.setText("Calculate Odds");
                       calculateButton.setEnabled(true);
+                      calculateButton.requestFocusInWindow();
                     }));
 
     calculator.setGameData(data);
@@ -1501,10 +1502,6 @@ class BattleCalculatorPanel extends JPanel {
       setIcon(new ImageIcon(uiContext.getFlagImageFactory().getSmallFlag(gamePlayer)));
       return this;
     }
-  }
-
-  void selectCalculateButton() {
-    calculateButton.requestFocus();
   }
 
   private static boolean doesPlayerHaveUnitsOnMap(final GamePlayer player, final GameState data) {


### PR DESCRIPTION
Solves some issues with the focus handling of the battle calculator dialog.

a. The "Calculate Odds" button was not focused because at the time the code called the `requestFocus()` method the button was disabled.  This is solved by calling the correct method after the button gets enabled.  Note that this moves the "requestFocus"-actor/location from the `BattleCalculatorDialog` to the `BattleCalculatorPanel`, i.e. a subcomponent of the dialog.  This is not bad per se and might or might not be an artefact from the organic growth of the code. If the `BattleCalculatorDialog` should trigger the focus request, then we must jump through more hoops.

b. This also changes (at least for my DE) that a new battle calculator dialog is now focused.

c. If the key bindings in #9518 are present (more precisely the CTRL-B for a new battle calculator dialog), then there is an odd behaviour:
The new battle calculator dialog is not put at the front if the last user-interaction was to move the window of an already existing battle calculator dialog.  Oddly enough, calling `toFront()` directly before or after `setVisible(true)` has no effect either, but delaying the call to the end of the queue of the Event Dispatch Thread solves the issue (though you can see the new dialog in the background for an blink of an eye).

It would be interesting to know whether this is a bug in TripleA or a bug/limitation of the windowing framework.  If someone has another Desktop Environment or OS, it would be nice to know whether the bug manifests there.

To reproduce this:
1. Use branch of #9518 (adds the necessary key bindings) and cherry-pick the first commit of this pull request ("Battle Calculator: Focus calculate odds button")
2. Start a game and focus the main window
3. Press CTRL-B, a focused battle calculator should show up
4. Move the battle calculator dialog slightly
5. Press CTRL-B (calculator dialog must not have lost focus!)
6. Check whether the new battle calculator dialog is below or on top the first dialog.

*Note* that if the dialog is not moved, or the main window has the focus after the move, then the new/second dialog is shown on top of the first one.

## Testing
Not reasonably possible?

## Release Note

<!--RELEASE_NOTE-->FIXED:The calculate odds button is now focused again by default<!--END_RELEASE_NOTE-->
