### PR TITLE
Fix: by default dispose JFrame

### DIFF
--- a/lib/swing-lib/src/main/java/org/triplea/swing/JFrameBuilder.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/JFrameBuilder.java
@@ -31,7 +31,7 @@ public class JFrameBuilder {
     EXIT
   }
 
-  private CloseBehavior closeBehavior;
+  private CloseBehavior closeBehavior = CloseBehavior.DISPOSE;
 
   private final Collection<Function<JFrame, Component>> children = new ArrayList<>();
   private boolean escapeClosesWindow;
@@ -93,12 +93,10 @@ public class JFrameBuilder {
     Optional.ofNullable(parent).ifPresent(frame::setLocationRelativeTo);
     Optional.ofNullable(layoutManager).ifPresent(frame.getContentPane()::setLayout);
 
-    if (closeBehavior != null) {
-      if (closeBehavior == CloseBehavior.DISPOSE) {
-        frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
-      } else {
-        frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
-      }
+    if (closeBehavior == CloseBehavior.EXIT) {
+      frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
+    } else {
+      frame.setDefaultCloseOperation(JFrame.DISPOSE_ON_CLOSE);
     }
 
     children.stream().map(component -> component.apply(frame)).forEach(frame::add);


### PR DESCRIPTION
Fixes a problem introduced in: 7e4884cb7241e23ba2e7fa1b40caf94c06862aa1
This update changes JFrameBuilder to by default dispose on close.
Before we would only dispose on close if explicitly set, this easily
results in JFrames not being disposed which causes the application
to remain open when these 'frames' are closed
