### PR TITLE
Fix NodeBB banned check

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/posted/game/pbf/NodeBbTokenGenerator.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/posted/game/pbf/NodeBbTokenGenerator.java
@@ -101,7 +101,8 @@ public class NodeBbTokenGenerator {
     if (!jsonObject.containsKey("uid")) {
       throw new IllegalStateException(String.format("User %s doesn't exist.", username));
     }
-    if (1 == (Integer) jsonObject.get("banned")) {
+    Object banned = jsonObject.get("banned");
+    if (banned instanceof Integer ? (Integer) banned == 1 : (Boolean) banned) {
       throw new IllegalStateException("Your account is banned from the forum.");
     }
     if (1 != (Integer) jsonObject.get("email:confirmed")) {


### PR DESCRIPTION
Fixes #10058
Fixes #10031
Looks like more recent versions of NodeBB use a boolean instead of an int in the json payload