### PR TITLE
Don't recompute getMovementLeft() excessively during sort operations.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/UnitComparator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/UnitComparator.java
@@ -12,13 +12,15 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import lombok.experimental.UtilityClass;
 
 /** A collection of comparators for sorting units based on various heuristics. */
+@UtilityClass
 public final class UnitComparator {
-  private UnitComparator() {}
 
   public static Comparator<Unit> getLowestToHighestMovementComparator() {
-    return Comparator.comparing(Unit::getMovementLeft);
+    final Map<Unit, BigDecimal> cache = new HashMap<>();
+    return Comparator.comparing(u -> cache.computeIfAbsent(u, Unit::getMovementLeft));
   }
 
   public static Comparator<Unit> getHighestToLowestMovementComparator() {
@@ -67,11 +69,12 @@ public final class UnitComparator {
   /** Return a Comparator that will order the specified units in preferred move order. */
   public static Comparator<Unit> getMovableUnitsComparator(
       final List<Unit> units, final Route route) {
+    final Map<Unit, BigDecimal> cache = new HashMap<>();
     final Comparator<Unit> decreasingCapacityComparator = getDecreasingCapacityComparator();
     return (u1, u2) -> {
       // Ensure units have enough movement
-      final BigDecimal left1 = u1.getMovementLeft();
-      final BigDecimal left2 = u2.getMovementLeft();
+      final BigDecimal left1 = cache.computeIfAbsent(u1, Unit::getMovementLeft);
+      final BigDecimal left2 = cache.computeIfAbsent(u2, Unit::getMovementLeft);
       if (route != null) {
         if (left1.compareTo(route.getMovementCost(u1)) >= 0
             && left2.compareTo(route.getMovementCost(u2)) < 0) {

--- a/lib/java-extras/src/main/java/org/triplea/performance/PerfTimer.java
+++ b/lib/java-extras/src/main/java/org/triplea/performance/PerfTimer.java
@@ -15,7 +15,7 @@ import org.triplea.java.function.ThrowingSupplier;
  * <p>Example usage with auto-close try block:
  *
  * <pre>{@code
- * try(PerfTimer timer = PerfTimer.startTimer("timer_name_0")) {
+ * try(final PerfTimer timer = PerfTimer.time("timer_name_0")) {
  *   // code to be timed
  * }
  * }</pre>

--- a/lib/java-extras/src/main/java/org/triplea/performance/PerfTimer.java
+++ b/lib/java-extras/src/main/java/org/triplea/performance/PerfTimer.java
@@ -15,7 +15,7 @@ import org.triplea.java.function.ThrowingSupplier;
  * <p>Example usage with auto-close try block:
  *
  * <pre>{@code
- * try(final PerfTimer timer = PerfTimer.time("timer_name_0")) {
+ * try (PerfTimer timer = PerfTimer.time("timer_name_0")) {
  *   // code to be timed
  * }
  * }</pre>


### PR DESCRIPTION
## Change Summary & Additional Notes
Don't recompute getMovementLeft() excessively during sort operations.

Use a cache object so that the value for each unit is only computed once during sorting. I noticed this in performance profiles of movement code.

Also add UtilityClass annotation and fix a comment in the PerfTimer class.


<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
