### PR TITLE
Deployment: Disable setting postgres user password

### DIFF
--- a/infrastructure/ansible/roles/database/postgres/tasks/main.yml
+++ b/infrastructure/ansible/roles/database/postgres/tasks/main.yml
@@ -22,13 +22,14 @@
     state: started
     enabled: yes
 
-- name: Set postgres user password
-  become_user: postgres
-  postgresql_user:
-    name: postgres
-    login_password: "{{ postgres_user_db_password }}"
-    password: "{{ postgres_user_db_password }}"
-    encrypted: yes
+# Disabled, does not consistently work.
+#- name: Set postgres user password
+#  become_user: postgres
+#  postgresql_user:
+#    name: postgres
+#    login_password: "{{ postgres_user_db_password }}"
+#    password: "{{ postgres_user_db_password }}"
+#    encrypted: yes
 
 - name: Create application database users
   become_user: postgres


### PR DESCRIPTION
The setting of postgres user password does not work reliably.
Disabling it for now to restore the deployment process back
to a working state.
