### PR TITLE
Extraction of common calls for SwingUtilities.isEventDispatchThread

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -17,6 +17,7 @@ import games.strategy.triplea.delegate.PoliticsDelegate;
 import games.strategy.triplea.delegate.TechnologyDelegate;
 import games.strategy.triplea.delegate.battle.BattleDelegate;
 import games.strategy.triplea.ui.UiContext;
+import games.strategy.ui.Util;
 import java.io.IOException;
 import java.io.ObjectInputStream;
 import java.io.Serializable;
@@ -32,7 +33,6 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
-import javax.swing.SwingUtilities;
 import org.triplea.injection.Injections;
 import org.triplea.io.FileUtils;
 import org.triplea.io.IoUtils;
@@ -491,8 +491,8 @@ public class GameData implements Serializable, GameState {
 
   /** Executes a change and notifies listeners. */
   public void performChange(final Change change) {
-    if (areChangesOnlyInSwingEventThread() && !SwingUtilities.isEventDispatchThread()) {
-      throw new IllegalStateException("Wrong thread");
+    if (areChangesOnlyInSwingEventThread()) {
+      Util.ensureEventDispatchThread();
     }
     try {
       acquireWriteLock();

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -492,7 +492,7 @@ public class GameData implements Serializable, GameState {
   /** Executes a change and notifies listeners. */
   public void performChange(final Change change) {
     if (areChangesOnlyInSwingEventThread()) {
-      Util.ensureEventDispatchThread();
+      Util.ensureOnEventDispatchThread();
     }
     try {
       acquireWriteLock();

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -170,7 +170,7 @@ public final class GameRunner {
 
   /** After the game has been left, call this. */
   public static void clientLeftGame() {
-    Util.ensureNoneEventDispatchThread();
+    Util.ensureNotOnEventDispatchThread();
     Interruptibles.await(() -> SwingAction.invokeAndWait(setupPanelModel::showSelectType));
     showMainFrame();
   }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/GameRunner.java
@@ -17,6 +17,7 @@ import games.strategy.engine.framework.startup.mc.ServerModel;
 import games.strategy.engine.framework.startup.ui.panels.main.SetupPanelModel;
 import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorModel;
 import games.strategy.engine.framework.ui.MainFrame;
+import games.strategy.ui.Util;
 import java.awt.Component;
 import java.awt.Frame;
 import java.net.URI;
@@ -169,9 +170,7 @@ public final class GameRunner {
 
   /** After the game has been left, call this. */
   public static void clientLeftGame() {
-    if (SwingUtilities.isEventDispatchThread()) {
-      throw new IllegalStateException("This method must not be called from the EDT");
-    }
+    Util.ensureNoneEventDispatchThread();
     Interruptibles.await(() -> SwingAction.invokeAndWait(setupPanelModel::showSelectType));
     showMainFrame();
   }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -14,6 +14,7 @@ import games.strategy.engine.framework.startup.ui.panels.main.game.selector.Game
 import games.strategy.engine.lobby.client.ui.action.EditGameCommentAction;
 import games.strategy.engine.lobby.client.ui.action.RemoveGameFromLobbyAction;
 import games.strategy.net.IServerMessenger;
+import games.strategy.ui.Util;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.GridBagConstraints;
@@ -325,9 +326,7 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
   }
 
   private void internalPlayersTakenChanged() {
-    if (!SwingUtilities.isEventDispatchThread()) {
-      throw new IllegalStateException("Wrong thread");
-    }
+    Util.ensureEventDispatchThread();
     final Map<String, String> playersToNode = model.getPlayersToNodeListing();
     final Map<String, Boolean> playersEnabled = model.getPlayersEnabledListing();
     for (final PlayerRow row : playerRows) {
@@ -337,9 +336,7 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
   }
 
   private void internalPlayerListChanged() {
-    if (!SwingUtilities.isEventDispatchThread()) {
-      throw new IllegalStateException("Wrong thread");
-    }
+    Util.ensureEventDispatchThread();
     playerRows = new ArrayList<>();
     final Map<String, String> players = model.getPlayersToNodeListing();
     final Map<String, Boolean> playersEnabled = model.getPlayersEnabledListing();

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/ServerSetupPanel.java
@@ -326,7 +326,7 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
   }
 
   private void internalPlayersTakenChanged() {
-    Util.ensureEventDispatchThread();
+    Util.ensureOnEventDispatchThread();
     final Map<String, String> playersToNode = model.getPlayersToNodeListing();
     final Map<String, Boolean> playersEnabled = model.getPlayersEnabledListing();
     for (final PlayerRow row : playerRows) {
@@ -336,7 +336,7 @@ public class ServerSetupPanel extends SetupPanel implements IRemoteModelListener
   }
 
   private void internalPlayerListChanged() {
-    Util.ensureEventDispatchThread();
+    Util.ensureOnEventDispatchThread();
     playerRows = new ArrayList<>();
     final Map<String, String> players = model.getPlayersToNodeListing();
     final Map<String, Boolean> playersEnabled = model.getPlayersEnabledListing();

--- a/game-app/game-core/src/main/java/games/strategy/engine/history/History.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/history/History.java
@@ -5,11 +5,11 @@ import games.strategy.engine.data.CompositeChange;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.triplea.ui.history.HistoryPanel;
+import games.strategy.ui.Util;
 import java.util.ArrayList;
 import java.util.Enumeration;
 import java.util.List;
 import java.util.Optional;
-import javax.swing.SwingUtilities;
 import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.DefaultTreeModel;
 
@@ -41,8 +41,8 @@ public class History extends DefaultTreeModel {
   }
 
   private void assertCorrectThread() {
-    if (gameData.areChangesOnlyInSwingEventThread() && !SwingUtilities.isEventDispatchThread()) {
-      throw new IllegalStateException("Wrong thread");
+    if (gameData.areChangesOnlyInSwingEventThread()) {
+      Util.ensureEventDispatchThread();
     }
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/history/History.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/history/History.java
@@ -42,7 +42,7 @@ public class History extends DefaultTreeModel {
 
   private void assertCorrectThread() {
     if (gameData.areChangesOnlyInSwingEventThread()) {
-      Util.ensureEventDispatchThread();
+      Util.ensureOnEventDispatchThread();
     }
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
@@ -189,7 +189,7 @@ public class PbemDiceRoller implements IRandomSource {
     }
 
     private void rollInternal() {
-      Util.ensureEventDispatchThread();
+      Util.ensureOnEventDispatchThread();
       reRollButton.setEnabled(false);
       exitButton.setEnabled(false);
       ThreadRunner.runInNewThread(this::rollInSeparateThread);

--- a/game-app/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/random/PbemDiceRoller.java
@@ -189,9 +189,7 @@ public class PbemDiceRoller implements IRandomSource {
     }
 
     private void rollInternal() {
-      if (!SwingUtilities.isEventDispatchThread()) {
-        throw new IllegalStateException("Wrong thread");
-      }
+      Util.ensureEventDispatchThread();
       reRollButton.setEnabled(false);
       exitButton.setEnabled(false);
       ThreadRunner.runInNewThread(this::rollInSeparateThread);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogUi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogUi.java
@@ -3,11 +3,11 @@ package games.strategy.triplea.ai.pro.logging;
 import games.strategy.engine.framework.GameShutdownRegistry;
 import games.strategy.triplea.ui.TripleAFrame;
 import games.strategy.triplea.ui.menubar.DebugMenu;
+import games.strategy.ui.Util;
 import java.awt.event.KeyEvent;
 import java.util.Collection;
 import java.util.List;
 import javax.swing.JMenuItem;
-import javax.swing.SwingUtilities;
 import org.triplea.swing.SwingAction;
 
 /** Class to manage log window display. */
@@ -27,9 +27,7 @@ public final class ProLogUi {
   }
 
   private static Collection<JMenuItem> initialize(final TripleAFrame frame) {
-    if (!SwingUtilities.isEventDispatchThread()) {
-      throw new IllegalStateException("Wrong thread, should be running on AWT thread.");
-    }
+    Util.ensureEventDispatchThread();
     if (settingsWindow == null) {
       settingsWindow = new ProLogWindow(frame);
       GameShutdownRegistry.registerShutdownAction(ProLogUi::clearCachedInstances);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogUi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/logging/ProLogUi.java
@@ -27,7 +27,7 @@ public final class ProLogUi {
   }
 
   private static Collection<JMenuItem> initialize(final TripleAFrame frame) {
-    Util.ensureEventDispatchThread();
+    Util.ensureOnEventDispatchThread();
     if (settingsWindow == null) {
       settingsWindow = new ProLogWindow(frame);
       GameShutdownRegistry.registerShutdownAction(ProLogUi::clearCachedInstances);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -19,6 +19,7 @@ import games.strategy.triplea.delegate.power.calculator.PowerStrengthAndRolls;
 import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.ui.UiContext;
 import games.strategy.triplea.util.TuvUtils;
+import games.strategy.ui.Util;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.Dimension;
@@ -1124,9 +1125,7 @@ class BattleCalculatorPanel extends JPanel {
   }
 
   private void updateStats() {
-    if (!SwingUtilities.isEventDispatchThread()) {
-      throw new IllegalStateException("Wrong thread");
-    }
+    Util.ensureEventDispatchThread();
     final AtomicReference<AggregateResults> results = new AtomicReference<>();
     final WaitDialog dialog =
         new WaitDialog(this, "Calculating Odds... (this may take a while)", calculator::cancel);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorPanel.java
@@ -1125,7 +1125,7 @@ class BattleCalculatorPanel extends JPanel {
   }
 
   private void updateStats() {
-    Util.ensureEventDispatchThread();
+    Util.ensureOnEventDispatchThread();
     final AtomicReference<AggregateResults> results = new AtomicReference<>();
     final WaitDialog dialog =
         new WaitDialog(this, "Calculating Odds... (this may take a while)", calculator::cancel);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -300,9 +300,7 @@ public class BattleDisplay extends JPanel {
   }
 
   void waitForConfirmation(final String message) {
-    if (SwingUtilities.isEventDispatchThread()) {
-      throw new IllegalStateException("This cannot be in dispatch thread");
-    }
+    Util.ensureNoneEventDispatchThread();
 
     final CountDownLatch continueLatch = new CountDownLatch(1);
     final Action buttonAction = SwingAction.of(message, e -> continueLatch.countDown());
@@ -338,9 +336,7 @@ public class BattleDisplay extends JPanel {
   @Nullable
   Territory getRetreat(
       final String message, final Collection<Territory> possible, final boolean submerge) {
-    if (SwingUtilities.isEventDispatchThread()) {
-      throw new IllegalStateException("Should not be called from dispatch thread");
-    }
+    Util.ensureNoneEventDispatchThread();
     final String title;
     final Supplier<RetreatResult> supplier;
     if (!submerge || possible.size() > 1) {
@@ -507,9 +503,7 @@ public class BattleDisplay extends JPanel {
       final GamePlayer hit,
       final CasualtyList defaultCasualties,
       final boolean allowMultipleHitsPerUnit) {
-    if (SwingUtilities.isEventDispatchThread()) {
-      throw new IllegalStateException("This method should not be run in the event dispatch thread");
-    }
+    Util.ensureNoneEventDispatchThread();
     final AtomicReference<CasualtyDetails> casualtyDetails =
         new AtomicReference<>(new CasualtyDetails());
     final CountDownLatch continueLatch = new CountDownLatch(1);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -300,7 +300,7 @@ public class BattleDisplay extends JPanel {
   }
 
   void waitForConfirmation(final String message) {
-    Util.ensureNoneEventDispatchThread();
+    Util.ensureNotOnEventDispatchThread();
 
     final CountDownLatch continueLatch = new CountDownLatch(1);
     final Action buttonAction = SwingAction.of(message, e -> continueLatch.countDown());
@@ -336,7 +336,7 @@ public class BattleDisplay extends JPanel {
   @Nullable
   Territory getRetreat(
       final String message, final Collection<Territory> possible, final boolean submerge) {
-    Util.ensureNoneEventDispatchThread();
+    Util.ensureNotOnEventDispatchThread();
     final String title;
     final Supplier<RetreatResult> supplier;
     if (!submerge || possible.size() > 1) {
@@ -503,7 +503,7 @@ public class BattleDisplay extends JPanel {
       final GamePlayer hit,
       final CasualtyList defaultCasualties,
       final boolean allowMultipleHitsPerUnit) {
-    Util.ensureNoneEventDispatchThread();
+    Util.ensureNotOnEventDispatchThread();
     final AtomicReference<CasualtyDetails> casualtyDetails =
         new AtomicReference<>(new CasualtyDetails());
     final CountDownLatch continueLatch = new CountDownLatch(1);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -192,7 +192,7 @@ public final class BattlePanel extends ActionPanel {
   }
 
   private boolean ensureBattleIsDisplayed(final UUID battleId) {
-    Util.ensureNoneEventDispatchThread();
+    Util.ensureNotOnEventDispatchThread();
     UUID displayed = currentBattleDisplayed;
     int count = 0;
     while (!battleId.equals(displayed)) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -192,9 +192,7 @@ public final class BattlePanel extends ActionPanel {
   }
 
   private boolean ensureBattleIsDisplayed(final UUID battleId) {
-    if (SwingUtilities.isEventDispatchThread()) {
-      throw new IllegalStateException("Wrong threads");
-    }
+    Util.ensureNoneEventDispatchThread();
     UUID displayed = currentBattleDisplayed;
     int count = 0;
     while (!battleId.equals(displayed)) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattleStepsPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattleStepsPanel.java
@@ -53,7 +53,7 @@ class BattleStepsPanel extends JPanel {
 
   /** Set the steps given, setting the selected step to the first step. */
   void listBattle(final List<String> steps) {
-    Util.ensureEventDispatchThread();
+    Util.ensureOnEventDispatchThread();
     synchronized (mutex) {
       listModel.removeAllElements();
       steps.forEach(listModel::addElement);
@@ -98,7 +98,7 @@ class BattleStepsPanel extends JPanel {
 
   /** Walks through and pause at each list item until we find our target. */
   private void walkStep() {
-    Util.ensureEventDispatchThread();
+    Util.ensureOnEventDispatchThread();
     if (doneWalkingSteps()) {
       wakeAll();
       return;
@@ -159,7 +159,7 @@ class BattleStepsPanel extends JPanel {
   }
 
   private void goToTarget() {
-    Util.ensureEventDispatchThread();
+    Util.ensureOnEventDispatchThread();
     waitThenWalk();
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattleStepsPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattleStepsPanel.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea.ui;
 
+import games.strategy.ui.Util;
 import java.awt.BorderLayout;
 import java.util.ArrayList;
 import java.util.List;
@@ -52,9 +53,7 @@ class BattleStepsPanel extends JPanel {
 
   /** Set the steps given, setting the selected step to the first step. */
   void listBattle(final List<String> steps) {
-    if (!SwingUtilities.isEventDispatchThread()) {
-      throw new IllegalStateException("Not in dispatch thread");
-    }
+    Util.ensureEventDispatchThread();
     synchronized (mutex) {
       listModel.removeAllElements();
       steps.forEach(listModel::addElement);
@@ -99,9 +98,7 @@ class BattleStepsPanel extends JPanel {
 
   /** Walks through and pause at each list item until we find our target. */
   private void walkStep() {
-    if (!SwingUtilities.isEventDispatchThread()) {
-      throw new IllegalStateException("Wrong thread");
-    }
+    Util.ensureEventDispatchThread();
     if (doneWalkingSteps()) {
       wakeAll();
       return;
@@ -162,9 +159,7 @@ class BattleStepsPanel extends JPanel {
   }
 
   private void goToTarget() {
-    if (!SwingUtilities.isEventDispatchThread()) {
-      throw new IllegalStateException("Not swing event thread");
-    }
+    Util.ensureEventDispatchThread();
     waitThenWalk();
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -1398,7 +1398,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
       final Map<Territory, Collection<Unit>> possibleUnitsToAttack,
       final Resource attackResourceToken,
       final int maxNumberOfAttacksAllowed) {
-    Util.ensureNoneEventDispatchThread();
+    Util.ensureNotOnEventDispatchThread();
     final Map<Territory, IntegerMap<Unit>> selection = new HashMap<>();
     if (possibleUnitsToAttack == null
         || possibleUnitsToAttack.isEmpty()
@@ -1522,7 +1522,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
       final Territory scrambleTo,
       final Map<Territory, Tuple<Collection<Unit>, Collection<Unit>>> possibleScramblers) {
     messageAndDialogThreadPool.waitForAll();
-    Util.ensureNoneEventDispatchThread();
+    Util.ensureNotOnEventDispatchThread();
     final CountDownLatch continueLatch = new CountDownLatch(1);
     final Map<Territory, Collection<Unit>> selection = new HashMap<>();
     final Collection<Tuple<Territory, UnitChooser>> choosers = new ArrayList<>();
@@ -1694,7 +1694,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
   public Collection<Unit> selectUnitsQuery(
       final Territory current, final Collection<Unit> possible, final String message) {
     messageAndDialogThreadPool.waitForAll();
-    Util.ensureNoneEventDispatchThread();
+    Util.ensureNotOnEventDispatchThread();
     final CountDownLatch continueLatch = new CountDownLatch(1);
     final Collection<Unit> selection = new ArrayList<>();
     SwingUtilities.invokeLater(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -78,6 +78,7 @@ import games.strategy.triplea.ui.panels.map.MapSelectionListener;
 import games.strategy.triplea.util.TuvUtils;
 import games.strategy.ui.ImageScrollModel;
 import games.strategy.ui.ImageScrollerSmallView;
+import games.strategy.ui.Util;
 import java.awt.BorderLayout;
 import java.awt.Color;
 import java.awt.Component;
@@ -1397,9 +1398,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
       final Map<Territory, Collection<Unit>> possibleUnitsToAttack,
       final Resource attackResourceToken,
       final int maxNumberOfAttacksAllowed) {
-    if (SwingUtilities.isEventDispatchThread()) {
-      throw new IllegalStateException("Should not be called from dispatch thread");
-    }
+    Util.ensureNoneEventDispatchThread();
     final Map<Territory, IntegerMap<Unit>> selection = new HashMap<>();
     if (possibleUnitsToAttack == null
         || possibleUnitsToAttack.isEmpty()
@@ -1523,9 +1522,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
       final Territory scrambleTo,
       final Map<Territory, Tuple<Collection<Unit>, Collection<Unit>>> possibleScramblers) {
     messageAndDialogThreadPool.waitForAll();
-    if (SwingUtilities.isEventDispatchThread()) {
-      throw new IllegalStateException("Should not be called from dispatch thread");
-    }
+    Util.ensureNoneEventDispatchThread();
     final CountDownLatch continueLatch = new CountDownLatch(1);
     final Map<Territory, Collection<Unit>> selection = new HashMap<>();
     final Collection<Tuple<Territory, UnitChooser>> choosers = new ArrayList<>();
@@ -1697,9 +1694,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
   public Collection<Unit> selectUnitsQuery(
       final Territory current, final Collection<Unit> possible, final String message) {
     messageAndDialogThreadPool.waitForAll();
-    if (SwingUtilities.isEventDispatchThread()) {
-      throw new IllegalStateException("Should not be called from dispatch thread");
-    }
+    Util.ensureNoneEventDispatchThread();
     final CountDownLatch continueLatch = new CountDownLatch(1);
     final Collection<Unit> selection = new ArrayList<>();
     SwingUtilities.invokeLater(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
@@ -5,6 +5,7 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.history.HistoryNode;
 import games.strategy.engine.history.Step;
 import games.strategy.triplea.ui.UiContext;
+import games.strategy.ui.Util;
 import java.awt.BorderLayout;
 import java.awt.Component;
 import java.awt.GridBagConstraints;
@@ -282,18 +283,14 @@ public class HistoryPanel extends JPanel {
   }
 
   private void treeSelectionChanged(final TreeSelectionEvent e) {
-    if (!SwingUtilities.isEventDispatchThread()) {
-      throw new IllegalStateException("Wrong thread");
-    }
+    Util.ensureEventDispatchThread();
     // move the game to the state of the selected node
     final HistoryNode node = (HistoryNode) e.getPath().getLastPathComponent();
     gotoNode(node);
   }
 
   private void gotoNode(final HistoryNode node) {
-    if (!SwingUtilities.isEventDispatchThread()) {
-      throw new IllegalStateException("Not EDT");
-    }
+    Util.ensureEventDispatchThread();
     if (details != null) {
       details.render(node);
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryPanel.java
@@ -283,14 +283,14 @@ public class HistoryPanel extends JPanel {
   }
 
   private void treeSelectionChanged(final TreeSelectionEvent e) {
-    Util.ensureEventDispatchThread();
+    Util.ensureOnEventDispatchThread();
     // move the game to the state of the selected node
     final HistoryNode node = (HistoryNode) e.getPath().getLastPathComponent();
     gotoNode(node);
   }
 
   private void gotoNode(final HistoryNode node) {
-    Util.ensureEventDispatchThread();
+    Util.ensureOnEventDispatchThread();
     if (details != null) {
       details.render(node);
     }

--- a/game-app/game-core/src/main/java/games/strategy/ui/Util.java
+++ b/game-app/game-core/src/main/java/games/strategy/ui/Util.java
@@ -139,13 +139,13 @@ public final class Util {
     return translatedPolygon;
   }
 
-  public static void ensureEventDispatchThread() {
+  public static void ensureOnEventDispatchThread() {
     if (!SwingUtilities.isEventDispatchThread()) {
       throw new IllegalStateException("Wrong thread (not Event Dispatch Thread)");
     }
   }
 
-  public static void ensureNoneEventDispatchThread() {
+  public static void ensureNotOnEventDispatchThread() {
     if (SwingUtilities.isEventDispatchThread()) {
       throw new IllegalStateException("This method should not called from Event Dispatch Thread");
     }

--- a/game-app/game-core/src/main/java/games/strategy/ui/Util.java
+++ b/game-app/game-core/src/main/java/games/strategy/ui/Util.java
@@ -16,6 +16,7 @@ import java.awt.Toolkit;
 import java.awt.Window;
 import java.awt.geom.GeneralPath;
 import java.awt.image.BufferedImage;
+import javax.swing.SwingUtilities;
 import lombok.experimental.UtilityClass;
 
 /** A collection of methods useful for rendering the UI. */
@@ -136,5 +137,17 @@ public final class Util {
         new Polygon(polygon.xpoints, polygon.ypoints, polygon.npoints);
     translatedPolygon.translate(deltaX, deltaY);
     return translatedPolygon;
+  }
+
+  public static void ensureEventDispatchThread() {
+    if (!SwingUtilities.isEventDispatchThread()) {
+      throw new IllegalStateException("Wrong thread (not Event Dispatch Thread)");
+    }
+  }
+
+  public static void ensureNoneEventDispatchThread() {
+    if (SwingUtilities.isEventDispatchThread()) {
+      throw new IllegalStateException("This method should not called from Event Dispatch Thread");
+    }
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/ui/UtilTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/ui/UtilTest.java
@@ -17,7 +17,7 @@ final class UtilTest {
   AtomicReference<Throwable> inThreadException;
 
   void runInEvenDispatchThreadAndRethrow(final Runnable run) throws Throwable {
-    inThreadException.set(null);
+    inThreadException = new AtomicReference<>();
     final Thread threadNotEventDispatchThread =
         new Thread(
             () -> {

--- a/game-app/game-core/src/test/java/games/strategy/ui/UtilTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/ui/UtilTest.java
@@ -8,37 +8,21 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.awt.Polygon;
 import java.lang.reflect.InvocationTargetException;
-import java.util.concurrent.atomic.AtomicReference;
 import javax.swing.SwingUtilities;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 final class UtilTest {
-  AtomicReference<Throwable> inThreadException;
 
-  void runInEvenDispatchThreadAndRethrow(final Runnable run) throws Throwable {
-    inThreadException = new AtomicReference<>();
-    final Thread threadNotEventDispatchThread =
-        new Thread(
-            () -> {
-              try {
-                SwingUtilities.invokeAndWait(run);
-              } catch (final InterruptedException e) {
-                inThreadException.set(e);
-              } catch (final InvocationTargetException e) {
-                inThreadException.set(e.getTargetException());
-              }
-            });
-
-    threadNotEventDispatchThread.start();
+  /**
+   * @param run Runnable to be executed
+   * @throws Throwable target exception raised in the Runnable executed in Event Dispatch Thread
+   */
+  static void runInEvenDispatchThreadAndRethrow(final Runnable run) throws Throwable {
     try {
-      threadNotEventDispatchThread.join();
-    } catch (final InterruptedException e) {
-      inThreadException.set(e);
-    }
-    final Throwable throwableResult = inThreadException.get();
-    if (throwableResult != null) {
-      throw throwableResult;
+      SwingUtilities.invokeAndWait(run);
+    } catch (final InvocationTargetException e) {
+      throw e.getTargetException();
     }
   }
 

--- a/game-app/game-core/src/test/java/games/strategy/ui/UtilTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/ui/UtilTest.java
@@ -2,12 +2,37 @@ package games.strategy.ui;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.awt.Polygon;
+import javax.swing.SwingUtilities;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
 final class UtilTest {
+  @Test
+  void ensureOnEventDispatchThread() {
+    new Thread(
+            () ->
+                assertAll(
+                    () -> SwingUtilities.invokeAndWait(() -> Util.ensureOnEventDispatchThread())))
+        .start();
+    assertThrows(IllegalStateException.class, () -> Util.ensureOnEventDispatchThread());
+  }
+
+  @Test
+  void ensureNotOnEventDispatchThread() {
+    new Thread(
+            () ->
+                assertThrows(
+                    IllegalStateException.class,
+                    () ->
+                        SwingUtilities.invokeAndWait(() -> Util.ensureNotOnEventDispatchThread())))
+        .start();
+    assertAll(() -> Util.ensureNotOnEventDispatchThread());
+  }
+
   @Nested
   final class TranslatePolygonTest {
     private final Polygon polygon = new Polygon(new int[] {1, 2, 3}, new int[] {4, 5, 6}, 3);


### PR DESCRIPTION
EDT-checks outsourced into new methods in Util.java:
-ensureEventDispatchThread
-ensureNoneEventDispatchThread

Maybe someone experienced in this thread stuff could write also a test method or we leave them without as they are short.