### PR TITLE
Fix some battle dependency issues and remove an extra slash in image path.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/AbstractBuiltInAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/AbstractBuiltInAi.java
@@ -16,6 +16,7 @@ import games.strategy.triplea.delegate.DiceRoll;
 import games.strategy.triplea.delegate.GameStepPropertiesHelper;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.PoliticsDelegate;
+import games.strategy.triplea.delegate.battle.BattleDelegate;
 import games.strategy.triplea.delegate.battle.IBattle.BattleType;
 import games.strategy.triplea.delegate.data.BattleListing;
 import games.strategy.triplea.delegate.data.CasualtyDetails;
@@ -609,7 +610,7 @@ public abstract class AbstractBuiltInAi extends AbstractBasePlayer {
         for (final Territory current : entry.getValue()) {
           final String error =
               battleDelegate.fightBattle(current, entry.getKey().isBombingRun(), entry.getKey());
-          if (error != null) {
+          if (error != null && !BattleDelegate.isBattleDependencyErrorMessage(error)) {
             log.warn(error);
           }
         }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -61,6 +61,8 @@ import org.triplea.util.Tuple;
 /** Delegate to track and fight all battles. */
 @AutoSave(beforeStepStart = true, afterStepEnd = true)
 public class BattleDelegate extends BaseTripleADelegate implements IBattleDelegate {
+  private static final String MUST_COMPLETE_BATTLE_PREFIX = "Must complete ";
+
   private BattleTracker battleTracker = new BattleTracker();
   private boolean needToInitialize = true;
   private boolean needToScramble = true;
@@ -238,15 +240,19 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     if (!allMustPrecede.isEmpty()) {
       final IBattle firstPrecede = allMustPrecede.iterator().next();
       final String name = firstPrecede.getTerritory().getName();
-      return "Must complete " + getFightingWord(firstPrecede) + " in " + name + " first";
+      return MUST_COMPLETE_BATTLE_PREFIX + getFightingWord(firstPrecede) + " in " + name + " first";
     }
     currentBattle = battle;
     battle.fight(bridge);
     return null;
   }
 
+  public static boolean isBattleDependencyErrorMessage(String message) {
+    return message.startsWith(MUST_COMPLETE_BATTLE_PREFIX);
+  }
+
   private static String getFightingWord(final IBattle battle) {
-    return battle.getBattleType().toString();
+    return battle.getBattleType().toDisplayText();
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/UnitImageFactory.java
@@ -238,7 +238,7 @@ public class UnitImageFactory {
         .orElseGet(
             () -> {
               BufferedImage image =
-                  resourceLoader.getImageOrThrow(FILE_NAME_BASE + "/missing_unit_image.png");
+                  resourceLoader.getImageOrThrow(FILE_NAME_BASE + "missing_unit_image.png");
               Color playerColor = mapData.getPlayerColor(imageKey.getPlayer().getName());
               ImageTransformer.colorize(playerColor, image);
 


### PR DESCRIPTION
## Change Summary & Additional Notes

Fix some battle dependency issues and remove an extra slash in image path.

Has the following changes:
  - Fix display name of battles in error messages (broken in commit 333f643e)
  - Remove an extra slash in a missing image path (from recent commit 652c081dfbca3ebb3773e3c616f9abdd09c60d30)
  - Don't show battle dependency errors from AI battle logic that are already handled properly.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
