### PR TITLE
Fix wrong tags on subsequent pushes to master

### DIFF
--- a/.github/workflows/deploy-artifacts.yml
+++ b/.github/workflows/deploy-artifacts.yml
@@ -37,6 +37,6 @@ jobs:
           tag: ${{ env.product_version }} 
           name: ${{ env.release_name }}
           prerelease: ${{ env.is_prerelease }}
-          commit: master
+          commit: ${{ github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
I noticed that sometimes the commits to master are not tagged correctly if they are pushed in quick succession to each other.
This should fix the issue if I read the documentation correctly