### PR TITLE
Battle Calculator: Use GameData instead of History

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorDialog.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorDialog.java
@@ -1,9 +1,9 @@
 package games.strategy.triplea.odds.calculator;
 
+import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.Unit;
-import games.strategy.engine.history.History;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.ui.TripleAFrame;
 import java.awt.BorderLayout;
@@ -46,14 +46,11 @@ public class BattleCalculatorDialog extends JDialog {
    * Shows the Odds Calculator dialog and initializes it using the current state of the specified
    * territory.
    */
-  public static void show(final TripleAFrame taFrame, final Territory t, final History history) {
-    // Note: The history param may not be the same as taFrame.getGame().getData().getHistory() as
-    // GameData
-    // gets cloned when showing history with a different History instance that doesn't correspond to
-    // what's
-    // shown.
-    final BattleCalculatorPanel panel =
-        new BattleCalculatorPanel(taFrame.getGame().getData(), history, taFrame.getUiContext(), t);
+  public static void show(final TripleAFrame taFrame, final Territory t, final GameData data) {
+    // Note: The data param may not be the same as taFrame.getGame().getData() as GameData gets
+    // cloned when showing history with a different History instance that doesn't correspond to
+    // what's shown.
+    final BattleCalculatorPanel panel = new BattleCalculatorPanel(data, taFrame.getUiContext(), t);
     final BattleCalculatorDialog dialog = new BattleCalculatorDialog(panel, taFrame);
     dialog.pack();
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -8,7 +8,6 @@ import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.framework.ui.background.WaitDialog;
-import games.strategy.engine.history.History;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TerritoryEffectHelper;
@@ -102,11 +101,7 @@ class BattleCalculatorPanel extends JPanel {
   private final Territory location;
   private final JList<String> territoryEffectsJList;
 
-  BattleCalculatorPanel(
-      final GameData data,
-      final History history,
-      final UiContext uiContext,
-      final Territory location) {
+  BattleCalculatorPanel(final GameData data, final UiContext uiContext, final Territory location) {
     this.data = data;
     this.uiContext = uiContext;
     this.location = location;
@@ -1055,7 +1050,7 @@ class BattleCalculatorPanel extends JPanel {
         landBattleCheckBox.setSelected(!location.isWater());
 
         // Default attacker to current player
-        final Optional<GamePlayer> currentPlayer = getCurrentPlayer(history);
+        final Optional<GamePlayer> currentPlayer = getCurrentPlayer();
         currentPlayer.ifPresent(this::setAttacker);
 
         // Get players with units sorted
@@ -1136,8 +1131,8 @@ class BattleCalculatorPanel extends JPanel {
     revalidate();
   }
 
-  public Optional<GamePlayer> getCurrentPlayer(final History history) {
-    final Optional<GamePlayer> player = history.getActivePlayer();
+  public Optional<GamePlayer> getCurrentPlayer() {
+    final Optional<GamePlayer> player = data.getHistory().getActivePlayer();
     if (player.isPresent()) {
       return player;
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -73,8 +73,7 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
     setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
     setBorder(new EmptyBorder(5, 5, 0, 0));
 
-    showOdds.addActionListener(
-        e -> BattleCalculatorDialog.show(frame, currentTerritory, gameData.getHistory()));
+    showOdds.addActionListener(e -> BattleCalculatorDialog.show(frame, currentTerritory, gameData));
     addAttackers.addActionListener(e -> BattleCalculatorDialog.addAttackers(currentTerritory));
     addDefenders.addActionListener(e -> BattleCalculatorDialog.addDefenders(currentTerritory));
     addBattleCalculatorKeyBindings(frame);
@@ -100,9 +99,7 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
    */
   public void addBattleCalculatorKeyBindings(final JFrame jframe) {
     SwingKeyBinding.addKeyBindingWithMetaAndCtrlMasks(
-        jframe,
-        KeyCode.B,
-        () -> BattleCalculatorDialog.show(frame, currentTerritory, gameData.getHistory()));
+        jframe, KeyCode.B, () -> BattleCalculatorDialog.show(frame, currentTerritory, gameData));
     SwingKeyBinding.addKeyBindingWithMetaAndCtrlMasks(
         jframe, KeyCode.A, () -> BattleCalculatorDialog.addAttackers(currentTerritory));
     SwingKeyBinding.addKeyBindingWithMetaAndCtrlMasks(
@@ -116,9 +113,7 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
    */
   public void addBattleCalculatorKeyBindings(final JDialog dialog) {
     SwingKeyBinding.addKeyBindingWithMetaAndCtrlMasks(
-        dialog,
-        KeyCode.B,
-        () -> BattleCalculatorDialog.show(frame, currentTerritory, gameData.getHistory()));
+        dialog, KeyCode.B, () -> BattleCalculatorDialog.show(frame, currentTerritory, gameData));
     SwingKeyBinding.addKeyBindingWithMetaAndCtrlMasks(
         dialog, KeyCode.A, () -> BattleCalculatorDialog.addAttackers(currentTerritory));
     SwingKeyBinding.addKeyBindingWithMetaAndCtrlMasks(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/GameMenu.java
@@ -80,8 +80,7 @@ final class GameMenu extends JMenu {
     }
     addMenuItemWithHotkey(
         SwingAction.of(
-            "Battle Calculator",
-            e -> BattleCalculatorDialog.show(frame, null, gameData.getHistory())),
+            "Battle Calculator", e -> BattleCalculatorDialog.show(frame, null, gameData)),
         KeyEvent.VK_B);
   }
 


### PR DESCRIPTION
I noticed that both GameData and History passed from external to be used in the Battle Simulator.  I'm not sure whether is intentional or organic growth.  I replaced the occurrences of `history` with `data.getHistory()`, which previously was done on the caller side.

Note that a comment warned that  `taFrame.getGame().getData().getHistory()` can be different from `history`. I guess this is still true for the game data.

## Additional Notes to Reviewer

I'm not yet 100% sure with the complete codebase, so there might be instances where the stored GameData and the passed history might differ but I'm confident there isn't.