### PR TITLE
Refactor code for querying unit tech for players.

### DIFF
--- a/game-app/ai/src/test/java/org/triplea/ai/flowfield/influence/InfluenceMapTest.java
+++ b/game-app/ai/src/test/java/org/triplea/ai/flowfield/influence/InfluenceMapTest.java
@@ -14,7 +14,6 @@ import games.strategy.engine.data.GameSequence;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.attachments.UnitAttachment;
-import games.strategy.triplea.delegate.TechTracker;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import java.util.List;

--- a/game-app/ai/src/test/java/org/triplea/ai/flowfield/influence/InfluenceMapTest.java
+++ b/game-app/ai/src/test/java/org/triplea/ai/flowfield/influence/InfluenceMapTest.java
@@ -1,6 +1,7 @@
 package org.triplea.ai.flowfield.influence;
 
 import static games.strategy.triplea.Constants.UNIT_ATTACHMENT_NAME;
+import static games.strategy.triplea.delegate.battle.steps.MockGameData.givenGameData;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.anEmptyMap;
 import static org.hamcrest.Matchers.is;
@@ -24,12 +25,6 @@ import org.triplea.ai.flowfield.neighbors.MapWithNeighbors;
 import org.triplea.ai.flowfield.odds.BattleDetails;
 
 class InfluenceMapTest {
-  private GameData createGameDataMock() {
-    final GameData gameData = mock(GameData.class);
-    when(gameData.getTechTracker()).thenReturn(mock(TechTracker.class));
-    return gameData;
-  }
-
   @Test
   void territories3InLineValues() {
     final List<Territory> territories =
@@ -175,7 +170,7 @@ class InfluenceMapTest {
                 return List.of(territories.get(1));
               }
             });
-    final GameData gameData = createGameDataMock();
+    final GameData gameData = givenGameData().build();
     final UnitType unitType = new UnitType("test", gameData);
     final UnitAttachment unitAttachment = new UnitAttachment("test", unitType, gameData);
     unitType.addAttachment(UNIT_ATTACHMENT_NAME, unitAttachment);
@@ -249,7 +244,7 @@ class InfluenceMapTest {
                 return List.of(territories.get(1));
               }
             });
-    final GameData gameData = createGameDataMock();
+    final GameData gameData = givenGameData().build();
     final UnitType unitType = new UnitType("test", gameData);
     final UnitAttachment unitAttachment = new UnitAttachment("test", unitType, gameData);
     unitType.addAttachment(UNIT_ATTACHMENT_NAME, unitAttachment);
@@ -331,7 +326,7 @@ class InfluenceMapTest {
                 return List.of();
               }
             });
-    final GameData gameData = createGameDataMock();
+    final GameData gameData = givenGameData().build();
     when(gameData.getDiceSides()).thenReturn(6);
     final UnitType unitType = new UnitType("test", gameData);
     final UnitAttachment unitAttachment = new UnitAttachment("test", unitType, gameData);
@@ -443,7 +438,7 @@ class InfluenceMapTest {
                 return List.of();
               }
             });
-    final GameData gameData = createGameDataMock();
+    final GameData gameData = givenGameData().build();
     when(gameData.getDiceSides()).thenReturn(6);
     final UnitType unitType = new UnitType("test", gameData);
     final UnitAttachment unitAttachment = new UnitAttachment("test", unitType, gameData);

--- a/game-app/ai/src/test/java/org/triplea/ai/flowfield/influence/InfluenceMapTest.java
+++ b/game-app/ai/src/test/java/org/triplea/ai/flowfield/influence/InfluenceMapTest.java
@@ -13,6 +13,7 @@ import games.strategy.engine.data.GameSequence;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.attachments.UnitAttachment;
+import games.strategy.triplea.delegate.TechTracker;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
 import java.util.List;
@@ -23,6 +24,11 @@ import org.triplea.ai.flowfield.neighbors.MapWithNeighbors;
 import org.triplea.ai.flowfield.odds.BattleDetails;
 
 class InfluenceMapTest {
+  private GameData createGameDataMock() {
+    final GameData gameData = mock(GameData.class);
+    when(gameData.getTechTracker()).thenReturn(mock(TechTracker.class));
+    return gameData;
+  }
 
   @Test
   void territories3InLineValues() {
@@ -169,7 +175,7 @@ class InfluenceMapTest {
                 return List.of(territories.get(1));
               }
             });
-    final GameData gameData = mock(GameData.class);
+    final GameData gameData = createGameDataMock();
     final UnitType unitType = new UnitType("test", gameData);
     final UnitAttachment unitAttachment = new UnitAttachment("test", unitType, gameData);
     unitType.addAttachment(UNIT_ATTACHMENT_NAME, unitAttachment);
@@ -243,7 +249,7 @@ class InfluenceMapTest {
                 return List.of(territories.get(1));
               }
             });
-    final GameData gameData = mock(GameData.class);
+    final GameData gameData = createGameDataMock();
     final UnitType unitType = new UnitType("test", gameData);
     final UnitAttachment unitAttachment = new UnitAttachment("test", unitType, gameData);
     unitType.addAttachment(UNIT_ATTACHMENT_NAME, unitAttachment);
@@ -325,7 +331,7 @@ class InfluenceMapTest {
                 return List.of();
               }
             });
-    final GameData gameData = mock(GameData.class);
+    final GameData gameData = createGameDataMock();
     when(gameData.getDiceSides()).thenReturn(6);
     final UnitType unitType = new UnitType("test", gameData);
     final UnitAttachment unitAttachment = new UnitAttachment("test", unitType, gameData);
@@ -437,7 +443,7 @@ class InfluenceMapTest {
                 return List.of();
               }
             });
-    final GameData gameData = mock(GameData.class);
+    final GameData gameData = createGameDataMock();
     when(gameData.getDiceSides()).thenReturn(6);
     final UnitType unitType = new UnitType("test", gameData);
     final UnitAttachment unitAttachment = new UnitAttachment("test", unitType, gameData);

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -14,6 +14,7 @@ import games.strategy.triplea.Constants;
 import games.strategy.triplea.TripleA;
 import games.strategy.triplea.delegate.AbstractMoveDelegate;
 import games.strategy.triplea.delegate.PoliticsDelegate;
