### PR TITLE
Header redirect/lobby variable port number

### DIFF
--- a/infrastructure/ansible/group_vars/all.yml
+++ b/infrastructure/ansible/group_vars/all.yml
@@ -8,3 +8,10 @@ admin_user: "admin"
 admin_home: "/home/{{ admin_user }}"
 github_releases_url: https://github.com/triplea-game/triplea/releases/download
 ansible_python_interpreter: /usr/bin/python3
+
+# When adding a new lobby, update 'nginx' to redirect
+# port numbers, 8080 -> old default, 9026 -> v2.6,  9027 -> v2.7
+lobby_25_port: 8080
+lobby_26_port: 9026
+lobby_http_port: "{{ lobby_26_port }}"
+lobby_name: lobby_26

--- a/infrastructure/ansible/roles/lobby_server/README.md
+++ b/infrastructure/ansible/roles/lobby_server/README.md
@@ -1,1 +1,5 @@
-Install dropwizard http server and lobby application
+# Lobby Server
+
+Installs the lobby server. We run lobby versions parallel to one another on different port numbers.
+This allows us to run multiple lobbies on the same host. Further, we have magic config in nginx
+to redirect to the correct server instance based on the `triplea-version` header value.

--- a/infrastructure/ansible/roles/lobby_server/defaults/main.yml
+++ b/infrastructure/ansible/roles/lobby_server/defaults/main.yml
@@ -1,5 +1,7 @@
 lobby_server_user: lobby_server
+lobby_name: lobby_default
 lobby_version: "{{ version }}"
+lobby_http_port: 8080
 lobby_server_home_folder: "/home/{{ lobby_server_user }}/{{ lobby_version }}"
 lobby_server_error_report_github_org: "triplea-game"
 lobby_server_error_report_github_repo: "test"

--- a/infrastructure/ansible/roles/lobby_server/tasks/main.yml
+++ b/infrastructure/ansible/roles/lobby_server/tasks/main.yml
@@ -49,7 +49,7 @@
   register: service_script
   template:
     src: lobby_server.service.j2
-    dest: /lib/systemd/system/lobby_server.service
+    dest: /lib/systemd/system/{{ lobby_name }}.service
     mode: "644"
 
 - name: reload systemd
@@ -62,6 +62,6 @@
   tags: [deploy]
   when: (lobby_restart_on_new_deployment) and ((deploy_artifact.changed) or (service_script.changed))
   service:
-    name: lobby_server
+    name: "{{ lobby_name }}"
     state: restarted
     enabled: yes

--- a/infrastructure/ansible/roles/lobby_server/templates/lobby_server.service.j2
+++ b/infrastructure/ansible/roles/lobby_server/templates/lobby_server.service.j2
@@ -1,5 +1,5 @@
 [Unit]
-Description=TripleA Lobby Server
+Description={{ lobby_name }}
 Documentation=
 
 [Service]
@@ -14,6 +14,8 @@ Environment=ERROR_REPORT_GITHUB_REPO=triplea
 Environment=GITHUB_API_TOKEN={{ github_api_token }}
 Environment=MAP_INDEXING_PERIOD_MINUTES={{ map_indexing_period_minutes }}
 Environment=MAP_INDEXING_DELAY_SECONDS={{ map_indexing_task_delay_seconds }}
+Environment=HTTP_PORT={{ lobby_http_port }}
+
 WorkingDirectory={{ lobby_server_home_folder }}
 User={{ lobby_server_user }}
 Group={{ lobby_server_user }}

--- a/infrastructure/ansible/roles/nginx/defaults/main.yml
+++ b/infrastructure/ansible/roles/nginx/defaults/main.yml
@@ -9,3 +9,19 @@ dhparams_pem_file: /etc/nginx/dhparam.pem
 nginx_allowed_ports:
   - 443
   - 80
