### PR TITLE
Change map scale maximum from 100% to 200%.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/UiContext.java
@@ -52,6 +52,8 @@ public class UiContext {
   static final String UNIT_SCALE_PREF = "UnitScale";
   static final String MAP_SCALE_PREF = "MapScale";
 
+  public static final double MAP_SCALE_MAX_VALUE = 2.0;
+
   private static final String ORIGINAL_SKIN_NAME = "Original";
 
   private static final String MAP_SKIN_PREF = "MapSkin";

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ViewMenu.java
@@ -114,7 +114,7 @@ final class ViewMenu extends JMenu {
             "Map Zoom",
             e -> {
               final SpinnerNumberModel model = new SpinnerNumberModel();
-              model.setMaximum(100);
+              model.setMaximum(UiContext.MAP_SCALE_MAX_VALUE * 100);
               model.setMinimum((int) Math.ceil(frame.getMapPanel().getMinScale() * 100));
               model.setStepSize(1);
               model.setValue((int) Math.round(frame.getMapPanel().getScale() * 100));

--- a/game-app/game-core/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
+++ b/game-app/game-core/src/main/java/games/strategy/ui/ImageScrollerLargeView.java
@@ -2,6 +2,7 @@ package games.strategy.ui;
 
 import com.google.common.primitives.Doubles;
 import games.strategy.triplea.settings.ClientSetting;
+import games.strategy.triplea.ui.UiContext;
 import java.awt.Dimension;
 import java.awt.Point;
 import java.awt.event.ActionEvent;
@@ -74,7 +75,7 @@ public class ImageScrollerLargeView extends JComponent {
             insideCount++;
             if (insideCount > 6) {
               // Scroll the map when the mouse has hovered inside the scroll zone for long enough
-              SwingUtilities.invokeLater(new Scroller());
+              SwingUtilities.invokeLater(ImageScrollerLargeView.this::scroll);
             }
           }
         }
@@ -317,7 +318,7 @@ public class ImageScrollerLargeView extends JComponent {
   }
 
   private double constrainScale(final double value) {
-    return Doubles.constrainToRange(value, getMinScale(), 1.0);
+    return Doubles.constrainToRange(value, getMinScale(), UiContext.MAP_SCALE_MAX_VALUE);
   }
 
   /** Update will not be seen until update is called. Resets the offscreen image to the original. */
@@ -327,13 +328,6 @@ public class ImageScrollerLargeView extends JComponent {
 
   public int getYOffset() {
     return model.getY();
-  }
-
-  private class Scroller implements Runnable {
-    @Override
-    public void run() {
-      scroll();
-    }
   }
 
   protected double getScaledWidth() {


### PR DESCRIPTION
## Change Summary & Additional Notes

Change map scale maximum from 100% to 200%.

This makes some maps, like Ultimate World much more usable.
However, the current implementation is such that tiles will simply be upscaled, which will make the quality not ideal. In particular, this makes unit images appear worse than they should. Improving this requires re-working how tiles are rendered (e.g. rendering them at the scaled resolution instead of at 1x and scaling them at draw time).

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->CHANGE|Map scale can now go above 100%, with 200% as maximum<!--END_RELEASE_NOTE-->
