### PR TITLE
Improve format of stack trace

### DIFF
--- a/game-app/game-core/src/main/java/org/triplea/debug/error/reporting/formatting/ErrorReportBodyFormatter.java
+++ b/game-app/game-core/src/main/java/org/triplea/debug/error/reporting/formatting/ErrorReportBodyFormatter.java
@@ -78,6 +78,7 @@ public class ErrorReportBodyFormatter {
                     }
                     return "Exception: "
                         + exception.getExceptionClassName()
+                        + " "
                         + Optional.ofNullable(exception.getExceptionMessage()).orElse("")
                         + "\n"
                         + outputStream.toString(StandardCharsets.UTF_8)


### PR DESCRIPTION
## Change Summary & Additional Notes

Added a missing whitespace in *Stack Trace* which @tripleabuilderbot posts.

![image](https://user-images.githubusercontent.com/66462458/165026110-e117be68-14a0-492e-8698-140bb7dc351e.png)


<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note

<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
