### PR TITLE
Fix NPE in calculateBombingRoutes().

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -401,17 +401,16 @@ public final class ProMoveUtils {
         unitList.add(u);
 
         // Determine route and add to move list
-        Route route = null;
-        if (!unitList.isEmpty() && unitList.stream().allMatch(Matches.unitIsAir())) {
-          route =
+        if (unitList.stream().allMatch(Matches.unitIsAir())) {
+          final Route route =
               map.getRouteForUnit(
                   startTerritory,
                   t,
                   ProMatches.territoryCanMoveAirUnitsAndNoAa(data, player, true),
                   u,
                   player);
+          moves.add(new MoveDescription(unitList, route));
         }
-        moves.add(new MoveDescription(unitList, route));
       }
     }
     return moves;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMoveUtils.java
@@ -409,7 +409,9 @@ public final class ProMoveUtils {
                   ProMatches.territoryCanMoveAirUnitsAndNoAa(data, player, true),
                   u,
                   player);
-          moves.add(new MoveDescription(unitList, route));
+          if (route != null) {
+            moves.add(new MoveDescription(unitList, route));
+          }
         }
       }
     }


### PR DESCRIPTION
The previous logic could result in a move being constructed with a null route. This change updates the logic to not create a move in that case.

## Change Summary & Additional Notes

Fixes https://github.com/triplea-game/triplea/issues/10183.

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Game can crash resulting from AI bombing logic<!--END_RELEASE_NOTE-->
