### PR TITLE
Improve unit test utility CollectionMatchers

### DIFF
--- a/lib/test-common/src/main/java/org/triplea/test/common/matchers/CollectionMatchers.java
+++ b/lib/test-common/src/main/java/org/triplea/test/common/matchers/CollectionMatchers.java
@@ -2,8 +2,9 @@ package org.triplea.test.common.matchers;
 
 import static org.hamcrest.core.IsNot.not;
 
-import java.util.List;
+import java.util.Collection;
 import java.util.function.Function;
+import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
 import org.hamcrest.Matcher;
 import org.triplea.test.common.CustomMatcher;
@@ -21,18 +22,20 @@ public class CollectionMatchers {
    * @param mappingFunction The mapping function to apply to the collection.
    * @param mappedItem The given item to assert is contained in the mapped collection.
    */
-  public static <T, X> Matcher<List<T>> containsMappedItem(
+  public static <T, X> Matcher<Collection<T>> containsMappedItem(
       final Function<T, X> mappingFunction, final X mappedItem) {
 
-    return CustomMatcher.<List<T>>builder()
+    return CustomMatcher.<Collection<T>>builder()
         .checkCondition(
             itemList -> itemList.stream().map(mappingFunction).anyMatch(mappedItem::equals))
-        .description("Collection containing subelement " + mappedItem)
-        .debug(Object::toString)
+        .description("Collection containing sub-element: " + mappedItem)
+        .debug(
+            collection ->
+                collection.stream().map(mappingFunction).collect(Collectors.toList()).toString())
         .build();
   }
 
-  public static <T, X> Matcher<List<T>> doesNotContainMappedItem(
+  public static <T, X> Matcher<Collection<T>> doesNotContainMappedItem(
       final Function<T, X> mappingFunction, final X mappedItem) {
     return not(containsMappedItem(mappingFunction, mappedItem));
   }


### PR DESCRIPTION
1) Update the collection matcher to actually match collections
   and not just lists.
2) Improve the collection matcher 'containsMappedItem' failure
   message. Instead of displaying each item of the collection
   on matcher failure, we will display each mapped item of
   the collection.

