### PR TITLE
Remove errorprone static analysis

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,9 +12,6 @@ updates:
   - dependency-name: com.diffplug.spotless
     versions:
     - 5.12.0
-  - dependency-name: com.google.errorprone:error_prone_core
-    versions:
-    - 2.6.0
   - dependency-name: com.fasterxml.jackson.datatype:jackson-datatype-jsr310
     versions:
     - 2.12.2

--- a/build.gradle
+++ b/build.gradle
@@ -1,10 +1,7 @@
-import net.ltgt.gradle.errorprone.CheckSeverity
-
 plugins {
     id 'java'
     id 'com.github.ben-manes.versions' version '0.39.0'
     id 'io.franzbecker.gradle-lombok' version '4.0.0' apply false
-    id 'net.ltgt.errorprone' version '2.0.2' apply false
     id 'com.diffplug.spotless' version '5.15.0' apply false
 }
 
@@ -54,7 +51,6 @@ subprojects {
     apply plugin: 'jacoco'
     apply plugin: 'java'
     apply plugin: 'pmd'
-    apply plugin: 'net.ltgt.errorprone'
     apply plugin: 'io.franzbecker.gradle-lombok'
 
     apply from: rootProject.file('gradle/scripts/release.gradle')
@@ -80,7 +76,6 @@ subprojects {
         dropwizardVersion = '2.0.25'
         dropwizardWebsocketsVersion = '1.3.14'
         equalsVerifierVersion = '3.7.1'
-        errorProneVersion = '2.6.0'
         feignCoreVersion = '11.6'
         feignGsonVersion = '11.6'
         javaWebSocketVersion = '1.5.2'
@@ -119,7 +114,6 @@ subprojects {
     }
 
     dependencies {
-        errorprone "com.google.errorprone:error_prone_core:$errorProneVersion"
         implementation "ch.qos.logback:logback-classic:$logbackClassicVersion"
         implementation "com.google.guava:guava:$guavaVersion"
         testImplementation "com.github.npathai:hamcrest-optional:$hamcrestOptionalVersion"
@@ -138,43 +132,6 @@ subprojects {
             '-Xlint:none,-processing'
         ]
         options.encoding = 'UTF-8'
-        options.errorprone {
-            check 'ByteBufferBackingArray', CheckSeverity.ERROR
-            check 'CatchAndPrintStackTrace', CheckSeverity.ERROR
-            check 'ClassCanBeStatic', CheckSeverity.ERROR
-            check 'DefaultCharset', CheckSeverity.ERROR
-            check 'EqualsGetClass', CheckSeverity.ERROR
-            check 'EqualsIncompatibleType', CheckSeverity.ERROR
-            check 'EqualsUnsafeCast', CheckSeverity.ERROR
-            check 'FutureReturnValueIgnored', CheckSeverity.ERROR
-            check 'ImmutableEnumChecker', CheckSeverity.ERROR
-            check 'InconsistentCapitalization', CheckSeverity.ERROR
-            check 'JdkObsolete', CheckSeverity.ERROR
-            check 'MissingOverride', CheckSeverity.ERROR
-            check 'MutableConstantField', CheckSeverity.ERROR
-            check 'NonAtomicVolatileUpdate', CheckSeverity.ERROR
-            check 'ObjectToString', CheckSeverity.ERROR
-            check 'OperatorPrecedence', CheckSeverity.ERROR
-            check 'PrivateConstructorForUtilityClass', CheckSeverity.ERROR
-            check 'ReferenceEquality', CheckSeverity.ERROR
-            check 'StringSplitter', CheckSeverity.ERROR
-            check 'ThreadPriorityCheck', CheckSeverity.ERROR
-            check 'UndefinedEquals', CheckSeverity.ERROR
-            check 'UnnecessaryParentheses', CheckSeverity.ERROR
-            check 'UnsafeReflectiveConstructionCast', CheckSeverity.ERROR
-            check 'UnsynchronizedOverridesSynchronized', CheckSeverity.ERROR
-            check 'WaitNotInLoop', CheckSeverity.ERROR
-            disable 'UnusedVariable' // Workaround for https://github.com/google/error-prone/issues/1250
-            disable 'SameNameButDifferent' // Workaround for https://github.com/google/error-prone/issues/2120
-            // UnnecessaryLambda: frequent false positive - we use lambda's assigned to variables
-            // frequently to facilitate testing.
-            disable 'UnnecessaryLambda'
-            // MissingSummary throws false positives on lombok @Builder annotations.
-            disable 'MissingSummary'
-
-            disable 'UnescapedEntity'
-            disable 'InvalidBlockTag'
-        }
         options.incremental = true
     }
 
@@ -225,12 +182,6 @@ subprojects {
         maxWarnings = 0
         source sourceSets.test.output.resourcesDir
         exclude '**/map-xmls/*.xml'
-    }
-
-    compileTestJava {
-        options.errorprone {
-            check 'ClassCanBeStatic', CheckSeverity.OFF
-        }
     }
 
     jacocoTestReport {

--- a/game-app/domain-data/src/main/java/org/triplea/domain/data/LobbyGame.java
+++ b/game-app/domain-data/src/main/java/org/triplea/domain/data/LobbyGame.java
@@ -15,9 +15,6 @@ import lombok.With;
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
-// See https://github.com/google/error-prone/pull/1195 and
-// https://github.com/rzwitserloot/lombok/issues/737
-@SuppressWarnings("ReferenceEquality")
 public class LobbyGame {
   private String hostAddress;
   private Integer hostPort;

--- a/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatController.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/chat/ChatController.java
@@ -68,8 +68,6 @@ public class ChatController implements IChatController {
     return CHAT_CHANNEL + chatName;
   }
 
-  @SuppressWarnings("FutureReturnValueIgnored") // false positive; see
-  // https://github.com/google/error-prone/issues/883
   private void startPinger() {
     pingThread.scheduleAtFixedRate(
         () -> {

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/MoveDescription.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/MoveDescription.java
@@ -65,7 +65,6 @@ public class MoveDescription extends AbstractMoveDescription {
         HashMultiset.create(getUnits()), route, new HashMap<>(unitsToTransports), dependentUnits);
   }
 
-  @SuppressWarnings("UndefinedEquals")
   private static boolean collectionsAreEqual(final Collection<Unit> a, final Collection<Unit> b) {
     // https://stackoverflow.com/questions/1565214/is-there-a-way-to-check-if-two-collections-contain-the-same-elements-independen
     return HashMultiset.create(a).equals(HashMultiset.create(b));

--- a/game-app/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/ActionTimeUnit.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/lobby/client/ui/action/ActionTimeUnit.java
@@ -6,7 +6,6 @@ import lombok.AllArgsConstructor;
 
 /** The possible time units and corresponding mappings. */
 @AllArgsConstructor
-@SuppressWarnings("ImmutableEnumChecker")
 enum ActionTimeUnit {
   MINUTES("Minutes", minutes -> (long) minutes),
 

--- a/game-app/game-core/src/main/java/org/triplea/debug/ErrorMessage.java
+++ b/game-app/game-core/src/main/java/org/triplea/debug/ErrorMessage.java
@@ -31,7 +31,6 @@ import org.triplea.swing.jpanel.JPanelBuilder;
  * error message is intended to be user friendly, clicking 'show details' would show full details of
  * all error messages.
  */
-@SuppressWarnings("ImmutableEnumChecker") // Enum singleton pattern
 public enum ErrorMessage {
   INSTANCE;
 

--- a/game-app/game-core/src/main/java/org/triplea/lobby/common/GameDescription.java
+++ b/game-app/game-core/src/main/java/org/triplea/lobby/common/GameDescription.java
@@ -18,9 +18,6 @@ import org.triplea.game.server.HeadlessGameServer;
 /**
  * Immutable Data class being used to send information about the current game state to the lobby.
  */
-// See https://github.com/google/error-prone/pull/1195 and
-// https://github.com/rzwitserloot/lombok/issues/737
-@SuppressWarnings("ReferenceEquality")
 @Value
 @Builder
 @AllArgsConstructor(access = AccessLevel.PRIVATE)

--- a/game-app/game-core/src/main/java/org/triplea/util/ExitStatus.java
+++ b/game-app/game-core/src/main/java/org/triplea/util/ExitStatus.java
@@ -6,7 +6,6 @@ import lombok.AllArgsConstructor;
 
 /** A process exit status. */
 @AllArgsConstructor
-@SuppressWarnings("ImmutableEnumChecker")
 public enum ExitStatus {
   /** The process exited successfully (0). */
   SUCCESS(0),

--- a/http-clients/feign-common/src/main/java/org/triplea/http/client/HttpClient.java
+++ b/http-clients/feign-common/src/main/java/org/triplea/http/client/HttpClient.java
@@ -3,7 +3,6 @@ package org.triplea.http.client;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.google.common.base.Preconditions;
-import com.google.errorprone.annotations.FormatMethod;
 import feign.Feign;
 import feign.Logger;
 import feign.Request;
@@ -72,7 +71,6 @@ public class HttpClient<ClientTypeT> implements Supplier<ClientTypeT> {
                     : super.logAndRebufferResponse(configKey, logLevel, response, elapsedTime);
               }
 
-              @FormatMethod
               @Override
               protected void log(
                   final String configKey, final String format, final Object... args) {

--- a/lib/java-extras/build.gradle
+++ b/lib/java-extras/build.gradle
@@ -1,7 +1,6 @@
 description = 'TripleA library for low-level helper APIs, ie: syntactic sugar'
 
 dependencies {
-    errorprone "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
     implementation "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
     implementation "org.apache.httpcomponents:httpclient:$apacheHttpComponentsVersion"
     implementation "org.snakeyaml:snakeyaml-engine:$snakeYamlVersion"

--- a/lib/java-extras/src/main/java/org/triplea/java/concurrency/CompletableFutureUtils.java
+++ b/lib/java-extras/src/main/java/org/triplea/java/concurrency/CompletableFutureUtils.java
@@ -12,7 +12,6 @@ public final class CompletableFutureUtils {
    * Invokes {@code exceptionHandler} with any exception thrown by {@code future} when it is
    * complete. If {@code future} completes normally, no action is taken.
    */
-  @SuppressWarnings("FutureReturnValueIgnored")
   public static void logExceptionWhenComplete(
       final CompletableFuture<?> future, final Consumer<Throwable> exceptionHandler) {
     future.whenComplete(

--- a/lib/java-extras/src/main/java/org/triplea/java/timer/Timers.java
+++ b/lib/java-extras/src/main/java/org/triplea/java/timer/Timers.java
@@ -21,7 +21,6 @@ public final class Timers {
    * @param delayTimeUnit The unit of the delay (eg: minutes, seconds).
    * @param runnable The task to be run.
    */
-  @SuppressWarnings("FutureReturnValueIgnored")
   public static void executeAfterDelay(
       final int delay, final TimeUnit delayTimeUnit, final Runnable runnable) {
     Preconditions.checkArgument(delay >= 0, "Delay must be non-negative, was %s", delay);

--- a/lib/websocket-client/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
+++ b/lib/websocket-client/src/test/java/org/triplea/http/client/web/socket/WebSocketConnectionTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-@SuppressWarnings({"InnerClassMayBeStatic", "FutureReturnValueIgnored"})
+@SuppressWarnings("InnerClassMayBeStatic")
 class WebSocketConnectionTest {
   private static final URI INVALID_URI = URI.create("wss://server.invalid");
   private static final String MESSAGE = "message";

--- a/lib/websocket-server/build.gradle
+++ b/lib/websocket-server/build.gradle
@@ -1,5 +1,4 @@
 dependencies {
-    errorprone "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
     implementation "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
     implementation "com.google.code.gson:gson:$gsonVersion"
     implementation "com.liveperson:dropwizard-websockets:$dropwizardWebsocketsVersion"

--- a/spitfire-server/error-reporting-module/build.gradle
+++ b/spitfire-server/error-reporting-module/build.gradle
@@ -1,5 +1,4 @@
 dependencies {
-    errorprone "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
     implementation "org.jdbi:jdbi3-core:$jdbiVersion"
     implementation "org.jdbi:jdbi3-sqlobject:$jdbiVersion"
     implementation project(':http-clients:github-client')

--- a/spitfire-server/lobby-module/build.gradle
+++ b/spitfire-server/lobby-module/build.gradle
@@ -1,5 +1,4 @@
 dependencies {
-    errorprone "com.github.ben-manes.caffeine:caffeine:$caffeineVersion"
     implementation "at.favre.lib:bcrypt:$bcryptVersion"
     implementation "com.liveperson:dropwizard-websockets:$dropwizardWebsocketsVersion"
     implementation "com.sun.mail:jakarta.mail:$jakartaMailVersion"


### PR DESCRIPTION
Removing for a number of reasons:
- relatively significant false positive rate
- redundancy with other static checkers means we do
  not get a lot of unique benefit.
- error prone is somewhat brittle by wrapping javac
- stuck on an older version
- does not play well with lombok
- failures during javac due to error prone does
  not play well with other tooling that well.
  Notably we want each static check to fail independently
  and not have a case where everything fails because
  of an error prone violation.

Further discussion in: #9599


<!-- If multiple commits please summarize the change above. -->

## Testing
<!-- Describe any manual testing performed below. -->

## Screens Shots
<!-- If there are UI updates, include screenshots below -->

## Additional Notes to Reviewer
<!-- Add any additional details that would be helpful to reviewers -->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
