### PR TITLE
Clear dependent units map when canceling a pending move.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
@@ -1518,6 +1518,7 @@ public class MovePanel extends AbstractMovePanel {
     mouseCurrentTerritory = null;
     forced = null;
     selectedUnits.clear();
+    dependentUnits.clear();
     currentCursorImage = null;
     updateRouteAndMouseShadowUnits(null);
     getMap().showMouseCursor();


### PR DESCRIPTION
## Change Summary & Additional Notes

Clear dependent units map when canceling a pending move.
This fixes a bug where if you start an air transport move, but then cancel it, the loaded units become unmovable.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Bug where units couldn't be moved after canceling an air transport move<!--END_RELEASE_NOTE-->
