### PR TITLE
Simplify/Update Error message formatting

### DIFF
--- a/game-app/game-core/src/main/java/org/triplea/debug/LoggerRecord.java
+++ b/game-app/game-core/src/main/java/org/triplea/debug/LoggerRecord.java
@@ -10,6 +10,10 @@ import java.util.List;
 public interface LoggerRecord {
   String getLoggerClassName();
 
+  /**
+   * Returns the log message, eg: {@code log.info("message"))}, or if the LoggerRecord is created
+   * from an uncaught exception then returns {@code exception.getMessage()}.
+   */
   String getLogMessage();
 
   boolean isError();


### PR DESCRIPTION
Update error message formatter to print logged text or else print 'an unexpected error ocurred'.
We then print the top 3 exceptions and their messages.

- We are able to greatly simplify by virtue that 'loggerRecord.getMessage()' is non-null.
Though, if we thrown an exception, then the message of the 'loggerRecord' and that of
the exception will be the same. This leads to duplicate printing of the same message.
This is why we print 'an unexpected error ocurred', in such a case there is an exception
and we will print its message on the next line.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
