### PR TITLE
Refactor/resource loader

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMapsListing.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMapsListing.java
@@ -40,6 +40,10 @@ public class InstalledMapsListing {
     return new InstalledMapsListing();
   }
 
+  public static Optional<Path> searchAllMapsForMapName(String mapName) {
+    return parseMapFiles().findContentRootForMapName(mapName);
+  }
+
   private static Collection<InstalledMap> readMapYamlsAndGenerateMissingMapYamls() {
     // loop over all maps, find and parse a 'map.yml' file, if not found attempt to generate it
     return FileUtils.listFiles(ClientFileSystemHelper.getUserMapsFolder()).stream()

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -2,8 +2,6 @@ package games.strategy.triplea;
 
 import com.google.common.annotations.VisibleForTesting;
 import games.strategy.engine.ClientFileSystemHelper;
-import games.strategy.engine.framework.map.file.system.loader.InstalledMapsListing;
-import games.strategy.engine.framework.startup.launcher.MapNotFoundException;
 import games.strategy.triplea.ui.OrderedProperties;
 import java.awt.Image;
 import java.awt.image.BufferedImage;
@@ -41,12 +39,8 @@ public class ResourceLoader implements Closeable {
   @Getter private final List<URL> searchUrls;
   @Getter private final Path mapLocation;
 
-  public ResourceLoader(final String mapName) {
-    mapLocation =
-        mapName == null || mapName.isBlank()
-            ? null
-            : InstalledMapsListing.searchAllMapsForMapName(mapName)
-                .orElseThrow(() -> new MapNotFoundException(mapName));
+  public ResourceLoader(@Nullable final Path mapLocation) {
+    this.mapLocation = mapLocation;
 
     // Add the assets folder from the game installation path. This assets folder supplements
     // any map resources.
@@ -66,13 +60,7 @@ public class ResourceLoader implements Closeable {
       loader = new URLClassLoader(searchUrls.toArray(URL[]::new));
     } catch (final MalformedURLException e) {
       throw new IllegalArgumentException(
-          "Error creating file system paths with map: "
-              + mapName
-              + ", engine assets path: "
-              + gameAssetsDirectory.toAbsolutePath()
-              + ", and path to map: "
-              + mapLocation.toAbsolutePath(),
-          e);
+          "Error creating file system paths with map: " + mapLocation, e);
     }
   }
 
@@ -89,7 +77,7 @@ public class ResourceLoader implements Closeable {
    * is to be used in the launching screens before any map has been launched.
    */
   public static ResourceLoader getGameEngineAssetLoader() {
-    return new ResourceLoader("");
+    return new ResourceLoader((Path) null);
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -2,7 +2,6 @@ package games.strategy.triplea;
 
 import com.google.common.annotations.VisibleForTesting;
 import games.strategy.engine.ClientFileSystemHelper;
-import games.strategy.engine.framework.map.download.DownloadMapsWindow;
 import games.strategy.engine.framework.map.file.system.loader.InstalledMapsListing;
 import games.strategy.engine.framework.startup.launcher.MapNotFoundException;
 import games.strategy.triplea.ui.OrderedProperties;
@@ -28,7 +27,6 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.io.ImageLoader;
 import org.triplea.java.UrlStreams;
-import org.triplea.swing.SwingComponents;
 
 /**
  * Utility for managing where images and property files for maps and units should be loaded from.
@@ -47,20 +45,8 @@ public class ResourceLoader implements Closeable {
     mapLocation =
         mapName == null || mapName.isBlank()
             ? null
-            : InstalledMapsListing.parseMapFiles()
-                .findContentRootForMapName(mapName)
-                .orElseThrow(
-                    () -> {
-                      SwingComponents.promptUser(
-                          "Download Map?",
-                          "Map missing: "
-                              + mapName
-                              + ", could not join game.\nWould you like to download the map now?"
-                              + "\nOnce the download completes, you may reconnect to this game.",
-                          () -> DownloadMapsWindow.showDownloadMapsWindowAndDownload(mapName));
-
-                      return new MapNotFoundException(mapName);
-                    });
+            : InstalledMapsListing.searchAllMapsForMapName(mapName)
+                .orElseThrow(() -> new MapNotFoundException(mapName));
 
     // Add the assets folder from the game installation path. This assets folder supplements
     // any map resources.

--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/TileImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/TileImageFactory.java
@@ -13,7 +13,6 @@ import java.awt.image.BufferedImage;
 import java.io.IOException;
 import java.lang.ref.SoftReference;
 import java.net.URL;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
@@ -40,8 +39,7 @@ public final class TileImageFactory {
           .getDefaultScreenDevice()
           .getDefaultConfiguration();
   // maps image name to ImageRef
-  private final Map<String, SoftReference<Image>> imageCache =
-      Collections.synchronizedMap(new HashMap<>());
+  private final Map<String, SoftReference<Image>> imageCache = new HashMap<>();
   private ResourceLoader resourceLoader;
 
   static {
@@ -121,13 +119,6 @@ public final class TileImageFactory {
     imageCache.clear();
   }
 
-  private Image isImageLoaded(final String fileName) {
-    if (imageCache.get(fileName) == null) {
-      return null;
-    }
-    return imageCache.get(fileName).get();
-  }
-
   public Image getBaseTile(final int x, final int y) {
     final String fileName = getBaseTileImageName(x, y);
     if (resourceLoader.getResource(fileName) == null) {
@@ -146,9 +137,9 @@ public final class TileImageFactory {
       isDirty = false;
       imageCache.clear();
     }
-    final Image image = isImageLoaded(fileName);
-    if (image != null) {
-      return image;
+
+    if (imageCache.get(fileName) != null) {
+      return imageCache.get(fileName).get();
     }
     // This is null if there is no image
     final URL url = resourceLoader.getResource(fileName);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/TileImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/TileImageFactory.java
@@ -116,7 +116,7 @@ public final class TileImageFactory {
     }
   }
 
-  public void setMapDir(final ResourceLoader loader) {
+  public void setResourceLoader(final ResourceLoader loader) {
     resourceLoader = loader;
     imageCache.clear();
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -65,6 +65,7 @@ import games.strategy.triplea.delegate.remote.IEditDelegate;
 import games.strategy.triplea.delegate.remote.IPoliticsDelegate;
 import games.strategy.triplea.delegate.remote.IUserActionDelegate;
 import games.strategy.triplea.formatter.MyFormatter;
+import games.strategy.triplea.image.TileImageFactory;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.export.ScreenshotExporter;
 import games.strategy.triplea.ui.history.HistoryDetailsPanel;
@@ -2361,6 +2362,11 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
   /** Displays the map located in the directory/archive {@code mapdir}. */
   public void changeMapSkin(final String skinName) {
     uiContext.changeMapSkin(data, skinName);
+    // when changing skins, always show relief images
+    if (uiContext.getMapData().getHasRelief()) {
+      TileImageFactory.setShowReliefImages(true);
+    }
+
     mapPanel.setGameData(data);
     // update map panels to use new image
     mapPanel.changeImage(uiContext.getMapData().getMapDimensions());

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -199,7 +199,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
   private final AtomicBoolean inHistory = new AtomicBoolean(false);
   private final AtomicBoolean inGame = new AtomicBoolean(true);
   private HistorySynchronizer historySyncher;
-  private final UiContext uiContext;
+  private UiContext uiContext;
   private final JPanel mapAndChatPanel;
   private final ChatPanel chatPanel;
   private final CommentPanel commentPanel;
@@ -2361,7 +2361,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
 
   /** Displays the map located in the directory/archive {@code mapdir}. */
   public void changeMapSkin(final String skinName) {
-    uiContext.changeMapSkin(data, skinName);
+    uiContext = UiContext.changeMapSkin(data, skinName);
     // when changing skins, always show relief images
     if (uiContext.getMapData().getHasRelief()) {
       TileImageFactory.setShowReliefImages(true);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -91,25 +91,21 @@ public class UiContext {
   }
 
   UiContext(final GameData data) {
-    internalSetMapDir(getDefaultMapDir(data.getMapName()), data);
-  }
-
-  private static String getDefaultMapDir(String mapName) {
-    if (mapName == null || mapName.isBlank()) {
+    if (data.getMapName() == null || data.getMapName().isBlank()) {
       throw new IllegalStateException("Map name property not set on game");
     }
-    final Preferences prefs = getPreferencesForMap(mapName);
-    final String mapDir = prefs.get(MAP_SKIN_PREF, mapName);
+    final Preferences prefs = getPreferencesForMap(data.getMapName());
+    final String mapDir = prefs.get(MAP_SKIN_PREF, data.getMapName());
     // check for existence
     try {
       new ResourceLoader(mapDir).close();
+      internalSetMapDir(mapDir, data);
     } catch (final RuntimeException re) {
       // an error, clear the skin
       prefs.remove(MAP_SKIN_PREF);
       // return the default
-      return mapName;
+      internalSetMapDir(data.getMapName(), data);
     }
-    return mapDir;
   }
 
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -94,6 +94,25 @@ public class UiContext {
     internalSetMapDir(getDefaultMapDir(data.getMapName()), data);
   }
 
+  private static String getDefaultMapDir(String mapName) {
+    if (mapName == null || mapName.isBlank()) {
+      throw new IllegalStateException("Map name property not set on game");
+    }
+    final Preferences prefs = getPreferencesForMap(mapName);
+    final String mapDir = prefs.get(MAP_SKIN_PREF, mapName);
+    // check for existence
+    try {
+      new ResourceLoader(mapDir).close();
+    } catch (final RuntimeException re) {
+      // an error, clear the skin
+      prefs.remove(MAP_SKIN_PREF);
+      // return the default
+      return mapName;
+    }
+    return mapDir;
+  }
+
+
   private void internalSetMapDir(final String dir, final GameData data) {
     if (resourceLoader != null) {
       resourceLoader.close();
@@ -258,24 +277,6 @@ public class UiContext {
   /** Get the preferences for the map or map skin. */
   private static Preferences getPreferencesMapOrSkin(final String mapDir) {
     return Preferences.userNodeForPackage(UiContext.class).node(mapDir);
-  }
-
-  private static String getDefaultMapDir(String mapName) {
-    if (mapName == null || mapName.isBlank()) {
-      throw new IllegalStateException("Map name property not set on game");
-    }
-    final Preferences prefs = getPreferencesForMap(mapName);
-    final String mapDir = prefs.get(MAP_SKIN_PREF, mapName);
-    // check for existence
-    try {
-      new ResourceLoader(mapDir).close();
-    } catch (final RuntimeException re) {
-      // an error, clear the skin
-      prefs.remove(MAP_SKIN_PREF);
-      // return the default
-      return mapName;
-    }
-    return mapDir;
   }
 
   public void changeMapSkin(final GameData data, final String skinName) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -94,20 +94,27 @@ public class UiContext {
     if (data.getMapName() == null || data.getMapName().isBlank()) {
       throw new IllegalStateException("Map name property not set on game");
     }
-    final Preferences prefs = getPreferencesForMap(data.getMapName());
-    final String mapDir = prefs.get(MAP_SKIN_PREF, data.getMapName());
-    // check for existence
-    try {
-      new ResourceLoader(mapDir).close();
-      internalSetMapDir(mapDir, data);
-    } catch (final RuntimeException re) {
-      // an error, clear the skin
-      prefs.remove(MAP_SKIN_PREF);
+
+    String preferredSkinPath =
+        getPreferencesForMap(data.getMapName()) //
+            .get(MAP_SKIN_PREF, null);
+
+    if (preferredSkinPath == null) {
       // return the default
       internalSetMapDir(data.getMapName(), data);
+    } else {
+      try {
+        // check skin exists
+        new ResourceLoader(preferredSkinPath).close();
+        internalSetMapDir(preferredSkinPath, data);
+      } catch (final RuntimeException re) {
+        // an error, clear the skin
+        getPreferencesForMap(data.getMapName()).remove(MAP_SKIN_PREF);
+        // return the default
+        internalSetMapDir(data.getMapName(), data);
+      }
     }
   }
-
 
   private void internalSetMapDir(final String mapName, final GameData data) {
     if (resourceLoader != null) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -87,12 +87,12 @@ public class UiContext {
   private final List<Runnable> activeToDeactivate = new ArrayList<>();
   private final CountDownLatchHandler latchesToCloseOnShutdown = new CountDownLatchHandler(false);
 
-  UiContext(final GameData data) {
-    internalSetMapDir(getDefaultMapDir(data.getMapName()), data);
-  }
-
   public static void setResourceLoader(final GameState gameData) {
     resourceLoader = new ResourceLoader(getDefaultMapDir(gameData.getMapName()));
+  }
+
+  UiContext(final GameData data) {
+    internalSetMapDir(getDefaultMapDir(data.getMapName()), data);
   }
 
   private void internalSetMapDir(final String dir, final GameData data) {
@@ -101,6 +101,7 @@ public class UiContext {
     }
     resourceLoader = new ResourceLoader(dir);
     mapData = new MapData(dir);
+    mapDir = dir;
     // DiceImageFactory needs loader and game data
     diceImageFactory = new DiceImageFactory(resourceLoader, data.getDiceSides());
     final double unitScale =
@@ -116,7 +117,6 @@ public class UiContext {
     tileImageFactory.setMapDir(resourceLoader);
     // load map data
     mapImage.loadMaps(resourceLoader);
-    mapDir = dir;
     drawTerritoryEffects = mapData.useTerritoryEffectMarkers();
     // load the sounds in a background thread,
     // avoids the pause where sounds dont load right away

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -128,7 +128,7 @@ public class UiContext {
     unitIconImageFactory.setResourceLoader(resourceLoader);
     flagIconImageFactory.setResourceLoader(resourceLoader);
     puImageFactory.setResourceLoader(resourceLoader);
-    tileImageFactory.setMapDir(resourceLoader);
+    tileImageFactory.setResourceLoader(resourceLoader);
     // load map data
     mapImage.loadMaps(resourceLoader);
     drawTerritoryEffects = mapData.useTerritoryEffectMarkers();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -3,7 +3,6 @@ package games.strategy.triplea.ui;
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
-import games.strategy.engine.data.GameState;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.framework.LocalPlayers;
 import games.strategy.triplea.ResourceLoader;
@@ -87,8 +86,8 @@ public class UiContext {
   private final List<Runnable> activeToDeactivate = new ArrayList<>();
   private final CountDownLatchHandler latchesToCloseOnShutdown = new CountDownLatchHandler(false);
 
-  public static void setResourceLoader(final GameState gameData) {
-    resourceLoader = new ResourceLoader(getDefaultMapDir(gameData.getMapName()));
+  public static void setResourceLoader(final String mapName) {
+    resourceLoader = new ResourceLoader(mapName);
   }
 
   UiContext(final GameData data) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -123,8 +123,9 @@ public class UiContext {
       resourceLoader.close();
     }
 
-    Path mapPath = InstalledMapsListing.searchAllMapsForMapName(mapName)
-        .orElseThrow(() -> new MapNotFoundException(mapName));
+    Path mapPath =
+        InstalledMapsListing.searchAllMapsForMapName(mapName)
+            .orElseThrow(() -> new MapNotFoundException(mapName));
 
     resourceLoader = new ResourceLoader(mapPath);
     mapData = new MapData(mapPath);
@@ -288,18 +289,18 @@ public class UiContext {
     return Preferences.userNodeForPackage(UiContext.class).node(mapDir);
   }
 
-  public void changeMapSkin(final GameData data, final String skinName) {
-    String mapDir = getSkinsWithPaths(data.getMapName()).get(skinName);
-    internalSetMapDir(mapDir, data);
-    mapData.verify(data);
+  public static UiContext changeMapSkin(GameData gameData, String skinName) {
     // set the default after internal succeeds, if an error is thrown we don't want to persist it
-    final Preferences prefs = getPreferencesForMap(data.getMapName());
-    prefs.put(MAP_SKIN_PREF, mapDir);
+    final Preferences prefs = getPreferencesForMap(mapName);
+    prefs.put(MAP_SKIN_PREF, skinName);
     try {
       prefs.flush();
     } catch (final BackingStoreException e) {
       log.error("Failed to flush preferences: " + prefs.absolutePath(), e);
     }
+    UiContext uiContext = new UiContext(gameData);
+    uiContext.getMapData().verify(gameData);
+    return uiContext;
   }
 
   public void removeShutdownHook(final Runnable hook) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -49,7 +49,7 @@ import org.triplea.sound.ClipPlayer;
 /** A place to find images and map data for a ui. */
 @Slf4j
 public class UiContext {
-  @Getter protected static String mapDir;
+  @Getter protected static String mapName;
   @Getter protected static ResourceLoader resourceLoader;
 
   static final String UNIT_SCALE_PREF = "UnitScale";
@@ -109,18 +109,18 @@ public class UiContext {
   }
 
 
-  private void internalSetMapDir(final String dir, final GameData data) {
+  private void internalSetMapDir(final String mapName, final GameData data) {
     if (resourceLoader != null) {
       resourceLoader.close();
     }
-    resourceLoader = new ResourceLoader(dir);
-    mapData = new MapData(dir);
-    mapDir = dir;
+    resourceLoader = new ResourceLoader(mapName);
+    mapData = new MapData(mapName);
+    UiContext.mapName = mapName;
     // DiceImageFactory needs loader and game data
     diceImageFactory = new DiceImageFactory(resourceLoader, data.getDiceSides());
     final double unitScale =
-        getPreferencesMapOrSkin(dir).getDouble(UNIT_SCALE_PREF, mapData.getDefaultUnitScale());
-    scale = getPreferencesMapOrSkin(dir).getDouble(MAP_SCALE_PREF, 1);
+        getPreferencesMapOrSkin(mapName).getDouble(UNIT_SCALE_PREF, mapData.getDefaultUnitScale());
+    scale = getPreferencesMapOrSkin(mapName).getDouble(MAP_SCALE_PREF, 1);
     unitImageFactory = new UnitImageFactory(resourceLoader, unitScale, mapData);
     // TODO: separate scale for resources
     resourceImageFactory.setResourceLoader(resourceLoader);
@@ -245,7 +245,7 @@ public class UiContext {
 
   public void setUnitScaleFactor(final double scaleFactor) {
     unitImageFactory = unitImageFactory.withScaleFactor(scaleFactor);
-    final Preferences prefs = getPreferencesMapOrSkin(getMapDir());
+    final Preferences prefs = getPreferencesMapOrSkin(mapName);
     prefs.putDouble(UNIT_SCALE_PREF, scaleFactor);
     try {
       prefs.flush();
@@ -256,7 +256,7 @@ public class UiContext {
 
   public void setScale(final double scale) {
     this.scale = scale;
-    final Preferences prefs = getPreferencesMapOrSkin(getMapDir());
+    final Preferences prefs = getPreferencesMapOrSkin(mapName);
     prefs.putDouble(MAP_SCALE_PREF, scale);
     try {
       prefs.flush();
@@ -399,7 +399,7 @@ public class UiContext {
 
     public MapSkin(String skinName) {
       this.skinName = skinName;
-      currentSkin = skinName.equals(UiContext.getMapDir());
+      currentSkin = skinName.equals(mapName);
     }
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -129,20 +129,16 @@ public class MapData {
   @Nullable private final Image blockadeImage;
   @Nullable private final Image errorImage;
   @Nullable private final Image warningImage;
-  private final String mapNameDir;
+  private final Path mapPath;
 
-  public MapData(final String mapNameDir) {
-    this.mapNameDir = mapNameDir;
-    try (ResourceLoader loader = new ResourceLoader(mapNameDir)) {
+  public MapData(final Path mapPath) {
+    this.mapPath = mapPath;
+    try (ResourceLoader loader = new ResourceLoader(mapPath)) {
       try {
         if (loader.getResource(POLYGON_FILE) == null) {
           throw new IllegalStateException(
-              "Error in resource loading for map: "
-                  + mapNameDir
-                  + ". Unable to load file: "
-                  + POLYGON_FILE
-                  + ", searched these locations: "
-                  + loader.getSearchUrls());
+              String.format(
+                  "Error loading map: %s. Unable to load file: %s", mapPath, POLYGON_FILE));
         }
 
         place.putAll(readOptionalPlacementsOneToMany(loader, PLACEMENT_FILE));
@@ -767,7 +763,7 @@ public class MapData {
   }
 
   public Optional<Image> getTerritoryEffectImage(final String effectName) {
-    try (ResourceLoader loader = new ResourceLoader(mapNameDir)) {
+    try (ResourceLoader loader = new ResourceLoader(mapPath)) {
       // TODO: what does this cache buy us? should we still keep it?
       if (effectImages.get(effectName) != null) {
         return Optional.of(effectImages.get(effectName));

--- a/game-app/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceReportModel.java
+++ b/game-app/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceReportModel.java
@@ -32,7 +32,10 @@ class StackTraceReportModel {
         .title(ErrorReportTitleFormatter.createTitle(stackTraceRecord))
         .body(
             ErrorReportBodyFormatter.buildBody(
-                view.readUserDescription(), UiContext.getMapName(), stackTraceRecord, engineVersion))
+                view.readUserDescription(),
+                UiContext.getMapName(),
+                stackTraceRecord,
+                engineVersion))
         .gameVersion(Injections.getInstance().getEngineVersion().toString())
         .build();
   }

--- a/game-app/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceReportModel.java
+++ b/game-app/game-core/src/main/java/org/triplea/debug/error/reporting/StackTraceReportModel.java
@@ -32,7 +32,7 @@ class StackTraceReportModel {
         .title(ErrorReportTitleFormatter.createTitle(stackTraceRecord))
         .body(
             ErrorReportBodyFormatter.buildBody(
-                view.readUserDescription(), UiContext.getMapDir(), stackTraceRecord, engineVersion))
+                view.readUserDescription(), UiContext.getMapName(), stackTraceRecord, engineVersion))
         .gameVersion(Injections.getInstance().getEngineVersion().toString())
         .build();
   }

--- a/game-app/game-core/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
+++ b/game-app/game-core/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
@@ -51,7 +51,7 @@ public class HeadlessLaunchAction implements LaunchAction {
       final IGame game,
       final Set<Player> players,
       final Chat chat) {
-    UiContext.setResourceLoader(game.getData());
+    UiContext.setResourceLoader(game.getData().getMapName());
     return new HeadlessDisplay();
   }
 

--- a/game-app/game-core/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
+++ b/game-app/game-core/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
@@ -6,6 +6,7 @@ import games.strategy.engine.framework.HeadlessAutoSaveFileUtils;
 import games.strategy.engine.framework.IGame;
 import games.strategy.engine.framework.LocalPlayers;
 import games.strategy.engine.framework.ServerGame;
+import games.strategy.engine.framework.map.file.system.loader.InstalledMapsListing;
 import games.strategy.engine.framework.startup.launcher.LaunchAction;
 import games.strategy.engine.framework.startup.mc.ServerModel;
 import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorModel;
@@ -51,7 +52,14 @@ public class HeadlessLaunchAction implements LaunchAction {
       final IGame game,
       final Set<Player> players,
       final Chat chat) {
-    UiContext.setResourceLoader(game.getData().getMapName());
+
+    Path mapPath =
+        InstalledMapsListing.searchAllMapsForMapName(game.getData().getMapName())
+            .orElseThrow(
+                () ->
+                    new IllegalStateException(
+                        "Unable to find map: " + game.getData().getMapName()));
+    UiContext.setResourceLoader(mapPath);
     return new HeadlessDisplay();
   }
 

--- a/game-app/game-core/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/game-app/game-core/src/main/java/tools/image/AutoPlacementFinder.java
@@ -250,7 +250,7 @@ public final class AutoPlacementFinder {
         "Place Dimensions in pixels, being used: " + placeWidth + "x" + placeHeight + "\r\n");
     textOptionPane.appendNewLine("Calculating, this may take a while...\r\n");
     final Map<String, List<Point>> placements = new HashMap<>();
-    final MapData mapData = new MapData(mapDir);
+    final MapData mapData = new MapData(mapFolderLocation);
     for (final String name : mapData.getTerritories()) {
       final Set<Polygon> containedPolygons = mapData.getContainedTerritoryPolygons(name);
       final List<Point> points =


### PR DESCRIPTION
## Change Summary & Additional Notes

Various refactors to resource loader:
- update UiContext so 'internalSetMap' is only called from constructor. To do this, we create a new UIContext when changing skins rather than mutating the UiContext
- various additional refactoring updates to distinguish map name from map path.
- update ResourceLoader to receive as input 'map path' rather than 'map name'

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
