### PR TITLE
Use current prod2-lobby as default

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/UrlConstants.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/UrlConstants.java
@@ -22,5 +22,5 @@ public final class UrlConstants {
   public static final String USER_GUIDE = "https://triplea-game.org/user-guide/";
   public static final String MARTI_REGISTRATION = "https://dice.marti.triplea-game.org/";
   public static final String PRERELEASE_LOBBY = "https://prerelease.triplea-game.org";
-  public static final String PROD_LOBBY = "https://prod.triplea-game.org";
+  public static final String PROD_LOBBY = "https://prod2-lobby.triplea-game.org";
 }


### PR DESCRIPTION
prod.triplea-game.org is not fully set up.
Update lobby prod host URL to the current DNS alias
in the meantime.