+
+# 'lobby_proxy_pass' captures common selection logic for redirecting clients based on their
+# TripleA Version.
+#
+# Note: header names automatically have dashes converted to underscores.
+# Headers containing underscores are ignored entirely!
+lobby_proxy_pass: |
+    if ($http_triplea_version = "") {
+      proxy_pass          http://localhost:{{ lobby_25_port }};
+    }
+    if ($http_triplea_version = "2.5") {
+      proxy_pass          http://localhost:{{ lobby_25_port }};
+    }
+    if ($http_triplea_version = "2.6") {
+      proxy_pass           http://localhost:{{ lobby_26_port }};
+    }

--- a/infrastructure/ansible/roles/nginx/templates/etc_nginx_sites_enabled_default.j2
+++ b/infrastructure/ansible/roles/nginx/templates/etc_nginx_sites_enabled_default.j2
@@ -6,7 +6,7 @@ server {
 
 # warning: be sure that we can run certbot role and then re-run the nginx
 # role without this file changing. If this file is changed (white-space included)
-# then nginx will be restarting, disconnecting all active connections.
+# then nginx will be restarted, disconnecting all active connections.
 
 server {
     listen 443 ssl http2;
@@ -33,23 +33,17 @@ server {
     add_header X-XSS-Protection "1; mode=block";
 
     location / {
-
+      {{ lobby_proxy_pass }}
       proxy_set_header        Host $host;
       proxy_set_header        X-Real-IP $remote_addr;
       proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header        X-Forwarded-Proto $scheme;
-
-      # Fix the “It appears that your reverse proxy set up is broken" error.
-      proxy_pass          http://localhost:8080;
       proxy_read_timeout  90;
-
-      proxy_redirect      https://localhost:443 https://localhost:8080;
     }
 
     location /game-connection/ws {
-      proxy_pass http://localhost:8080;
+      {{ lobby_proxy_pass }}
       proxy_http_version 1.1;
-
       proxy_set_header        Host $host;
       proxy_set_header        X-Real-IP $remote_addr;
       proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -60,9 +54,8 @@ server {
     }
 
     location /player-connection/ws {
-      proxy_pass http://localhost:8080;
+      {{ lobby_proxy_pass }}
       proxy_http_version 1.1;
-
       proxy_set_header        Host $host;
       proxy_set_header        X-Real-IP $remote_addr;
       proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;

--- a/infrastructure/ansible/roles/nginx/templates/etc_nginx_sites_enabled_default.j2
+++ b/infrastructure/ansible/roles/nginx/templates/etc_nginx_sites_enabled_default.j2
@@ -15,7 +15,6 @@ server {
     ssl_certificate {{ cert }} 
     ssl_certificate_key {{ cert_key }}
 
-    ssl on;
     ssl_protocols  TLSv1.2 TLSv1.3;
     ssl_ciphers EECDH+AESGCM:EDH+AESGCM;
     ssl_prefer_server_ciphers on;

--- a/spitfire-server/dropwizard-server/configuration.yml
+++ b/spitfire-server/dropwizard-server/configuration.yml
@@ -81,7 +81,7 @@ logging:
 server:
   applicationConnectors:
     - type: http
-      port: 8080
+      port: ${HTTP_PORT:-8080}
       # useForwardedHeaders is important for when behind a reverse proxy (NGINX)
       # Without this 'getRemoteAddr' will return the IP of the reverse proxy server.
       # By default when building locally useForwardedPorts should be 'false', but


### PR DESCRIPTION
## Change Summary & Additional Notes

commit f68abbeb399b7298106b4b88537db9c0ca0bbad3

    Nginx config to redirect to differing lobby depending on header version
    
    Adds an NGINX config that checks the 'triplea-version' header value,
    and based on that value redirects. To support running multiple servers
    on the same host, we need to parameterize the lobby server to be able
    to inject port number. The end goal is we can have multiple lobbies
    running on the same host, different port numbers, and clients will
    be redirected to the correct lobby based on version number in header.

commit 860ed083909beaf1fb39ffe9903cc9454012523a (header-redirect/wip)

    Nginx Config: remove deprecated ssl property
    
    'sudo nginx -t' was generating this warning:
    
    > nginx: [warn] the "ssl" directive is deprecated, use the "listen ... ssl" directive instead in /etc/nginx/sites-enabled/default:21



<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
