### PR TITLE
Optimize getNeighbors().

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameMap.java
@@ -115,8 +115,7 @@ public class GameMap extends GameDataComponent implements Iterable<Territory> {
 
   private Set<Territory> getNeighbors(
       final Territory territory, final BiPredicate<Territory, Territory> routeCondition) {
-
-    return connections.getOrDefault(territory, Set.of()).parallelStream()
+    return connections.get(territory).stream()
         .filter(n -> routeCondition.test(territory, n))
         .collect(Collectors.toSet());
   }


### PR DESCRIPTION
## Change Summary & Additional Notes

Optimize getNeighbors().

Two small tweaks to getNeighbors() result in a 2x speed up in my testing of logic related to calculations when moving air units:
  - Use a regular stream, not parallel, since the direct neighbors of a given territory will be usually less than 10 (and never really in thousands+).
  - No need for getOrDefault() since `connections` is always populated.

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
