### PR TITLE
Introduce isOwnedBy() and streamline some matchers.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GamePlayer.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GamePlayer.java
@@ -186,7 +186,7 @@ public class GamePlayer extends NamedAttachable implements NamedUnitHolder {
                   .and(Matches.unitIsLand()))) {
         return true;
       }
-      if (t.getOwner().equals(this)
+      if (t.isOwnedBy(this)
           && t.getUnitCollection()
               .anyMatch(Matches.unitIsOwnedBy(this).and(Matches.unitCanProduceUnits()))) {
         return true;

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Route.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Route.java
@@ -317,7 +317,7 @@ public class Route implements Serializable, Iterable<Territory> {
   public boolean hasNeutralBeforeEnd() {
     for (final Territory current : getMiddleSteps()) {
       // neutral is owned by null and is not sea
-      if (!current.isWater() && current.getOwner().equals(GamePlayer.NULL_PLAYERID)) {
+      if (!current.isWater() && current.isOwnedBy(GamePlayer.NULL_PLAYERID)) {
         return true;
       }
     }

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Territory.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Territory.java
@@ -34,6 +34,10 @@ public class Territory extends NamedAttachable implements NamedUnitHolder, Compa
     getData().notifyTerritoryOwnerChanged(this);
   }
 
+  public boolean isOwnedBy(final GamePlayer player) {
+    return owner.equals(player);
+  }
+
   /** refers to unit holder being changed. */
   @Override
   public void notifyChanged() {

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Territory.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Territory.java
@@ -34,8 +34,9 @@ public class Territory extends NamedAttachable implements NamedUnitHolder, Compa
     getData().notifyTerritoryOwnerChanged(this);
   }
 
-  public boolean isOwnedBy(final GamePlayer player) {
-    return owner.equals(player);
+  public final boolean isOwnedBy(final GamePlayer player) {
+    // Use getOwner() to allow test mocks to override that method.
+    return getOwner().equals(player);
   }
 
   /** refers to unit holder being changed. */

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Unit.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Unit.java
@@ -120,8 +120,9 @@ public class Unit extends GameDataComponent implements DynamicallyModifiable {
     owner = Optional.ofNullable(player).orElse(GamePlayer.NULL_PLAYERID);
   }
 
-  public boolean isOwnedBy(final GamePlayer player) {
-    return owner.equals(player);
+  public final boolean isOwnedBy(final GamePlayer player) {
+    // Use getOwner() to allow test mocks to override that method.
+    return getOwner().equals(player);
   }
 
   public boolean isEquivalent(final Unit unit) {

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/Unit.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/Unit.java
@@ -120,6 +120,10 @@ public class Unit extends GameDataComponent implements DynamicallyModifiable {
     owner = Optional.ofNullable(player).orElse(GamePlayer.NULL_PLAYERID);
   }
 
+  public boolean isOwnedBy(final GamePlayer player) {
+    return owner.equals(player);
+  }
+
   public boolean isEquivalent(final Unit unit) {
     return type != null
         && type.equals(unit.getType())

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/UnitCollection.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/UnitCollection.java
@@ -1,5 +1,6 @@
 package games.strategy.engine.data;
 
+import games.strategy.triplea.delegate.Matches;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -55,12 +56,11 @@ public class UnitCollection extends GameDataComponent implements Collection<Unit
   }
 
   public int getUnitCount(final UnitType type, final GamePlayer owner) {
-    return (int)
-        units.stream().filter(u -> u.getType().equals(type) && u.getOwner().equals(owner)).count();
+    return (int) units.stream().filter(u -> u.getType().equals(type) && u.isOwnedBy(owner)).count();
   }
 
   int getUnitCount(final GamePlayer owner) {
-    return (int) units.stream().filter(u -> u.getOwner().equals(owner)).count();
+    return (int) units.stream().filter(u -> u.isOwnedBy(owner)).count();
   }
 
   @Override
@@ -133,7 +133,7 @@ public class UnitCollection extends GameDataComponent implements Collection<Unit
   public IntegerMap<UnitType> getUnitsByType(final GamePlayer gamePlayer) {
     final IntegerMap<UnitType> count = new IntegerMap<>();
     units.stream()
-        .filter(unit -> unit.getOwner().equals(gamePlayer))
+        .filter(Matches.unitIsOwnedBy(gamePlayer))
         .forEach(unit -> count.add(unit.getType(), 1));
     return count;
   }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/AbstractProAi.java
@@ -240,7 +240,7 @@ public abstract class AbstractProAi extends AbstractBuiltInAi {
         } else if (stepName.endsWith("Politics")) {
           proData.initializeSimulation(this, dataCopy, player);
           // Can only do politics if this player still owns its capital.
-          if (proData.getMyCapital() == null || proData.getMyCapital().getOwner().equals(player)) {
+          if (proData.getMyCapital() == null || proData.getMyCapital().isOwnedBy(player)) {
             final PoliticsDelegate politicsDelegate = dataCopy.getPoliticsDelegate();
             politicsDelegate.setDelegateBridgeAndPlayer(bridge);
             final List<PoliticalActionAttachment> actions = politicsAi.politicalActions();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProCombatMoveAi.java
@@ -123,7 +123,7 @@ public class ProCombatMoveAi {
     removeTerritoriesWhereTransportsAreExposed();
 
     // Determine if capital can be held if I still own it
-    if (proData.getMyCapital() != null && proData.getMyCapital().getOwner().equals(player)) {
+    if (proData.getMyCapital() != null && proData.getMyCapital().isOwnedBy(player)) {
       removeAttacksUntilCapitalCanBeHeld(
           attackOptions, proData.getPurchaseOptions().getLandOptions());
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProNonCombatMoveAi.java
@@ -881,7 +881,7 @@ class ProNonCombatMoveAi {
             continue; // skip moving air to water if not enough carrier capacity
           }
           if (!t.isWater()
-              && !t.getOwner().equals(player)
+              && !t.isOwnedBy(player)
               && Matches.unitIsAir().test(unit)
               && !ProMatches.territoryHasInfraFactoryAndIsLand().test(t)) {
             continue; // skip moving air units to allied land without a factory

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPoliticsAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPoliticsAi.java
@@ -104,8 +104,8 @@ class ProPoliticsAi {
         int count = 0;
         final List<GamePlayer> enemyPlayers = enemyMap.get(action);
         for (final ProTerritory patd : attackOptions) {
-          if (Matches.isTerritoryOwnedBy(enemyPlayers).test(patd.getTerritory())
-              || Matches.territoryHasUnitsThatMatch(Matches.unitOwnedBy(enemyPlayers))
+          if (Matches.isTerritoryOwnedByAnyOf(enemyPlayers).test(patd.getTerritory())
+              || Matches.territoryHasUnitsThatMatch(Matches.unitIsOwnedByAnyOf(enemyPlayers))
                   .test(patd.getTerritory())) {
             count++;
           }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/ProPurchaseAi.java
@@ -890,7 +890,7 @@ class ProPurchaseAi {
           final int numNearbyEnemyTerritories =
               CollectionUtils.countMatches(
                   nearbyLandTerritories,
-                  Matches.isTerritoryOwnedBy(ProUtils.getPotentialEnemyPlayers(player)));
+                  Matches.isTerritoryOwnedByAnyOf(ProUtils.getPotentialEnemyPlayers(player)));
           final boolean hasLocalLandSuperiority =
               ProBattleUtils.territoryHasLocalLandSuperiority(
                   proData, t, ProBattleUtils.SHORT_RANGE, player);
@@ -1030,7 +1030,7 @@ class ProPurchaseAi {
                   ProMatches.territoryCanPotentiallyMoveLandUnits(player, data.getProperties()));
       final List<Territory> enemyLandTerritories =
           CollectionUtils.getMatches(
-              landTerritories, Matches.isTerritoryOwnedBy(ProUtils.getEnemyPlayers(player)));
+              landTerritories, Matches.isTerritoryOwnedByAnyOf(ProUtils.getEnemyPlayers(player)));
       territoriesToCheck.addAll(enemyLandTerritories);
     }
     final Map<Territory, Double> territoryValueMap =

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/simulate/ProSimulateTurnUtils.java
@@ -243,7 +243,7 @@ public final class ProSimulateTurnUtils {
               Matches.isTerritoryAllied(terrOrigOwner, data.getRelationshipTracker()));
       friendlyTerritories.add(t);
       for (final Territory item : friendlyTerritories) {
-        if (item.getOwner().equals(terrOrigOwner)) {
+        if (item.isOwnedBy(terrOrigOwner)) {
           continue;
         }
         final Change takeOverFriendlyTerritories = ChangeFactory.changeOwner(item, terrOrigOwner);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProMatches.java
@@ -292,7 +292,7 @@ public final class ProMatches {
       final RelationshipTracker relationshipTracker,
       final List<GamePlayer> players) {
     return Matches.territoryHasEnemyUnits(player, relationshipTracker)
-        .or(Matches.territoryHasUnitsThatMatch(Matches.unitOwnedBy(players)));
+        .or(Matches.territoryHasUnitsThatMatch(Matches.unitIsOwnedByAnyOf(players)));
   }
 
   public static Predicate<Territory> territoryHasNoEnemyUnitsOrCleared(
@@ -331,7 +331,7 @@ public final class ProMatches {
     final Predicate<Territory> ownedAndCantBeHeld =
         Matches.isTerritoryOwnedBy(player).and(territoriesThatCantBeHeld::contains);
     final Predicate<Territory> enemyOrOwnedCantBeHeld =
-        Matches.isTerritoryOwnedBy(players).or(ownedAndCantBeHeld);
+        Matches.isTerritoryOwnedByAnyOf(players).or(ownedAndCantBeHeld);
     return territoryHasInfraFactoryAndIsLand().and(enemyOrOwnedCantBeHeld);
   }
 
@@ -398,7 +398,7 @@ public final class ProMatches {
   public static Predicate<Territory> territoryHasNeighborOwnedByAndHasLandUnit(
       final GameMap gameMap, final List<GamePlayer> players) {
     final Predicate<Territory> territoryMatch =
-        Matches.isTerritoryOwnedBy(players)
+        Matches.isTerritoryOwnedByAnyOf(players)
             .and(Matches.territoryHasUnitsThatMatch(Matches.unitIsLand()));
     return Matches.territoryHasNeighborMatching(gameMap, territoryMatch);
   }
@@ -461,7 +461,7 @@ public final class ProMatches {
       final RelationshipTracker relationshipTracker,
       final List<GamePlayer> players) {
     return Matches.isTerritoryEnemyAndNotUnownedWater(player, relationshipTracker)
-        .or(Matches.isTerritoryOwnedBy(players));
+        .or(Matches.isTerritoryOwnedByAnyOf(players));
   }
 
   public static Predicate<Territory> territoryIsPotentialEnemyOrHasPotentialEnemyUnits(
@@ -619,7 +619,7 @@ public final class ProMatches {
   }
 
   static Predicate<Unit> unitIsOwnedAir(final GamePlayer player) {
-    return Matches.unitOwnedBy(player).and(Matches.unitIsAir());
+    return Matches.unitIsOwnedBy(player).and(Matches.unitIsAir());
   }
 
   public static Predicate<Unit> unitIsOwnedAndMatchesTypeAndIsTransporting(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProTerritoryValueUtils.java
@@ -230,7 +230,8 @@ public final class ProTerritoryValueUtils {
                     player, ProUtils.getPotentialEnemyPlayers(player), territoriesThatCantBeHeld)));
     final int numPotentialEnemyTerritories =
         CollectionUtils.countMatches(
-            allTerritories, Matches.isTerritoryOwnedBy(ProUtils.getPotentialEnemyPlayers(player)));
+            allTerritories,
+            Matches.isTerritoryOwnedByAnyOf(ProUtils.getPotentialEnemyPlayers(player)));
     if (enemyCapitalsAndFactories.size() * 2 >= numPotentialEnemyTerritories) {
       enemyCapitalsAndFactories.clear();
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/pro/util/ProUtils.java
@@ -118,7 +118,7 @@ public final class ProUtils {
     for (final Territory place : data.getMap().getTerritories()) {
       // Match will Check if terr is a Land Convoy Route and check ownership of neighboring Sea
       // Zone, or if contested
-      if (place.getOwner().equals(player)
+      if (place.isOwnedBy(player)
           && Matches.territoryCanCollectIncomeFrom(
                   player, data.getProperties(), data.getRelationshipTracker())
               .test(place)) {
@@ -147,7 +147,7 @@ public final class ProUtils {
             Matches.territoryIsNotImpassableToLandUnits(player, data.getProperties())));
     enemyCapitals.retainAll(
         CollectionUtils.getMatches(
-            enemyCapitals, Matches.isTerritoryOwnedBy(getPotentialEnemyPlayers(player))));
+            enemyCapitals, Matches.isTerritoryOwnedByAnyOf(getPotentialEnemyPlayers(player))));
     return enemyCapitals;
   }
 
@@ -184,7 +184,7 @@ public final class ProUtils {
                 ProMatches.territoryCanPotentiallyMoveLandUnits(player, data.getProperties()));
     final List<Territory> enemyLandTerritories =
         CollectionUtils.getMatches(
-            landTerritories, Matches.isTerritoryOwnedBy(getPotentialEnemyPlayers(player)));
+            landTerritories, Matches.isTerritoryOwnedByAnyOf(getPotentialEnemyPlayers(player)));
     int minDistance = 10;
     for (final Territory enemyLandTerritory : enemyLandTerritories) {
       final int distance =
@@ -218,7 +218,7 @@ public final class ProUtils {
                 ProMatches.territoryCanPotentiallyMoveLandUnits(player, data.getProperties()));
     final List<Territory> enemyLandTerritories =
         CollectionUtils.getMatches(
-            landTerritories, Matches.isTerritoryOwnedBy(getEnemyPlayers(player)));
+            landTerritories, Matches.isTerritoryOwnedByAnyOf(getEnemyPlayers(player)));
     int minDistance = 10;
     for (final Territory enemyLandTerritory : enemyLandTerritories) {
       if (territoryValueMap.get(enemyLandTerritory) <= 0) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ai/weak/WeakAi.java
@@ -98,7 +98,7 @@ public class WeakAi extends AbstractBuiltInAi {
     final Territory capitol =
         TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data.getMap());
     // we dont own our own capitol
-    if (capitol == null || !capitol.getOwner().equals(player)) {
+    if (capitol == null || !capitol.isOwnedBy(player)) {
       return false;
     }
     // find a land route to an enemy territory from our capitol
@@ -160,7 +160,7 @@ public class WeakAi extends AbstractBuiltInAi {
     }
     final Territory capitol =
         TerritoryAttachment.getFirstOwnedCapitalOrFirstUnownedCapital(player, data.getMap());
-    if (capitol == null || !capitol.getOwner().equals(player)) {
+    if (capitol == null || !capitol.isOwnedBy(player)) {
       return List.of();
     }
     final var moves = new ArrayList<MoveDescription>();
@@ -1084,7 +1084,7 @@ public class WeakAi extends AbstractBuiltInAi {
     Collections.shuffle(randomTerritories);
     for (final Territory t : randomTerritories) {
       if (!t.equals(capitol)
-          && t.getOwner().equals(player)
+          && t.isOwnedBy(player)
           && t.getUnitCollection().anyMatch(Matches.unitCanProduceUnits())) {
         placeAllWeCanOn(data, t, placeDelegate, player);
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/RulesAttachment.java
@@ -997,8 +997,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       switch (exclType) {
         case "direct":
           allUnits.removeAll(
-              CollectionUtils.getMatches(
-                  allUnits, Matches.unitIsOwnedByOfAnyOfThesePlayers(players).negate()));
+              CollectionUtils.getMatches(allUnits, Matches.unitIsOwnedByAnyOf(players).negate()));
           break;
         case "allied":
           allUnits.retainAll(
@@ -1085,8 +1084,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
       switch (exclType) {
         case "allied": // any allied units in the territory. (does not include owned units)
           allUnits.removeAll(
-              CollectionUtils.getMatches(
-                  allUnits, Matches.unitIsOwnedByOfAnyOfThesePlayers(players)));
+              CollectionUtils.getMatches(allUnits, Matches.unitIsOwnedByAnyOf(players)));
           allUnits.retainAll(
               CollectionUtils.getMatches(
                   allUnits,
@@ -1094,8 +1092,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
           break;
         case "direct":
           allUnits.removeAll(
-              CollectionUtils.getMatches(
-                  allUnits, Matches.unitIsOwnedByOfAnyOfThesePlayers(players).negate()));
+              CollectionUtils.getMatches(allUnits, Matches.unitIsOwnedByAnyOf(players).negate()));
           break;
         case "enemy": // any enemy units in the territory
           allUnits.retainAll(
@@ -1176,7 +1173,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
             Matches.isAlliedWithAnyOfThesePlayers(players, data.getRelationshipTracker()));
     for (final Territory listedTerr : listedTerrs) {
       // if the territory owner is an ally
-      if (Matches.isTerritoryOwnedBy(allies).test(listedTerr)) {
+      if (Matches.isTerritoryOwnedByAnyOf(allies).test(listedTerr)) {
         numberMet += 1;
         if (numberMet >= numberNeeded) {
           satisfied = true;
@@ -1203,7 +1200,7 @@ public class RulesAttachment extends AbstractPlayerRulesAttachment {
     int numberMet = 0;
     boolean satisfied = false;
     for (final Territory listedTerr : listedTerrs) {
-      if (Matches.isTerritoryOwnedBy(players).test(listedTerr)) {
+      if (Matches.isTerritoryOwnedByAnyOf(players).test(listedTerr)) {
         numberMet += 1;
         if (numberMet >= numberNeeded) {
           satisfied = true;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractEndTurnDelegate.java
@@ -418,7 +418,7 @@ public abstract class AbstractEndTurnDelegate extends BaseTripleADelegate
               currTerritory
                   .getUnitCollection()
                   .getMatches(
-                      Matches.unitOwnedBy(player)
+                      Matches.unitIsOwnedBy(player)
                           .and(Matches.unitCanBeGivenByTerritoryTo(newOwner)));
           if (!units.isEmpty()) {
             change.add(ChangeFactory.changeOwner(units, newOwner, currTerritory));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/AbstractPlaceDelegate.java
@@ -656,15 +656,14 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
     // units can be null if we are just testing the territory itself...
     final Collection<Unit> testUnits = (units == null ? new ArrayList<>() : units);
     final boolean canProduceInConquered = isPlacementAllowedInCapturedTerritory(player);
-    if (!producer.getOwner().equals(player)) {
+    if (!producer.isOwnedBy(player)) {
       // sea constructions require either owning the sea zone or owning a surrounding land territory
       if (producer.isWater()
           && testUnits.stream().anyMatch(Matches.unitIsSea().and(Matches.unitIsConstruction()))) {
         boolean ownedNeighbor = false;
         for (final Territory current :
             getData().getMap().getNeighbors(to, Matches.territoryIsLand())) {
-          if (current.getOwner().equals(player)
-              && (canProduceInConquered || !wasConquered(current))) {
+          if (current.isOwnedBy(player) && (canProduceInConquered || !wasConquered(current))) {
             ownedNeighbor = true;
             break;
           }
@@ -826,7 +825,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
       }
     } else {
       // make sure we own the territory
-      if (!to.getOwner().equals(player)) {
+      if (!to.isOwnedBy(player)) {
         if (GameStepPropertiesHelper.isBid(getData())) {
           final PlayerAttachment pa = PlayerAttachment.get(to.getOwner());
           if ((pa == null
@@ -967,7 +966,7 @@ public abstract class AbstractPlaceDelegate extends BaseTripleADelegate
                   .anyMatch(
                       Matches.unitIsCarrier()
                           .and(
-                              Matches.unitIsOwnedByOfAnyOfThesePlayers(
+                              Matches.unitIsOwnedByAnyOf(
                                   GameStepPropertiesHelper.getCombinedTurns(
                                       getData(), player)))))) {
         placeableUnits.addAll(

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/BidPlaceDelegate.java
@@ -53,9 +53,7 @@ public class BidPlaceDelegate extends AbstractPlaceDelegate {
     // we can place on territories we own
     if (units.stream().anyMatch(Matches.unitIsSea())) {
       return "Cant place sea units on land";
-    } else if (to.getOwner() == null) {
-      return "You dont own " + to.getName();
-    } else if (!to.getOwner().equals(player)) {
+    } else if (!to.isOwnedBy(player)) {
       final PlayerAttachment pa = PlayerAttachment.get(to.getOwner());
       if (pa != null
           && pa.getGiveUnitControl() != null

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EditValidator.java
@@ -39,8 +39,8 @@ final class EditValidator {
   }
 
   static String validateChangeTerritoryOwner(final GameData data, final Territory territory) {
-    if (Matches.territoryIsWater().test(territory)
-        && territory.getOwner().equals(GamePlayer.NULL_PLAYERID)
+    if (territory.isWater()
+        && territory.isOwnedBy(GamePlayer.NULL_PLAYERID)
         && TerritoryAttachment.get(territory) == null) {
       return "Territory is water and has no attachment";
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/EndRoundDelegate.java
@@ -241,7 +241,7 @@ public class EndRoundDelegate extends BaseTripleADelegate {
           data.getAllianceTracker().getPlayersInAlliance(allianceName);
       int teamVCs = 0;
       for (final Territory t : territories) {
-        if (Matches.isTerritoryOwnedBy(teamMembers).test(t)) {
+        if (Matches.isTerritoryOwnedByAnyOf(teamMembers).test(t)) {
           final TerritoryAttachment ta = TerritoryAttachment.get(t);
           if (ta != null) {
             teamVCs += ta.getVictoryCity();

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/SpecialMoveDelegate.java
@@ -335,7 +335,7 @@ public class SpecialMoveDelegate extends AbstractMoveDelegate {
 
   private static Predicate<Unit> getAirborneMatch(
       final Set<UnitType> types, final Collection<GamePlayer> unitOwners) {
-    return Matches.unitIsOwnedByOfAnyOfThesePlayers(unitOwners)
+    return Matches.unitIsOwnedByAnyOf(unitOwners)
         .and(Matches.unitIsOfTypes(types))
         .and(Matches.unitIsNotDisabled())
         .and(Matches.unitHasNotMoved())

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TransportTracker.java
@@ -211,7 +211,7 @@ public class TransportTracker {
       // the owner of the unit
       if (unit.getWasLoadedThisTurn()
           && unit.getTransportedBy() != null
-          && !unit.getTransportedBy().getOwner().equals(unit.getOwner())) {
+          && !unit.getTransportedBy().isOwnedBy(unit.getOwner())) {
         loadedUnits.add(unit);
       }
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/BattleTracker.java
@@ -780,7 +780,7 @@ public class BattleTracker implements Serializable {
         newOwner = gamePlayer;
         for (final Territory current :
             TerritoryAttachment.getAllCapitals(terrOrigOwner, data.getMap())) {
-          if (territory.equals(current) || current.getOwner().equals(GamePlayer.NULL_PLAYERID)) {
+          if (territory.equals(current) || current.isOwnedBy(GamePlayer.NULL_PLAYERID)) {
             // if a neutral controls our capital, our territories get liberated (ie: china in ww2v3)
             newOwner = terrOrigOwner;
             break;
@@ -877,7 +877,7 @@ public class BattleTracker implements Serializable {
               Matches.isTerritoryAllied(terrOrigOwner, data.getRelationshipTracker()));
       // give back the factories as well.
       for (final Territory item : friendlyTerritories) {
-        if (item.getOwner().equals(terrOrigOwner)) {
+        if (item.isOwnedBy(terrOrigOwner)) {
           continue;
         }
         final Change takeOverFriendlyTerritories = ChangeFactory.changeOwner(item, terrOrigOwner);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/MustFightBattle.java
@@ -270,8 +270,8 @@ public class MustFightBattle extends DependentBattle
         CollectionUtils.getMatches(
             unitsLeftInTerritory,
             getWhoWon() != WhoWon.DEFENDER
-                ? Matches.unitOwnedBy(attacker)
-                : Matches.unitOwnedBy(attacker)
+                ? Matches.unitIsOwnedBy(attacker)
+                : Matches.unitIsOwnedBy(attacker)
                     .and(Matches.unitIsAir())
                     .and(Matches.unitIsNotInfrastructure())));
     return new ArrayList<>(remaining);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/UnitBattleComparator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/battle/UnitBattleComparator.java
@@ -65,7 +65,7 @@ public class UnitBattleComparator implements Comparator<Unit> {
     final UnitAttachment ua1 = UnitAttachment.get(u1.getType());
     final UnitAttachment ua2 = UnitAttachment.get(u2.getType());
     if (ua1.equals(ua2)
-        && u1.getOwner().equals(u2.getOwner())
+        && u1.isOwnedBy(u2.getOwner())
         && u1.getWasAmphibious() == u2.getWasAmphibious()) {
       if (transporting1 && !transporting2) {
         return 1;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/AirMovementValidator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/move/validation/AirMovementValidator.java
@@ -621,7 +621,9 @@ public final class AirMovementValidator {
   private static List<Unit> getAirUnitsToValidate(
       final Collection<Unit> units, final Route route, final GamePlayer player) {
     final Predicate<Unit> ownedAirMatch =
-        Matches.unitIsAir().and(Matches.unitOwnedBy(player)).and(Matches.unitIsKamikaze().negate());
+        Matches.unitIsAir()
+            .and(Matches.unitIsOwnedBy(player))
+            .and(Matches.unitIsKamikaze().negate());
     final List<Unit> ownedAir = new ArrayList<>();
     ownedAir.addAll(CollectionUtils.getMatches(route.getEnd().getUnits(), ownedAirMatch));
     ownedAir.addAll(CollectionUtils.getMatches(units, ownedAirMatch));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportCalculator.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/power/calculator/SupportCalculator.java
@@ -62,7 +62,7 @@ public class SupportCalculator {
       }
       final Predicate<Unit> canSupport =
           Matches.unitIsOfType((UnitType) rule.getAttachedTo())
-              .and(Matches.unitOwnedBy(rule.getPlayers()));
+              .and(Matches.unitIsOwnedByAnyOf(rule.getPlayers()));
       final List<Unit> supporters = CollectionUtils.getMatches(unitsGivingTheSupport, canSupport);
       if (supporters.isEmpty()) {
         continue;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/PlayerUnitsPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/odds/calculator/PlayerUnitsPanel.java
@@ -69,10 +69,10 @@ public class PlayerUnitsPanel extends JPanel {
 
     categories.sort(
         (c1, c2) -> {
-          if (!c1.getOwner().equals(c2.getOwner())) {
-            if (c1.getOwner().equals(gamePlayer)) {
+          if (!c1.isOwnedBy(c2.getOwner())) {
+            if (c1.isOwnedBy(gamePlayer)) {
               return -1;
-            } else if (c2.getOwner().equals(gamePlayer)) {
+            } else if (c2.isOwnedBy(gamePlayer)) {
               return 1;
             } else {
               return c1.getOwner().getName().compareTo(c2.getOwner().getName());
@@ -130,7 +130,7 @@ public class PlayerUnitsPanel extends JPanel {
     JPanel panel = null;
     for (final UnitCategory category : categories) {
       if (predicate.test(category.getType())) {
-        if (!category.getOwner().equals(previousPlayer)) {
+        if (!category.isOwnedBy(previousPlayer)) {
           panel = new JPanel();
           panel.setLayout(new BoxLayout(panel, BoxLayout.Y_AXIS));
           panel.setBorder(BorderFactory.createEmptyBorder(0, 0, 0, 10));
@@ -209,7 +209,7 @@ public class PlayerUnitsPanel extends JPanel {
     }
     for (final Territory t : data.getMap()) {
       for (final Unit u : t.getUnitCollection()) {
-        if (u.getOwner().equals(player)) {
+        if (u.isOwnedBy(player)) {
           unitTypes.add(u.getType());
         }
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/EditProductionPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/EditProductionPanel.java
@@ -67,7 +67,7 @@ class EditProductionPanel extends ProductionPanel {
       // art for, so only use the units on a map.
       for (final Territory t : data.getMap()) {
         for (final Unit u : t.getUnitCollection()) {
-          if (u.getOwner().equals(player)) {
+          if (u.isOwnedBy(player)) {
             final UnitType ut = u.getType();
             if (!unitsAllowed.contains(ut)) {
               unitsAllowed.add(ut);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/PlacePanel.java
@@ -209,7 +209,7 @@ class PlacePanel extends AbstractMovePanel implements GameDataChangeListener {
     getData().acquireReadLock();
     try {
       // not our territory
-      if (!territory.isWater() && !territory.getOwner().equals(getCurrentPlayer())) {
+      if (!territory.isWater() && !territory.isOwnedBy(getCurrentPlayer())) {
         if (GameStepPropertiesHelper.isBid(getData())) {
           final PlayerAttachment pa = PlayerAttachment.get(territory.getOwner());
           if ((pa == null

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/ProductionRepairPanel.java
@@ -132,7 +132,7 @@ class ProductionRepairPanel extends JPanel {
       this.gamePlayer = player;
       this.allowedPlayersToRepair = allowedPlayersToRepair;
       Predicate<Unit> myDamagedUnits =
-          Matches.unitIsOwnedByOfAnyOfThesePlayers(this.allowedPlayersToRepair)
+          Matches.unitIsOwnedByAnyOf(this.allowedPlayersToRepair)
               .and(Matches.unitHasTakenSomeBombingUnitDamage());
       if (GameStepPropertiesHelper.isOnlyRepairIfDisabled(data)) {
         myDamagedUnits = myDamagedUnits.and(Matches.unitIsDisabled());

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/TerritoryDetailPanel.java
@@ -201,7 +201,7 @@ public class TerritoryDetailPanel extends JPanel {
     @Nullable GamePlayer currentPlayer = null;
     for (final UnitCategory item : units) {
       // separate players with a separator
-      if (!item.getOwner().equals(currentPlayer)) {
+      if (!item.isOwnedBy(currentPlayer)) {
         currentPlayer = item.getOwner();
         panel.add(Box.createVerticalStrut(15));
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/history/HistoryLog.java
@@ -486,7 +486,7 @@ public class HistoryLog extends JFrame {
         .append(" : \n\n");
     for (final Territory t : territories) {
       final List<Unit> ownedUnits =
-          t.getUnitCollection().getMatches(Matches.unitIsOwnedByOfAnyOfThesePlayers(players));
+          t.getUnitCollection().getMatches(Matches.unitIsOwnedByAnyOf(players));
       // see if there's a flag
       final TerritoryAttachment ta = TerritoryAttachment.get(t);
       final boolean hasFlag =
@@ -560,10 +560,10 @@ public class HistoryLog extends JFrame {
           || (ta != null
               && !GamePlayer.NULL_PLAYERID.equals(OriginalOwnerTracker.getOriginalOwner(place))
               && player.equals(OriginalOwnerTracker.getOriginalOwner(place))
-              && place.getOwner().equals(player))) {
+              && place.isOwnedBy(player))) {
         isConvoyOrLand = true;
       }
-      if (place.getOwner().equals(player) && isConvoyOrLand && ta != null) {
+      if (place.isOwnedBy(player) && isConvoyOrLand && ta != null) {
         production += ta.getProduction();
       }
     }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/UnitStatsTable.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/menubar/help/UnitStatsTable.java
@@ -134,7 +134,7 @@ public class UnitStatsTable {
     // art for, so only use the units on a map.
     for (final Territory t : data.getMap()) {
       for (final Unit u : t.getUnitCollection()) {
-        if (u.getOwner().equals(player)) {
+        if (u.isOwnedBy(player)) {
           final UnitType ut = u.getType();
           unitTypes.add(ut);
         }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
@@ -885,7 +885,7 @@ public class MovePanel extends AbstractMovePanel {
         final Collection<Unit> transporting = transport.getTransporting();
         for (final Unit candidate : transporting) {
           if (selected.getType().equals(candidate.getType())
-              && selected.getOwner().equals(candidate.getOwner())
+              && selected.isOwnedBy(candidate.getOwner())
               && selected.getHits() == candidate.getHits()) {
             hasChanged = true;
             selectedUnitsToUnload.add(candidate);
@@ -906,7 +906,7 @@ public class MovePanel extends AbstractMovePanel {
       while (candidateIter.hasNext()) {
         final Unit candidate = candidateIter.next();
         if (selected.getType().equals(candidate.getType())
-            && selected.getOwner().equals(candidate.getOwner())
+            && selected.isOwnedBy(candidate.getOwner())
             && selected.getHits() == candidate.getHits()) {
           selectedUnitsToUnload.add(candidate);
           candidateIter.remove();
@@ -1177,7 +1177,7 @@ public class MovePanel extends AbstractMovePanel {
         CollectionUtils.getMatches(
             capableTransports, Matches.transportCannotUnload(route.getEnd()));
     capableTransports.removeAll(incapableTransports);
-    final Predicate<Unit> alliedMatch = transport -> !transport.getOwner().equals(unitOwner);
+    final Predicate<Unit> alliedMatch = Matches.unitIsOwnedBy(unitOwner).negate();
     final Collection<Unit> alliedTransports =
         CollectionUtils.getMatches(capableTransports, alliedMatch);
     capableTransports.removeAll(alliedTransports);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/util/UnitCategory.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/util/UnitCategory.java
@@ -178,6 +178,10 @@ public class UnitCategory implements Comparable<UnitCategory> {
     return owner;
   }
 
+  public boolean isOwnedBy(GamePlayer player) {
+    return owner.equals(player);
+  }
+
   public void addUnit(final Unit unit) {
     units.add(unit);
   }

--- a/game-app/game-core/src/test/java/games/strategy/engine/data/changefactory/OwnerChangeTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/engine/data/changefactory/OwnerChangeTest.java
@@ -11,6 +11,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.delegate.GameDataTestUtil;
 import games.strategy.triplea.xml.TestMapGameData;
 import org.junit.jupiter.api.Test;
+import org.triplea.java.collections.CollectionUtils;
 
 class OwnerChangeTest {
 
@@ -32,7 +33,7 @@ class OwnerChangeTest {
     assertThat(
         "The (non-mobile) factory should be taken over"
             + " when the allied player takes over the territory",
-        territory.getUnits().iterator().next().getOwner().equals(americans),
+        CollectionUtils.getAny(territory.getUnits()).isOwnedBy(americans),
         is(true));
   }
 
@@ -54,7 +55,7 @@ class OwnerChangeTest {
     assertThat(
         "The (mobile) anti air gun should be taken over"
             + " when the allied player takes over the territory",
-        territory.getUnits().iterator().next().getOwner().equals(british),
+        CollectionUtils.getAny(territory.getUnits()).isOwnedBy(british),
         is(true));
   }
 }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/WW2V3Year41Test.java
@@ -499,7 +499,7 @@ class WW2V3Year41Test {
     // battle already fought
     // make sure the infantry die with the transport
     assertTrue(
-        sz7.getUnitCollection().getMatches(Matches.unitOwnedBy(british)).isEmpty(),
+        sz7.getUnitCollection().getMatches(Matches.unitIsOwnedBy(british)).isEmpty(),
         sz7.getUnitCollection().toString());
   }
 
@@ -993,7 +993,7 @@ class WW2V3Year41Test {
     // move the transport out
     assertValid(
         moveDelegate.move(
-            sz7.getUnitCollection().getMatches(Matches.unitOwnedBy(british(gameData))),
+            sz7.getUnitCollection().getMatches(Matches.unitIsOwnedBy(british(gameData))),
             new Route(sz7, sz6)));
   }
 
@@ -1257,7 +1257,7 @@ class WW2V3Year41Test {
     move(sz14.getUnits(), new Route(sz14, sz15));
     // move troops from Libya
     move(
-        li.getUnitCollection().getMatches(Matches.unitOwnedBy(italians(gameData))),
+        li.getUnitCollection().getMatches(Matches.unitIsOwnedBy(italians(gameData))),
         new Route(li, eg));
     // unload the transports
     move(sz15.getUnitCollection().getMatches(Matches.unitIsLand()), new Route(sz15, eg));
@@ -1378,7 +1378,7 @@ class WW2V3Year41Test {
     move(sz14.getUnits(), new Route(sz14, sz15));
     // move troops from Libya
     move(
-        li.getUnitCollection().getMatches(Matches.unitOwnedBy(italians(gameData))),
+        li.getUnitCollection().getMatches(Matches.unitIsOwnedBy(italians(gameData))),
         new Route(li, eg));
     // unload the transports
     move(sz15.getUnitCollection().getMatches(Matches.unitIsLand()), new Route(sz15, eg));


### PR DESCRIPTION
## Change Summary & Additional Notes
Introduce isOwnedBy() and streamline some matchers.

isOwnedBy() is a convenience method that should be used in place of getOwner().equals(). This change also streamlines some related matchers.

No functional changes.


<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
