### PR TITLE
Simplify latest engine version check logic

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/auto/update/EngineVersionCheck.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/auto/update/EngineVersionCheck.java
@@ -1,12 +1,9 @@
 package games.strategy.engine.auto.update;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Splitter;
 import games.strategy.triplea.settings.ClientSetting;
-import games.strategy.triplea.settings.GameSetting;
-import java.time.LocalDate;
-import java.time.ZoneId;
-import java.util.List;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 import lombok.experimental.UtilityClass;
@@ -17,10 +14,13 @@ import org.triplea.swing.EventThreadJOptionPane;
 @UtilityClass
 final class EngineVersionCheck {
 
+  public static final int CHECK_FREQUENCY_IN_DAYS = 2;
+
   static void checkForLatestEngineVersionOut() {
     if (!isEngineUpdateCheckRequired()) {
       return;
     }
+    ClientSetting.lastCheckForEngineUpdate.setValueAndFlush(Instant.now().toEpochMilli());
 
     new LiveServersFetcher()
         .latestVersion()
@@ -38,47 +38,9 @@ final class EngineVersionCheck {
                             JOptionPane.INFORMATION_MESSAGE)));
   }
 
-  private static boolean isEngineUpdateCheckRequired() {
-    return isEngineUpdateCheckRequired(
-        LocalDate.now(ZoneId.systemDefault()),
-        ClientSetting.firstTimeThisVersion,
-        ClientSetting.lastCheckForEngineUpdate,
-        ClientSetting::flush);
-  }
-
   @VisibleForTesting
