### PR TITLE
Add build check for 'spotlessCheck'

### DIFF
--- a/.github/workflows/check-formatting.yml
+++ b/.github/workflows/check-formatting.yml
@@ -1,0 +1,17 @@
+name: Check Formatting
+on:
+  push:
+    branches: master
+  pull_request:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Run SpotlessCheck
+      run: ./gradlew spotlessCheck
+


### PR DESCRIPTION
Runs 'spotlessCheck' as a build check. To fix violations found by
'spotlessCheck', run './gradlew spotlessCheck'
