### PR TITLE
Consolidate lobby related max and min lengths to a constants class

### DIFF
--- a/game-app/domain-data/src/main/java/org/triplea/domain/data/LobbyConstants.java
+++ b/game-app/domain-data/src/main/java/org/triplea/domain/data/LobbyConstants.java
@@ -1,0 +1,15 @@
+package org.triplea.domain.data;
+
+import lombok.experimental.UtilityClass;
+
+/**
+ * Class that stores constants related to the lobby, lobby users, etc... Note, changes to max or min
+ * lengths might require database changes, notably column sizes.
+ */
+@UtilityClass
+public class LobbyConstants {
+  public static final int USERNAME_MIN_LENGTH = 3;
+  public static final int USERNAME_MAX_LENGTH = 40;
+  public static final int EMAIL_MAX_LENGTH = 40;
+  public static final int PASSWORD_MIN_LENGTH = 3;
+}

--- a/game-app/domain-data/src/main/java/org/triplea/domain/data/PlayerEmailValidation.java
+++ b/game-app/domain-data/src/main/java/org/triplea/domain/data/PlayerEmailValidation.java
@@ -20,6 +20,12 @@ public final class PlayerEmailValidation {
     final String localPart = word + "(?:\\." + word + ")*";
     final String email = localPart + "@" + domain;
     final String regex = "(\\s*" + email + "\\s*)*";
-    return emailAddress.matches(regex) ? null : "Invalid email address";
+    if (!emailAddress.matches(regex)) {
+      return "Invalid email address";
+    }
+    if (emailAddress.length() > LobbyConstants.EMAIL_MAX_LENGTH) {
+      return "Email address exceeds max length: " + LobbyConstants.EMAIL_MAX_LENGTH;
+    }
+    return null;
   }
 }

