### PR TITLE
Introduce CollectionUtils.getAny() as well as rule.getAnyResultKey().

### DIFF
--- a/game-app/ai/src/main/java/org/triplea/ai/flowfield/influence/InfluenceMap.java
+++ b/game-app/ai/src/main/java/org/triplea/ai/flowfield/influence/InfluenceMap.java
@@ -16,6 +16,7 @@ import java.util.stream.Collectors;
 import lombok.Value;
 import org.triplea.ai.flowfield.neighbors.MapWithNeighbors;
 import org.triplea.ai.flowfield.odds.BattleDetails;
+import org.triplea.java.collections.CollectionUtils;
 
 /** Diffuses an initial value from an initial set of territories to the rest of the territories */
 @Value
@@ -41,7 +42,8 @@ public class InfluenceMap {
         influenceMapSetup.getTerritoryValuations().size() == 1,
         "A custom getBattleDetails only works if one territory has an initial value");
     diffuseBattleDetails(
-        territories.get(influenceMapSetup.getTerritoryValuations().keySet().iterator().next()),
+        territories.get(
+            CollectionUtils.getAny(influenceMapSetup.getTerritoryValuations().keySet())),
         getBattleDetails,
         mapWithNeighbors);
   }

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/PlayerManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/PlayerManager.java
@@ -6,6 +6,7 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.triplea.java.collections.CollectionUtils;
 
 /** Tracks what Node in the networks is playing which roles in the game. */
 public class PlayerManager {
@@ -72,7 +73,7 @@ public class PlayerManager {
             .orElse(null);
     // we aren't playing anyone, return any
     if (local == null) {
-      final String remote = playerMapping.keySet().iterator().next();
+      final String remote = CollectionUtils.getAny(playerMapping.keySet());
       return data.getPlayerList().getPlayerId(remote);
     }
     String any = null;

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/ProductionRule.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/ProductionRule.java
@@ -2,6 +2,7 @@ package games.strategy.engine.data;
 
 import games.strategy.triplea.Constants;
 import java.util.Map.Entry;
+import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 
 /** A production rule. */
@@ -44,6 +45,10 @@ public class ProductionRule extends DefaultNamed {
 
   public IntegerMap<NamedAttachable> getResults() {
     return results;
+  }
+
+  public NamedAttachable getAnyResultKey() {
+    return CollectionUtils.getAny(results.keySet());
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/RepairRule.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/RepairRule.java
@@ -2,6 +2,7 @@ package games.strategy.engine.data;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 
 /** A repair rule. */
@@ -48,6 +49,10 @@ public class RepairRule extends DefaultNamed {
 
   public IntegerMap<NamedAttachable> getResults() {
     return results;
+  }
+
+  public NamedAttachable getAnyResultKey() {
+    return CollectionUtils.getAny(results.keySet());
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/ZippedMapsExtractor.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/map/file/system/loader/ZippedMapsExtractor.java
@@ -17,6 +17,7 @@ import org.triplea.io.FileUtils;
 import org.triplea.io.ZipExtractor;
 import org.triplea.io.ZipExtractor.FileSystemException;
 import org.triplea.io.ZipExtractor.ZipReadException;
+import org.triplea.java.collections.CollectionUtils;
 import org.triplea.map.description.file.MapDescriptionYaml;
 
 /**
@@ -132,10 +133,10 @@ public class ZippedMapsExtractor {
 
     // Typically the next step is to move and rename the temp folder to the maps folder.
     // But, if we just extracted exactly one folder, then we need to move and rename *that* folder.
+    final Collection<Path> files = FileUtils.listFiles(tempFolder);
     final Path tempFolderWithExtractedMap =
-        FileUtils.listFiles(tempFolder).size() == 1
-                && Files.isDirectory(FileUtils.listFiles(tempFolder).iterator().next())
-            ? FileUtils.listFiles(tempFolder).iterator().next()
+        files.size() == 1 && Files.isDirectory(CollectionUtils.getAny(files))
+            ? CollectionUtils.getAny(files)
             : tempFolder;
 
     // replace extraction target folder contents with the temp folder containing the extracted zip

--- a/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbf/ForumPosterEditorViewModel.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/framework/startup/ui/posted/game/pbf/ForumPosterEditorViewModel.java
@@ -26,6 +26,7 @@ import org.triplea.java.Interruptibles;
 import org.triplea.java.Postconditions;
 import org.triplea.java.StringUtils;
 import org.triplea.java.ViewModelListener;
+import org.triplea.java.collections.CollectionUtils;
 
 class ForumPosterEditorViewModel {
   private static final int DUMMY_PASSWORD_LENGTH = 4;
@@ -157,7 +158,7 @@ class ForumPosterEditorViewModel {
     this.forumSelection =
         Optional.ofNullable(forumSelection)
             .filter(Predicate.not(String::isBlank))
-            .orElse(getForumSelectionOptions().iterator().next());
+            .orElse(CollectionUtils.getAny(getForumSelectionOptions()));
     Postconditions.assertState(
         this.forumSelection != null && !this.forumSelection.isBlank(),
         "Forum selection is driven by a drop-down to ensure user can never set it to null, "

--- a/game-app/game-core/src/main/java/games/strategy/engine/message/UnifiedMessengerHub.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/message/UnifiedMessengerHub.java
@@ -14,6 +14,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import org.triplea.java.collections.CollectionUtils;
 
 /** The hub node in a spoke-hub messaging architecture. */
 public class UnifiedMessengerHub implements IMessageListener, IConnectionChangeListener {
@@ -131,7 +132,7 @@ public class UnifiedMessengerHub implements IMessageListener, IConnectionChangeL
             "Too many nodes:" + remote + " for remote name " + hubInvoke.call);
       }
       final InvocationInProgress invocationInProgress =
-          new InvocationInProgress(remote.iterator().next(), hubInvoke, from);
+          new InvocationInProgress(CollectionUtils.getAny(remote), hubInvoke, from);
       invocations.put(hubInvoke.methodCallId, invocationInProgress);
     }
     // invoke remotely

--- a/game-app/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/EndPoint.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/message/unifiedmessenger/EndPoint.java
@@ -12,6 +12,7 @@ import java.util.concurrent.CopyOnWriteArraySet;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.triplea.java.collections.CollectionUtils;
 
 /**
  * This is where the methods finally get called. An end point contains the implementors for a given
@@ -45,7 +46,7 @@ class EndPoint {
     if (!hasSingleImplementor()) {
       throw new IllegalStateException("Invalid implementor count, " + implementors);
     }
-    return implementors.iterator().next();
+    return CollectionUtils.getAny(implementors);
   }
 
   public long takeANumber() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/UnitUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/UnitUtils.java
@@ -77,7 +77,7 @@ public class UnitUtils {
       return null;
     }
     final IntegerMap<Unit> productionPotential = new IntegerMap<>();
-    Unit highestUnit = factories.iterator().next();
+    Unit highestUnit = CollectionUtils.getAny(factories);
     int highestCapacity = Integer.MIN_VALUE;
     for (final Unit u : factories) {
       final int capacity =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/AbstractBuiltInAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/AbstractBuiltInAi.java
@@ -75,7 +75,7 @@ public abstract class AbstractBuiltInAi extends AbstractBasePlayer {
       final Territory unitTerritory,
       final Collection<Territory> territories,
       final boolean noneAvailable) {
-    return territories.iterator().next();
+    return CollectionUtils.getAny(territories);
   }
 
   @Override
@@ -106,7 +106,7 @@ public abstract class AbstractBuiltInAi extends AbstractBasePlayer {
   @Override
   public Territory whereShouldRocketsAttack(
       final Collection<Territory> candidates, final Territory from) {
-    return candidates.iterator().next();
+    return CollectionUtils.getAny(candidates);
   }
 
   @Override
@@ -154,9 +154,9 @@ public abstract class AbstractBuiltInAi extends AbstractBasePlayer {
     final Collection<Unit> factories =
         CollectionUtils.getMatches(potentialTargets, Matches.unitCanProduceUnitsAndCanBeDamaged());
     if (factories.isEmpty()) {
-      return potentialTargets.iterator().next();
+      return CollectionUtils.getAny(potentialTargets);
     }
-    return factories.iterator().next();
+    return CollectionUtils.getAny(factories);
   }
 
   @Override
@@ -176,7 +176,7 @@ public abstract class AbstractBuiltInAi extends AbstractBasePlayer {
       final Collection<Territory> candidates,
       final Territory currentTerritory,
       final String unitMessage) {
-    return candidates.iterator().next();
+    return CollectionUtils.getAny(candidates);
   }
 
   @Override
@@ -302,7 +302,7 @@ public abstract class AbstractBuiltInAi extends AbstractBasePlayer {
           continue;
         }
         final IntegerMap<Resource> resourceMap = new IntegerMap<>();
-        final Resource resource = attackTokens.keySet().iterator().next();
+        final Resource resource = CollectionUtils.getAny(attackTokens.keySet());
         final int num =
             Math.min(
                 attackTokens.getInt(resource),
@@ -450,7 +450,7 @@ public abstract class AbstractBuiltInAi extends AbstractBasePlayer {
       }
     }
     final Set<Unit> unitsToPlace = new HashSet<>();
-    if (unitChoices != null && !unitChoices.isEmpty() && unitsPerPick > 0) {
+    if (!unitChoices.isEmpty() && unitsPerPick > 0) {
       Collections.shuffle(unitChoices);
       final List<Unit> nonFactory =
           CollectionUtils.getMatches(unitChoices, Matches.unitCanProduceUnits().negate());
@@ -459,7 +459,7 @@ public abstract class AbstractBuiltInAi extends AbstractBasePlayer {
           unitsToPlace.add(unitChoices.get(0));
         }
       } else {
-        for (int i = 0; i < unitsPerPick && !nonFactory.isEmpty(); i++) {
+        for (int i = 0; i < unitsPerPick; i++) {
           unitsToPlace.add(nonFactory.get(0));
         }
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -1298,7 +1298,8 @@ public class ProCombatMoveAi {
         estimatesMap.put(estimate, t);
       }
       if (!estimatesMap.isEmpty() && estimatesMap.firstKey() < 40) {
-        final Territory minWinTerritory = estimatesMap.entrySet().iterator().next().getValue();
+        final Territory minWinTerritory =
+            CollectionUtils.getAny(estimatesMap.entrySet()).getValue();
         final List<Unit> unitsToAdd =
             ProTransportUtils.getUnitsToAdd(proData, unit, alreadyMovedUnits, attackMap);
         attackMap.get(minWinTerritory).addUnits(unitsToAdd);
@@ -1877,7 +1878,7 @@ public class ProCombatMoveAi {
             data.getMap()
                 .getNeighbors(t, ProMatches.territoryCanMoveSeaUnitsThrough(data, player, true));
         if (!possibleMoveTerritories.isEmpty()) {
-          final Territory moveToTerritory = possibleMoveTerritories.iterator().next();
+          final Territory moveToTerritory = CollectionUtils.getAny(possibleMoveTerritories);
           final List<Unit> mySeaUnits =
               t.getUnitCollection()
                   .getMatches(ProMatches.unitCanBeMovedAndIsOwnedSea(player, true));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -250,7 +250,7 @@ class ProNonCombatMoveAi {
     for (final Iterator<Unit> it = unitMoveMap.keySet().iterator(); it.hasNext(); ) {
       final Unit u = it.next();
       if (unitMoveMap.get(u).size() == 1) {
-        final Territory onlyTerritory = unitMoveMap.get(u).iterator().next();
+        final Territory onlyTerritory = CollectionUtils.getAny(unitMoveMap.get(u));
         if (onlyTerritory.equals(unitTerritoryMap.get(u))) {
           boolean canBeTransported = false;
           for (final ProTransport pad : transportMapList) {
@@ -1666,7 +1666,7 @@ class ProNonCombatMoveAi {
                         ProMatches.territoryCanMoveLandUnitsAndIsAllied(data, player));
             if (!possibleUnloadTerritories.isEmpty()) {
               // Find best unload territory
-              Territory unloadToTerritory = possibleUnloadTerritories.iterator().next();
+              Territory unloadToTerritory = CollectionUtils.getAny(possibleUnloadTerritories);
               for (final Territory t : possibleUnloadTerritories) {
                 if (moveMap.get(t) != null && moveMap.get(t).isCanHold()) {
                   unloadToTerritory = t;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -110,10 +110,7 @@ class ProPurchaseAi {
       ProLogger.debug("Factories that need repaired: " + unitsThatCanProduceNeedingRepair);
       for (final var repairRule : player.getRepairFrontier().getRules()) {
         for (final Unit fixUnit : unitsThatCanProduceNeedingRepair.keySet()) {
-          if (fixUnit == null
-              || !fixUnit
-                  .getType()
-                  .equals(repairRule.getAnyResultKey())) {
+          if (fixUnit == null || !fixUnit.getType().equals(repairRule.getAnyResultKey())) {
             continue;
           }
           if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -111,7 +111,9 @@ class ProPurchaseAi {
       for (final var repairRule : player.getRepairFrontier().getRules()) {
         for (final Unit fixUnit : unitsThatCanProduceNeedingRepair.keySet()) {
           if (fixUnit == null
-              || !fixUnit.getType().equals(repairRule.getResults().keySet().iterator().next())) {
+              || !fixUnit
+                  .getType()
+                  .equals(repairRule.getAnyResultKey())) {
             continue;
           }
           if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProOtherMoveOptions.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProOtherMoveOptions.java
@@ -13,6 +13,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.triplea.java.collections.CollectionUtils;
 
 /** The result of an AI movement analysis for another player's possible moves. */
 public class ProOtherMoveOptions {
@@ -65,13 +66,10 @@ public class ProOtherMoveOptions {
         // Get current player
         final Set<Unit> currentUnits = new HashSet<>(moveMap.get(t).getMaxUnits());
         currentUnits.addAll(moveMap.get(t).getMaxAmphibUnits());
-        final GamePlayer movePlayer;
-        if (!currentUnits.isEmpty()) {
-          movePlayer = currentUnits.iterator().next().getOwner();
-        } else {
+        if (currentUnits.isEmpty()) {
           continue;
         }
-
+        final GamePlayer movePlayer = CollectionUtils.getAny(currentUnits).getOwner();
         // Skip if checking allied moves and their turn doesn't come before territory owner's
         if (proData.getData().getRelationshipTracker().isAllied(player, movePlayer)
             && !ProUtils.isPlayersTurnFirst(players, movePlayer, t.getOwner())) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOptionMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOptionMap.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.triplea.java.collections.CollectionUtils;
 
 /**
  * Takes all available purchase options, filters out those which the AI can't handle, and sorts them
@@ -59,7 +60,7 @@ public class ProPurchaseOptionMap {
     for (final ProductionRule rule : productionFrontier.getRules()) {
 
       // Check if rule is for a unit
-      final NamedAttachable resourceOrUnit = rule.getResults().keySet().iterator().next();
+      final NamedAttachable resourceOrUnit = rule.getAnyResultKey();
       if (!(resourceOrUnit instanceof UnitType)) {
         continue;
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOptionMap.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProPurchaseOptionMap.java
@@ -13,7 +13,6 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import org.triplea.java.collections.CollectionUtils;
 
 /**
  * Takes all available purchase options, filters out those which the AI can't handle, and sorts them

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/data/ProTerritoryManager.java
@@ -200,7 +200,7 @@ public class ProTerritoryManager {
         if (!alliedUnits.isEmpty()) {
 
           // Make sure allies' capital isn't next to territory
-          final GamePlayer alliedPlayer = alliedUnits.iterator().next().getOwner();
+          final GamePlayer alliedPlayer = CollectionUtils.getAny(alliedUnits).getOwner();
           final Territory capital =
               TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(alliedPlayer, gameMap);
           if (capital != null && !gameMap.getNeighbors(capital).contains(t)) {
@@ -212,7 +212,7 @@ public class ProTerritoryManager {
               final Set<Unit> enemyUnits = new HashSet<>(enemyDefendOption.getMaxUnits());
               enemyUnits.addAll(enemyDefendOption.getMaxAmphibUnits());
               if (!enemyUnits.isEmpty()) {
-                final GamePlayer enemyPlayer = enemyUnits.iterator().next().getOwner();
+                final GamePlayer enemyPlayer = CollectionUtils.getAny(enemyUnits).getOwner();
                 if (ProUtils.isPlayersTurnFirst(players, enemyPlayer, alliedPlayer)) {
                   additionalEnemyDefenders.addAll(enemyUnits);
                 }
@@ -259,7 +259,7 @@ public class ProTerritoryManager {
                   "Checking strafing territory: "
                       + t
                       + ", alliedPlayer="
-                      + alliedUnits.iterator().next().getOwner().getName()
+                      + CollectionUtils.getAny(alliedUnits).getOwner().getName()
                       + ", maxWin%="
                       + patd.getMaxBattleResult().getWinPercentage()
                       + ", maxAttackers="

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProOddsCalculator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProOddsCalculator.java
@@ -219,8 +219,8 @@ public class ProOddsCalculator {
 
     final int minArmySize = Math.min(attackingUnits.size(), defendingUnits.size());
     final int runCount = Math.max(16, 100 - minArmySize);
-    final GamePlayer attacker = attackingUnits.iterator().next().getOwner();
-    final GamePlayer defender = defendingUnits.iterator().next().getOwner();
+    final GamePlayer attacker = CollectionUtils.getAny(attackingUnits).getOwner();
+    final GamePlayer defender = CollectionUtils.getAny(defendingUnits).getOwner();
     final AggregateResults results =
         calc.calculate(
             attacker,
@@ -281,7 +281,7 @@ public class ProOddsCalculator {
     // Create battle result object
     final List<Territory> territoryList = new ArrayList<>();
     territoryList.add(t);
-    return (!territoryList.isEmpty() && territoryList.stream().allMatch(Matches.territoryIsLand()))
+    return territoryList.stream().allMatch(Matches.territoryIsLand())
         ? new ProBattleResult(
             winPercentage,
             tuvSwing,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProPurchaseUtils.java
@@ -72,7 +72,7 @@ public final class ProPurchaseUtils {
         return Optional.of(ppo);
       }
     }
-    return Optional.of(purchasePercentages.keySet().iterator().next());
+    return Optional.of(CollectionUtils.getAny(purchasePercentages.keySet()));
   }
 
   /**
@@ -266,7 +266,7 @@ public final class ProPurchaseUtils {
         return factory2.getOriginalOwner();
       }
     }
-    return factoryUnits.iterator().next().getOriginalOwner();
+    return CollectionUtils.getAny(factoryUnits).getOriginalOwner();
   }
 
   /** Comparator that sorts cheaper units before expensive ones. */

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -896,7 +896,7 @@ public class WeakAi extends AbstractBuiltInAi {
       int maxUnits = (totalPu - 1) / minimumUnitPrice;
       if ((capProduction <= maxUnits / 2 || repairFactories.isEmpty()) && capUnit != null) {
         for (final RepairRule rrule : repairRules) {
-          if (!capUnit.getType().equals(rrule.getAnyResultKey()) {
+          if (!capUnit.getType().equals(rrule.getAnyResultKey())) {
             continue;
           }
           if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(
@@ -941,8 +941,7 @@ public class WeakAi extends AbstractBuiltInAi {
       while (currentProduction < maxUnits && i < 2) {
         for (final RepairRule rrule : repairRules) {
           for (final Unit fixUnit : unitsThatCanProduceNeedingRepair.keySet()) {
-            if (fixUnit == null
-                || !fixUnit.getType().equals(rrule.getAnyResultKey()))) {
+            if (fixUnit == null || !fixUnit.getType().equals(rrule.getAnyResultKey())) {
               continue;
             }
             if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -773,7 +773,7 @@ public class WeakAi extends AbstractBuiltInAi {
       while ((minCost == Integer.MAX_VALUE || leftToSpend >= minCost) && i < 100000) {
         i++;
         for (final ProductionRule rule : rules) {
-          final NamedAttachable resourceOrUnit = rule.getResults().keySet().iterator().next();
+          final NamedAttachable resourceOrUnit = rule.getAnyResultKey();
           if (!(resourceOrUnit instanceof UnitType)) {
             continue;
           }
@@ -896,7 +896,7 @@ public class WeakAi extends AbstractBuiltInAi {
       int maxUnits = (totalPu - 1) / minimumUnitPrice;
       if ((capProduction <= maxUnits / 2 || repairFactories.isEmpty()) && capUnit != null) {
         for (final RepairRule rrule : repairRules) {
-          if (!capUnit.getType().equals(rrule.getResults().keySet().iterator().next())) {
+          if (!capUnit.getType().equals(rrule.getAnyResultKey()) {
             continue;
           }
           if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(
@@ -942,7 +942,7 @@ public class WeakAi extends AbstractBuiltInAi {
         for (final RepairRule rrule : repairRules) {
           for (final Unit fixUnit : unitsThatCanProduceNeedingRepair.keySet()) {
             if (fixUnit == null
-                || !fixUnit.getType().equals(rrule.getResults().keySet().iterator().next())) {
+                || !fixUnit.getType().equals(rrule.getAnyResultKey()))) {
               continue;
             }
             if (!Matches.territoryIsOwnedAndHasOwnedUnitMatching(
@@ -1004,7 +1004,7 @@ public class WeakAi extends AbstractBuiltInAi {
     while ((minCost == Integer.MAX_VALUE || leftToSpend >= minCost) && i < 100000) {
       i++;
       for (final ProductionRule rule : rules) {
-        final NamedAttachable resourceOrUnit = rule.getResults().keySet().iterator().next();
+        final NamedAttachable resourceOrUnit = rule.getAnyResultKey();
         if (!(resourceOrUnit instanceof UnitType)) {
           continue;
         }
@@ -1116,7 +1116,7 @@ public class WeakAi extends AbstractBuiltInAi {
         final Set<Territory> seaNeighbors =
             data.getMap().getNeighbors(placeAt, Matches.territoryIsWater());
         if (!seaNeighbors.isEmpty()) {
-          seaPlaceAt = seaNeighbors.iterator().next();
+          seaPlaceAt = CollectionUtils.getAny(seaNeighbors);
         }
       }
       if (seaPlaceAt != null) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TerritoryAttachment.java
@@ -31,6 +31,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
+import org.triplea.java.collections.CollectionUtils;
 
 /** An attachment for instances of {@link Territory}. */
 public class TerritoryAttachment extends DefaultAttachment {
@@ -100,10 +101,10 @@ public class TerritoryAttachment extends DefaultAttachment {
       }
     }
     if (!capitals.isEmpty()) {
-      return capitals.iterator().next();
+      return CollectionUtils.getAny(capitals);
     }
     if (!noNeighborCapitals.isEmpty()) {
-      return noNeighborCapitals.iterator().next();
+      return CollectionUtils.getAny(noNeighborCapitals);
     }
     // Added check for optional players- no error thrown for them
     if (player.getOptional()) {
@@ -735,7 +736,7 @@ public class TerritoryAttachment extends DefaultAttachment {
               .append(
                   resources.toStringForHtml().replaceAll("<br>", "<br>&nbsp;&nbsp;&nbsp;&nbsp;"));
         } else {
-          sb.append(resources.toString());
+          sb.append(resources);
         }
         sb.append(br);
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -3541,7 +3541,7 @@ public class UnitAttachment extends DefaultAttachment {
 
     if (getConsumesUnits() != null && getConsumesUnits().totalValues() == 1) {
       formatter.append(
-          "Unit is an Upgrade Of", getConsumesUnits().keySet().iterator().next().getName());
+          "Unit is an Upgrade Of", CollectionUtils.getAny(getConsumesUnits().keySet()).getName());
     } else if (getConsumesUnits() != null && getConsumesUnits().totalValues() > 0) {
       if (getConsumesUnits().size() <= 4) {
         formatter.append(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AaInMoveUtil.java
@@ -97,7 +97,7 @@ class AaInMoveUtil implements Serializable {
       final Collection<Unit> currentPossibleAa =
           CollectionUtils.getMatches(defendingAa, Matches.unitIsAaOfTypeAa(currentTypeAa));
       final Set<UnitType> targetUnitTypesForThisTypeAa =
-          UnitAttachment.get(currentPossibleAa.iterator().next().getType())
+          UnitAttachment.get(CollectionUtils.getAny(currentPossibleAa).getType())
               .getTargetsAa(getData().getUnitTypeList());
       final Set<UnitType> airborneTypesTargettedToo = airborneTechTargetsAllowed.get(currentTypeAa);
       final Collection<Unit> validTargetedUnitsForThisRoll =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -429,7 +429,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate
     }
     if (!change.isEmpty() && !changeList.isEmpty()) {
       if (changeList.size() == 1) {
-        final Tuple<Territory, Collection<Unit>> tuple = changeList.iterator().next();
+        final Tuple<Territory, Collection<Unit>> tuple = CollectionUtils.getAny(changeList);
         bridge
             .getHistoryWriter()
             .startEvent(
@@ -541,7 +541,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate
               bridge.getRandom(
                   CONVOY_BLOCKADE_DICE_SIDES,
                   numberOfDice,
-                  enemies.iterator().next().getOwner(),
+                  CollectionUtils.getAny(enemies).getOwner(),
                   DiceType.BOMBING,
                   transcript);
           transcripts.add(transcript + ". Rolls: " + MyFormatter.asDice(dice));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractMoveDelegate.java
@@ -17,6 +17,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.stream.IntStream;
+import org.triplea.java.collections.CollectionUtils;
 
 /** An abstraction of MoveDelegate in order to allow other delegates to extend this. */
 public abstract class AbstractMoveDelegate extends BaseTripleADelegate implements IMoveDelegate {
@@ -109,7 +110,7 @@ public abstract class AbstractMoveDelegate extends BaseTripleADelegate implement
     // these are.
     return (units.isEmpty() || !BaseEditDelegate.getEditMode(getData().getProperties()))
         ? player
-        : units.iterator().next().getOwner();
+        : CollectionUtils.getAny(units).getOwner();
   }
 
   public String move(final Collection<Unit> units, final Route route) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -602,7 +602,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       return "No factory in or adjacent to " + to.getName();
     }
     if (producers.size() == 1) {
-      return canProduce(producers.iterator().next(), to, units, player);
+      return canProduce(CollectionUtils.getAny(producers), to, units, player);
     }
     final Collection<Territory> failingProducers = new ArrayList<>();
     final StringBuilder error = new StringBuilder();
@@ -1730,7 +1730,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
         return factory.getOriginalOwner();
       }
     }
-    return factoryUnits.iterator().next().getOriginalOwner();
+    return CollectionUtils.getAny(factoryUnits).getOriginalOwner();
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EditDelegate.java
@@ -75,7 +75,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
       return null;
     }
     // now make sure land units are put on transports properly
-    final GamePlayer player = units.iterator().next().getOwner();
+    final GamePlayer player = CollectionUtils.getAny(units).getOwner();
     final GameData data = getData();
     Map<Unit, Unit> mapLoading = null;
     if (territory.isWater()
@@ -110,7 +110,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
     // now perform the changes
     logEvent(
         "Adding units owned by "
-            + units.iterator().next().getOwner().getName()
+            + CollectionUtils.getAny(units).getOwner().getName()
             + " to "
             + territory.getName()
             + ": "
@@ -249,7 +249,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
     final Collection<Unit> unitsFinal = new ArrayList<>(unitDamageMap.keySet());
     logEvent(
         "Changing unit hit damage for these "
-            + unitsFinal.iterator().next().getOwner().getName()
+            + CollectionUtils.getAny(unitsFinal).getOwner().getName()
             + " owned units to: "
             + MyFormatter.integerUnitMapToString(unitDamageMap, ", ", " = ", false),
         unitsFinal);
@@ -285,7 +285,7 @@ public class EditDelegate extends BaseEditDelegate implements IEditDelegate {
     final Collection<Unit> unitsFinal = new ArrayList<>(unitDamageMap.keySet());
     logEvent(
         "Changing unit bombing damage for these "
-            + unitsFinal.iterator().next().getOwner().getName()
+            + CollectionUtils.getAny(unitsFinal).getOwner().getName()
             + " owned units to: "
             + MyFormatter.integerUnitMapToString(unitDamageMap, ", ", " = ", false),
         unitsFinal);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -52,7 +52,7 @@ final class EditValidator {
     if (units.isEmpty()) {
       return "No units selected";
     }
-    final GamePlayer player = units.iterator().next().getOwner();
+    final GamePlayer player = CollectionUtils.getAny(units).getOwner();
     // check land/water sanity
     if (territory.isWater()) {
       if (units.isEmpty() || !units.stream().allMatch(Matches.unitIsSea())) {
@@ -218,7 +218,7 @@ final class EditValidator {
     if (!territory.getUnits().containsAll(units)) {
       return "Selected Territory does not contain all of the selected units";
     }
-    final GamePlayer player = units.iterator().next().getOwner();
+    final GamePlayer player = CollectionUtils.getAny(units).getOwner();
     // all units should be same owner
     if (units.isEmpty() || !units.stream().allMatch(Matches.unitIsOwnedBy(player))) {
       return "Not all units have the same owner";
@@ -252,7 +252,7 @@ final class EditValidator {
     if (!territory.getUnits().containsAll(units)) {
       return "Selected Territory does not contain all of the selected units";
     }
-    final GamePlayer player = units.iterator().next().getOwner();
+    final GamePlayer player = CollectionUtils.getAny(units).getOwner();
     // all units should be same owner
     if (units.isEmpty() || !units.stream().allMatch(Matches.unitIsOwnedBy(player))) {
       return "Not all units have the same owner";

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -56,7 +56,8 @@ public class EndRoundDelegate extends BaseTripleADelegate {
         final Collection<GamePlayer> winners =
             data.getAllianceTracker()
                 .getPlayersInAlliance(
-                    data.getAllianceTracker().getAlliancesPlayerIsIn(japanese).iterator().next());
+                    CollectionUtils.getAny(
+                        data.getAllianceTracker().getAlliancesPlayerIsIn(japanese)));
         signalGameOver(victoryMessage, winners, bridge);
       }
     }
@@ -300,7 +301,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
           .playSoundForAll(
               SoundPath.CLIP_GAME_WON,
               ((this.winners != null && !this.winners.isEmpty())
-                  ? this.winners.iterator().next()
+                  ? CollectionUtils.getAny(this.winners)
                   : GamePlayer.NULL_PLAYERID));
       // send a message to everyone's screen except the HOST (there is no 'current player' for the
       // end round delegate)

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndTurnDelegate.java
@@ -161,7 +161,7 @@ public class EndTurnDelegate extends AbstractEndTurnDelegate {
       return null;
     }
     if (territories.size() == 1) {
-      return territories.iterator().next();
+      return CollectionUtils.getAny(territories);
     }
     // there is an issue with maps that have lots of rolls without any pause between them: they are
     // causing the crypted

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -289,16 +289,14 @@ public class InitializationDelegate extends BaseTripleADelegate {
           data.getProductionFrontierList().getProductionFrontier("production");
       final Collection<ProductionRule> rules = frontierNonShipyards.getRules();
       for (final ProductionRule rule : rules) {
-        final String ruleName = rule.getName();
-        final IntegerMap<NamedAttachable> ruleResults = rule.getResults();
-        final NamedAttachable named = ruleResults.keySet().iterator().next();
+        final NamedAttachable named = rule.getAnyResultKey();
         if (!(named instanceof UnitType)) {
           continue;
         }
         final UnitType unit = data.getUnitTypeList().getUnitType(named.getName());
         final boolean isSea = UnitAttachment.get(unit).getIsSea();
         if (!isSea) {
-          final ProductionRule prodRule = data.getProductionRuleList().getProductionRule(ruleName);
+          final ProductionRule prodRule = data.getProductionRuleList().getProductionRule(rule.getName());
           change.add(ChangeFactory.addProductionRule(prodRule, frontierShipyards));
         }
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/InitializationDelegate.java
@@ -25,7 +25,6 @@ import java.util.Collection;
 import java.util.function.Predicate;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.java.collections.CollectionUtils;
-import org.triplea.java.collections.IntegerMap;
 
 /** This delegate is only supposed to be run once, per game, at the start of the game. */
 @Slf4j
@@ -296,7 +295,8 @@ public class InitializationDelegate extends BaseTripleADelegate {
         final UnitType unit = data.getUnitTypeList().getUnitType(named.getName());
         final boolean isSea = UnitAttachment.get(unit).getIsSea();
         if (!isSea) {
-          final ProductionRule prodRule = data.getProductionRuleList().getProductionRule(rule.getName());
+          final ProductionRule prodRule =
+              data.getProductionRuleList().getProductionRule(rule.getName());
           change.add(ChangeFactory.addProductionRule(prodRule, frontierShipyards));
         }
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -841,7 +841,7 @@ public final class Matches {
   public static Predicate<Territory> territoryIsIsland() {
     return t -> {
       final Collection<Territory> neighbors = t.getData().getMap().getNeighbors(t);
-      return neighbors.size() == 1 && territoryIsWater().test(neighbors.iterator().next());
+      return neighbors.size() == 1 && territoryIsWater().test(CollectionUtils.getAny(neighbors));
     };
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -227,10 +227,10 @@ public class MovePerformer implements Serializable {
                         getRemotePlayer()
                             .whatShouldBomberBomb(route.getEnd(), enemyTargets, arrived);
                   } else if (!enemyTargets.isEmpty()) {
-                    target = enemyTargets.iterator().next();
+                    target = CollectionUtils.getAny(enemyTargets);
                   } else {
                     // in case we are escorts only
-                    target = enemyTargetsTotal.iterator().next();
+                    target = CollectionUtils.getAny(enemyTargetsTotal);
                   }
                   if (target == null) {
                     targetedAttack = false;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -49,9 +49,7 @@ public class PurchaseDelegate extends BaseTripleADelegate
     implements IPurchaseDelegate, IAbstractForumPosterDelegate {
   public static final String NOT_ENOUGH_RESOURCES = "Not enough resources";
   private static final Comparator<RepairRule> repairRuleComparator =
-      Comparator.comparing(
-          o -> (UnitType) o.getAnyResultKey(),
-          new UnitTypeComparator());
+      Comparator.comparing(o -> (UnitType) o.getAnyResultKey(), new UnitTypeComparator());
 
   private boolean needToInitialize = true;
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/PurchaseDelegate.java
@@ -50,7 +50,8 @@ public class PurchaseDelegate extends BaseTripleADelegate
   public static final String NOT_ENOUGH_RESOURCES = "Not enough resources";
   private static final Comparator<RepairRule> repairRuleComparator =
       Comparator.comparing(
-          o -> (UnitType) o.getResults().keySet().iterator().next(), new UnitTypeComparator());
+          o -> (UnitType) o.getAnyResultKey(),
+          new UnitTypeComparator());
 
   private boolean needToInitialize = true;
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/RocketsFireHelper.java
@@ -151,7 +151,7 @@ public class RocketsFireHelper implements Serializable {
             continue;
           }
           if (enemyTargets.size() == 1) {
-            unitTarget = enemyTargets.iterator().next();
+            unitTarget = CollectionUtils.getAny(enemyTargets);
           } else {
             final Player remotePlayer = bridge.getRemotePlayer(player);
             unitTarget =
@@ -528,7 +528,8 @@ public class RocketsFireHelper implements Serializable {
     if (attackFrom != null) {
       if (!rockets.isEmpty()) {
         // TODO: only a certain number fired...
-        final Change change = ChangeFactory.markNoMovementChange(Set.of(rockets.iterator().next()));
+        final Change change =
+            ChangeFactory.markNoMovementChange(Set.of(CollectionUtils.getAny(rockets)));
         bridge.addChange(change);
       } else {
         throw new IllegalStateException("No rockets?" + attackFrom.getUnits());

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
@@ -274,7 +274,7 @@ public class TransportTracker {
     if (unloaded.isEmpty()) {
       return null;
     }
-    return unloaded.iterator().next().getUnloadedTo();
+    return CollectionUtils.getAny(unloaded).getUnloadedTo();
   }
 
   /** If a transport has been in combat, it cannot both load AND unload in NCM. */

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/UndoableMove.java
@@ -62,7 +62,9 @@ public class UndoableMove extends AbstractUndoableMove {
     if (reasonCantUndo != null) {
       return reasonCantUndo;
     } else if (!dependents.isEmpty()) {
-      return "Move " + (dependents.iterator().next().getIndex() + 1) + " must be undone first";
+      return "Move "
+          + (CollectionUtils.getAny(dependents).getIndex() + 1)
+          + " must be undone first";
     } else {
       throw new IllegalStateException("no reason");
     }
@@ -142,7 +144,7 @@ public class UndoableMove extends AbstractUndoableMove {
                         .whatShouldBomberBomb(end, enemyTargets, List.of(unit));
               }
             } else if (!enemyTargets.isEmpty()) {
-              target = enemyTargets.iterator().next();
+              target = CollectionUtils.getAny(enemyTargets);
             }
             if (target != null) {
               targets = new HashMap<>();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/AirBattle.java
@@ -368,7 +368,7 @@ public class AirBattle extends AbstractBattle {
                     getRemote(bridge).whatShouldBomberBomb(battleSite, enemyTargets, List.of(unit));
               }
             } else {
-              target = enemyTargets.iterator().next();
+              target = CollectionUtils.getAny(enemyTargets);
             }
             if (target != null) {
               targets = new HashMap<>();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleDelegate.java
@@ -238,7 +238,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
     // are there battles that must occur first
     final Collection<IBattle> allMustPrecede = battleTracker.getDependentOn(battle);
     if (!allMustPrecede.isEmpty()) {
-      final IBattle firstPrecede = allMustPrecede.iterator().next();
+      final IBattle firstPrecede = CollectionUtils.getAny(allMustPrecede);
       final String name = firstPrecede.getTerritory().getName();
       return MUST_COMPLETE_BATTLE_PREFIX + getFightingWord(firstPrecede) + " in " + name + " first";
     }
@@ -348,8 +348,8 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
   private IBattle selectBombardingBattle(
       final Unit u, final Territory unitTerritory, final Collection<IBattle> battles) {
     // If only one battle to select from just return that battle
-    if ((battles.size() == 1)) {
-      return battles.iterator().next();
+    if (battles.size() == 1) {
+      return CollectionUtils.getAny(battles);
     }
     final List<Territory> territories = new ArrayList<>();
     final Map<Territory, IBattle> battleTerritories = new HashMap<>();
@@ -966,7 +966,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
                             + "): "
                             + MyFormatter.unitsToText(List.of(u)));
           } else if (possible.size() == 1) {
-            landingTerr = possible.iterator().next();
+            landingTerr = CollectionUtils.getAny(possible);
           }
           if (landingTerr == null || landingTerr.equals(t)) {
             carrierCostOfCurrentTerr += AirMovementValidator.carrierCost(List.of(u));
@@ -1109,7 +1109,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
                           + MyFormatter.unitsToText(defendingAir));
           // added for test script
           if (territory == null) {
-            territory = canLandHere.iterator().next();
+            territory = CollectionUtils.getAny(canLandHere);
           }
           if (territory.isWater()) {
             landPlanesOnCarriers(
@@ -1129,7 +1129,7 @@ public class BattleDelegate extends BaseTripleADelegate implements IBattleDelega
         }
         // Land in the last remaining territory
         if (!canLandHere.isEmpty() && !defendingAir.isEmpty()) {
-          territory = canLandHere.iterator().next();
+          territory = CollectionUtils.getAny(canLandHere);
           if (territory.isWater()) {
             landPlanesOnCarriers(
                 bridge,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -1415,7 +1415,8 @@ public class BattleTracker implements Serializable {
   public void fightBattleIfOnlyOne(final IDelegateBridge bridge) {
     final Collection<Territory> territories = getPendingBattleSites(false);
     if (territories.size() == 1) {
-      final IBattle battle = getPendingBattle(territories.iterator().next(), BattleType.NORMAL);
+      final IBattle battle =
+          getPendingBattle(CollectionUtils.getAny(territories), BattleType.NORMAL);
       battle.fight(bridge);
     }
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/FireAa.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/FireAa.java
@@ -109,7 +109,7 @@ public class FireAa implements IExecutable {
       final List<Collection<Unit>> firingGroups = newFiringUnitGroups(aaTypeUnits);
       for (final Collection<Unit> firingGroup : firingGroups) {
         final Set<UnitType> validTargetTypes =
-            UnitAttachment.get(firingGroup.iterator().next().getType())
+            UnitAttachment.get(CollectionUtils.getAny(firingGroup).getType())
                 .getTargetsAa(bridge.getData().getUnitTypeList());
 
         final Set<UnitType> airborneTypesTargeted =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/StrategicBombingRaidBattle.java
@@ -458,7 +458,7 @@ public class StrategicBombingRaidBattle extends AbstractBattle implements Battle
         final Collection<Unit> currentPossibleAa =
             CollectionUtils.getMatches(defendingAa, Matches.unitIsAaOfTypeAa(currentTypeAa));
         final Set<UnitType> targetUnitTypesForThisTypeAa =
-            UnitAttachment.get(currentPossibleAa.iterator().next().getType())
+            UnitAttachment.get(CollectionUtils.getAny(currentPossibleAa).getType())
                 .getTargetsAa(gameData.getUnitTypeList());
 
         final Set<UnitType> airborneTypesTargetedToo =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/casualty/CasualtySelector.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.UUID;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
+import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.util.Tuple;
 
@@ -315,7 +316,7 @@ public class CasualtySelector {
                 .dependents(dependents)
                 .build());
     if (categorized.size() == 1) {
-      final UnitCategory unitCategory = categorized.iterator().next();
+      final UnitCategory unitCategory = CollectionUtils.getAny(categorized);
       return unitCategory.getHitPoints() - unitCategory.getDamaged() <= 1;
     }
     return false;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/FiringGroup.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/FiringGroup.java
@@ -155,7 +155,7 @@ public class FiringGroup implements Serializable {
 
     // add a suffix to suicide groups that includes their type name to differentiate them
     return firingUnits.stream().allMatch(Matches.unitIsSuicideOnHit())
-        ? originalName + " suicide " + firingUnits.iterator().next().getType().getName()
+        ? originalName + " suicide " + CollectionUtils.getAny(firingUnits).getType().getName()
         : originalName;
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/FiringGroupSplitterAa.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/aa/FiringGroupSplitterAa.java
@@ -80,7 +80,7 @@ public class FiringGroupSplitterAa
 
       // grab the unit types that this typeAa can fire at
       final Set<UnitType> validTargetTypes =
-          UnitAttachment.get(firingUnits.iterator().next().getType())
+          UnitAttachment.get(CollectionUtils.getAny(firingUnits).getType())
               .getTargetsAa(battleState.getGameData().getUnitTypeList());
 
       final Collection<Unit> targetUnits =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/general/FiringGroupSplitterGeneral.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/steps/fire/general/FiringGroupSplitterGeneral.java
@@ -147,12 +147,11 @@ public class FiringGroupSplitterGeneral
 
     if (targetGroups.size() == 1) {
       firingGroups.addAll(
-          buildFiringGroups(name, canFire, enemyUnits, targetGroups.iterator().next()));
-
+          buildFiringGroups(name, canFire, enemyUnits, CollectionUtils.getAny(targetGroups)));
     } else {
       // use the first unitType name of each TargetGroup as a suffix for the FiringGroup name
       for (final TargetGroup targetGroup : targetGroups) {
-        final UnitType type = targetGroup.getFiringUnits(canFire).iterator().next().getType();
+        final UnitType type = CollectionUtils.getAny(targetGroup.getFiringUnits(canFire)).getType();
         firingGroups.addAll(
             buildFiringGroups(name + " " + type.getName(), canFire, enemyUnits, targetGroup));
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/dice/RollDiceFactory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/dice/RollDiceFactory.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import lombok.experimental.UtilityClass;
+import org.triplea.java.collections.CollectionUtils;
 
 @UtilityClass
 public class RollDiceFactory {
@@ -35,8 +36,8 @@ public class RollDiceFactory {
       final Territory battleSite,
       final CombatValue combatValueCalculator) {
 
-    final String typeAa = UnitAttachment.get(aaUnits.iterator().next().getType()).getTypeAa();
-    final GamePlayer player = aaUnits.iterator().next().getOwner();
+    final String typeAa = UnitAttachment.get(CollectionUtils.getAny(aaUnits).getType()).getTypeAa();
+    final GamePlayer player = CollectionUtils.getAny(aaUnits).getOwner();
     final String annotation =
         player.getName() + " roll " + typeAa + " dice in " + battleSite.getName();
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AvailableSupports.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/AvailableSupports.java
@@ -13,6 +13,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
+import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 
 /**
@@ -148,7 +149,7 @@ class AvailableSupports {
    */
   private Unit getNextAvailableSupporter(final UnitSupportAttachment support) {
     final Set<Unit> supporters = supportUnits.get(support).keySet();
-    final Unit u = supporters.iterator().next();
+    final Unit u = CollectionUtils.getAny(supporters);
     supportUnits.get(support).add(u, -1);
     if (supportUnits.get(support).getInt(u) <= 0) {
       supportUnits.get(support).removeKey(u);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/PowerStrengthAndRolls.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/PowerStrengthAndRolls.java
@@ -10,6 +10,7 @@ import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Value;
+import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 
 /**
@@ -41,7 +42,7 @@ public class PowerStrengthAndRolls implements TotalPowerAndTotalRolls {
 
   private PowerStrengthAndRolls(final Collection<Unit> units, final CombatValue calculator) {
     this.calculator = calculator;
-    this.diceSides = units.isEmpty() ? 0 : calculator.getDiceSides(units.iterator().next());
+    this.diceSides = units.isEmpty() ? 0 : calculator.getDiceSides(CollectionUtils.getAny(units));
     addUnits(units);
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorDialog.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/BattleCalculatorDialog.java
@@ -20,6 +20,7 @@ import javax.swing.JDialog;
 import javax.swing.JFrame;
 import javax.swing.SwingUtilities;
 import javax.swing.WindowConstants;
+import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.swing.key.binding.KeyCode;
 import org.triplea.swing.key.binding.SwingKeyBinding;
@@ -148,7 +149,7 @@ public class BattleCalculatorDialog extends JDialog {
     // select the defending side to match any unit in the current territory
     if (!currentDialog.panel.hasAttackingUnitsAdded()
         && !currentDialog.panel.hasDefendingUnitsAdded()) {
-      Optional.ofNullable(t.getUnitCollection().iterator().next())
+      Optional.ofNullable(CollectionUtils.getAny(t.getUnitCollection()))
           .map(Unit::getOwner)
           .ifPresent(currentDialog.panel::setDefender);
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyPlayer.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/DummyPlayer.java
@@ -150,7 +150,7 @@ class DummyPlayer extends AbstractBuiltInAi {
           && enemyUnits.stream().allMatch(planeNotDestroyer)
           && !ourUnits.isEmpty()
           && ourUnits.stream().allMatch(Matches.unitCanNotBeTargetedByAll())) {
-        return possibleTerritories.iterator().next();
+        return CollectionUtils.getAny(possibleTerritories);
       }
       return null;
     }
@@ -160,7 +160,7 @@ class DummyPlayer extends AbstractBuiltInAi {
       return null;
     }
     if (retreatAfterRound > -1 && battle.getBattleRound() >= retreatAfterRound) {
-      return possibleTerritories.iterator().next();
+      return CollectionUtils.getAny(possibleTerritories);
     }
     if (!retreatWhenOnlyAirLeft && retreatAfterXUnitsLeft <= -1) {
       return null;
@@ -180,11 +180,11 @@ class DummyPlayer extends AbstractBuiltInAi {
         retreatNum += retreatAfterXUnitsLeft;
       }
       if (retreatNum >= unitsLeft.size()) {
-        return possibleTerritories.iterator().next();
+        return CollectionUtils.getAny(possibleTerritories);
       }
     }
     if (retreatAfterXUnitsLeft > -1 && retreatAfterXUnitsLeft >= unitsLeft.size()) {
-      return possibleTerritories.iterator().next();
+      return CollectionUtils.getAny(possibleTerritories);
     }
     return null;
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/BattleDisplay.java
@@ -413,7 +413,9 @@ public class BattleDisplay extends JPanel {
   private RetreatResult showRetreatDialog(
       final String message, final Collection<Territory> possible) {
     final String yes =
-        possible.size() == 1 ? "Retreat to " + possible.iterator().next().getName() : "Retreat";
+        possible.size() == 1
+            ? "Retreat to " + CollectionUtils.getAny(possible).getName()
+            : "Retreat";
     final String no = "Remain";
     final String cancel = "Ask Me Later";
     final String[] options = {yes, no, cancel};
@@ -438,7 +440,7 @@ public class BattleDisplay extends JPanel {
 
     // retreat
     if (possible.size() == 1) {
-      return RetreatResult.retreatTo(possible.iterator().next());
+      return RetreatResult.retreatTo(CollectionUtils.getAny(possible));
     }
 
     return showRetreatOptions(message, possible);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/EditPanel.java
@@ -298,8 +298,7 @@ class EditPanel extends ActionPanel {
               final Collection<Unit> units = new ArrayList<>();
               for (final ProductionRule productionRule : production.keySet()) {
                 final int quantity = production.getInt(productionRule);
-                final NamedAttachable resourceOrUnit =
-                    productionRule.getResults().keySet().iterator().next();
+                final NamedAttachable resourceOrUnit = productionRule.getAnyResultKey();
                 if (!(resourceOrUnit instanceof UnitType)) {
                   continue;
                 }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/PoliticsPanel.java
@@ -28,6 +28,7 @@ import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JSplitPane;
 import javax.swing.SwingUtilities;
+import org.triplea.java.collections.CollectionUtils;
 import org.triplea.sound.ClipPlayer;
 import org.triplea.sound.SoundPath;
 import org.triplea.swing.JButtonBuilder;
@@ -350,9 +351,9 @@ public class PoliticsPanel extends ActionPanel {
         return 0;
       }
       final PoliticalActionAttachment.RelationshipChange paa1RelationshipChange =
-          paa1.getRelationshipChanges().iterator().next();
+          CollectionUtils.getAny(paa1.getRelationshipChanges());
       final PoliticalActionAttachment.RelationshipChange paa2RelationshipChange =
-          paa2.getRelationshipChanges().iterator().next();
+          CollectionUtils.getAny(paa2.getRelationshipChanges());
       final RelationshipType paa1NewType = paa1RelationshipChange.relationshipType;
       final RelationshipType paa2NewType = paa2RelationshipChange.relationshipType;
       // sort by player

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
@@ -143,7 +143,7 @@ class ProductionRepairPanel extends JPanel {
       for (final RepairRule repairRule : player.getRepairFrontier()) {
         for (final Territory terr : terrsWithPotentiallyDamagedUnits) {
           for (final Unit unit : CollectionUtils.getMatches(terr.getUnits(), myDamagedUnits)) {
-            if (!repairRule.getResults().keySet().iterator().next().equals(unit.getType())) {
+            if (!repairRule.getAnyResultKey().equals(unit.getType())) {
               continue;
             }
             final Rule rule = new Rule(repairRule, unit, terr);
@@ -295,7 +295,7 @@ class ProductionRepairPanel extends JPanel {
       this.unit = repairUnit;
       this.rule = rule;
       cost = rule.getCosts();
-      final UnitType type = (UnitType) rule.getResults().keySet().iterator().next();
+      final UnitType type = (UnitType) rule.getAnyResultKey();
       if (!type.equals(repairUnit.getType())) {
         throw new IllegalStateException(
             "Rule unit type "

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ProductionTabsProperties.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ProductionTabsProperties.java
@@ -6,6 +6,7 @@ import games.strategy.triplea.ui.ProductionPanel.Rule;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+import org.triplea.java.collections.CollectionUtils;
 import org.triplea.util.Tuple;
 
 class ProductionTabsProperties {
@@ -59,8 +60,7 @@ class ProductionTabsProperties {
           List.of(properties.getProperty(TAB_UNITS + "." + i).split(":"));
       final List<Rule> ruleList = new ArrayList<>();
       for (final Rule rule : rules) {
-        if (tabValues.contains(
-            rule.getProductionRule().getResults().keySet().iterator().next().getName())) {
+        if (tabValues.contains(rule.getProductionRule().getAnyResultKey().getName())) {
           ruleList.add(rule);
         }
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ProductionTabsProperties.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ProductionTabsProperties.java
@@ -6,7 +6,6 @@ import games.strategy.triplea.ui.ProductionPanel.Rule;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
-import org.triplea.java.collections.CollectionUtils;
 import org.triplea.util.Tuple;
 
 class ProductionTabsProperties {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/PurchasePanel.java
@@ -172,7 +172,7 @@ public class PurchasePanel extends ActionPanel {
       // sum production for all units except factories
       int totalProduced = 0;
       for (final ProductionRule rule : purchase.keySet()) {
-        final NamedAttachable resourceOrUnit = rule.getResults().keySet().iterator().next();
+        final NamedAttachable resourceOrUnit = rule.getAnyResultKey();
         if (resourceOrUnit instanceof UnitType) {
           final UnitType type = (UnitType) resourceOrUnit;
           if (!Matches.unitTypeIsConstruction().test(type)) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
@@ -24,6 +24,7 @@ import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import lombok.extern.slf4j.Slf4j;
+import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.swing.WrapLayout;
 
@@ -46,8 +47,8 @@ public class SimpleUnitPanel extends JPanel {
         @Override
         public int compare(final ProductionRule o1, final ProductionRule o2) {
           if (o1.getResults().size() == 1 && o2.getResults().size() == 1) {
-            final NamedAttachable n1 = o1.getResults().keySet().iterator().next();
-            final NamedAttachable n2 = o2.getResults().keySet().iterator().next();
+            final NamedAttachable n1 = o1.getAnyResultKey();
+            final NamedAttachable n2 = o2.getAnyResultKey();
             if (n1 instanceof UnitType) {
               final UnitType u1 = (UnitType) n1;
               if (n2 instanceof UnitType) {
@@ -88,8 +89,8 @@ public class SimpleUnitPanel extends JPanel {
         @Override
         public int compare(final RepairRule o1, final RepairRule o2) {
           if (o1.getResults().size() == 1 && o2.getResults().size() == 1) {
-            final NamedAttachable n1 = o1.getResults().keySet().iterator().next();
-            final NamedAttachable n2 = o2.getResults().keySet().iterator().next();
+            final NamedAttachable n1 = o1.getAnyResultKey();
+            final NamedAttachable n2 = o2.getAnyResultKey();
             if (n1 instanceof UnitType) {
               final UnitType u1 = (UnitType) n1;
               if (n2 instanceof UnitType) {
@@ -180,7 +181,7 @@ public class SimpleUnitPanel extends JPanel {
       for (final RepairRule repairRule : repairRules) {
         // check to see if the repair rule matches the damaged unit
         if (Properties.getDamageFromBombingDoneToUnitsInsteadOfTerritories(data.getProperties())
-            && unit.getType().equals(repairRule.getResults().keySet().iterator().next())) {
+            && unit.getType().equals(repairRule.getAnyResultKey())) {
           addUnits(
               player,
               rules.getInt(repairRule),

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
@@ -24,7 +24,6 @@ import javax.swing.ImageIcon;
 import javax.swing.JLabel;
 import javax.swing.JPanel;
 import lombok.extern.slf4j.Slf4j;
-import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.swing.WrapLayout;
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TabbedProductionPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TabbedProductionPanel.java
@@ -21,6 +21,7 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
+import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.swing.jpanel.JPanelBuilder;
 import org.triplea.util.Tuple;
@@ -218,8 +219,7 @@ class TabbedProductionPanel extends ProductionPanel {
     final List<Rule> resourceRules = new ArrayList<>();
     for (final Rule rule : rules) {
       allRules.add(rule);
-      final NamedAttachable resourceOrUnit =
-          rule.getProductionRule().getResults().keySet().iterator().next();
+      final NamedAttachable resourceOrUnit = rule.getProductionRule().getAnyResultKey();
       if (resourceOrUnit instanceof UnitType) {
         final UnitType type = (UnitType) resourceOrUnit;
         final UnitAttachment attach = UnitAttachment.get(type);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TabbedProductionPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TabbedProductionPanel.java
@@ -21,7 +21,6 @@ import javax.swing.JLabel;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
 import javax.swing.JTabbedPane;
-import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.swing.jpanel.JPanelBuilder;
 import org.triplea.util.Tuple;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TripleAFrame.java
@@ -146,6 +146,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.triplea.injection.Injections;
 import org.triplea.java.Interruptibles;
 import org.triplea.java.ThreadRunner;
+import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 import org.triplea.java.concurrency.CompletableFutureUtils;
 import org.triplea.sound.ClipPlayer;
@@ -795,7 +796,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
     final String ok = movePhase ? "End Move Phase" : "Kill Planes";
     final String cancel = movePhase ? "Keep Moving" : "Change Placement";
     final String[] options = {cancel, ok};
-    mapPanel.centerOn(airCantLand.iterator().next());
+    mapPanel.centerOn(CollectionUtils.getAny(airCantLand));
     final int choice =
         EventThreadJOptionPane.showOptionDialog(
             this,
@@ -833,7 +834,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
     final String ok = "Done Moving";
     final String cancel = "Keep Moving";
     final String[] options = {cancel, ok};
-    this.mapPanel.centerOn(unitsCantFight.iterator().next());
+    this.mapPanel.centerOn(CollectionUtils.getAny(unitsCantFight));
     final int choice =
         EventThreadJOptionPane.showOptionDialog(
             this,
@@ -945,7 +946,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
       final Collection<Unit> potentialTargets,
       final Collection<Unit> bombers) {
     if (potentialTargets.size() == 1) {
-      return potentialTargets.iterator().next();
+      return CollectionUtils.getAny(potentialTargets);
     }
     messageAndDialogThreadPool.waitForAll();
     final AtomicReference<Unit> selected = new AtomicReference<>();
@@ -1077,7 +1078,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
       return null;
     }
     if (candidates.size() == 1) {
-      return candidates.iterator().next();
+      return CollectionUtils.getAny(candidates);
     }
     messageAndDialogThreadPool.waitForAll();
     final Supplier<SelectTerritoryComponent> action =
@@ -1206,7 +1207,7 @@ public final class TripleAFrame extends JFrame implements QuitHandler {
           }
           mapPanel.centerOn(
               data.getMap()
-                  .getTerritory(possibleUnitsToAttackStringForm.keySet().iterator().next()));
+                  .getTerritory(CollectionUtils.getAny(possibleUnitsToAttackStringForm.keySet())));
           final IndividualUnitPanelGrouped unitPanel =
               new IndividualUnitPanelGrouped(
                   possibleUnitsToAttackStringForm,

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/mapdata/IslandTerritoryFinder.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/mapdata/IslandTerritoryFinder.java
@@ -9,6 +9,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.experimental.UtilityClass;
+import org.triplea.java.collections.CollectionUtils;
 
 @UtilityClass
 class IslandTerritoryFinder {
@@ -68,7 +69,7 @@ class IslandTerritoryFinder {
 
     // Function where given a territory name, give us a polygon for that territory
     final Function<String, Polygon> polygonLookup =
-        territoryName -> polygons.get(territoryName).iterator().next();
+        territoryName -> CollectionUtils.getAny(polygons.get(territoryName));
 
     return land -> {
       final Polygon seaPoly = polygonLookup.apply(seaTerritory);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -49,7 +49,6 @@ import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.TreeNode;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.injection.Injections;
-import org.triplea.java.collections.CollectionUtils;
 import org.triplea.map.data.elements.Game;
 import org.triplea.map.xml.writer.GameXmlWriter;
 import org.triplea.swing.JMenuItemBuilder;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/ExportMenu.java
@@ -49,6 +49,7 @@ import javax.swing.tree.DefaultMutableTreeNode;
 import javax.swing.tree.TreeNode;
 import lombok.extern.slf4j.Slf4j;
 import org.triplea.injection.Injections;
+import org.triplea.java.collections.CollectionUtils;
 import org.triplea.map.data.elements.Game;
 import org.triplea.map.xml.writer.GameXmlWriter;
 import org.triplea.swing.JMenuItemBuilder;
@@ -224,8 +225,8 @@ final class ExportMenu extends JMenu {
         for (final ProductionRule pr : purchaseOptions) {
           final String costString = pr.toStringCosts().replaceAll(";? ", ",");
           writer.append(pr.getName()).append(',');
-          writer.append(pr.getResults().keySet().iterator().next().getName()).append(',');
-          writer.print(pr.getResults().getInt(pr.getResults().keySet().iterator().next()));
+          writer.append(pr.getAnyResultKey().getName()).append(',');
+          writer.print(pr.getResults().getInt(pr.getAnyResultKey()));
           writer.append(',').append(costString).println(',');
         }
         writer.println();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panels/map/MapPanel.java
@@ -862,7 +862,10 @@ public class MapPanel extends ImageScrollerLargeView {
       try {
         movementFuelCost =
             Route.getMovementFuelCostCharge(
-                units, routeDescription.getRoute(), units.iterator().next().getOwner(), gameData);
+                units,
+                routeDescription.getRoute(),
+                CollectionUtils.getAny(units).getOwner(),
+                gameData);
       } finally {
         gameData.releaseReadLock();
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/util/TransportUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/util/TransportUtils.java
@@ -152,7 +152,7 @@ public final class TransportUtils {
         findTransportsThatUnitsCouldUnloadFrom(units, transports);
     while (!unitToPotentialTransports.isEmpty()) {
       unitToPotentialTransports = sortByTransportOptionsAscending(unitToPotentialTransports);
-      final Unit currentUnit = unitToPotentialTransports.keySet().iterator().next();
+      final Unit currentUnit = CollectionUtils.getAny(unitToPotentialTransports.keySet());
       final Unit selectedTransport =
           findOptimalTransportToUnloadFrom(currentUnit, unitToPotentialTransports);
       unitToPotentialTransports =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/util/TuvUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/util/TuvUtils.java
@@ -21,6 +21,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import lombok.experimental.UtilityClass;
 import org.triplea.java.collections.CollectionUtils;
@@ -53,7 +54,7 @@ public class TuvUtils {
     final ProductionFrontier frontier = player.getProductionFrontier();
     if (frontier != null) {
       for (final ProductionRule rule : frontier.getRules()) {
-        final NamedAttachable resourceOrUnit = rule.getResults().keySet().iterator().next();
+        final NamedAttachable resourceOrUnit = rule.getAnyResultKey();
         if (!(resourceOrUnit instanceof UnitType)) {
           continue;
         }
@@ -105,7 +106,7 @@ public class TuvUtils {
     for (final ProductionRule rule : data.getProductionRuleList().getProductionRules()) {
       // only works for the first result, so we are assuming each purchase frontier only gives one
       // type of unit
-      final NamedAttachable resourceOrUnit = rule.getResults().keySet().iterator().next();
+      final NamedAttachable resourceOrUnit = rule.getAnyResultKey();
       if (!(resourceOrUnit instanceof UnitType)) {
         continue;
       }
@@ -209,7 +210,7 @@ public class TuvUtils {
         }
         final int totalProduced = unitMap.totalValues();
         if (totalProduced == 1) {
-          current.put(units.iterator().next(), costPerGroup);
+          current.put(CollectionUtils.getAny(units), costPerGroup);
         } else if (totalProduced > 1) {
           costPerGroup.discount((double) 1 / (double) totalProduced);
           for (final UnitType ut : units) {
@@ -273,7 +274,7 @@ public class TuvUtils {
       }
       final int totalProduced = unitMap.totalValues();
       if (totalProduced == 1) {
-        final UnitType ut = units.iterator().next();
+        final UnitType ut = CollectionUtils.getAny(units);
         final List<ResourceCollection> current =
             backups.computeIfAbsent(ut, k -> new ArrayList<>());
         current.add(costPerGroup);
@@ -306,11 +307,7 @@ public class TuvUtils {
       }
       if (costs.isEmpty()) {
         final ResourceCollection backup = backupAveraged.get(ut);
-        if (backup != null) {
-          costs.add(backup);
-        } else {
-          costs.add(defaultResources);
-        }
+        costs.add(Objects.requireNonNullElse(backup, defaultResources));
       }
       final ResourceCollection avgCost =
           new ResourceCollection(costs.toArray(new ResourceCollection[0]), data);

--- a/lib/java-extras/src/main/java/org/triplea/io/ZipExtractor.java
+++ b/lib/java-extras/src/main/java/org/triplea/io/ZipExtractor.java
@@ -10,6 +10,7 @@ import java.nio.file.StandardCopyOption;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.experimental.UtilityClass;
+import org.triplea.java.collections.CollectionUtils;
 
 /**
  * Class with method to extract a zip file with check against "Zip Slip" vulnerability
@@ -81,7 +82,7 @@ public class ZipExtractor {
     // iterate over each zip entry and write to a corresponding file
     // Note: We can switch to the single-param version of newFileSystem() once on Java 13+.
     try (FileSystem zipFileSystem = FileSystems.newFileSystem(fileZip, (ClassLoader) null)) {
-      final Path zipRoot = zipFileSystem.getRootDirectories().iterator().next();
+      final Path zipRoot = CollectionUtils.getAny(zipFileSystem.getRootDirectories());
       try (Stream<Path> files = Files.walk(zipRoot, MAX_DEPTH)) {
         for (final Path zipEntry : files.collect(Collectors.toList())) {
           unzipZipEntry(destDir, zipRoot, zipEntry);

--- a/lib/java-extras/src/main/java/org/triplea/java/collections/CollectionUtils.java
+++ b/lib/java-extras/src/main/java/org/triplea/java/collections/CollectionUtils.java
@@ -127,4 +127,8 @@ public class CollectionUtils {
     sortedCollection.addAll(elements);
     return sortedCollection;
   }
+
+  public static <T> T getAny(final Iterable<T> elements) {
+    return elements.iterator().next();
+  }
 }


### PR DESCRIPTION
## Change Summary & Additional Notes

Introduce CollectionUtils.getAny() as well as rule.getAnyResultKey().
Switches most callers to the new helpers.
Also, a few minor clean ups in related code, no functional changes.

CollectionUtils.getAny() is a wrapper over foo.iterator().next() that conveys the semantics clearer. getAnyResultKey() is a convenience method for a common call sequence on production and repair rules.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
