### PR TITLE
Clean up temp files from map extraction

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/ZippedMapsExtractor.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/ZippedMapsExtractor.java
@@ -142,6 +142,7 @@ public class ZippedMapsExtractor {
     final boolean folderReplaced =
         FileUtils.replaceFolder(tempFolderWithExtractedMap, extractionTarget);
     if (!folderReplaced) {
+      FileUtils.deleteDirectory(tempFolder);
       return Optional.empty();
     }
 


### PR DESCRIPTION
If we are extracting a map and fail to replace the existing map on the file system,
this extracted map will hang out in /tmp. The prerelease server recently had 3GB of
content in /tmp, largely due to left over temp files.
