### PR TITLE
Improve code health of PlayerAttachment while keeping Triple.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java
@@ -19,6 +19,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.util.Triple;
@@ -52,6 +53,7 @@ public class PlayerAttachment extends DefaultAttachment {
   private IntegerMap<Resource> suicideAttackResources = new IntegerMap<>();
   // what can be hit by suicide attacks
   private Set<UnitType> suicideAttackTargets = null;
+
   // placement limits on a flexible per player basis
   private Set<Triple<Integer, String, Set<UnitType>>> placementLimit = new HashSet<>();
 
@@ -81,33 +83,7 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   private void setPlacementLimit(final String value) throws GameParseException {
-    final String[] s = splitOnColon(value);
-    if (s.length < 3) {
-      throw new GameParseException(
-          "placementLimit must have 3 parts: count, type, unit list" + thisErrorMsg());
-    }
-    final int max = getInt(s[0]);
-    if (max < 0) {
-      throw new GameParseException(
-          "placementLimit count must have a positive number" + thisErrorMsg());
-    }
-    if (!(s[1].equals("owned") || s[1].equals("allied") || s[1].equals("total"))) {
-      throw new GameParseException(
-          "placementLimit type must be: owned, allied, or total" + thisErrorMsg());
-    }
-    final Set<UnitType> types = new HashSet<>();
-    if (s[2].equalsIgnoreCase("all")) {
-      types.addAll(getData().getUnitTypeList().getAllUnitTypes());
-    } else {
-      for (int i = 2; i < s.length; i++) {
-        final UnitType ut = getData().getUnitTypeList().getUnitType(s[i]);
-        if (ut == null) {
-          throw new GameParseException("No unit called: " + s[i] + thisErrorMsg());
-        }
-        types.add(ut);
-      }
-    }
-    placementLimit.add(Triple.of(max, s[1], types));
+    placementLimit.add(parseUnitLimit("placementLimit", value));
   }
 
   private void setPlacementLimit(final Set<Triple<Integer, String, Set<UnitType>>> value) {
@@ -123,33 +99,7 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   private void setMovementLimit(final String value) throws GameParseException {
-    final String[] s = splitOnColon(value);
-    if (s.length < 3) {
-      throw new GameParseException(
-          "movementLimit must have 3 parts: count, type, unit list" + thisErrorMsg());
-    }
-    final int max = getInt(s[0]);
-    if (max < 0) {
-      throw new GameParseException(
-          "movementLimit count must have a positive number" + thisErrorMsg());
-    }
-    if (!(s[1].equals("owned") || s[1].equals("allied") || s[1].equals("total"))) {
-      throw new GameParseException(
-          "movementLimit type must be: owned, allied, or total" + thisErrorMsg());
-    }
-    final Set<UnitType> types = new HashSet<>();
-    if (s[2].equalsIgnoreCase("all")) {
-      types.addAll(getData().getUnitTypeList().getAllUnitTypes());
-    } else {
-      for (int i = 2; i < s.length; i++) {
-        final UnitType ut = getData().getUnitTypeList().getUnitType(s[i]);
-        if (ut == null) {
-          throw new GameParseException("No unit called: " + s[i] + thisErrorMsg());
-        }
-        types.add(ut);
-      }
-    }
-    movementLimit.add(Triple.of(max, s[1], types));
+    movementLimit.add(parseUnitLimit("movementLimit", value));
   }
 
   private void setMovementLimit(final Set<Triple<Integer, String, Set<UnitType>>> value) {
@@ -165,19 +115,35 @@ public class PlayerAttachment extends DefaultAttachment {
   }
 
   private void setAttackingLimit(final String value) throws GameParseException {
+    attackingLimit.add(parseUnitLimit("attackingLimit", value));
+  }
+
+  private void setAttackingLimit(final Set<Triple<Integer, String, Set<UnitType>>> value) {
+    attackingLimit = value;
+  }
+
+  private Set<Triple<Integer, String, Set<UnitType>>> getAttackingLimit() {
+    return attackingLimit;
+  }
+
+  private void resetAttackingLimit() {
+    attackingLimit = new HashSet<>();
+  }
+
+  private Triple<Integer, String, Set<UnitType>> parseUnitLimit(
+      final String type, final String value) throws GameParseException {
     final String[] s = splitOnColon(value);
     if (s.length < 3) {
       throw new GameParseException(
-          "attackingLimit must have 3 parts: count, type, unit list" + thisErrorMsg());
+          type + " must have 3 parts: count, type, unit list" + thisErrorMsg());
     }
     final int max = getInt(s[0]);
     if (max < 0) {
-      throw new GameParseException(
-          "attackingLimit count must have a positive number" + thisErrorMsg());
+      throw new GameParseException(type + " count must have a positive number" + thisErrorMsg());
     }
     if (!(s[1].equals("owned") || s[1].equals("allied") || s[1].equals("total"))) {
       throw new GameParseException(
-          "attackingLimit type must be: owned, allied, or total" + thisErrorMsg());
+          type + " type must be: owned, allied, or total" + thisErrorMsg());
     }
     final Set<UnitType> types = new HashSet<>();
     if (s[2].equalsIgnoreCase("all")) {
@@ -191,19 +157,7 @@ public class PlayerAttachment extends DefaultAttachment {
         types.add(ut);
       }
     }
-    attackingLimit.add(Triple.of(max, s[1], types));
-  }
-
-  private void setAttackingLimit(final Set<Triple<Integer, String, Set<UnitType>>> value) {
-    attackingLimit = value;
-  }
-
-  private Set<Triple<Integer, String, Set<UnitType>>> getAttackingLimit() {
-    return attackingLimit;
-  }
-
-  private void resetAttackingLimit() {
-    attackingLimit = new HashSet<>();
+    return Triple.of(max, s[1], types);
   }
 
   /**
@@ -232,42 +186,33 @@ public class PlayerAttachment extends DefaultAttachment {
         stackingLimits = pa.getPlacementLimit();
         break;
       default:
-        throw new IllegalStateException(
-            "getCanTheseUnitsMoveWithoutViolatingStackingLimit does not allow limitType: "
-                + limitType);
+        throw new IllegalStateException("Invalid limitType: " + limitType);
     }
     if (stackingLimits.isEmpty()) {
       return true;
     }
+    final Predicate<Unit> notOwned = Matches.unitIsOwnedBy(owner).negate();
+    final Predicate<Unit> notAllied =
+        Matches.alliedUnit(owner, data.getRelationshipTracker()).negate();
     for (final Triple<Integer, String, Set<UnitType>> currentLimit : stackingLimits) {
       // first make a copy of unitsMoving
       final Collection<Unit> copyUnitsMoving = new ArrayList<>(unitsMoving);
-      final int max = currentLimit.getFirst();
-      final String type = currentLimit.getSecond();
-      final Set<UnitType> unitsToTest = currentLimit.getThird();
       final Collection<Unit> currentInTerritory = new ArrayList<>(toMoveInto.getUnits());
+      final String type = currentLimit.getSecond();
       // first remove units that do not apply to our current type
       if (type.equals("owned")) {
-        currentInTerritory.removeAll(
-            CollectionUtils.getMatches(currentInTerritory, Matches.unitIsOwnedBy(owner).negate()));
-        copyUnitsMoving.removeAll(
-            CollectionUtils.getMatches(copyUnitsMoving, Matches.unitIsOwnedBy(owner).negate()));
+        currentInTerritory.removeAll(CollectionUtils.getMatches(currentInTerritory, notOwned));
+        copyUnitsMoving.removeAll(CollectionUtils.getMatches(copyUnitsMoving, notOwned));
       } else if (type.equals("allied")) {
-        currentInTerritory.removeAll(
-            CollectionUtils.getMatches(
-                currentInTerritory,
-                Matches.alliedUnit(owner, data.getRelationshipTracker()).negate()));
-        copyUnitsMoving.removeAll(
-            CollectionUtils.getMatches(
-                copyUnitsMoving,
-                Matches.alliedUnit(owner, data.getRelationshipTracker()).negate()));
+        currentInTerritory.removeAll(CollectionUtils.getMatches(currentInTerritory, notAllied));
+        copyUnitsMoving.removeAll(CollectionUtils.getMatches(copyUnitsMoving, notAllied));
       }
       // now remove units that are not part of our list
-      currentInTerritory.retainAll(
-          CollectionUtils.getMatches(currentInTerritory, Matches.unitIsOfTypes(unitsToTest)));
-      copyUnitsMoving.retainAll(
-          CollectionUtils.getMatches(copyUnitsMoving, Matches.unitIsOfTypes(unitsToTest)));
+      final Predicate<Unit> matchesUnits = Matches.unitIsOfTypes(currentLimit.getThird());
+      currentInTerritory.retainAll(CollectionUtils.getMatches(currentInTerritory, matchesUnits));
+      copyUnitsMoving.retainAll(CollectionUtils.getMatches(copyUnitsMoving, matchesUnits));
       // now test
+      final Integer max = currentLimit.getFirst();
       if (max < (currentInTerritory.size() + copyUnitsMoving.size())) {
         return false;
       }

--- a/smoke-testing/src/test/java/games/strategy/engine/data/GameSaveTest.java
+++ b/smoke-testing/src/test/java/games/strategy/engine/data/GameSaveTest.java
@@ -68,7 +68,7 @@ class GameSaveTest {
     final ServerGame game = startGameWithAis(gameSelector);
     final Path saveFile = Files.createTempFile("save", GameDataFileUtils.getExtension());
     game.saveGame(saveFile);
-    assertThat(Files.size(saveFile), is(not(0)));
+    assertThat(Files.size(saveFile), is(not(0L)));
   }
 
   private static Path downloadMap(final URI uri) throws IOException {

--- a/smoke-testing/src/test/java/games/strategy/engine/data/GameSaveTest.java
+++ b/smoke-testing/src/test/java/games/strategy/engine/data/GameSaveTest.java
@@ -3,6 +3,7 @@ package games.strategy.engine.data;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.not;
+import static org.hamcrest.io.FileMatchers.aFileWithSize;
 
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.GameDataFileUtils;
@@ -68,7 +69,7 @@ class GameSaveTest {
     final ServerGame game = startGameWithAis(gameSelector);
     final Path saveFile = Files.createTempFile("save", GameDataFileUtils.getExtension());
     game.saveGame(saveFile);
-    assertThat(Files.size(saveFile), is(not(0L)));
+    assertThat(saveFile.toFile(), is(not(aFileWithSize(0))));
   }
 
   private static Path downloadMap(final URI uri) throws IOException {


### PR DESCRIPTION
## Change Summary & Additional Notes

Improve code health of PlayerAttachment while keeping Triple.

- Make a helper function for repeated code
- Use local variables to reduce wrapping

Many of these issues are identified by Code Climate:
https://codeclimate.com/github/triplea-game/triplea/game-app/game-core/src/main/java/games/strategy/triplea/attachments/PlayerAttachment.java/source#issue-ce7383fb8c1afa54231b9722856166f2

Originally, this also removed the use of the deprecated Triple type, but this would have
caused a save game incompatibility, so this part was reverted.

Also fixes a smoke test condition.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
