### PR TITLE
Reduce Duplicate Code by Introducing an Interface and a Comparator for It.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/ProductionRule.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/ProductionRule.java
@@ -25,6 +25,10 @@ public class ProductionRule extends DefaultNamed implements Rule {
     this.costs = costs;
   }
 
+  public void addCost(final Resource resource, final int quantity) {
+    costs.put(resource, quantity);
+  }
+
   @Override
   public IntegerMap<Resource> getCosts() {
     return new IntegerMap<>(costs);

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/ProductionRule.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/ProductionRule.java
@@ -2,11 +2,10 @@ package games.strategy.engine.data;
 
 import games.strategy.triplea.Constants;
 import java.util.Map.Entry;
-import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 
 /** A production rule. */
-public class ProductionRule extends DefaultNamed {
+public class ProductionRule extends DefaultNamed implements Rule {
   private static final long serialVersionUID = -6598296283127741307L;
 
   private IntegerMap<Resource> costs = new IntegerMap<>();
@@ -26,29 +25,14 @@ public class ProductionRule extends DefaultNamed {
     this.costs = costs;
   }
 
-  public void addCost(final Resource resource, final int quantity) {
-    costs.put(resource, quantity);
-  }
-
-  /** Benefits must be a resource or a unit. */
-  public void addResult(final NamedAttachable obj, final int quantity) {
-    if (!(obj instanceof UnitType) && !(obj instanceof Resource)) {
-      throw new IllegalArgumentException(
-          "results must be units or resources, not:" + obj.getClass().getName());
-    }
-    results.put(obj, quantity);
-  }
-
+  @Override
   public IntegerMap<Resource> getCosts() {
     return new IntegerMap<>(costs);
   }
 
+  @Override
   public IntegerMap<NamedAttachable> getResults() {
     return results;
-  }
-
-  public NamedAttachable getAnyResultKey() {
-    return CollectionUtils.getAny(results.keySet());
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/RepairRule.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/RepairRule.java
@@ -29,6 +29,10 @@ public class RepairRule extends DefaultNamed implements Rule {
     this.results = new IntegerMap<>(results);
   }
 
+  public void addCost(final Resource resource, final int quantity) {
+    costs.put(resource, quantity);
+  }
+
   @Override
   public IntegerMap<Resource> getCosts() {
     return new IntegerMap<>(costs);

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/RepairRule.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/RepairRule.java
@@ -2,11 +2,10 @@ package games.strategy.engine.data;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 
 /** A repair rule. */
-public class RepairRule extends DefaultNamed {
+public class RepairRule extends DefaultNamed implements Rule {
   private static final long serialVersionUID = -45646671022993959L;
 
   private final IntegerMap<Resource> costs;
@@ -30,29 +29,14 @@ public class RepairRule extends DefaultNamed {
     this.results = new IntegerMap<>(results);
   }
 
-  public void addCost(final Resource resource, final int quantity) {
-    costs.put(resource, quantity);
-  }
-
-  /** Benefits must be a resource or a unit. */
-  public void addResult(final NamedAttachable obj, final int quantity) {
-    if (!(obj instanceof UnitType) && !(obj instanceof Resource)) {
-      throw new IllegalArgumentException(
-          "results must be units or resources, not:" + obj.getClass().getName());
-    }
-    results.put(obj, quantity);
-  }
-
+  @Override
   public IntegerMap<Resource> getCosts() {
     return new IntegerMap<>(costs);
   }
 
+  @Override
   public IntegerMap<NamedAttachable> getResults() {
     return results;
-  }
-
-  public NamedAttachable getAnyResultKey() {
-    return CollectionUtils.getAny(results.keySet());
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Rule.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Rule.java
@@ -1,12 +1,18 @@
 package games.strategy.engine.data;
 
+import org.triplea.java.ChangeOnNextMajorRelease;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 
 /**
  * Superclass for {@link games.strategy.engine.data.RepairRule} and {@link
  * games.strategy.engine.data.ProductionRule}.
+ *
+ * <p>It could become an {@code abstract class} instead in to contain more common code chunks from
+ * its children. That way, probably {@link games.strategy.engine.data.RuleComparator} can be
+ * entirely removed by making the child classes implement {@link java.lang.Comparable}.
  */
+@ChangeOnNextMajorRelease
 public interface Rule {
   String getName();
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Rule.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Rule.java
@@ -14,7 +14,12 @@ public interface Rule {
 
   IntegerMap<NamedAttachable> getResults();
 
-  /** Benefits must be a resource or a unit. */
+  /**
+   * Benefits must be a resource or a unit.
+   *
+   * <p>It's not going to work if any of {@link Rule#getResults()} implementations returns, for
+   * example, a copy of {@link org.triplea.java.collections.IntegerMap}.
+   */
   default void addResult(final NamedAttachable obj, final int quantity) {
     if (!(obj instanceof UnitType) && !(obj instanceof Resource)) {
       throw new IllegalArgumentException(

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Rule.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Rule.java
@@ -4,6 +4,8 @@ import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 
 public interface Rule {
+  String getName();
+
   IntegerMap<Resource> getCosts();
 
   IntegerMap<NamedAttachable> getResults();

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Rule.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Rule.java
@@ -8,7 +8,7 @@ import org.triplea.java.collections.IntegerMap;
  * Superclass for {@link games.strategy.engine.data.RepairRule} and {@link
  * games.strategy.engine.data.ProductionRule}.
  *
- * <p>It could become an {@code abstract class} instead in to contain more common code chunks from
+ * <p>It could become an {@code abstract class} instead in order to contain more common code chunks from
  * its children. That way, probably {@link games.strategy.engine.data.RuleComparator} can be
  * entirely removed by making the child classes implement {@link java.lang.Comparable}.
  */

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Rule.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Rule.java
@@ -14,10 +14,6 @@ public interface Rule {
 
   IntegerMap<NamedAttachable> getResults();
 
-  default void addCost(final Resource resource, final int quantity) {
-    getCosts().put(resource, quantity);
-  }
-
   /** Benefits must be a resource or a unit. */
   default void addResult(final NamedAttachable obj, final int quantity) {
     if (!(obj instanceof UnitType) && !(obj instanceof Resource)) {

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Rule.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Rule.java
@@ -3,6 +3,10 @@ package games.strategy.engine.data;
 import org.triplea.java.collections.CollectionUtils;
 import org.triplea.java.collections.IntegerMap;
 
+/**
+ * Superclass for {@link games.strategy.engine.data.RepairRule} and {@link
+ * games.strategy.engine.data.ProductionRule}.
+ */
 public interface Rule {
   String getName();
 

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Rule.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Rule.java
@@ -1,0 +1,28 @@
+package games.strategy.engine.data;
+
+import org.triplea.java.collections.CollectionUtils;
+import org.triplea.java.collections.IntegerMap;
+
+public interface Rule {
+  IntegerMap<Resource> getCosts();
+
+  IntegerMap<NamedAttachable> getResults();
+
+  default void addCost(final Resource resource, final int quantity) {
+    getCosts().put(resource, quantity);
+  }
+
+  /** Benefits must be a resource or a unit. */
+  default void addResult(final NamedAttachable obj, final int quantity) {
+    if (!(obj instanceof UnitType) && !(obj instanceof Resource)) {
+      throw new IllegalArgumentException(
+          "results must be units or resources, not:" + obj.getClass().getName());
+    }
+
+    getResults().put(obj, quantity);
+  }
+
+  default NamedAttachable getAnyResultKey() {
+    return CollectionUtils.getAny(getResults().keySet());
+  }
+}

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Rule.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Rule.java
@@ -8,8 +8,8 @@ import org.triplea.java.collections.IntegerMap;
  * Superclass for {@link games.strategy.engine.data.RepairRule} and {@link
  * games.strategy.engine.data.ProductionRule}.
  *
- * <p>It could become an {@code abstract class} instead in order to contain more common code chunks from
- * its children. That way, probably {@link games.strategy.engine.data.RuleComparator} can be
+ * <p>It could become an {@code abstract class} instead in order to contain more common code chunks
+ * from its children. That way, probably {@link games.strategy.engine.data.RuleComparator} can be
  * entirely removed by making the child classes implement {@link java.lang.Comparable}.
  */
 @ChangeOnNextMajorRelease

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/RuleComparator.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/RuleComparator.java
@@ -1,0 +1,46 @@
+package games.strategy.engine.data;
+
+import games.strategy.triplea.attachments.UnitTypeComparator;
+import java.util.Comparator;
+
+public class RuleComparator<T extends Rule> implements Comparator<T> {
+  private static final UnitTypeComparator unitTypeComparator = new UnitTypeComparator();
+
+  @Override
+  public int compare(T o1, T o2) {
+    int o1ResultsSize = o1.getResults().size();
+    int o2ResultsSize = o2.getResults().size();
+
+    if (o1ResultsSize == 1 && o2ResultsSize == 1) {
+      final NamedAttachable n1 = o1.getAnyResultKey();
+      final NamedAttachable n2 = o2.getAnyResultKey();
+      if (n1 instanceof UnitType) {
+        final UnitType u1 = (UnitType) n1;
+        if (n2 instanceof UnitType) {
+          final UnitType u2 = (UnitType) n2;
+          return unitTypeComparator.compare(u1, u2);
+        } else if (n2 instanceof Resource) {
+          // final Resource r2 = (Resource) n2;
+          return -1;
+        }
+
+        return n1.getName().compareTo(n2.getName());
+      } else if (n1 instanceof Resource) {
+        final Resource r1 = (Resource) n1;
+        if (n2 instanceof UnitType) {
+          // final UnitType u2 = (UnitType) n2;
+          return 1;
+        } else if (n2 instanceof Resource) {
+          final Resource r2 = (Resource) n2;
+          return r1.getName().compareTo(r2.getName());
+        } else {
+          return n1.getName().compareTo(n2.getName());
+        }
+      }
+
+      return n1.getName().compareTo(n2.getName());
+    }
+
+    return Integer.compare(o2ResultsSize, o1ResultsSize);
+  }
+}

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/RuleComparator.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/RuleComparator.java
@@ -41,6 +41,12 @@ public class RuleComparator<T extends Rule> implements Comparator<T> {
       return n1.getName().compareTo(n2.getName());
     }
 
-    return Integer.compare(o2ResultsSize, o1ResultsSize);
+    if (o1ResultsSize > o2ResultsSize) {
+      return -1;
+    } else if (o1ResultsSize < o2ResultsSize) {
+      return 1;
+    } else {
+      return o1.getName().compareTo(o2.getName());
+    }
   }
 }

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/RuleComparator.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/RuleComparator.java
@@ -4,7 +4,7 @@ import games.strategy.triplea.attachments.UnitTypeComparator;
 import java.util.Comparator;
 
 public class RuleComparator<T extends Rule> implements Comparator<T> {
-  private static final UnitTypeComparator unitTypeComparator = new UnitTypeComparator();
+  private final UnitTypeComparator unitTypeComparator = new UnitTypeComparator();
 
   @Override
   public int compare(T o1, T o2) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
@@ -6,10 +6,10 @@ import games.strategy.engine.data.NamedAttachable;
 import games.strategy.engine.data.ProductionRule;
 import games.strategy.engine.data.RepairRule;
 import games.strategy.engine.data.Resource;
+import games.strategy.engine.data.RuleComparator;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.Properties;
-import games.strategy.triplea.attachments.UnitTypeComparator;
 import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.util.UnitCategory;
@@ -40,88 +40,10 @@ public class SimpleUnitPanel extends JPanel {
   }
 
   private final Comparator<ProductionRule> productionRuleComparator =
-      new Comparator<>() {
-        final UnitTypeComparator utc = new UnitTypeComparator();
-
-        @Override
-        public int compare(final ProductionRule o1, final ProductionRule o2) {
-          if (o1.getResults().size() == 1 && o2.getResults().size() == 1) {
-            final NamedAttachable n1 = o1.getAnyResultKey();
-            final NamedAttachable n2 = o2.getAnyResultKey();
-            if (n1 instanceof UnitType) {
-              final UnitType u1 = (UnitType) n1;
-              if (n2 instanceof UnitType) {
-                final UnitType u2 = (UnitType) n2;
-                return utc.compare(u1, u2);
-              } else if (n2 instanceof Resource) {
-                // final Resource r2 = (Resource) n2;
-                return -1;
-              }
-              return n1.getName().compareTo(n2.getName());
-            } else if (n1 instanceof Resource) {
-              final Resource r1 = (Resource) n1;
-              if (n2 instanceof UnitType) {
-                // final UnitType u2 = (UnitType) n2;
-                return 1;
-              } else if (n2 instanceof Resource) {
-                final Resource r2 = (Resource) n2;
-                return r1.getName().compareTo(r2.getName());
-              } else {
-                return n1.getName().compareTo(n2.getName());
-              }
-            }
-            return n1.getName().compareTo(n2.getName());
-          }
-          if (o1.getResults().size() > o2.getResults().size()) {
-            return -1;
-          } else if (o1.getResults().size() < o2.getResults().size()) {
-            return 1;
-          }
-          return o1.getName().compareTo(o2.getName());
-        }
-      };
+      new RuleComparator<ProductionRule>().thenComparing(ProductionRule::getName);
 
   private final Comparator<RepairRule> repairRuleComparator =
-      new Comparator<>() {
-        final UnitTypeComparator utc = new UnitTypeComparator();
-
-        @Override
-        public int compare(final RepairRule o1, final RepairRule o2) {
-          if (o1.getResults().size() == 1 && o2.getResults().size() == 1) {
-            final NamedAttachable n1 = o1.getAnyResultKey();
-            final NamedAttachable n2 = o2.getAnyResultKey();
-            if (n1 instanceof UnitType) {
-              final UnitType u1 = (UnitType) n1;
-              if (n2 instanceof UnitType) {
-                final UnitType u2 = (UnitType) n2;
-                return utc.compare(u1, u2);
-              } else if (n2 instanceof Resource) {
-                // final Resource r2 = (Resource) n2;
-                return -1;
-              }
-              return n1.getName().compareTo(n2.getName());
-            } else if (n1 instanceof Resource) {
-              final Resource r1 = (Resource) n1;
-              if (n2 instanceof UnitType) {
-                // final UnitType u2 = (UnitType) n2;
-                return 1;
-              } else if (n2 instanceof Resource) {
-                final Resource r2 = (Resource) n2;
-                return r1.getName().compareTo(r2.getName());
-              } else {
-                return n1.getName().compareTo(n2.getName());
-              }
-            }
-            return n1.getName().compareTo(n2.getName());
-          }
-          if (o1.getResults().size() > o2.getResults().size()) {
-            return -1;
-          } else if (o1.getResults().size() < o2.getResults().size()) {
-            return 1;
-          }
-          return o1.getName().compareTo(o2.getName());
-        }
-      };
+      new RuleComparator<RepairRule>().thenComparing(RepairRule::getName);
 
   public SimpleUnitPanel(final UiContext uiContext) {
     this(uiContext, Style.LARGE_ICONS_COLUMN);
@@ -146,6 +68,7 @@ public class SimpleUnitPanel extends JPanel {
   void setUnitsFromProductionRuleMap(
       final IntegerMap<ProductionRule> units, final GamePlayer player) {
     removeAll();
+
     final TreeSet<ProductionRule> productionRules = new TreeSet<>(productionRuleComparator);
     productionRules.addAll(units.keySet());
     for (final ProductionRule productionRule : productionRules) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/SimpleUnitPanel.java
@@ -14,7 +14,6 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.image.UnitImageFactory;
 import games.strategy.triplea.util.UnitCategory;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -38,12 +37,6 @@ public class SimpleUnitPanel extends JPanel {
     LARGE_ICONS_COLUMN,
     SMALL_ICONS_WRAPPED_WITH_LABEL_WHEN_EMPTY
   }
-
-  private final Comparator<ProductionRule> productionRuleComparator =
-      new RuleComparator<ProductionRule>().thenComparing(ProductionRule::getName);
-
-  private final Comparator<RepairRule> repairRuleComparator =
-      new RuleComparator<RepairRule>().thenComparing(RepairRule::getName);
 
   public SimpleUnitPanel(final UiContext uiContext) {
     this(uiContext, Style.LARGE_ICONS_COLUMN);
@@ -69,7 +62,7 @@ public class SimpleUnitPanel extends JPanel {
       final IntegerMap<ProductionRule> units, final GamePlayer player) {
     removeAll();
 
-    final TreeSet<ProductionRule> productionRules = new TreeSet<>(productionRuleComparator);
+    final TreeSet<ProductionRule> productionRules = new TreeSet<>(new RuleComparator<>());
     productionRules.addAll(units.keySet());
     for (final ProductionRule productionRule : productionRules) {
       final int quantity = units.getInt(productionRule);
@@ -98,7 +91,7 @@ public class SimpleUnitPanel extends JPanel {
     final Set<Unit> entries = units.keySet();
     for (final Unit unit : entries) {
       final IntegerMap<RepairRule> rules = units.get(unit);
-      final TreeSet<RepairRule> repairRules = new TreeSet<>(repairRuleComparator);
+      final TreeSet<RepairRule> repairRules = new TreeSet<>(new RuleComparator<>());
       repairRules.addAll(rules.keySet());
       for (final RepairRule repairRule : repairRules) {
         // check to see if the repair rule matches the damaged unit


### PR DESCRIPTION
## Change Summary & Additional Notes

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

It's an alternative to [this](https://github.com/triplea-game/triplea/pull/10374).
Introducing a common `abstract class` in my case broke the save game compatibility hence an `interface` this time.

As @asvitkine [suggested](https://github.com/triplea-game/triplea/pull/10374#issuecomment-1109796034), I did the save game compatibility tests with the code below and the output wasn't affected by the changes.
```java
private void readObject(java.io.ObjectInputStream in) throws ClassNotFoundException, java.io.IOException {
  in.defaultReadObject();

  System.out.format("%s%ncosts: %s%nresults: %s%n", getClass().getSimpleName(), getCosts(), getResults());
}
```

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
