### PR TITLE
Simplify how out-of-date/available/installed maps are calculated.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/download/DownloadMapsWindow.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -302,7 +303,12 @@ public class DownloadMapsWindow extends JFrame {
     }
 
     if (!mapList.getInstalled().isEmpty()) {
-      final JPanel installed = newMapSelectionPanel(mapList.getInstalled(), MapAction.REMOVE);
+      final JPanel installed =
+          newMapSelectionPanel(
+              mapList.getInstalled().keySet().stream()
+                  .sorted(Comparator.comparing(m -> m.getMapName().toUpperCase()))
+                  .collect(Collectors.toList()),
+              MapAction.REMOVE);
       tabbedPane.addTab("Installed", installed);
     }
     return tabbedPane;

--- a/game-app/game-core/src/test/java/games/strategy/engine/auto/update/UpdatedMapsCheckTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/auto/update/UpdatedMapsCheckTest.java
@@ -2,17 +2,12 @@ package games.strategy.engine.auto.update;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.collection.IsEmptyCollection.empty;
-import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.mockito.Mockito.verify;
 
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.util.Collection;
 import java.util.List;
-import java.util.function.Function;
 import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -73,17 +68,6 @@ final class UpdatedMapsCheckTest {
         NOW.minus(UpdatedMapsCheck.THRESHOLD_DAYS, ChronoUnit.DAYS).plusSeconds(60).toEpochMilli());
   }
 
-  @Test
-  void localMapIsCurrent() {
-    final var availableMaps = List.of(buildDownloadDescription("map name", 2));
-    final Function<String, Integer> mapVersionLookupFunction = anyMapName -> 2;
-
-    final Collection<String> result =
-        UpdatedMapsCheck.computeOutOfDateMaps(availableMaps, mapVersionLookupFunction);
-
-    assertThat(result, is(empty()));
-  }
-
   @SuppressWarnings("SameParameterValue")
   private static MapDownloadItem buildDownloadDescription(final String mapName, final int version) {
     return MapDownloadItem.builder()
@@ -94,38 +78,5 @@ final class UpdatedMapsCheckTest {
         .previewImageUrl("preview-url")
         .lastCommitDateEpochMilli(50L)
         .build();
-  }
-
-  @Test
-  void localMapIsAhead() {
-    final var availableMaps = List.of(buildDownloadDescription("map name", 2));
-    final Function<String, Integer> mapVersionLookupFunction = anyMapName -> 3;
-
-    final Collection<String> result =
-        UpdatedMapsCheck.computeOutOfDateMaps(availableMaps, mapVersionLookupFunction);
-
-    assertThat(result, is(empty()));
-  }
-
-  @Test
-  void localMapIsOutOfDate() {
-    final var availableMaps =
-        List.of(
-            buildDownloadDescription("isCurrent", 2),
-            buildDownloadDescription("new name version", 2));
-
-    // if version function receives 'isCurrent', we'll return the current version of '2',
-    // otherwise we'll return '1' which is less than the available current version.
-    final Function<String, Integer> mapVersionLookupFunction =
-        mapName -> mapName.equals("isCurrent") ? 2 : 1;
-
-    final Collection<String> result =
-        UpdatedMapsCheck.computeOutOfDateMaps(availableMaps, mapVersionLookupFunction);
-
-    assertThat(
-        "we stubbed an old version for the 'new map version', we expect it to"
-            + "be on the return list of out of date maps",
-        result,
-        hasItem("new name version"));
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadMapsWindowMapsListingTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadMapsWindowMapsListingTest.java
@@ -38,8 +38,8 @@ class DownloadMapsWindowMapsListingTest extends AbstractClientSettingTestCase {
         new DownloadMapsWindowMapsListing(List.of(TEST_MAP), installedMapsListing);
 
     assertThat(downloadMapsWindowMapsListing.getAvailable(), hasSize(1));
-    assertThat(downloadMapsWindowMapsListing.getInstalled(), is(empty()));
-    assertThat(downloadMapsWindowMapsListing.getOutOfDate(), is(empty()));
+    assertThat(downloadMapsWindowMapsListing.getInstalled().entrySet(), is(empty()));
+    assertThat(downloadMapsWindowMapsListing.getOutOfDate().entrySet(), is(empty()));
   }
 
   @Test
@@ -91,8 +91,8 @@ class DownloadMapsWindowMapsListingTest extends AbstractClientSettingTestCase {
             List.of(newInstalledDownloadWithUrl("url")), installedMapsListing);
 
     assertThat(downloadMapsWindowMapsListing.getAvailable(), is(empty()));
-    assertThat(downloadMapsWindowMapsListing.getInstalled(), hasSize(1));
-    assertThat(downloadMapsWindowMapsListing.getOutOfDate(), is(empty()));
+    assertThat(downloadMapsWindowMapsListing.getInstalled().entrySet(), hasSize(1));
+    assertThat(downloadMapsWindowMapsListing.getOutOfDate().entrySet(), is(empty()));
   }
 
   private static InstalledMapsListing buildIndexWithMapVersions(
@@ -126,8 +126,8 @@ class DownloadMapsWindowMapsListingTest extends AbstractClientSettingTestCase {
             List.of(newInstalledDownloadWithUrl("url")), installedMapsListing);
 
     assertThat(downloadMapsWindowMapsListing.getAvailable(), is(empty()));
-    assertThat(downloadMapsWindowMapsListing.getInstalled(), is(empty()));
-    assertThat(downloadMapsWindowMapsListing.getOutOfDate(), hasSize(1));
+    assertThat(downloadMapsWindowMapsListing.getInstalled().entrySet(), is(empty()));
+    assertThat(downloadMapsWindowMapsListing.getOutOfDate().entrySet(), hasSize(1));
   }
 
   @Test


### PR DESCRIPTION
Moves the logic to calculate which maps are installed vs out-of-date
or not installed from the map download window to model object
'InstalledMapsListing'. No changes are made to the algorithm deciding
which maps are out of date, installed or available.

