### PR TITLE
Fix error if the same "undo" is clicked twice in succession.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
@@ -145,7 +145,8 @@ public abstract class AbstractUndoableMovesPanel extends JPanel {
           scrollBarPreviousValue = scroll.getVerticalScrollBar().getValue();
           final String error = movePanel.undoMove(moveIndex);
           if (error == null) {
-            // Disable the button so it can't be clicked again until the UI is updated.
+            // Disable the button so it can't be clicked again. Note: Undoing will cause a later
+            // setMoves() call on this object, which will re-build the UI for all the moves.
             undoButton.setEnabled(false);
             previousVisibleIndex = Math.max(0, moveIndex - 1);
           } else {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
@@ -139,18 +139,19 @@ public abstract class AbstractUndoableMovesPanel extends JPanel {
     textBox.add(Box.createHorizontalGlue());
     final JButton undoButton = new JButton("Undo");
     final int moveIndex = move.getIndex();
-    undoButton.addActionListener((e) -> {
-      // Record position of scroll bar as percentage.
-      scrollBarPreviousValue = scroll.getVerticalScrollBar().getValue();
-      final String error = movePanel.undoMove(moveIndex);
-      if (error == null) {
-        // Disable the button so it can't be clicked again until the UI is updated.
-        undoButton.setEnabled(false);
-        previousVisibleIndex = Math.max(0, moveIndex - 1);
-      } else {
-        previousVisibleIndex = null;
-      }
-    });
+    undoButton.addActionListener(
+        (e) -> {
+          // Record position of scroll bar as percentage.
+          scrollBarPreviousValue = scroll.getVerticalScrollBar().getValue();
+          final String error = movePanel.undoMove(moveIndex);
+          if (error == null) {
+            // Disable the button so it can't be clicked again until the UI is updated.
+            undoButton.setEnabled(false);
+            previousVisibleIndex = Math.max(0, moveIndex - 1);
+          } else {
+            previousVisibleIndex = null;
+          }
+        });
     setSize(buttonSize, undoButton);
     final JButton viewButton = new JButton(new ViewAction(move));
     setSize(buttonSize, viewButton);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/AbstractUndoableMovesPanel.java
@@ -137,13 +137,26 @@ public abstract class AbstractUndoableMovesPanel extends JPanel {
     final Box textBox = new Box(BoxLayout.X_AXIS);
     textBox.add(text);
     textBox.add(Box.createHorizontalGlue());
-    final JButton cancelButton = new JButton(new UndoMoveActionListener(move.getIndex()));
-    setSize(buttonSize, cancelButton);
+    final JButton undoButton = new JButton("Undo");
+    final int moveIndex = move.getIndex();
+    undoButton.addActionListener((e) -> {
+      // Record position of scroll bar as percentage.
+      scrollBarPreviousValue = scroll.getVerticalScrollBar().getValue();
+      final String error = movePanel.undoMove(moveIndex);
+      if (error == null) {
+        // Disable the button so it can't be clicked again until the UI is updated.
+        undoButton.setEnabled(false);
+        previousVisibleIndex = Math.max(0, moveIndex - 1);
+      } else {
+        previousVisibleIndex = null;
+      }
+    });
+    setSize(buttonSize, undoButton);
     final JButton viewButton = new JButton(new ViewAction(move));
     setSize(buttonSize, viewButton);
     final Box buttonsBox = new Box(BoxLayout.X_AXIS);
     buttonsBox.add(viewButton);
-    buttonsBox.add(cancelButton);
+    buttonsBox.add(undoButton);
     buttonsBox.add(Box.createHorizontalGlue());
     final Box containerBox = new Box(BoxLayout.Y_AXIS);
     containerBox.add(unitsBox);
@@ -161,28 +174,6 @@ public abstract class AbstractUndoableMovesPanel extends JPanel {
     cancelButton.setMinimumSize(buttonSize);
     cancelButton.setPreferredSize(buttonSize);
     cancelButton.setMaximumSize(buttonSize);
-  }
-
-  class UndoMoveActionListener extends AbstractAction {
-    private static final long serialVersionUID = -397312652244693138L;
-    private final int moveIndex;
-
-    UndoMoveActionListener(final int index) {
-      super("Undo");
-      moveIndex = index;
-    }
-
-    @Override
-    public void actionPerformed(final ActionEvent e) {
-      // Record position of scroll bar as percentage.
-      scrollBarPreviousValue = scroll.getVerticalScrollBar().getValue();
-      final String error = movePanel.undoMove(moveIndex);
-      if (error == null) {
-        previousVisibleIndex = Math.max(0, moveIndex - 1);
-      } else {
-        previousVisibleIndex = null;
-      }
-    }
   }
 
   class ViewAction extends AbstractAction {


### PR DESCRIPTION
## Change Summary & Additional Notes

Fix error if the same "undo" is clicked twice in succession.

This change disables the button once it's clicked, so that clicking it again won't do anything. Previously, it would result in an "move index out of bounds" error dialog shown.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Fixed error that would be shown when an undo move button would be quickly clicked twice<!--END_RELEASE_NOTE-->
