### PR TITLE
Updates for additive map skins (still work in progress) / Put map skins behind a beta feature flag

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -552,7 +552,7 @@ public class GameData implements Serializable, GameState {
 
   private Optional<MapDescriptionYaml> findMapDescriptionYaml() {
     return FileUtils.findFileInParentFolders(
-            UiContext.getResourceLoader().getMapLocation(), MapDescriptionYaml.MAP_YAML_FILE_NAME)
+            UiContext.getMapLocation(), MapDescriptionYaml.MAP_YAML_FILE_NAME)
         .flatMap(MapDescriptionYaml::fromFile);
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMap.java
@@ -107,7 +107,7 @@ public class InstalledMap {
 
   public Optional<Path> findMapSkin(String skinName) {
     Path mapPath = mapDescriptionYaml.getYamlFileLocation().getParent();
-    Collection<Path> skinYamlFiles = FileUtils.find(mapPath, 4, "skin.yml");
+    Collection<Path> skinYamlFiles = FileUtils.find(mapPath, 7, "skin.yml");
 
     return skinYamlFiles.stream()
         .map(SkinDescriptionYaml::readSkinDescriptionYamlFile)
@@ -115,6 +115,20 @@ public class InstalledMap {
         .map(Optional::get)
         .filter(skinDescriptionYaml -> skinDescriptionYaml.getSkinName().equalsIgnoreCase(skinName))
         .findAny()
-        .map(SkinDescriptionYaml::getFilePath);
+        .map(SkinDescriptionYaml::getFilePath)
+        .map(Path::getParent);
+  }
+
+  public Collection<String> getSkinNames() {
+    Path mapPath = mapDescriptionYaml.getYamlFileLocation().getParent();
+    Collection<Path> skinYamlFiles = FileUtils.find(mapPath, 4, "skin.yml");
+
+    return skinYamlFiles.stream()
+        .map(SkinDescriptionYaml::readSkinDescriptionYamlFile)
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .map(SkinDescriptionYaml::getSkinName)
+        .sorted()
+        .collect(Collectors.toList());
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMap.java
@@ -42,8 +42,7 @@ public class InstalledMap {
     if (contentRoot == null) {
       // relative to the 'map.yml' file location, search current and child directories for
       // a polygons file, the location of the polygons file is the map content root.
-      final Path mapYamlParentFolder =
-          Path.of(mapDescriptionYaml.getYamlFileLocation()).getParent();
+      final Path mapYamlParentFolder = mapDescriptionYaml.getYamlFileLocation().getParent();
       contentRoot =
           FileUtils.find(mapYamlParentFolder, 3, MapData.POLYGON_FILE)
               .map(Path::getParent)
@@ -103,5 +102,9 @@ public class InstalledMap {
 
     final Instant lastCommitDate = Instant.ofEpochMilli(download.getLastCommitDateEpochMilli());
     return lastModifiedDate.isBefore(lastCommitDate);
+  }
+
+  Optional<Path> findMapSkin(final String skinName) {
+    return Optional.empty();
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMap.java
@@ -15,6 +15,7 @@ import lombok.ToString;
 import org.triplea.http.client.maps.listing.MapDownloadItem;
 import org.triplea.io.FileUtils;
 import org.triplea.map.description.file.MapDescriptionYaml;
+import org.triplea.map.description.file.SkinDescriptionYaml;
 import org.triplea.map.game.notes.GameNotes;
 import org.triplea.util.LocalizeHtml;
 
@@ -44,7 +45,7 @@ public class InstalledMap {
       // a polygons file, the location of the polygons file is the map content root.
       final Path mapYamlParentFolder = mapDescriptionYaml.getYamlFileLocation().getParent();
       contentRoot =
-          FileUtils.find(mapYamlParentFolder, 3, MapData.POLYGON_FILE)
+          FileUtils.findOne(mapYamlParentFolder, 3, MapData.POLYGON_FILE)
               .map(Path::getParent)
               .orElse(null);
     }
@@ -104,7 +105,16 @@ public class InstalledMap {
     return lastModifiedDate.isBefore(lastCommitDate);
   }
 
-  Optional<Path> findMapSkin(final String skinName) {
-    return Optional.empty();
+  public Optional<Path> findMapSkin(String skinName) {
+    Path mapPath = mapDescriptionYaml.getYamlFileLocation().getParent();
+    Collection<Path> skinYamlFiles = FileUtils.find(mapPath, 4, "skin.yml");
+
+    return skinYamlFiles.stream()
+        .map(SkinDescriptionYaml::readSkinDescriptionYamlFile)
+        .filter(Optional::isPresent)
+        .map(Optional::get)
+        .filter(skinDescriptionYaml -> skinDescriptionYaml.getSkinName().equalsIgnoreCase(skinName))
+        .findAny()
+        .map(SkinDescriptionYaml::getFilePath);
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMap.java
@@ -45,7 +45,7 @@ public class InstalledMap {
       // a polygons file, the location of the polygons file is the map content root.
       final Path mapYamlParentFolder = mapDescriptionYaml.getYamlFileLocation().getParent();
       contentRoot =
-          FileUtils.findOne(mapYamlParentFolder, 3, MapData.POLYGON_FILE)
+          FileUtils.findAny(mapYamlParentFolder, 3, MapData.POLYGON_FILE)
               .map(Path::getParent)
               .orElse(null);
     }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMapsListing.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMapsListing.java
@@ -55,10 +55,6 @@ public class InstalledMapsListing {
         .collect(Collectors.toList());
   }
 
-  public static Optional<Path> findMapSkin(final String mapName, final String preferredSkinPath) {
-    return Optional.empty();
-  }
-
   /** Returns the list of all installed game names. */
   public List<String> getSortedGameList() {
     return installedMaps.stream()
@@ -124,6 +120,13 @@ public class InstalledMapsListing {
    */
   public Optional<Path> findMapFolderByName(final String mapName) {
     return findContentRootForMapName(mapName).map(Path::getParent);
+  }
+
+  public Optional<Path> findMapSkin(final String mapName, final String skinName) {
+    return installedMaps.stream()
+        .filter(d -> mapName.equals(normalizeName(d.getMapName())))
+        .findAny()
+        .flatMap(installedMap -> installedMap.findMapSkin(skinName));
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMapsListing.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMapsListing.java
@@ -128,7 +128,7 @@ public class InstalledMapsListing {
 
   public Optional<Path> findMapSkin(final String mapName, final String skinName) {
     return installedMaps.stream()
-        .filter(d -> mapName.equals(normalizeName(d.getMapName())))
+        .filter(d -> normalizeName(mapName).equals(normalizeName(d.getMapName())))
         .findAny()
         .flatMap(installedMap -> installedMap.findMapSkin(skinName));
   }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMapsListing.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMapsListing.java
@@ -55,6 +55,10 @@ public class InstalledMapsListing {
         .collect(Collectors.toList());
   }
 
+  public static Optional<Path> findMapSkin(final String mapName, final String preferredSkinPath) {
+    return Optional.empty();
+  }
+
   /** Returns the list of all installed game names. */
   public List<String> getSortedGameList() {
     return installedMaps.stream()

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMapsListing.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMapsListing.java
@@ -28,8 +28,8 @@ import org.triplea.map.description.file.MapDescriptionYaml;
 public class InstalledMapsListing {
   @Singular private final Collection<InstalledMap> installedMaps;
 
-  private InstalledMapsListing() {
-    this(readMapYamlsAndGenerateMissingMapYamls());
+  private InstalledMapsListing(Path folder) {
+    this(readMapYamlsAndGenerateMissingMapYamls(folder));
   }
 
   /**
@@ -37,16 +37,20 @@ public class InstalledMapsListing {
    * returns the list of available games found.
    */
   public static synchronized InstalledMapsListing parseMapFiles() {
-    return new InstalledMapsListing();
+    return parseMapFiles(ClientFileSystemHelper.getUserMapsFolder());
+  }
+
+  public static synchronized InstalledMapsListing parseMapFiles(Path folder) {
+    return new InstalledMapsListing(folder);
   }
 
   public static Optional<Path> searchAllMapsForMapName(String mapName) {
     return parseMapFiles().findContentRootForMapName(mapName);
   }
 
-  private static Collection<InstalledMap> readMapYamlsAndGenerateMissingMapYamls() {
+  private static Collection<InstalledMap> readMapYamlsAndGenerateMissingMapYamls(Path folder) {
     // loop over all maps, find and parse a 'map.yml' file, if not found attempt to generate it
-    return FileUtils.listFiles(ClientFileSystemHelper.getUserMapsFolder()).stream()
+    return FileUtils.listFiles(folder).stream()
         .filter(Files::isDirectory)
         .map(MapDescriptionYaml::fromMap)
         .filter(Optional::isPresent)

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -38,7 +38,6 @@ public class ResourceLoader implements Closeable {
   private final URLClassLoader loader;
 
   @Getter private final List<URL> searchUrls;
-  @Getter private final Path mapLocation;
 
   public ResourceLoader(@Nonnull final Path mapLocation) {
     this(mapLocation, null);
@@ -56,8 +55,6 @@ public class ResourceLoader implements Closeable {
    *     first location where we will search for assets.
    */
   public ResourceLoader(@Nullable final Path mapLocation, @Nullable final Path skinLocation) {
-    this.mapLocation = mapLocation;
-
     // Add the assets folder from the game installation path. This assets folder supplements
     // any map resources.
     final Path gameAssetsDirectory =
@@ -87,7 +84,6 @@ public class ResourceLoader implements Closeable {
   ResourceLoader(final URLClassLoader loader) {
     this.loader = loader;
     searchUrls = List.of();
-    mapLocation = null;
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -24,7 +24,6 @@ import javax.annotation.Nullable;
 import javax.imageio.ImageIO;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
-import org.triplea.io.FileUtils;
 import org.triplea.io.ImageLoader;
 import org.triplea.java.UrlStreams;
 
@@ -112,6 +111,14 @@ public class ResourceLoader implements Closeable {
     }
   }
 
+  /**
+   * Searches from a starting directory for a given directory. If not found, recursively goes up to
+   * parent directories searching for the given directory.
+   *
+   * @param startDir The start of the search path.
+   * @param targetDirName The name of the directory to find (must be a directory, not a file)
+   * @return Path of the directory as found, otherwise empty.
+   */
   @VisibleForTesting
   static Optional<Path> findDirectory(final Path startDir, final String targetDirName) {
     for (Path currentDir = startDir; currentDir != null; currentDir = currentDir.getParent()) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -40,6 +40,21 @@ public class ResourceLoader implements Closeable {
   @Getter private final Path mapLocation;
 
   public ResourceLoader(@Nullable final Path mapLocation) {
+    this(mapLocation, null);
+  }
+
+  /**
+   * Creates a resource loader that will look for assets in the following order:<br>
+   * - map skin<br>
+   * - map<br>
+   * - game engine<br>
+   *
+   * @param mapLocation Location Nullable location of the map. We search for assets in a map first
+   *     before looking for pre-installed assets.
+   * @param skinLocation Nullable location of the current skin. The skin if specified will be the
+   *     first location where we will search for assets.
+   */
+  public ResourceLoader(@Nullable final Path mapLocation, @Nullable final Path skinLocation) {
     this.mapLocation = mapLocation;
 
     // Add the assets folder from the game installation path. This assets folder supplements
@@ -53,6 +68,9 @@ public class ResourceLoader implements Closeable {
     // the assets folder.
     try {
       searchUrls = new ArrayList<>();
+      if (skinLocation != null) {
+        searchUrls.add(skinLocation.toUri().toURL());
+      }
       if (mapLocation != null) {
         searchUrls.add(mapLocation.toUri().toURL());
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -37,8 +37,7 @@ public class ResourceLoader implements Closeable {
 
   private final URLClassLoader loader;
 
-  @Getter
-  private final List<Path> assetPaths;
+  @Getter private final List<Path> assetPaths;
 
   public ResourceLoader(@Nonnull final Path assetFolder) {
     this(List.of(assetFolder));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -19,10 +19,12 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Properties;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.imageio.ImageIO;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.triplea.io.FileUtils;
 import org.triplea.io.ImageLoader;
 import org.triplea.java.UrlStreams;
 
@@ -39,7 +41,7 @@ public class ResourceLoader implements Closeable {
   @Getter private final List<URL> searchUrls;
   @Getter private final Path mapLocation;
 
-  public ResourceLoader(@Nullable final Path mapLocation) {
+  public ResourceLoader(@Nonnull final Path mapLocation) {
     this(mapLocation, null);
   }
 
@@ -87,15 +89,6 @@ public class ResourceLoader implements Closeable {
     this.loader = loader;
     searchUrls = List.of();
     mapLocation = null;
-  }
-
-  /**
-   * Resource loader that loads generic sounds and images, no map loaded. A standard resource loader
-   * will look for map assets first before falling back to game engine assets. This resource loader
-   * is to be used in the launching screens before any map has been launched.
-   */
-  public static ResourceLoader getGameEngineAssetLoader() {
-    return new ResourceLoader((Path) null);
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ResourceLoader.java
@@ -21,6 +21,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.imageio.ImageIO;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.io.ImageLoader;
 import org.triplea.io.PathUtils;
@@ -36,11 +37,15 @@ public class ResourceLoader implements Closeable {
 
   private final URLClassLoader loader;
 
+  @Getter
+  private final List<Path> assetPaths;
+
   public ResourceLoader(@Nonnull final Path assetFolder) {
     this(List.of(assetFolder));
   }
 
   public ResourceLoader(List<Path> assetPaths) {
+    this.assetPaths = assetPaths;
     List<URL> searchUrls = assetPaths.stream().map(PathUtils::toUrl).collect(Collectors.toList());
 
     Path gameEngineAssets =
@@ -59,6 +64,7 @@ public class ResourceLoader implements Closeable {
   @VisibleForTesting
   ResourceLoader(final URLClassLoader loader) {
     this.loader = loader;
+    this.assetPaths = List.of();
   }
 
   /**
@@ -163,8 +169,7 @@ public class ResourceLoader implements Closeable {
     final URL url = getResource(imageName);
     if (url == null) {
       // this is actually pretty common that we try to read images that are not there. Let the
-      // caller
-      // decide if this is an error or not.
+      // caller decide if this is an error or not.
       return Optional.empty();
     }
     try {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -321,8 +321,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
       } else {
         // now tell the HOST, and see if they want to continue the game.
         String displayMessage =
-            LocalizeHtml.localizeImgLinksInHtml(
-                status, UiContext.getResourceLoader().getMapLocation());
+            LocalizeHtml.localizeImgLinksInHtml(status, UiContext.getMapLocation());
         if (displayMessage.endsWith("</body>")) {
           displayMessage =
               displayMessage.substring(0, displayMessage.length() - "</body>".length())

--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/MapImage.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/MapImage.java
@@ -52,6 +52,8 @@ public class MapImage {
 
   private BufferedImage smallMapImage;
 
+
+
   public static Font getPropertyMapFont() {
     if (propertyMapFont == null) {
       final Preferences pref = Preferences.userNodeForPackage(MapImage.class);
@@ -240,7 +242,7 @@ public class MapImage {
     return smallMapImage;
   }
 
-  public void loadMaps(final ResourceLoader loader) {
+  public MapImage(final ResourceLoader loader) {
     final Image smallFromFile =
         loadImage(loader, Constants.SMALL_MAP_FILENAME, Constants.SMALL_MAP_EXTENSIONS);
     smallMapImage =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/MapImage.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/MapImage.java
@@ -52,8 +52,6 @@ public class MapImage {
 
   private BufferedImage smallMapImage;
 
-
-
   public static Font getPropertyMapFont() {
     if (propertyMapFont == null) {
       final Preferences pref = Preferences.userNodeForPackage(MapImage.class);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/MissingImageException.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/MissingImageException.java
@@ -1,16 +1,27 @@
 package games.strategy.triplea.image;
 
 import games.strategy.triplea.image.UnitImageFactory.ImageKey;
+import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.util.UnitCategory;
 
 public class MissingImageException extends RuntimeException {
   private static final long serialVersionUID = -1278382391054838356L;
 
   public MissingImageException(final UnitCategory unitCategory) {
-    super("Missing image for: " + unitCategory.getOwner() + ":" + unitCategory.getType());
+    super(
+        "Missing image for: "
+            + unitCategory.getOwner()
+            + ":"
+            + unitCategory.getType()
+            + ", search folders: "
+            + UiContext.getResourceLoader().getAssetPaths());
   }
 
   public MissingImageException(final ImageKey imageKey) {
-    super("Missing image: " + imageKey);
+    super(
+        "Missing image: "
+            + imageKey
+            + ", search folders: "
+            + UiContext.getResourceLoader().getAssetPaths());
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/TileImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/TileImageFactory.java
@@ -206,7 +206,7 @@ public final class TileImageFactory {
 
     // This does the blend
     final float alpha = getShowMapBlendAlpha();
-    if (reliefFile == null) {
+    if (reliefFile == null && urlBlankRelief != null) {
       try {
         reliefFile = loadCompatibleImage(urlBlankRelief);
       } catch (final IOException e) {
@@ -214,7 +214,7 @@ public final class TileImageFactory {
       }
     }
     // This fixes the blank land territories
-    if (baseFile == null) {
+    if (baseFile == null && reliefFile != null) {
       baseFile = makeMissingBaseTile(reliefFile);
     }
     /* reversing the to/from files leaves white underlays visible */

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TooltipProperties.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TooltipProperties.java
@@ -24,8 +24,7 @@ public final class TooltipProperties extends PropertyFile {
 
     final String customTip = getToolTip(unitType, gamePlayer, false);
     if (!customTip.isEmpty()) {
-      return LocalizeHtml.localizeImgLinksInHtml(
-          customTip, UiContext.getResourceLoader().getMapLocation());
+      return LocalizeHtml.localizeImgLinksInHtml(customTip, UiContext.getMapLocation());
     }
     final String generated =
         UnitAttachment.get(unitType)
@@ -34,8 +33,7 @@ public final class TooltipProperties extends PropertyFile {
     final String appendedTip = getToolTip(unitType, gamePlayer, true);
     if (!appendedTip.isEmpty()) {
       return generated
-          + LocalizeHtml.localizeImgLinksInHtml(
-              appendedTip, UiContext.getResourceLoader().getMapLocation());
+          + LocalizeHtml.localizeImgLinksInHtml(appendedTip, UiContext.getMapLocation());
     }
     return generated;
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -918,8 +918,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
   /** We do NOT want to block the next player from beginning their turn. */
   public void notifyError(final String message) {
     final String displayMessage =
-        LocalizeHtml.localizeImgLinksInHtml(
-            message, UiContext.getResourceLoader().getMapLocation());
+        LocalizeHtml.localizeImgLinksInHtml(message, UiContext.getMapLocation());
     messageAndDialogThreadPool.submit(
         () ->
             EventThreadJOptionPane.showMessageDialogWithScrollPane(
@@ -955,8 +954,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
       return;
     }
     final String displayMessage =
-        LocalizeHtml.localizeImgLinksInHtml(
-            message, UiContext.getResourceLoader().getMapLocation());
+        LocalizeHtml.localizeImgLinksInHtml(message, UiContext.getMapLocation());
     messageAndDialogThreadPool.submit(
         () ->
             EventThreadJOptionPane.showMessageDialogWithScrollPane(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -126,7 +126,7 @@ public class UiContext {
       resourceLoader.close();
     }
     resourceLoader = new ResourceLoader(resourceLoadingPaths);
-    mapData = new MapData(mapPath);
+    mapData = new MapData(resourceLoader);
     // DiceImageFactory needs loader and game data
     diceImageFactory = new DiceImageFactory(resourceLoader, data.getDiceSides());
     final double unitScale =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -73,7 +73,7 @@ public class UiContext {
   private final ResourceImageFactory resourceImageFactory = new ResourceImageFactory();
   private final TerritoryEffectImageFactory territoryEffectImageFactory =
       new TerritoryEffectImageFactory();
-  private final MapImage mapImage = new MapImage();
+  private final MapImage mapImage;
   private final UnitIconImageFactory unitIconImageFactory = new UnitIconImageFactory();
   private final FlagIconImageFactory flagIconImageFactory = new FlagIconImageFactory();
   private DiceImageFactory diceImageFactory;
@@ -127,22 +127,19 @@ public class UiContext {
     }
     resourceLoader = new ResourceLoader(resourceLoadingPaths);
     mapData = new MapData(resourceLoader);
-    // DiceImageFactory needs loader and game data
     diceImageFactory = new DiceImageFactory(resourceLoader, data.getDiceSides());
     final double unitScale =
         getPreferencesMapOrSkin(data.getMapName())
             .getDouble(UNIT_SCALE_PREF, mapData.getDefaultUnitScale());
     scale = getPreferencesMapOrSkin(data.getMapName()).getDouble(MAP_SCALE_PREF, 1);
     unitImageFactory = new UnitImageFactory(resourceLoader, unitScale, mapData);
-    // TODO: separate scale for resources
     resourceImageFactory.setResourceLoader(resourceLoader);
     territoryEffectImageFactory.setResourceLoader(resourceLoader);
     unitIconImageFactory.setResourceLoader(resourceLoader);
     flagIconImageFactory.setResourceLoader(resourceLoader);
     puImageFactory.setResourceLoader(resourceLoader);
     tileImageFactory.setResourceLoader(resourceLoader);
-    // load map data
-    mapImage.loadMaps(resourceLoader);
+    mapImage = new MapImage(resourceLoader);
     drawTerritoryEffects = mapData.useTerritoryEffectMarkers();
     // change the resource loader (this allows us to play sounds the map folder, rather than just
     // default sounds)

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -89,7 +89,12 @@ public class UiContext {
   private final List<Runnable> activeToDeactivate = new ArrayList<>();
   private final CountDownLatchHandler latchesToCloseOnShutdown = new CountDownLatchHandler(false);
 
-  public static void setResourceLoader(final Path mapPath) {
+  public static void setResourceLoader(final GameData gameData) {
+    final Path mapPath =
+        InstalledMapsListing.searchAllMapsForMapName(gameData.getMapName())
+            .orElseThrow(
+                () -> new IllegalStateException("Unable to find map: " + gameData.getMapName()));
+
     resourceLoader = new ResourceLoader(mapPath);
     mapLocation = mapPath;
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -116,17 +116,16 @@ public class UiContext {
             resourceLoadingPaths::add,
             () -> getPreferencesForMap(data.getMapName()).remove(MAP_SKIN_PREF));
 
-    if (resourceLoader != null) {
-      resourceLoader.close();
-    }
-
     Path mapPath =
         InstalledMapsListing.searchAllMapsForMapName(data.getMapName())
             .orElseThrow(() -> new MapNotFoundException(data.getMapName()));
-
-    resourceLoadingPaths.add(mapPath);
-    resourceLoader = new ResourceLoader(resourceLoadingPaths);
     mapLocation = mapPath;
+    resourceLoadingPaths.add(mapPath);
+
+    if (resourceLoader != null) {
+      resourceLoader.close();
+    }
+    resourceLoader = new ResourceLoader(resourceLoadingPaths);
     mapData = new MapData(mapPath);
     // DiceImageFactory needs loader and game data
     diceImageFactory = new DiceImageFactory(resourceLoader, data.getDiceSides());

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -67,7 +67,7 @@ public class UiContext {
   protected MapData mapData;
   @Getter @Setter protected LocalPlayers localPlayers;
 
-  @Getter protected double scale = 1;
+  @Getter protected double scale;
   private final TileImageFactory tileImageFactory = new TileImageFactory();
   private UnitImageFactory unitImageFactory;
   private final ResourceImageFactory resourceImageFactory = new ResourceImageFactory();
@@ -76,12 +76,12 @@ public class UiContext {
   private final MapImage mapImage;
   private final UnitIconImageFactory unitIconImageFactory = new UnitIconImageFactory();
   private final FlagIconImageFactory flagIconImageFactory = new FlagIconImageFactory();
-  private DiceImageFactory diceImageFactory;
+  private final DiceImageFactory diceImageFactory;
   private final PuImageFactory puImageFactory = new PuImageFactory();
   private boolean drawUnits = true;
-  private boolean drawTerritoryEffects = false;
+  private boolean drawTerritoryEffects;
 
-  @Getter private Cursor cursor = Cursor.getDefaultCursor();
+  @Getter private Cursor cursor;
 
   @Getter private boolean isShutDown = false;
 
@@ -131,7 +131,7 @@ public class UiContext {
     final double unitScale =
         getPreferencesMapOrSkin(data.getMapName())
             .getDouble(UNIT_SCALE_PREF, mapData.getDefaultUnitScale());
-    scale = getPreferencesMapOrSkin(data.getMapName()).getDouble(MAP_SCALE_PREF, 1);
+    scale = getPreferencesMapOrSkin(data.getMapName()).getDouble(MAP_SCALE_PREF, 1.0);
     unitImageFactory = new UnitImageFactory(resourceLoader, unitScale, mapData);
     resourceImageFactory.setResourceLoader(resourceLoader);
     territoryEffectImageFactory.setResourceLoader(resourceLoader);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -111,7 +111,8 @@ public class UiContext {
         getPreferencesForMap(data.getMapName()) //
             .get(MAP_SKIN_PREF, null);
 
-    InstalledMapsListing.findMapSkin(data.getMapName(), preferredSkinPath)
+    InstalledMapsListing.parseMapFiles()
+        .findMapSkin(data.getMapName(), preferredSkinPath)
         .ifPresentOrElse(
             resourceLoadingPaths::add,
             () -> getPreferencesForMap(data.getMapName()).remove(MAP_SKIN_PREF));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -52,6 +52,7 @@ import org.triplea.sound.ClipPlayer;
 @Slf4j
 public class UiContext {
   @Getter protected static String mapName;
+  @Getter protected static Path mapLocation;
   @Getter protected static ResourceLoader resourceLoader;
 
   static final String UNIT_SCALE_PREF = "UnitScale";
@@ -90,6 +91,7 @@ public class UiContext {
 
   public static void setResourceLoader(final Path mapPath) {
     resourceLoader = new ResourceLoader(mapPath);
+    mapLocation = mapPath;
   }
 
   UiContext(final GameData data) {
@@ -128,6 +130,7 @@ public class UiContext {
             .orElseThrow(() -> new MapNotFoundException(mapName));
 
     resourceLoader = new ResourceLoader(mapPath);
+    mapLocation = mapPath;
     mapData = new MapData(mapPath);
     UiContext.mapName = mapName;
     // DiceImageFactory needs loader and game data

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -5,6 +5,7 @@ import games.strategy.engine.data.GameState;
 import games.strategy.engine.data.Territory;
 import games.strategy.triplea.ResourceLoader;
 import games.strategy.triplea.image.UnitImageFactory;
+import games.strategy.triplea.ui.UiContext;
 import games.strategy.ui.Util;
 import java.awt.Color;
 import java.awt.Dimension;
@@ -129,53 +130,43 @@ public class MapData {
   @Nullable private final Image blockadeImage;
   @Nullable private final Image errorImage;
   @Nullable private final Image warningImage;
-  private final Path mapPath;
 
-  public MapData(final Path mapPath) {
-    this.mapPath = mapPath;
-    try (ResourceLoader loader = new ResourceLoader(mapPath)) {
-      try {
-        if (loader.getResource(POLYGON_FILE) == null) {
-          throw new IllegalStateException(
-              String.format(
-                  "Error loading map: %s. Unable to load file: %s", mapPath, POLYGON_FILE));
-        }
+  public MapData(final ResourceLoader loader) {
+    try {
+      place.putAll(readOptionalPlacementsOneToMany(loader, PLACEMENT_FILE));
+      territoryEffects.putAll(readOptionalPointsOneToMany(loader, TERRITORY_EFFECT_FILE));
 
-        place.putAll(readOptionalPlacementsOneToMany(loader, PLACEMENT_FILE));
-        territoryEffects.putAll(readOptionalPointsOneToMany(loader, TERRITORY_EFFECT_FILE));
+      polys.putAll(
+          PointFileReaderWriter.readOneToManyPolygons(loader.requiredResource(POLYGON_FILE)));
+      centers.putAll(PointFileReaderWriter.readOneToOne(loader.requiredResource(CENTERS_FILE)));
+      vcPlace.putAll(readOptionalPointsOneToOne(loader, VC_MARKERS));
+      convoyPlace.putAll(readOptionalPointsOneToOne(loader, CONVOY_MARKERS));
+      commentPlace.putAll(readOptionalPointsOneToOne(loader, COMMENT_MARKERS));
+      blockadePlace.putAll(readOptionalPointsOneToOne(loader, BLOCKADE_MARKERS));
+      capitolPlace.putAll(readOptionalPointsOneToOne(loader, CAPITAL_MARKERS));
+      puPlace.putAll(readOptionalPointsOneToOne(loader, PU_PLACE_FILE));
+      namePlace.putAll(readOptionalPointsOneToOne(loader, TERRITORY_NAME_PLACE_FILE));
+      kamikazePlace.putAll(readOptionalPointsOneToOne(loader, KAMIKAZE_FILE));
+      decorations.putAll(loadDecorations(loader));
+      territoryNameImages.putAll(territoryNameImages(loader));
 
-        polys.putAll(
-            PointFileReaderWriter.readOneToManyPolygons(loader.requiredResource(POLYGON_FILE)));
-        centers.putAll(PointFileReaderWriter.readOneToOne(loader.requiredResource(CENTERS_FILE)));
-        vcPlace.putAll(readOptionalPointsOneToOne(loader, VC_MARKERS));
-        convoyPlace.putAll(readOptionalPointsOneToOne(loader, CONVOY_MARKERS));
-        commentPlace.putAll(readOptionalPointsOneToOne(loader, COMMENT_MARKERS));
-        blockadePlace.putAll(readOptionalPointsOneToOne(loader, BLOCKADE_MARKERS));
-        capitolPlace.putAll(readOptionalPointsOneToOne(loader, CAPITAL_MARKERS));
-        puPlace.putAll(readOptionalPointsOneToOne(loader, PU_PLACE_FILE));
-        namePlace.putAll(readOptionalPointsOneToOne(loader, TERRITORY_NAME_PLACE_FILE));
-        kamikazePlace.putAll(readOptionalPointsOneToOne(loader, KAMIKAZE_FILE));
-        decorations.putAll(loadDecorations(loader));
-        territoryNameImages.putAll(territoryNameImages(loader));
-
-        try (InputStream inputStream =
-            Files.newInputStream(loader.requiredResource(MAP_PROPERTIES))) {
-          mapProperties.load(inputStream);
-        } catch (final Exception e) {
-          log.error("Error reading map.properties", e);
-        }
-
-        contains.putAll(IslandTerritoryFinder.findIslands(polys));
-      } catch (final IOException ex) {
-        log.error("Failed to initialize map data", ex);
+      try (InputStream inputStream =
+          Files.newInputStream(loader.requiredResource(MAP_PROPERTIES))) {
+        mapProperties.load(inputStream);
+      } catch (final Exception e) {
+        log.warn("Error reading map.properties, {}", e.getMessage(), e);
       }
 
-      playerColors = new PlayerColors(mapProperties);
-      vcImage = loader.loadImage("misc/vc.png").orElse(null);
-      blockadeImage = loader.loadImage("misc/blockade.png").orElse(null);
-      errorImage = loader.loadImage("misc/error.gif").orElse(null);
-      warningImage = loader.loadImage("misc/warning.gif").orElse(null);
+      contains.putAll(IslandTerritoryFinder.findIslands(polys));
+    } catch (final IOException ex) {
+      log.warn("Failed to initialize map data: {}", ex.getMessage(), ex);
     }
+
+    playerColors = new PlayerColors(mapProperties);
+    vcImage = loader.loadImage("misc/vc.png").orElse(null);
+    blockadeImage = loader.loadImage("misc/blockade.png").orElse(null);
+    errorImage = loader.loadImage("misc/error.gif").orElse(null);
+    warningImage = loader.loadImage("misc/warning.gif").orElse(null);
   }
 
   private static Map<String, Point> readOptionalPointsOneToOne(
@@ -763,18 +754,17 @@ public class MapData {
   }
 
   public Optional<Image> getTerritoryEffectImage(final String effectName) {
-    try (ResourceLoader loader = new ResourceLoader(mapPath)) {
-      // TODO: what does this cache buy us? should we still keep it?
-      if (effectImages.get(effectName) != null) {
-        return Optional.of(effectImages.get(effectName));
-      }
-      Optional<Image> effectImage =
-          loader.loadImage("territoryEffects/" + effectName + "_large.png");
-      if (effectImage.isEmpty()) {
-        effectImage = loader.loadImage("territoryEffects/" + effectName + ".png");
-      }
-      effectImages.put(effectName, effectImage.orElse(null));
-      return effectImage;
+    if (effectImages.get(effectName) != null) {
+      return Optional.of(effectImages.get(effectName));
     }
+    String largeImageName = "territoryEffects/" + effectName + "_large.png";
+    String standardImageName = "territoryEffects/" + effectName + ".png";
+    Image effectImage =
+        UiContext.getResourceLoader()
+            .loadImage(largeImageName)
+            .or(() -> UiContext.getResourceLoader().loadImage(standardImageName))
+            .orElse(null);
+    effectImages.put(effectName, effectImage);
+    return Optional.ofNullable(effectImage);
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -754,17 +754,17 @@ public class MapData {
   }
 
   public Optional<Image> getTerritoryEffectImage(final String effectName) {
-    if (effectImages.get(effectName) != null) {
-      return Optional.of(effectImages.get(effectName));
-    }
-    String largeImageName = "territoryEffects/" + effectName + "_large.png";
-    String standardImageName = "territoryEffects/" + effectName + ".png";
-    Image effectImage =
-        UiContext.getResourceLoader()
-            .loadImage(largeImageName)
-            .or(() -> UiContext.getResourceLoader().loadImage(standardImageName))
-            .orElse(null);
-    effectImages.put(effectName, effectImage);
-    return Optional.ofNullable(effectImage);
+    return Optional.ofNullable(
+        effectImages.computeIfAbsent(
+            effectName,
+            key -> {
+              String largeImageName = "territoryEffects/" + effectName + "_large.png";
+              String standardImageName = "territoryEffects/" + effectName + ".png";
+
+              return UiContext.getResourceLoader()
+                  .loadImage(largeImageName)
+                  .or(() -> UiContext.getResourceLoader().loadImage(standardImageName))
+                  .orElse(null);
+            }));
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -79,7 +79,9 @@ final class ViewMenu extends JMenu {
     if (uiContext.getMapData().useTerritoryEffectMarkers()) {
       addShowTerritoryEffects();
     }
-    addMapSkinsMenu();
+    if (ClientSetting.showBetaFeatures.getValueOrThrow()) {
+      addMapSkinsMenu();
+    }
     addShowMapDetails();
     addShowMapBlends();
     addMapFontAndColorEditorMenu();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/GameNotesMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/GameNotesMenu.java
@@ -42,8 +42,7 @@ class GameNotesMenu {
 
   private static JComponent notesPanel(final String gameNotes) {
     final String localizedHtml =
-        LocalizeHtml.localizeImgLinksInHtml(
-            gameNotes.trim(), UiContext.getResourceLoader().getMapLocation());
+        LocalizeHtml.localizeImgLinksInHtml(gameNotes.trim(), UiContext.getMapLocation());
 
     final JEditorPane gameNotesPane = new JEditorPane("text/html", localizedHtml);
     gameNotesPane.setEditable(false);

--- a/game-app/game-core/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
+++ b/game-app/game-core/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
@@ -6,7 +6,6 @@ import games.strategy.engine.framework.HeadlessAutoSaveFileUtils;
 import games.strategy.engine.framework.IGame;
 import games.strategy.engine.framework.LocalPlayers;
 import games.strategy.engine.framework.ServerGame;
-import games.strategy.engine.framework.map.file.system.loader.InstalledMapsListing;
 import games.strategy.engine.framework.startup.launcher.LaunchAction;
 import games.strategy.engine.framework.startup.mc.ServerModel;
 import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorModel;

--- a/game-app/game-core/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
+++ b/game-app/game-core/src/main/java/org/triplea/game/server/HeadlessLaunchAction.java
@@ -53,13 +53,7 @@ public class HeadlessLaunchAction implements LaunchAction {
       final Set<Player> players,
       final Chat chat) {
 
-    Path mapPath =
-        InstalledMapsListing.searchAllMapsForMapName(game.getData().getMapName())
-            .orElseThrow(
-                () ->
-                    new IllegalStateException(
-                        "Unable to find map: " + game.getData().getMapName()));
-    UiContext.setResourceLoader(mapPath);
+    UiContext.setResourceLoader(game.getData());
     return new HeadlessDisplay();
   }
 

--- a/game-app/game-core/src/main/java/org/triplea/sound/ClipPlayer.java
+++ b/game-app/game-core/src/main/java/org/triplea/sound/ClipPlayer.java
@@ -230,7 +230,7 @@ public class ClipPlayer {
   public static void play(final String clipPath, final GamePlayer gamePlayer) {
     synchronized (ClipPlayer.class) {
       if (clipPlayer == null) {
-        clipPlayer = new ClipPlayer(ResourceLoader.getGameEngineAssetLoader());
+        clipPlayer = new ClipPlayer(new ResourceLoader(Path.of("sounds")));
       }
     }
     clipPlayer.playClip(clipPath, gamePlayer);

--- a/game-app/game-core/src/main/java/tools/image/AutoPlacementFinder.java
+++ b/game-app/game-core/src/main/java/tools/image/AutoPlacementFinder.java
@@ -3,6 +3,7 @@ package tools.image;
 import static com.google.common.base.Preconditions.checkState;
 
 import games.strategy.engine.ClientFileSystemHelper;
+import games.strategy.triplea.ResourceLoader;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.ui.mapdata.MapData;
 import java.awt.Point;
@@ -250,7 +251,7 @@ public final class AutoPlacementFinder {
         "Place Dimensions in pixels, being used: " + placeWidth + "x" + placeHeight + "\r\n");
     textOptionPane.appendNewLine("Calculating, this may take a while...\r\n");
     final Map<String, List<Point>> placements = new HashMap<>();
-    final MapData mapData = new MapData(mapFolderLocation);
+    final MapData mapData = new MapData(new ResourceLoader(mapFolderLocation));
     for (final String name : mapData.getTerritories()) {
       final Set<Polygon> containedPolygons = mapData.getContainedTerritoryPolygons(name);
       final List<Point> points =

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadMapsWindowMapsListingTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/map/download/DownloadMapsWindowMapsListingTest.java
@@ -102,7 +102,7 @@ class DownloadMapsWindowMapsListingTest extends AbstractClientSettingTestCase {
                         .lastModifiedDate(Instant.ofEpochMilli(entry.getValue()))
                         .mapDescriptionYaml(
                             MapDescriptionYaml.builder()
-                                .yamlFileLocation(Path.of("/local/file").toUri())
+                                .yamlFileLocation(Path.of("/local/file"))
                                 .mapName(entry.getKey())
                                 .mapGameList(
                                     List.of(

--- a/game-app/game-core/src/test/java/games/strategy/engine/framework/map/file/system/loader/InstalledMapsListingTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/framework/map/file/system/loader/InstalledMapsListingTest.java
@@ -26,7 +26,7 @@ class InstalledMapsListingTest {
               InstalledMap.builder()
                   .mapDescriptionYaml(
                       MapDescriptionYaml.builder()
-                          .yamlFileLocation(Path.of("/path/map0/map.yml").toUri())
+                          .yamlFileLocation(Path.of("/path/map0/map.yml"))
                           .mapName("map-name0")
                           .game(
                               MapDescriptionYaml.MapGame.builder()
@@ -39,7 +39,7 @@ class InstalledMapsListingTest {
               InstalledMap.builder()
                   .mapDescriptionYaml(
                       MapDescriptionYaml.builder()
-                          .yamlFileLocation(Path.of("/path/map1/map.yml").toUri())
+                          .yamlFileLocation(Path.of("/path/map1/map.yml"))
                           .mapName("map-name1")
                           .game(
                               MapDescriptionYaml.MapGame.builder()

--- a/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYaml.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYaml.java
@@ -210,7 +210,7 @@ public class MapDescriptionYaml {
   /** Find 'games' folder starting from map.yml parent folder. */
   private Optional<Path> findGamesFolder() {
     final Path mapFolder = yamlFileLocation.getParent();
-    final Optional<Path> gamesFolder = FileUtils.find(mapFolder, 5, "games");
+    final Optional<Path> gamesFolder = FileUtils.findOne(mapFolder, 5, "games");
 
     if (gamesFolder.isEmpty()) {
       log.warn("No 'games' folder found under location: {}", mapFolder.toAbsolutePath());
@@ -220,7 +220,7 @@ public class MapDescriptionYaml {
 
   /** Search 'games' folder for a game-xml-file. */
   private Optional<Path> searchForGameFile(final Path gamesFolder, final String xmlFileName) {
-    final Optional<Path> gameFile = FileUtils.find(gamesFolder, 3, xmlFileName);
+    final Optional<Path> gameFile = FileUtils.findOne(gamesFolder, 3, xmlFileName);
     if (gameFile.isEmpty()) {
       log.warn(
           "Failed to find game file: {}, within directory tree rooted at: {}",

--- a/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYaml.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYaml.java
@@ -2,7 +2,6 @@ package org.triplea.map.description.file;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -47,7 +46,9 @@ public class MapDescriptionYaml {
   private static final int MAX_GAME_NAME_LENGTH = 70;
   private static final int MAX_MAP_NAME_LENGTH = 70;
 
-  @Nonnull private final URI yamlFileLocation;
+  /** The location on disk where we read this 'map description yaml' data. */
+  @Nonnull private final Path yamlFileLocation;
+
   @Nonnull private final String mapName;
 
   @Singular(value = "game")
@@ -208,7 +209,7 @@ public class MapDescriptionYaml {
 
   /** Find 'games' folder starting from map.yml parent folder. */
   private Optional<Path> findGamesFolder() {
-    final Path mapFolder = Path.of(yamlFileLocation).getParent();
+    final Path mapFolder = yamlFileLocation.getParent();
     final Optional<Path> gamesFolder = FileUtils.find(mapFolder, 5, "games");
 
     if (gamesFolder.isEmpty()) {

--- a/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYaml.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYaml.java
@@ -210,7 +210,7 @@ public class MapDescriptionYaml {
   /** Find 'games' folder starting from map.yml parent folder. */
   private Optional<Path> findGamesFolder() {
     final Path mapFolder = yamlFileLocation.getParent();
-    final Optional<Path> gamesFolder = FileUtils.findOne(mapFolder, 5, "games");
+    final Optional<Path> gamesFolder = FileUtils.findAny(mapFolder, 5, "games");
 
     if (gamesFolder.isEmpty()) {
       log.warn("No 'games' folder found under location: {}", mapFolder.toAbsolutePath());
@@ -220,7 +220,7 @@ public class MapDescriptionYaml {
 
   /** Search 'games' folder for a game-xml-file. */
   private Optional<Path> searchForGameFile(final Path gamesFolder, final String xmlFileName) {
-    final Optional<Path> gameFile = FileUtils.findOne(gamesFolder, 3, xmlFileName);
+    final Optional<Path> gameFile = FileUtils.findAny(gamesFolder, 3, xmlFileName);
     if (gameFile.isEmpty()) {
       log.warn(
           "Failed to find game file: {}, within directory tree rooted at: {}",

--- a/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYamlGenerator.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYamlGenerator.java
@@ -57,7 +57,7 @@ class MapDescriptionYamlGenerator {
 
     final MapDescriptionYaml mapDescriptionYaml =
         MapDescriptionYaml.builder()
-            .yamlFileLocation(mapYmlTargetFileLocation.toUri())
+            .yamlFileLocation(mapYmlTargetFileLocation)
             .mapName(mapName)
             .mapGameList(games)
             .build();

--- a/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYamlReader.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYamlReader.java
@@ -37,7 +37,8 @@ class MapDescriptionYamlReader {
      * 'map.yml' file at depth 2, eg: 'map_folder-master/map_folder/map/map.yml'.
      */
     final int maxMapYmlSearchDepth = 2;
-    return FileUtils.find(mapFolder, maxMapYmlSearchDepth, MapDescriptionYaml.MAP_YAML_FILE_NAME);
+    return FileUtils.findOne(
+        mapFolder, maxMapYmlSearchDepth, MapDescriptionYaml.MAP_YAML_FILE_NAME);
   }
 
   /** Factory method, finds the map.yml file in a folder and reads it. */

--- a/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYamlReader.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYamlReader.java
@@ -37,7 +37,7 @@ class MapDescriptionYamlReader {
      * 'map.yml' file at depth 2, eg: 'map_folder-master/map_folder/map/map.yml'.
      */
     final int maxMapYmlSearchDepth = 2;
-    return FileUtils.findOne(
+    return FileUtils.findAny(
         mapFolder, maxMapYmlSearchDepth, MapDescriptionYaml.MAP_YAML_FILE_NAME);
   }
 

--- a/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYamlReader.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYamlReader.java
@@ -56,7 +56,7 @@ class MapDescriptionYamlReader {
       final Map<String, Object> yamlData = YamlReader.readMap(inputStream);
       final MapDescriptionYaml mapDescriptionYaml =
           MapDescriptionYaml.builder()
-              .yamlFileLocation(ymlFile.toUri())
+              .yamlFileLocation(ymlFile)
               .mapName(Strings.nullToEmpty((String) yamlData.get(MAP_NAME)))
               .mapGameList(parseGameList(yamlData))
               .build();

--- a/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYamlWriter.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/description/file/MapDescriptionYamlWriter.java
@@ -22,7 +22,7 @@ class MapDescriptionYamlWriter {
   static Optional<Path> writeYmlPojoToFile(final MapDescriptionYaml mapDescriptionYaml) {
 
     final String yamlString = toYamlString(mapDescriptionYaml);
-    final Path mapYmlTargetPath = Path.of(mapDescriptionYaml.getYamlFileLocation());
+    final Path mapYmlTargetPath = mapDescriptionYaml.getYamlFileLocation();
 
     try {
       Files.writeString(mapYmlTargetPath, yamlString);

--- a/game-app/map-data/src/main/java/org/triplea/map/description/file/SkinDescriptionYaml.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/description/file/SkinDescriptionYaml.java
@@ -1,0 +1,38 @@
+package org.triplea.map.description.file;
+
+import java.io.InputStream;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nonnull;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import org.triplea.io.FileUtils;
+import org.triplea.yaml.YamlReader;
+
+@Builder(access = AccessLevel.PRIVATE)
+@Getter
+public class SkinDescriptionYaml {
+  @Nonnull private final Path filePath;
+  @Nonnull private final String skinName;
+
+  public static Optional<SkinDescriptionYaml> readSkinDescriptionYamlFile(Path skinYamlPath) {
+    return FileUtils.openInputStream(skinYamlPath, inputStream -> parse(skinYamlPath, inputStream));
+  }
+
+  private static Optional<SkinDescriptionYaml> parse(Path filePath, InputStream inputStream) {
+    final Map<String, Object> yamlData = YamlReader.readMap(inputStream);
+
+    // TODO: validation that we read a valid yaml file, warn the user if we did not find
+    // 'skin_name'!!
+
+    return Optional.ofNullable(String.valueOf(yamlData.get("skin_name")))
+        .map(
+            skinName ->
+                SkinDescriptionYaml.builder() //
+                    .filePath(filePath)
+                    .skinName(skinName)
+                    .build());
+  }
+}

--- a/game-app/map-data/src/test/java/org/triplea/map/description/file/MapDescriptionYamlTest.java
+++ b/game-app/map-data/src/test/java/org/triplea/map/description/file/MapDescriptionYamlTest.java
@@ -24,7 +24,7 @@ class MapDescriptionYamlTest {
   static List<MapDescriptionYaml> isValid() {
     return List.of(
         MapDescriptionYaml.builder()
-            .yamlFileLocation(Path.of("/path/on/disk/map.yml").toUri())
+            .yamlFileLocation(Path.of("/path/on/disk/map.yml"))
             .mapName("map name")
             .mapGameList(
                 List.of(
@@ -57,7 +57,7 @@ class MapDescriptionYamlTest {
   void findGameNameFromXmlFileName_PositiveCase() {
     final MapDescriptionYaml mapDescriptionYaml =
         MapDescriptionYaml.builder()
-            .yamlFileLocation(Path.of("/path/on/disk/map.yml").toUri())
+            .yamlFileLocation(Path.of("/path/on/disk/map.yml"))
             .mapName("map name")
             .mapGameList(
                 List.of(
@@ -77,7 +77,7 @@ class MapDescriptionYamlTest {
   void findGameNameFromXmlFileName_NegativeCase() {
     final MapDescriptionYaml mapDescriptionYaml =
         MapDescriptionYaml.builder()
-            .yamlFileLocation(Path.of("/path/on/disk/map.yml").toUri())
+            .yamlFileLocation(Path.of("/path/on/disk/map.yml"))
             .mapName("map name")
             .mapGameList(
                 List.of(

--- a/lib/java-extras/src/main/java/org/triplea/io/FileUtils.java
+++ b/lib/java-extras/src/main/java/org/triplea/io/FileUtils.java
@@ -82,7 +82,7 @@ public final class FileUtils {
    * @param fileName The name of the file to be search for.
    * @return A file matching the given name or empty if not found.
    */
-  public Optional<Path> findOne(final Path searchRoot, final int maxDepth, final String fileName) {
+  public Optional<Path> findAny(final Path searchRoot, final int maxDepth, final String fileName) {
     return find(searchRoot, maxDepth, fileName).stream().findAny();
   }
 

--- a/lib/java-extras/src/main/java/org/triplea/io/FileUtils.java
+++ b/lib/java-extras/src/main/java/org/triplea/io/FileUtils.java
@@ -82,17 +82,23 @@ public final class FileUtils {
    * @param fileName The name of the file to be search for.
    * @return A file matching the given name or empty if not found.
    */
-  public Optional<Path> find(final Path searchRoot, final int maxDepth, final String fileName) {
+  public Optional<Path> findOne(final Path searchRoot, final int maxDepth, final String fileName) {
+    return find(searchRoot, maxDepth, fileName).stream().findAny();
+  }
+
+  public Collection<Path> find(final Path searchRoot, final int maxDepth, final String fileName) {
     Preconditions.checkArgument(Files.isDirectory(searchRoot), searchRoot.toAbsolutePath());
     Preconditions.checkArgument(Files.exists(searchRoot), searchRoot.toAbsolutePath());
     Preconditions.checkArgument(maxDepth > -1);
     Preconditions.checkArgument(!fileName.isBlank());
     try (Stream<Path> files = Files.walk(searchRoot, maxDepth)) {
-      return files.filter(f -> f.getFileName().toString().equals(fileName)).findAny();
+      return files
+          .filter(f -> f.getFileName().toString().equals(fileName))
+          .collect(Collectors.toList());
     } catch (final IOException e) {
       log.error(
           "Unable to access files in: " + searchRoot.toAbsolutePath() + ", " + e.getMessage(), e);
-      return Optional.empty();
+      return List.of();
     }
   }
 

--- a/lib/java-extras/src/main/java/org/triplea/io/PathUtils.java
+++ b/lib/java-extras/src/main/java/org/triplea/io/PathUtils.java
@@ -1,0 +1,20 @@
+package org.triplea.io;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.nio.file.Path;
+import lombok.experimental.UtilityClass;
+
+/** Util class to wrap & simplify interactions with {@code java.nio.file.Path} */
+@UtilityClass
+public class PathUtils {
+
+  public URL toUrl(Path path) {
+    try {
+      return path.toUri().toURL();
+    } catch (final MalformedURLException e) {
+      throw new IllegalArgumentException(
+          String.format("Error creating file system path: %s, %s", path, e.getMessage()), e);
+    }
+  }
+}


### PR DESCRIPTION
## Change Summary & Additional Notes

An incomplete update to try and get map skins working again. Notable changes:
- map skin functionality is placed behind the beta feature flag
- map skins are now additive to the base map. Meaning if a map skin is missing an image, we'll default to the original map and then to the game engine.
- map skins are detected via the presence of a 'skin.yml' file and are located within a map
- missing unit image warning message will now print out search paths
- removed an invocation to 'parse all maps' when rendering territory effects, this could improve performance

Next Steps:
- ResourceLoader when changed mid-game does not update cleanly. This needs to be fixed up for map skins to be brought back out from the 'beta' feature flag. 


<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
