### PR TITLE
Reduce disk usage: keep a smaller journal file

### DIFF
--- a/infrastructure/ansible/roles/system/journald/files/journald.conf
+++ b/infrastructure/ansible/roles/system/journald/files/journald.conf
@@ -7,7 +7,7 @@
 #RateLimitIntervalSec=30s
 #RateLimitBurst=10000
 #SystemMaxUse=
-SystemMaxUse=2000M
+SystemMaxUse=500M
 #SystemKeepFree=
 #SystemMaxFileSize=
 #SystemMaxFiles=100


### PR DESCRIPTION
Journal file can currently be up to 2G large. On a 25G system, that is pretty
significant. We also do not really need to store that much log data on any
given system, hence reducing the size of the journal file here to 500M

## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
