### PR TITLE
Fix text overlap in air transport load dialog.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -37,6 +37,9 @@ import javax.swing.JTextArea;
 import lombok.experimental.UtilityClass;
 import org.triplea.java.Postconditions;
 import org.triplea.java.collections.IntegerMap;
+import org.triplea.swing.jpanel.GridBagConstraintsAnchor;
+import org.triplea.swing.jpanel.GridBagConstraintsBuilder;
+import org.triplea.swing.jpanel.GridBagConstraintsFill;
 
 /**
  * Shows units to choose including the controls to make the choice. Units are grouped by owner, type
@@ -475,9 +478,9 @@ public final class UnitChooser extends JPanel {
 
     void createComponents(final JPanel panel, final int rowIndex) {
       int gridx = 0;
-      for (int i = 0;
-          i < (hasMultipleHits ? Math.max(1, category.getHitPoints() - category.getDamaged()) : 1);
-          i++) {
+      int iterations =
+          (hasMultipleHits ? Math.max(1, category.getHitPoints() - category.getDamaged()) : 1);
+      for (int i = 0; i < iterations; i++) {
         final boolean damaged = i > 0;
         final ScrollableTextField scroll = new ScrollableTextField(0, category.getUnits().size());
         hitTexts.add(scroll);
@@ -485,83 +488,29 @@ public final class UnitChooser extends JPanel {
         scroll.addChangeListener(textFieldListener);
         final JLabel label = new JLabel("x" + category.getUnits().size());
         hitLabel.add(label);
+        final var builder =
+            new GridBagConstraintsBuilder(gridx, rowIndex)
+                .gridWidth(1)
+                .gridHeight(1)
+                .anchor(GridBagConstraintsAnchor.WEST)
+                .fill(GridBagConstraintsFill.HORIZONTAL);
         panel.add(
             new UnitChooserEntryIcon(damaged),
-            new GridBagConstraints(
-                gridx++,
-                rowIndex,
-                1,
-                1,
-                0,
-                0,
-                GridBagConstraints.WEST,
-                GridBagConstraints.HORIZONTAL,
-                new Insets(0, (i == 0 ? 0 : 8), 0, 0),
-                0,
-                0));
+            builder.insets(new Insets(0, (i == 0 ? 0 : 8), 0, 0)).gridX(gridx++).build());
         if (i == 0) {
           if (category.getMovement().compareTo(new BigDecimal(-1)) != 0) {
             panel.add(
                 new JLabel("mvt " + category.getMovement()),
-                new GridBagConstraints(
-                    gridx,
-                    rowIndex,
-                    1,
-                    1,
-                    0,
-                    0,
-                    GridBagConstraints.WEST,
-                    GridBagConstraints.HORIZONTAL,
-                    new Insets(0, 4, 0, 4),
-                    0,
-                    0));
+                builder.insets(new Insets(0, 4, 0, 4)).gridX(gridx++).build());
           }
-          gridx++;
           if (category.getTransportCost() != -1) {
             panel.add(
                 new JLabel("cst " + category.getTransportCost()),
-                new GridBagConstraints(
-                    gridx,
-                    rowIndex,
-                    1,
-                    1,
-                    0,
-                    0,
-                    GridBagConstraints.WEST,
-                    GridBagConstraints.HORIZONTAL,
-                    new Insets(0, 4, 0, 4),
-                    0,
-                    0));
+                builder.insets(new Insets(0, 4, 0, 4)).gridX(gridx++).build());
           }
         }
-        panel.add(
-            label,
-            new GridBagConstraints(
-                gridx++,
-                rowIndex,
-                1,
-                1,
-                0,
-                0,
-                GridBagConstraints.WEST,
-                GridBagConstraints.HORIZONTAL,
-                emptyInsets,
-                0,
-                0));
-        panel.add(
-            scroll,
-            new GridBagConstraints(
-                gridx++,
-                rowIndex,
-                1,
-                1,
-                0,
-                0,
-                GridBagConstraints.WEST,
-                GridBagConstraints.HORIZONTAL,
-                new Insets(0, 4, 0, 0),
-                0,
-                0));
+        panel.add(label, builder.insets(new Insets(0, 4, 0, 4)).gridX(gridx++).build());
+        panel.add(scroll, builder.insets(new Insets(0, 4, 0, 0)).gridX(gridx++).build());
         scroll.addChangeListener(field -> updateLeftToSelect());
       }
       updateLeftToSelect();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UnitChooser.java
@@ -509,7 +509,7 @@ public final class UnitChooser extends JPanel {
                 builder.insets(new Insets(0, 4, 0, 4)).gridX(gridx++).build());
           }
         }
-        panel.add(label, builder.insets(new Insets(0, 4, 0, 4)).gridX(gridx++).build());
+        panel.add(label, builder.insets(emptyInsets).gridX(gridx++).build());
         panel.add(scroll, builder.insets(new Insets(0, 4, 0, 0)).gridX(gridx++).build());
         scroll.addChangeListener(field -> updateLeftToSelect());
       }

--- a/lib/swing-lib/src/main/java/org/triplea/swing/jpanel/GridBagConstraintsBuilder.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/jpanel/GridBagConstraintsBuilder.java
@@ -26,8 +26,8 @@ import java.awt.Insets;
  * </pre></code>
  */
 public class GridBagConstraintsBuilder {
-  private final int gridX;
-  private final int gridY;
+  private int gridX;
+  private int gridY;
 
   private int gridWidth = 1;
   private int gridHeight = 1;
@@ -132,6 +132,16 @@ public class GridBagConstraintsBuilder {
   /** Default value is 0 */
   public GridBagConstraintsBuilder padY(final int padY) {
     this.padY = padY;
+    return this;
+  }
+
+  public GridBagConstraintsBuilder gridY(final int gridY) {
+    this.gridY = gridY;
+    return this;
+  }
+
+  public GridBagConstraintsBuilder gridX(final int gridX) {
+    this.gridX = gridX;
     return this;
   }
 }


### PR DESCRIPTION
## Change Summary & Additional Notes

Fix text overlap in air transport load dialog.

Also switch to a builder for grid bag constraints to improve readability.

The problem was the gridX value wasn't being incremented when adding the "cst" label.

UI before:
<img width="374" alt="Screen Shot 2022-04-08 at 10 11 21 AM" src="https://user-images.githubusercontent.com/17648/162463326-9e02c70b-d041-47bd-a018-80e3ba85d09f.png">

UI after:
<img width="377" alt="Screen Shot 2022-04-08 at 10 44 17 AM" src="https://user-images.githubusercontent.com/17648/162463281-6b9993b2-bcc0-4a89-8143-f6bbb03c6ab7.png">

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Text overlap in dialog when loading air transports<!--END_RELEASE_NOTE-->
