### PR TITLE
Update failure to connect to lobby as a reportable-error

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -8,6 +8,7 @@ import java.net.URI;
 import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.swing.JFrame;
+import lombok.extern.slf4j.Slf4j;
 import org.triplea.domain.data.ApiKey;
 import org.triplea.domain.data.UserName;
 import org.triplea.http.client.AuthenticationHeaders;
@@ -27,6 +28,7 @@ import org.triplea.swing.SwingComponents;
  * containing the user's name. The server will send back an authentication challenge. The client
  * then sends a response to the challenge to prove the user knows the correct password.
  */
+@Slf4j
 public class LobbyLogin {
   private static final String CONNECTING_TO_LOBBY = "Connecting to lobby...";
   private final JFrame parentWindow;
@@ -107,11 +109,11 @@ public class LobbyLogin {
                 .passwordChangeRequired(loginResponse.isPasswordChangeRequired())
                 .build());
       } else {
-        showError("Login Failed", loginResponse.getFailReason());
+        showMessage("Login Failed", loginResponse.getFailReason());
         return loginToServer(loginMode);
       }
-    } catch (final FeignException e) {
-      showError("Could Not Connect To Lobby", "Error: " + e.getMessage());
+    } catch (final HttpInteractionException e) {
+      log.error("Could Not Connect To Lobby", e);
       return Optional.empty();
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
@@ -119,7 +121,7 @@ public class LobbyLogin {
     }
   }
 
-  private void showError(final String title, final String message) {
+  private void showMessage(final String title, final String message) {
     // We use 'null' parentWindow in case there is an async failure connecting to the lobby
     // server. In the async case, we close the parent window while still connecting, the close
     // of the parent window will close the child dialog error message as well.
@@ -168,7 +170,7 @@ public class LobbyLogin {
     try {
       final CreateAccountResponse createAccountResponse = sendCreateAccountRequest(panel);
       if (!createAccountResponse.isSuccess()) {
-        showError("Account Creation Failed", createAccountResponse.getErrorMessage());
+        showMessage("Account Creation Failed", createAccountResponse.getErrorMessage());
         return Optional.empty();
       }
 
@@ -242,7 +244,7 @@ public class LobbyLogin {
           .infoMessage(response)
           .showDialog();
     } catch (final IOException e) {
-      showError("Error", "Failed to generate a temporary password: " + e.getMessage());
+      showMessage("Error", "Failed to generate a temporary password: " + e.getMessage());
     } catch (final InterruptedException e) {
       Thread.currentThread().interrupt();
     }

--- a/game-app/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/lobby/client/login/LobbyLogin.java
@@ -1,7 +1,6 @@
 package games.strategy.engine.lobby.client.login;
 
 import com.google.common.base.Strings;
-import feign.FeignException;
 import games.strategy.engine.framework.ui.background.BackgroundTaskRunner;
 import java.io.IOException;
 import java.net.URI;


### PR DESCRIPTION
Rename 'showError' to 'showMessage' in lobby and use 'logger' to convey unable
to connect to lobby.

This will be of mixed benefit because we de-dupe errors once per version of the
game. Nonetheless, even if users are commenting on a closed issue, that can still
be helpful to notify us of problems.