-  static boolean isEngineUpdateCheckRequired(
-      final LocalDate now,
-      final GameSetting<Boolean> firstRunSetting,
-      final GameSetting<String> updateCheckDateSetting,
-      final Runnable flushSetting) {
-    // check at most once per 2 days (but still allow a 'first run message' for a new version of
-    // TripleA)
-    final boolean updateCheckRequired =
-        firstRunSetting.getValueOrThrow()
-            || updateCheckDateSetting
-                .getValue()
-                .map(
-                    encodedUpdateCheckDate ->
-                        !parseUpdateCheckDate(encodedUpdateCheckDate).isAfter(now.minusDays(2)))
-                .orElse(true);
-    if (!updateCheckRequired) {
-      return false;
-    }
-
-    updateCheckDateSetting.setValue(formatUpdateCheckDate(now));
-    flushSetting.run();
-    return true;
-  }
-
-  @VisibleForTesting
-  static LocalDate parseUpdateCheckDate(final String encodedUpdateCheckDate) {
-    final List<String> tokens = Splitter.on(':').splitToList(encodedUpdateCheckDate);
-    return LocalDate.ofYearDay(Integer.parseInt(tokens.get(0)), Integer.parseInt(tokens.get(1)));
-  }
-
-  @VisibleForTesting
-  static String formatUpdateCheckDate(final LocalDate updateCheckDate) {
-    return updateCheckDate.getYear() + ":" + updateCheckDate.getDayOfYear();
+  static boolean isEngineUpdateCheckRequired() {
+    return Instant.ofEpochMilli(ClientSetting.lastCheckForEngineUpdate.getValue().orElseThrow())
+        .isBefore(Instant.now().minus(CHECK_FREQUENCY_IN_DAYS, ChronoUnit.DAYS));
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -135,8 +135,8 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
       new BooleanClientSetting("SOUND_ENABLED", true);
   public static final ClientSetting<Boolean> firstTimeThisVersion =
       new BooleanClientSetting("TRIPLEA_FIRST_TIME_THIS_VERSION_PROPERTY", true);
-  public static final ClientSetting<String> lastCheckForEngineUpdate =
-      new StringClientSetting("TRIPLEA_LAST_CHECK_FOR_ENGINE_UPDATE");
+  public static final ClientSetting<Long> lastCheckForEngineUpdate =
+      new LongClientSetting("LAST_CHECK_FOR_ENGINE_UPDATE_EPOCH_MILLI", 0);
   public static final ClientSetting<Long> lastCheckForMapUpdates =
       new LongClientSetting("TRIPLEA_LAST_CHECK_FOR_MAP_UPDATES_EPOCH_MILLI", 0);
   public static final ClientSetting<Boolean> promptToDownloadTutorialMap =

--- a/game-app/game-core/src/test/java/games/strategy/engine/auto/update/EngineVersionCheckTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/auto/update/EngineVersionCheckTest.java
@@ -1,147 +1,51 @@
 package games.strategy.engine.auto.update;
 
-import static games.strategy.engine.auto.update.EngineVersionCheck.formatUpdateCheckDate;
-import static games.strategy.engine.auto.update.EngineVersionCheck.parseUpdateCheckDate;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
-import games.strategy.triplea.settings.GameSetting;
-import java.time.LocalDate;
+import games.strategy.triplea.settings.AbstractClientSettingTestCase;
+import games.strategy.triplea.settings.ClientSetting;
+import java.time.Instant;
 import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalUnit;
-import java.util.Optional;
-import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
 
-final class EngineVersionCheckTest {
-  @ExtendWith(MockitoExtension.class)
-  @Nested
-  final class IsEngineUpdateCheckRequiredTest {
-    private final LocalDate now = LocalDate.of(2008, 6, 1);
-    @Mock private GameSetting<Boolean> firstRunSetting;
-    @Mock private GameSetting<String> updateCheckDateSetting;
-    @Mock private Runnable flushSetting;
+final class EngineVersionCheckTest extends AbstractClientSettingTestCase {
 
-    private void givenFirstRun() {
-      when(firstRunSetting.getValueOrThrow()).thenReturn(true);
-    }
+  @DisplayName("If there is no last updated engine check set, then we need to check")
+  @Test
+  void engineUpdateCheckRequired_lastCheckNeverRun() {
+    ClientSetting.lastCheckForEngineUpdate.setValueAndFlush(0L);
 
-    private void givenNotFirstRun() {
-      when(firstRunSetting.getValueOrThrow()).thenReturn(false);
-    }
+    final boolean checkNeeded = EngineVersionCheck.isEngineUpdateCheckRequired();
 
-    private void givenEngineUpdateCheckNeverRun() {
-      when(updateCheckDateSetting.getValue()).thenReturn(Optional.empty());
-    }
-
-    private void givenEngineUpdateCheckLastRunRelativeToNow(
-        final long amountToAdd, final TemporalUnit unit) {
-      when(updateCheckDateSetting.getValue())
-          .thenReturn(Optional.of(formatUpdateCheckDate(now.plus(amountToAdd, unit))));
-    }
-
-    private boolean whenIsEngineUpdateCheckRequired() {
-      return EngineVersionCheck.isEngineUpdateCheckRequired(
-          now, firstRunSetting, updateCheckDateSetting, flushSetting);
-    }
-
-    @Test
-    void shouldReturnTrueWhenFirstRun() {
-      givenFirstRun();
-
-      assertThat(whenIsEngineUpdateCheckRequired(), is(true));
-    }
-
-    @Test
-    void shouldReturnTrueWhenNotFirstRunAndEngineUpdateCheckLastRunOneYearAgo() {
-      givenNotFirstRun();
-      givenEngineUpdateCheckLastRunRelativeToNow(-1, ChronoUnit.YEARS);
-
-      assertThat(whenIsEngineUpdateCheckRequired(), is(true));
-    }
-
-    @Test
-    void shouldReturnTrueWhenNotFirstRunAndEngineUpdateCheckLastRunTwoDaysAgo() {
-      givenNotFirstRun();
-      givenEngineUpdateCheckLastRunRelativeToNow(-2, ChronoUnit.DAYS);
-
-      assertThat(whenIsEngineUpdateCheckRequired(), is(true));
-    }
-
-    @Test
-    void shouldReturnTrueWhenNotFirstRunAndEngineUpdateCheckNeverRun() {
-      givenNotFirstRun();
-      givenEngineUpdateCheckNeverRun();
-
-      assertThat(whenIsEngineUpdateCheckRequired(), is(true));
-    }
-
-    @Test
-    void shouldSaveAndFlushLastUpdateCheckDateSettingWhenReturnsTrue() {
-      givenFirstRun();
-
-      assertThat(whenIsEngineUpdateCheckRequired(), is(true));
-      verify(updateCheckDateSetting).setValue(formatUpdateCheckDate(now));
-      verify(flushSetting).run();
-    }
-
-    @Test
-    void shouldReturnFalseWhenNotFirstRunAndEngineUpdateCheckLastRunOneDayAgo() {
-      givenNotFirstRun();
-      givenEngineUpdateCheckLastRunRelativeToNow(-1, ChronoUnit.DAYS);
-
-      assertThat(whenIsEngineUpdateCheckRequired(), is(false));
-    }
-
-    @Test
-    void shouldReturnFalseWhenNotFirstRunAndEngineUpdateCheckLastRunToday() {
-      givenNotFirstRun();
-      givenEngineUpdateCheckLastRunRelativeToNow(0, ChronoUnit.DAYS);
-
-      assertThat(whenIsEngineUpdateCheckRequired(), is(false));
-    }
-
-    @Test
-    void shouldReturnFalseWhenNotFirstRunAndEngineUpdateCheckLastRunOneDayHence() {
-      givenNotFirstRun();
-      givenEngineUpdateCheckLastRunRelativeToNow(1, ChronoUnit.DAYS);
-
-      assertThat(whenIsEngineUpdateCheckRequired(), is(false));
-    }
-
-    @Test
-    void shouldNotSaveAndFlushLastUpdateCheckDateSettingWhenReturnsFalse() {
-      givenNotFirstRun();
-      givenEngineUpdateCheckLastRunRelativeToNow(0, ChronoUnit.DAYS);
-
-      assertThat(whenIsEngineUpdateCheckRequired(), is(false));
-      verify(updateCheckDateSetting, never()).setValue(anyString());
-      verify(flushSetting, never()).run();
-    }
+    assertThat(checkNeeded, is(true));
   }
 
-  @Nested
-  final class ParseUpdateCheckDateTest {
-    @Test
-    void shouldParseStringAsDate() {
-      assertThat(parseUpdateCheckDate("2018:1"), is(LocalDate.ofYearDay(2018, 1)));
-      assertThat(parseUpdateCheckDate("1941:365"), is(LocalDate.ofYearDay(1941, 365)));
-    }
+  @DisplayName("If last updated engine check is earlier than the cut-off, then we need to check")
+  @Test
+  void engineUpdateCheckRequired_beforeCutoff() {
+    ClientSetting.lastCheckForEngineUpdate.setValueAndFlush(
+        Instant.now()
+            .minus((EngineVersionCheck.CHECK_FREQUENCY_IN_DAYS + 1), ChronoUnit.DAYS)
+            .toEpochMilli());
+
+    final boolean checkNeeded = EngineVersionCheck.isEngineUpdateCheckRequired();
+
+    assertThat(checkNeeded, is(true));
   }
 
-  @Nested
-  final class FormatUpdateCheckDateTest {
-    @Test
-    void shouldFormatDateAsString() {
-      assertThat(formatUpdateCheckDate(LocalDate.ofYearDay(2018, 1)), is("2018:1"));
-      assertThat(formatUpdateCheckDate(LocalDate.ofYearDay(1941, 365)), is("1941:365"));
-    }
+  @DisplayName("If last updated engine check is after the cut-off, then we do not need to check")
+  @Test
+  void engineUpdateCheckRequired_afterCutoff() {
+
+    ClientSetting.lastCheckForEngineUpdate.setValueAndFlush(
+        Instant.now()
+            .minus((EngineVersionCheck.CHECK_FREQUENCY_IN_DAYS - 1), ChronoUnit.DAYS)
+            .toEpochMilli());
+
+    final boolean checkNeeded = EngineVersionCheck.isEngineUpdateCheckRequired();
+
+    assertThat(checkNeeded, is(false));
   }
 }


### PR DESCRIPTION
- Use epoch milli instead of a formatted local-date-time string
to remember the time of the last updated check

- Push the flush of the last-updated-check game setting
higher in the call stack so that the 'is check required'
method can be without side-effects.

