### PR TITLE
Acquire lock in TerritoryDetailPanel to avoid concurrent exception.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -6,7 +6,6 @@ import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.Territory;
 import games.strategy.triplea.attachments.TerritoryAttachment;
-import games.strategy.triplea.delegate.BaseEditDelegate;
 import games.strategy.triplea.odds.calculator.BattleCalculatorDialog;
 import games.strategy.triplea.ui.panels.map.MapPanel;
 import games.strategy.triplea.util.UnitCategory;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -177,10 +177,11 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
     gameData.acquireReadLock();
     try {
       unitsList = UnitSeparator.getSortedUnitCategories(territory, uiContext.getMapData());
-      unitsLabel = "Units: "
-          + territory.getUnits().stream()
-          .filter(u -> uiContext.getMapData().shouldDrawUnit(u.getType().getName()))
-          .count();
+      unitsLabel =
+          "Units: "
+              + territory.getUnits().stream()
+                  .filter(u -> uiContext.getMapData().shouldDrawUnit(u.getType().getName()))
+                  .count();
     } finally {
       gameData.releaseReadLock();
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -168,29 +168,32 @@ public class TerritoryDetailPanel extends AbstractStatPanel {
       labelText = "<html>" + ta.toStringForInfo(true, true) + "<br>" + additionalText + "</html>";
     }
     territoryInfo.setText(labelText);
-    unitInfo.setText(
-        "Units: "
-            + territory.getUnits().stream()
-                .filter(u -> uiContext.getMapData().shouldDrawUnit(u.getType().getName()))
-                .count());
-    units.setViewportView(unitsInTerritoryPanel(territory, uiContext, gameData));
-  }
 
-  private static JPanel unitsInTerritoryPanel(
-      final Territory territory, final UiContext uiContext, final GameData gameData) {
-    final JPanel panel = new JPanel();
-    panel.setBorder(BorderFactory.createEmptyBorder(2, 20, 2, 2));
-    panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
+    final List<UnitCategory> unitsList;
+    final String unitsLabel;
 
-    final List<UnitCategory> units;
-    // Get unit types under lock as otherwise they may change on the game thread causing a
+    // Get the unit information under lock as otherwise they may change on the game thread causing a
     // ConcurrentModificationException.
     gameData.acquireReadLock();
     try {
-      units = UnitSeparator.getSortedUnitCategories(territory, uiContext.getMapData());
+      unitsList = UnitSeparator.getSortedUnitCategories(territory, uiContext.getMapData());
+      unitsLabel = "Units: "
+          + territory.getUnits().stream()
+          .filter(u -> uiContext.getMapData().shouldDrawUnit(u.getType().getName()))
+          .count();
     } finally {
       gameData.releaseReadLock();
     }
+
+    unitInfo.setText(unitsLabel);
+    units.setViewportView(unitsInTerritoryPanel(unitsList, uiContext));
+  }
+
+  private static JPanel unitsInTerritoryPanel(
+      final List<UnitCategory> units, final UiContext uiContext) {
+    final JPanel panel = new JPanel();
+    panel.setBorder(BorderFactory.createEmptyBorder(2, 20, 2, 2));
+    panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
 
     @Nullable GamePlayer currentPlayer = null;
     for (final UnitCategory item : units) {


### PR DESCRIPTION
Acquire lock in TerritoryDetailPanel to avoid concurrent exceptions.

## Change Summary & Additional Notes

Fixes https://github.com/triplea-game/triplea/issues/10024 and https://github.com/triplea-game/triplea/issues/9453.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|ConcurrentModificationException in territory details panel.<!--END_RELEASE_NOTE-->
