### PR TITLE
Resource loading/remove image factory cache

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/ImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/ImageFactory.java
@@ -4,8 +4,6 @@ import games.strategy.triplea.ResourceLoader;
 import java.awt.Image;
 import java.io.IOException;
 import java.net.URL;
-import java.util.HashMap;
-import java.util.Map;
 import javax.imageio.ImageIO;
 
 /**
@@ -15,12 +13,10 @@ import javax.imageio.ImageIO;
  * the EDT.
  */
 public class ImageFactory {
-  private final Map<String, Image> images = new HashMap<>();
   private ResourceLoader resourceLoader;
 
   public void setResourceLoader(final ResourceLoader loader) {
     resourceLoader = loader;
-    images.clear();
   }
 
   protected Image getImage(final String key1, final String key2, final boolean throwIfNotFound) {
@@ -32,21 +28,17 @@ public class ImageFactory {
   }
 
   protected Image getImage(final String key, final boolean throwIfNotFound) {
-    if (!images.containsKey(key) || (throwIfNotFound && images.get(key) == null)) {
-      final URL url = resourceLoader.getResource(key);
-      if (url == null) {
-        if (throwIfNotFound) {
-          throw new IllegalStateException("Image Not Found:" + key);
-        }
-        images.put(key, null);
-        return null;
+    final URL url = resourceLoader.getResource(key);
+    if (url == null) {
+      if (throwIfNotFound) {
+        throw new IllegalStateException("Image Not Found:" + key);
       }
-      try {
-        images.put(key, ImageIO.read(url));
-      } catch (final IOException e) {
-        throw new IllegalStateException(e);
-      }
+      return null;
     }
-    return images.get(key);
+    try {
+      return ImageIO.read(url);
+    } catch (final IOException e) {
+      throw new IllegalStateException(e);
+    }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/ImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/ImageFactory.java
@@ -36,6 +36,8 @@ public class ImageFactory {
       return null;
     }
     try {
+      // use cache refers whether to "use a disk based cache" or to use a memory based cache
+      ImageIO.setUseCache(false);
       return ImageIO.read(url);
     } catch (final IOException e) {
       throw new IllegalStateException(e);


### PR DESCRIPTION
## Change Summary & Additional Notes

ImageIO already provides us a cache. This update removes the cache in ImageFactory and toggles ImageIO to use a memory based cache (instead of a file & disk based cache, which is otherwise default).
<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
