### PR TITLE
Add gradle jvmargs to allow spotlessApply to work with newer Java.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,6 @@
 org.gradle.caching=true
+org.gradle.jvmargs=--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED


### PR DESCRIPTION
Add gradle jvmargs to allow spotlessApply to work with newer Java.

Without this, running spotlessApply hits an error.

See https://github.com/diffplug/spotless/issues/834.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
