### PR TITLE
Error Handling: update MapsClient to log errors and return an empty list

### DIFF
--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/maps/listing/MapsClient.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/maps/listing/MapsClient.java
@@ -23,7 +23,7 @@ public class MapsClient {
     try {
       return mapsFeignClient.fetchMapListing(AuthenticationHeaders.systemIdHeaders());
     } catch (FeignException e) {
-      log.error("Failed to fetch map download list", e);
+      log.error("Failed to download the list of available maps from TripleA servers.", e);
       return List.of();
     }
   }

--- a/http-clients/lobby-client/src/main/java/org/triplea/http/client/maps/listing/MapsClient.java
+++ b/http-clients/lobby-client/src/main/java/org/triplea/http/client/maps/listing/MapsClient.java
@@ -1,13 +1,16 @@
 package org.triplea.http.client.maps.listing;
 
+import feign.FeignException;
 import java.net.URI;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.triplea.http.client.AuthenticationHeaders;
 import org.triplea.http.client.HttpClient;
 
 /**
  * Http client to communicate with the maps server and get a listing of maps available for download.
  */
+@Slf4j
 public class MapsClient {
   public static final String MAPS_LISTING_PATH = "/maps/listing";
   private final MapsFeignClient mapsFeignClient;
@@ -17,6 +20,11 @@ public class MapsClient {
   }
 
   public List<MapDownloadItem> fetchMapDownloads() {
-    return mapsFeignClient.fetchMapListing(AuthenticationHeaders.systemIdHeaders());
+    try {
+      return mapsFeignClient.fetchMapListing(AuthenticationHeaders.systemIdHeaders());
+    } catch (FeignException e) {
+      log.error("Failed to fetch map download list", e);
+      return List.of();
+    }
   }
 }


### PR DESCRIPTION
Returning an empty list and logging an error makes client code simpler,
it can deal with empty data and does not have to worry about error messaging.
