### PR TITLE
Style Checks: Add rule to avoid 'Optional.*='   (an optional local variable)

### DIFF
--- a/.build/code-convention-checks/check-custom-style
+++ b/.build/code-convention-checks/check-custom-style
@@ -26,6 +26,7 @@ status=0
 
 
 function main() {
+  avoidAssigningToOptionalVariables
   favorJava9CollectionsApi
   #referToCollectionsByInterfaceType
   removeUnusedLogAnnotations
@@ -56,6 +57,23 @@ function displayResult() {
   echo ""
   
 }
+
+function avoidAssigningToOptionalVariables() {
+  title "Use null local variables instead of optional local variables"
+  example "instead of 'Optional<Object> maybeObject = optionalMethod() use Object maybeObject = optionalMethod().orElseNull(null)"
+  local found=0
+
+
+  while read -r file; do
+    if grep --color=auto -EHn "Optional.*=" "$file"; then
+      found=1
+      status=1
+    fi
+  done <<< "$(cat "$javaFiles" | grep -v "Test.java$")"
+
+  displayResult "$found"
+}
+
 
 function favorJava9CollectionsApi() {
   title "Verifying preference to use List.of(), Map.of() and Set.of() compared to java.util.Collections.*"

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/battle/phase/BattlePhase.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/battle/phase/BattlePhase.java
@@ -42,14 +42,15 @@ public class BattlePhase {
    */
   public CombatUnitAbility addAbilityOrMergeAttached(
       final GamePlayer player, final CombatUnitAbility unitAbility) {
-    final Optional<CombatUnitAbility> duplicateAbility =
+    final CombatUnitAbility duplicateAbility =
         abilities.computeIfAbsent(player, p -> new ArrayList<>()).stream()
             .filter(unitAbility::canMergeAttachedUnitTypes)
-            .findFirst();
-    if (duplicateAbility.isPresent()) {
+            .findFirst()
+            .orElse(null);
+    if (duplicateAbility != null) {
       // this ability already exists so combine the unit types that have this ability
-      duplicateAbility.get().mergeAttachedUnitTypes(unitAbility);
-      return duplicateAbility.get();
+      duplicateAbility.mergeAttachedUnitTypes(unitAbility);
+      return duplicateAbility;
     } else {
       abilities.get(player).add(unitAbility);
       return unitAbility;

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
@@ -103,23 +103,24 @@ public final class GameParser {
    */
   public static Optional<GameData> parse(final Path xmlFile) {
     log.debug("Parsing game XML: {}", xmlFile.toAbsolutePath());
-    final Optional<GameData> gameData =
+    final GameData gameData =
         GameParser.parse(
-            xmlFile, new XmlGameElementMapper(), Injections.getInstance().getEngineVersion());
+            xmlFile, new XmlGameElementMapper(), Injections.getInstance().getEngineVersion())
+            .orElse(null);
 
     // if parsed, find the 'map.yml' from a parent folder and set the 'mapName' property
     // using the 'map name' from 'map.yml'
-    if (gameData.isPresent()) {
+    if (gameData != null) {
       FileUtils.findFileInParentFolders(xmlFile, MapDescriptionYaml.MAP_YAML_FILE_NAME)
           .flatMap(MapDescriptionYaml::fromFile)
           .ifPresent(
               mapDescriptionYaml -> {
-                gameData.get().setGameName(mapDescriptionYaml.findGameNameFromXmlFileName(xmlFile));
-                gameData.get().setMapName(mapDescriptionYaml.getMapName());
+                gameData.setGameName(mapDescriptionYaml.findGameNameFromXmlFileName(xmlFile));
+                gameData.setMapName(mapDescriptionYaml.getMapName());
               });
     }
 
-    return gameData;
+    return Optional.ofNullable(gameData);
   }
 
   @VisibleForTesting

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/GameDataUtils.java
@@ -25,9 +25,10 @@ public final class GameDataUtils {
       final GameData data, final boolean copyDelegates, final Version engineVersion) {
     final History temp = data.getHistory();
     data.resetHistory();
-    final Optional<GameData> dataCopy = cloneGameData(data, copyDelegates, engineVersion);
+    final GameData dataCopy = cloneGameData(data, copyDelegates, engineVersion)
+        .orElse(null);
     data.setHistory(temp);
-    return dataCopy;
+    return Optional.ofNullable(dataCopy);
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ProcessRunnerUtil.java
@@ -7,7 +7,6 @@ import java.lang.management.ManagementFactory;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Optional;
 import lombok.extern.slf4j.Slf4j;
 
 /** To hold various static utility methods for running a java program. */
@@ -21,17 +20,15 @@ final class ProcessRunnerUtil {
     commands.add("-classpath");
     commands.add(SystemProperties.getJavaClassPath());
 
-    final Optional<String> maxMemory =
-        ManagementFactory.getRuntimeMXBean().getInputArguments().stream()
-            .filter(s -> s.toLowerCase().startsWith("-xmx"))
-            .map(s -> s.substring(4))
-            .findFirst();
-    maxMemory.ifPresent(max -> commands.add("-Xmx" + max));
-    final Optional<String> maxStackSize =
-        ManagementFactory.getRuntimeMXBean().getInputArguments().stream()
-            .filter(s -> s.toLowerCase().startsWith("-xss"))
-            .findFirst();
-    maxStackSize.ifPresent(commands::add);
+    ManagementFactory.getRuntimeMXBean().getInputArguments().stream()
+        .filter(s -> s.toLowerCase().startsWith("-xmx"))
+        .map(s -> s.substring(4))
+        .findFirst()
+        .ifPresent(max -> commands.add("-Xmx" + max));
+    ManagementFactory.getRuntimeMXBean().getInputArguments().stream()
+        .filter(s -> s.toLowerCase().startsWith("-xss"))
+        .findFirst()
+        .ifPresent(commands::add);
     if (SystemProperties.isMac()) {
       commands.add("-Dapple.laf.useScreenMenuBar=true");
       commands.add("-Xdock:name=\"TripleA\"");

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMap.java
@@ -73,15 +73,15 @@ public class InstalledMap {
    * notes file cannot be found.
    */
   public Optional<String> readGameNotes(final String gameName) {
-    final Optional<Path> xmlPath = getGameXmlFilePath(gameName);
-    final Optional<Path> mapContentRoot = findContentRoot();
+    final Path xmlPath = getGameXmlFilePath(gameName).orElse(null);
+    final Path mapContentRoot = findContentRoot().orElse(null);
 
-    if (xmlPath.isEmpty() || mapContentRoot.isEmpty()) {
+    if (xmlPath == null || mapContentRoot == null) {
       return Optional.empty();
     } else {
       return Optional.of(
           LocalizeHtml.localizeImgLinksInHtml(
-              GameNotes.loadGameNotes(xmlPath.get(), gameName), mapContentRoot.get()));
+              GameNotes.loadGameNotes(xmlPath, gameName), mapContentRoot));
     }
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/system/HttpProxy.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/system/HttpProxy.java
@@ -35,14 +35,14 @@ public final class HttpProxy {
 
   /** Get the latest system proxy settings and apply them. */
   public static void updateSystemProxy() {
-    final Optional<InetSocketAddress> address = getSystemProxy();
+    final InetSocketAddress address = getSystemProxy().orElse(null);
     final @Nullable String host;
     final @Nullable Integer port;
-    if (address.isEmpty()) {
+    if (address == null) {
       host = null;
       port = null;
     } else {
-      host = Strings.nullToEmpty(address.get().getHostName()).trim();
+      host = Strings.nullToEmpty(addressget().getHostName()).trim();
       port = host.isEmpty() ? null : address.get().getPort();
     }
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/posted/game/pbem/PbemMessagePoster.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/posted/game/pbem/PbemMessagePoster.java
@@ -81,10 +81,10 @@ public class PbemMessagePoster implements Serializable {
    * @return true if all posts were successful
    */
   public boolean post(final IDelegateHistoryWriter historyWriter, final String title) {
-    final Optional<NodeBbForumPoster> forumPoster = newForumPoster();
+    final NodeBbForumPoster forumPoster = newForumPoster().orElse(null);
     final StringBuilder saveGameSb = new StringBuilder().append("triplea_");
 
-    if (forumPoster.isPresent()) {
+    if (forumPoster != null) {
       saveGameSb.append(gameProperties.get(IForumPoster.TOPIC_ID)).append("_");
     }
     saveGameSb
@@ -92,11 +92,10 @@ public class PbemMessagePoster implements Serializable {
         .append(currentPlayer.getName(), 0, Math.min(3, currentPlayer.getName().length() - 1));
     final String saveGameName = GameDataFileUtils.addExtension(saveGameSb.toString());
     CompletableFuture<String> forumSuccess = null;
-    if (forumPoster.isPresent()) {
+    if (forumPoster != null) {
       try {
         forumSuccess =
             forumPoster
-                .get()
                 .postTurnSummary(
                     (gameNameAndInfo + "\n\n" + turnSummary),
                     "TripleA " + title + ": " + currentPlayer.getName() + " round " + roundNumber,
@@ -159,7 +158,7 @@ public class PbemMessagePoster implements Serializable {
             .append(forumSuccess.isDone() && !forumSuccess.isCancelled());
       }
       if (emailSender.isPresent()) {
-        sb.append(forumPoster.isPresent() ? " and to " : " to ");
+        sb.append(forumPoster != null ? " and to " : " to ");
         sb.append(gameProperties.get(IEmailSender.RECIPIENTS))
             .append(" success = ")
             .append(emailSuccess);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -771,12 +771,11 @@ class ProPurchaseAi {
                       unusedLocalCarrierCapacity));
             }
           }
-          final Optional<ProPurchaseOption> optionalSelectedOption =
-              ProPurchaseUtils.randomizePurchaseOption(defenseEfficiencies, "Defense");
-          if (optionalSelectedOption.isEmpty()) {
+          final ProPurchaseOption selectedOption =
+              ProPurchaseUtils.randomizePurchaseOption(defenseEfficiencies, "Defense").orElse(null);
+          if (selectedOption == null) {
             break;
           }
-          final ProPurchaseOption selectedOption = optionalSelectedOption.get();
           if (selectedOption.isDestroyer()) {
             needDestroyer = false;
           }
@@ -1124,39 +1123,42 @@ class ProPurchaseAi {
             purchaseTerritories);
 
         // Select purchase option
-        Optional<ProPurchaseOption> optionalSelectedOption = Optional.empty();
+        ProPurchaseOption selectedOption = null;
         if (!selectFodderUnit && attackAndDefenseDifference > 0 && !landDefenseOptions.isEmpty()) {
           final Map<ProPurchaseOption, Double> defenseEfficiencies = new HashMap<>();
           for (final ProPurchaseOption ppo : landDefenseOptions) {
             defenseEfficiencies.put(
                 ppo, ppo.getDefenseEfficiency(enemyDistance, data, ownedLocalUnits, unitsToPlace));
           }
-          optionalSelectedOption =
-              ProPurchaseUtils.randomizePurchaseOption(defenseEfficiencies, "Land Defense");
+          selectedOption =
+              ProPurchaseUtils.randomizePurchaseOption(defenseEfficiencies, "Land Defense")
+                  .orElse(null);
         } else if (!selectFodderUnit && !landAttackOptions.isEmpty()) {
           final Map<ProPurchaseOption, Double> attackEfficiencies = new HashMap<>();
           for (final ProPurchaseOption ppo : landAttackOptions) {
             attackEfficiencies.put(
                 ppo, ppo.getAttackEfficiency(enemyDistance, data, ownedLocalUnits, unitsToPlace));
           }
-          optionalSelectedOption =
-              ProPurchaseUtils.randomizePurchaseOption(attackEfficiencies, "Land Attack");
+          selectedOption =
+              ProPurchaseUtils.randomizePurchaseOption(attackEfficiencies, "Land Attack")
+                  .orElse(null);
         } else if (!landFodderOptions.isEmpty()) {
           final Map<ProPurchaseOption, Double> fodderEfficiencies = new HashMap<>();
           for (final ProPurchaseOption ppo : landFodderOptions) {
             fodderEfficiencies.put(
                 ppo, ppo.getFodderEfficiency(enemyDistance, data, ownedLocalUnits, unitsToPlace));
           }
-          optionalSelectedOption =
-              ProPurchaseUtils.randomizePurchaseOption(fodderEfficiencies, "Land Fodder");
-          if (optionalSelectedOption.isPresent()) {
-            addedFodderUnits += optionalSelectedOption.get().getQuantity();
+          selectedOption =
+              ProPurchaseUtils.randomizePurchaseOption(fodderEfficiencies, "Land Fodder")
+                  .orElse(null);
+
+          if (selectedOption != null) {
+            addedFodderUnits += selectedOption.getQuantity();
           }
         }
-        if (optionalSelectedOption.isEmpty()) {
+        if (selectedOption == null) {
           break;
         }
-        final ProPurchaseOption selectedOption = optionalSelectedOption.get();
 
         // Create new temp units
         resourceTracker.purchase(selectedOption);
@@ -1605,12 +1607,12 @@ class ProPurchaseAi {
                       unusedCarrierCapacity,
                       unusedLocalCarrierCapacity));
             }
-            final Optional<ProPurchaseOption> optionalSelectedOption =
-                ProPurchaseUtils.randomizePurchaseOption(defenseEfficiencies, "Sea Defense");
-            if (optionalSelectedOption.isEmpty()) {
+            final ProPurchaseOption selectedOption =
+                ProPurchaseUtils.randomizePurchaseOption(defenseEfficiencies, "Sea Defense")
+                    .orElse(null);
+            if (selectedOption == null) {
               break;
             }
-            final ProPurchaseOption selectedOption = optionalSelectedOption.get();
             if (selectedOption.isDestroyer()) {
               needDestroyer = false;
             }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -246,10 +246,10 @@ public class UnitImageFactory {
     final GamePlayer gamePlayer = imageKey.getPlayer();
     final UnitType type = imageKey.getType();
 
-    final Optional<URL> imageLocation = getBaseImageUrl(imageKey);
+    final URL imageLocation = getBaseImageUrl(imageKey).orElse(null);
     Image image = null;
-    if (imageLocation.isPresent()) {
-      image = Toolkit.getDefaultToolkit().getImage(imageLocation.get());
+    if (imageLocation != null) {
+      image = Toolkit.getDefaultToolkit().getImage(imageLocation);
       Util.ensureImageLoaded(image);
       if (needToTransformImage(gamePlayer, type, mapData)) {
         image = convertToBufferedImage(image);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/SelectionComponentFactory.java
@@ -692,8 +692,8 @@ final class SelectionComponentFactory {
             "Fetching Login Token...",
             () -> {
               final NodeBbTokenGenerator tokenGenerator = new NodeBbTokenGenerator(forumUrl);
-              final Optional<Integer> oldUserId = uidSetting.getValue();
-              final Optional<char[]> oldToken = tokenSetting.getValue();
+              final Integer oldUserId = uidSetting.getValue().orElse(null);
+              final char[] oldToken = tokenSetting.getValue().orElse(null);
               if (!usernameField.getText().isBlank()) {
                 final TokenInfo tokenInfo =
                     tokenGenerator.generateToken(
@@ -712,10 +712,9 @@ final class SelectionComponentFactory {
                 context.setValue(tokenSetting, null);
               }
 
-              oldUserId.ifPresent(
-                  userId ->
-                      oldToken.ifPresent(
-                          token -> tokenGenerator.revokeToken(new String(token), userId)));
+              if (oldUserId != null && oldToken != null) {
+                tokenGenerator.revokeToken(new String(oldToken), oldUserId);
+              }
             });
       }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/EditProductionPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/EditProductionPanel.java
@@ -13,7 +13,6 @@ import games.strategy.triplea.image.UnitImageFactory;
 import java.awt.Image;
 import java.util.HashSet;
 import java.util.Map.Entry;
-import java.util.Optional;
 import java.util.Set;
 import javax.swing.JFrame;
 import org.triplea.java.collections.IntegerMap;
@@ -91,10 +90,11 @@ class EditProductionPanel extends ProductionPanel {
           try {
             final UnitImageFactory imageFactory = uiContext.getUnitImageFactory();
             if (imageFactory != null) {
-              final Optional<Image> unitImage =
-                  imageFactory.getImage(
-                      UnitImageFactory.ImageKey.builder().player(player).type(ut).build());
-              if (unitImage.isPresent()) {
+              final Image unitImage =
+                  imageFactory
+                      .getImage(UnitImageFactory.ImageKey.builder().player(player).type(ut).build())
+                      .orElse(null);
+              if (unitImage != null) {
                 unitsAllowed.add(ut);
                 final IntegerMap<NamedAttachable> result = new IntegerMap<>();
                 result.add(ut, 1);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ProductionPanel.java
@@ -25,7 +25,6 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import javax.swing.Action;
 import javax.swing.BorderFactory;
@@ -341,7 +340,7 @@ class ProductionPanel extends JPanel {
           name.getFont().deriveFont(Map.of(TextAttribute.WEIGHT, TextAttribute.WEIGHT_BOLD)));
       final JLabel info = new JLabel("  ");
       final Color defaultForegroundLabelColor = name.getForeground();
-      Optional<ImageIcon> icon = Optional.empty();
+      ImageIcon icon = null;
       final StringBuilder tooltip = new StringBuilder();
       final Set<NamedAttachable> results = new HashSet<>(rule.getResults().keySet());
       final Iterator<NamedAttachable> iter = results.iterator();
@@ -352,7 +351,8 @@ class ProductionPanel extends JPanel {
           icon =
               uiContext
                   .getUnitImageFactory()
-                  .getIcon(ImageKey.builder().type(type).player(player).build());
+                  .getIcon(ImageKey.builder().type(type).player(player).build())
+                  .orElse(null);
           final UnitAttachment attach = UnitAttachment.get(type);
           final int attack = attach.getAttack(player);
           final int movement = attach.getMovement(player);
@@ -373,7 +373,7 @@ class ProductionPanel extends JPanel {
           }
         } else if (resourceOrUnit instanceof Resource) {
           final Resource resource = (Resource) resourceOrUnit;
-          icon = Optional.of(uiContext.getResourceImageFactory().getIcon(resource, true));
+          icon = uiContext.getResourceImageFactory().getIcon(resource, true);
           info.setText("resource");
           tooltip.append(resource.getName()).append(": resource");
           name.setText(resource.getName());
@@ -426,7 +426,9 @@ class ProductionPanel extends JPanel {
                 0));
       }
       final JPanel label = new JPanel();
-      icon.ifPresent(imageIcon -> label.add(new JLabel(imageIcon)));
+      if (icon != null) {
+        label.add(new JLabel(icon));
+      }
       label.add(costPanel);
 
       final ScrollableTextField textField = new ScrollableTextField(0, Integer.MAX_VALUE);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
@@ -712,16 +712,16 @@ public class MapPanel extends ImageScrollerLargeView {
           continue;
         }
 
-        final Optional<Image> image =
-            uiContext
-                .getUnitImageFactory()
-                .getHighlightImage(UnitImageFactory.ImageKey.of(category));
-        if (image.isPresent()) {
-          final AffineTransform transform =
-              AffineTransform.getTranslateInstance(
-                  normalizeX(r.getX() - getXOffset()), normalizeY(r.getY() - getYOffset()));
-          g2d.drawImage(image.get(), transform, this);
-        }
+        uiContext
+            .getUnitImageFactory()
+            .getHighlightImage(UnitImageFactory.ImageKey.of(category))
+            .ifPresent(
+                image -> {
+                  final AffineTransform transform =
+                      AffineTransform.getTranslateInstance(
+                          normalizeX(r.getX() - getXOffset()), normalizeY(r.getY() - getYOffset()));
+                  g2d.drawImage(image, transform, this);
+                });
       }
     }
     // draw the tiles nearest us first

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/UnitsDrawer.java
@@ -22,7 +22,6 @@ import java.awt.Point;
 import java.awt.Rectangle;
 import java.awt.RenderingHints;
 import java.util.List;
-import java.util.Optional;
 import java.util.function.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.util.Tuple;
@@ -122,8 +121,8 @@ public class UnitsDrawer extends AbstractDrawable {
             .disabled(disabled)
             .build();
 
-    final Optional<Image> img = uiContext.getUnitImageFactory().getImage(imageKey);
-    if (img.isEmpty() && !uiContext.isShutDown()) {
+    final Image img = uiContext.getUnitImageFactory().getImage(imageKey).orElse(null);
+    if (img == null && !uiContext.isShutDown()) {
       final String imageName = imageKey.getBaseImageName();
       log.error(
           "MISSING UNIT IMAGE (won't be displayed): "
@@ -138,27 +137,27 @@ public class UnitsDrawer extends AbstractDrawable {
 
     final UnitFlagDrawMode drawMode =
         ClientSetting.unitFlagDrawMode.getValue().orElse(UnitFlagDrawMode.NONE);
-    if (img.isPresent()) {
+    if (img != null) {
       if (drawMode == UnitFlagDrawMode.LARGE_FLAG) {
         // If unit is not in the "excluded list" it will get drawn
         if (maxRange != 0) {
           final Image flag = uiContext.getFlagImageFactory().getFlag(owner);
-          final int xoffset = img.get().getWidth(null) / 2 - flag.getWidth(null) / 2;
-          final int yoffset = img.get().getHeight(null) / 2 - flag.getHeight(null) / 4 - 5;
+          final int xoffset = img.getWidth(null) / 2 - flag.getWidth(null) / 2;
+          final int yoffset = img.getHeight(null) / 2 - flag.getHeight(null) / 4 - 5;
           graphics.drawImage(
               flag,
               (placementPoint.x - bounds.x) + xoffset,
               (placementPoint.y - bounds.y) + yoffset,
               null);
         }
-        drawUnit(graphics, img.get(), bounds, data);
+        drawUnit(graphics, img, bounds, data);
       } else if (drawMode == UnitFlagDrawMode.SMALL_FLAG) {
-        drawUnit(graphics, img.get(), bounds, data);
+        drawUnit(graphics, img, bounds, data);
         // If unit is not in the "excluded list" it will get drawn
         if (maxRange != 0) {
           final Image flag = uiContext.getFlagImageFactory().getSmallFlag(owner);
-          final int xoffset = img.get().getWidth(null) - flag.getWidth(null);
-          final int yoffset = img.get().getHeight(null) - flag.getHeight(null);
+          final int xoffset = img.getWidth(null) - flag.getWidth(null);
+          final int yoffset = img.getHeight(null) - flag.getHeight(null);
           // This Method draws the Flag in the lower right corner of the unit image. Since the
           // position is the upper
           // left corner we have to move the picture up by the height and left by the width.
@@ -169,7 +168,7 @@ public class UnitsDrawer extends AbstractDrawable {
               null);
         }
       } else {
-        drawUnit(graphics, img.get(), bounds, data);
+        drawUnit(graphics, img, bounds, data);
       }
     }
 
@@ -178,9 +177,9 @@ public class UnitsDrawer extends AbstractDrawable {
       final int stackSize = mapData.getDefaultUnitsStackSize();
       if (stackSize > 0) { // Display more units as a stack
         for (int i = 1; i < count && i < stackSize; i++) {
-          if (img.isPresent()) {
+          if (img != null) {
             graphics.drawImage(
-                img.get(),
+                img,
                 placementPoint.x + 2 * i - bounds.x,
                 placementPoint.y - 2 * i - bounds.y,
                 null);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/util/TransportUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/util/TransportUtils.java
@@ -62,13 +62,13 @@ public final class TransportUtils {
     final Map<Unit, Unit> mapping = new HashMap<>();
     final IntegerMap<Unit> addedLoad = new IntegerMap<>();
     for (final Unit unit : canBeTransported) {
-      final Optional<Unit> transport =
-          loadUnitIntoFirstAvailableTransport(unit, canTransport, mapping, addedLoad);
+      final Unit transportLoaded =
+          loadUnitIntoFirstAvailableTransport(unit, canTransport, mapping, addedLoad).orElse(null);
 
-      // Move loaded transport to end of list
-      if (transport.isPresent()) {
-        canTransport.remove(transport.get());
-        canTransport.add(transport.get());
+      // Move transport loaded to end of list
+      if (transportLoaded != null) {
+        canTransport.remove(transportLoaded);
+        canTransport.add(transportLoaded);
       }
     }
     return mapping;

--- a/game-app/game-core/src/main/java/tools/image/DecorationPlacer.java
+++ b/game-app/game-core/src/main/java/tools/image/DecorationPlacer.java
@@ -817,13 +817,14 @@ public final class DecorationPlacer {
           && staticImageForPlacing != null
           && currentSelectedImage == null) {
         // create a new point here in this territory
-        final Optional<String> territoryName =
-            ToolsUtil.findTerritoryName(currentMousePoint, polygons);
-        if (territoryName.isPresent()) {
-          final List<Point> points = new ArrayList<>();
-          points.add(new Point(currentMousePoint));
-          currentImagePoints.put(territoryName.get(), Tuple.of(staticImageForPlacing, points));
-        }
+
+        ToolsUtil.findTerritoryName(currentMousePoint, polygons)
+            .ifPresent(
+                territoryName -> {
+                  final List<Point> points = new ArrayList<>();
+                  points.add(new Point(currentMousePoint));
+                  currentImagePoints.put(territoryName, Tuple.of(staticImageForPlacing, points));
+                });
       } else if (rightMouse && !ctrlDown && imagePointType.isCanHaveMultiplePoints()) {
         // if none selected find the image we are clicking on, and duplicate it (not replace/move
         // it)

--- a/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYaml.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYaml.java
@@ -155,13 +155,13 @@ public class MapDescriptionYaml {
    * then underneath that folder we search for a matching file name.
    */
   public Optional<Path> getGameXmlPathByGameName(final String gameName) {
-    final Optional<String> xmlFileName = findFileNameForGame(gameName);
-    final Optional<Path> gamesFolder = findGamesFolder();
+    final String xmlFileName = findFileNameForGame(gameName).orElse(null);
+    final Path gamesFolder = findGamesFolder().orElse(null);
 
-    if (xmlFileName.isEmpty() || gamesFolder.isEmpty()) {
+    if (xmlFileName == null || gamesFolder == null) {
       return Optional.empty();
     } else {
-      return searchForGameFile(gamesFolder.get(), xmlFileName.get());
+      return searchForGameFile(gamesFolder, xmlFileName);
     }
   }
 

--- a/lib/java-extras/src/main/java/org/triplea/java/Retryable.java
+++ b/lib/java-extras/src/main/java/org/triplea/java/Retryable.java
@@ -100,9 +100,9 @@ public class Retryable<T> {
    */
   public Optional<T> execute() {
     for (int i = 1; i < maxAttempts; i++) {
-      final Optional<T> result = taskRunner.get();
-      if (result.isPresent()) {
-        return result;
+      final T result = taskRunner.get().orElse(null);
+      if (result != null) {
+        return Optional.of(result);
       }
       threadSleeper.accept(fixedBackOff);
     }

--- a/lib/java-extras/src/main/java/org/triplea/java/UrlStreams.java
+++ b/lib/java-extras/src/main/java/org/triplea/java/UrlStreams.java
@@ -67,7 +67,7 @@ public final class UrlStreams {
    */
   public static <T> Optional<T> openStream(
       final URI uri, final Function<InputStream, T> streamOperation) {
-    InputStream stream = openStream(uri).orElse(null);
+    final InputStream stream = openStream(uri).orElse(null);
     if (stream != null) {
       try (InputStream inputStream = stream) {
         return Optional.ofNullable(streamOperation.apply(inputStream));

--- a/lib/java-extras/src/main/java/org/triplea/java/UrlStreams.java
+++ b/lib/java-extras/src/main/java/org/triplea/java/UrlStreams.java
@@ -67,9 +67,9 @@ public final class UrlStreams {
    */
   public static <T> Optional<T> openStream(
       final URI uri, final Function<InputStream, T> streamOperation) {
-    final Optional<InputStream> stream = openStream(uri);
-    if (stream.isPresent()) {
-      try (InputStream inputStream = stream.get()) {
+    InputStream stream = openStream(uri).orElse(null)
+    if (stream != null) {
+      try (InputStream inputStream = stream) {
         return Optional.ofNullable(streamOperation.apply(inputStream));
       } catch (final IOException e) {
         log.error("Unable to open: " + uri + ", " + e.getMessage(), e);

--- a/lib/java-extras/src/main/java/org/triplea/java/UrlStreams.java
+++ b/lib/java-extras/src/main/java/org/triplea/java/UrlStreams.java
@@ -67,7 +67,7 @@ public final class UrlStreams {
    */
   public static <T> Optional<T> openStream(
       final URI uri, final Function<InputStream, T> streamOperation) {
-    InputStream stream = openStream(uri).orElse(null)
+    InputStream stream = openStream(uri).orElse(null);
     if (stream != null) {
       try (InputStream inputStream = stream) {
         return Optional.ofNullable(streamOperation.apply(inputStream));

--- a/lib/java-extras/src/main/java/org/triplea/java/cache/ttl/ExpiringAfterWriteTtlCache.java
+++ b/lib/java-extras/src/main/java/org/triplea/java/cache/ttl/ExpiringAfterWriteTtlCache.java
@@ -45,10 +45,10 @@ public class ExpiringAfterWriteTtlCache<IdT, ValueT> implements TtlCache<IdT, Va
 
   @Override
   public boolean refresh(final IdT id) {
-    final Optional<ValueT> value = get(id);
+    final ValueT value = get(id).orElse(null);
 
-    if (value.isPresent()) {
-      put(id, value.get());
+    if (value != null) {
+      put(id, value);
       return true;
     }
 

--- a/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
+++ b/lib/websocket-client/src/main/java/org/triplea/http/client/web/socket/WebSocketConnection.java
@@ -96,8 +96,7 @@ class WebSocketConnection {
    */
   private void sendPingTask() {
     if (!client.isOutputClosed()) {
-
-      final Optional<Boolean> pingSuccess =
+      final boolean pingSuccess =
           Retryable.<Boolean>builder()
               .withMaxAttempts(5)
               .withFixedBackOff(Duration.ofSeconds(3))
@@ -110,9 +109,10 @@ class WebSocketConnection {
                       return Optional.empty();
                     }
                   })
-              .buildAndExecute();
+              .buildAndExecute()
+              .orElse(false);
 
-      if (pingSuccess.isEmpty()) {
+      if (!pingSuccess) {
         log.warn(
             "Failed to send pings to server, retries exhausted. "
                 + "If the server does not receive pings then the connection to "

--- a/spitfire-server/lobby-module/src/main/java/org/triplea/modules/user/account/login/LoginModule.java
+++ b/spitfire-server/lobby-module/src/main/java/org/triplea/modules/user/account/login/LoginModule.java
@@ -47,9 +47,9 @@ public class LoginModule {
   public LobbyLoginResponse doLogin(
       final LoginRequest loginRequest, final String systemId, final String ip) {
 
-    final Optional<String> nameValidationError = nameValidation.apply(loginRequest.getName());
-    if (nameValidationError.isPresent()) {
-      return LobbyLoginResponse.builder().failReason(nameValidationError.get()).build();
+    final String nameValidationError = nameValidation.apply(loginRequest.getName()).orElse(null);
+    if (nameValidationError != null) {
+      return LobbyLoginResponse.builder().failReason(nameValidationError).build();
     }
 
     if (Strings.nullToEmpty(loginRequest.getName()).isEmpty()


### PR DESCRIPTION
Adds to custom style check patterns of `Optional.*=`. What we are looking for are assignments to optional types and avoiding these. Optional type assignments indicate we have some sort of local or a class variable which we should almost always avoid.

Optional variables have several problems:
- naming: often they have some sort of odd hungarian naming, eg: `stateOptional = ...; state = stateOptional.get();`
- encourages the use of the 'get()' API. Optional.get() should never be used, always 'orElseThrow'
- often indicates a mixture of java "functional-streaming"  style mixed with imperative.

Optional variables policy:
- favor optional return values over nullable return values
- avoid assigning to an optional, instead use nullable variables.
- ensure the scope of a nullable variable is small
- annotate nullable class variables


TODO:
- [] squash up commits that fix the custom-style check
- [] finish fixing up local optional variables
- [] ensure documentation exists around the Java `Optional` style
