### PR TITLE
Improve display of game notes with dark themes and increase window size.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/GameChooser.java
@@ -1,14 +1,13 @@
 package games.strategy.engine.framework.ui;
 
 import games.strategy.engine.framework.map.file.system.loader.InstalledMapsListing;
+import games.strategy.ui.Util;
 import java.awt.BorderLayout;
-import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Frame;
 import java.awt.GridBagConstraints;
 import java.awt.GridBagLayout;
 import java.awt.Insets;
-import java.awt.Rectangle;
 import java.awt.event.MouseAdapter;
 import java.awt.event.MouseEvent;
 import java.nio.file.Path;
@@ -19,12 +18,10 @@ import javax.swing.Box;
 import javax.swing.DefaultListModel;
 import javax.swing.JButton;
 import javax.swing.JDialog;
-import javax.swing.JEditorPane;
 import javax.swing.JList;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
-import javax.swing.SwingUtilities;
 import lombok.experimental.UtilityClass;
 import org.triplea.swing.JButtonBuilder;
 import org.triplea.swing.JLabelBuilder;
@@ -108,11 +105,7 @@ public class GameChooser {
             0));
     mainSplit.setLeftComponent(leftPanel);
 
-    final JEditorPane notesPanel = new JEditorPane();
-    notesPanel.setEditable(false);
-    notesPanel.setContentType("text/html");
-    notesPanel.setForeground(Color.BLACK);
-
+    final GameNotesView notesPanel = new GameNotesView();
     Optional.ofNullable(gameList.getSelectedValue())
         .map(DefaultGameChooserEntry::readGameNotes)
         .ifPresent(notesPanel::setText);
@@ -155,9 +148,6 @@ public class GameChooser {
             Optional.ofNullable(gameList.getSelectedValue())
                 .map(DefaultGameChooserEntry::readGameNotes)
                 .ifPresent(notesPanel::setText);
-            // scroll to the top of the notes screen
-            SwingUtilities.invokeLater(
-                () -> notesPanel.scrollRectToVisible(new Rectangle(0, 0, 0, 0)));
           }
         });
     gameList.addMouseListener(
@@ -169,10 +159,13 @@ public class GameChooser {
             }
           }
         });
-    // scroll to the top of the notes screen
-    SwingUtilities.invokeLater(() -> notesPanel.scrollRectToVisible(new Rectangle(0, 0, 0, 0)));
 
-    dialog.setSize(800, 600);
+    final Dimension screenSize = Util.getScreenSize(dialog);
+    if (screenSize.width > 1024 && screenSize.height > 768) {
+      dialog.setSize(new Dimension(1024, 768));
+    } else {
+      dialog.setSize(800, 600);
+    }
     dialog.setLocationRelativeTo(owner);
     dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
     dialog.setVisible(true); // Blocking and waits for user action

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/GameNotesView.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/GameNotesView.java
@@ -16,7 +16,7 @@ public class GameNotesView extends JEditorPane {
     // If the background color isn't set, a dark theme may have a very dark window background, which
     // will make it hard to read the black text against. Note: For some reason, some dark themes
     // show the background as light gray even if white is set, but it doesn't actually look too bad.
-    // setBackground(Color.WHITE);
+    setBackground(Color.WHITE);
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/GameNotesView.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/GameNotesView.java
@@ -1,0 +1,28 @@
+package games.strategy.engine.framework.ui;
+
+import java.awt.Color;
+import java.awt.Rectangle;
+import javax.swing.JEditorPane;
+import javax.swing.SwingUtilities;
+
+/** Component for displaying HTML-formatted game notes. */
+public class GameNotesView extends JEditorPane {
+  public GameNotesView() {
+    setEditable(false);
+    setContentType("text/html");
+    // If the foreground color isn't set, a dark theme may make the text color white, which will be
+    // unreadable if the html sets a light background color.
+    setForeground(Color.BLACK);
+    // If the background color isn't set, a dark theme may have a very dark window background, which
+    // will make it hard to read the black text against. Note: For some reason, some dark themes
+    // show the background as light gray even if white is set, but it doesn't actually look too bad.
+    // setBackground(Color.WHITE);
+  }
+
+  @Override
+  public void setText(String text) {
+    super.setText(text);
+    // Scroll to the top of the notes screen when the text is updated.
+    SwingUtilities.invokeLater(() -> scrollRectToVisible(new Rectangle()));
+  }
+}

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/GameNotesMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/GameNotesMenu.java
@@ -1,11 +1,10 @@
 package games.strategy.triplea.ui.menubar.help;
 
+import games.strategy.engine.framework.ui.GameNotesView;
 import games.strategy.triplea.ui.UiContext;
-import java.awt.Color;
 import javax.swing.Action;
 import javax.swing.JComponent;
 import javax.swing.JDialog;
-import javax.swing.JEditorPane;
 import javax.swing.SwingUtilities;
 import lombok.experimental.UtilityClass;
 import org.triplea.swing.SwingAction;
@@ -44,10 +43,8 @@ class GameNotesMenu {
     final String localizedHtml =
         LocalizeHtml.localizeImgLinksInHtml(gameNotes.trim(), UiContext.getMapLocation());
 
-    final JEditorPane gameNotesPane = new JEditorPane("text/html", localizedHtml);
-    gameNotesPane.setEditable(false);
-    gameNotesPane.setForeground(Color.BLACK);
-    gameNotesPane.setCaretPosition(0);
+    final GameNotesView gameNotesPane = new GameNotesView();
+    gameNotesPane.setText(localizedHtml);
     return SwingComponents.newJScrollPane(gameNotesPane);
   }
 }


### PR DESCRIPTION
## Change Summary & Additional Notes

Improve display of game notes with dark themes, so that black text isn't shown on a very dark background.

Also, default the map selection window to 1024x768 on larger screens.

Screenshots with Substance Graphite UI theme:

Before:
![before](https://user-images.githubusercontent.com/17648/163501815-477c742a-68f8-4746-8433-2d8bf5ed25c6.PNG)

After:
![after](https://user-images.githubusercontent.com/17648/163501826-107145f9-ad20-4fb5-86cc-6c20271d3138.PNG)

Light themes are unaffected since they default to a white background already (e.g. Metal theme):
![after_light](https://user-images.githubusercontent.com/17648/163501936-bef890b1-370e-4810-9552-927917ad4c8c.PNG)

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->CHANGE|Styling of game notes with dark themes will no longer be black on black. The map selection window size is now 1024x768 on screens supporting that size.<!--END_RELEASE_NOTE-->