### PR TITLE
Fix long delay when using "undo all" with lots of moves.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ResourceBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ResourceBar.java
@@ -84,13 +84,13 @@ public class ResourceBar extends JPanel implements GameDataChangeListener {
               continue;
             }
             final double quantity = resourceStat.getValue(player, gameData, uiContext.getMapData());
-            final StringBuilder text = new StringBuilder(IStat.DECIMAL_FORMAT.format(quantity));
             final int income = resourceIncomes.getInt(resource);
+            final StringBuilder text = new StringBuilder(IStat.DECIMAL_FORMAT.format(quantity));
             text.append(" (").append(income >= 0 ? "+" : "").append(income).append(")");
             final JLabel label =
                 uiContext.getResourceImageFactory().getLabel(resource, text.toString());
             label.setBorder(BorderFactory.createEmptyBorder(0, 10, 0, 10));
-            add(label, new GridBagConstraintsBuilder(count++, 0).weightX(0).weightY(1).build());
+            add(label, new GridBagConstraintsBuilder(count++, 0).weightY(1).build());
           }
         });
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ResourceBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ResourceBar.java
@@ -66,6 +66,7 @@ public class ResourceBar extends JPanel implements GameDataChangeListener {
           final GamePlayer player;
           final IntegerMap<Resource> resourceIncomes;
           try {
+            needsUpdate = false;
             gameData.acquireReadLock();
             player = gameData.getSequence().getStep().getPlayerId();
             if (player == null) {
@@ -74,7 +75,6 @@ public class ResourceBar extends JPanel implements GameDataChangeListener {
             resourceIncomes = AbstractEndTurnDelegate.findEstimatedIncome(player, gameData);
           } finally {
             gameData.releaseReadLock();
-            needsUpdate = false;
           }
 
           this.removeAll();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ResourceBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ResourceBar.java
@@ -56,7 +56,7 @@ public class ResourceBar extends JPanel implements GameDataChangeListener {
   public void gameDataChanged(final Change change) {
     // When there are multiple gameDataChanged() notifications in a row, for example
     // from an "undo all" action, no need to do this repeatedly. This will just run
-    // once if the swing code runs after all the notifications have been received.
+    // once if the async code runs after all the notifications have been received.
     if (updateScheduled) {
       return;
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ResourceBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ResourceBar.java
@@ -55,7 +55,7 @@ public class ResourceBar extends JPanel implements GameDataChangeListener {
   public void gameDataChanged(final Change change) {
     // When there are multiple gameDataChanged() notifications in a row, for example
     // from an "undo all" action, no need to do this repeatedly. This will just run
-    // once if this code runs after all the notifications have been received.
+    // once if the swing code runs after all the notifications have been received.
     if (updateScheduled) {
       return;
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ResourceBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ResourceBar.java
@@ -61,9 +61,9 @@ public class ResourceBar extends JPanel implements GameDataChangeListener {
       return;
     }
     updateScheduled = true;
-    // Note: The two layers of async logic is because we don't want to get do the resource
-    // income computation inline (since it's heavy) to benefit from the optimization above
-    // and we don't want to do it on the UI thread to avoid a locking operation blocking UI.
+    // Note: The two layers of async logic is because we don't want to do the resource incomes
+    // computation immediately (since it's heavy) to benefit from the optimization above and we
+    // also don't want to do it on the UI thread to avoid a locking operation blocking UI.
     AsyncRunner.runAsync(
             () -> {
               updateScheduled = false;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ResourceBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ResourceBar.java
@@ -28,6 +28,7 @@ public class ResourceBar extends JPanel implements GameDataChangeListener {
   private final GameData gameData;
   private final UiContext uiContext;
   private final List<ResourceStat> resourceStats = new ArrayList<>();
+  private volatile boolean needsUpdate;
 
   public ResourceBar(final GameData data, final UiContext uiContext) {
     this.gameData = data;
@@ -53,51 +54,61 @@ public class ResourceBar extends JPanel implements GameDataChangeListener {
 
   @Override
   public void gameDataChanged(final Change change) {
-    gameData.acquireReadLock();
-    try {
-      final GamePlayer player = gameData.getSequence().getStep().getPlayerId();
-      if (player != null) {
-        final IntegerMap<Resource> resourceIncomes =
-            AbstractEndTurnDelegate.findEstimatedIncome(player, gameData);
-        SwingUtilities.invokeLater(
-            () -> {
-              this.removeAll();
-              int count = 0;
-              for (final ResourceStat resourceStat : resourceStats) {
-                final Resource resource = resourceStat.resource;
-                if (!resource.isDisplayedFor(player)) {
-                  continue;
-                }
-                final double quantity =
-                    resourceStat.getValue(player, gameData, uiContext.getMapData());
-                final StringBuilder text =
-                    new StringBuilder(IStat.DECIMAL_FORMAT.format(quantity) + " (");
-                if (resourceIncomes.getInt(resource) >= 0) {
-                  text.append("+");
-                }
-                text.append(resourceIncomes.getInt(resource)).append(")");
-                final JLabel label =
-                    uiContext.getResourceImageFactory().getLabel(resource, text.toString());
-                label.setBorder(BorderFactory.createEmptyBorder(0, 10, 0, 10));
-                add(
-                    label,
-                    new GridBagConstraints(
-                        count++,
-                        0,
-                        1,
-                        1,
-                        0,
-                        1,
-                        GridBagConstraints.WEST,
-                        GridBagConstraints.BOTH,
-                        new Insets(0, 0, 0, 0),
-                        0,
-                        0));
-              }
-            });
-      }
-    } finally {
-      gameData.releaseReadLock();
-    }
+    needsUpdate = true;
+    SwingUtilities.invokeLater(
+        () -> {
+          // When there are multiple gameDataChanged() notifications in a row, for example
+          // from an "undo all" action, no need to do this repeatedly. This will just run
+          // once if this code runs after all the notifications have been received.
+          if (needsUpdate) {
+            return;
+          }
+          final GamePlayer player;
+          final IntegerMap<Resource> resourceIncomes;
+          try {
+            gameData.acquireReadLock();
+            player = gameData.getSequence().getStep().getPlayerId();
+            if (player == null) {
+              return;
+            }
+            resourceIncomes = AbstractEndTurnDelegate.findEstimatedIncome(player, gameData);
+          } finally {
+            gameData.releaseReadLock();
+            needsUpdate = false;
+          }
+
+          this.removeAll();
+          int count = 0;
+          for (final ResourceStat resourceStat : resourceStats) {
+            final Resource resource = resourceStat.resource;
+            if (!resource.isDisplayedFor(player)) {
+              continue;
+            }
+            final double quantity = resourceStat.getValue(player, gameData, uiContext.getMapData());
+            final StringBuilder text =
+                new StringBuilder(IStat.DECIMAL_FORMAT.format(quantity) + " (");
+            if (resourceIncomes.getInt(resource) >= 0) {
+              text.append("+");
+            }
+            text.append(resourceIncomes.getInt(resource)).append(")");
+            final JLabel label =
+                uiContext.getResourceImageFactory().getLabel(resource, text.toString());
+            label.setBorder(BorderFactory.createEmptyBorder(0, 10, 0, 10));
+            add(
+                label,
+                new GridBagConstraints(
+                    count++,
+                    0,
+                    1,
+                    1,
+                    0,
+                    1,
+                    GridBagConstraints.WEST,
+                    GridBagConstraints.BOTH,
+                    new Insets(0, 0, 0, 0),
+                    0,
+                    0));
+          }
+        });
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ResourceBar.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ResourceBar.java
@@ -60,7 +60,7 @@ public class ResourceBar extends JPanel implements GameDataChangeListener {
           // When there are multiple gameDataChanged() notifications in a row, for example
           // from an "undo all" action, no need to do this repeatedly. This will just run
           // once if this code runs after all the notifications have been received.
-          if (needsUpdate) {
+          if (!needsUpdate) {
             return;
           }
           final GamePlayer player;


### PR DESCRIPTION
## Change Summary & Additional Notes
Fix long delay when using "undo all" with lots of moves.

The delay was caused by slow execution of resource bar updates. This change makes it so we only update it once if we receive lots of updates at once, assuming the swing code runs after the updates (which seems to be the case in the case of undo all).

Also makes the code more concise with some clean up.

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|The undo all action has been sped up<!--END_RELEASE_NOTE-->
