### PR TITLE
Remove the auto-generated game title on the 'select game' screen

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -546,7 +546,7 @@ public class GameData implements Serializable, GameState {
     // From the game-xml file name, we can find the game-notes file.
     return findMapDescriptionYaml()
         .flatMap(yaml -> yaml.getGameXmlPathByGameName(getGameName()))
-        .map(gameFilePath -> GameNotes.loadGameNotes(gameFilePath, getGameName()))
+        .map(GameNotes::loadGameNotes)
         .orElse("");
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/InstalledMap.java
@@ -81,7 +81,7 @@ public class InstalledMap {
     } else {
       return Optional.of(
           LocalizeHtml.localizeImgLinksInHtml(
-              GameNotes.loadGameNotes(xmlPath.get(), gameName), mapContentRoot.get()));
+              GameNotes.loadGameNotes(xmlPath.get()), mapContentRoot.get()));
     }
   }
 

--- a/game-app/map-data/src/main/java/org/triplea/map/game/notes/GameNotes.java
+++ b/game-app/map-data/src/main/java/org/triplea/map/game/notes/GameNotes.java
@@ -11,13 +11,12 @@ import org.triplea.java.StringUtils;
 public class GameNotes {
   /**
    * Given the path to an XML file, reads an expected corresponding game notes and returns the
-   * contents of that file. Returns empty if the game notes file does not exist or if there are any
-   * errors reading the file.
+   * contents of that file. Returns an empty String if the game notes file does not exist or if
+   * there are any errors reading the file.
    *
    * @param xmlGameFile Path to game-xml file whose game notes we will be loading.
-   * @param gameName Name of the game, will be embedded into the game notes as a title.
    */
-  public static String loadGameNotes(final Path xmlGameFile, final String gameName) {
+  public static String loadGameNotes(final Path xmlGameFile) {
     Preconditions.checkArgument(
         Files.exists(xmlGameFile),
         "Error, expected file did not exist: " + xmlGameFile.toAbsolutePath());
@@ -28,10 +27,7 @@ public class GameNotes {
     final String notesFileName = createExpectedNotesFileName(xmlGameFile);
     final Path notesFile = xmlGameFile.resolveSibling(notesFileName);
 
-    final String gameNotes =
-        Files.exists(notesFile) ? FileUtils.readContents(notesFile).orElse("") : "";
-    return String.format(
-        "<h1>%s</h1>Path: %s<br>%s", gameName, xmlGameFile.toAbsolutePath(), gameNotes);
+    return Files.exists(notesFile) ? FileUtils.readContents(notesFile).orElse("") : "";
   }
 
   /**

--- a/game-app/map-data/src/test/java/org/triplea/map/game/notes/GameNotesTest.java
+++ b/game-app/map-data/src/test/java/org/triplea/map/game/notes/GameNotesTest.java
@@ -24,14 +24,7 @@ class GameNotesTest {
 
     final String result = GameNotes.loadGameNotes(gameXmlPath);
 
-    assertThat(
-        result,
-        is(
-            "<h1>Game Name</h1>"
-                + "Path: "
-                + gameXmlPath.toAbsolutePath()
-                + "<br>"
-                + "<blink>Game notes!</blink>"));
+    assertThat(result, is("<blink>Game notes!</blink>"));
   }
 
   @Test

--- a/game-app/map-data/src/test/java/org/triplea/map/game/notes/GameNotesTest.java
+++ b/game-app/map-data/src/test/java/org/triplea/map/game/notes/GameNotesTest.java
@@ -22,7 +22,7 @@ class GameNotesTest {
     FileUtils.writeToFile(gameXmlPath, "dummy content");
     gameXmlPath.toFile().deleteOnExit();
 
-    final String result = GameNotes.loadGameNotes(gameXmlPath, "Game Name");
+    final String result = GameNotes.loadGameNotes(gameXmlPath);
 
     assertThat(
         result,


### PR DESCRIPTION
Most games have the title built into the game notes. Displaying the game
name and path in a different style compared to the rest of the game notes
does not look good and is almost always redundant (notably the game
notes very typically include the name of the game).

## Change Summary & Additional Notes

### Before
![Screenshot from 2021-12-04 18-42-15](https://user-images.githubusercontent.com/12397753/144731437-f7519688-518c-49fb-bb38-2c5153dd8eb3.png)

### After
![Screenshot from 2021-12-04 18-39-48](https://user-images.githubusercontent.com/12397753/144731429-6c8a2899-424d-486d-ab6d-7102b00a8efb.png)

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
