### PR TITLE
Maps/out date detection by modified timestamp

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -385,24 +385,18 @@ public class DownloadMapsWindow extends JFrame {
     final String doubleSpace = "&nbsp;&nbsp;";
 
     final StringBuilder sb = new StringBuilder();
-    sb.append("<html>")
-        .append(map.getMapName())
-        .append(doubleSpace)
-        .append(" v")
-        .append(map.getVersion());
+    sb.append("<html>").append(map.getMapName()).append(doubleSpace);
 
     if (!downloadMapsWindowModel.isInstalled(map)) {
       final String mapUrl = map.getDownloadUrl();
-      if (mapUrl != null) {
-        DownloadConfiguration.downloadLengthReader()
-            .getDownloadLength(mapUrl)
-            .ifPresent(
-                downloadSize ->
-                    sb.append(doubleSpace)
-                        .append(" (")
-                        .append(newSizeLabel(downloadSize))
-                        .append(")"));
-      }
+      DownloadConfiguration.downloadLengthReader()
+          .getDownloadLength(mapUrl)
+          .ifPresent(
+              downloadSize ->
+                  sb.append(doubleSpace)
+                      .append(" (")
+                      .append(newSizeLabel(downloadSize))
+                      .append(")"));
     } else {
       sb.append(doubleSpace).append(" (");
       try {

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMap.java
@@ -38,6 +38,7 @@ public class InstalledMap {
    * missing).
    */
   Optional<Path> findContentRoot() {
+    // contentRoot is cached to avoid searching on the file system
     if (contentRoot == null) {
       // relative to the 'map.yml' file location, search current and child directories for
       // a polygons file, the location of the polygons file is the map content root.
@@ -90,6 +91,9 @@ public class InstalledMap {
    * date of the map-download.
    */
   boolean isOutOfDate(final MapDownloadItem download) {
+    // we cache lastModifiedDate for two reasons:
+    // 1. *primarily* test can inject a value
+    // 2. avoid file system access
     if (lastModifiedDate == null) {
       lastModifiedDate = findContentRoot().flatMap(FileUtils::getLastModified).orElse(null);
       if (lastModifiedDate == null) {

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMapsListing.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMapsListing.java
@@ -4,15 +4,17 @@ import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.ui.DefaultGameChooserEntry;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Singular;
 import org.triplea.http.client.maps.listing.MapDownloadItem;
 import org.triplea.io.FileUtils;
 import org.triplea.map.description.file.MapDescriptionYaml;
@@ -21,9 +23,10 @@ import org.triplea.map.description.file.MapDescriptionYaml;
  * Data structure for the list of available games, games that a player has downloaded or installed
  * onto their hard drive.
  */
+@Builder
 @AllArgsConstructor
 public class InstalledMapsListing {
-  private final Collection<InstalledMap> installedMaps;
+  @Singular private final Collection<InstalledMap> installedMaps;
 
   private InstalledMapsListing() {
     this(readMapYamlsAndGenerateMissingMapYamls());
@@ -93,10 +96,6 @@ public class InstalledMapsListing {
     return findGameXmlPathByGameName(gameName).isPresent();
   }
 
-  public int getMapVersionByName(final String mapName) {
-    return findInstalledMapByName(mapName).map(InstalledMap::getMapVersion).orElse(0);
-  }
-
   /**
    * Finds the 'root' of a map folder containing map content files. This will typically be a folder
    * called something like "downloadedMaps/mapName/map". Returns empty if no map with the given name
@@ -147,26 +146,25 @@ public class InstalledMapsListing {
         .collect(Collectors.toList());
   }
 
+  /** Find any installed maps that are out of date compared to available downloads. */
   public Map<MapDownloadItem, InstalledMap> findOutOfDateMaps(
       final Collection<MapDownloadItem> downloads) {
+
     final Map<MapDownloadItem, InstalledMap> outOfDate = new HashMap<>();
 
     for (final MapDownloadItem download : downloads) {
       findInstalledMapByName(download.getMapName())
-          .ifPresent(
-              installedMap -> {
-                final int mapVersion = getMapVersionByName(download.getMapName());
-                if (download.getVersion() != null && download.getVersion() > mapVersion) {
-                  outOfDate.put(download, installedMap);
-                }
-              });
+          .filter(installedMap -> installedMap.isOutOfDate(download))
+          .ifPresent(installedMap -> outOfDate.put(download, installedMap));
     }
     return outOfDate;
   }
 
   /**
-   * Given a map download list, finds the corresponding installed maps that are already installed on
-   * teh system. Note: out-of-date maps are not considered installed.
+   * Given a map download set, return the set of map-downloads that are installed on the file
+   * system.
+   *
+   * @return Map of input 'MapDownload' items mapped to the corresponding 'installed map'
    */
   public Map<MapDownloadItem, InstalledMap> findInstalledMapsFromDownloadList(
       final Collection<MapDownloadItem> downloads) {
@@ -177,15 +175,16 @@ public class InstalledMapsListing {
           .ifPresent(installedMap -> installed.put(download, installedMap));
     }
 
-    final Map<MapDownloadItem, InstalledMap> outOfDate = findOutOfDateMaps(downloads);
-    outOfDate.forEach(installed::remove);
-
     return installed;
   }
 
+  /**
+   * Given a set of map-downloads, returns the set of map-downloads that are not already installed
+   * on the file system.
+   */
   public Collection<MapDownloadItem> findNotInstalledMapsFromDownloadList(
       final Collection<MapDownloadItem> downloads) {
-    final Collection<MapDownloadItem> notInstalled = new ArrayList<>();
+    final Collection<MapDownloadItem> notInstalled = new HashSet<>();
 
     for (final MapDownloadItem download : downloads) {
       if (findInstalledMapByName(download.getMapName()).isEmpty()) {

--- a/game-app/game-core/src/test/java/games/strategy/engine/auto/update/UpdatedMapsCheckTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/auto/update/UpdatedMapsCheckTest.java
@@ -73,7 +73,6 @@ final class UpdatedMapsCheckTest {
     return MapDownloadItem.builder()
         .description("description")
         .mapName(mapName)
-        .version(version)
         .downloadUrl("url")
         .previewImageUrl("preview-url")
         .lastCommitDateEpochMilli(50L)

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadFileTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadFileTest.java
@@ -19,7 +19,6 @@ class DownloadFileTest {
             .previewImageUrl("preview-url")
             .description("description")
             .mapName("mapName")
-            .version(0)
             .lastCommitDateEpochMilli(60L)
             .build();
     final DownloadFile testObj = new DownloadFile(mapDownloadItem, mock(DownloadListener.class));

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadMapsWindowMapsListingTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadMapsWindowMapsListingTest.java
@@ -9,6 +9,7 @@ import games.strategy.engine.framework.map.file.system.loader.InstalledMap;
 import games.strategy.engine.framework.map.file.system.loader.InstalledMapsListing;
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -18,14 +19,12 @@ import org.triplea.map.description.file.MapDescriptionYaml;
 
 class DownloadMapsWindowMapsListingTest extends AbstractClientSettingTestCase {
   private static final String MAP_NAME = "new_test_order";
-  private static final int MAP_VERSION = 10;
 
   private static final MapDownloadItem TEST_MAP =
       MapDownloadItem.builder()
           .downloadUrl("")
           .previewImageUrl("")
           .mapName(MAP_NAME)
-          .version(MAP_VERSION)
           .description("description")
           .lastCommitDateEpochMilli(10L)
           .build();
@@ -65,83 +64,97 @@ class DownloadMapsWindowMapsListingTest extends AbstractClientSettingTestCase {
         .previewImageUrl(url)
         .description("description")
         .mapName("mapName " + url)
-        .version(MAP_VERSION)
+        .lastCommitDateEpochMilli(Instant.now().toEpochMilli())
         .lastCommitDateEpochMilli(40L)
         .build();
   }
 
-  private static MapDownloadItem newInstalledDownloadWithUrl(final String url) {
-    return MapDownloadItem.builder()
-        .downloadUrl(url)
-        .previewImageUrl(url)
-        .description("description")
-        .mapName("mapName " + url)
-        .version(MAP_VERSION)
-        .lastCommitDateEpochMilli(30L)
-        .build();
-  }
-
+  /**
+   * - List of maps installed contains 1 <br>
+   * - List of available maps contains same 1 with an older last update date
+   *
+   * <p>Expecting this map to be listed as installed (and otherwise up-to-date).
+   */
   @Test
   void testInstalled() {
+    final MapDownloadItem installed = newDownloadWithUrl("url");
+
     final InstalledMapsListing installedMapsListing =
-        buildIndexWithMapVersions(Map.of("mapName url", MAP_VERSION));
+        buildInstalledMapsListing(
+            Map.of(installed.getMapName(), installed.getLastCommitDateEpochMilli() + 30));
 
     final DownloadMapsWindowMapsListing downloadMapsWindowMapsListing =
-        new DownloadMapsWindowMapsListing(
-            List.of(newInstalledDownloadWithUrl("url")), installedMapsListing);
+        new DownloadMapsWindowMapsListing(List.of(installed), installedMapsListing);
 
     assertThat(downloadMapsWindowMapsListing.getAvailable(), is(empty()));
     assertThat(downloadMapsWindowMapsListing.getInstalled().entrySet(), hasSize(1));
     assertThat(downloadMapsWindowMapsListing.getOutOfDate().entrySet(), is(empty()));
   }
 
-  private static InstalledMapsListing buildIndexWithMapVersions(
-      final Map<String, Integer> mapNameToVersion) {
+  private static InstalledMapsListing buildInstalledMapsListing(
+      final Map<String, Long> mapNameToVersion) {
 
     return new InstalledMapsListing(
         mapNameToVersion.entrySet().stream()
             .map(
                 entry ->
-                    new InstalledMap(
-                        MapDescriptionYaml.builder()
-                            .yamlFileLocation(Path.of("/local/file").toUri())
-                            .mapName(entry.getKey())
-                            .mapVersion(entry.getValue())
-                            .mapGameList(
-                                List.of(
-                                    MapDescriptionYaml.MapGame.builder()
-                                        .xmlFileName("path.xml")
-                                        .gameName("game")
-                                        .build()))
-                            .build()))
+                    InstalledMap.builder()
+                        .lastModifiedDate(Instant.ofEpochMilli(entry.getValue()))
+                        .mapDescriptionYaml(
+                            MapDescriptionYaml.builder()
+                                .yamlFileLocation(Path.of("/local/file").toUri())
+                                .mapName(entry.getKey())
+                                .mapGameList(
+                                    List.of(
+                                        MapDescriptionYaml.MapGame.builder()
+                                            .xmlFileName("path.xml")
+                                            .gameName("game")
+                                            .build()))
+                                .build())
+                        .build())
             .collect(Collectors.toList()));
   }
 
+  /**
+   * - List of maps installed contains 1 <br>
+   * - List of available maps contains same 1 with a newer last update date
+   *
+   * <p>Expecting this map to be listed as out of date.
+   */
   @Test
   void testOutOfDate() {
+    final MapDownloadItem installed = newDownloadWithUrl("url");
+
     final InstalledMapsListing installedMapsListing =
-        buildIndexWithMapVersions(Map.of("mapName url", MAP_VERSION - 1));
+        buildInstalledMapsListing(
+            Map.of(installed.getMapName(), installed.getLastCommitDateEpochMilli() - 30));
+
     final DownloadMapsWindowMapsListing downloadMapsWindowMapsListing =
-        new DownloadMapsWindowMapsListing(
-            List.of(newInstalledDownloadWithUrl("url")), installedMapsListing);
+        new DownloadMapsWindowMapsListing(List.of(installed), installedMapsListing);
 
     assertThat(downloadMapsWindowMapsListing.getAvailable(), is(empty()));
-    assertThat(downloadMapsWindowMapsListing.getInstalled().entrySet(), is(empty()));
-    assertThat(downloadMapsWindowMapsListing.getOutOfDate().entrySet(), hasSize(1));
+    assertThat(
+        "we expect the one map available for download to be detected as installed",
+        downloadMapsWindowMapsListing.getInstalled().entrySet(),
+        hasSize(1));
+    assertThat(
+        "we expect the one map available for download to be detected as out of date",
+        downloadMapsWindowMapsListing.getOutOfDate().entrySet(),
+        hasSize(1));
   }
 
   @Test
   void testOutOfDateExcluding() {
-    final MapDownloadItem download1 = newInstalledDownloadWithUrl("url1");
-    final MapDownloadItem download2 = newInstalledDownloadWithUrl("url2");
-    final MapDownloadItem download3 = newInstalledDownloadWithUrl("url3");
+    final MapDownloadItem download1 = newDownloadWithUrl("url1");
+    final MapDownloadItem download2 = newDownloadWithUrl("url2");
+    final MapDownloadItem download3 = newDownloadWithUrl("url3");
 
     final InstalledMapsListing installedMapsListing =
-        buildIndexWithMapVersions(
+        buildInstalledMapsListing(
             Map.of(
-                download1.getMapName(), download1.getVersion() - 1,
-                download2.getMapName(), download2.getVersion() - 1,
-                download3.getMapName(), download3.getVersion() - 1));
+                download1.getMapName(), download1.getLastCommitDateEpochMilli() - 10,
+                download2.getMapName(), download1.getLastCommitDateEpochMilli() - 10,
+                download3.getMapName(), download1.getLastCommitDateEpochMilli() - 10));
 
     final DownloadMapsWindowMapsListing downloadMapsWindowMapsListing =
         new DownloadMapsWindowMapsListing(

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/map/file/system/loader/InstalledMapsListingTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/map/file/system/loader/InstalledMapsListingTest.java
@@ -4,12 +4,18 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
 import static org.hamcrest.core.IsCollectionContaining.hasItems;
+import static org.triplea.test.common.matchers.CollectionMatchers.containsMappedItem;
+import static org.triplea.test.common.matchers.CollectionMatchers.doesNotContainMappedItem;
 
 import java.nio.file.Path;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.triplea.http.client.maps.listing.MapDownloadItem;
 import org.triplea.map.description.file.MapDescriptionYaml;
 
 class InstalledMapsListingTest {
@@ -17,34 +23,37 @@ class InstalledMapsListingTest {
   final InstalledMapsListing installedMapsListing =
       new InstalledMapsListing(
           List.of(
-              new InstalledMap(
-                  MapDescriptionYaml.builder()
-                      .yamlFileLocation(Path.of("/path/map0/map.yml").toUri())
-                      .mapName("map-name0")
-                      .mapVersion(0)
-                      .mapGameList(
-                          List.of(
+              InstalledMap.builder()
+                  .mapDescriptionYaml(
+                      MapDescriptionYaml.builder()
+                          .yamlFileLocation(Path.of("/path/map0/map.yml").toUri())
+                          .mapName("map-name0")
+                          .game(
                               MapDescriptionYaml.MapGame.builder()
                                   .gameName("aGame0")
                                   .xmlFileName("path.xml")
-                                  .build()))
-                      .build()),
-              new InstalledMap(
-                  MapDescriptionYaml.builder()
-                      .yamlFileLocation(Path.of("/path/map1/map.yml").toUri())
-                      .mapName("map-name1")
-                      .mapVersion(2)
-                      .mapGameList(
-                          List.of(
+                                  .build())
+                          .build())
+                  .lastModifiedDate(Instant.now())
+                  .build(),
+              InstalledMap.builder()
+                  .mapDescriptionYaml(
+                      MapDescriptionYaml.builder()
+                          .yamlFileLocation(Path.of("/path/map1/map.yml").toUri())
+                          .mapName("map-name1")
+                          .game(
                               MapDescriptionYaml.MapGame.builder()
                                   .gameName("gameName0")
                                   .xmlFileName("path0.xml")
-                                  .build(),
+                                  .build())
+                          .game(
                               MapDescriptionYaml.MapGame.builder()
                                   .gameName("gameName1")
                                   .xmlFileName("path1.xml")
-                                  .build()))
-                      .build())));
+                                  .build())
+                          .build())
+                  .lastModifiedDate(Instant.now())
+                  .build()));
 
   @Test
   void getSortedGamesList() {
@@ -52,22 +61,6 @@ class InstalledMapsListingTest {
 
     assertThat(sortedGameNames, hasSize(3));
     assertThat(sortedGameNames, hasItems("aGame0", "gameName0", "gameName1"));
-  }
-
-  @Test
-  void getMapVersionByName() {
-    assertThat(
-        "If a map does not exist, we default version value to '0'",
-        installedMapsListing.getMapVersionByName("DNE"),
-        is(0));
-    assertThat(
-        "This map in the listing has a version value of '0'",
-        installedMapsListing.getMapVersionByName("map-name0"),
-        is(0));
-    assertThat(
-        "This map in the listing has a version value of '2'",
-        installedMapsListing.getMapVersionByName("map-name1"),
-        is(2));
   }
 
   @ParameterizedTest
@@ -99,5 +92,40 @@ class InstalledMapsListingTest {
       })
   void isMapInstalled_PositiveCases(final String mapName) {
     assertThat(installedMapsListing.isMapInstalled(mapName), is(true));
+  }
+
+  /**
+   * We have 2 installed maps and are presented with a list of updates for those maps. Both
+   * installed maps have an updated date of 'now', one of the maps available is updated 3 months
+   * ago, and the other 3 months in the future. The map with an available future update should show
+   * up as out of date (there is a newer version available for download).
+   */
+  @Test
+  void getOutODate() {
+    // map-name0 -> most recent version available is older
+    // map-name1 -> most recent version available is newer
+
+    final Map<MapDownloadItem, InstalledMap> results =
+        installedMapsListing.findOutOfDateMaps(
+            List.of(
+                MapDownloadItem.builder()
+                    .mapName("map-name0")
+                    .lastCommitDateEpochMilli(
+                        Instant.now().minus(90, ChronoUnit.DAYS).toEpochMilli())
+                    .downloadUrl("url")
+                    .description("description")
+                    .previewImageUrl("url")
+                    .build(),
+                MapDownloadItem.builder()
+                    .mapName("map-name1")
+                    .lastCommitDateEpochMilli(
+                        Instant.now().plus(90, ChronoUnit.DAYS).toEpochMilli())
+                    .downloadUrl("url")
+                    .description("description")
+                    .previewImageUrl("url")
+                    .build()));
+
+    assertThat(results.values(), doesNotContainMappedItem(InstalledMap::getMapName, "map-name0"));
+    assertThat(results.values(), containsMappedItem(InstalledMap::getMapName, "map-name1"));
   }
 }

--- a/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYaml.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYaml.java
@@ -15,6 +15,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.Singular;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.io.FileUtils;
@@ -28,7 +29,6 @@ import org.triplea.io.FileUtils;
  *
  * <pre>
  *   map_name: [string]
- *   version: [number]
  *   games:
  *   - name: [string]
  *     xml_path: [string]
@@ -49,12 +49,13 @@ public class MapDescriptionYaml {
 
   @Nonnull private final URI yamlFileLocation;
   @Nonnull private final String mapName;
-  @Nonnull private final Integer mapVersion;
-  @Nonnull private final List<MapGame> mapGameList;
+
+  @Singular(value = "game")
+  @Nonnull
+  private final List<MapGame> mapGameList;
 
   interface YamlKeys {
     String MAP_NAME = "map_name";
-    String VERSION = "version";
     String GAMES_LIST = "games";
     String GAME_NAME = "game_name";
     String FILE_NAME = "file_name";

--- a/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYamlGenerator.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYamlGenerator.java
@@ -1,16 +1,13 @@
 package org.triplea.map.description.file;
 
 import com.google.common.base.Preconditions;
-import com.google.common.primitives.Ints;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
@@ -51,9 +48,6 @@ class MapDescriptionYamlGenerator {
 
     final String mapName = mapFolder.getFileName().toString();
 
-    final Path propsFile = mapFolder.resolveSibling(mapName + ".properties");
-    final int downloadVersion = Files.exists(propsFile) ? readDownloadVersion(propsFile) : 0;
-
     final List<MapDescriptionYaml.MapGame> games = readGameInformationFromXmls(mapFolder);
     if (games.isEmpty()) {
       return Optional.empty();
@@ -65,7 +59,6 @@ class MapDescriptionYamlGenerator {
         MapDescriptionYaml.builder()
             .yamlFileLocation(mapYmlTargetFileLocation.toUri())
             .mapName(mapName)
-            .mapVersion(downloadVersion)
             .mapGameList(games)
             .build();
 
@@ -76,6 +69,7 @@ class MapDescriptionYamlGenerator {
     final Optional<Path> writtenYmlFile =
         MapDescriptionYamlWriter.writeYmlPojoToFile(mapDescriptionYaml);
 
+    final Path propsFile = mapFolder.resolveSibling(mapName + ".properties");
     if (writtenYmlFile.isPresent() && Files.exists(propsFile)) {
       // clean up the properties file, it is no longer needed
       try {
@@ -95,29 +89,6 @@ class MapDescriptionYamlGenerator {
       log.info("Unable to parse XML file: " + xmlFile.toAbsolutePath(), e);
       return Optional.empty();
     }
-  }
-
-  /** Reads a properties file for the map version or zero if it cannot be read. */
-  private static int readDownloadVersion(final Path propsFile) {
-    final Properties props = new Properties();
-    try (InputStream fis = Files.newInputStream(propsFile)) {
-      props.load(fis);
-    } catch (final IllegalArgumentException | IOException e) {
-      log.error(
-          "Failed to read property file: " + propsFile.toAbsolutePath() + ", " + e.getMessage(), e);
-      return 0;
-    }
-
-    // mapVersion will likely be in a '2.0.0' format. We expect only the leading digit to ever
-    // be non-zero. This is because we get an integer from the download description, but this
-    // was written as 'Version' object which appends trailing zeros.
-    return Optional.ofNullable(props.getProperty("mapVersion"))
-        .flatMap(
-            version ->
-                Arrays.stream(version.split("\\.")) //
-                    .findFirst()
-                    .map(Ints::tryParse))
-        .orElse(0);
   }
 
   /**

--- a/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYamlReader.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYamlReader.java
@@ -2,7 +2,6 @@ package org.triplea.map.description.file;
 
 import static org.triplea.map.description.file.MapDescriptionYaml.YamlKeys.GAMES_LIST;
 import static org.triplea.map.description.file.MapDescriptionYaml.YamlKeys.MAP_NAME;
-import static org.triplea.map.description.file.MapDescriptionYaml.YamlKeys.VERSION;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
@@ -59,7 +58,6 @@ class MapDescriptionYamlReader {
           MapDescriptionYaml.builder()
               .yamlFileLocation(ymlFile.toUri())
               .mapName(Strings.nullToEmpty((String) yamlData.get(MAP_NAME)))
-              .mapVersion((Integer) Optional.ofNullable(yamlData.get(VERSION)).orElse(0))
               .mapGameList(parseGameList(yamlData))
               .build();
 

--- a/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYamlWriter.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYamlWriter.java
@@ -42,7 +42,6 @@ class MapDescriptionYamlWriter {
   String toYamlString(final MapDescriptionYaml mapDescriptionYaml) {
     final Map<String, Object> data = new HashMap<>();
     data.put(MapDescriptionYaml.YamlKeys.MAP_NAME, mapDescriptionYaml.getMapName());
-    data.put(MapDescriptionYaml.YamlKeys.VERSION, mapDescriptionYaml.getMapVersion());
     // generate game list
     data.put(
         MapDescriptionYaml.YamlKeys.GAMES_LIST,

--- a/game-app/map-data/src/test/java/org/triplea/map/description/file/MapDescriptionYamlGeneratorTest.java
+++ b/game-app/map-data/src/test/java/org/triplea/map/description/file/MapDescriptionYamlGeneratorTest.java
@@ -4,17 +4,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.hamcrest.core.Is.is;
 
-import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.ValueSource;
 
 class MapDescriptionYamlGeneratorTest {
 
   private Path exampleMapFolder;
-  private Path propertiesFilePath;
 
   @BeforeEach
   void setup() throws Exception {
@@ -24,9 +20,6 @@ class MapDescriptionYamlGeneratorTest {
                 .getClassLoader()
                 .getResource("map_description_yml_generator/example-map")
                 .toURI());
-
-    propertiesFilePath =
-        exampleMapFolder.resolveSibling(exampleMapFolder.getFileName().toString() + ".properties");
   }
 
   // functionality under test
@@ -39,41 +32,12 @@ class MapDescriptionYamlGeneratorTest {
     return MapDescriptionYamlReader.readFromMap(exampleMapFolder).orElseThrow();
   }
 
-  @Test
-  void noVersionFile() throws Exception {
-    Files.deleteIfExists(propertiesFilePath);
-
-    final MapDescriptionYaml mapDescriptionYaml = generateAndReadDescriptionYamlFile();
-
-    assertThat(
-        "Without a properties file present, map version should default to zero",
-        mapDescriptionYaml.getMapVersion(),
-        is(0));
-  }
-
-  @Test
-  void versionFileWithNoVersionValueInIt() throws Exception {
-    Files.writeString(propertiesFilePath, "mapVersion=");
-
-    final MapDescriptionYaml mapDescriptionYaml = generateAndReadDescriptionYamlFile();
-
-    assertThat(
-        "If the version file is invalid, or missing a version value, "
-            + "then map versions should default to zero.",
-        mapDescriptionYaml.getMapVersion(),
-        is(0));
-  }
-
   /** Verify data generated using a minimal map with properties file and two XML files. */
-  @ParameterizedTest
-  @ValueSource(strings = {"2", "2.0", "2.0.0"})
-  void verifyGeneration(final String versionValue) throws Exception {
-    Files.writeString(propertiesFilePath, "mapVersion=" + versionValue);
-
+  @Test
+  void verifyGeneration() {
     final MapDescriptionYaml mapDescriptionYaml = generateAndReadDescriptionYamlFile();
 
     assertThat(mapDescriptionYaml.getMapName(), is("example-map"));
-    assertThat(mapDescriptionYaml.getMapVersion(), is(versionValue.isBlank() ? 0 : 2));
     assertThat(mapDescriptionYaml.getMapGameList(), hasSize(2));
 
     assertThat(

--- a/game-app/map-data/src/test/java/org/triplea/map/description/file/MapDescriptionYamlReaderTest.java
+++ b/game-app/map-data/src/test/java/org/triplea/map/description/file/MapDescriptionYamlReaderTest.java
@@ -59,7 +59,6 @@ public class MapDescriptionYamlReaderTest {
               .orElseThrow();
 
       assertThat(mapDescriptionYaml.getMapName(), is("MapName"));
-      assertThat(mapDescriptionYaml.getMapVersion(), is(10));
       assertThat(mapDescriptionYaml.getMapGameList(), hasSize(2));
       assertThat(mapDescriptionYaml.getMapGameList().get(0).getGameName(), is("GameName0"));
       assertThat(

--- a/game-app/map-data/src/test/java/org/triplea/map/description/file/MapDescriptionYamlTest.java
+++ b/game-app/map-data/src/test/java/org/triplea/map/description/file/MapDescriptionYamlTest.java
@@ -26,7 +26,6 @@ class MapDescriptionYamlTest {
         MapDescriptionYaml.builder()
             .yamlFileLocation(Path.of("/path/on/disk/map.yml").toUri())
             .mapName("map name")
-            .mapVersion(1)
             .mapGameList(
                 List.of(
                     MapDescriptionYaml.MapGame.builder() //
@@ -60,7 +59,6 @@ class MapDescriptionYamlTest {
         MapDescriptionYaml.builder()
             .yamlFileLocation(Path.of("/path/on/disk/map.yml").toUri())
             .mapName("map name")
-            .mapVersion(1)
             .mapGameList(
                 List.of(
                     MapDescriptionYaml.MapGame.builder() //
@@ -81,7 +79,6 @@ class MapDescriptionYamlTest {
         MapDescriptionYaml.builder()
             .yamlFileLocation(Path.of("/path/on/disk/map.yml").toUri())
             .mapName("map name")
-            .mapVersion(1)
             .mapGameList(
                 List.of(
                     MapDescriptionYaml.MapGame.builder() //

--- a/game-app/map-data/src/test/resources/map_description_yml_generator/example-map.properties
+++ b/game-app/map-data/src/test/resources/map_description_yml_generator/example-map.properties
@@ -1,3 +1,0 @@
-#Sun Dec 27 21:10:12 PST 2020
-map.version=2.0.0
-

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/maps/listing/MapDownloadItem.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/maps/listing/MapDownloadItem.java
@@ -27,10 +27,8 @@ public class MapDownloadItem {
   @Nonnull private final Long lastCommitDateEpochMilli;
   /** HTML description of the map. */
   @Nonnull private final String description;
-  /** @deprecated use lastCommitDateEpochMilli and file time stamps instead. */
-  @Deprecated private final Integer version;
 
-  /** Mapping of {tag name -> tag value} */
+  /** Additional meta data about the map, eg: categories, rating, etc... */
   private final List<MapTag> mapTags;
 
   /**

--- a/lib/java-extras/src/main/java/org/triplea/io/FileUtils.java
+++ b/lib/java-extras/src/main/java/org/triplea/io/FileUtils.java
@@ -12,6 +12,7 @@ import java.net.URL;
 import java.nio.charset.MalformedInputException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
@@ -323,6 +324,23 @@ public final class FileUtils {
             dest.toAbsolutePath());
       }
       return false;
+    }
+  }
+
+  /**
+   * Returns the file system 'last modified' time stamp for a given path. Returns an empty if the
+   * path does not exist or if there are any errors reading the last modified time stamp.
+   */
+  public static Optional<Instant> getLastModified(final Path path) {
+    if (!Files.exists(path)) {
+      return Optional.empty();
+    }
+
+    try {
+      return Optional.of(Files.getLastModifiedTime(path).toInstant());
+    } catch (final IOException e) {
+      log.error("Unable to read file system at: " + path + ", " + e.getMessage(), e);
+      return Optional.empty();
     }
   }
 }

--- a/lib/java-extras/src/test/java/org/triplea/io/FileUtilsTest.java
+++ b/lib/java-extras/src/test/java/org/triplea/io/FileUtilsTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.doCallRealMethod;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.time.Instant;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -235,5 +236,21 @@ final class FileUtilsTest {
           Files.exists(src.resolve("temp-file")),
           is(true));
     }
+  }
+
+  @Test
+  void getLastModifiedForFileThatDoesNotExist() {
+    final Path doesNotExist = Path.of("DNE");
+
+    assertThat(FileUtils.getLastModified(doesNotExist), isEmpty());
+  }
+
+  @SuppressWarnings("OptionalGetWithoutIsPresent")
+  @Test
+  void getLastModified() throws IOException {
+    final Path tempFile = Files.createTempFile("test", "txt");
+
+    assertThat(FileUtils.getLastModified(tempFile), isPresent());
+    assertThat(FileUtils.getLastModified(tempFile).get().isBefore(Instant.now()), is(true));
   }
 }


### PR DESCRIPTION
Changes the out of date criterion to be timestamp instead of version.
Related to: #9516

== Draft Status ==
Still rough, but works.

- [x] extract fix for update map to its own PR (#9598)
- [x] ensure test coverage
- [x] fix build checks
- [x] remove out-of-date map check hack to run all the time (commented out lines)
- [x] manual testing
- [x] refactor for clarity
- [x] squash rebase and fix commit commentary
