### PR TITLE
Fix opening a save game from the OS on macOS.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/MainPanel.java
@@ -19,7 +19,6 @@ import javax.swing.JPanel;
 import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
-import javax.swing.SwingUtilities;
 import javax.swing.border.EmptyBorder;
 import javax.swing.border.EtchedBorder;
 import org.triplea.game.chat.ChatModel;
@@ -38,7 +37,6 @@ import org.triplea.swing.jpanel.JPanelBuilder;
 public class MainPanel extends JPanel {
   private static final long serialVersionUID = -5548760379892913464L;
   private static final Dimension initialSize = new Dimension(900, 780);
-  private static MainPanel instance;
 
   private final JButton playButton =
       new JButtonBuilder()
@@ -115,22 +113,10 @@ public class MainPanel extends JPanel {
     add(buttonsPanel, BorderLayout.SOUTH);
     setPreferredSize(initialSize);
     updatePlayButtonState();
-    instance = this;
   }
 
-  public static void loadSaveFile(final Path file) {
-    // This may be called at any time, including during start up.
-    SwingUtilities.invokeLater(
-        () -> {
-          // If the MainPanel is up already, load the save file.
-          if (instance != null) {
-            instance.gameSelectorPanel.loadSaveFile(file);
-            return;
-          }
-
-          // Otherwise "recurse" to invokeLater() to try again.
-          loadSaveFile(file);
-        });
+  public void loadSaveFile(final Path file) {
+    gameSelectorPanel.loadSaveFile(file);
   }
 
   private void addChat(final Component chatComponent) {

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -336,6 +336,33 @@ public final class GameSelectorPanel extends JPanel implements Observer {
     updateGameData();
   }
 
+  public void loadSaveFile(final Path file) {
+    TaskRunner.builder()
+        .waitDialogTitle("Loading Save Game")
+        .exceptionHandler(
+            e ->
+                SwingComponents.showDialogWithLinks(
+                    DialogWithLinksParams.builder()
+                        .title("Failed To Load Save Game")
+                        .dialogType(DialogWithLinksTypes.ERROR)
+                        .dialogText(
+                            String.format(
+                                "<html>Error: %s<br/><br/>"
+                                    + "If this is not expected, please "
+                                    + "file a <a href=%s>bug report</a><br/>"
+                                    + "and attach the error message above and the "
+                                    + "save game you are trying to load.",
+                                e.getMessage(), UrlConstants.GITHUB_ISSUES))
+                        .build()))
+        .build()
+        .run(
+            () -> {
+              if (model.load(file)) {
+                setOriginalPropertiesMap(model.getGameData());
+              }
+            });
+  }
+
   private void selectSavedGameFile() {
     GameFileSelector.builder()
         .fileDoesNotExistAction(
@@ -347,32 +374,7 @@ public final class GameSelectorPanel extends JPanel implements Observer {
                     .showDialog())
         .build()
         .selectGameFile(JOptionPane.getFrameForComponent(this))
-        .ifPresent(
-            file ->
-                TaskRunner.builder()
-                    .waitDialogTitle("Loading Save Game")
-                    .exceptionHandler(
-                        e ->
-                            SwingComponents.showDialogWithLinks(
-                                DialogWithLinksParams.builder()
-                                    .title("Failed To Load Save Game")
-                                    .dialogType(DialogWithLinksTypes.ERROR)
-                                    .dialogText(
-                                        String.format(
-                                            "<html>Error: %s<br/><br/>"
-                                                + "If this is not expected, please "
-                                                + "file a <a href=%s>bug report</a><br/>"
-                                                + "and attach the error message above and the "
-                                                + "save game you are trying to load.",
-                                            e.getMessage(), UrlConstants.GITHUB_ISSUES))
-                                    .build()))
-                    .build()
-                    .run(
-                        () -> {
-                          if (model.load(file)) {
-                            setOriginalPropertiesMap(model.getGameData());
-                          }
-                        }));
+        .ifPresent(file -> loadSaveFile(file));
   }
 
   private void selectGameFile() {

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/panels/main/game/selector/GameSelectorPanel.java
@@ -336,6 +336,20 @@ public final class GameSelectorPanel extends JPanel implements Observer {
     updateGameData();
   }
 
+  private void selectSavedGameFile() {
+    GameFileSelector.builder()
+        .fileDoesNotExistAction(
+            file ->
+                DialogBuilder.builder()
+                    .parent(this)
+                    .title("Save Game File Not Found")
+                    .errorMessage("File does not exist: " + file.toAbsolutePath())
+                    .showDialog())
+        .build()
+        .selectGameFile(JOptionPane.getFrameForComponent(this))
+        .ifPresent(file -> loadSaveFile(file));
+  }
+
   public void loadSaveFile(final Path file) {
     TaskRunner.builder()
         .waitDialogTitle("Loading Save Game")
@@ -361,20 +375,6 @@ public final class GameSelectorPanel extends JPanel implements Observer {
                 setOriginalPropertiesMap(model.getGameData());
               }
             });
-  }
-
-  private void selectSavedGameFile() {
-    GameFileSelector.builder()
-        .fileDoesNotExistAction(
-            file ->
-                DialogBuilder.builder()
-                    .parent(this)
-                    .title("Save Game File Not Found")
-                    .errorMessage("File does not exist: " + file.toAbsolutePath())
-                    .showDialog())
-        .build()
-        .selectGameFile(JOptionPane.getFrameForComponent(this))
-        .ifPresent(file -> loadSaveFile(file));
   }
 
   private void selectGameFile() {

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/MainFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/MainFrame.java
@@ -82,7 +82,7 @@ public class MainFrame {
     loadSaveFileImpl(file, Instant.now());
   }
 
-  public static void loadSaveFileImpl(final Path file, final Instant startTime) {
+  private static void loadSaveFileImpl(final Path file, final Instant startTime) {
     // This may be called at any time, including during start up.
     SwingUtilities.invokeLater(
         () -> {

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/MainFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/ui/MainFrame.java
@@ -88,5 +88,4 @@ public class MainFrame {
           loadSaveFile(file);
         });
   }
-
 }

--- a/game-app/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
+++ b/game-app/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
@@ -5,12 +5,12 @@ import static com.google.common.base.Preconditions.checkState;
 
 import games.strategy.engine.ClientFileSystemHelper;
 import games.strategy.engine.framework.ArgParser;
-import games.strategy.engine.framework.CliProperties;
 import games.strategy.engine.framework.GameRunner;
 import games.strategy.engine.framework.lookandfeel.LookAndFeel;
 import games.strategy.engine.framework.map.download.DownloadMapsWindow;
 import games.strategy.engine.framework.map.file.system.loader.ZippedMapsExtractor;
 import games.strategy.engine.framework.startup.ui.PlayerTypes;
+import games.strategy.engine.framework.startup.ui.panels.main.MainPanel;
 import games.strategy.engine.framework.system.HttpProxy;
 import games.strategy.engine.framework.system.SystemProperties;
 import games.strategy.engine.framework.ui.background.BackgroundTaskRunner;
@@ -26,7 +26,6 @@ import java.util.ServiceLoader;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-import javax.swing.JOptionPane;
 import javax.swing.SwingUtilities;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.ai.does.nothing.DoesNothingAiProvider;
@@ -69,16 +68,7 @@ public final class HeadedGameRunner {
           });
       MacOsIntegration.setOpenFileHandler(
           file -> {
-            SwingUtilities.invokeLater(
-                () ->
-                    JOptionPane.showMessageDialog(
-                        null,
-                        "Unfortunately opening save-games via the OS"
-                            + " is currently not supported on macOS.",
-                        "Unsupported feature",
-                        JOptionPane.INFORMATION_MESSAGE));
-            System.setProperty(CliProperties.TRIPLEA_GAME, file.toAbsolutePath().toString());
-            GameRunner.showMainFrame();
+            MainPanel.loadSaveFile(file);
           });
     }
 

--- a/game-app/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
+++ b/game-app/game-headed/src/main/java/org/triplea/game/client/HeadedGameRunner.java
@@ -10,9 +10,9 @@ import games.strategy.engine.framework.lookandfeel.LookAndFeel;
 import games.strategy.engine.framework.map.download.DownloadMapsWindow;
 import games.strategy.engine.framework.map.file.system.loader.ZippedMapsExtractor;
 import games.strategy.engine.framework.startup.ui.PlayerTypes;
-import games.strategy.engine.framework.startup.ui.panels.main.MainPanel;
 import games.strategy.engine.framework.system.HttpProxy;
 import games.strategy.engine.framework.system.SystemProperties;
+import games.strategy.engine.framework.ui.MainFrame;
 import games.strategy.engine.framework.ui.background.BackgroundTaskRunner;
 import games.strategy.triplea.ai.AiProvider;
 import games.strategy.triplea.settings.ClientSetting;
@@ -66,10 +66,7 @@ public final class HeadedGameRunner {
             SwingUtilities.invokeLater(
                 () -> DownloadMapsWindow.showDownloadMapsWindowAndDownload(mapName));
           });
-      MacOsIntegration.setOpenFileHandler(
-          file -> {
-            MainPanel.loadSaveFile(file);
-          });
+      MacOsIntegration.setOpenFileHandler(MainFrame::loadSaveFile);
     }
 
     if (HttpProxy.isUsingSystemProxy()) {


### PR DESCRIPTION
## Change Summary & Additional Notes

Fix opening a save game from the OS on macOS (https://github.com/triplea-game/triplea/issues/5253).

The fix is tricky because we may be sent the event to open a save game either asynchrously while we're starting up, or when the app is running already. The implementation handles both (tested manually). It hooks into the same code for when the save game is selected from the UI, which is refactored to split into a separate function.


<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Opening saved games from the OS on macOS<!--END_RELEASE_NOTE-->
