### PR TITLE
Move logic supporting legacy (1.8) spelling to setter.

### DIFF
--- a/docs/development/background/design/engine-code-overview.md
+++ b/docs/development/background/design/engine-code-overview.md
@@ -81,7 +81,7 @@ will stop the parser, and terminate the program.
 
 getAttachment,
 where key is the name of the attachment.
-In the above example key would be unitAttachment.  Objects implementing the Attatchable
+In the above example key would be unitAttachment.  Objects implementing the Attachable
 interface are PlayerID, Resource, Territory, and UnitType.
 
 ##

--- a/docs/map-making/tutorial/creating-custom-map-xml.md
+++ b/docs/map-making/tutorial/creating-custom-map-xml.md
@@ -298,7 +298,7 @@
 		<td><b>Capital XML Option</b></td>
 	</tr>
 	<tr>
-		<td><pre><code>&lt;attachment id="territoryAttachment" attatchTo="Germany" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory"&gt;
+		<td><pre><code>&lt;attachment id="territoryAttachment" attachTo="Germany" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory"&gt;
          &lt;option id="production" value="10"/&gt;
          &lt;option id="capital" value="Germans"/&gt;
 &lt;/attachment&gt;</code></pre></td>
@@ -378,7 +378,7 @@
 		<td><b>Victory City XML Option</b></td>
 	</tr>
 	<tr>
-		<td><pre><code>&lt;attachment id="territoryAttachment" attatchTo="Karelia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory"&gt;<br>&nbsp;&lt;option id="production" value="10"/&gt;<br>&nbsp;&lt;option id="victoryCity" value="true"/&gt;<br>&lt;/attachment&gt;</code></pre></td>
+		<td><pre><code>&lt;attachment id="territoryAttachment" attachTo="Karelia" javaClass="games.strategy.triplea.attachments.TerritoryAttachment" type="territory"&gt;<br>&nbsp;&lt;option id="production" value="10"/&gt;<br>&nbsp;&lt;option id="victoryCity" value="true"/&gt;<br>&lt;/attachment&gt;</code></pre></td>
 	</tr>
 </table>
 <br>
@@ -1221,7 +1221,7 @@ Options and Values for <b>result</b> tag:<br>
 		<td><b>Unit Attachment Example</b></td>
 	</tr>
 	<tr>
-		<td><pre><code>&lt;attachment id="unitAttachment" attatchTo="battleship" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType"&gt;
+		<td><pre><code>&lt;attachment id="unitAttachment" attachTo="battleship" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType"&gt;
 	&lt;option id="movement" value="2"/&gt;
 	&lt;option id="isSea" value="true"/&gt;
 	&lt;option id="attack" value="4"/&gt;
@@ -1229,14 +1229,14 @@ Options and Values for <b>result</b> tag:<br>
 	&lt;option id="canBombard" value="true"/&gt;
 	&lt;option id="isTwoHit" value="false"/&gt;
 &lt;/attachment&gt;
-&lt;attachment id="unitAttachment" attatchTo="infantry" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType"&gt;
+&lt;attachment id="unitAttachment" attachTo="infantry" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType"&gt;
     &lt;option id="movement" value="1"/&gt;
     &lt;option id="transportCost" value="2"/&gt;
     &lt;option id="attack" value="1"/&gt;
     &lt;option id="defense" value="2"/&gt;
     &lt;option id="artillerySupportable" value="true"/&gt;
 &lt;/attachment&gt;
-&lt;attachment id="unitAttachment" attatchTo="factory" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType"&gt;
+&lt;attachment id="unitAttachment" attachTo="factory" javaClass="games.strategy.triplea.attachments.UnitAttachment" type="unitType"&gt;
     &lt;option id="isFactory" value="true"/&gt;
 &lt;/attachment&gt;</code></pre></td>
 	</tr>
@@ -1342,7 +1342,7 @@ Options and Values for <b>result</b> tag:<br>
 		<td><b>Tech Attachment Example</b></td>
 	</tr>
 	<tr>
-		<td><pre><code>&lt;attachment id="techAttachment" attatchTo="British" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player"&gt;
+		<td><pre><code>&lt;attachment id="techAttachment" attachTo="British" javaClass="games.strategy.triplea.attachments.TechAttachment" type="player"&gt;
 	&lt;option id="heavyBomber" value="false"/&gt;
 	&lt;option id="jetPower" value="false"/&gt;
 	&lt;option id="industrialTechnology" value="false"/&gt;

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
@@ -120,10 +120,12 @@ public abstract class DefaultAttachment extends GameDataComponent implements IAt
 
   @Override
   public void setName(final String name) {
-    this.name = Optional.ofNullable(name)
-        // replace-all to automatically correct legacy (1.8) attachment spelling
-        .map(attachmentName -> attachmentName.replaceAll("ttatch", "ttach"))
-        .orElse(null);;
+    this.name =
+        Optional.ofNullable(name)
+            // replace-all to automatically correct legacy (1.8) attachment spelling
+            .map(attachmentName -> attachmentName.replaceAll("ttatch", "ttach"))
+            .orElse(null);
+    ;
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/DefaultAttachment.java
@@ -115,15 +115,15 @@ public abstract class DefaultAttachment extends GameDataComponent implements IAt
 
   @Override
   public String getName() {
-    return Optional.ofNullable(name)
-        // replace-all to automatically correct legacy (1.8) attachment spelling
-        .map(attachmentName -> attachmentName.replaceAll("ttatch", "ttach"))
-        .orElse(null);
+    return name;
   }
 
   @Override
   public void setName(final String name) {
-    this.name = name;
+    this.name = Optional.ofNullable(name)
+        // replace-all to automatically correct legacy (1.8) attachment spelling
+        .map(attachmentName -> attachmentName.replaceAll("ttatch", "ttach"))
+        .orElse(null);;
   }
 
   /**


### PR DESCRIPTION
Move logic supporting legacy (1.8) spelling to setter.

## Change Summary & Additional Notes

The getter version was showing up in my profiles of unit movement UI code. Also updates some docs to use the non-legacy names.

Note: I checked if we could get rid of this entirely, but there are still maps that still use the old names:
https://github.com/search?q=org%3Atriplea-maps+attatchment&type=code
https://github.com/search?q=org%3Atriplea-maps+attatchto&type=code


<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
