### PR TITLE
Deprecate Tuple and Triplet

### DIFF
--- a/game-app/game-core/src/main/java/org/triplea/util/Triple.java
+++ b/game-app/game-core/src/main/java/org/triplea/util/Triple.java
@@ -9,8 +9,17 @@ import lombok.Value;
  * @param <F> The type of the first value.
  * @param <S> The type of the second value.
  * @param <T> The type of the third value.
+ * @deprecated Instead use a simple value object, eg:
+ *     <pre>{@code
+ * @Value
+ * class ValueObject {
+ *   String first;
+ *   String second;
+ * }
+ * }</pre>
  */
 @Value(staticConstructor = "of")
+@Deprecated
 public final class Triple<F, S, T> implements Serializable {
   private static final long serialVersionUID = -8188046743232005918L;
   private final F first;

--- a/game-app/game-core/src/main/java/org/triplea/util/Tuple.java
+++ b/game-app/game-core/src/main/java/org/triplea/util/Tuple.java
@@ -9,8 +9,17 @@ import lombok.EqualsAndHashCode;
  *
  * @param <T> The type of the first value.
  * @param <S> The type of the second value.
+ * @deprecated Instead use a simple value object, eg:
+ *     <pre>{@code
+ * @Value
+ * class ValueObject {
+ *   String first;
+ *   String second;
+ * }
+ * }</pre>
  */
 @EqualsAndHashCode
+@Deprecated
 public final class Tuple<T, S> implements Serializable {
   private static final long serialVersionUID = -5091545494950868125L;
   private final T first;


### PR DESCRIPTION
Mark Tuple and Triplet deprecated. Their usage is discouraged and should
be replaced with value objects. The reason is readability, it is difficult
to understand something like "diceRolle.getFirst()" compared to "diceRoll.getNumberRolled"

