### PR TITLE
Improve list of moves UI, especially on small screens.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/posted/game/AbstractForumPosterPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/posted/game/AbstractForumPosterPanel.java
@@ -11,7 +11,6 @@ import games.strategy.triplea.delegate.remote.IAbstractForumPosterDelegate;
 import games.strategy.triplea.ui.ActionPanel;
 import games.strategy.triplea.ui.TripleAFrame;
 import games.strategy.triplea.ui.panels.map.MapPanel;
-import javax.swing.JLabel;
 import javax.swing.SwingUtilities;
 
 abstract class AbstractForumPosterPanel extends ActionPanel {
@@ -20,12 +19,10 @@ abstract class AbstractForumPosterPanel extends ActionPanel {
   IPlayerBridge playerBridge;
   PbemMessagePoster pbemMessagePoster;
   final ForumPosterComponent forumPosterComponent;
-  private final JLabel actionLabel;
   private TripleAFrame tripleAFrame;
 
   AbstractForumPosterPanel(final GameData data, final MapPanel map) {
     super(data, map);
-    actionLabel = new JLabel();
     forumPosterComponent = new ForumPosterComponent(data, this::performDone, getTitle());
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -34,7 +34,6 @@ import org.triplea.swing.key.binding.SwingKeyBinding;
 @Slf4j
 public abstract class AbstractMovePanel extends ActionPanel {
   private static final long serialVersionUID = -4153574987414031433L;
-  private static final int entryPadding = 15;
 
   protected AbstractUndoableMovesPanel undoableMovesPanel;
   private final TripleAFrame frame;
@@ -258,18 +257,19 @@ public abstract class AbstractMovePanel extends ActionPanel {
 
     this.actionLabel.setText(gamePlayer.getName() + actionLabel);
     movedUnitsPanel.add(SwingComponents.leftBox(this.actionLabel));
+    final JPanel buttonsPanel = new JPanel();
     if (setCancelButton()) {
-      movedUnitsPanel.add(SwingComponents.leftBox(cancelMoveButton));
+      buttonsPanel.add(SwingComponents.leftBox(cancelMoveButton));
     }
-    movedUnitsPanel.add(
+    buttonsPanel.add(
         SwingComponents.leftBox(
             new JButtonBuilder()
                 .title("Done")
                 .toolTip(ActionButtons.DONE_BUTTON_TOOLTIP)
                 .actionListener(this::performDone)
                 .build()));
+    movedUnitsPanel.add(buttonsPanel);
     getAdditionalButtons().forEach(movedUnitsPanel::add);
-    movedUnitsPanel.add(Box.createVerticalStrut(entryPadding));
     movedUnitsPanel.add(undoableMovesPanel);
     movedUnitsPanel.add(Box.createGlue());
     return movedUnitsPanel;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
@@ -87,18 +87,9 @@ public abstract class AbstractUndoableMovesPanel extends JPanel {
       scrollIncrement = moveComponent.getPreferredSize().height;
       items.add(moveComponent);
     }
-    /*
-    if (movePanel.getUndoableMoves() != null && movePanel.getUndoableMoves().size() > 1) {
-      final JButton undoAllButton = new JButton("Undo All");
-      undoAllButton.addActionListener(new UndoAllMovesActionListener());
-      final Box box = Box.createHorizontalBox();
-      box.add(undoAllButton);
-      box.add(Box.createHorizontalGlue());
-      items.add(box);
-    }*/
 
     final int scrollIncrementFinal = scrollIncrement; // + separatorSize.height;
-    final JScrollPane scroll =
+    scroll =
         new JScrollPane(items) {
           private static final long serialVersionUID = -1064967105431785533L;
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
@@ -9,7 +9,6 @@ import games.strategy.triplea.util.UnitSeparator;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
 import java.awt.Graphics;
-import java.awt.Image;
 import java.awt.Rectangle;
 import java.awt.event.ActionEvent;
 import java.util.ArrayList;
@@ -28,6 +27,7 @@ import javax.swing.JComponent;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
+import javax.swing.JSeparator;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
 
@@ -62,8 +62,13 @@ public abstract class AbstractUndoableMovesPanel extends JPanel {
   private void initLayout() {
     removeAll();
     setLayout(new BorderLayout());
-    if (!moves.isEmpty()) {
-      add(new JLabel(getLabelText()), BorderLayout.NORTH);
+    if (movesMade()) {
+      Box box = Box.createVerticalBox();
+      JLabel titleLabel = ActionPanel.createIndentedLabel();
+      titleLabel.setText(getLabelText());
+      box.add(titleLabel);
+      box.add(new JSeparator());
+      add(box, BorderLayout.NORTH);
     }
     add(createScrollPane(), BorderLayout.CENTER);
     SwingUtilities.invokeLater(this::validate);
@@ -79,6 +84,7 @@ public abstract class AbstractUndoableMovesPanel extends JPanel {
       scrollIncrement = moveComponent.getPreferredSize().height;
       items.add(moveComponent);
     }
+    /*
     if (movePanel.getUndoableMoves() != null && movePanel.getUndoableMoves().size() > 1) {
       final JButton undoAllButton = new JButton("Undo All");
       undoAllButton.addActionListener(new UndoAllMovesActionListener());
@@ -86,7 +92,7 @@ public abstract class AbstractUndoableMovesPanel extends JPanel {
       box.add(undoAllButton);
       box.add(Box.createHorizontalGlue());
       items.add(box);
-    }
+    }*/
 
     final int scrollIncrementFinal = scrollIncrement; // + separatorSize.height;
     final JScrollPane scroll =
@@ -122,16 +128,9 @@ public abstract class AbstractUndoableMovesPanel extends JPanel {
     final Collection<UnitCategory> unitCategories = UnitSeparator.categorize(move.getUnits());
     final Dimension buttonSize = new Dimension(80, 22);
     for (final UnitCategory category : unitCategories) {
-      Optional<ImageIcon> icon =
+      final Optional<ImageIcon> icon =
           movePanel.getMap().getUiContext().getUnitImageFactory().getIcon(ImageKey.of(category));
       if (icon.isPresent()) {
-        Image image = icon.get().getImage(); // transform it
-        Image newimg =
-            image.getScaledInstance(
-                icon.get().getIconWidth() / 2,
-                icon.get().getIconHeight() / 2,
-                java.awt.Image.SCALE_SMOOTH); // scale it the smooth way
-        icon = Optional.of(new ImageIcon(newimg)); // transform it back
         final JLabel label =
             new JLabel("x" + category.getUnits().size() + " ", icon.get(), SwingConstants.LEFT);
         unitsBox.add(label);
@@ -188,23 +187,6 @@ public abstract class AbstractUndoableMovesPanel extends JPanel {
         previousVisibleIndex = Math.max(0, moveIndex - 1);
       } else {
         previousVisibleIndex = null;
-      }
-    }
-  }
-
-  class UndoAllMovesActionListener extends AbstractAction {
-    private static final long serialVersionUID = 7908136093303143896L;
-
-    UndoAllMovesActionListener() {
-      super("UndoAllMoves");
-    }
-
-    @Override
-    public void actionPerformed(final ActionEvent e) {
-      final int moveCount = movePanel.getUndoableMoves().size();
-      final boolean suppressErrorMsgToUser = true;
-      for (int i = moveCount - 1; i >= 0; i--) {
-        movePanel.undoMove(i, suppressErrorMsgToUser);
       }
     }
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
@@ -71,7 +71,10 @@ public abstract class AbstractUndoableMovesPanel extends JPanel {
       add(box, BorderLayout.NORTH);
     }
     add(createScrollPane(), BorderLayout.CENTER);
-    SwingUtilities.invokeLater(this::validate);
+    // The two lines below are needed to ensure the view redraws at the correct size
+    // when first loaded.
+    revalidate();
+    doLayout();
   }
 
   private JScrollPane createScrollPane() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
@@ -88,7 +88,7 @@ public abstract class AbstractUndoableMovesPanel extends JPanel {
       items.add(moveComponent);
     }
 
-    final int scrollIncrementFinal = scrollIncrement; // + separatorSize.height;
+    final int scrollIncrementFinal = scrollIncrement;
     scroll =
         new JScrollPane(items) {
           private static final long serialVersionUID = -1064967105431785533L;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
@@ -82,11 +82,10 @@ public abstract class AbstractUndoableMovesPanel extends JPanel {
     if (movePanel.getUndoableMoves() != null && movePanel.getUndoableMoves().size() > 1) {
       final JButton undoAllButton = new JButton("Undo All");
       undoAllButton.addActionListener(new UndoAllMovesActionListener());
-      items.add(undoAllButton);
-      Box b1 = Box.createHorizontalBox();
-      b1.add(undoAllButton);
-      b1.add(Box.createHorizontalGlue());
-      items.add(b1);
+      final Box box = Box.createHorizontalBox();
+      box.add(undoAllButton);
+      box.add(Box.createHorizontalGlue());
+      items.add(box);
     }
 
     final int scrollIncrementFinal = scrollIncrement; // + separatorSize.height;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ActionPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ActionPanel.java
@@ -5,18 +5,21 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.triplea.ui.panels.map.MapPanel;
 import java.awt.Dimension;
 import java.util.concurrent.CountDownLatch;
+import javax.swing.BorderFactory;
 import javax.swing.BoxLayout;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
-import javax.swing.border.EmptyBorder;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
+import org.triplea.swing.JLabelBuilder;
 import org.triplea.swing.SwingComponents;
 
 /** Abstract superclass for all action panels. */
 public abstract class ActionPanel extends JPanel {
   private static final long serialVersionUID = -5954576036704958641L;
+  protected final JLabel actionLabel = createIndentedLabel();
 
   @Getter(AccessLevel.PROTECTED)
   protected final MapPanel map;
@@ -40,8 +43,17 @@ public abstract class ActionPanel extends JPanel {
     this.data = data;
     this.map = map;
     setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
-    setBorder(new EmptyBorder(5, 5, 0, 0));
+    setBorder(BorderFactory.createEmptyBorder(5, 0, 0, 0));
     setMinimumSize(new Dimension(240, 0));
+  }
+
+  /**
+   * Creates a label suitable for showing text directly in the action panel. This allows for
+   * consistent indentation between different panels without requiring other non-label component to
+   * be indented.
+   */
+  public static JLabel createIndentedLabel() {
+    return new JLabelBuilder().border(BorderFactory.createEmptyBorder(0, 5, 0, 0)).build();
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattlePanel.java
@@ -54,7 +54,7 @@ import org.triplea.swing.jpanel.JPanelBuilder;
 @Slf4j
 public final class BattlePanel extends ActionPanel {
   private static final long serialVersionUID = 5304208569738042592L;
-  private final JLabel actionLabel = new JLabel();
+
   private FightBattleDetails fightBattleMessage;
   private volatile BattleDisplay battleDisplay;
   // if we are showing a battle, then this will be set to the currently displayed battle. This will

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -346,7 +346,6 @@ class EditPanel extends ActionPanel {
   EditPanel(final GameData data, final MapPanel map, final TripleAFrame frame) {
     super(data, map);
     this.frame = frame;
-    final JLabel actionLabel = new JLabel();
     performMoveAction =
         new AbstractAction("Perform Move or Other Actions") {
           private static final long serialVersionUID = 2205085537962024476L;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/PickTerritoryAndUnitsPanel.java
@@ -18,7 +18,6 @@ import javax.annotation.Nullable;
 import javax.swing.AbstractAction;
 import javax.swing.Action;
 import javax.swing.JButton;
-import javax.swing.JLabel;
 import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 import lombok.extern.slf4j.Slf4j;
@@ -33,7 +32,6 @@ import org.triplea.util.Tuple;
 public class PickTerritoryAndUnitsPanel extends ActionPanel {
   private static final long serialVersionUID = -2672163347536778594L;
   private final TripleAFrame parent;
-  private final JLabel actionLabel = new JLabel();
   private JButton doneButton = null;
   private JButton selectTerritoryButton = null;
   private JButton selectUnitsButton = null;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -39,8 +39,7 @@ import org.triplea.swing.SwingComponents;
 
 class PlacePanel extends AbstractMovePanel implements GameDataChangeListener {
   private static final long serialVersionUID = -4411301492537704785L;
-  private final JLabel actionLabel = new JLabel();
-  private final JLabel leftToPlaceLabel = new JLabel();
+  private final JLabel leftToPlaceLabel = createIndentedLabel();
   private PlaceData placeData;
 
   private final SimpleUnitPanel unitsToPlacePanel;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
@@ -43,7 +43,6 @@ import org.triplea.swing.key.binding.SwingKeyBinding;
  */
 public class PoliticsPanel extends ActionPanel {
   private static final long serialVersionUID = -4661479948450261578L;
-  private final JLabel actionLabel = new JLabel();
   private JButton selectPoliticalActionButton = null;
   private JButton doneButton = null;
   private PoliticalActionAttachment choice = null;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
@@ -36,13 +36,12 @@ public class PurchasePanel extends ActionPanel {
   private static final String BUY = "Buy...";
   private static final String CHANGE = "Change...";
 
-  private final JLabel actionLabel = new JLabel();
   private IntegerMap<ProductionRule> purchase;
   private boolean bid;
   private final SimpleUnitPanel purchasedPreviousRoundsUnits;
   private final JLabel purchasedPreviousRoundsLabel;
   private final SimpleUnitPanel purchasedUnits;
-  private final JLabel purchasedLabel = new JLabel();
+  private final JLabel purchasedLabel = createIndentedLabel();
   private final JButton buyButton;
 
   private final AbstractAction purchaseAction =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/RepairPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/RepairPanel.java
@@ -24,12 +24,11 @@ class RepairPanel extends ActionPanel {
   private static final long serialVersionUID = 3045997038627313714L;
   private static final String CHANGE = "Change...";
   private static final String BUY = "Repair...";
-  private final JLabel actionLabel = new JLabel();
   private Map<Unit, IntegerMap<RepairRule>> repair;
   private boolean bid;
   private Collection<GamePlayer> allowedPlayersToRepair;
   private final SimpleUnitPanel unitsPanel;
-  private final JLabel repairedSoFar = new JLabel();
+  private final JLabel repairedSoFar = createIndentedLabel();
   private final JButton buyButton;
 
   private final ActionListener purchaseAction =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TechPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TechPanel.java
@@ -40,7 +40,6 @@ import org.triplea.swing.SwingComponents;
 
 class TechPanel extends ActionPanel {
   private static final long serialVersionUID = -6477919141575138007L;
-  private final JLabel actionLabel = new JLabel();
   private TechRoll techRoll;
   private int currTokens = 0;
   private int quantity;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -157,6 +157,7 @@ import org.triplea.java.collections.IntegerMap;
 import org.triplea.java.concurrency.CompletableFutureUtils;
 import org.triplea.sound.ClipPlayer;
 import org.triplea.sound.SoundPath;
+import org.triplea.swing.CollapsiblePanel;
 import org.triplea.swing.EventThreadJOptionPane;
 import org.triplea.swing.EventThreadJOptionPane.ConfirmDialogType;
 import org.triplea.swing.SwingAction;
@@ -577,13 +578,21 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
     final MovePanel movePanel = new MovePanel(data, mapPanel, this);
     actionButtons = new ActionButtons(data, mapPanel, movePanel, this);
 
+    final CollapsiblePanel placementsPanel =
+        new PlacementUnitsCollapsiblePanel(data, uiContext).getPanel();
     rightHandSidePanel.add(
         new JPanelBuilder()
             .borderLayout()
-            .addNorth(new PlacementUnitsCollapsiblePanel(data, uiContext).getPanel())
+            .addNorth(placementsPanel)
             .addSouth(movePanel.getUnitScrollerPanel())
             .build(),
         BorderLayout.SOUTH);
+
+    final Frame parent = JOptionPane.getFrameForComponent(this);
+    if (Util.getScreenSize(parent).height < 1000) {
+      placementsPanel.collapse();
+      movePanel.getUnitScrollerPanel().collapse();
+    }
 
     SwingUtilities.invokeLater(() -> mapPanel.addKeyListener(getArrowKeyListener()));
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UndoablePlacementsPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UndoablePlacementsPanel.java
@@ -10,5 +10,10 @@ class UndoablePlacementsPanel extends AbstractUndoableMovesPanel {
   }
 
   @Override
+  protected String getLabelText() {
+    return "Placements:";
+  }
+
+  @Override
   protected void specificViewAction(final AbstractUndoableMove move) {}
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UserActionPanel.java
@@ -35,7 +35,6 @@ import org.triplea.swing.SwingAction;
 /** Similar to PoliticsPanel, but for UserActionAttachment/Delegate. */
 public class UserActionPanel extends ActionPanel {
   private static final long serialVersionUID = -2735582890226625860L;
-  private final JLabel actionLabel = new JLabel();
   private JButton selectUserActionButton = null;
   private JButton doneButton = null;
   private UserActionAttachment choice = null;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
@@ -36,7 +36,6 @@ import games.strategy.triplea.ui.unit.scroller.UnitScroller;
 import games.strategy.triplea.util.TransportUtils;
 import games.strategy.triplea.util.UnitCategory;
 import games.strategy.triplea.util.UnitSeparator;
-import java.awt.Component;
 import java.awt.Dimension;
 import java.awt.Image;
 import java.awt.Point;
@@ -66,6 +65,7 @@ import org.triplea.java.ObjectUtils;
 import org.triplea.java.PredicateBuilder;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
+import org.triplea.swing.CollapsiblePanel;
 import org.triplea.swing.JLabelBuilder;
 import org.triplea.swing.jpanel.JPanelBuilder;
 import org.triplea.swing.key.binding.KeyCode;
@@ -109,7 +109,7 @@ public class MovePanel extends AbstractMovePanel {
   private final UnitScroller unitScroller;
 
   @Getter(onMethod_ = @Override)
-  private final Component unitScrollerPanel;
+  private final CollapsiblePanel unitScrollerPanel;
 
   private final UnitSelectionListener unitSelectionListener =
       new UnitSelectionListener() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -12,7 +12,6 @@ import games.strategy.triplea.ui.MouseDetails;
 import games.strategy.triplea.ui.panels.map.MapPanel;
 import games.strategy.triplea.ui.panels.map.MapSelectionListener;
 import java.awt.BorderLayout;
-import java.awt.Component;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -228,7 +227,7 @@ public class UnitScroller {
   }
 
   /** Constructs a UI component for the UnitScroller. */
-  public Component build() {
+  public CollapsiblePanel build() {
     final JPanel panel = new JPanel();
     collapsiblePanel = new CollapsiblePanel(panel, "");
     updateMovesLeft();

--- a/lib/swing-lib/src/main/java/org/triplea/swing/CollapsiblePanel.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/CollapsiblePanel.java
@@ -27,10 +27,9 @@ public class CollapsiblePanel extends JPanel {
   private final JButton toggleButton;
 
   private String title;
-  private String currentToggleIndicator = EXPANDED_TEXT;
+  private String currentToggleIndicator;
 
   public CollapsiblePanel(final JPanel content, final String title) {
-    super();
     this.title = title;
     this.content = content;
     this.toggleButton = new JButton();
@@ -53,7 +52,14 @@ public class CollapsiblePanel extends JPanel {
     expand();
   }
 
+  public boolean isCollapsed() {
+    return currentToggleIndicator == COLLAPSED_TEXT;
+  }
+
   public void collapse() {
+    if (isCollapsed()) {
+      return;
+    }
     currentToggleIndicator = COLLAPSED_TEXT;
     toggleButton.setText(title + currentToggleIndicator);
     content.setVisible(false);
@@ -61,6 +67,9 @@ public class CollapsiblePanel extends JPanel {
   }
 
   public void expand() {
+    if (!isCollapsed()) {
+      return;
+    }
     currentToggleIndicator = EXPANDED_TEXT;
     toggleButton.setText(title + currentToggleIndicator);
     content.setVisible(true);

--- a/lib/swing-lib/src/main/java/org/triplea/swing/CollapsiblePanel.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/CollapsiblePanel.java
@@ -52,12 +52,8 @@ public class CollapsiblePanel extends JPanel {
     expand();
   }
 
-  public boolean isCollapsed() {
-    return currentToggleIndicator == COLLAPSED_TEXT;
-  }
-
   public void collapse() {
-    if (isCollapsed()) {
+    if (currentToggleIndicator == COLLAPSED_TEXT) {
       return;
     }
     currentToggleIndicator = COLLAPSED_TEXT;
@@ -67,7 +63,7 @@ public class CollapsiblePanel extends JPanel {
   }
 
   public void expand() {
-    if (!isCollapsed()) {
+    if (currentToggleIndicator == EXPANDED_TEXT) {
       return;
     }
     currentToggleIndicator = EXPANDED_TEXT;


### PR DESCRIPTION
## Change Summary & Additional Notes

Improve list of moves UI, especially on small screens.

This change includes a number of changes to streamline the undoable moves action panel, so that it is more useable on smaller screens:
  - ~~Makes the placements and active units panels collapsed by default if the screen height is low.~~
  - Reduces padding between moves in the list.
  - Changes the buttons at the top of the move panel to be in a row, instead of in a column
  - Moves the "Undo All" button to the button row, instead of at the end of the move list
  - Moves the "Moves:" label to be outside of the scroll area and adds a horizontal separator.
  - Fixes some redrawing bugs.

Here are the before and after screenshots on a MacBook air with Dock and menu bar visible:

*Before:*
<img width="1552" alt="Screen Shot 2022-04-07 at 3 27 13 PM" src="https://user-images.githubusercontent.com/17648/162282042-a2e8680d-c681-411a-ab8c-7b508322355f.png">

*Before with bottom panels manually collapsed:*
<img width="1552" alt="Screen Shot 2022-04-07 at 3 27 19 PM" src="https://user-images.githubusercontent.com/17648/162282177-8bcb1749-1108-45d5-a670-3c69d4e26b00.png">

*After with bottom panels manually collapsed:*
<img width="1552" alt="Screen Shot 2022-04-07 at 3 17 23 PM" src="https://user-images.githubusercontent.com/17648/162282225-ac787236-12c1-47d6-bc7e-efb979f7efa3.png">

Edit: The change originally made the placement & active unit panels start collapsed on a smaller screen, but this was omitted from this PR per discussion.

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->CHANGE|Improved layout of move list, especially on smaller screens.<!--END_RELEASE_NOTE-->