--- a/game-app/domain-data/src/main/java/org/triplea/domain/data/UserName.java
+++ b/game-app/domain-data/src/main/java/org/triplea/domain/data/UserName.java
@@ -16,10 +16,8 @@ import lombok.Getter;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
 public class UserName implements Serializable {
-  public static final int MAX_LENGTH = 40;
 
   private static final long serialVersionUID = 8356372044000232198L;
-  private static final int MIN_LENGTH = 3;
   @Getter private final String value;
 
   public static UserName of(final String name) {
@@ -42,10 +40,10 @@ public class UserName implements Serializable {
    * @return Error message if username is not valid, otherwise returns an error message.
    */
   public static @Nullable String validate(final String username) {
-    if ((username == null) || (username.length() < MIN_LENGTH)) {
-      return "Name is too short (minimum " + MIN_LENGTH + " characters)";
-    } else if (username.length() > MAX_LENGTH) {
-      return "Name is too long (maximum " + MAX_LENGTH + " characters)";
+    if ((username == null) || (username.length() < LobbyConstants.USERNAME_MIN_LENGTH)) {
+      return "Name is too short (minimum " + LobbyConstants.USERNAME_MIN_LENGTH + " characters)";
+    } else if (username.length() > LobbyConstants.USERNAME_MAX_LENGTH) {
+      return "Name is too long (maximum " + LobbyConstants.USERNAME_MAX_LENGTH + " characters)";
     } else if (!username.matches("[a-zA-Z][0-9a-zA-Z_-]+")) {
       return "Name can only contain alphanumeric characters, hyphens (-), and underscores (_)";
     }

--- a/game-app/domain-data/src/test/java/org/triplea/domain/data/UserNameTest.java
+++ b/game-app/domain-data/src/test/java/org/triplea/domain/data/UserNameTest.java
@@ -18,7 +18,7 @@ class UserNameTest {
         "",
         "a",
         "ab", // still too short
-        Strings.repeat("a", UserName.MAX_LENGTH + 1),
+        Strings.repeat("a", LobbyConstants.USERNAME_MAX_LENGTH + 1),
         "ab*", // no special characters other than '-' and '_'
         "ab$",
         ".ab",
@@ -49,7 +49,7 @@ class UserNameTest {
 
   @SuppressWarnings("unused")
   private static List<String> usernameValidationWithValidNames() {
-    return List.of("abc", Strings.repeat("a", UserName.MAX_LENGTH), "a12", "a--");
+    return List.of("abc", Strings.repeat("a", LobbyConstants.USERNAME_MAX_LENGTH), "a12", "a--");
   }
 
   @ParameterizedTest

--- a/game-app/game-core/src/main/java/games/strategy/engine/lobby/client/login/LoginPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/lobby/client/login/LoginPanel.java
@@ -20,6 +20,7 @@ import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JPasswordField;
 import javax.swing.JTextField;
+import org.triplea.domain.data.LobbyConstants;
 import org.triplea.domain.data.UserName;
 import org.triplea.java.Sha512Hasher;
 import org.triplea.swing.JButtonBuilder;
@@ -228,10 +229,12 @@ final class LoginPanel extends JPanel {
       JOptionPane.showMessageDialog(
           this, "You must enter a password", "No Password", JOptionPane.ERROR_MESSAGE);
       return;
-    } else if (password.getPassword().length < 3 && !anonymousLogin.isSelected()) {
+    } else if (password.getPassword().length < LobbyConstants.PASSWORD_MIN_LENGTH
+        && !anonymousLogin.isSelected()) {
       JOptionPane.showMessageDialog(
           this,
-          "Passwords must be at least three characters long",
+          String.format(
+              "Passwords must be at least %s characters long", LobbyConstants.PASSWORD_MIN_LENGTH),
           "Invalid Password",
           JOptionPane.ERROR_MESSAGE);
       return;

--- a/game-app/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/banned/names/BannedUsernamesTab.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/banned/names/BannedUsernamesTab.java
@@ -8,6 +8,7 @@ import javax.swing.JFrame;
 import javax.swing.JPanel;
 import javax.swing.JTable;
 import javax.swing.JTextField;
+import org.triplea.domain.data.LobbyConstants;
 import org.triplea.http.client.lobby.moderator.toolbox.banned.name.ToolboxUsernameBanClient;
 import org.triplea.swing.ButtonColumn;
 import org.triplea.swing.DocumentListenerBuilder;
@@ -36,7 +37,6 @@ import org.triplea.swing.jpanel.JPanelBuilder;
  * </pre>
  */
 public final class BannedUsernamesTab implements Supplier<Component> {
-  private static final int MIN_LENGTH = 4;
   private final BannedUsernamesTabModel bannedUsernamesTabModel;
   private final BannedUsernamesTabActions bannedUsernamesTabActions;
 
@@ -78,8 +78,11 @@ public final class BannedUsernamesTab implements Supplier<Component> {
     final JTextField addField =
         JTextFieldBuilder.builder()
             .columns(10)
-            .maxLength(20)
-            .toolTip("Username to ban, must be at least " + MIN_LENGTH + " characters long")
+            .maxLength(LobbyConstants.USERNAME_MAX_LENGTH)
+            .toolTip(
+                "Username to ban, must be at least "
+                    + LobbyConstants.USERNAME_MIN_LENGTH
+                    + " characters long")
             .build();
 
     final JButton addButton =
@@ -92,7 +95,9 @@ public final class BannedUsernamesTab implements Supplier<Component> {
             .build();
 
     new DocumentListenerBuilder(
-            () -> addButton.setEnabled(addField.getText().trim().length() >= MIN_LENGTH))
+            () ->
+                addButton.setEnabled(
+                    addField.getText().trim().length() >= LobbyConstants.USERNAME_MIN_LENGTH))
         .attachTo(addField);
 
     return new JPanelBuilder()

--- a/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/controllers/lobby/LobbyWatcherController.java
+++ b/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/controllers/lobby/LobbyWatcherController.java
@@ -18,6 +18,7 @@ import org.eclipse.jetty.http.HttpStatus;
 import org.jdbi.v3.core.Jdbi;
 import org.triplea.db.dao.user.role.UserRole;
 import org.triplea.domain.data.ApiKey;
+import org.triplea.domain.data.LobbyConstants;
 import org.triplea.domain.data.UserName;
 import org.triplea.http.client.lobby.game.lobby.watcher.ChatMessageUpload;
 import org.triplea.http.client.lobby.game.lobby.watcher.GamePostingRequest;
@@ -141,7 +142,8 @@ public class LobbyWatcherController extends HttpController {
     Preconditions.checkArgument(chatMessageUpload.getGameId() != null);
     Preconditions.checkArgument(chatMessageUpload.getApiKey() != null);
 
-    Preconditions.checkArgument(chatMessageUpload.getFromPlayer().length() <= UserName.MAX_LENGTH);
+    Preconditions.checkArgument(
+        chatMessageUpload.getFromPlayer().length() <= LobbyConstants.USERNAME_MAX_LENGTH);
     Preconditions.checkArgument(chatMessageUpload.getApiKey().length() <= ApiKey.MAX_LENGTH);
 
     if (!chatUploadModule.upload(chatMessageUpload)) {

--- a/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/controllers/user/account/CreateAccountController.java
+++ b/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/controllers/user/account/CreateAccountController.java
@@ -7,6 +7,7 @@ import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import lombok.Builder;
 import org.jdbi.v3.core.Jdbi;
+import org.triplea.domain.data.LobbyConstants;
 import org.triplea.http.client.lobby.login.CreateAccountRequest;
 import org.triplea.http.client.lobby.login.CreateAccountResponse;
 import org.triplea.http.client.lobby.login.LobbyLoginClient;
@@ -29,8 +30,17 @@ public class CreateAccountController extends HttpController {
   public CreateAccountResponse createAccount(final CreateAccountRequest createAccountRequest) {
     Preconditions.checkArgument(createAccountRequest != null);
     Preconditions.checkArgument(createAccountRequest.getUsername() != null);
+    Preconditions.checkArgument(
+        createAccountRequest.getUsername().length() <= LobbyConstants.USERNAME_MAX_LENGTH);
+    Preconditions.checkArgument(
+        createAccountRequest.getUsername().length() >= LobbyConstants.USERNAME_MIN_LENGTH);
     Preconditions.checkArgument(createAccountRequest.getEmail() != null);
+    Preconditions.checkArgument(
+        createAccountRequest.getEmail().length() <= LobbyConstants.EMAIL_MAX_LENGTH);
     Preconditions.checkArgument(createAccountRequest.getPassword() != null);
+    Preconditions.checkArgument(
+        createAccountRequest.getPassword().length() >= LobbyConstants.PASSWORD_MIN_LENGTH);
+    Preconditions.checkArgument(createAccountRequest.getEmail() != null);
 
     return createAccountModule.apply(createAccountRequest);
   }

--- a/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/controllers/user/account/LoginController.java
+++ b/spitfire-server/dropwizard-server/src/main/java/org/triplea/spitfire/server/controllers/user/account/LoginController.java
@@ -9,6 +9,7 @@ import javax.ws.rs.core.Context;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import org.jdbi.v3.core.Jdbi;
+import org.triplea.domain.data.LobbyConstants;
 import org.triplea.http.client.AuthenticationHeaders;
 import org.triplea.http.client.lobby.login.LobbyLoginClient;
 import org.triplea.http.client.lobby.login.LobbyLoginResponse;
@@ -34,6 +35,11 @@ public class LoginController extends HttpController {
       @Context final HttpServletRequest request, final LoginRequest loginRequest) {
     Preconditions.checkArgument(loginRequest != null);
     Preconditions.checkArgument(loginRequest.getName() != null);
+    Preconditions.checkArgument(
+        loginRequest.getName().length() <= LobbyConstants.USERNAME_MAX_LENGTH);
+    Preconditions.checkArgument(
+        loginRequest.getName().length() >= LobbyConstants.USERNAME_MIN_LENGTH);
+
     return loginModule.doLogin(
         loginRequest,
         request.getHeader(AuthenticationHeaders.SYSTEM_ID_HEADER),


### PR DESCRIPTION
Aggregates magic values for max/min lengths into a single class.

Fixes inconsistent max lengths enforced in UI (#9104)

