### PR TITLE
Switch macOS install4j artifact to app bundle.

### DIFF
--- a/game-app/game-headed/build.install4j
+++ b/game-app/game-headed/build.install4j
@@ -804,9 +804,7 @@ return true;</property>
     <windows name="Windows 64 bit" id="87" mediaFileName="${compiler:sys.fullName}_${compiler:sys.version}_windows-64bit">
       <jreBundle usePack200="false" directDownload="true" />
     </windows>
-    <macos name="Mac OS X" id="35" compressDmg="true" launcherId="33">
-      <jreBundle usePack200="false" directDownload="true" />
-    </macos>
+    <macosArchive name="macOS Single Bundle Archive" id="557" launcherId="33" />
     <unixInstaller name="Unix" id="36">
       <jreBundle usePack200="false" directDownload="true" installOnlyIfNecessary="true" />
     </unixInstaller>


### PR DESCRIPTION
The previous setting was an Installer w/ macOS single bundle, which is not recommended:
https://www.ej-technologies.com/resources/install4j/help/doc/concepts/mediaFiles.html

## Change Summary & Additional Notes

This should result in changing the TripleA release for macOS to be a .dmg containing the app bundle, rather than containing an installer that installs the app bundle. Since the TripleA app bundle is self contained, this is preferable and also recommended by install4j.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->CHANGE|macOS releases no longer use an installer.<!--END_RELEASE_NOTE-->
