### PR TITLE
Refactor: replace 'UiContext.getResourceLoader.getMapLocation' with 'UiContext.getMapLocation'

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -552,7 +552,7 @@ public class GameData implements Serializable, GameState {
 
   private Optional<MapDescriptionYaml> findMapDescriptionYaml() {
     return FileUtils.findFileInParentFolders(
-            UiContext.getResourceLoader().getMapLocation(), MapDescriptionYaml.MAP_YAML_FILE_NAME)
+            UiContext.getMapLocation(), MapDescriptionYaml.MAP_YAML_FILE_NAME)
         .flatMap(MapDescriptionYaml::fromFile);
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -37,10 +37,7 @@ public class ResourceLoader implements Closeable {
   private final URLClassLoader loader;
 
   @Getter private final List<URL> searchUrls;
-  @Getter private final Path mapLocation;
 
-  public ResourceLoader(@Nullable final Path mapLocation) {
-    this.mapLocation = mapLocation;
 
     // Add the assets folder from the game installation path. This assets folder supplements
     // any map resources.
@@ -68,16 +65,6 @@ public class ResourceLoader implements Closeable {
   ResourceLoader(final URLClassLoader loader) {
     this.loader = loader;
     searchUrls = List.of();
-    mapLocation = null;
-  }
-
-  /**
-   * Resource loader that loads generic sounds and images, no map loaded. A standard resource loader
-   * will look for map assets first before falling back to game engine assets. This resource loader
-   * is to be used in the launching screens before any map has been launched.
-   */
-  public static ResourceLoader getGameEngineAssetLoader() {
-    return new ResourceLoader((Path) null);
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -321,8 +321,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
       } else {
         // now tell the HOST, and see if they want to continue the game.
         String displayMessage =
-            LocalizeHtml.localizeImgLinksInHtml(
-                status, UiContext.getResourceLoader().getMapLocation());
+            LocalizeHtml.localizeImgLinksInHtml(status, UiContext.getMapLocation());
         if (displayMessage.endsWith("</body>")) {
           displayMessage =
               displayMessage.substring(0, displayMessage.length() - "</body>".length())

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TooltipProperties.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TooltipProperties.java
@@ -24,8 +24,7 @@ public final class TooltipProperties extends PropertyFile {
 
     final String customTip = getToolTip(unitType, gamePlayer, false);
     if (!customTip.isEmpty()) {
-      return LocalizeHtml.localizeImgLinksInHtml(
-          customTip, UiContext.getResourceLoader().getMapLocation());
+      return LocalizeHtml.localizeImgLinksInHtml(customTip, UiContext.getMapLocation());
     }
     final String generated =
         UnitAttachment.get(unitType)
@@ -34,8 +33,7 @@ public final class TooltipProperties extends PropertyFile {
     final String appendedTip = getToolTip(unitType, gamePlayer, true);
     if (!appendedTip.isEmpty()) {
       return generated
-          + LocalizeHtml.localizeImgLinksInHtml(
-              appendedTip, UiContext.getResourceLoader().getMapLocation());
+          + LocalizeHtml.localizeImgLinksInHtml(appendedTip, UiContext.getMapLocation());
     }
     return generated;
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -918,8 +918,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
   /** We do NOT want to block the next player from beginning their turn. */
   public void notifyError(final String message) {
     final String displayMessage =
-        LocalizeHtml.localizeImgLinksInHtml(
-            message, UiContext.getResourceLoader().getMapLocation());
+        LocalizeHtml.localizeImgLinksInHtml(message, UiContext.getMapLocation());
     messageAndDialogThreadPool.submit(
         () ->
             EventThreadJOptionPane.showMessageDialogWithScrollPane(
@@ -955,8 +954,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
       return;
     }
     final String displayMessage =
-        LocalizeHtml.localizeImgLinksInHtml(
-            message, UiContext.getResourceLoader().getMapLocation());
+        LocalizeHtml.localizeImgLinksInHtml(message, UiContext.getMapLocation());
     messageAndDialogThreadPool.submit(
         () ->
             EventThreadJOptionPane.showMessageDialogWithScrollPane(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -52,6 +52,7 @@ import org.triplea.sound.ClipPlayer;
 @Slf4j
 public class UiContext {
   @Getter protected static String mapName;
+  @Getter protected static Path mapLocation;
   @Getter protected static ResourceLoader resourceLoader;
 
   static final String UNIT_SCALE_PREF = "UnitScale";
@@ -90,6 +91,7 @@ public class UiContext {
 
   public static void setResourceLoader(final Path mapPath) {
     resourceLoader = new ResourceLoader(mapPath);
+    mapLocation = mapPath;
   }
 
   UiContext(final GameData data) {
@@ -128,6 +130,7 @@ public class UiContext {
             .orElseThrow(() -> new MapNotFoundException(mapName));
 
     resourceLoader = new ResourceLoader(mapPath);
+    mapLocation = mapPath;
     mapData = new MapData(mapPath);
     UiContext.mapName = mapName;
     // DiceImageFactory needs loader and game data

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/GameNotesMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/GameNotesMenu.java
@@ -42,8 +42,7 @@ class GameNotesMenu {
 
   private static JComponent notesPanel(final String gameNotes) {
     final String localizedHtml =
-        LocalizeHtml.localizeImgLinksInHtml(
-            gameNotes.trim(), UiContext.getResourceLoader().getMapLocation());
+        LocalizeHtml.localizeImgLinksInHtml(gameNotes.trim(), UiContext.getMapLocation());
 
     final JEditorPane gameNotesPane = new JEditorPane("text/html", localizedHtml);
     gameNotesPane.setEditable(false);


### PR DESCRIPTION
Moves 'mapLocation' information from ResourceLoader to UiContext. This clarifies the meaning of 'map location', in resource loader its meaning is ambiguous as that is really the assets folder location rather than the map location.