### PR TITLE
Fix issue preventing units being unloaded from transports.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
@@ -749,6 +749,9 @@ public class MovePanel extends AbstractMovePanel {
     final Collection<Unit> allUnits = getFirstSelectedTerritory().getUnits();
     final List<Unit> candidateUnits =
         CollectionUtils.getMatches(allUnits, getUnloadableMatch(route, unitsToUnload));
+    if (unitsToUnload.size() == candidateUnits.size()) {
+      return ImmutableList.copyOf(unitsToUnload);
+    }
     final List<Unit> candidateTransports =
         CollectionUtils.getMatches(
             allUnits, Matches.unitIsTransportingSomeCategories(candidateUnits));

--- a/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/ui/panel/move/MovePanel.java
@@ -766,8 +766,8 @@ public class MovePanel extends AbstractMovePanel {
     }
 
     if (candidateTransports.size() == 1) {
-      // All transports of the same type, don't show a dialog but still run the unload algorithm
-      // so that units on incapable transports are replaced with units on capable ones.
+      // Only one transport after filtering out incapable ones. Don't show a dialog but still run
+      // the unload algorithm to substitute units on incapable transports with ones on capable ones.
       return chooseUnitsToUnload(route, unitsToUnload, candidateUnits, candidateTransports);
     }
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/util/TransportUtilsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/util/TransportUtilsTest.java
@@ -1,0 +1,115 @@
+package games.strategy.triplea.util;
+
+import static games.strategy.triplea.delegate.GameDataTestUtil.addTo;
+import static games.strategy.triplea.delegate.GameDataTestUtil.armour;
+import static games.strategy.triplea.delegate.GameDataTestUtil.germans;
+import static games.strategy.triplea.delegate.GameDataTestUtil.infantry;
+import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
+import static games.strategy.triplea.delegate.GameDataTestUtil.transport;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.equalTo;
+
+import games.strategy.engine.data.GameData;
+import games.strategy.engine.data.GameStep;
+import games.strategy.engine.data.MutableProperty;
+import games.strategy.engine.data.Route;
+import games.strategy.engine.data.Territory;
+import games.strategy.engine.data.Unit;
+import games.strategy.triplea.xml.TestMapGameData;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+public class TransportUtilsTest {
+  private final GameData gameData = createGameData();
+
+  private final Territory sz5 = territory("5 Sea Zone", gameData);
+  private final Territory norway = territory("Norway", gameData);
+  private final Territory karelia = territory("Karelia S.S.R.", gameData);
+  private final Route toNorway = new Route(sz5, norway);
+
+  private final Unit transport1 = transport(gameData).create(germans(gameData));
+  private final Unit transport2 = transport(gameData).create(germans(gameData));
+  private final Unit transport3 = transport(gameData).create(germans(gameData));
+  private final Unit transport4 = transport(gameData).create(germans(gameData));
+  private final Unit infantry1 = infantry(gameData).create(germans(gameData));
+  private final Unit infantry2 = infantry(gameData).create(germans(gameData));
+  private final Unit infantry3 = infantry(gameData).create(germans(gameData));
+  private final Unit infantry4 = infantry(gameData).create(germans(gameData));
+  private final Unit tank1 = armour(gameData).create(germans(gameData));
+  private final Unit tank2 = armour(gameData).create(germans(gameData));
+  private final Unit tank3 = armour(gameData).create(germans(gameData));
+
+  private static GameData createGameData() {
+    GameData data = TestMapGameData.REVISED.getGameData();
+    data.getSequence().setRoundAndStep(1, GameStep.PropertyKeys.NON_COMBAT_MOVE, germans(data));
+    return data;
+  }
+
+  private static void addTransportedUnits(Territory t, Unit transport, List<Unit> units) {
+    addTo(t, List.of(transport));
+    addTo(t, units);
+    units.forEach(u -> u.setTransportedBy(transport));
+  }
+
+  private static void setUnloadedTo(Unit transport, Territory t)
+      throws MutableProperty.InvalidValueException {
+    // Create a dummy unit that was "unloaded".
+    final Unit dummyUnit = infantry(transport.getData()).create(transport.getOwner());
+    transport.setUnloaded(List.of(dummyUnit));
+    dummyUnit.getPropertyOrThrow(Unit.UNLOADED_TO).setValue(t);
+    assertThat(dummyUnit.getUnloadedTo(), equalTo(t));
+  }
+
+  @Nested
+  class ChooseEquivalentUnitsToUnload {
+    @Test
+    void testNoSubstitutions() {
+      addTransportedUnits(sz5, transport1, List.of(infantry1, infantry2));
+      addTransportedUnits(sz5, transport2, List.of(infantry3, tank1));
+
+      final var units = List.of(infantry1, infantry2, infantry3, tank1);
+      final var result = TransportUtils.chooseEquivalentUnitsToUnload(toNorway, units);
+      assertThat(result, containsInAnyOrder(units.toArray()));
+    }
+
+    @Test
+    void testSubstituteOneUnit() throws MutableProperty.InvalidValueException {
+      addTransportedUnits(sz5, transport1, List.of(infantry1, infantry2));
+      addTransportedUnits(sz5, transport2, List.of(infantry3));
+      setUnloadedTo(transport2, karelia);
+
+      final var units = List.of(infantry2, infantry3);
+      final var result = TransportUtils.chooseEquivalentUnitsToUnload(toNorway, units);
+      assertThat(result, containsInAnyOrder(infantry1, infantry2));
+    }
+
+    @Test
+    void testSubstituteTwoForTwo() throws MutableProperty.InvalidValueException {
+      addTransportedUnits(sz5, transport1, List.of(infantry1, infantry2));
+      addTransportedUnits(sz5, transport2, List.of(infantry3));
+      addTransportedUnits(sz5, transport3, List.of(infantry4));
+      setUnloadedTo(transport2, karelia);
+      setUnloadedTo(transport3, karelia);
+
+      final var units = List.of(infantry3, infantry4);
+      final var result = TransportUtils.chooseEquivalentUnitsToUnload(toNorway, units);
+      assertThat(result, containsInAnyOrder(infantry1, infantry2));
+    }
+
+    @Test
+    void testGroupOfDifferentUnits() throws MutableProperty.InvalidValueException {
+      addTransportedUnits(sz5, transport1, List.of(infantry1, tank1));
+      addTransportedUnits(sz5, transport2, List.of(infantry2, tank2));
+      addTransportedUnits(sz5, transport3, List.of(infantry3));
+      setUnloadedTo(transport3, karelia);
+      addTransportedUnits(sz5, transport4, List.of(tank3));
+      setUnloadedTo(transport4, karelia);
+
+      final var units = List.of(infantry1, tank1, infantry3, tank3);
+      final var result = TransportUtils.chooseEquivalentUnitsToUnload(toNorway, units);
+      assertThat(result, containsInAnyOrder(infantry1, tank1, infantry2, tank2));
+    }
+  }
+}

--- a/game-app/game-core/src/test/java/games/strategy/triplea/util/TransportUtilsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/util/TransportUtilsTest.java
@@ -2,6 +2,8 @@ package games.strategy.triplea.util;
 
 import static games.strategy.triplea.delegate.GameDataTestUtil.addTo;
 import static games.strategy.triplea.delegate.GameDataTestUtil.armour;
+import static games.strategy.triplea.delegate.GameDataTestUtil.bomber;
+import static games.strategy.triplea.delegate.GameDataTestUtil.fighter;
 import static games.strategy.triplea.delegate.GameDataTestUtil.germans;
 import static games.strategy.triplea.delegate.GameDataTestUtil.infantry;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
@@ -25,9 +27,11 @@ public class TransportUtilsTest {
   private final GameData gameData = createGameData();
 
   private final Territory sz5 = territory("5 Sea Zone", gameData);
+  private final Territory sz6 = territory("6 Sea Zone", gameData);
   private final Territory norway = territory("Norway", gameData);
   private final Territory karelia = territory("Karelia S.S.R.", gameData);
   private final Route toNorway = new Route(sz5, norway);
+  private final Route toSz6 = new Route(sz5, sz6);
 
   private final Unit transport1 = transport(gameData).create(germans(gameData));
   private final Unit transport2 = transport(gameData).create(germans(gameData));
@@ -110,6 +114,25 @@ public class TransportUtilsTest {
       final var units = List.of(infantry1, tank1, infantry3, tank3);
       final var result = TransportUtils.chooseEquivalentUnitsToUnload(toNorway, units);
       assertThat(result, containsInAnyOrder(infantry1, tank1, infantry2, tank2));
+    }
+
+    @Test
+    void testNonUnload() {
+      addTransportedUnits(sz5, transport1, List.of(infantry1, tank1));
+      addTransportedUnits(sz5, transport2, List.of(infantry2, tank2));
+      final var units = List.of(transport1, transport2, infantry1, infantry2, tank1, tank2);
+      final var result = TransportUtils.chooseEquivalentUnitsToUnload(toSz6, units);
+      assertThat(result, containsInAnyOrder(units.toArray()));
+    }
+
+    @Test
+    void testNoTransports() {
+      final Unit fighter = fighter(gameData).create(germans(gameData));
+      final Unit bomber = bomber(gameData).create(germans(gameData));
+      final var units = List.of(fighter, bomber);
+      addTo(sz5, units);
+      final var result = TransportUtils.chooseEquivalentUnitsToUnload(toNorway, units);
+      assertThat(result, containsInAnyOrder(units.toArray()));
     }
   }
 }


### PR DESCRIPTION
## Change Summary & Additional Notes

This fixes an issue where the move UI could prevent the user from making valid transport unload moves.

The core of the issue is that when you select a singular unit from a sea territory where there may be several units of that type with different restrictions (e.g. on transports that have previously unloaded to different territories), there was no logic to determine which unit should be selected. In fact, when you just click the unit, it's impossible to choose the "right" one at that point, given we don't know where the user will move that unit.

The fix is a new TransportUtils function that can substitute equivalent units based on destination territory, which is then used when validating the pending move as the mouse is moved around (for the purpose of the UI showing whether the move is OK or not).

Additionally, when the move is actually performed (i.e. end point clicked), a couple of early returns are modified to still use the algorithm for selecting which units/transports to use for unloading, as opposed to just using the selected unit. 

With the above fixes, the following now works:
  1. Load the save game attached here: https://github.com/triplea-game/triplea/issues/10362#issuecomment-1108637030
  2. Move 2 arti to Iwo Jima, one at a time.
  3. Undo both moves.
  4. Try to re-do the moves in 2.

Without this change, step 4 fails via the UI disallowing the moves. With this change, the UI allows the moves to be made.
<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Some valid transport unloads being prevented by the UI<!--END_RELEASE_NOTE-->
