### PR TITLE
Parallelize downloads in smoke tests.

### DIFF
--- a/smoke-testing/build.gradle
+++ b/smoke-testing/build.gradle
@@ -25,14 +25,19 @@ tasks.test.dependsOn("downloadXmls", "downloadSaveGames")
 task downloadXmls {
     doLast {
         mkdir "$projectDir/src/test/resources/map-xmls/"
+
+        def urls = []
         file('map-list.txt').eachLine { path ->
             if (!path.startsWith('#')) {
-                download.run {
-                    src "$path"
-                    dest "$projectDir/src/test/resources/map-xmls/"
-                    overwrite false
-                }
+                urls.add(path)
             }
+        }
+
+        // Use a single download.run invocation to download in parallel.
+        download.run {
+             src(urls)
+             dest "$projectDir/src/test/resources/map-xmls/"
+             overwrite false
         }
     }
 }
@@ -40,14 +45,19 @@ task downloadXmls {
 task downloadSaveGames {
     doLast {
         mkdir "$projectDir/src/test/resources/save-games/"
+
+        def urls = []
         file('save-game-list.txt').eachLine { path ->
             if (!path.startsWith('#')) {
-                download.run {
-                    src "$path"
-                    dest "$projectDir/src/test/resources/save-games/"
-                    overwrite false
-                }
+                urls.add(path)
             }
+        }
+
+        // Use a single download.run invocation to download in parallel.
+        download.run {
+            src(urls)
+            dest "$projectDir/src/test/resources/save-games/"
+            overwrite false
         }
     }
 }


### PR DESCRIPTION
## Change Summary & Additional Notes
Parallelize downloads in smoke tests.

With this change, ./gradlew :smoke-testing:downloadXmls goes from 13s to 3s on my machine.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
