### PR TITLE
Refactor: move 'bad words' toolbox error handling closer to http client

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/bad/words/BadWordsTabModel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/lobby/moderator/toolbox/tabs/bad/words/BadWordsTabModel.java
@@ -21,13 +21,9 @@ class BadWordsTabModel {
    * words table, the second column value is the "remove" button.
    */
   List<List<String>> fetchTableData() {
-    try {
-      return toolboxBadWordsClient.getBadWords().stream()
-          .map(word -> List.of(word, BadWordsTabActions.REMOVE_BUTTON_TEXT))
-          .collect(Collectors.toList());
-    } catch (final RuntimeException e) {
-      return List.of();
-    }
+    return toolboxBadWordsClient.getBadWords().stream()
+        .map(word -> List.of(word, BadWordsTabActions.REMOVE_BUTTON_TEXT))
+        .collect(Collectors.toList());
   }
 
   void removeBadWord(final String wordToRemove) {

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/lobby/moderator/toolbox/words/ToolboxBadWordsClient.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/lobby/moderator/toolbox/words/ToolboxBadWordsClient.java
@@ -1,16 +1,19 @@
 package org.triplea.http.client.lobby.moderator.toolbox.words;
 
+import feign.FeignException;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.triplea.domain.data.ApiKey;
 import org.triplea.http.client.AuthenticationHeaders;
 import org.triplea.http.client.HttpClient;
 import org.triplea.http.client.HttpInteractionException;
 
 /** Http client class for fetching the list of bad words and adding and removing them. */
+@Slf4j
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ToolboxBadWordsClient {
   public static final String BAD_WORD_ADD_PATH = "/moderator-toolbox/bad-words/add";
@@ -35,11 +38,15 @@ public class ToolboxBadWordsClient {
   }
 
   /**
-   * Returns list of bad words present in the bad words table.
-   *
-   * @throws HttpInteractionException thrown if there are any HTTP errors or a non-200 return code.
+   * Returns list of bad words present in the bad words table. On error, logs an error message and
+   * returns an empty list.
    */
   public List<String> getBadWords() {
-    return client.getBadWords(authenticationHeaders);
+    try {
+      return client.getBadWords(authenticationHeaders);
+    } catch (final HttpInteractionException e) {
+      log.error("Failed to fetch list of bad words", e);
+      return List.of();
+    }
   }
 }

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/lobby/moderator/toolbox/words/ToolboxBadWordsClient.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/lobby/moderator/toolbox/words/ToolboxBadWordsClient.java
@@ -1,6 +1,5 @@
 package org.triplea.http.client.lobby.moderator.toolbox.words;
 
-import feign.FeignException;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;

--- a/spitfire-server/dropwizard-server/src/test/java/org/triplea/spitfire/server/ControllerIntegrationTest.java
+++ b/spitfire-server/dropwizard-server/src/test/java/org/triplea/spitfire/server/ControllerIntegrationTest.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.fail;
 import com.github.database.rider.core.api.dataset.DataSet;
 import com.github.database.rider.junit5.DBUnitExtension;
 import com.google.common.base.Preconditions;
+import feign.FeignException;
 import java.util.Collection;
 import java.util.List;
 import java.util.function.Consumer;
@@ -76,8 +77,8 @@ public abstract class ControllerIntegrationTest {
         try {
           invocation.accept(client);
           fail("Invocation did not produce a 403");
-        } catch (final HttpInteractionException httpInteractionException) {
-          assertThat(httpInteractionException.status(), is(403));
+        } catch (final FeignException feignException) {
+          assertThat(feignException.status(), is(403));
         }
       }
     }

--- a/spitfire-server/dropwizard-server/src/test/java/org/triplea/spitfire/server/controllers/BadWordsControllerIntegrationTest.java
+++ b/spitfire-server/dropwizard-server/src/test/java/org/triplea/spitfire/server/controllers/BadWordsControllerIntegrationTest.java
@@ -15,11 +15,9 @@ import org.triplea.spitfire.server.ControllerIntegrationTest;
 @SuppressWarnings("UnmatchedTest")
 class BadWordsControllerIntegrationTest extends ControllerIntegrationTest {
 
-  private final URI localhost;
   private final ToolboxBadWordsClient client;
 
   BadWordsControllerIntegrationTest(final URI localhost) {
-    this.localhost = localhost;
     this.client = ToolboxBadWordsClient.newClient(localhost, ControllerIntegrationTest.MODERATOR);
   }
 

--- a/spitfire-server/dropwizard-server/src/test/java/org/triplea/spitfire/server/controllers/BadWordsControllerIntegrationTest.java
+++ b/spitfire-server/dropwizard-server/src/test/java/org/triplea/spitfire/server/controllers/BadWordsControllerIntegrationTest.java
@@ -24,17 +24,6 @@ class BadWordsControllerIntegrationTest extends ControllerIntegrationTest {
   }
 
   @Test
-  @SuppressWarnings({"Convert2MethodRef", "unchecked"})
-  void mustBeAuthorized() {
-    assertNotAuthorized(
-        ControllerIntegrationTest.NOT_MODERATORS,
-        apiKey -> ToolboxBadWordsClient.newClient(localhost, apiKey),
-        client -> client.getBadWords(),
-        client -> client.addBadWord("bad-word"),
-        client -> client.removeBadWord("bad-word"));
-  }
-
-  @Test
   void badRequests() {
     assertBadRequest(() -> client.addBadWord(""));
     assertBadRequest(() -> client.removeBadWord(""));


### PR DESCRIPTION
Moves error handling closer to our http client, on error returns empty data. Avoids client
code from having to catch exceptions or worry about messaging errors.
