### PR TITLE
Parse JSON first as map then as list to handle new nodeBB API

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/posted/game/pbf/NodeBbForumPoster.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/posted/game/pbf/NodeBbForumPoster.java
@@ -156,8 +156,14 @@ public class NodeBbForumPoster {
       final int status = response.getStatusLine().getStatusCode();
       if (status == HttpURLConnection.HTTP_OK) {
         final String json = EntityUtils.toString(response.getEntity());
-        final String url = (String) YamlReader.readList(json).get(0).get("url");
-        return "\n[Savegame](" + url + ")";
+        try {
+          final String url = (String) YamlReader.readMap(json).get("url");
+          return "\n[Savegame](" + url + ")";
+        } catch (final Exception e) {
+          // This is a temporary hack to handle old versions of nodeBB forum json
+          final String url = (String) YamlReader.readList(json).get(0).get("url");
+          return "\n[Savegame](" + url + ")";
+        }
       }
       throw new IllegalStateException(
           "Failed to upload savegame, server returned Error Code "


### PR DESCRIPTION
## Change Summary & Additional Notes
Fix #10117 by first trying to parse the payload as a map as that is what the new nodeBB API returns and if that fails then parse as a list to support old nodeBB versions

I did some basic testing and this seems to allow successful posting to A&A.org: https://www.axisandallies.org/forums/topic/20781/panther-s-triplea-pre-release-test-thread/171

## Release Note
If this is confirmed to fix the PBF issues then we can look to put this change and #10059 into a patch fix branch to release it.

@DanVanAtta @asvitkine @RoiEXLab I would appreciate if one of you can do a quick review so we can have some folks test this fix.

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
