### PR TITLE
Battle Calculator: Allow fighting any player

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -957,14 +957,6 @@ class BattleCalculatorPanel extends JPanel {
 
     defenderCombo.addActionListener(
         e -> {
-          data.acquireReadLock();
-          try {
-            if (data.getRelationshipTracker().isAllied(getDefender(), getAttacker())) {
-              attackerCombo.setSelectedItem(getEnemy(getDefender()));
-            }
-          } finally {
-            data.releaseReadLock();
-          }
           setDefendingUnits(
               defendingUnitsPanel.getUnits().stream().anyMatch(Matches.unitIsOwnedBy(getDefender()))
                   ? defendingUnitsPanel.getUnits()
@@ -973,14 +965,6 @@ class BattleCalculatorPanel extends JPanel {
         });
     attackerCombo.addActionListener(
         e -> {
-          data.acquireReadLock();
-          try {
-            if (data.getRelationshipTracker().isAllied(getDefender(), getAttacker())) {
-              defenderCombo.setSelectedItem(getEnemy(getAttacker()));
-            }
-          } finally {
-            data.releaseReadLock();
-          }
           setAttackingUnits(null);
           setWidgetActivation();
         });
@@ -1375,21 +1359,6 @@ class BattleCalculatorPanel extends JPanel {
 
   private boolean isLand() {
     return landBattleCheckBox.isSelected();
-  }
-
-  private GamePlayer getEnemy(final GamePlayer player) {
-    for (final GamePlayer gamePlayer : data.getPlayerList()) {
-      if (data.getRelationshipTracker().isAtWar(player, gamePlayer)) {
-        return gamePlayer;
-      }
-    }
-    for (final GamePlayer gamePlayer : data.getPlayerList()) {
-      if (!data.getRelationshipTracker().isAllied(player, gamePlayer)) {
-        return gamePlayer;
-      }
-    }
-    // TODO: do we allow fighting allies in the battle calc?
-    throw new IllegalStateException("No enemies or non-allies for :" + player);
   }
 
   private void setResultsToBlank() {


### PR DESCRIPTION
When changing a player, do not set the other player automatically to an
enemy.  This allows fights between any two players.  Moreover, it does
not erase the battle configuration in case of a missclick.

The later point is for me a pain, as I set up the unit configuration for one
party and then set the other party to the other player and from time to
time is miss the tiny entry with the player and select an ally and just
like that is all the preparation gone.

The first point is important for FFA maps as you might still be allied
with someone but an inevitable war is looming, so you want to be
prepared.

Note: It is not always possible to use a substitute, that is a enemy player
which has the same or similar enough units, to do the calculation as
there are quite some maps with "asymmetric" units, e.g. 270BC.

Most of the time (i.e. n-1 out of n) the automatically selected player was
the wrong enemy, so this feature wasn't that useful after all in my opinion.


## Additional Notes to Reviewer

I hope this is the only place where the setting of the other player is done.


## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->CHANGE|The battle calculator now allows to select any two players to battle against not only enemies<!--END_RELEASE_NOTE-->