+import games.strategy.triplea.delegate.TechTracker;
 import games.strategy.triplea.delegate.TechnologyDelegate;
 import games.strategy.triplea.delegate.battle.BattleDelegate;
 import games.strategy.triplea.ui.UiContext;
@@ -33,6 +34,7 @@ import java.util.Set;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
+import lombok.Getter;
 import org.triplea.injection.Injections;
 import org.triplea.io.FileUtils;
 import org.triplea.io.IoUtils;
@@ -102,6 +104,7 @@ public class GameData implements Serializable, GameState {
   private final UnitsList unitsList = new UnitsList();
   private final TechnologyFrontier technologyFrontier =
       new TechnologyFrontier("allTechsForGame", this);
+  @Getter private final TechTracker techTracker = new TechTracker(this);
   private final IGameLoader loader = new TripleA();
   private History gameHistory = new History(this);
   private final List<Tuple<IAttachment, List<Tuple<String, String>>>> attachmentOrderAndValues =

--- a/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
+++ b/game-app/game-core/src/main/java/games/strategy/engine/data/GameData.java
@@ -104,7 +104,7 @@ public class GameData implements Serializable, GameState {
   private final UnitsList unitsList = new UnitsList();
   private final TechnologyFrontier technologyFrontier =
       new TechnologyFrontier("allTechsForGame", this);
-  @Getter private final TechTracker techTracker = new TechTracker(this);
+  @Getter private transient TechTracker techTracker = new TechTracker(this);
   private final IGameLoader loader = new TripleA();
   private History gameHistory = new History(this);
   private final List<Tuple<IAttachment, List<Tuple<String, String>>>> attachmentOrderAndValues =
@@ -119,6 +119,7 @@ public class GameData implements Serializable, GameState {
     readWriteLock = new ReentrantReadWriteLock();
     in.defaultReadObject();
     gameDataEventListeners = new GameDataEventListeners();
+    techTracker = new TechTracker(this);
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -1,7 +1,6 @@
 package games.strategy.triplea.attachments;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import games.strategy.engine.data.Attachable;
 import games.strategy.engine.data.DefaultAttachment;
@@ -20,6 +19,7 @@ import games.strategy.triplea.delegate.Matches;
 import games.strategy.triplea.delegate.TechAdvance;
 import games.strategy.triplea.delegate.TechTracker;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -121,8 +121,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     putter.accept(getUnitType(s[1]), getInt(s[0]));
   }
 
-  @VisibleForTesting
-  static int sumIntegerMap(
+  public static int sumIntegerMap(
       final Function<TechAbilityAttachment, IntegerMap<UnitType>> mapper,
       final UnitType ut,
       final Collection<TechAdvance> techAdvances) {
@@ -170,12 +169,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     attackBonus = value;
   }
 
-  private IntegerMap<UnitType> getAttackBonus() {
+  public IntegerMap<UnitType> getAttackBonus() {
     return attackBonus;
-  }
-
-  public static int getAttackBonus(final UnitType ut, final Collection<TechAdvance> techAdvances) {
-    return sumIntegerMap(TechAbilityAttachment::getAttackBonus, ut, techAdvances);
   }
 
   private void resetAttackBonus() {
@@ -190,12 +185,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     defenseBonus = value;
   }
 
-  private IntegerMap<UnitType> getDefenseBonus() {
+  public IntegerMap<UnitType> getDefenseBonus() {
     return defenseBonus;
-  }
-
-  public static int getDefenseBonus(final UnitType ut, final Collection<TechAdvance> techAdvances) {
-    return sumIntegerMap(TechAbilityAttachment::getDefenseBonus, ut, techAdvances);
   }
 
   private void resetDefenseBonus() {
@@ -210,13 +201,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     movementBonus = value;
   }
 
-  private IntegerMap<UnitType> getMovementBonus() {
+  public IntegerMap<UnitType> getMovementBonus() {
     return movementBonus;
-  }
-
-  public static int getMovementBonus(
-      final UnitType ut, final Collection<TechAdvance> techAdvances) {
-    return sumIntegerMap(TechAbilityAttachment::getMovementBonus, ut, techAdvances);
   }
 
   private void resetMovementBonus() {
@@ -231,12 +217,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     radarBonus = value;
   }
 
-  private IntegerMap<UnitType> getRadarBonus() {
+  public IntegerMap<UnitType> getRadarBonus() {
     return radarBonus;
-  }
-
-  public static int getRadarBonus(final UnitType ut, final Collection<TechAdvance> techAdvances) {
-    return sumIntegerMap(TechAbilityAttachment::getRadarBonus, ut, techAdvances);
   }
 
   private void resetRadarBonus() {
@@ -251,13 +233,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     airAttackBonus = value;
   }
 
-  private IntegerMap<UnitType> getAirAttackBonus() {
+  public IntegerMap<UnitType> getAirAttackBonus() {
     return airAttackBonus;
-  }
-
-  public static int getAirAttackBonus(
-      final UnitType ut, final Collection<TechAdvance> techAdvances) {
-    return sumIntegerMap(TechAbilityAttachment::getAirAttackBonus, ut, techAdvances);
   }
 
   private void resetAirAttackBonus() {
@@ -272,13 +249,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     airDefenseBonus = value;
   }
 
-  private IntegerMap<UnitType> getAirDefenseBonus() {
+  public IntegerMap<UnitType> getAirDefenseBonus() {
     return airDefenseBonus;
-  }
-
-  public static int getAirDefenseBonus(
-      final UnitType ut, final Collection<TechAdvance> techAdvances) {
-    return sumIntegerMap(TechAbilityAttachment::getAirDefenseBonus, ut, techAdvances);
   }
 
   private void resetAirDefenseBonus() {
@@ -529,23 +501,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     unitAbilitiesGained = value;
   }
 
-  private Map<UnitType, Set<String>> getUnitAbilitiesGained() {
-    return unitAbilitiesGained;
-  }
-
-  public static boolean getUnitAbilitiesGained(
-      final String filterForAbility,
-      final UnitType ut,
-      final Collection<TechAdvance> techAdvances) {
-    Preconditions.checkNotNull(filterForAbility);
-    return techAdvances.stream()
-        .map(TechAbilityAttachment::get)
-        .filter(Objects::nonNull)
-        .map(TechAbilityAttachment::getUnitAbilitiesGained)
-        .map(m -> m.get(ut))
-        .filter(Objects::nonNull)
-        .flatMap(Collection::stream)
-        .anyMatch(filterForAbility::equals);
+  public Map<UnitType, Set<String>> getUnitAbilitiesGained() {
+    return Collections.unmodifiableMap(unitAbilitiesGained);
   }
 
   private void resetUnitAbilitiesGained() {
@@ -744,13 +701,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     attackRollsBonus = value;
   }
 
-  private IntegerMap<UnitType> getAttackRollsBonus() {
+  public IntegerMap<UnitType> getAttackRollsBonus() {
     return attackRollsBonus;
-  }
-
-  public static int getAttackRollsBonus(
-      final UnitType ut, final Collection<TechAdvance> techAdvances) {
-    return sumIntegerMap(TechAbilityAttachment::getAttackRollsBonus, ut, techAdvances);
   }
 
   private void resetAttackRollsBonus() {
@@ -765,13 +717,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     defenseRollsBonus = value;
   }
 
-  private IntegerMap<UnitType> getDefenseRollsBonus() {
+  public IntegerMap<UnitType> getDefenseRollsBonus() {
     return defenseRollsBonus;
-  }
-
-  public static int getDefenseRollsBonus(
-      final UnitType ut, final Collection<TechAdvance> techAdvances) {
-    return sumIntegerMap(TechAbilityAttachment::getDefenseRollsBonus, ut, techAdvances);
   }
 
   private void setBombingBonus(final String value) throws GameParseException {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/TechAbilityAttachment.java
@@ -174,7 +174,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return attackBonus;
   }
 
-  static int getAttackBonus(final UnitType ut, final Collection<TechAdvance> techAdvances) {
+  public static int getAttackBonus(final UnitType ut, final Collection<TechAdvance> techAdvances) {
     return sumIntegerMap(TechAbilityAttachment::getAttackBonus, ut, techAdvances);
   }
 
@@ -194,7 +194,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return defenseBonus;
   }
 
-  static int getDefenseBonus(final UnitType ut, final Collection<TechAdvance> techAdvances) {
+  public static int getDefenseBonus(final UnitType ut, final Collection<TechAdvance> techAdvances) {
     return sumIntegerMap(TechAbilityAttachment::getDefenseBonus, ut, techAdvances);
   }
 
@@ -214,7 +214,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return movementBonus;
   }
 
-  static int getMovementBonus(final UnitType ut, final Collection<TechAdvance> techAdvances) {
+  public static int getMovementBonus(
+      final UnitType ut, final Collection<TechAdvance> techAdvances) {
     return sumIntegerMap(TechAbilityAttachment::getMovementBonus, ut, techAdvances);
   }
 
@@ -234,7 +235,7 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return radarBonus;
   }
 
-  static int getRadarBonus(final UnitType ut, final Collection<TechAdvance> techAdvances) {
+  public static int getRadarBonus(final UnitType ut, final Collection<TechAdvance> techAdvances) {
     return sumIntegerMap(TechAbilityAttachment::getRadarBonus, ut, techAdvances);
   }
 
@@ -254,7 +255,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return airAttackBonus;
   }
 
-  static int getAirAttackBonus(final UnitType ut, final Collection<TechAdvance> techAdvances) {
+  public static int getAirAttackBonus(
+      final UnitType ut, final Collection<TechAdvance> techAdvances) {
     return sumIntegerMap(TechAbilityAttachment::getAirAttackBonus, ut, techAdvances);
   }
 
@@ -274,7 +276,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return airDefenseBonus;
   }
 
-  static int getAirDefenseBonus(final UnitType ut, final Collection<TechAdvance> techAdvances) {
+  public static int getAirDefenseBonus(
+      final UnitType ut, final Collection<TechAdvance> techAdvances) {
     return sumIntegerMap(TechAbilityAttachment::getAirDefenseBonus, ut, techAdvances);
   }
 
@@ -745,7 +748,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return attackRollsBonus;
   }
 
-  static int getAttackRollsBonus(final UnitType ut, final Collection<TechAdvance> techAdvances) {
+  public static int getAttackRollsBonus(
+      final UnitType ut, final Collection<TechAdvance> techAdvances) {
     return sumIntegerMap(TechAbilityAttachment::getAttackRollsBonus, ut, techAdvances);
   }
 
@@ -765,7 +769,8 @@ public class TechAbilityAttachment extends DefaultAttachment {
     return defenseRollsBonus;
   }
 
-  static int getDefenseRollsBonus(final UnitType ut, final Collection<TechAdvance> techAdvances) {
+  public static int getDefenseRollsBonus(
+      final UnitType ut, final Collection<TechAdvance> techAdvances) {
     return sumIntegerMap(TechAbilityAttachment::getDefenseRollsBonus, ut, techAdvances);
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -628,9 +628,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public boolean getCanBlitz(final GamePlayer player) {
-    return canBlitz
-        || getTechTracker()
-            .getUnitAbilitiesGained(player, getUnitType(), TechAbilityAttachment.ABILITY_CAN_BLITZ);
+    return canBlitz || getTechTracker().canBlitz(player, getUnitType());
   }
 
   private void resetCanBlitz() {
@@ -825,10 +823,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public boolean getCanBombard(final GamePlayer player) {
-    return canBombard
-        || getTechTracker()
-            .getUnitAbilitiesGained(
-                player, getUnitType(), TechAbilityAttachment.ABILITY_CAN_BOMBARD);
+    return canBombard || getTechTracker().canBombard(player, getUnitType());
   }
 
   private void resetCanBombard() {
@@ -1551,7 +1546,6 @@ public class UnitAttachment extends DefaultAttachment {
 
   public int getAttack(final GamePlayer player) {
     final int bonus = getTechTracker().getAttackBonus(player, getUnitType());
-    ;
     return Math.min(getData().getDiceSides(), Math.max(0, attack + bonus));
   }
 
@@ -2175,7 +2169,6 @@ public class UnitAttachment extends DefaultAttachment {
     // TODO: this may cause major problems with Low Luck, if they have diceSides equal to something
     // other than 6, or it does not divide perfectly into attackAAmaxDieSides
     final int bonus = getTechTracker().getRadarBonus(player, getUnitType());
-    ;
     return Math.max(0, Math.min(getAttackAaMaxDieSides(), attackAa + bonus));
   }
 
@@ -2201,7 +2194,6 @@ public class UnitAttachment extends DefaultAttachment {
     // TODO: this may cause major problems with Low Luck, if they have diceSides equal to something
     // other than 6, or it does not divide perfectly into attackAAmaxDieSides
     final int bonus = getTechTracker().getRadarBonus(player, getUnitType());
-    ;
     return Math.max(0, Math.min(getOffensiveAttackAaMaxDieSides(), offensiveAttackAa + bonus));
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -264,6 +264,14 @@ public class UnitAttachment extends DefaultAttachment {
     return units.stream().map(Unit::getType).collect(Collectors.toSet());
   }
 
+  private TechTracker getTechTracker() {
+    return getData().getTechTracker();
+  }
+
+  private UnitType getUnitType() {
+    return (UnitType) getAttachedTo();
+  }
+
   private void setCanIntercept(final String value) {
     canIntercept = getBool(value);
   }
@@ -342,10 +350,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public int getAirDefense(final GamePlayer player) {
-    final int bonus =
-        TechAbilityAttachment.getAirDefenseBonus(
-            (UnitType) this.getAttachedTo(),
-            TechTracker.getCurrentTechAdvances(player, getData().getTechnologyFrontier()));
+    final int bonus = getTechTracker().getAirDefenseBonus(player, getUnitType());
     return Math.min(getData().getDiceSides(), Math.max(0, airDefense + bonus));
   }
 
@@ -367,10 +372,7 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public int getAirAttack(final GamePlayer player) {
-    final int bonus =
-        TechAbilityAttachment.getAirAttackBonus(
-            (UnitType) this.getAttachedTo(),
-            TechTracker.getCurrentTechAdvances(player, getData().getTechnologyFrontier()));
+    final int bonus = getTechTracker().getAirAttackBonus(player, getUnitType());
     return Math.min(getData().getDiceSides(), Math.max(0, airAttack + bonus));
   }
 
@@ -626,12 +628,9 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public boolean getCanBlitz(final GamePlayer player) {
-
     return canBlitz
-        || TechAbilityAttachment.getUnitAbilitiesGained(
-            TechAbilityAttachment.ABILITY_CAN_BLITZ,
-            (UnitType) this.getAttachedTo(),
-            TechTracker.getCurrentTechAdvances(player, getData().getTechnologyFrontier()));
+        || getTechTracker()
+            .getUnitAbilitiesGained(player, getUnitType(), TechAbilityAttachment.ABILITY_CAN_BLITZ);
   }
 
   private void resetCanBlitz() {
@@ -826,12 +825,10 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public boolean getCanBombard(final GamePlayer player) {
-
     return canBombard
-        || TechAbilityAttachment.getUnitAbilitiesGained(
-            TechAbilityAttachment.ABILITY_CAN_BOMBARD,
-            (UnitType) this.getAttachedTo(),
-            TechTracker.getCurrentTechAdvances(player, getData().getTechnologyFrontier()));
+        || getTechTracker()
+            .getUnitAbilitiesGained(
+                player, getUnitType(), TechAbilityAttachment.ABILITY_CAN_BOMBARD);
   }
 
   private void resetCanBombard() {
@@ -1530,11 +1527,8 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public int getMovement(final GamePlayer player) {
-    final int bonus =
-        TechAbilityAttachment.getMovementBonus(
-            (UnitType) this.getAttachedTo(),
-            TechTracker.getCurrentTechAdvances(player, getData().getTechnologyFrontier()));
-    return Math.max(0, movement + bonus);
+    final int bonus = getTechTracker().getMovementBonus(player, getUnitType());
+    return Math.max(0, movement + getTechTracker().getMovementBonus(player, getUnitType()));
   }
 
   private void resetMovement() {
@@ -1556,10 +1550,8 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public int getAttack(final GamePlayer player) {
-    final int bonus =
-        TechAbilityAttachment.getAttackBonus(
-            (UnitType) this.getAttachedTo(),
-            TechTracker.getCurrentTechAdvances(player, getData().getTechnologyFrontier()));
+    final int bonus = getTechTracker().getAttackBonus(player, getUnitType());
+    ;
     return Math.min(getData().getDiceSides(), Math.max(0, attack + bonus));
   }
 
@@ -1582,10 +1574,8 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public int getAttackRolls(final GamePlayer player) {
-    final int bonus =
-        TechAbilityAttachment.getAttackRollsBonus(
-            (UnitType) this.getAttachedTo(),
-            TechTracker.getCurrentTechAdvances(player, getData().getTechnologyFrontier()));
+    final int bonus = getTechTracker().getAttackRollsBonus(player, getUnitType());
+    ;
     return Math.max(0, attackRolls + bonus);
   }
 
@@ -1608,10 +1598,8 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public int getDefense(final GamePlayer player) {
-    final int bonus =
-        TechAbilityAttachment.getDefenseBonus(
-            (UnitType) this.getAttachedTo(),
-            TechTracker.getCurrentTechAdvances(player, getData().getTechnologyFrontier()));
+    final int bonus = getTechTracker().getDefenseBonus(player, getUnitType());
+    ;
     int defenseValue = defense + bonus;
     if (defenseValue > 0 && getIsFirstStrike() && TechTracker.hasSuperSubs(player)) {
       final int superSubBonus = Properties.getSuperSubDefenseBonus(getData().getProperties());
@@ -1639,10 +1627,8 @@ public class UnitAttachment extends DefaultAttachment {
   }
 
   public int getDefenseRolls(final GamePlayer player) {
-    final int bonus =
-        TechAbilityAttachment.getDefenseRollsBonus(
-            (UnitType) this.getAttachedTo(),
-            TechTracker.getCurrentTechAdvances(player, getData().getTechnologyFrontier()));
+    final int bonus = getTechTracker().getDefenseRollsBonus(player, getUnitType());
+    ;
     return Math.max(0, defenseRolls + bonus);
   }
 
@@ -2188,10 +2174,8 @@ public class UnitAttachment extends DefaultAttachment {
   public int getAttackAa(final GamePlayer player) {
     // TODO: this may cause major problems with Low Luck, if they have diceSides equal to something
     // other than 6, or it does not divide perfectly into attackAAmaxDieSides
-    int bonus =
-        TechAbilityAttachment.getRadarBonus(
-            (UnitType) this.getAttachedTo(),
-            TechTracker.getCurrentTechAdvances(player, getData().getTechnologyFrontier()));
+    final int bonus = getTechTracker().getRadarBonus(player, getUnitType());
+    ;
     return Math.max(0, Math.min(getAttackAaMaxDieSides(), attackAa + bonus));
   }
 
@@ -2216,10 +2200,8 @@ public class UnitAttachment extends DefaultAttachment {
   public int getOffensiveAttackAa(final GamePlayer player) {
     // TODO: this may cause major problems with Low Luck, if they have diceSides equal to something
     // other than 6, or it does not divide perfectly into attackAAmaxDieSides
-    int bonus =
-        TechAbilityAttachment.getRadarBonus(
-            (UnitType) this.getAttachedTo(),
-            TechTracker.getCurrentTechAdvances(player, getData().getTechnologyFrontier()));
+    final int bonus = getTechTracker().getRadarBonus(player, getUnitType());
+    ;
     return Math.max(0, Math.min(getOffensiveAttackAaMaxDieSides(), offensiveAttackAa + bonus));
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/attachments/UnitAttachment.java
@@ -1523,7 +1523,7 @@ public class UnitAttachment extends DefaultAttachment {
 
   public int getMovement(final GamePlayer player) {
     final int bonus = getTechTracker().getMovementBonus(player, getUnitType());
-    return Math.max(0, movement + getTechTracker().getMovementBonus(player, getUnitType()));
+    return Math.max(0, movement + bonus);
   }
 
   private void resetMovement() {
@@ -1569,7 +1569,6 @@ public class UnitAttachment extends DefaultAttachment {
 
   public int getAttackRolls(final GamePlayer player) {
     final int bonus = getTechTracker().getAttackRollsBonus(player, getUnitType());
-    ;
     return Math.max(0, attackRolls + bonus);
   }
 
@@ -1593,7 +1592,6 @@ public class UnitAttachment extends DefaultAttachment {
 
   public int getDefense(final GamePlayer player) {
     final int bonus = getTechTracker().getDefenseBonus(player, getUnitType());
-    ;
     int defenseValue = defense + bonus;
     if (defenseValue > 0 && getIsFirstStrike() && TechTracker.hasSuperSubs(player)) {
       final int superSubBonus = Properties.getSuperSubDefenseBonus(getData().getProperties());
@@ -1622,7 +1620,6 @@ public class UnitAttachment extends DefaultAttachment {
 
   public int getDefenseRolls(final GamePlayer player) {
     final int bonus = getTechTracker().getDefenseRollsBonus(player, getUnitType());
-    ;
     return Math.max(0, defenseRolls + bonus);
   }
 

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TechTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TechTracker.java
@@ -11,14 +11,12 @@ import games.strategy.triplea.attachments.TechAbilityAttachment;
 import games.strategy.triplea.attachments.TechAttachment;
 import java.util.ArrayList;
 import java.util.Collection;
+import lombok.AllArgsConstructor;
 
 /** A collection of methods for tracking which players have which technology advances. */
+@AllArgsConstructor
 public final class TechTracker {
-  private GameData data;
-
-  public TechTracker(final GameData data) {
-    this.data = data;
-  }
+  private final GameData data;
 
   private Collection<TechAdvance> getCurrentTechAdvances(GamePlayer player) {
     return getCurrentTechAdvances(player, data.getTechnologyFrontier());
@@ -56,9 +54,14 @@ public final class TechTracker {
     return TechAbilityAttachment.getRadarBonus(type, getCurrentTechAdvances(player));
   }
 
-  public boolean getUnitAbilitiesGained(GamePlayer player, UnitType type, String filterForAbility) {
+  public boolean canBlitz(GamePlayer player, UnitType type) {
     return TechAbilityAttachment.getUnitAbilitiesGained(
-        filterForAbility, type, getCurrentTechAdvances(player));
+        TechAbilityAttachment.ABILITY_CAN_BLITZ, type, getCurrentTechAdvances(player));
+  }
+
+  public boolean canBombard(GamePlayer player, UnitType type) {
+    return TechAbilityAttachment.getUnitAbilitiesGained(
+        TechAbilityAttachment.ABILITY_CAN_BOMBARD, type, getCurrentTechAdvances(player));
   }
 
   /**

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TechTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TechTracker.java
@@ -15,7 +15,7 @@ import lombok.AllArgsConstructor;
 
 /** A collection of methods for tracking which players have which technology advances. */
 @AllArgsConstructor
-public final class TechTracker {
+public class TechTracker {
   private final GameData data;
 
   private Collection<TechAdvance> getCurrentTechAdvances(GamePlayer player) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TechTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TechTracker.java
@@ -1,17 +1,65 @@
 package games.strategy.triplea.delegate;
 
 import games.strategy.engine.data.Change;
+import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.TechnologyFrontier;
+import games.strategy.engine.data.UnitType;
 import games.strategy.engine.data.changefactory.ChangeFactory;
 import games.strategy.engine.delegate.IDelegateBridge;
+import games.strategy.triplea.attachments.TechAbilityAttachment;
 import games.strategy.triplea.attachments.TechAttachment;
 import java.util.ArrayList;
 import java.util.Collection;
 
 /** A collection of methods for tracking which players have which technology advances. */
 public final class TechTracker {
-  private TechTracker() {}
+  private GameData data;
+
+  public TechTracker(final GameData data) {
+    this.data = data;
+  }
+
+  private Collection<TechAdvance> getCurrentTechAdvances(GamePlayer player) {
+    return getCurrentTechAdvances(player, data.getTechnologyFrontier());
+  }
+
+  public int getAirDefenseBonus(GamePlayer player, UnitType type) {
+    return TechAbilityAttachment.getAirDefenseBonus(type, getCurrentTechAdvances(player));
+  }
+
+  public int getAirAttackBonus(GamePlayer player, UnitType type) {
+    return TechAbilityAttachment.getAirAttackBonus(type, getCurrentTechAdvances(player));
+  }
+
+  public int getMovementBonus(GamePlayer player, UnitType type) {
+    return TechAbilityAttachment.getMovementBonus(type, getCurrentTechAdvances(player));
+  }
+
+  public int getAttackBonus(GamePlayer player, UnitType type) {
+    return TechAbilityAttachment.getAttackBonus(type, getCurrentTechAdvances(player));
+  }
+
+  public int getAttackRollsBonus(GamePlayer player, UnitType type) {
+    return TechAbilityAttachment.getAttackRollsBonus(type, getCurrentTechAdvances(player));
+  }
+
+  public int getDefenseBonus(GamePlayer player, UnitType type) {
+    return TechAbilityAttachment.getDefenseBonus(type, getCurrentTechAdvances(player));
+  }
+
+  public int getDefenseRollsBonus(GamePlayer player, UnitType type) {
+    return TechAbilityAttachment.getDefenseRollsBonus(type, getCurrentTechAdvances(player));
+  }
+
+  public int getRadarBonus(GamePlayer player, UnitType type) {
+    return TechAbilityAttachment.getRadarBonus(type, getCurrentTechAdvances(player));
+  }
+
+  public boolean getUnitAbilitiesGained(GamePlayer player, UnitType type, String filterForAbility) {
+    return TechAbilityAttachment.getUnitAbilitiesGained(
+        filterForAbility, type, getCurrentTechAdvances(player));
+  }
 
   /**
    * Returns what tech advances this player already has successfully researched (including ones that

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TechTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TechTracker.java
@@ -62,14 +62,14 @@ public class TechTracker {
   }
 
   private int getSumOfBonuses(
-      final Function<TechAbilityAttachment, IntegerMap<UnitType>> mapper,
-      final UnitType type,
-      final GamePlayer player) {
+      Function<TechAbilityAttachment, IntegerMap<UnitType>> mapper,
+      UnitType type,
+      GamePlayer player) {
     return TechAbilityAttachment.sumIntegerMap(mapper, type, getCurrentTechAdvances(player));
   }
 
   private boolean getUnitAbilitiesGained(
-      final String filterForAbility, final UnitType unitType, final GamePlayer player) {
+      String filterForAbility, UnitType unitType, GamePlayer player) {
     return getCurrentTechAdvances(player).stream()
         .map(TechAbilityAttachment::get)
         .filter(Objects::nonNull)

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TechTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TechTracker.java
@@ -11,7 +11,10 @@ import games.strategy.triplea.attachments.TechAbilityAttachment;
 import games.strategy.triplea.attachments.TechAttachment;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Objects;
+import java.util.function.Function;
 import lombok.AllArgsConstructor;
+import org.triplea.java.collections.IntegerMap;
 
 /** A collection of methods for tracking which players have which technology advances. */
 @AllArgsConstructor
@@ -19,45 +22,62 @@ public class TechTracker {
   private final GameData data;
 
   public int getAirDefenseBonus(GamePlayer player, UnitType type) {
-    return TechAbilityAttachment.getAirDefenseBonus(type, getCurrentTechAdvances(player));
+    return getSumOfBonuses(TechAbilityAttachment::getAirDefenseBonus, type, player);
   }
 
   public int getAirAttackBonus(GamePlayer player, UnitType type) {
-    return TechAbilityAttachment.getAirAttackBonus(type, getCurrentTechAdvances(player));
+    return getSumOfBonuses(TechAbilityAttachment::getAirAttackBonus, type, player);
   }
 
   public int getMovementBonus(GamePlayer player, UnitType type) {
-    return TechAbilityAttachment.getMovementBonus(type, getCurrentTechAdvances(player));
+    return getSumOfBonuses(TechAbilityAttachment::getMovementBonus, type, player);
   }
 
   public int getAttackBonus(GamePlayer player, UnitType type) {
-    return TechAbilityAttachment.getAttackBonus(type, getCurrentTechAdvances(player));
+    return getSumOfBonuses(TechAbilityAttachment::getAttackBonus, type, player);
   }
 
   public int getAttackRollsBonus(GamePlayer player, UnitType type) {
-    return TechAbilityAttachment.getAttackRollsBonus(type, getCurrentTechAdvances(player));
+    return getSumOfBonuses(TechAbilityAttachment::getAttackRollsBonus, type, player);
   }
 
   public int getDefenseBonus(GamePlayer player, UnitType type) {
-    return TechAbilityAttachment.getDefenseBonus(type, getCurrentTechAdvances(player));
+    return getSumOfBonuses(TechAbilityAttachment::getDefenseBonus, type, player);
   }
 
   public int getDefenseRollsBonus(GamePlayer player, UnitType type) {
-    return TechAbilityAttachment.getDefenseRollsBonus(type, getCurrentTechAdvances(player));
+    return getSumOfBonuses(TechAbilityAttachment::getDefenseRollsBonus, type, player);
   }
 
   public int getRadarBonus(GamePlayer player, UnitType type) {
-    return TechAbilityAttachment.getRadarBonus(type, getCurrentTechAdvances(player));
+    return getSumOfBonuses(TechAbilityAttachment::getRadarBonus, type, player);
   }
 
   public boolean canBlitz(GamePlayer player, UnitType type) {
-    return TechAbilityAttachment.getUnitAbilitiesGained(
-        TechAbilityAttachment.ABILITY_CAN_BLITZ, type, getCurrentTechAdvances(player));
+    return getUnitAbilitiesGained(TechAbilityAttachment.ABILITY_CAN_BLITZ, type, player);
   }
 
   public boolean canBombard(GamePlayer player, UnitType type) {
-    return TechAbilityAttachment.getUnitAbilitiesGained(
-        TechAbilityAttachment.ABILITY_CAN_BOMBARD, type, getCurrentTechAdvances(player));
+    return getUnitAbilitiesGained(TechAbilityAttachment.ABILITY_CAN_BOMBARD, type, player);
+  }
+
+  private int getSumOfBonuses(
+      final Function<TechAbilityAttachment, IntegerMap<UnitType>> mapper,
+      final UnitType type,
+      final GamePlayer player) {
+    return TechAbilityAttachment.sumIntegerMap(mapper, type, getCurrentTechAdvances(player));
+  }
+
+  private boolean getUnitAbilitiesGained(
+      final String filterForAbility, final UnitType unitType, final GamePlayer player) {
+    return getCurrentTechAdvances(player).stream()
+        .map(TechAbilityAttachment::get)
+        .filter(Objects::nonNull)
+        .map(TechAbilityAttachment::getUnitAbilitiesGained)
+        .map(m -> m.get(unitType))
+        .filter(Objects::nonNull)
+        .flatMap(Collection::stream)
+        .anyMatch(filterForAbility::equals);
   }
 
   private Collection<TechAdvance> getCurrentTechAdvances(GamePlayer player) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TechTracker.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/TechTracker.java
@@ -18,10 +18,6 @@ import lombok.AllArgsConstructor;
 public class TechTracker {
   private final GameData data;
 
-  private Collection<TechAdvance> getCurrentTechAdvances(GamePlayer player) {
-    return getCurrentTechAdvances(player, data.getTechnologyFrontier());
-  }
-
   public int getAirDefenseBonus(GamePlayer player, UnitType type) {
     return TechAbilityAttachment.getAirDefenseBonus(type, getCurrentTechAdvances(player));
   }
@@ -62,6 +58,10 @@ public class TechTracker {
   public boolean canBombard(GamePlayer player, UnitType type) {
     return TechAbilityAttachment.getUnitAbilitiesGained(
         TechAbilityAttachment.ABILITY_CAN_BOMBARD, type, getCurrentTechAdvances(player));
+  }
+
+  private Collection<TechAdvance> getCurrentTechAdvances(GamePlayer player) {
+    return getCurrentTechAdvances(player, data.getTechnologyFrontier());
   }
 
   /**

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/BattleTrackerTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/BattleTrackerTest.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea.delegate.battle;
 
+import static games.strategy.triplea.delegate.battle.steps.MockGameData.givenGameData;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -27,7 +28,7 @@ class BattleTrackerTest {
 
   @Mock private IDelegateBridge mockDelegateBridge;
 
-  @Mock private GameData mockGameData;
+  private GameData mockGameData = givenGameData().build();
 
   @Mock private GameProperties mockGameProperties;
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/BattleStepsTest.java
@@ -174,7 +174,8 @@ public class BattleStepsTest {
       final BattleState.Side side,
       final String aaType) {
     final UnitAndAttachment unitAndAttachment = newUnitAndAttachment();
-    when(unitAndAttachment.unit.getData()).thenReturn(mock(GameData.class));
+    final GameData gameData = givenGameData().build();
+    when(unitAndAttachment.unit.getData()).thenReturn(gameData);
     when(unitAndAttachment.unitAttachment.getTypeAa()).thenReturn(aaType);
     when(unitAndAttachment.unitAttachment.getTargetsAa(any())).thenReturn(aaTarget);
     when(unitAndAttachment.unitAttachment.getIsAaForCombatOnly()).thenReturn(true);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/MockGameData.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/MockGameData.java
@@ -52,7 +52,6 @@ public class MockGameData {
     lenient().when(gameData.getSequence()).thenReturn(gameSequence);
     lenient().when(gameData.getTechTracker()).thenReturn(techTracker);
     lenient().when(gameData.getResourceList()).thenReturn(resourceList);
-
   }
 
   public static MockGameData givenGameData() {

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/MockGameData.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/MockGameData.java
@@ -30,6 +30,7 @@ import games.strategy.engine.data.TechnologyFrontier;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.UnitTypeList;
 import games.strategy.engine.data.properties.GameProperties;
+import games.strategy.triplea.delegate.TechTracker;
 import java.util.Set;
 
 public class MockGameData {
@@ -39,6 +40,7 @@ public class MockGameData {
   private final GameMap gameMap = mock(GameMap.class);
   private final UnitTypeList unitTypeList = mock(UnitTypeList.class);
   private final GameSequence gameSequence = mock(GameSequence.class);
+  private final TechTracker techTracker = mock(TechTracker.class);
 
   private MockGameData() {
     lenient().when(gameData.getProperties()).thenReturn(gameProperties);
@@ -46,6 +48,7 @@ public class MockGameData {
     lenient().when(gameData.getMap()).thenReturn(gameMap);
     lenient().when(gameData.getUnitTypeList()).thenReturn(unitTypeList);
     lenient().when(gameData.getSequence()).thenReturn(gameSequence);
+    lenient().when(gameData.getTechTracker()).thenReturn(techTracker);
   }
 
   public static MockGameData givenGameData() {

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/MockGameData.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/battle/steps/MockGameData.java
@@ -26,6 +26,7 @@ import games.strategy.engine.data.GamePlayer;
 import games.strategy.engine.data.GameSequence;
 import games.strategy.engine.data.GameStep;
 import games.strategy.engine.data.RelationshipTracker;
+import games.strategy.engine.data.ResourceList;
 import games.strategy.engine.data.TechnologyFrontier;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.UnitTypeList;
@@ -41,6 +42,7 @@ public class MockGameData {
   private final UnitTypeList unitTypeList = mock(UnitTypeList.class);
   private final GameSequence gameSequence = mock(GameSequence.class);
   private final TechTracker techTracker = mock(TechTracker.class);
+  private final ResourceList resourceList = mock(ResourceList.class);
 
   private MockGameData() {
     lenient().when(gameData.getProperties()).thenReturn(gameProperties);
@@ -49,6 +51,8 @@ public class MockGameData {
     lenient().when(gameData.getUnitTypeList()).thenReturn(unitTypeList);
     lenient().when(gameData.getSequence()).thenReturn(gameSequence);
     lenient().when(gameData.getTechTracker()).thenReturn(techTracker);
+    lenient().when(gameData.getResourceList()).thenReturn(resourceList);
+
   }
 
   public static MockGameData givenGameData() {

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/data/CasualtyDetailsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/data/CasualtyDetailsTest.java
@@ -1,9 +1,12 @@
 package games.strategy.triplea.delegate.data;
 
 import static games.strategy.triplea.Constants.UNIT_ATTACHMENT_NAME;
+import static games.strategy.triplea.delegate.battle.steps.MockGameData.givenGameData;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
@@ -11,6 +14,7 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
+import games.strategy.triplea.delegate.TechTracker;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Comparator;
@@ -23,7 +27,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class CasualtyDetailsTest {
 
-  @Mock private GameData gameData;
+  private GameData gameData = givenGameData().build();
   private GamePlayer player1 = new GamePlayer("player1", gameData);
   private GamePlayer player2 = new GamePlayer("player2", gameData);
 

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/data/CasualtyDetailsTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/data/CasualtyDetailsTest.java
@@ -5,8 +5,6 @@ import static games.strategy.triplea.delegate.battle.steps.MockGameData.givenGam
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
@@ -14,14 +12,12 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.Matches;
-import games.strategy.triplea.delegate.TechTracker;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)

--- a/game-app/game-core/src/test/java/games/strategy/triplea/image/UnitImageFactoryTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/image/UnitImageFactoryTest.java
@@ -1,8 +1,10 @@
 package games.strategy.triplea.image;
 
+import static games.strategy.triplea.delegate.battle.steps.MockGameData.givenGameData;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import games.strategy.engine.data.GameData;
@@ -14,17 +16,17 @@ import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
+import games.strategy.triplea.delegate.TechTracker;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class UnitImageFactoryTest {
-  @Mock GameData gameData;
+  GameData gameData = givenGameData().build();
 
   @Nested
   class GetBaseImageName {

--- a/game-app/game-core/src/test/java/games/strategy/triplea/image/UnitImageFactoryTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/image/UnitImageFactoryTest.java
@@ -4,7 +4,6 @@ import static games.strategy.triplea.delegate.battle.steps.MockGameData.givenGam
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.mockito.Mockito.lenient;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import games.strategy.engine.data.GameData;
@@ -16,7 +15,6 @@ import games.strategy.engine.data.properties.GameProperties;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.attachments.TechAttachment;
 import games.strategy.triplea.attachments.UnitAttachment;
-import games.strategy.triplea.delegate.TechTracker;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;

--- a/game-app/game-core/src/test/java/games/strategy/triplea/odds/calculator/DummyPlayerTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/odds/calculator/DummyPlayerTest.java
@@ -1,5 +1,6 @@
 package games.strategy.triplea.odds.calculator;
 
+import static games.strategy.triplea.delegate.battle.steps.MockGameData.givenGameData;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.sameInstance;
@@ -10,9 +11,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
-import games.strategy.engine.data.ResourceList;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.attachments.UnitAttachment;
@@ -68,9 +67,8 @@ class DummyPlayerTest {
           final var unitAttachment = mock(UnitAttachment.class);
           when(unitType.getAttachment(any())).thenReturn(unitAttachment);
           when(unitAttachment.getIsAir()).thenReturn(!unit.equals(unitPool.get(0)));
-          final var gameData = mock(GameData.class);
+          final var gameData = givenGameData().build();
           when(unit.getData()).thenReturn(gameData);
-          when(gameData.getResourceList()).thenReturn(mock(ResourceList.class));
           final var playerId = mock(GamePlayer.class);
           when(unit.getOwner()).thenReturn(playerId);
         }

--- a/game-app/game-core/src/test/java/games/strategy/triplea/util/UnitSeparatorTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/util/UnitSeparatorTest.java
@@ -5,7 +5,6 @@ import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static games.strategy.triplea.delegate.battle.steps.MockGameData.givenGameData;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import games.strategy.engine.data.GameData;
@@ -16,7 +15,6 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.GameDataTestUtil;
-import games.strategy.triplea.delegate.TechTracker;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.math.BigDecimal;

--- a/game-app/game-core/src/test/java/games/strategy/triplea/util/UnitSeparatorTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/util/UnitSeparatorTest.java
@@ -2,8 +2,10 @@ package games.strategy.triplea.util;
 
 import static games.strategy.triplea.Constants.UNIT_ATTACHMENT_NAME;
 import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
+import static games.strategy.triplea.delegate.battle.steps.MockGameData.givenGameData;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import games.strategy.engine.data.GameData;
@@ -14,6 +16,7 @@ import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.triplea.attachments.UnitAttachment;
 import games.strategy.triplea.delegate.GameDataTestUtil;
+import games.strategy.triplea.delegate.TechTracker;
 import games.strategy.triplea.ui.mapdata.MapData;
 import games.strategy.triplea.xml.TestMapGameData;
 import java.math.BigDecimal;
@@ -28,7 +31,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
 class UnitSeparatorTest {
-  @Mock private GameData gameData;
+  private GameData gameData = givenGameData().build();
   private GamePlayer player1 = new GamePlayer("player1", gameData);
 
   @Mock private MapData mockMapData;


### PR DESCRIPTION
## Change Summary & Additional Notes

This change makes TechTracker an actual instance class on GameData and cleans up the APIs to retrieve tech information from UnitAttachment.

This is a pure code re-organizing change, no functional changes.

Besides improving the API, this should pave way for allowing the TechTracker to cache this information and only update it when tech changes, which should speed up the engine quite a bit - since very basic things like getting unit attack / defense / movement currently requires expensive tech look up operations (which shows up in profiles). I plan to send the follow-up PR to implement this caching - preliminary results show that it can speed up battle simulations by AI by ~25%.

Tested loading and saving games.
<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE--><!--END_RELEASE_NOTE-->
