### PR TITLE
UI: Improve error message window

### DIFF
--- a/game-app/game-core/src/main/java/org/triplea/debug/ErrorMessage.java
+++ b/game-app/game-core/src/main/java/org/triplea/debug/ErrorMessage.java
@@ -3,6 +3,7 @@ package org.triplea.debug;
 import com.google.common.base.Preconditions;
 import games.strategy.triplea.settings.ClientSetting;
 import java.awt.Dialog;
+import java.awt.Dimension;
 import java.awt.GraphicsEnvironment;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
@@ -34,7 +35,7 @@ import org.triplea.swing.jpanel.JPanelBuilder;
 public enum ErrorMessage {
   INSTANCE;
 
-  private final JFrame windowReference = new JFrame("TripleA Error");
+  private final JFrame windowReference = new JFrame("Error");
   private final JEditorPaneWithClickableLinks errorMessage = new JEditorPaneWithClickableLinks("");
   private final AtomicBoolean isVisible = new AtomicBoolean(false);
   private volatile boolean enableErrorPopup = false;
@@ -47,6 +48,8 @@ public enum ErrorMessage {
 
   ErrorMessage() {
     windowReference.setAlwaysOnTop(true);
+    windowReference.setMinimumSize(new Dimension(350, 150));
+    windowReference.setPreferredSize(new Dimension(900, 200));
     windowReference.setModalExclusionType(Dialog.ModalExclusionType.APPLICATION_EXCLUDE);
     windowReference.addWindowListener(
         new WindowAdapter() {
@@ -60,13 +63,7 @@ public enum ErrorMessage {
         new JPanelBuilder()
             .border(10)
             .borderLayout()
-            .addCenter(
-                new JPanelBuilder()
-                    .boxLayoutHorizontal()
-                    .addHorizontalGlue()
-                    .add(SwingComponents.newJScrollPane(errorMessage))
-                    .addHorizontalGlue()
-                    .build())
+            .addCenter(SwingComponents.newJScrollPane(errorMessage))
             .addSouth(
                 new JPanelBuilder()
                     .border(20, 0, 0, 0)


### PR DESCRIPTION
- Remove left and right glue that created odd borders around the error message
- Set a better starting width so that text lines are less likely to wrap.
- Set a window minimum size, avoids the window from being scaled down to an unusable size

## Change Summary & Additional Notes

## Example: uncaught exception with no message (eg: `new RuntimeException()`)

### Before:

![Screenshot from 2021-12-24 18-06-01](https://user-images.githubusercontent.com/12397753/147375872-43554ebe-5bf0-40c9-a461-fdf862c667af.png)

### After: (includes changes from other unmerged PRs)

![Screenshot from 2021-12-19 21-56-34](https://user-images.githubusercontent.com/12397753/147375877-9ffca11f-b881-41f3-b1ca-fd12492a3b80.png)

## Example: Uncaught Exception with long message (eg: `new RuntimeException("Commodo odio...`)

### Before
(note how the error message is duplicated)

![Screenshot from 2021-12-24 18-08-04](https://user-images.githubusercontent.com/12397753/147375891-3fa6127e-b740-49ae-8846-78a02c947d2b.png)


### After (includes changes from other unmerged PRs)
![Screenshot from 2021-12-24 18-09-45](https://user-images.githubusercontent.com/12397753/147375906-20ccf981-fa39-4e37-9ac3-18cfb608091f.png)

## Example: logged error, (eg: `log.error("message to user", e )`)

### Before
![Screenshot from 2021-12-24 18-13-47](https://user-images.githubusercontent.com/12397753/147375960-49184779-fcb5-4f90-9be7-566933c5bd33.png)

### After (includes changes from other unmerged PRs)
![Screenshot from 2021-12-24 18-12-50](https://user-images.githubusercontent.com/12397753/147375962-577c127d-d677-4f90-964b-624fb024f4bc.png)


<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
