### PR TITLE
Fix PBEM To field to not delete spaces when typing two addresses.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbem/EmailSenderEditor.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbem/EmailSenderEditor.java
@@ -277,8 +277,10 @@ public class EmailSenderEditor implements ViewModelListener<EmailSenderEditorVie
       final JTextField textField, final String incomingValue) {
     // avoid updating fields to the same value; setting field text
     // resets the carat position to the end, very annoying if a user is
-    // editing text.
-    if (!textField.getText().equals(incomingValue)) {
+    // editing text. Trim the text before comparing as the model will
+    // trim email addresses internally, which breaks typing multiple
+    // space-separated emails in the To field.
+    if (!textField.getText().trim().equals(incomingValue)) {
       textField.setText(incomingValue);
     }
   }


### PR DESCRIPTION
Fix PBEM To field to not delete spaces when typing two addresses.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|PBEM To field issue input of multiple space-separated emails.<!--END_RELEASE_NOTE-->
