### PR TITLE
Use an in-memory cache in ImageFactory by string key.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/ImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/ImageFactory.java
@@ -24,7 +24,8 @@ import javax.imageio.ImageIO;
 public class ImageFactory {
   private ResourceLoader resourceLoader;
   private final LoadingCache<URL, Image> cache =
-      CacheBuilder.newBuilder().softValues()
+      CacheBuilder.newBuilder()
+          .softValues()
           .build(
               new CacheLoader<>() {
                 @Override

--- a/game-app/game-core/src/main/java/games/strategy/triplea/image/ImageFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/image/ImageFactory.java
@@ -58,14 +58,6 @@ public class ImageFactory {
    *     returned.
    */
   protected Optional<Image> getImage(final String... keys) {
-    /*for (String key : keys) {
-      var result = cache.getUnchecked(key);
-      if (!result.isEmpty()) {
-        return result;
-      }
-    }
-    return Optional.empty();
-    */
     return Arrays.stream(keys)
         .map(cache::getUnchecked)
         .filter(Optional::isPresent)


### PR DESCRIPTION
## Change Summary & Additional Notes
Use an in-memory cache in ImageFactory by string key.

I noticed this showed up in execution time profiles when looking at the performance of handling mouse events during the move phase, which spent a lot of time in `updateRouteAndMouseShadowUnits()` that eventually call down to this for country small flags.

This prevents excessive resource look up and ImageIO calls.

I tested this by sampling CPU in VisualVM on a given save game, where I shift-click all the units from Japan and move my mouse around between Japan, SZ 36 and SZ 24, with 10 territory transition totals on each run.

Here's the profile before:
![before_profile](https://user-images.githubusercontent.com/17648/165567673-6e078f3c-ba89-4618-8107-04de0d11746e.png)

Here's the one after this change:
![after_profile2](https://user-images.githubusercontent.com/17648/165569470-90223153-ae29-48d1-bea4-bce4e6f03240.PNG)

In particular, you can see that `setMouseShadowUnits()` is much faster and no longer has `getSmallFlag()` taking a lot of time to execute and total CPU time of the AWT event thread is significantly reduced.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
