### PR TITLE
Infra: remove update apt cache

### DIFF
--- a/infrastructure/ansible/roles/certbot/tasks/main.yml
+++ b/infrastructure/ansible/roles/certbot/tasks/main.yml
@@ -5,7 +5,7 @@
 
 - name: install certbot and python for certbot on nginx
   apt:
-    update_cache: yes
+    state: present
     name:
       - certbot
       - python3-certbot-nginx

--- a/infrastructure/ansible/roles/java/tasks/main.yml
+++ b/infrastructure/ansible/roles/java/tasks/main.yml
@@ -1,5 +1,4 @@
 - name: install java
   apt:
     state: present
-    update_cache: true
     name: "{{ java_version }}"


### PR DESCRIPTION
Apt cache update is not always strictly necessary. If needed,
we'll need to add it back in to run at an explicit time and
with retries.

Meanwhile removing the apt cache avoids errors like:

> fatal: [prerelease.triplea-game.org]: FAILED! => changed=false
  msg: 'Failed to update apt cache: '
