### PR TITLE
Refactor: Consolidate ownership of  'skin name' -> 'skin path' mapping to 'UiContext' (remove from UI)

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -2360,8 +2360,8 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
   }
 
   /** Displays the map located in the directory/archive {@code mapdir}. */
-  public void changeMapSkin(final String mapdir) {
-    uiContext.changeMapSkin(data, mapdir);
+  public void changeMapSkin(final String skinName) {
+    uiContext.changeMapSkin(data, skinName);
     mapPanel.setGameData(data);
     // update map panels to use new image
     mapPanel.changeImage(uiContext.getMapData().getMapDimensions());

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -2361,7 +2361,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
   }
 
   /** Displays the map located in the directory/archive {@code mapdir}. */
-  public void updateMap(final String mapdir) {
+  public void changeMapSkin(final String mapdir) {
     uiContext.setMapDir(data, mapdir);
     // when changing skins, always show relief images
     if (uiContext.getMapData().getHasRelief()) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -65,7 +65,6 @@ import games.strategy.triplea.delegate.remote.IEditDelegate;
 import games.strategy.triplea.delegate.remote.IPoliticsDelegate;
 import games.strategy.triplea.delegate.remote.IUserActionDelegate;
 import games.strategy.triplea.formatter.MyFormatter;
-import games.strategy.triplea.image.TileImageFactory;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.export.ScreenshotExporter;
 import games.strategy.triplea.ui.history.HistoryDetailsPanel;
@@ -2362,7 +2361,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
 
   /** Displays the map located in the directory/archive {@code mapdir}. */
   public void changeMapSkin(final String mapdir) {
-    uiContext.setMapDir(data, mapdir);
+    uiContext.changeMapSkin(data, mapdir);
     mapPanel.setGameData(data);
     // update map panels to use new image
     mapPanel.changeImage(uiContext.getMapData().getMapDimensions());

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -682,8 +682,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
     Preconditions.checkState(
         !SwingUtilities.isEventDispatchThread(), "This method must not be called on the EDT");
 
-    final UiContext uiContext = new UiContext();
-    uiContext.setDefaultMapDir(game.getData());
+    final UiContext uiContext = new UiContext(game.getData());
     uiContext.getMapData().verify(game.getData());
     uiContext.setLocalPlayers(players);
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -2363,10 +2363,6 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
   /** Displays the map located in the directory/archive {@code mapdir}. */
   public void changeMapSkin(final String mapdir) {
     uiContext.setMapDir(data, mapdir);
-    // when changing skins, always show relief images
-    if (uiContext.getMapData().getHasRelief()) {
-      TileImageFactory.setShowReliefImages(true);
-    }
     mapPanel.setGameData(data);
     // update map panels to use new image
     mapPanel.changeImage(uiContext.getMapData().getMapDimensions());

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -281,7 +281,7 @@ public class UiContext {
 
   public void setMapDir(final GameData data, final String mapDir) {
     internalSetMapDir(mapDir, data);
-    this.getMapData().verify(data);
+    mapData.verify(data);
     // set the default after internal succeeds, if an error is thrown we don't want to persist it
     final Preferences prefs = getPreferencesForMap(data.getMapName());
     prefs.put(MAP_SKIN_PREF, mapDir);
@@ -289,6 +289,10 @@ public class UiContext {
       prefs.flush();
     } catch (final BackingStoreException e) {
       log.error("Failed to flush preferences: " + prefs.absolutePath(), e);
+    }
+    // when changing skins, always show relief images
+    if (mapData.getHasRelief()) {
+      TileImageFactory.setShowReliefImages(true);
     }
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -91,7 +91,7 @@ public class UiContext {
     resourceLoader = new ResourceLoader(getDefaultMapDir(gameData));
   }
 
-  protected void internalSetMapDir(final String dir, final GameData data) {
+  private void internalSetMapDir(final String dir, final GameData data) {
     if (resourceLoader != null) {
       resourceLoader.close();
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -408,9 +408,7 @@ public class UiContext {
   }
 
   public static Collection<MapSkin> getSkins(final String mapName) {
-    return getSkinsWithPaths(mapName)
-        .values()
-        .stream()
+    return getSkinsWithPaths(mapName).values().stream()
         .map(MapSkin::new)
         .collect(Collectors.toList());
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -87,7 +87,9 @@ public class UiContext {
   private final List<Runnable> activeToDeactivate = new ArrayList<>();
   private final CountDownLatchHandler latchesToCloseOnShutdown = new CountDownLatchHandler(false);
 
-  UiContext() {}
+  UiContext(final GameData data) {
+    internalSetMapDir(getDefaultMapDir(data.getMapName()), data);
+  }
 
   public static void setResourceLoader(final GameState gameData) {
     resourceLoader = new ResourceLoader(getDefaultMapDir(gameData.getMapName()));
@@ -275,10 +277,6 @@ public class UiContext {
       return mapName;
     }
     return mapDir;
-  }
-
-  public void setDefaultMapDir(final GameData data) {
-    internalSetMapDir(getDefaultMapDir(data.getMapName()), data);
   }
 
   public void changeMapSkin(final GameData data, final String skinName) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -253,7 +253,7 @@ public class UiContext {
   }
 
   /** Get the preferences for the map or map skin. */
-  static Preferences getPreferencesMapOrSkin(final String mapDir) {
+  private static Preferences getPreferencesMapOrSkin(final String mapDir) {
     return Preferences.userNodeForPackage(UiContext.class).node(mapDir);
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -88,7 +88,7 @@ public class UiContext {
   UiContext() {}
 
   public static void setResourceLoader(final GameState gameData) {
-    resourceLoader = new ResourceLoader(getDefaultMapDir(gameData));
+    resourceLoader = new ResourceLoader(getDefaultMapDir(gameData.getMapName()));
   }
 
   private void internalSetMapDir(final String dir, final GameData data) {
@@ -257,8 +257,7 @@ public class UiContext {
     return Preferences.userNodeForPackage(UiContext.class).node(mapDir);
   }
 
-  private static String getDefaultMapDir(final GameState data) {
-    final String mapName = data.getMapName();
+  private static String getDefaultMapDir(String mapName) {
     if (mapName == null || mapName.isBlank()) {
       throw new IllegalStateException("Map name property not set on game");
     }
@@ -277,7 +276,7 @@ public class UiContext {
   }
 
   public void setDefaultMapDir(final GameData data) {
-    internalSetMapDir(getDefaultMapDir(data), data);
+    internalSetMapDir(getDefaultMapDir(data.getMapName()), data);
   }
 
   public void setMapDir(final GameData data, final String mapDir) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -279,7 +279,7 @@ public class UiContext {
     internalSetMapDir(getDefaultMapDir(data.getMapName()), data);
   }
 
-  public void setMapDir(final GameData data, final String mapDir) {
+  public void changeMapSkin(final GameData data, final String mapDir) {
     internalSetMapDir(mapDir, data);
     mapData.verify(data);
     // set the default after internal succeeds, if an error is thrown we don't want to persist it

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -395,8 +395,12 @@ public class UiContext {
     }
   }
 
-  /** returns the map skins for the game data. returns is a map of display-name -> map directory */
   public static Map<String, String> getSkins(final String mapName) {
+    return getSkinsWithPaths(mapName);
+  }
+
+  /** returns the map skins for the game data. returns is a map of display-name -> map directory */
+  private static Map<String, String> getSkinsWithPaths(final String mapName) {
     final Map<String, String> skinsByDisplayName = new LinkedHashMap<>();
     skinsByDisplayName.put("Original", mapName);
     for (final Path path : FileUtils.listFiles(ClientFileSystemHelper.getUserMapsFolder())) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -26,6 +26,7 @@ import java.awt.Window;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +36,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
+import java.util.stream.Collectors;
 import javax.imageio.ImageIO;
 import javax.swing.JLabel;
 import javax.swing.SwingUtilities;
@@ -279,7 +281,8 @@ public class UiContext {
     internalSetMapDir(getDefaultMapDir(data.getMapName()), data);
   }
 
-  public void changeMapSkin(final GameData data, final String mapDir) {
+  public void changeMapSkin(final GameData data, final String skinName) {
+    String mapDir = getSkinsWithPaths(data.getMapName()).get(skinName);
     internalSetMapDir(mapDir, data);
     mapData.verify(data);
     // set the default after internal succeeds, if an error is thrown we don't want to persist it
@@ -395,8 +398,23 @@ public class UiContext {
     }
   }
 
-  public static Map<String, String> getSkins(final String mapName) {
-    return getSkinsWithPaths(mapName);
+  @Getter
+  public static class MapSkin {
+    private final boolean currentSkin;
+    private final String skinName;
+
+    public MapSkin(String skinName) {
+      this.skinName = skinName;
+      currentSkin = skinName.equals(UiContext.getMapDir());
+    }
+  }
+
+  public static Collection<MapSkin> getSkins(final String mapName) {
+    return getSkinsWithPaths(mapName)
+        .values()
+        .stream()
+        .map(MapSkin::new)
+        .collect(Collectors.toList());
   }
 
   /** returns the map skins for the game data. returns is a map of display-name -> map directory */

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -24,7 +24,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Enumeration;
 import java.util.List;
-import java.util.Map;
 import java.util.prefs.BackingStoreException;
 import java.util.prefs.Preferences;
 import javax.swing.AbstractAction;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -21,6 +21,7 @@ import java.awt.event.KeyEvent;
 import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
@@ -242,19 +243,18 @@ final class ViewMenu extends JMenu {
     mapSubMenu.setMnemonic(KeyEvent.VK_K);
     add(mapSubMenu);
     final ButtonGroup mapButtonGroup = new ButtonGroup();
-    final Map<String, String> skins = UiContext.getSkins(frame.getGame().getData().getMapName());
+    final Collection<UiContext.MapSkin> skins =
+        UiContext.getSkins(frame.getGame().getData().getMapName());
     mapSubMenu.setEnabled(skins.size() > 1);
-    for (final String key : skins.keySet()) {
-      final JMenuItem mapMenuItem = new JRadioButtonMenuItem(key);
+    for (final UiContext.MapSkin mapSkin : skins) {
+      final JMenuItem mapMenuItem = new JRadioButtonMenuItem(mapSkin.getSkinName());
       mapButtonGroup.add(mapMenuItem);
       mapSubMenu.add(mapMenuItem);
-      if (skins.get(key).equals(UiContext.getMapDir())) {
-        mapMenuItem.setSelected(true);
-      }
+      mapMenuItem.setSelected(mapSkin.isCurrentSkin());
       mapMenuItem.addActionListener(
           e -> {
             try {
-              frame.changeMapSkin(skins.get(key));
+              frame.changeMapSkin(mapSkin.getSkinName());
               if (uiContext.getMapData().getHasRelief()) {
                 showMapDetails.setSelected(true);
               }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -254,7 +254,7 @@ final class ViewMenu extends JMenu {
       mapMenuItem.addActionListener(
           e -> {
             try {
-              frame.updateMap(skins.get(key));
+              frame.changeMapSkin(skins.get(key));
               if (uiContext.getMapData().getHasRelief()) {
                 showMapDetails.setSelected(true);
               }


### PR DESCRIPTION
## Change Summary & Additional Notes
UI layer previous had a lot of knowledge about UiContext (effectively a model):
- knows the definition of the current skin
- knows skins names are mapped to skin paths
- knows that UiContext uses skin paths to set map directory

Instead we want the UI to get a list of skin names and be told which one is selected. The UI ought to then render this and then inform the model when a new skin name has been selected.

This PR would be best reviewed commit-by-commit or started by reviewing the UI changes first. 

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
