### PR TITLE
Clean up game data update code in StatPanel.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/StatPanel.java
@@ -53,6 +53,7 @@ class StatPanel extends AbstractStatPanel implements GameDataChangeListener {
     techModel = new TechTableModel();
     fillPlayerIcons();
     initLayout();
+    gameData.addDataChangeListener(this);
   }
 
   protected void initLayout() {
@@ -150,7 +151,6 @@ class StatPanel extends AbstractStatPanel implements GameDataChangeListener {
 
     StatTableModel() {
       setStatColumns();
-      gameData.addDataChangeListener(this);
     }
 
     void setStatColumns() {
@@ -255,7 +255,6 @@ class StatPanel extends AbstractStatPanel implements GameDataChangeListener {
     private final Map<String, Integer> rowMap = new HashMap<>();
 
     TechTableModel() {
-      gameData.addDataChangeListener(this);
       initColList();
       /* Load the country -> col mapping */
       for (int i = 0; i < colList.length; i++) {


### PR DESCRIPTION
## Change Summary & Additional Notes

Changes the StatPanel to be the one listening for game data updates. This fixes incorrect logic where two nested classes were incorrectly handling setGameData() calls, since the gameData variable was coming from the outer class already.

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
