### PR TITLE
Improvements to the placements and unit scroller collapsible panels.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/settings/ClientSetting.java
@@ -186,6 +186,13 @@ public abstract class ClientSetting<T> implements GameSetting<T> {
 
   public static final ClientSetting<Boolean> unitScrollerHighlightTerritory =
       new BooleanClientSetting("UNIT_SCROLLER_HIGHLIGHT_TERRITORY", true);
+
+  public static final ClientSetting<Boolean> unitScrollerCollapsed =
+      new BooleanClientSetting("UNIT_SCROLLER_COLLAPSED", false);
+
+  public static final ClientSetting<Boolean> placementsCollapsed =
+      new BooleanClientSetting("PLACEMENTS_COLLAPSED", false);
+
   public static final ClientSetting<String> emailProvider =
       new StringClientSetting("EMAIL_PROVIDER");
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/PlacementUnitsCollapsiblePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/PlacementUnitsCollapsiblePanel.java
@@ -26,13 +26,8 @@ class PlacementUnitsCollapsiblePanel {
         new SimpleUnitPanel(
             uiContext, SimpleUnitPanel.Style.SMALL_ICONS_WRAPPED_WITH_LABEL_WHEN_EMPTY);
     panel =
-        new CollapsiblePanel(unitsToPlacePanel, "Placements") {
-          @Override
-          protected void toggleState() {
-            super.toggleState();
-            ClientSetting.placementsCollapsed.setValueAndFlush(isCollapsed());
-          }
-        };
+        new CollapsiblePanel(
+            unitsToPlacePanel, "Placements", ClientSetting.placementsCollapsed::setValueAndFlush);
     panel.setCollapsed(ClientSetting.placementsCollapsed.getValueOrThrow());
     panel.setVisible(false);
     gameData.addGameDataEventListener(GameDataEvent.GAME_STEP_CHANGED, this::updateStep);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/PlacementUnitsCollapsiblePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/PlacementUnitsCollapsiblePanel.java
@@ -6,6 +6,7 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.GameState;
 import games.strategy.engine.data.GameStep;
 import games.strategy.engine.data.Unit;
+import games.strategy.triplea.settings.ClientSetting;
 import games.strategy.triplea.util.UnitSeparator;
 import java.util.Collection;
 import java.util.List;
@@ -24,7 +25,15 @@ class PlacementUnitsCollapsiblePanel {
     unitsToPlacePanel =
         new SimpleUnitPanel(
             uiContext, SimpleUnitPanel.Style.SMALL_ICONS_WRAPPED_WITH_LABEL_WHEN_EMPTY);
-    panel = new CollapsiblePanel(unitsToPlacePanel, "Placements");
+    panel =
+        new CollapsiblePanel(unitsToPlacePanel, "Placements") {
+          @Override
+          protected void toggleState() {
+            super.toggleState();
+            ClientSetting.placementsCollapsed.setValueAndFlush(isCollapsed());
+          }
+        };
+    panel.setCollapsed(ClientSetting.placementsCollapsed.getValueOrThrow());
     panel.setVisible(false);
     gameData.addGameDataEventListener(GameDataEvent.GAME_STEP_CHANGED, this::updateStep);
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -384,11 +384,6 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
         BorderLayout.SOUTH);
 
     final Frame parent = JOptionPane.getFrameForComponent(this);
-    if (Util.getScreenSize(parent).height < 1000) {
-      placementsPanel.collapse();
-      movePanel.getUnitScrollerPanel().collapse();
-    }
-
     SwingUtilities.invokeLater(() -> mapPanel.addKeyListener(getArrowKeyListener()));
 
     addTab("Actions", actionButtons, KeyCode.C);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -383,7 +383,6 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
             .build(),
         BorderLayout.SOUTH);
 
-    final Frame parent = JOptionPane.getFrameForComponent(this);
     SwingUtilities.invokeLater(() -> mapPanel.addKeyListener(getArrowKeyListener()));
 
     addTab("Actions", actionButtons, KeyCode.C);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -230,13 +230,7 @@ public class UnitScroller {
   public CollapsiblePanel build() {
     final JPanel panel = new JPanel();
     collapsiblePanel =
-        new CollapsiblePanel(panel, "") {
-          @Override
-          protected void toggleState() {
-            super.toggleState();
-            ClientSetting.unitScrollerCollapsed.setValueAndFlush(isCollapsed());
-          }
-        };
+        new CollapsiblePanel(panel, "", ClientSetting.unitScrollerCollapsed::setValueAndFlush);
     collapsiblePanel.setCollapsed(ClientSetting.unitScrollerCollapsed.getValueOrThrow());
     updateMovesLeft();
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/unit/scroller/UnitScroller.java
@@ -229,7 +229,15 @@ public class UnitScroller {
   /** Constructs a UI component for the UnitScroller. */
   public CollapsiblePanel build() {
     final JPanel panel = new JPanel();
-    collapsiblePanel = new CollapsiblePanel(panel, "");
+    collapsiblePanel =
+        new CollapsiblePanel(panel, "") {
+          @Override
+          protected void toggleState() {
+            super.toggleState();
+            ClientSetting.unitScrollerCollapsed.setValueAndFlush(isCollapsed());
+          }
+        };
+    collapsiblePanel.setCollapsed(ClientSetting.unitScrollerCollapsed.getValueOrThrow());
     updateMovesLeft();
 
     panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));

--- a/lib/swing-lib/src/main/java/org/triplea/swing/CollapsiblePanel.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/CollapsiblePanel.java
@@ -3,6 +3,7 @@ package org.triplea.swing;
 import games.strategy.engine.framework.system.SystemProperties;
 import java.awt.BorderLayout;
 import java.awt.Dimension;
+import java.util.function.Consumer;
 import javax.swing.JButton;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
@@ -27,11 +28,14 @@ public class CollapsiblePanel extends JPanel {
   private final JPanel content;
   private String title;
   private final JButton toggleButton;
+  private final Consumer<Boolean> toggleStatePersistence;
 
-  public CollapsiblePanel(final JPanel content, final String title) {
+  public CollapsiblePanel(
+      final JPanel content, final String title, final Consumer<Boolean> toggleStatePersistence) {
     this.content = content;
     this.title = title;
     this.toggleButton = new JButton();
+    this.toggleStatePersistence = toggleStatePersistence;
     toggleButton.addActionListener(e -> toggleState());
     setLayout(new BorderLayout());
     if (SystemProperties.isMac() && SwingComponents.isUsingNativeLookAndFeel()) {
@@ -54,12 +58,10 @@ public class CollapsiblePanel extends JPanel {
     SwingUtilities.invokeLater(this::updateButtonText);
   }
 
-  /**
-   * Called when the button is clicked by the user to toggle the state. Subclasses can override to
-   * monitor the toggle.
-   */
-  protected void toggleState() {
-    setCollapsed(!isCollapsed());
+  private void toggleState() {
+    final boolean newState = !isCollapsed();
+    setCollapsed(newState);
+    toggleStatePersistence.accept(newState);
   }
 
   public boolean isCollapsed() {

--- a/lib/swing-lib/src/main/java/org/triplea/swing/CollapsiblePanel.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/CollapsiblePanel.java
@@ -2,6 +2,7 @@ package org.triplea.swing;
 
 import games.strategy.engine.framework.system.SystemProperties;
 import java.awt.BorderLayout;
+import java.awt.Dimension;
 import javax.swing.JButton;
 import javax.swing.JPanel;
 import javax.swing.SwingUtilities;
@@ -24,56 +25,58 @@ public class CollapsiblePanel extends JPanel {
       SwingComponents.canDisplayCharacter(EXPANDED_INDICATOR) ? " " + EXPANDED_INDICATOR : "";
 
   private final JPanel content;
+  private String title;
   private final JButton toggleButton;
 
-  private String title;
-  private String currentToggleIndicator;
-
   public CollapsiblePanel(final JPanel content, final String title) {
-    this.title = title;
     this.content = content;
+    this.title = title;
     this.toggleButton = new JButton();
-    // We want the button to have square edges. On Mac, there's a special property for that.
-    if (SystemProperties.isMac()) {
-      toggleButton.putClientProperty("JButton.buttonType", "gradient");
-    }
-
-    toggleButton.addActionListener(
-        e -> {
-          if (content.isVisible()) {
-            collapse();
-          } else {
-            expand();
-          }
-        });
+    toggleButton.addActionListener(e -> toggleState());
     setLayout(new BorderLayout());
+    if (SystemProperties.isMac() && SwingComponents.isUsingNativeLookAndFeel()) {
+      // We want the button to have square corners with the Mac native look and feel. Setting the
+      // the preferred size achieves that. Note: The "JButton.buttonType" client property will also
+      // provide a square look, but results in too much padding around the button. We actually want
+      // a bit of padding, so do that using the vgap on the layout (as changing the border loses the
+      // look of the button). Also, remove the focus ring, which doesn't look great.
+      toggleButton.setPreferredSize(new Dimension(80, 22));
+      ((BorderLayout) getLayout()).setVgap(1);
+      toggleButton.setFocusPainted(false);
+    }
     add(toggleButton, BorderLayout.NORTH);
     add(content, BorderLayout.CENTER);
-    expand();
-  }
-
-  public void collapse() {
-    if (currentToggleIndicator == COLLAPSED_TEXT) {
-      return;
-    }
-    currentToggleIndicator = COLLAPSED_TEXT;
-    toggleButton.setText(title + currentToggleIndicator);
-    content.setVisible(false);
-    revalidate();
-  }
-
-  public void expand() {
-    if (currentToggleIndicator == EXPANDED_TEXT) {
-      return;
-    }
-    currentToggleIndicator = EXPANDED_TEXT;
-    toggleButton.setText(title + currentToggleIndicator);
-    content.setVisible(true);
-    revalidate();
+    updateButtonText();
   }
 
   public void setTitle(final String title) {
     this.title = title;
-    SwingUtilities.invokeLater(() -> toggleButton.setText(title + currentToggleIndicator));
+    SwingUtilities.invokeLater(this::updateButtonText);
+  }
+
+  /**
+   * Called when the button is clicked by the user to toggle the state. Subclasses can override to
+   * monitor the toggle.
+   */
+  protected void toggleState() {
+    setCollapsed(!isCollapsed());
+  }
+
+  public boolean isCollapsed() {
+    return !content.isVisible();
+  }
+
+  public void setCollapsed(final boolean collapsed) {
+    if (content.isVisible() != collapsed) {
+      return;
+    }
+    content.setVisible(!collapsed);
+    updateButtonText();
+    revalidate();
+  }
+
+  private void updateButtonText() {
+    final String indicator = isCollapsed() ? COLLAPSED_TEXT : EXPANDED_TEXT;
+    toggleButton.setText(title + indicator);
   }
 }

--- a/lib/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
@@ -40,6 +40,7 @@ import javax.swing.JTabbedPane;
 import javax.swing.ListModel;
 import javax.swing.SwingUtilities;
 import javax.swing.SwingWorker;
+import javax.swing.UIManager;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.experimental.UtilityClass;
@@ -356,6 +357,10 @@ public final class SwingComponents {
    */
   public static boolean canDisplayCharacter(final char character) {
     return new JLabel().getFont().canDisplay(character);
+  }
+
+  public static boolean isUsingNativeLookAndFeel() {
+    return UIManager.getLookAndFeel().getName().equals(UIManager.getSystemLookAndFeelClassName());
   }
 
   /**

--- a/lib/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
+++ b/lib/swing-lib/src/main/java/org/triplea/swing/SwingComponents.java
@@ -359,8 +359,10 @@ public final class SwingComponents {
     return new JLabel().getFont().canDisplay(character);
   }
 
+  /** Whether the current look and feel is the platform "native" one. */
   public static boolean isUsingNativeLookAndFeel() {
-    return UIManager.getLookAndFeel().getName().equals(UIManager.getSystemLookAndFeelClassName());
+    return UIManager.getSystemLookAndFeelClassName()
+        .equals(UIManager.getLookAndFeel().getClass().getName());
   }
 
   /**


### PR DESCRIPTION
## Change Summary & Additional Notes

Improvements to the placements and unit scroller collapsible panels.

- Remove the logic to collapse them based on screen size, which was unintentionally landed on https://github.com/triplea-game/triplea/pull/10281. This was meant to be reverted from that PR, but possibly I forgot to do a push with the changes.
- Persist their collapsed/expanded state.
- Improve the look of the buttons on Mac with the native look and feel, so there's not so much padding around them.

Look of the buttons on Mac before:
<img width="984" alt="Screen Shot 2022-04-22 at 9 16 12 PM" src="https://user-images.githubusercontent.com/17648/164850447-bfe9f9a6-4a8a-4d8f-9cf1-5acea6f62f8f.png">

Look of the buttons on Mac after:
<img width="983" alt="Screen Shot 2022-04-22 at 9 14 48 PM" src="https://user-images.githubusercontent.com/17648/164850342-a2f2b405-8b67-483e-8655-6a2ec9307db4.png">

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->CHANGE|Collapsible placements and unit scroller panels will now remember their state across games/restarts<!--END_RELEASE_NOTE-->
