### PR TITLE
Disk usage: stop automatically downloading maps on bots

### DIFF
--- a/infrastructure/ansible/roles/bot/tasks/main.yml
+++ b/infrastructure/ansible/roles/bot/tasks/main.yml
@@ -35,10 +35,6 @@
     - "{{ bot_install_home }}"
     - "{{ bot_maps_folder }}"
 
-- name: download maps on bot server
-  tags: [update_maps]
-  command: "{{ admin_home }}/download-all-maps"
-
 - name: deploy zip file (prerelease build only)
   tags: [prerelease, deploy]
   copy:


### PR DESCRIPTION
The download script for maps on bots is a bit odd now as it does not
take into account that maps are unzipped. This results in repeated downloads
of map zips which then remain on the system occupying significant disk
space. This update removes this functionality until it can be altered in some
way to avoid disk space issues.

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
