### PR TITLE
Install specific ansible version when deploying from github actions

### DIFF
--- a/.github/workflows/deploy-prerelease-provisioning.yml
+++ b/.github/workflows/deploy-prerelease-provisioning.yml
@@ -10,6 +10,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run Ansible to Provision Prerelease Servers
         run: |
+          pip install ansible==2.9.13
           .build/set-build-number ${{ github.run_number }}
           eval "$(ssh-agent -s)"
           cd infrastructure

--- a/.github/workflows/deploy-prerelease.yml
+++ b/.github/workflows/deploy-prerelease.yml
@@ -17,6 +17,7 @@ jobs:
           echo "product_version=$BUILD_NUMBER" | tee -a $GITHUB_ENV
       - name: Deploy to Prerelease
         run: |
+          pip install ansible==2.9.13
           .build/set-build-number ${{ github.run_number }}
           eval "$(ssh-agent -s)"
           cd infrastructure

--- a/.github/workflows/deploy-production-provisioning.yml
+++ b/.github/workflows/deploy-production-provisioning.yml
@@ -10,6 +10,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run Ansible to Provision Production Servers
         run: |
+          pip install ansible==2.9.13
           cd infrastructure
           echo "$ANSIBLE_VAULT_PASSWORD" > vault_password
           ./run_ansible --deploy-type full --environment production

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -10,6 +10,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run Ansible to Deploy
         run: |
+          pip install ansible==2.9.13
           cd infrastructure
           echo "$ANSIBLE_VAULT_PASSWORD" > vault_password
           ./run_ansible --deploy-type minimal --environment prerelease

--- a/.github/workflows/run-bot-update-maps.yml
+++ b/.github/workflows/run-bot-update-maps.yml
@@ -10,6 +10,7 @@ jobs:
         uses: actions/checkout@v2
       - name: Run Ansible to Deploy
         run: |
+          pip install ansible==2.9.13
           cd infrastructure
           echo "$ANSIBLE_VAULT_PASSWORD" > vault_password
           ./run_ansible --tags update_maps --environment production


### PR DESCRIPTION
Mitogen is not compabitle with the default 2.11.4 version that is
installed:

> ERROR! Your Ansible version (2.11.4) is too recent. The most recent version
supported by Mitogen for Ansible is (2, 9).x. Please check the Mitogen
release notes to see if a new version is available, otherwise
subscribe to the corresponding GitHub issue to be notified when
support becomes available.


<!-- If multiple commits please summarize the change above. -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
