### PR TITLE
Fix (remove) hanging game data lock release

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -1067,23 +1067,19 @@ class BattleCalculatorPanel extends JPanel {
   }
 
   private void setupAttackerAndDefender() {
-    try {
-      final AttackerAndDefenderSelector.AttackerAndDefender attAndDef =
-          AttackerAndDefenderSelector.builder()
-              .players(data.getPlayerList().getPlayers())
-              .currentPlayer(data.getSequence().getStep().getPlayerId())
-              .relationshipTracker(data.getRelationshipTracker())
-              .territory(location)
-              .build()
-              .getAttackerAndDefender();
+    final AttackerAndDefenderSelector.AttackerAndDefender attAndDef =
+        AttackerAndDefenderSelector.builder()
+            .players(data.getPlayerList().getPlayers())
+            .currentPlayer(data.getSequence().getStep().getPlayerId())
+            .relationshipTracker(data.getRelationshipTracker())
+            .territory(location)
+            .build()
+            .getAttackerAndDefender();
 
-      attAndDef.getAttacker().ifPresent(this::setAttacker);
-      attAndDef.getDefender().ifPresent(this::setDefender);
-      setAttackingUnits(attAndDef.getAttackingUnits());
-      setDefendingUnits(attAndDef.getDefendingUnits());
-    } finally {
-      data.releaseReadLock();
-    }
+    attAndDef.getAttacker().ifPresent(this::setAttacker);
+    attAndDef.getDefender().ifPresent(this::setDefender);
+    setAttackingUnits(attAndDef.getAttackingUnits());
+    setDefendingUnits(attAndDef.getDefendingUnits());
   }
 
   GamePlayer getAttacker() {


### PR DESCRIPTION
Lock acquisition was removed in a prior commit, if we remove a lock
we have not acquired there is an error. This update fixes this by
removing the lock release (rather than adding back in the lock
acquisition).

Looking over where we are locking, we are accessing immutable data
and do not need to lock game data.

Reported in, and fixes: #9890
