### PR TITLE
Clean up move panel code for air transport dependent units.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -22,7 +22,6 @@ import games.strategy.triplea.delegate.battle.IBattle;
 import games.strategy.triplea.delegate.battle.IBattle.BattleType;
 import games.strategy.triplea.delegate.move.validation.MoveValidator;
 import games.strategy.triplea.formatter.MyFormatter;
-import games.strategy.triplea.ui.panel.move.MovePanel;
 import games.strategy.triplea.util.TransportUtils;
 import java.io.Serializable;
 import java.math.BigDecimal;
@@ -406,9 +405,6 @@ public class MovePerformer implements Serializable {
   /** Marks transports and units involved in unloading with no movement left. */
   private void markTransportsMovement(
       final Collection<Unit> arrived, final Map<Unit, Unit> transporting, final Route route) {
-    if (transporting == null) {
-      return;
-    }
     final GameData data = bridge.getData();
     final Predicate<Unit> paratroopNAirTransports =
         Matches.unitIsAirTransport().or(Matches.unitIsAirTransportable());
@@ -438,7 +434,6 @@ public class MovePerformer implements Serializable {
       final Collection<Unit> airTransports =
           CollectionUtils.getMatches(arrived, Matches.unitIsAirTransport());
       airTransports.addAll(dependentAirTransportableUnits.keySet());
-      MovePanel.clearDependents(airTransports);
     }
     // load the transports
     if (route.isLoad() || paratroopsLanding) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
@@ -13,7 +13,6 @@ import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.battle.BattleTracker;
 import games.strategy.triplea.delegate.battle.IBattle;
-import games.strategy.triplea.ui.panel.move.MovePanel;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -155,8 +154,6 @@ public class UndoableMove extends AbstractUndoableMove {
         }
       }
     }
-    // Clear any temporary dependents
-    MovePanel.clearDependents(units);
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/AbstractMovePanel.java
@@ -298,17 +298,12 @@ public abstract class AbstractMovePanel extends ActionPanel {
    */
   protected abstract void setUpSpecific();
 
-  protected void clearDependencies() {
-    // used by some subclasses
-  }
-
   public final MoveDescription waitForMove(final IPlayerBridge bridge) {
     setUp(bridge);
     waitForRelease();
     cleanUp();
     final MoveDescription returnValue = moveMessage;
     moveMessage = null;
-    clearDependencies();
     return returnValue;
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
@@ -1152,8 +1152,8 @@ public class MovePanel extends AbstractMovePanel {
   }
 
   /**
-   * Allow the user to select what transports to load. If null is returned, the move should be
-   * canceled.
+   * Allow the user to select what transports to load. If an empty collection is returned, the move
+   * should be canceled.
    */
   private Collection<Unit> getTransportsToLoad(
       final Route route, final Collection<Unit> unitsToLoad) {


### PR DESCRIPTION
## Change Summary & Additional Notes

Clean up move panel code for air transport dependent units.

The previous code was unnecessarily complex given dependentUnits was tracking only the loaded units for the current move, so they only need to be cleared when the move is issued or canceled.

Also cleans up a few things in related code, such as unnecessary conditionals that are always true.

No functional changes.

Tested by loading air transports and landing them, undoing moves and canceling a move in progress.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
