### PR TITLE
Reload nginx to apply updates instead of Restart

### DIFF
--- a/infrastructure/ansible/roles/nginx/tasks/main.yml
+++ b/infrastructure/ansible/roles/nginx/tasks/main.yml
@@ -83,7 +83,7 @@
     proto: tcp
   with_items: "{{ nginx_allowed_ports }}"
 
-- name: restart nginx if config changed
+- name: reload nginx if config changed
   tags: [deploy]
   when: |
     (nginx_config_changed.changed) 
@@ -91,7 +91,7 @@
       or (has_cert.stat.exists == false)
   systemd:
     name: nginx
-    state: restarted
+    state: reloaded
 
 - name: ensure nginx is started
   systemd:


### PR DESCRIPTION
'nginx' reload is advertised to not disconnect current connections.
Because of this, it is a better way to pick up configuration changes.
Seemingly it is rare for any changes to need a full blown restart,
hence we probably prefer 'reload' over 'restart'

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
