### PR TITLE
Refactor getImage APIs to be var-arg

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/DiceImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/DiceImageFactory.java
@@ -57,7 +57,7 @@ public class DiceImageFactory {
       final Color color,
       final int dieSide) {
     if (loader != null) {
-      final Image image = factory.getImage(getDiceResourceName(color, dieSide), false);
+      final Image image = factory.getImage(getDiceResourceName(color, dieSide)).orElse(null);
       if (image != null) {
         return image;
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/FlagIconImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/FlagIconImageFactory.java
@@ -10,29 +10,29 @@ public class FlagIconImageFactory extends ImageFactory {
   public Image getFlag(final GamePlayer gamePlayer) {
     final String key = PREFIX + gamePlayer.getName() + ".gif";
     final String key2 = PREFIX + gamePlayer.getName() + ".png";
-    return getImage(key, key2, true);
+    return getImageOrThrow(key, key2);
   }
 
   public Image getSmallFlag(final GamePlayer gamePlayer) {
     final String key = PREFIX + gamePlayer.getName() + "_small.gif";
     final String key2 = PREFIX + gamePlayer.getName() + "_small.png";
-    return getImage(key, key2, true);
+    return getImageOrThrow(key, key2);
   }
 
   public Image getLargeFlag(final GamePlayer gamePlayer) {
     final String key = PREFIX + gamePlayer.getName() + "_large.png";
-    return getImage(key, true);
+    return getImageOrThrow(key);
   }
 
   public Image getFadedFlag(final GamePlayer gamePlayer) {
     final String key = PREFIX + gamePlayer.getName() + "_fade.gif";
     final String key2 = PREFIX + gamePlayer.getName() + "_fade.png";
-    return getImage(key, key2, true);
+    return getImageOrThrow(key, key2);
   }
 
   public Image getConvoyFlag(final GamePlayer gamePlayer) {
     final String key = PREFIX + gamePlayer.getName() + "_convoy.gif";
     final String key2 = PREFIX + gamePlayer.getName() + "_convoy.png";
-    return getImage(key, key2, true);
+    return getImageOrThrow(key, key2);
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/PuImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/PuImageFactory.java
@@ -1,13 +1,14 @@
 package games.strategy.triplea.image;
 
 import java.awt.Image;
+import java.util.Optional;
 
 /**
  * A factory for creating territory production images. These images are overlaid on a territory to
  * indicate how many PUs the territory produces each turn.
  */
 public class PuImageFactory extends ImageFactory {
-  public Image getPuImage(final int value) {
-    return getImage("PUs/" + value + ".png", false);
+  public Optional<Image> getPuImage(final int value) {
+    return getImage("PUs/" + value + ".png");
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitIconImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitIconImageFactory.java
@@ -13,7 +13,7 @@ public class UnitIconImageFactory extends ImageFactory {
 
   public List<Image> getImages(final String player, final String unitType, final GameData data) {
     return UnitIconProperties.getInstance(data).getImagePaths(player, unitType, data).stream()
-        .map(imagePath -> getImage(PREFIX + imagePath, false))
+        .map(imagePath -> getImage(PREFIX + imagePath).orElse(null))
         .filter(Objects::nonNull)
         .collect(Collectors.toList());
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryNameDrawable.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/screen/drawable/TerritoryNameDrawable.java
@@ -125,7 +125,7 @@ public class TerritoryNameDrawable extends AbstractDrawable {
     }
     // draw the PUs.
     if (ta != null && ta.getProduction() > 0 && mapData.drawResources()) {
-      final Image img = uiContext.getPuImageFactory().getPuImage(ta.getProduction());
+      final Image img = uiContext.getPuImageFactory().getPuImage(ta.getProduction()).orElse(null);
       final String prod = Integer.valueOf(ta.getProduction()).toString();
       final Optional<Point> place = mapData.getPuPlacementPoint(territory);
       // if pu_place.txt is specified draw there


### PR DESCRIPTION
Instead of having two APIs like:
```
getImage(String, String boolean) : Image
getImage(String, boolean) : Image
```

We replace this with two var-arg methods:
```
getImageOrThrow(String, [String...]) : Image
getImage(String, [String...]) : Optional<Image>
```

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
