### PR TITLE
Fix failing unit test

### DIFF
--- a/lib/java-extras/src/main/java/org/triplea/io/ZipExtractor.java
+++ b/lib/java-extras/src/main/java/org/triplea/io/ZipExtractor.java
@@ -133,6 +133,9 @@ public class ZipExtractor {
 
     // ensure that the destination to write is within the target folder. Avoids
     // 'zip slip' vulnerability: https://snyk.io/research/zip-slip-vulnerability
+    // Recent versions of Java protect against this vulnerability by simply
+    // not parsing paths containing '..' at all, so this check can be
+    // removed once this fix is widely available.
     if (!destFile.normalize().startsWith(destinationDir.normalize())) {
       throw new ZipSecurityException(zipEntry);
     }

--- a/lib/java-extras/src/test/java/org/triplea/io/ZipExtractorTest.java
+++ b/lib/java-extras/src/test/java/org/triplea/io/ZipExtractorTest.java
@@ -78,7 +78,7 @@ class ZipExtractorTest {
 
     final Exception exception =
         assertThrows(
-            ZipExtractor.ZipSecurityException.class, () -> ZipExtractor.unzipFile(zip, subfolder));
+            ZipExtractor.ZipReadException.class, () -> ZipExtractor.unzipFile(zip, subfolder));
 
     assertThat(Files.exists(destinationFolder.resolve("matrix.jpg")), is(false));
     // Make sure file isn't extracted at all

--- a/lib/java-extras/src/test/java/org/triplea/io/ZipExtractorTest.java
+++ b/lib/java-extras/src/test/java/org/triplea/io/ZipExtractorTest.java
@@ -85,6 +85,6 @@ class ZipExtractorTest {
     assertThat(Files.exists(subfolder.resolve("matrix.jpg")), is(false));
 
     // Folder creation outside of the extraction directory should be prevented!
-    assertThat(exception.getMessage(), containsString("/.."));
+    assertThat(exception.getMessage(), containsString(".."));
   }
 }


### PR DESCRIPTION
So the OpenJDK implemented some security measures to prevent the zip-slip vulnerability by simply refusing to parse zip files with relative paths (containing `..` or `.`). This is why the unit tests checking that our code is safe suddenly fails with a different exception.

In order to prevent this vulnerability for unpatched java versions our code is kept for now, but we might be able to remove this in a future version.

FYI @DanVanAtta will self-merge to get the build green again, feel free to ask any questions