### PR TITLE
Clean up code and fix the logic for Pacific-ruleset Naval base move boosting.

### DIFF
--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1152,6 +1152,7 @@ public final class Matches {
       if (ua.getIsSea() && stepName.getDisplayName().equals("Non Combat Move")) {
         // If a zone adjacent to the starting and ending sea zones are allied naval bases, increase
         // the range.
+        // TODO Still need to be able to handle stops on the way
         // (history to get route.getStart()
         for (final Territory terrNext : unit.getData().getMap().getNeighbors(route.getStart(), 1)) {
           final TerritoryAttachment taNeighbor = TerritoryAttachment.get(terrNext);

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -3,7 +3,6 @@ package games.strategy.triplea.delegate;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameMap;
 import games.strategy.engine.data.GamePlayer;
-import games.strategy.engine.data.GameStep;
 import games.strategy.engine.data.RelationshipTracker;
 import games.strategy.engine.data.RelationshipTracker.Relationship;
 import games.strategy.engine.data.RelationshipType;
@@ -1139,7 +1138,6 @@ public final class Matches {
     return unit -> {
       BigDecimal left = unit.getMovementLeft();
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      final GamePlayer player = unit.getOwner();
       if (ua.getIsAir()) {
         if (TerritoryAttachment.hasAirBase(route.getStart())) {
           left = left.add(BigDecimal.ONE);
@@ -1148,28 +1146,13 @@ public final class Matches {
           left = left.add(BigDecimal.ONE);
         }
       }
-      final GameStep stepName = unit.getData().getSequence().getStep();
-      if (ua.getIsSea() && stepName.getDisplayName().equals("Non Combat Move")) {
+      if (ua.getIsSea() && unit.getData().getSequence().getStep().isNonCombat()) {
         // If a zone adjacent to the starting and ending sea zones are allied naval bases, increase
         // the range.
         // TODO Still need to be able to handle stops on the way
-        // (history to get route.getStart()
-        for (final Territory terrNext : unit.getData().getMap().getNeighbors(route.getStart(), 1)) {
-          final TerritoryAttachment taNeighbor = TerritoryAttachment.get(terrNext);
-          if (taNeighbor != null
-              && taNeighbor.getNavalBase()
-              && unit.getData().getRelationshipTracker().isAllied(terrNext.getOwner(), player)) {
-            for (final Territory terrEnd :
-                unit.getData().getMap().getNeighbors(route.getEnd(), 1)) {
-              final TerritoryAttachment taEndNeighbor = TerritoryAttachment.get(terrEnd);
-              if (taEndNeighbor != null
-                  && taEndNeighbor.getNavalBase()
-                  && unit.getData().getRelationshipTracker().isAllied(terrEnd.getOwner(), player)) {
-                left = left.add(BigDecimal.ONE);
-                break;
-              }
-            }
-          }
+        if (hasNeighboringAlliedNavalBase(route.getStart(), unit.getOwner())
+            && hasNeighboringAlliedNavalBase(route.getStart(), unit.getOwner())) {
+          left = left.add(BigDecimal.ONE);
         }
       }
       if (left.compareTo(BigDecimal.ZERO) < 0) {
@@ -1182,6 +1165,16 @@ public final class Matches {
       }
       return hasMovementForRoute;
     };
+  }
+
+  private static boolean hasNeighboringAlliedNavalBase(Territory t, GamePlayer player) {
+    return t.getData().getMap().getNeighbors(t).stream()
+        .anyMatch(t2 -> hasAlliedNavalBase(t2, player));
+  }
+
+  private static boolean hasAlliedNavalBase(Territory t, GamePlayer player) {
+    return TerritoryAttachment.hasNavalBase(t)
+        && t.getData().getRelationshipTracker().isAllied(t.getOwner(), player);
   }
 
   public static Predicate<Unit> unitHasMovementLeft() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1139,7 +1139,6 @@ public final class Matches {
     return unit -> {
       BigDecimal left = unit.getMovementLeft();
       final UnitAttachment ua = UnitAttachment.get(unit.getType());
-      final GamePlayer player = unit.getOwner();
       if (ua.getIsAir()) {
         if (TerritoryAttachment.hasAirBase(route.getStart())) {
           left = left.add(BigDecimal.ONE);
@@ -1148,28 +1147,13 @@ public final class Matches {
           left = left.add(BigDecimal.ONE);
         }
       }
-      final GameStep stepName = unit.getData().getSequence().getStep();
-      if (ua.getIsSea() && stepName.getDisplayName().equals("Non Combat Move")) {
+      if (ua.getIsSea() && unit.getData().getSequence().getStep().isNonCombat()) {
         // If a zone adjacent to the starting and ending sea zones are allied naval bases, increase
         // the range.
         // TODO Still need to be able to handle stops on the way
-        // (history to get route.getStart()
-        for (final Territory terrNext : unit.getData().getMap().getNeighbors(route.getStart(), 1)) {
-          final TerritoryAttachment taNeighbor = TerritoryAttachment.get(terrNext);
-          if (taNeighbor != null
-              && taNeighbor.getNavalBase()
-              && unit.getData().getRelationshipTracker().isAllied(terrNext.getOwner(), player)) {
-            for (final Territory terrEnd :
-                unit.getData().getMap().getNeighbors(route.getEnd(), 1)) {
-              final TerritoryAttachment taEndNeighbor = TerritoryAttachment.get(terrEnd);
-              if (taEndNeighbor != null
-                  && taEndNeighbor.getNavalBase()
-                  && unit.getData().getRelationshipTracker().isAllied(terrEnd.getOwner(), player)) {
-                left = left.add(BigDecimal.ONE);
-                break;
-              }
-            }
-          }
+        if (hasNeighboringAlliedNavalBase(route.getStart(), unit.getOwner())
+            && hasNeighboringAlliedNavalBase(route.getEnd(), unit.getOwner())) {
+          left = left.add(BigDecimal.ONE);
         }
       }
       if (left.compareTo(BigDecimal.ZERO) < 0) {
@@ -1182,6 +1166,16 @@ public final class Matches {
       }
       return hasMovementForRoute;
     };
+  }
+
+  private static boolean hasNeighboringAlliedNavalBase(Territory t, GamePlayer player) {
+    return t.getData().getMap().getNeighbors(t).stream()
+        .anyMatch(t2 -> hasAlliedNavalBase(t2, player));
+  }
+
+  private static boolean hasAlliedNavalBase(Territory t, GamePlayer player) {
+    return TerritoryAttachment.hasNavalBase(t)
+        && t.getData().getRelationshipTracker().isAllied(t.getOwner(), player);
   }
 
   public static Predicate<Unit> unitHasMovementLeft() {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1151,7 +1151,7 @@ public final class Matches {
         // the range.
         // TODO Still need to be able to handle stops on the way
         if (hasNeighboringAlliedNavalBase(route.getStart(), unit.getOwner())
-            && hasNeighboringAlliedNavalBase(route.getStart(), unit.getOwner())) {
+            && hasNeighboringAlliedNavalBase(route.getEnd(), unit.getOwner())) {
           left = left.add(BigDecimal.ONE);
         }
       }

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -1146,6 +1146,8 @@ public final class Matches {
           left = left.add(BigDecimal.ONE);
         }
       }
+      // Apply "AAP" (Pacific) Naval base bonus. Note: In "AAG40" (1940) naval bases are implemented
+      // differently: via a naval base _unit_ that boosts movement rather than territory attachment.
       if (ua.getIsSea() && unit.getData().getSequence().getStep().isNonCombat()) {
         // If a zone adjacent to the starting and ending sea zones are allied naval bases, increase
         // the range.

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/Matches.java
@@ -3,7 +3,6 @@ package games.strategy.triplea.delegate;
 import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GameMap;
 import games.strategy.engine.data.GamePlayer;
-import games.strategy.engine.data.GameStep;
 import games.strategy.engine.data.RelationshipTracker;
 import games.strategy.engine.data.RelationshipTracker.Relationship;
 import games.strategy.engine.data.RelationshipType;

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -375,10 +375,11 @@ public class MovePerformer implements Serializable {
         change.add(ChangeFactory.markNoMovementChange(Set.of(unit)));
       }
     }
-    if (routeEnd != null
+    if (route.getEnd() != null
         && Properties.getSubsCanEndNonCombatMoveWithEnemies(data.getProperties())
         && GameStepPropertiesHelper.isNonCombatMove(data, false)
-        && routeEnd.anyUnitsMatch(
+        && route
+            .getEnd().anyUnitsMatch(
             Matches.unitIsEnemyOf(data.getRelationshipTracker(), gamePlayer)
                 .and(Matches.unitIsDestroyer()))) {
       // if we are allowed to have our subs enter any sea zone with enemies during noncombat, we

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -375,11 +375,10 @@ public class MovePerformer implements Serializable {
         change.add(ChangeFactory.markNoMovementChange(Set.of(unit)));
       }
     }
-    if (route.getEnd() != null
+    if (routeEnd != null
         && Properties.getSubsCanEndNonCombatMoveWithEnemies(data.getProperties())
         && GameStepPropertiesHelper.isNonCombatMove(data, false)
-        && route
-            .getEnd()
+        && routeEnd
             .anyUnitsMatch(
                 Matches.unitIsEnemyOf(data.getRelationshipTracker(), gamePlayer)
                     .and(Matches.unitIsDestroyer()))) {

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -379,9 +379,10 @@ public class MovePerformer implements Serializable {
         && Properties.getSubsCanEndNonCombatMoveWithEnemies(data.getProperties())
         && GameStepPropertiesHelper.isNonCombatMove(data, false)
         && route
-            .getEnd().anyUnitsMatch(
-            Matches.unitIsEnemyOf(data.getRelationshipTracker(), gamePlayer)
-                .and(Matches.unitIsDestroyer()))) {
+            .getEnd()
+            .anyUnitsMatch(
+                Matches.unitIsEnemyOf(data.getRelationshipTracker(), gamePlayer)
+                    .and(Matches.unitIsDestroyer()))) {
       // if we are allowed to have our subs enter any sea zone with enemies during noncombat, we
       // want to make sure we
       // can't keep moving them if there is an enemy destroyer there

--- a/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
+++ b/game-app/game-core/src/main/java/games/strategy/triplea/delegate/MovePerformer.java
@@ -378,10 +378,9 @@ public class MovePerformer implements Serializable {
     if (routeEnd != null
         && Properties.getSubsCanEndNonCombatMoveWithEnemies(data.getProperties())
         && GameStepPropertiesHelper.isNonCombatMove(data, false)
-        && routeEnd
-            .anyUnitsMatch(
-                Matches.unitIsEnemyOf(data.getRelationshipTracker(), gamePlayer)
-                    .and(Matches.unitIsDestroyer()))) {
+        && routeEnd.anyUnitsMatch(
+            Matches.unitIsEnemyOf(data.getRelationshipTracker(), gamePlayer)
+                .and(Matches.unitIsDestroyer()))) {
       // if we are allowed to have our subs enter any sea zone with enemies during noncombat, we
       // want to make sure we
       // can't keep moving them if there is an enemy destroyer there

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/AbstractDelegateTestCase.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/AbstractDelegateTestCase.java
@@ -75,6 +75,7 @@ public abstract class AbstractDelegateTestCase {
   protected UnitType infantry = GameDataTestUtil.infantry(gameData);
   protected UnitType transport = GameDataTestUtil.transport(gameData);
   protected UnitType submarine = GameDataTestUtil.submarine(gameData);
+  protected UnitType destroyer = GameDataTestUtil.destroyer(gameData);
   protected UnitType factory = GameDataTestUtil.factory(gameData);
   protected UnitType aaGun = GameDataTestUtil.aaGun(gameData);
   protected UnitType fighter = GameDataTestUtil.fighter(gameData);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/GameDataTestUtil.java
@@ -212,6 +212,11 @@ public final class GameDataTestUtil {
     return unitType(Constants.UNIT_TYPE_INFANTRY, data);
   }
 
+  /** Returns a marine UnitType object for the specified GameData object. */
+  public static UnitType marine(final GameState data) {
+    return unitType(Constants.UNIT_TYPE_MARINE, data);
+  }
+
   /** Returns an artillery UnitType object for the specified GameData object. */
   public static UnitType artillery(final GameState data) {
     return unitType(Constants.UNIT_TYPE_ARTILLERY, data);

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
@@ -1,14 +1,23 @@
 package games.strategy.triplea.delegate;
 
+import static games.strategy.triplea.delegate.GameDataTestUtil.addTo;
+import static games.strategy.triplea.delegate.GameDataTestUtil.assertMoveError;
 import static games.strategy.triplea.delegate.GameDataTestUtil.load;
 import static games.strategy.triplea.delegate.GameDataTestUtil.move;
+import static games.strategy.triplea.delegate.GameDataTestUtil.removeFrom;
+import static games.strategy.triplea.delegate.GameDataTestUtil.submarine;
+import static games.strategy.triplea.delegate.GameDataTestUtil.territory;
 import static games.strategy.triplea.delegate.MockDelegateBridge.advanceToStep;
 import static games.strategy.triplea.delegate.MockDelegateBridge.newDelegateBridge;
 import static games.strategy.triplea.delegate.MockDelegateBridge.whenGetRandom;
 import static games.strategy.triplea.delegate.MockDelegateBridge.withValues;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import games.strategy.engine.data.GameData;
 import games.strategy.engine.data.GamePlayer;
+import games.strategy.engine.data.MutableProperty;
 import games.strategy.engine.data.Route;
 import games.strategy.engine.data.Territory;
 import games.strategy.engine.data.TerritoryEffect;
@@ -17,6 +26,7 @@ import games.strategy.engine.data.UnitType;
 import games.strategy.engine.delegate.IDelegateBridge;
 import games.strategy.triplea.Constants;
 import games.strategy.triplea.Properties;
+import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.battle.BattleState;
 import games.strategy.triplea.delegate.dice.RollDiceFactory;
 import games.strategy.triplea.delegate.power.calculator.CombatValueBuilder;
@@ -27,62 +37,45 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.triplea.java.collections.IntegerMap;
 
-class PacificTest extends AbstractDelegateTestCase {
-  private UnitType marine;
-  // Define players
-  private GamePlayer americans;
-  private GamePlayer chinese;
-  // Define territories
-  private Territory queensland;
-  private Territory unitedStates;
-  private Territory newBritain;
-  private Territory midway;
-  private Territory bonin;
-  // Define Sea Zones
-  private Territory sz4;
-  private Territory sz5;
-  private Territory sz7;
-  private Territory sz8;
-  private Territory sz10;
-  private Territory sz16;
-  private Territory sz20;
-  private Territory sz24;
-  private Territory sz27;
+class PacificTest {
+  private final GameData gameData = TestMapGameData.PACIFIC_INCOMPLETE.getGameData();
   private IDelegateBridge bridge;
   private MoveDelegate delegate;
 
+  private final UnitType infantry = GameDataTestUtil.infantry(gameData);
+  private final UnitType marine = GameDataTestUtil.marine(gameData);
+  private final UnitType transport = GameDataTestUtil.transport(gameData);
+  private final UnitType submarine = GameDataTestUtil.submarine(gameData);
+  private final UnitType destroyer = GameDataTestUtil.destroyer(gameData);
+  private final UnitType carrier = GameDataTestUtil.carrier(gameData);
+  private final UnitType fighter = GameDataTestUtil.fighter(gameData);
+  // Define players
+  private final GamePlayer americans = GameDataTestUtil.americans(gameData);
+  private final GamePlayer chinese = GameDataTestUtil.chinese(gameData);
+  private final GamePlayer japanese = GameDataTestUtil.japanese(gameData);
+  // Define territories
+  private final Territory queensland = territory("Queensland", gameData);
+  private final Territory unitedStates = territory("United States", gameData);
+  private final Territory newBritain = territory("New Britain", gameData);
+  private final Territory midway = territory("Midway", gameData);
+  private final Territory bonin = territory("Bonin", gameData);
+  private final Territory canada = territory("Canada", gameData);
+  // Define Sea Zones
+  private final Territory sz4 = territory("4 Sea Zone", gameData);
+  private final Territory sz5 = territory("5 Sea Zone", gameData);
+  private final Territory sz7 = territory("7 Sea Zone", gameData);
+  private final Territory sz8 = territory("8 Sea Zone", gameData);
+  private final Territory sz10 = territory("10 Sea Zone", gameData);
+  private final Territory sz14 = territory("14 Sea Zone", gameData);
+  private final Territory sz16 = territory("16 Sea Zone", gameData);
+  private final Territory sz20 = territory("20 Sea Zone", gameData);
+  private final Territory sz21 = territory("21 Sea Zone", gameData);
+  private final Territory sz24 = territory("24 Sea Zone", gameData);
+  private final Territory sz27 = territory("27 Sea Zone", gameData);
+  private final Territory sz30 = territory("30 Sea Zone", gameData);
+
   @BeforeEach
   void setupPacificTest() {
-    gameData = TestMapGameData.PACIFIC_INCOMPLETE.getGameData();
-    // Define units
-    infantry = GameDataTestUtil.infantry(gameData);
-    marine = gameData.getUnitTypeList().getUnitType(Constants.UNIT_TYPE_MARINE);
-    fighter = GameDataTestUtil.fighter(gameData);
-    bomber = GameDataTestUtil.bomber(gameData);
-    carrier = GameDataTestUtil.carrier(gameData);
-    transport = GameDataTestUtil.transport(gameData);
-    // Define players
-    americans = GameDataTestUtil.americans(gameData);
-    chinese = GameDataTestUtil.chinese(gameData);
-    british = GameDataTestUtil.british(gameData);
-    japanese = GameDataTestUtil.japanese(gameData);
-    // Define territories
-    queensland = gameData.getMap().getTerritory("Queensland");
-    japan = gameData.getMap().getTerritory("Japan");
-    unitedStates = gameData.getMap().getTerritory("United States");
-    newBritain = gameData.getMap().getTerritory("New Britain");
-    midway = gameData.getMap().getTerritory("Midway");
-    bonin = gameData.getMap().getTerritory("Bonin");
-    // Define Sea Zones
-    sz4 = gameData.getMap().getTerritory("4 Sea Zone");
-    sz5 = gameData.getMap().getTerritory("5 Sea Zone");
-    sz7 = gameData.getMap().getTerritory("7 Sea Zone");
-    sz8 = gameData.getMap().getTerritory("8 Sea Zone");
-    sz10 = gameData.getMap().getTerritory("10 Sea Zone");
-    sz16 = gameData.getMap().getTerritory("16 Sea Zone");
-    sz20 = gameData.getMap().getTerritory("20 Sea Zone");
-    sz24 = gameData.getMap().getTerritory("24 Sea Zone");
-    sz27 = gameData.getMap().getTerritory("27 Sea Zone");
     bridge = newDelegateBridge(americans);
     advanceToStep(bridge, "japaneseCombatMove");
     delegate = new MoveDelegate();
@@ -322,12 +315,47 @@ class PacificTest extends AbstractDelegateTestCase {
   }
 
   @Test
-  void testCanMoveNavalBase() {
-    advanceToStep(bridge, "americanNonCombatMove");
-    final Route route = new Route(sz5, sz7, sz8, sz20);
+  void testCanMoveFurtherBetweenNavalBases() throws MutableProperty.InvalidValueException {
+    // Remove Japanese units from sz20 so that we can move ships there non-combat.
+    removeFrom(sz20, sz20.getUnits());
+
     final IntegerMap<UnitType> map = new IntegerMap<>();
-    map.put(fighter, 1);
-    move(GameDataTestUtil.getUnits(map, route.getStart()), route);
+    map.put(submarine, 1);
+    addTo(sz5, submarine.create(10, americans));
+    map.put(transport, 1);
+    addTo(sz5, transport.create(10, americans));
+    map.put(destroyer, 1);
+    addTo(sz5, destroyer.create(10, americans));
+    map.put(carrier, 1);
+    addTo(sz5, carrier.create(10, americans));
+
+    advanceToStep(bridge, "americanCombatMove");
+    // During combat move, naval bases do not boost movement.
+    final Route toSz20 = new Route(sz5, sz7, sz8, sz20);
+    assertMoveError(GameDataTestUtil.getUnits(map, toSz20.getStart()), toSz20);
+
+    // But they do, during non-combat.
+    advanceToStep(bridge, "americanNonCombatMove");
+    // Moving 3 spaces to sz20 is allowed, since there's a Naval base at the destination.
+    move(GameDataTestUtil.getUnits(map, toSz20.getStart()), toSz20);
+
+    // Moving 3 spaces to sz21 is not allowed, since there is no naval base at destination.
+    final Route toSz21 = new Route(sz5, sz7, sz8, sz21);
+    assertMoveError(GameDataTestUtil.getUnits(map, toSz21.getStart()), toSz21);
+
+    // Going 3 spaces to sz14 is OK, since it's an allied naval base.
+    final Route toSz14 = new Route(sz5, sz4, sz10, sz14);
+    move(GameDataTestUtil.getUnits(map, toSz14.getStart()), toSz14);
+
+    // But can't go 4 spaces to sz30, even with a base at the destination.
+    final Route toSz30 = new Route(sz5, sz4, sz10, sz14, sz30);
+    assertMoveError(GameDataTestUtil.getUnits(map, toSz30.getStart()), toSz30);
+
+    // Finally, adding a naval base in Canada shouldn't boost movement further.
+    TerritoryAttachment.get(canada).getPropertyMap().get("navalBase").setValue(true);
+    assertThat(TerritoryAttachment.hasNavalBase(canada), is(true));
+    // Should still fail to move 4.
+    assertMoveError(GameDataTestUtil.getUnits(map, toSz30.getStart()), toSz30);
   }
 
   @Test

--- a/game-app/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
+++ b/game-app/game-core/src/test/java/games/strategy/triplea/delegate/PacificTest.java
@@ -24,7 +24,6 @@ import games.strategy.engine.data.TerritoryEffect;
 import games.strategy.engine.data.Unit;
 import games.strategy.engine.data.UnitType;
 import games.strategy.engine.delegate.IDelegateBridge;
-import games.strategy.triplea.Constants;
 import games.strategy.triplea.Properties;
 import games.strategy.triplea.attachments.TerritoryAttachment;
 import games.strategy.triplea.delegate.battle.BattleState;


### PR DESCRIPTION
## Change Summary & Additional Notes

Clean up code and fix the logic for Pacific-ruleset Naval base move boosting. The previous code was messy and inefficient and actually had a bug where a unit starting next to multiple Naval bases could get multiple boosts, which does not match the Pacific rule set, although this situation doesn't appear on the Pacific map (and new Naval bases can't be built there).

There was no actual test coverage of this logic, although there was a test that intended to do this, but used a fighter unit instead of a naval unit in the test, thus not exercising the code. This PR expands this test to provide much more extensive test coverage of this logic.

<!--
- If multiple commits, summarize what has changed
- Mention any manual testing done.
- If there are UI updates, please include before & after screenshots
-->

## Release Note
<!--
Include a release note if there is a bug fix or a visible change for players.
For format & syntax help, see:
https://github.com/triplea-game/triplea/blob/master/docs/development/reference/pr-release-notes.md
-->

<!--RELEASE_NOTE-->FIX|Fixed the Pacific ruleset Naval base territory attachment logic<!--END_RELEASE_NOTE-->
