### PR TITLE
Fix for 'unable to move properties file' following map zip extraction

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/ZippedMapsExtractor.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/ZippedMapsExtractor.java
@@ -145,13 +145,11 @@ public class ZippedMapsExtractor {
       return Optional.empty();
     }
 
-    // move properties file if it exists
+    // delete properties file if it exists
     final Path propertiesFile =
         mapZip.resolveSibling(mapZip.getFileName().toString() + ".properties");
     if (Files.exists(propertiesFile)) {
-      Files.move(
-          propertiesFile,
-          extractionTarget.resolveSibling(extractionTarget.getFileName() + ".properties"));
+      FileUtils.delete(propertiesFile);
     }
 
     final boolean successfullyExtracted = Files.exists(extractionTarget);


### PR DESCRIPTION
Not sure why the code was trying to move a properties file following
map zip extraction. Instead we should delete these files as they
are no longer used.

Meanwhile, the presence of any .properties file can generate
an error message on startup. Notably this can be done if we re-download
an already extracted map and create a new .properties file which
would then collide with the already moved file.
