### PR TITLE
Show territory map in scramble landing dialog.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -56,12 +56,10 @@ import javax.swing.ImageIcon;
 import javax.swing.JButton;
 import javax.swing.JComponent;
 import javax.swing.JLabel;
-import javax.swing.JList;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTable;
-import javax.swing.ListSelectionModel;
 import javax.swing.ScrollPaneConstants;
 import javax.swing.SwingConstants;
 import javax.swing.SwingUtilities;
@@ -76,7 +74,6 @@ import org.triplea.java.Interruptibles;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.swing.ScrollableJPanel;
 import org.triplea.swing.SwingAction;
-import org.triplea.swing.SwingComponents;
 import org.triplea.swing.key.binding.KeyCode;
 import org.triplea.swing.key.binding.SwingKeyBinding;
 
@@ -182,8 +179,7 @@ public class BattleDisplay extends JPanel {
 
   void takeFocus() {
     // we want a component on this frame to take focus so that pressing space will work (since it
-    // requires in focused
-    // window). Only seems to be an issue on windows
+    // requires in focused window). Only seems to be an issue on Windows.
     actionButton.requestFocus();
   }
 
@@ -307,7 +303,7 @@ public class BattleDisplay extends JPanel {
     SwingUtilities.invokeLater(() -> actionButton.setAction(buttonAction));
     uiContext.addShutdownLatch(continueLatch);
 
-    // Set a auto-wait expiration if the option is set or
+    // Set an auto-wait expiration if the option is set or
     // waits for the button to be pressed otherwise.
     if (!ClientSetting.confirmDefensiveRolls.getValueOrThrow()) {
       final int maxWaitTime = 1500;
@@ -437,7 +433,8 @@ public class BattleDisplay extends JPanel {
 
   private RetreatResult showRetreatOptions(
       final String message, final Collection<Territory> possible) {
-    final RetreatComponent comp = new RetreatComponent(possible);
+    final SelectTerritoryComponent comp =
+        new SelectTerritoryComponent(battleLocation, possible, mapPanel);
     final int option =
         JOptionPane.showConfirmDialog(
             BattleDisplay.this,
@@ -449,49 +446,6 @@ public class BattleDisplay extends JPanel {
     return option == JOptionPane.OK_OPTION && comp.getSelection() != null
         ? RetreatResult.retreatTo(comp.getSelection())
         : RetreatResult.noResult();
-  }
-
-  private class RetreatComponent extends JPanel {
-    private static final long serialVersionUID = 3855054934860687832L;
-    private final JList<Territory> list;
-    private final JLabel retreatTerritory = new JLabel("");
-
-    RetreatComponent(final Collection<Territory> possible) {
-      this.setLayout(new BorderLayout());
-      final JLabel label = new JLabel("Retreat to...");
-      label.setBorder(new EmptyBorder(0, 0, 10, 0));
-      this.add(label, BorderLayout.NORTH);
-      final JPanel imagePanel = new JPanel();
-      imagePanel.setLayout(new FlowLayout(FlowLayout.CENTER));
-      imagePanel.add(retreatTerritory);
-      imagePanel.setBorder(new EmptyBorder(10, 10, 10, 0));
-      this.add(imagePanel, BorderLayout.EAST);
-      list = new JList<>(SwingComponents.newListModel(possible));
-      list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-      if (!possible.isEmpty()) {
-        list.setSelectedIndex(0);
-      }
-      final JScrollPane scroll = new JScrollPane(list);
-      this.add(scroll, BorderLayout.CENTER);
-      scroll.setBorder(new EmptyBorder(10, 0, 10, 0));
-      updateImage();
-      list.addListSelectionListener(e -> updateImage());
-    }
-
-    private void updateImage() {
-      final int width = 250;
-      final int height = 250;
-      final Image img = mapPanel.getTerritoryImage(list.getSelectedValue(), battleLocation);
-      final Image finalImage = Util.newImage(width, height, true);
-      final Graphics g = finalImage.getGraphics();
-      g.drawImage(img, 0, 0, width, height, this);
-      g.dispose();
-      retreatTerritory.setIcon(new ImageIcon(finalImage));
-    }
-
-    public Territory getSelection() {
-      return list.getSelectedValue();
-    }
   }
 
   CasualtyDetails getCasualties(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/SelectTerritoryComponent.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/SelectTerritoryComponent.java
@@ -1,0 +1,72 @@
+package games.strategy.triplea.ui;
+
+import games.strategy.engine.data.Territory;
+import games.strategy.triplea.ui.panels.map.MapPanel;
+import games.strategy.ui.Util;
+import java.awt.BorderLayout;
+import java.awt.FlowLayout;
+import java.awt.Graphics;
+import java.awt.Image;
+import java.util.Collection;
+import javax.swing.ImageIcon;
+import javax.swing.JLabel;
+import javax.swing.JList;
+import javax.swing.JPanel;
+import javax.swing.JScrollPane;
+import javax.swing.ListSelectionModel;
+import javax.swing.border.EmptyBorder;
+import org.triplea.swing.SwingComponents;
+
+public class SelectTerritoryComponent extends JPanel {
+  private static final long serialVersionUID = 3855054934860687832L;
+  private final Territory battleLocation;
+  private final MapPanel mapPanel;
+  private final JList<Territory> list;
+  private final JLabel label = new JLabel("Retreat to...");
+  private final JLabel retreatTerritory = new JLabel("");
+
+  SelectTerritoryComponent(
+      final Territory battleLocation,
+      final Collection<Territory> possible,
+      final MapPanel mapPanel) {
+    this.battleLocation = battleLocation;
+    this.mapPanel = mapPanel;
+    this.setLayout(new BorderLayout());
+    label.setBorder(new EmptyBorder(0, 0, 10, 0));
+    this.add(label, BorderLayout.NORTH);
+    final JPanel imagePanel = new JPanel();
+    imagePanel.setLayout(new FlowLayout(FlowLayout.CENTER));
+    imagePanel.add(retreatTerritory);
+    imagePanel.setBorder(new EmptyBorder(10, 10, 10, 0));
+    this.add(imagePanel, BorderLayout.EAST);
+    list = new JList<>(SwingComponents.newListModel(possible));
+    list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
+    if (!possible.isEmpty()) {
+      list.setSelectedIndex(0);
+    }
+    final JScrollPane scroll = new JScrollPane(list);
+    this.add(scroll, BorderLayout.CENTER);
+    scroll.setBorder(new EmptyBorder(10, 0, 10, 0));
+    updateImage();
+    list.addListSelectionListener(e -> updateImage());
+  }
+
+  public void setLabelText(String text) {
+    label.setText(text);
+  }
+
+  private void updateImage() {
+    final int width = 250;
+    final int height = 250;
+    final Image img = mapPanel.getTerritoryImage(list.getSelectedValue(), battleLocation);
+    final Image finalImage = Util.newImage(width, height, true);
+    final Graphics g = finalImage.getGraphics();
+    g.drawImage(img, 0, 0, width, height, this);
+    g.dispose();
+    retreatTerritory.setIcon(new ImageIcon(finalImage));
+  }
+
+  public Territory getSelection() {
+    return list.getSelectedValue();
+  }
+}

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -138,7 +138,6 @@ import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
 import javax.swing.JTabbedPane;
-import javax.swing.JTextArea;
 import javax.swing.JToggleButton;
 import javax.swing.ListCellRenderer;
 import javax.swing.ListSelectionModel;
@@ -1300,29 +1299,16 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
       return candidates.iterator().next();
     }
     messageAndDialogThreadPool.waitForAll();
-    final Supplier<Tuple<JPanel, JList<Territory>>> action =
+    final Supplier<SelectTerritoryComponent> action =
         () -> {
-          mapPanel.centerOn(currentTerritory);
-          final JList<Territory> list = new JList<>(SwingComponents.newListModel(candidates));
-          list.setSelectionMode(ListSelectionModel.SINGLE_SELECTION);
-          list.setSelectedIndex(0);
-          final JPanel panel = new JPanel();
-          panel.setLayout(new BorderLayout());
-          final JScrollPane scroll = new JScrollPane(list);
-          final JTextArea text = new JTextArea(unitMessage, 8, 30);
-          text.setLineWrap(true);
-          text.setEditable(false);
-          text.setWrapStyleWord(true);
-          panel.add(text, BorderLayout.NORTH);
-          panel.add(scroll, BorderLayout.CENTER);
-          return Tuple.of(panel, list);
+          var panel = new SelectTerritoryComponent(currentTerritory, candidates, mapPanel);
+          panel.setLabelText(unitMessage);
+          return panel;
         };
     return Interruptibles.awaitResult(() -> SwingAction.invokeAndWaitResult(action))
         .result
         .map(
-            comps -> {
-              final JPanel panel = comps.getFirst();
-              final JList<?> list = comps.getSecond();
+            panel -> {
               final String[] options = {"OK"};
               final String title =
                   "Select territory for air units to land, current territory is "
@@ -1337,7 +1323,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
                   options,
                   null,
                   getUiContext().getCountDownLatchHandler());
-              return (Territory) list.getSelectedValue();
+              return panel.getSelection();
             })
         .orElse(null);
   }


### PR DESCRIPTION
## Change Summary & Additional Notes

This change re-uses the UI for retreat for scrambling landing, which brings the benefit of showing a map showing the territory being selected. Moves RetreatComponent to its own file, renaming it to SelectTerritoryComponent.

Before the change:
![old_scramble](https://user-images.githubusercontent.com/17648/163423886-ed064893-b232-4d81-91af-5b4abe096792.PNG)

After the change:
![new_scramble](https://user-images.githubusercontent.com/17648/163423852-ef00a2ea-9dca-4bed-9745-50597d4cf176.png)

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->CHANGE|UI for landing scrambled planes will now show the map of territories, same as retreating<!--END_RELEASE_NOTE-->
