### PR TITLE
Dev-Config: Disable code climate too many return statements warning.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -4,6 +4,8 @@ version: "2"
 # https://docs.codeclimate.com/docs/maintainability#section-checks
 # https://docs.codeclimate.com/docs/advanced-configuration
 checks:
+  return-statements:
+    enabled: false
   argument-count:
     config:
       threshold: 5


### PR DESCRIPTION
Turning this check off, we'll know too many return statements
code smell when we see it. In principle we want a check that
verifies the code paths to a methods return statements
are easy to understand, counting the number of return statements
alone is a somewhat poor proxy for that.

