### PR TITLE
Add smoke test that downloads some maps and verifies game saving.

### DIFF
--- a/smoke-testing/src/test/java/games/strategy/engine/data/GameSaveTest.java
+++ b/smoke-testing/src/test/java/games/strategy/engine/data/GameSaveTest.java
@@ -21,7 +21,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.triplea.config.product.ProductVersionReader;
@@ -30,13 +30,17 @@ import org.triplea.injection.Injections;
 import org.triplea.io.ContentDownloader;
 import org.triplea.io.FileUtils;
 
+/**
+ * Checks that no error is encountered when saving a game on several different maps. This test
+ * downloads the maps in question and starts an all-AI game on each of them, before saving.
+ *
+ * <p>Note: A variety of maps are used to ensure different engine features are exercised since
+ * object serialization may run into errors that depend on the state of the object graph.
+ */
 class GameSaveTest {
 
-  @BeforeEach
-  public void setUp() throws IOException {
-    if (Injections.getInstance() != null) {
-      return;
-    }
+  @BeforeAll
+  public static void setUp() throws IOException {
     Injections.init(
         Injections.builder()
             .engineVersion(new ProductVersionReader().getVersion())

--- a/smoke-testing/src/test/java/games/strategy/engine/data/GameSaveTest.java
+++ b/smoke-testing/src/test/java/games/strategy/engine/data/GameSaveTest.java
@@ -76,11 +76,7 @@ class GameSaveTest {
     try (ContentDownloader downloader = new ContentDownloader(uri)) {
       Files.copy(downloader.getStream(), targetTempFileToDownloadTo);
     }
-
-    final Path[] mapFolderPath = new Path[1];
-    ZippedMapsExtractor.unzipMap(targetTempFileToDownloadTo)
-        .ifPresent(installedMap -> mapFolderPath[0] = installedMap);
-    return mapFolderPath[0];
+    return ZippedMapsExtractor.unzipMap(targetTempFileToDownloadTo).get();
   }
 
   private static URI getMapDownloadURI(final String mapName) throws URISyntaxException {

--- a/smoke-testing/src/test/java/games/strategy/engine/data/GameSaveTest.java
+++ b/smoke-testing/src/test/java/games/strategy/engine/data/GameSaveTest.java
@@ -70,7 +70,7 @@ class GameSaveTest {
     final Path saveFile = Files.createTempFile("save", GameDataFileUtils.getExtension());
     game.saveGame(saveFile);
     assertNotEquals(Files.size(saveFile), 0);
-    assertThat(Files.size(saveFile), is(not(0));
+    assertThat(Files.size(saveFile), is(not(0)));
   }
 
   private static Path downloadMap(final URI uri) throws IOException {
@@ -81,10 +81,7 @@ class GameSaveTest {
 
     final Path[] mapFolderPath = new Path[1];
     ZippedMapsExtractor.unzipMap(targetTempFileToDownloadTo)
-        .ifPresent(
-            installedMap -> {
-              mapFolderPath[0] = installedMap;
-            });
+        .ifPresent(installedMap -> mapFolderPath[0] = installedMap);
     return mapFolderPath[0];
   }
 

--- a/smoke-testing/src/test/java/games/strategy/engine/data/GameSaveTest.java
+++ b/smoke-testing/src/test/java/games/strategy/engine/data/GameSaveTest.java
@@ -1,0 +1,97 @@
+package games.strategy.engine.data;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import games.strategy.engine.ClientFileSystemHelper;
+import games.strategy.engine.framework.GameDataFileUtils;
+import games.strategy.engine.framework.ServerGame;
+import games.strategy.engine.framework.map.file.system.loader.ZippedMapsExtractor;
+import games.strategy.engine.framework.startup.ui.PlayerTypes;
+import games.strategy.engine.framework.startup.ui.panels.main.game.selector.GameSelectorModel;
+import games.strategy.engine.player.Player;
+import games.strategy.net.LocalNoOpMessenger;
+import games.strategy.net.Messengers;
+import games.strategy.net.websocket.ClientNetworkBridge;
+import games.strategy.triplea.settings.ClientSetting;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.triplea.config.product.ProductVersionReader;
+import org.triplea.game.server.HeadlessLaunchAction;
+import org.triplea.injection.Injections;
+import org.triplea.io.ContentDownloader;
+import org.triplea.io.FileUtils;
+
+class GameSaveTest {
+
+  private static Injections constructInjections() {
+    return Injections.builder()
+        .engineVersion(new ProductVersionReader().getVersion())
+        .playerTypes(PlayerTypes.getBuiltInPlayerTypes())
+        .build();
+  }
+
+  @Test
+  void testSaveGame() throws Exception {
+    if (Injections.getInstance() == null) {
+      Injections.init(constructInjections());
+      ClientSetting.initialize();
+      Path tempFolder = FileUtils.newTempFolder();
+      FileUtils.writeToFile(tempFolder.resolve(".triplea-root"), "");
+      Files.createDirectory(tempFolder.resolve("assets"));
+      ClientFileSystemHelper.setCodeSourceFolder(tempFolder);
+    }
+
+    String path = "https://github.com/triplea-maps/pacific_challenge/archive/master.zip";
+
+    final Path mapName = downloadMap(path);
+    final GameSelectorModel gameSelector = new GameSelectorModel();
+    gameSelector.load(mapName.resolve("map/games/Pacific_Theater_Solo_Challenge.xml"));
+    final ServerGame game = startGameWithAis(gameSelector);
+    final Path saveFile = Files.createTempFile("save", GameDataFileUtils.getExtension());
+    game.saveGame(saveFile);
+    assertNotEquals(Files.size(saveFile), 0);
+  }
+
+  private static Path downloadMap(final String path) throws IOException, URISyntaxException {
+    final Path targetTempFileToDownloadTo = FileUtils.newTempFolder().resolve("map.zip");
+    try (ContentDownloader downloader = new ContentDownloader(new URI(path))) {
+      Files.copy(downloader.getStream(), targetTempFileToDownloadTo);
+    }
+
+    final Path[] mapName = new Path[1];
+    ZippedMapsExtractor.unzipMap(targetTempFileToDownloadTo)
+        .ifPresent(
+            installedMap -> {
+              mapName[0] = installedMap;
+            });
+    return mapName[0];
+  }
+  
+  private static ServerGame startGameWithAis(final GameSelectorModel gameSelector) {
+    final GameData gameData = gameSelector.getGameData();
+    Map<String, PlayerTypes.Type> playerTypes = new HashMap<>();
+    for (var player : gameData.getPlayerList().getPlayers()) {
+      playerTypes.put(player.getName(), PlayerTypes.PRO_AI);
+    }
+    final Set<Player> gamePlayers = gameData.getGameLoader().newPlayers(playerTypes);
+    HeadlessLaunchAction launchAction = new HeadlessLaunchAction();
+    final Messengers messengers = new Messengers(new LocalNoOpMessenger());
+    final ServerGame game =
+        new ServerGame(
+            gameData,
+            gamePlayers,
+            new HashMap<>(),
+            messengers,
+            ClientNetworkBridge.NO_OP_SENDER,
+            launchAction);
+    gameData.getGameLoader().startGame(game, gamePlayers, launchAction, null);
+    return game;
+  }
+}

--- a/smoke-testing/src/test/java/games/strategy/engine/data/GameSaveTest.java
+++ b/smoke-testing/src/test/java/games/strategy/engine/data/GameSaveTest.java
@@ -3,7 +3,6 @@ package games.strategy.engine.data;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.GameDataFileUtils;
@@ -69,7 +68,6 @@ class GameSaveTest {
     final ServerGame game = startGameWithAis(gameSelector);
     final Path saveFile = Files.createTempFile("save", GameDataFileUtils.getExtension());
     game.saveGame(saveFile);
-    assertNotEquals(Files.size(saveFile), 0);
     assertThat(Files.size(saveFile), is(not(0)));
   }
 

--- a/smoke-testing/src/test/java/games/strategy/engine/data/GameSaveTest.java
+++ b/smoke-testing/src/test/java/games/strategy/engine/data/GameSaveTest.java
@@ -37,10 +37,11 @@ class GameSaveTest {
     if (Injections.getInstance() != null) {
       return;
     }
-    Injections.init(Injections.builder()
-        .engineVersion(new ProductVersionReader().getVersion())
-        .playerTypes(PlayerTypes.getBuiltInPlayerTypes())
-        .build());
+    Injections.init(
+        Injections.builder()
+            .engineVersion(new ProductVersionReader().getVersion())
+            .playerTypes(PlayerTypes.getBuiltInPlayerTypes())
+            .build());
     ClientSetting.initialize();
     final Path tempFolder = FileUtils.newTempFolder();
     FileUtils.writeToFile(tempFolder.resolve(".triplea-root"), "");
@@ -50,8 +51,8 @@ class GameSaveTest {
 
   @ParameterizedTest
   @CsvSource({
-      "world_war_ii_revised,map/games/ww2v2.xml",
-      "pacific_challenge,map/games/Pacific_Theater_Solo_Challenge.xml"
+    "world_war_ii_revised,map/games/ww2v2.xml",
+    "pacific_challenge,map/games/Pacific_Theater_Solo_Challenge.xml"
   })
   void testSaveGame(final String mapName, final String mapXmlPath) throws Exception {
     final Path mapFolderPath = downloadMap(getMapDownloadURI(mapName));

--- a/smoke-testing/src/test/java/games/strategy/engine/data/GameSaveTest.java
+++ b/smoke-testing/src/test/java/games/strategy/engine/data/GameSaveTest.java
@@ -1,5 +1,8 @@
 package games.strategy.engine.data;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import games.strategy.engine.ClientFileSystemHelper;
@@ -35,7 +38,8 @@ import org.triplea.io.FileUtils;
  * downloads the maps in question and starts an all-AI game on each of them, before saving.
  *
  * <p>Note: A variety of maps are used to ensure different engine features are exercised since
- * object serialization may run into errors that depend on the state of the object graph.
+ * object serialization may run into errors that depend on the state of the object graph. For
+ * example, if there's a non-null reference to a non-serializable object.
  */
 class GameSaveTest {
 
@@ -66,6 +70,7 @@ class GameSaveTest {
     final Path saveFile = Files.createTempFile("save", GameDataFileUtils.getExtension());
     game.saveGame(saveFile);
     assertNotEquals(Files.size(saveFile), 0);
+    assertThat(Files.size(saveFile), is(not(0));
   }
 
   private static Path downloadMap(final URI uri) throws IOException {


### PR DESCRIPTION
## Change Summary & Additional Notes

This test downloads several maps (the list can be easily expanded) and start the game on each and tries doing a game save.

This test is able to catch the problem introduced by the pending PR https://github.com/triplea-game/triplea/pull/10220 which introduces a non-serializable type into the game save object graph. Note: We should probably expand the list of maps being tested so that a variety of features are exercised. This initial PR just adds two maps.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
