### PR TITLE
Update mac install4j options to associate save games and web urls.

### DIFF
--- a/game-app/game-headed/build.install4j
+++ b/game-app/game-headed/build.install4j
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<install4j version="9.0.5" transformSequenceNumber="9">
+<install4j version="9.0.6" transformSequenceNumber="9">
   <directoryPresets config=".triplea-root" />
   <application name="TripleA" applicationId="5251-3669-9623-1649" mediaDir="build/releases" mediaFilePattern="${compiler:sys.fullName}_${compiler:sys.version}_${compiler:sys.platform}" compression="9" lzmaCompression="true" pack200Compression="true" createChecksums="false" shortName="TripleA" publisher="TripleA Developer Team" publisherWeb="https://triplea-game.org" version="${compiler:sys.version}" allPathsRelative="true" autoSave="true" convertDotsToUnderscores="false" macVolumeId="af9346379363d40e" javaMinVersion="11" jdkMode="jdk">
     <jreBundles jdkProviderId="AdoptOpenJDK" release="11/jdk-11.0.9.1+1" />
@@ -17,7 +17,7 @@
     </entries>
   </files>
   <launchers>
-    <launcher name="TripleA" id="33" menuName="TripleA-${compiler:sys.version}">
+    <launcher name="TripleA" id="33" menuName="TripleA-${compiler:sys.version}" macStaticAssociationsForInstallers="true">
       <executable name="TripleA" iconSet="true" stderrMode="append" executableMode="gui" checkConsoleParameter="true" dpiAware="true">
         <versionInfo internalName="TripleA" productName="TripleA Game" />
       </executable>
@@ -32,7 +32,10 @@
           <scanDirectory location="bin" failOnError="false" />
         </classPath>
       </java>
-      <macStaticAssociationActions mode="selected" />
+      <macStaticAssociationActions mode="selected">
+        <id>554</id>
+        <id>263</id>
+      </macStaticAssociationActions>
       <vmOptionsFile mode="none" overwriteMode="3" />
       <iconImageFiles>
         <file path="./assets/icons/triplea_icon_16_16.png" />


### PR DESCRIPTION
## Change Summary & Additional Notes
Update mac install4j options to associate save games and web urls.

Needed to fix https://github.com/triplea-game/triplea/issues/5253.

I verified the Info.plist file has the extra options set.
<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
