### PR TITLE
Draft/Discussion: Add services files to fix 'unable to find service'

### DIFF
--- a/game-app/game-core/src/test/java/games/strategy/engine/ClientFileSystemHelperTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/ClientFileSystemHelperTest.java
@@ -2,14 +2,28 @@ package games.strategy.engine;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.core.IsNull.notNullValue;
 
 import games.strategy.triplea.settings.AbstractClientSettingTestCase;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 @SuppressWarnings("InnerClassMayBeStatic")
 final class ClientFileSystemHelperTest {
+
+  @Test
+  void getRootFolder() {
+    Path rootFolder = ClientFileSystemHelper.getRootFolder();
+
+    assertThat(rootFolder, is(notNullValue()));
+    assertThat("should be a folder", Files.isDirectory(rootFolder));
+    assertThat(
+        "should contain the '.triplea-root' touch file",
+        Files.exists(rootFolder.resolve(".triplea-root")));
+  }
+
   @Nested
   final class GetUserMapsFolderTest extends AbstractClientSettingTestCase {
     @Test

--- a/game-app/game-core/src/test/java/games/strategy/engine/TestApplicationContext.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/TestApplicationContext.java
@@ -1,0 +1,10 @@
+package games.strategy.engine;
+
+import org.triplea.game.ApplicationContext;
+
+public class TestApplicationContext implements ApplicationContext {
+  @Override
+  public Class<?> getMainClass() {
+    return TestApplicationContext.class;
+  }
+}

--- a/game-app/game-core/src/test/resources/META-INF/services/org.triplea.game.ApplicationContext
+++ b/game-app/game-core/src/test/resources/META-INF/services/org.triplea.game.ApplicationContext
@@ -1,0 +1,1 @@
+games.strategy.engine.TestApplicationContext


### PR DESCRIPTION
Posting for discussion.

The below solves finding an application context from a test instance. Essentially we register an 'application context' implementation so that 'codeSource' then becomes `triplea/game-core/test/out` (where `out` is the output directory for builds)

We then recursively search up for the file '.triplea-root', which is in 'triplea/game-headed/' and not 'triplea/game-core',  so we will not find it. It's difficult to think how to structure this differently for that search to succeed. Ultimately we are looking for the 'assets' folder, and to find that we have to recursively go up directories to then come back down. The real problem is that we have sub-projects that do not match how the file system would look in a deployed context, so we are contorting to try and get this to work.

Possible solutions for how to deal with this situation in test:

(1) Perhaps we can add a 'ROOT_FOLDER_PATH' environment variable that can be used to override the 'root folder'. We can then set that from within test code as needed and/or include runners that set the variable as appropriate.

(2) An alternative solution is for us to use the custom 'Injections' class to get instances of `ClientFileSystemHelper` wherever needed. In this case we can override the injection for test.

(3) We could replace usages of `ClientFileSystemHelper` with equivalent lambdas and then inject those lambda implementations from test. EG:  `ClientFileSystemHelper.getRootFolder` vs `Supplier<Path> rootFolderFinder`, and the `Supplier` becomes a constructor arg to the class.




