### PR TITLE
Fix map update, replace existing maps on update

### DIFF
--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/map/file/system/loader/ZippedMapsExtractorTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/map/file/system/loader/ZippedMapsExtractorTest.java
@@ -9,9 +9,9 @@ class ZippedMapsExtractorTest {
 
   @Test
   void testExtractionFolderNaming() {
-    assertThat(ZippedMapsExtractor.createExtractionFolderName("zip"), is("zip"));
-    assertThat(ZippedMapsExtractor.createExtractionFolderName("zip-master"), is("zip"));
-    assertThat(ZippedMapsExtractor.createExtractionFolderName("zip-master.zip"), is("zip"));
-    assertThat(ZippedMapsExtractor.createExtractionFolderName("zip.zip"), is("zip"));
+    assertThat(ZippedMapsExtractor.computeExtractionFolderName("zip"), is("zip"));
+    assertThat(ZippedMapsExtractor.computeExtractionFolderName("zip-master"), is("zip"));
+    assertThat(ZippedMapsExtractor.computeExtractionFolderName("zip-master.zip"), is("zip"));
+    assertThat(ZippedMapsExtractor.computeExtractionFolderName("zip.zip"), is("zip"));
   }
 }

--- a/lib/java-extras/src/test/java/org/triplea/io/FileUtilsTest.java
+++ b/lib/java-extras/src/test/java/org/triplea/io/FileUtilsTest.java
@@ -7,6 +7,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doCallRealMethod;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -15,6 +17,9 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 @SuppressWarnings("InnerClassMayBeStatic")
 final class FileUtilsTest {
@@ -130,5 +135,105 @@ final class FileUtilsTest {
     FileUtils.deleteDirectory(directory);
 
     assertThat(Files.exists(directory), is(false));
+  }
+
+  @ExtendWith(MockitoExtension.class)
+  @Nested
+  class ReplaceFolder {
+
+    /**
+     * Set up two temp folders, one that exists (src) with a child file and another (dest) that does
+     * not exist. Do a 'replace' operation to move the 'src' folder to 'dest', verify the 'src' file
+     * is deleted and then exists at the 'dest' location.
+     */
+    @DisplayName("If dest folder does not exist, then replace folder behaves like a move operation")
+    @Test
+    void destFolderDoesNotExist() throws IOException {
+      final Path src = Files.createTempDirectory("temp-dir");
+      Files.createFile(src.resolve("temp-file"));
+
+      final Path dest = Files.createTempDirectory("temp-dest");
+      Files.delete(dest);
+      // 'dest' is guaranteed to not exist
+
+      final boolean result = FileUtils.replaceFolder(src, dest);
+
+      assertThat(result, is(true));
+      assertThat("Destination folder should now exist", Files.exists(dest), is(true));
+      assertThat(
+          "'temp-file' from the source folder should now exist under the dest folder",
+          Files.exists(dest.resolve("temp-file")),
+          is(true));
+      assertThat(
+          "The original source folder is moved and should no longer exist",
+          Files.exists(src),
+          is(false));
+    }
+
+    @DisplayName("Verify happy case of replace folder where dest folder is cleanly overwitten")
+    @Test
+    void destFolderDoesExist() throws IOException {
+      final Path src = Files.createTempDirectory("temp-dir");
+      Files.createFile(src.resolve("temp-file"));
+
+      final Path dest = Files.createTempDirectory("temp-dest");
+      // 'dest-temp-file' is a child of 'dest' folder and should not exist after the file move
+      // operation
+      Files.createFile(dest.resolve("dest-temp-file"));
+
+      final boolean result = FileUtils.replaceFolder(src, dest);
+
+      assertThat(result, is(true));
+      assertThat("Destination folder should exist", Files.exists(dest), is(true));
+      assertThat(
+          "Destination folder should contain the child file of 'src'",
+          Files.exists(dest.resolve("temp-file")),
+          is(true));
+      assertThat(
+          "Previous contents of destination folder should be deleted",
+          Files.exists(dest.resolve("dest-temp-file")),
+          is(false));
+      assertThat("src folder should be moved and no longer exist", Files.exists(src), is(false));
+    }
+
+    @DisplayName("Simulate a failure to replace the dest directory, we should see a rollback")
+    @Test
+    void destFolderDoesExistAndFileMoveFails() throws IOException {
+      final Path src = Files.createTempDirectory("temp-dir");
+      Files.createFile(src.resolve("temp-file"));
+
+      final Path dest = Files.createTempDirectory("temp-dest");
+      // 'dest-temp-file' is a child of 'dest' folder and should exist after the failed file move
+      Files.createFile(dest.resolve("dest-temp-file"));
+
+      final FileUtils.FileMoveOperation fileMoveSpy =
+          Mockito.spy(new FileUtils.FileMoveOperation());
+
+      // first move is to create backup
+      doCallRealMethod()
+          // second move replace dest with src (simulate failure here)
+          .doThrow(new IOException("simulated file move exception"))
+          // third move is a rollback moving backup back to dest
+          .doCallRealMethod()
+          .when(fileMoveSpy)
+          .move(any(), any());
+
+      final boolean result = FileUtils.replaceFolder(src, dest, fileMoveSpy);
+      assertThat(result, is(false));
+
+      assertThat("Destination folder should exist", Files.exists(dest), is(true));
+      assertThat(
+          "Destination folder should contain original child file",
+          Files.exists(dest.resolve("dest-temp-file")),
+          is(true));
+      assertThat(
+          "Destination folder should not contain src child file",
+          Files.exists(dest.resolve("temp-file")),
+          is(false));
+      assertThat(
+          "Previous src folder child file should still exist",
+          Files.exists(src.resolve("temp-file")),
+          is(true));
+    }
   }
 }


### PR DESCRIPTION
Map update was written to not expect an unzipped map to already
exist. In the case of map update, then there will be an already
existing map folder. This update fixes the update to do a replace
of any existing content.

The folder replace is done with a backup and rollback if it fails.
Before we replace the old map, we will move it to temp. If the
move of the new map fails, then we will move the old map
from the temp backup to its original location.


<!-- If multiple commits please summarize the change above. -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
