### PR TITLE
Move 1.8-compatibility replaceAll logic to GameParser.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/engine/data/NamedAttachable.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/NamedAttachable.java
@@ -26,8 +26,7 @@ public class NamedAttachable extends DefaultNamed implements Attachable {
 
   @Override
   public void addAttachment(final String key, final IAttachment value) {
-    // replace-all to automatically correct legacy (1.8) attachment spelling
-    attachments.put(key.replaceAll("ttatchment", "ttachment"), value);
+    attachments.put(key, value);
   }
 
   @Override

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/gameparser/GameParser.java
@@ -879,7 +879,8 @@ public final class GameParser {
                 () ->
                     new GameParseException(
                         "Attachment of type " + className + " could not be instantiated"));
-    attachable.addAttachment(name, attachment);
+    // replace-all to automatically correct legacy (1.8) attachment spelling
+    attachable.addAttachment(name.replaceAll("ttatchment", "ttachment"), attachment);
 
     final List<Tuple<String, String>> attachmentOptionValues =
         setOptions(attachment, current.getOptions(), foreach, variables);


### PR DESCRIPTION
## Change Summary & Additional Notes

addAttachment() is called from other places than the game parser, which all use constants from the codebase that do not need replacement. This avoids those needing to go through this codepath.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
