### PR TITLE
Fix ConcurrentModificationException in getTerritoryEffectImage().

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -28,6 +28,7 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
@@ -125,7 +126,7 @@ public class MapData {
   private final Map<Image, List<Point>> decorations = new HashMap<>();
   private final Map<String, Image> territoryNameImages = new HashMap<>();
   // Use a synchronized map since getTerritoryEffectImage() is called from multiple threads.
-  private final Map<String, Image> effectImages = Collections.synchronizedMap(new HashMap<>());
+  private final Map<String, Image> effectImages = new ConcurrentHashMap<>();
 
   @Nullable private final Image vcImage;
   @Nullable private final Image blockadeImage;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/mapdata/MapData.java
@@ -124,7 +124,8 @@ public class MapData {
   private Set<String> undrawnTerritoriesNames;
   private final Map<Image, List<Point>> decorations = new HashMap<>();
   private final Map<String, Image> territoryNameImages = new HashMap<>();
-  private final Map<String, Image> effectImages = new HashMap<>();
+  // Use a synchronized map since getTerritoryEffectImage() is called from multiple threads.
+  private final Map<String, Image> effectImages = Collections.synchronizedMap(new HashMap<>());
 
   @Nullable private final Image vcImage;
   @Nullable private final Image blockadeImage;


### PR DESCRIPTION
## Change Summary & Additional Notes

Fix ConcurrentModificationException in getTerritoryEffectImage(). It's called from multiple threads which add entries to the map. I encountered this exception once when starting a new game in my testing.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Fixed ConcurrentModificationException in map drawing code<!--END_RELEASE_NOTE-->
