### PR TITLE
Keep player lists and select save if a game ends due to a disconnect.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -255,10 +255,10 @@ public class ServerLauncher implements ILauncher {
    * example, a disconnected participant will cause the game to be stopped, while a disconnected
    * observer will have no effect.
    */
-  public void connectionLost(final INode node) {
+  public void connectionLost(final INode droppedNode) {
     if (isLaunching) {
       // this is expected, we told the observer he couldn't join, so now we lose the connection
-      if (observersThatTriedToJoinDuringStartup.remove(node)) {
+      if (observersThatTriedToJoinDuringStartup.remove(droppedNode)) {
         return;
       }
       // a player has dropped out, abort
@@ -268,12 +268,12 @@ public class ServerLauncher implements ILauncher {
     }
     // if we lose a connection to a player, shut down the game (after saving) and go back to the
     // main screen
-    if (serverGame.getPlayerManager().isPlaying(node)) {
+    if (serverGame.getPlayerManager().isPlaying(droppedNode)) {
       if (serverGame.isGameSequenceRunning()) {
-        saveAndEndGame(node);
-        // Release any countries played by this player. This ensures the slots are freed up in the
-        // game lobby as we keep the other player mappings for resuming from the saved game.
-        for (final String countryName : serverGame.getPlayerManager().getPlayedBy(node)) {
+        saveAndEndGame(droppedNode);
+        // Release any countries played by the player that dropped. The other seating assignments
+        // are preserved for the game lobby that will be shown.
+        for (final String countryName : serverGame.getPlayerManager().getPlayedBy(droppedNode)) {
           serverModel.releasePlayer(countryName);
         }
         serverModel.persistPlayersToNodesMapping();

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/launcher/ServerLauncher.java
@@ -271,6 +271,12 @@ public class ServerLauncher implements ILauncher {
     if (serverGame.getPlayerManager().isPlaying(node)) {
       if (serverGame.isGameSequenceRunning()) {
         saveAndEndGame(node);
+        // Release any countries played by this player. This ensures the slots are freed up in the
+        // game lobby as we keep the other player mappings for resuming from the saved game.
+        for (final String countryName : serverGame.getPlayerManager().getPlayedBy(node)) {
+          serverModel.releasePlayer(countryName);
+        }
+        serverModel.persistPlayersToNodesMapping();
       } else {
         stopGame();
       }
@@ -294,6 +300,7 @@ public class ServerLauncher implements ILauncher {
     final Path f = launchAction.getAutoSaveFile();
     try {
       serverGame.saveGame(f);
+      gameSelectorModel.setSaveGameFileToLoad(f);
     } catch (final Exception e) {
       log.error("Failed to save game: " + f.toAbsolutePath(), e);
     }

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -342,10 +342,12 @@ public class ServerModel extends Observable implements IConnectionChangeListener
       playersToNodesMappingPersisted = false;
       final Set<String> dataPlayers =
           data.getPlayerList().stream().map(GamePlayer::getName).collect(Collectors.toSet());
+      // Sanity check that the list of countries matches.
       if (dataPlayers.equals(playersToNodeListing.keySet())) {
-        // List of countries matches, keep the persisted mappings.
+        // Don't regenerate the mappings, persist existing ones.
         return;
       }
+      throw new IllegalStateException("Expected countries to match when persisting seatings");
     }
 
     // Reset setting based on game data.

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/mc/ServerModel.java
@@ -323,6 +323,19 @@ public class ServerModel extends Observable implements IConnectionChangeListener
     this.playersToNodesMappingPersisted = true;
   }
 
+  private void gameDataChanged() {
+    synchronized (this) {
+      data = gameSelectorModel.getGameData();
+      if (data != null) {
+        updatePlayersOnGameDataChanged(data);
+      }
+      objectStreamFactory.setData(data);
+      localPlayerTypes.clear();
+    }
+    notifyChannelPlayersChanged();
+    remoteModelListener.playerListChanged();
+  }
+
   private void updatePlayersOnGameDataChanged(final GameData data) {
     // If specified, keep the previous player data.
     if (playersToNodesMappingPersisted) {
@@ -360,19 +373,6 @@ public class ServerModel extends Observable implements IConnectionChangeListener
           name, data.getAllianceTracker().getAlliancesPlayerIsIn(player));
       playersEnabledListing.put(name, !player.getIsDisabled());
     }
-  }
-
-  private void gameDataChanged() {
-    synchronized (this) {
-      data = gameSelectorModel.getGameData();
-      if (data != null) {
-        updatePlayersOnGameDataChanged(data);
-      }
-      objectStreamFactory.setData(data);
-      localPlayerTypes.clear();
-    }
-    notifyChannelPlayersChanged();
-    remoteModelListener.playerListChanged();
   }
 
   private Optional<ServerConnectionProps> getServerProps() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ActionButtons.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ActionButtons.java
@@ -46,22 +46,23 @@ public class ActionButtons extends JPanel {
   private static final long serialVersionUID = 2175685892863042399L;
   private final CardLayout layout = new CardLayout();
 
-  @Getter private BattlePanel battlePanel;
+  @Getter private @Nullable BattlePanel battlePanel;
 
-  private MovePanel movePanel;
+  private @Nullable MovePanel movePanel;
 
-  private PurchasePanel purchasePanel;
-  private RepairPanel repairPanel;
+  private @Nullable PurchasePanel purchasePanel;
+  private @Nullable RepairPanel repairPanel;
 
   @Getter private PlacePanel placePanel;
 
-  private TechPanel techPanel;
-  private EndTurnPanel endTurnPanel;
-  private MoveForumPosterPanel moveForumPosterPanel;
+  private @Nullable TechPanel techPanel;
+  private @Nullable EndTurnPanel endTurnPanel;
+  private @Nullable MoveForumPosterPanel moveForumPosterPanel;
+  private @Nullable PoliticsPanel politicsPanel;
+  private @Nullable UserActionPanel userActionPanel;
+  private @Nullable PickTerritoryAndUnitsPanel pickTerritoryAndUnitsPanel;
+
   private @Nullable ActionPanel actionPanel;
-  private PoliticsPanel politicsPanel;
-  private UserActionPanel userActionPanel;
-  private PickTerritoryAndUnitsPanel pickTerritoryAndUnitsPanel;
 
   public ActionButtons(
       final GameData data,
@@ -128,11 +129,13 @@ public class ActionButtons extends JPanel {
   }
 
   void changeToMove(final GamePlayer gamePlayer, final boolean nonCombat, final String stepName) {
-    movePanel.setNonCombat(nonCombat);
-    final boolean airBorne = stepName.endsWith("AirborneCombatMove");
-    final String displayText = (airBorne ? " Airborne" : (nonCombat ? " Non" : ""));
-    movePanel.setDisplayText(displayText + " Combat Move");
-    movePanel.setMoveType(airBorne ? MoveType.SPECIAL : MoveType.DEFAULT);
+    if (movePanel != null) {
+      movePanel.setNonCombat(nonCombat);
+      final boolean airBorne = stepName.endsWith("AirborneCombatMove");
+      final String displayText = (airBorne ? " Airborne" : (nonCombat ? " Non" : ""));
+      movePanel.setDisplayText(displayText + " Combat Move");
+      movePanel.setMoveType(airBorne ? MoveType.SPECIAL : MoveType.DEFAULT);
+    }
     changeTo(gamePlayer, movePanel);
   }
 
@@ -150,7 +153,9 @@ public class ActionButtons extends JPanel {
 
   public void changeToBattle(
       final GamePlayer gamePlayer, final Map<BattleType, Collection<Territory>> battles) {
-    battlePanel.setBattlesAndBombing(battles);
+    if (battlePanel != null) {
+      battlePanel.setBattlesAndBombing(battles);
+    }
     changeTo(gamePlayer, battlePanel);
   }
 
@@ -198,6 +203,9 @@ public class ActionButtons extends JPanel {
    * @return null if no move was made.
    */
   public IntegerMap<ProductionRule> waitForPurchase(final boolean bid) {
+    if (purchasePanel == null) {
+      return null;
+    }
     return purchasePanel.waitForPurchase(bid);
   }
 
@@ -208,6 +216,9 @@ public class ActionButtons extends JPanel {
    */
   public Map<Unit, IntegerMap<RepairRule>> waitForRepair(
       final boolean bid, final Collection<GamePlayer> allowedPlayersToRepair) {
+    if (repairPanel == null) {
+      return null;
+    }
     return repairPanel.waitForRepair(bid, allowedPlayersToRepair);
   }
 
@@ -217,6 +228,9 @@ public class ActionButtons extends JPanel {
    * @return null if no move was made.
    */
   public MoveDescription waitForMove(final IPlayerBridge bridge) {
+    if (movePanel == null) {
+      return null;
+    }
     return movePanel.waitForMove(bridge);
   }
 
@@ -226,6 +240,9 @@ public class ActionButtons extends JPanel {
    * @return null if no tech roll was made.
    */
   public TechRoll waitForTech() {
+    if (techPanel == null) {
+      return null;
+    }
     return techPanel.waitForTech();
   }
 
@@ -236,6 +253,9 @@ public class ActionButtons extends JPanel {
    */
   public PoliticalActionAttachment waitForPoliticalAction(
       final boolean firstRun, final IPoliticsDelegate politicsDelegate) {
+    if (politicsPanel == null) {
+      return null;
+    }
     return politicsPanel.waitForPoliticalAction(firstRun, politicsDelegate);
   }
 
@@ -246,6 +266,9 @@ public class ActionButtons extends JPanel {
    */
   public UserActionAttachment waitForUserActionAction(
       final boolean firstRun, final IUserActionDelegate userActionDelegate) {
+    if (userActionPanel == null) {
+      return null;
+    }
     return userActionPanel.waitForUserActionAction(firstRun, userActionDelegate);
   }
 
@@ -255,20 +278,30 @@ public class ActionButtons extends JPanel {
    * @return null if no placement was made.
    */
   public PlaceData waitForPlace(final boolean bid, final IPlayerBridge bridge) {
+    if (placePanel == null) {
+      return null;
+    }
     return placePanel.waitForPlace(bid, bridge);
   }
 
   /** Blocks until the user selects an end-of-turn action. */
   public void waitForEndTurn(final TripleAFrame frame, final IPlayerBridge bridge) {
-    endTurnPanel.waitForDone(frame, bridge);
+    if (endTurnPanel != null) {
+      endTurnPanel.waitForDone(frame, bridge);
+    }
   }
 
   public void waitForMoveForumPosterPanel(final TripleAFrame frame, final IPlayerBridge bridge) {
-    moveForumPosterPanel.waitForDone(frame, bridge);
+    if (moveForumPosterPanel != null) {
+      moveForumPosterPanel.waitForDone(frame, bridge);
+    }
   }
 
   /** Blocks until the user selects a battle to fight. */
   public FightBattleDetails waitForBattleSelection() {
+    if (battlePanel == null) {
+      return null;
+    }
     return battlePanel.waitForBattleSelection();
   }
 
@@ -276,6 +309,9 @@ public class ActionButtons extends JPanel {
       final List<Territory> territoryChoices,
       final List<Unit> unitChoices,
       final int unitsPerPick) {
+    if (pickTerritoryAndUnitsPanel == null) {
+      return Tuple.of(null, Set.of());
+    }
     return pickTerritoryAndUnitsPanel.waitForPickTerritoryAndUnits(
         territoryChoices, unitChoices, unitsPerPick);
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ActionButtons.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ActionButtons.java
@@ -182,9 +182,9 @@ public class ActionButtons extends JPanel {
     actionPanel = newCurrent;
 
     // newCurrent might be null if we are shutting down
-    if (actionPanel != null) {
-      actionPanel.display(gamePlayer);
-      SwingUtilities.invokeLater(() -> layout.show(ActionButtons.this, actionPanel.toString()));
+    if (newCurrent != null) {
+      newCurrent.display(gamePlayer);
+      SwingUtilities.invokeLater(() -> layout.show(ActionButtons.this, newCurrent.toString()));
     }
   }
 


### PR DESCRIPTION
Keep player lists and select save if a game ends due to a disconnect.

With this change, if a networked game ends because a joined player disconnects, the
game lobby dialog that will be re-opened for the server is now improved in these ways:
  - The save game that was produced on disconnect will now be selected.
  - The countries / players set up from the ended game will be kept.
     This includes which players have selected which countries and the AI settings
     for the host. Countries that were played by the disconnected player will be cleared
     and be opened to be chosen.
  - Additionally, this PR fixes some NPEs that could happen on disconnect that I discovered
     in my testing.

This makes it much easier to continue the game when the disconnected player re-connects.

## Change Summary & Additional Notes

- No UI changes, this just sets up the existing UI on a game disconnect.
- I've tested on Revised, running three copies of TripleA on my computer, with
  different countries being played by different players, including AIs.

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->CHANGE: If a joined player disconnects, the game lobby will now select the auto-saved game and persist the player list from the previous game.<!--END_RELEASE_NOTE-->
