### PR TITLE
Fix: hide empty debug menu

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/DebugMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/DebugMenu.java
@@ -55,6 +55,9 @@ public final class DebugMenu extends JMenu {
               add(playerDebugMenu);
               renderDebugOption(option.getOptions()).forEach(playerDebugMenu::add);
             });
+    if (menuItemsAndFactories.isEmpty() && debugOptions.isEmpty()) {
+      setVisible(false);
+    }
   }
 
   private Collection<JMenuItem> renderDebugOption(final Collection<AiPlayerDebugOption> options) {


### PR DESCRIPTION
If debug menu is empty, then hide it.

## Change Summary & Additional Notes

Before:
![Screenshot from 2021-11-13 19-22-32](https://user-images.githubusercontent.com/12397753/141666171-229c52d3-98de-4ff3-9c2b-a25940d21120.png)

After:
![Screenshot from 2021-11-13 19-20-19](https://user-images.githubusercontent.com/12397753/141666169-98d307ca-a8fd-4a92-a156-ea4e1811103a.png)

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
